### PR TITLE
feat(macos): decode native frames off main actor

### DIFF
--- a/lib/mix/tasks/swift_harness.ex
+++ b/lib/mix/tasks/swift_harness.ex
@@ -5,6 +5,7 @@ defmodule Mix.Tasks.Swift.Harness do
   ## Usage
 
       mix swift.harness
+      mix swift.harness --release
 
   Compiles `macos/Sources/TestHarness/main.swift` along with the shared
   protocol files into `priv/minga-test-harness`. Required before running
@@ -37,6 +38,9 @@ defmodule Mix.Tasks.Swift.Harness do
     "macos/.generated/protocol/ProtocolCommandSize.generated.swift",
     "macos/.generated/protocol/ProtocolSemanticDecode.generated.swift",
     "macos/Sources/Protocol/ProtocolConstants.swift",
+    "macos/Sources/Protocol/ByteCursor.swift",
+    "macos/Sources/Protocol/DecodedFrame.swift",
+    "macos/Sources/Protocol/ProtocolEventHandoff.swift",
     "macos/Sources/Protocol/ProtocolDecoder.swift",
     "macos/TestHarness/main.swift"
   ]
@@ -48,7 +52,7 @@ defmodule Mix.Tasks.Swift.Harness do
 
   @impl Mix.Task
   @spec run(list()) :: :ok
-  def run(_args) do
+  def run(args) do
     Mix.Task.run("protocol.gen", [])
 
     priv_dir = Path.join(Mix.Project.app_path(), "priv")
@@ -67,10 +71,15 @@ defmodule Mix.Tasks.Swift.Harness do
       (@protocol_module_sources ++ @harness_app_sources)
       |> Enum.map(&preprocess_source(&1, src_dir))
 
-    args = compile_sources ++ ["-o", output]
+    compiler_args = compile_sources ++ optimization_args(args) ++ ["-o", output]
 
     System.find_executable("swiftc")
-    |> run_with_swiftc(args, output)
+    |> run_with_swiftc(compiler_args, output)
+  end
+
+  @spec optimization_args([String.t()]) :: [String.t()]
+  defp optimization_args(args) do
+    if "--release" in args, do: ["-O"], else: []
   end
 
   @spec preprocess_source(String.t(), String.t()) :: String.t()

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -142,12 +142,14 @@
 		79E8353F67F7638721A02A54 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		7AFD153489353DC030087B75 /* NotificationCenterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FF59E5F1800200A69FB8FB /* NotificationCenterView.swift */; };
 		7BA75B36E9A9573C57571C53 /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D118F59FBCA463A52B84FA /* AgentContextBar.swift */; };
+		7BCDF8E63FDADFCADFCA5276 /* ByteCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D220B640A214311083EE8B4 /* ByteCursorTests.swift */; };
 		7C9B7CB6670412D9F4DE60BB /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		7FE374C007A79192530A6B26 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		83ACC5A2A0BF5F5F3BA34894 /* HoverPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38E8668FFBC3522674AE29C /* HoverPopupOverlay.swift */; };
 		842F37A4A6D1D95F63E41E2A /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
 		86526CCD268BB390F0C14C53 /* AgentSurfaceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483AA21EF140F07296D1E16A /* AgentSurfaceTypes.swift */; };
 		87D39424AC2980D7E33F5DB0 /* PortLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E23DC6E0ACB156F21293E87 /* PortLogger.swift */; };
+		885F2754A698ACF4B679D98F /* DecodedFrameTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 892582CEE169FA9B95827153 /* DecodedFrameTests.swift */; };
 		888A35D1348A7A3CAE935561 /* DecoderFuzzTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */; };
 		88D0A6915FA4D55AB0859E57 /* LiveResizeDebounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */; };
 		88EA849750435A68E025FF03 /* PreviewFixtures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2BAB83B99298DE01101D3C60 /* PreviewFixtures.swift */; };
@@ -180,6 +182,7 @@
 		9D1D5E11F9839F86F7A7BA70 /* EditorScrollTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44800E8F274B5EC453CAE7EB /* EditorScrollTrack.swift */; };
 		9E0440F139946089F30E6DBF /* FileTreeState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 202B9FAA0B926E0B23C0BA88 /* FileTreeState.swift */; };
 		9F615B0B1750281E84BD25C1 /* GitStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECFA1BAF013281143087097 /* GitStatusView.swift */; };
+		9F7CBB6787243AC4F0F1E8B7 /* ProtocolEventHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */; };
 		A07B320CE2B623ADBA433732 /* PreviewRegistry+Chrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF40BCB1722FAD446E1E6E52 /* PreviewRegistry+Chrome.swift */; };
 		A17019B3C14044971571A5F1 /* ProtocolCommandSize.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762CD389E04B0DE6A86CDBF2 /* ProtocolCommandSize.generated.swift */; };
 		A23A42248D022DE42E122D0B /* WorkspaceIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BD32DD25D2C6C5A90D898 /* WorkspaceIndicatorView.swift */; };
@@ -207,6 +210,7 @@
 		B00499E91B66E7A6E167D808 /* WhichKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEC828C1445B3314C8989E1 /* WhichKeyState.swift */; };
 		B050A8B433483CADBF75035A /* SparklineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D721181E284AD8BA34F0354 /* SparklineView.swift */; };
 		B0A5712B943D48F8F72C1DDA /* KeyboardInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */; };
+		B0ED5B46A4F6317344D58C88 /* ByteCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E609A9FCD637B39DD56497B /* ByteCursor.swift */; };
 		B12FA22E8F25CE3E5F55366F /* WindowContentRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */; };
 		B21401DDB10E990350A3FB3F /* FrameMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */; };
 		B215CFD8C30AA26BAA9C5448 /* PickerOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3947E679EE2D80E4D8FED9E /* PickerOverlay.swift */; };
@@ -214,6 +218,7 @@
 		B308ADA08963E550E47FCDED /* EditorScrollTrackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2E468DA824CDB99FCEF94A /* EditorScrollTrackTests.swift */; };
 		B36F6632677AC067B8A7A2A4 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568352180EC6FAF208830660 /* FileTreeView.swift */; };
 		B3B08F3C63B5A5D2605C8611 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5647A59C841B3C408994CC7 /* Assets.xcassets */; };
+		B5D79AA3EB89928091967F73 /* ProtocolEventHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */; };
 		B7203DF9CF85663B0A266580 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
 		B7EA51EE1C9145223251B68C /* ProtocolSemanticDecode.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B639BCE7660087F70778E839 /* ProtocolSemanticDecode.generated.swift */; };
 		B909887B329ECB88EB605B85 /* MingaProtocol.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -248,10 +253,12 @@
 		D394B6B62354CC4ADD76DB74 /* LatencyRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749F7E4A3595F1289002943E /* LatencyRecorder.swift */; };
 		D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */; };
 		D486A1CE007AF228798286B7 /* SidebarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34C34EC8FF8D20C141F2290 /* SidebarContainer.swift */; };
+		D52E7150799D94DC2204882A /* ByteCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E609A9FCD637B39DD56497B /* ByteCursor.swift */; };
 		D5F45455932847E76CA9A4E4 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA08D322A0BCE2491D4489D /* MessagesContentView.swift */; };
 		D916997E44A9619D08995FDA /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */; };
 		DA224DFB69915CFBFC50DDAE /* EditorGeometry+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */; };
 		DA2EDB0295FDA3FBF421E0E8 /* ToolManagerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28C576F6F2E779DEEABFE79C /* ToolManagerView.swift */; };
+		DAB6615DF756BFD9BFC420FF /* DecodedFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */; };
 		DB4EE4C9D35A3CCEA80442D6 /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EC68F918782FE2FCDB2413 /* WorkspaceState.swift */; };
 		DB83E9F1763A0D2E7BD7F7D3 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = BD2531C0969FD21CC18D2FDB /* ViewInspector */; };
 		DCCC540FD702D8D37013173F /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25503C21E0D55E1515A38C7D /* ScrollAccumulator.swift */; };
@@ -262,6 +269,7 @@
 		E139B8F9FCA100EBDDC042AB /* ExtensionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9302C5E00767815DD10A7 /* ExtensionOverlayView.swift */; };
 		E1601C8BE90E7A7CB8F7F5DA /* ResyncState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953A62EE436C9B1F73B97D07 /* ResyncState.swift */; };
 		E20D436BEA6628E24B9FFA2C /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
+		E2162A8A372C564E37940E11 /* ByteCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E609A9FCD637B39DD56497B /* ByteCursor.swift */; };
 		E27074789DFFC30C49DD40D0 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DB822E0C8D06C7B45D329F /* EditorNSView.swift */; };
 		E28B13C9D7A0CFE84CC086EB /* EditorGeometry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13C8650724242FD0A50EC3CA /* EditorGeometry.swift */; };
 		E2BC69E1121328310B830E45 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
@@ -282,6 +290,8 @@
 		F12D6284209D6D32037E6644 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
 		F3BB64E36F257BD7FACEA5D6 /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
 		F3C4A9DABEF6FD369F8B1F45 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84218125A9F97DBE87F349 /* ContentView.swift */; };
+		F47F466346CB7353AD5B4028 /* DecodedFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */; };
+		F6774D86515DEFEFD0F3894B /* ProtocolEventHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */; };
 		F6F56719C285CB9C3EA62A57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5647A59C841B3C408994CC7 /* Assets.xcassets */; };
 		F984C67E0F2861DE6A25DBD4 /* PreviewRegistry+GitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB5DAD0EAB1AE583E45AF5C /* PreviewRegistry+GitStatus.swift */; };
 		F986D696164E7D7483EF2DB4 /* PreviewRegistry+Overlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0D41B1D748FBFE7916342C /* PreviewRegistry+Overlays.swift */; };
@@ -292,6 +302,7 @@
 		FCC1D0710DF8573446AA5EAB /* FrontendExtensionRuntime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 752F8FD906F48C58D51FBBA1 /* FrontendExtensionRuntime.swift */; };
 		FD4F1E64AF19C8199D4AAEAA /* RecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A6769D066EC44A58791CFC /* RecoveryManager.swift */; };
 		FEA7FDF0B8C5551790872FCA /* WindowContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */; };
+		FEE7A22BC5E84F37E0054B6F /* DecodedFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */; };
 		FEFCEFCDC21C5AA5456036D0 /* SystemColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B00002D020FED57D265C74 /* SystemColorTests.swift */; };
 		FFA8B5D73FABC2792F4A3589 /* ProtocolDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */; };
 		FFE9F4F1490B1937AD3AC129 /* PreviewRegistry+Overlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0D41B1D748FBFE7916342C /* PreviewRegistry+Overlays.swift */; };
@@ -465,7 +476,9 @@
 		59D39027C365C5768029E593 /* ToolManagerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolManagerState.swift; sourceTree = "<group>"; };
 		5A84E92F596D0DDF8FF11049 /* MinibufferView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinibufferView.swift; sourceTree = "<group>"; };
 		5C6CC43E02AE08773B90E8AC /* ObservatoryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservatoryView.swift; sourceTree = "<group>"; };
+		5D220B640A214311083EE8B4 /* ByteCursorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteCursorTests.swift; sourceTree = "<group>"; };
 		5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreTextMetalRenderer.swift; sourceTree = "<group>"; };
+		5E609A9FCD637B39DD56497B /* ByteCursor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ByteCursor.swift; sourceTree = "<group>"; };
 		5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "EditorGeometry+App.swift"; sourceTree = "<group>"; };
 		60980E90FDD864409144BA5B /* PickerState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PickerState.swift; sourceTree = "<group>"; };
 		620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRendererTests.swift; sourceTree = "<group>"; };
@@ -494,12 +507,14 @@
 		7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoder.swift; sourceTree = "<group>"; };
 		7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MingaUI.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeyboardInputTests.swift; sourceTree = "<group>"; };
+		7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodedFrame.swift; sourceTree = "<group>"; };
 		7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LiveResizeDebounce.swift; sourceTree = "<group>"; };
 		801F49D62225A511B8510EAA /* ConformanceTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConformanceTranscriptTests.swift; sourceTree = "<group>"; };
 		82B744449C852E13511FFE8D /* MinibufferStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MinibufferStateTests.swift; sourceTree = "<group>"; };
 		848E04E4F242C861887769F3 /* MingaProtocol.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = MingaProtocol.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		86478D5660213F165B7E1E35 /* SwiftUIViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwiftUIViewTests.swift; sourceTree = "<group>"; };
 		86A4DA796E10E4A7D98A18E1 /* AgentChatHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatHeaderView.swift; sourceTree = "<group>"; };
+		892582CEE169FA9B95827153 /* DecodedFrameTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DecodedFrameTests.swift; sourceTree = "<group>"; };
 		8A733EF649EF21A761608D75 /* MingaWindow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MingaWindow.swift; sourceTree = "<group>"; };
 		8A84218125A9F97DBE87F349 /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		8AD9302C5E00767815DD10A7 /* ExtensionOverlayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionOverlayView.swift; sourceTree = "<group>"; };
@@ -533,6 +548,7 @@
 		B9B4DF5FEB6C8DFCA427A692 /* Minga.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Minga.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		B9FC2118EA77254CBCAE7B0B /* AppState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppState.swift; sourceTree = "<group>"; };
 		BAB74638990EB35D97E428E2 /* ChangeSummaryView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChangeSummaryView.swift; sourceTree = "<group>"; };
+		BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEventHandoff.swift; sourceTree = "<group>"; };
 		BBA4340DA5B9E9B544083A8B /* SidebarHostState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHostState.swift; sourceTree = "<group>"; };
 		BD2DE335B00721CBB29329F9 /* FontTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontTests.swift; sourceTree = "<group>"; };
 		C089C5163F2C513D3DC21E7C /* ExtensionPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionPanelView.swift; sourceTree = "<group>"; };
@@ -842,6 +858,8 @@
 			isa = PBXGroup;
 			children = (
 				483AA21EF140F07296D1E16A /* AgentSurfaceTypes.swift */,
+				5E609A9FCD637B39DD56497B /* ByteCursor.swift */,
+				7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */,
 				F330603D06228BB2A18F71F5 /* FrontendExtensionRuntimeMessage.swift */,
 				C6154F8ABA71694035D38ED2 /* GUIColorSlots.swift */,
 				92E717A483EC2E50C536785C /* InputEncoder.swift */,
@@ -850,6 +868,7 @@
 				C441427A427E23B912F70092 /* ProtocolConstants.swift */,
 				56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */,
 				7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */,
+				BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */,
 				4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */,
 				08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */,
 				8D450D75A36486FD84AD6BB8 /* StatusBarUpdate.swift */,
@@ -974,10 +993,12 @@
 			isa = PBXGroup;
 			children = (
 				1F2A06C5BA9E3F53A59E202F /* BEAMProcessManagerTests.swift */,
+				5D220B640A214311083EE8B4 /* ByteCursorTests.swift */,
 				470991E7B3850B1AADFD46FD /* CommandDispatcherTests.swift */,
 				FEA19E7E243EB130E1969551 /* CompletionStateTests.swift */,
 				801F49D62225A511B8510EAA /* ConformanceTranscriptTests.swift */,
 				A5BA668E827BD6B77C72E9D6 /* CoreTextMetalRendererCursorTests.swift */,
+				892582CEE169FA9B95827153 /* DecodedFrameTests.swift */,
 				053D515EC453DEBFF51FB6CB /* DecoderFuzzTests.swift */,
 				57B35E8311966948B1BA7AEF /* DecoderRobustnessTests.swift */,
 				CE2E468DA824CDB99FCEF94A /* EditorScrollTrackTests.swift */,
@@ -1304,10 +1325,12 @@
 				AB200EDC2BD9693D8D52CE98 /* AppState.swift in Sources */,
 				19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */,
 				18F0DDA03D08C0B4302DCCF4 /* BitmapRasterizer.swift in Sources */,
+				B0ED5B46A4F6317344D58C88 /* ByteCursor.swift in Sources */,
 				AFE31388980EE451C8F734A3 /* CachedLineTexture.swift in Sources */,
 				C44D9CF03C49E7BCA39A76A9 /* CommandDispatcher.swift in Sources */,
 				23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */,
 				16116567DD7218A82575360A /* CoreTextShaders.metal in Sources */,
+				DAB6615DF756BFD9BFC420FF /* DecodedFrame.swift in Sources */,
 				DA224DFB69915CFBFC50DDAE /* EditorGeometry+App.swift in Sources */,
 				ED8592B57E8A2A3EAAE24295 /* EditorNSView.swift in Sources */,
 				281A9531103F9E962B3F31A7 /* EditorScrollTrack.swift in Sources */,
@@ -1335,6 +1358,7 @@
 				A409AE210CBAE48D4DCE47F7 /* ProtocolConstants.swift in Sources */,
 				FFA8B5D73FABC2792F4A3589 /* ProtocolDecoder.swift in Sources */,
 				BF41C04B7AF7C400A4DC1474 /* ProtocolEncoder.swift in Sources */,
+				9F7CBB6787243AC4F0F1E8B7 /* ProtocolEventHandoff.swift in Sources */,
 				2C176B25F957ABFA236A1F31 /* ProtocolOpcodes.generated.swift in Sources */,
 				364C48575BB95C9CA535A9C8 /* ProtocolReader.swift in Sources */,
 				CED32F817C08FC30D21E09AC /* ProtocolSemanticDecode.generated.swift in Sources */,
@@ -1353,10 +1377,12 @@
 				A29BB96B8F84AA489CBA0C5F /* AppState.swift in Sources */,
 				E20D436BEA6628E24B9FFA2C /* BEAMProcessManager.swift in Sources */,
 				932C189ED218AC16620D8C19 /* BitmapRasterizer.swift in Sources */,
+				E2162A8A372C564E37940E11 /* ByteCursor.swift in Sources */,
 				5CF105289D5A9C9AD4B8548A /* CachedLineTexture.swift in Sources */,
 				45A352459C76907D8E4CB596 /* CommandDispatcher.swift in Sources */,
 				8FB0DF76DEB5112AD590BB11 /* CoreTextMetalRenderer.swift in Sources */,
 				1A7BC027E152504B67F6F418 /* CoreTextShaders.metal in Sources */,
+				FEE7A22BC5E84F37E0054B6F /* DecodedFrame.swift in Sources */,
 				6DC89F81DBC022B3FCBA39BB /* EditorGeometry+App.swift in Sources */,
 				E27074789DFFC30C49DD40D0 /* EditorNSView.swift in Sources */,
 				CE65FF332E03ED47ADFBA48E /* EditorScrollTrack.swift in Sources */,
@@ -1385,6 +1411,7 @@
 				78644398F50FDB9206F731CB /* ProtocolConstants.swift in Sources */,
 				72CC62FDCBD531FEFE4D07DF /* ProtocolDecoder.swift in Sources */,
 				A4E838B0B19ED0B8F9CC4654 /* ProtocolEncoder.swift in Sources */,
+				F6774D86515DEFEFD0F3894B /* ProtocolEventHandoff.swift in Sources */,
 				6AFA24DC3EE21023636C136A /* ProtocolOpcodes.generated.swift in Sources */,
 				4451B7F61D8FB50D964406A0 /* ProtocolReader.swift in Sources */,
 				A911CF7DE0346417471AF27A /* ProtocolSemanticDecode.generated.swift in Sources */,
@@ -1517,6 +1544,8 @@
 				79E8353F67F7638721A02A54 /* BEAMProcessManager.swift in Sources */,
 				43116CD030B0374BE3F4B3FE /* BEAMProcessManagerTests.swift in Sources */,
 				64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */,
+				D52E7150799D94DC2204882A /* ByteCursor.swift in Sources */,
+				7BCDF8E63FDADFCADFCA5276 /* ByteCursorTests.swift in Sources */,
 				E2BC69E1121328310B830E45 /* CachedLineTexture.swift in Sources */,
 				07C32C28178AE5675ACF4539 /* CommandDispatcher.swift in Sources */,
 				28F3D7BFADCE4A2509D66C2B /* CommandDispatcherTests.swift in Sources */,
@@ -1525,6 +1554,8 @@
 				527C7DB557EFD09B3161BC20 /* CoreTextMetalRenderer.swift in Sources */,
 				BF89605C029E1F2F4EE328EA /* CoreTextMetalRendererCursorTests.swift in Sources */,
 				F3BB64E36F257BD7FACEA5D6 /* CoreTextShaders.metal in Sources */,
+				F47F466346CB7353AD5B4028 /* DecodedFrame.swift in Sources */,
+				885F2754A698ACF4B679D98F /* DecodedFrameTests.swift in Sources */,
 				888A35D1348A7A3CAE935561 /* DecoderFuzzTests.swift in Sources */,
 				A6327C6FAB3DCFD57327FBF4 /* DecoderRobustnessTests.swift in Sources */,
 				2388D1CC8878556958DA4A0D /* EditorGeometry+App.swift in Sources */,
@@ -1577,6 +1608,7 @@
 				7C9B7CB6670412D9F4DE60BB /* ProtocolEncoder.swift in Sources */,
 				778C6A917140005C0C0643CB /* ProtocolEncoderBinaryTests.swift in Sources */,
 				DF3B2A645C089F616B9DBD1B /* ProtocolEncoderDisconnectTests.swift in Sources */,
+				B5D79AA3EB89928091967F73 /* ProtocolEventHandoff.swift in Sources */,
 				647346FE3161B2C2FC4A5436 /* ProtocolOpcodes.generated.swift in Sources */,
 				FA582944CD6B90BCABC13FCE /* ProtocolReader.swift in Sources */,
 				F0A2BCCA095F1CA4FBE9BE3F /* ProtocolSchemaTests.swift in Sources */,

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -200,6 +200,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var fontManager: FontManager?
     private var editorNSView: EditorNSView?
     private var workspaceNotificationTasks: [Task<Void, Never>] = []
+    private var protocolDeliveryTask: Task<Void, Never>?
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Ignore SIGPIPE so broken pipe writes return EPIPE instead of
@@ -415,13 +416,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // @unchecked Sendable and disconnect() is lock-protected.
         let disconnectEncoder = enc
 
-        // Start reading protocol commands.
+        // Start reading protocol commands. One stream consumer preserves the
+        // reader's wire order across successful packets and decode failures.
+        let protocolHandoff = installProtocolEventHandoff()
         let reader = ProtocolReader(
             input: protocolInput,
-            handler: { [weak self] data in
-                DispatchQueue.main.async {
-                    self?.handleProtocolData(data)
-                }
+            handler: { frame in
+                protocolHandoff.deliver(frame)
+            },
+            onDecodeFailure: { error in
+                protocolHandoff.deliver(error)
             },
             onDisconnect: { [weak self] in
                 // Immediately mark the encoder as disconnected so any
@@ -655,13 +659,16 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Capture for the background-thread disconnect callback.
         let disconnectEncoder = enc
 
-        // Create new reader for the new pipe.
+        // Create new reader for the new pipe. Reconnection replaces the one
+        // ordered stream consumer instead of spawning a task per event.
+        let protocolHandoff = installProtocolEventHandoff()
         let reader = ProtocolReader(
             input: readHandle,
-            handler: { [weak self] data in
-                DispatchQueue.main.async {
-                    self?.handleProtocolData(data)
-                }
+            handler: { frame in
+                protocolHandoff.deliver(frame)
+            },
+            onDecodeFailure: { error in
+                protocolHandoff.deliver(error)
             },
             onDisconnect: { [weak self] in
                 disconnectEncoder.disconnect()
@@ -784,19 +791,42 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     // MARK: - Protocol handling
 
-    private func handleProtocolData(_ data: Data) {
-        guard let dispatcher else { return }
-        do {
-            try decodeCommands(from: data) { command, opcode in
-                dispatcher.dispatch(command, opcode: opcode)
+    private func installProtocolEventHandoff() -> ProtocolEventHandoff {
+        protocolDeliveryTask?.cancel()
+        let handoff = ProtocolEventHandoff()
+        protocolDeliveryTask = Task { @MainActor [weak self] in
+            for await event in handoff.events {
+                guard let self else { return }
+                switch event {
+                case .frame(let frame):
+                    self.handleDecodedFrame(frame)
+                case .decodeFailure(let error):
+                    self.handleProtocolDecodeFailure(error)
+                }
             }
-        } catch {
-            // A decode failure (sizing error or unknown opcode) mid-stream means
-            // the byte boundaries are no longer trustworthy. If a frame
-            // transaction is open, this tightens the usual log-and-continue policy:
-            // discard the staged frame and request a keyframe (#2219 child D).
-            PortLogger.error("Protocol decode error: \(error)")
-            dispatcher.decodeFailed()
         }
+        return handoff
+    }
+
+    private func handleDecodedFrame(_ frame: DecodedFrame) {
+        os_signpost(
+            .event,
+            log: protocolLog,
+            name: "ProtocolPayloadDelivered",
+            "bytes=%{public}d hops=%{public}d",
+            frame.metrics.packetBytes,
+            frame.metrics.actorHopCount
+        )
+        guard let dispatcher else { return }
+        for decoded in frame.commands {
+            dispatcher.dispatch(decoded.command, opcode: decoded.opcode)
+        }
+    }
+
+    private func handleProtocolDecodeFailure(_ error: ProtocolDecodeError) {
+        // The packet is transactional: no command from it crossed actor isolation,
+        // so discarding the staged frame cannot leave a partially applied update.
+        PortLogger.error("Protocol decode error: \(error)")
+        dispatcher?.decodeFailed()
     }
 }

--- a/macos/Sources/Protocol/ByteCursor.swift
+++ b/macos/Sources/Protocol/ByteCursor.swift
@@ -1,0 +1,116 @@
+/// Checked, zero-copy cursor primitives for protocol packet decoding.
+
+import Foundation
+
+/// A bounds-checked, `Sendable` cursor over an immutable `Data` range.
+///
+/// `readSlice(count:)` and `readSubcursor(count:)` retain a bounded view of the
+/// packet instead of materializing the unconsumed tail. Owned values are only
+/// created by operations such as `readString(count:)` that publish a final
+/// immutable value beyond the decode call.
+struct ByteCursor: Sendable {
+    struct BoundsError: Error, Equatable, Sendable {
+        let offset: Int
+        let required: Int
+        let remaining: Int
+    }
+
+    private let data: Data
+    private let bounds: Range<Data.Index>
+    private(set) var index: Data.Index
+    private(set) var bytesCopied = 0
+    private(set) var allocations = 0
+
+    init(_ data: Data) {
+        self.data = data
+        self.bounds = data.startIndex..<data.endIndex
+        self.index = data.startIndex
+    }
+
+    init(_ data: Data, range: Range<Data.Index>) throws {
+        guard range.lowerBound >= data.startIndex,
+              range.upperBound >= range.lowerBound,
+              range.upperBound <= data.endIndex else {
+            let offset = max(data.startIndex, min(range.lowerBound, data.endIndex))
+            throw BoundsError(
+                offset: data.distance(from: data.startIndex, to: offset),
+                required: max(range.count, 0),
+                remaining: data.distance(from: offset, to: data.endIndex)
+            )
+        }
+        self.data = data
+        self.bounds = range
+        self.index = range.lowerBound
+    }
+
+    private init(data: Data, bounds: Range<Data.Index>) {
+        self.data = data
+        self.bounds = bounds
+        self.index = bounds.lowerBound
+    }
+
+    var offset: Int { data.distance(from: data.startIndex, to: index) }
+    var remaining: Int { data.distance(from: index, to: bounds.upperBound) }
+    var isAtEnd: Bool { index == bounds.upperBound }
+
+    mutating func readUInt8() throws -> UInt8 {
+        try require(1)
+        let value = data[index]
+        data.formIndex(after: &index)
+        return value
+    }
+
+    mutating func readUInt16() throws -> UInt16 {
+        let high = UInt16(try readUInt8())
+        return high << 8 | UInt16(try readUInt8())
+    }
+
+    mutating func readUInt32() throws -> UInt32 {
+        let high = UInt32(try readUInt16())
+        return high << 16 | UInt32(try readUInt16())
+    }
+
+    mutating func readUInt64() throws -> UInt64 {
+        let high = UInt64(try readUInt32())
+        return high << 32 | UInt64(try readUInt32())
+    }
+
+    /// Returns a bounded packet view without copying its bytes.
+    mutating func readSlice(count: Int) throws -> Data.SubSequence {
+        let range = try consumeRange(count: count)
+        return data[range]
+    }
+
+    /// Returns a checked cursor restricted to the next `count` bytes.
+    mutating func readSubcursor(count: Int) throws -> ByteCursor {
+        ByteCursor(data: data, bounds: try consumeRange(count: count))
+    }
+
+    /// Decodes one final immutable UTF-8 value and accounts for its owned bytes.
+    mutating func readString(count: Int) throws -> String {
+        let slice = try readSlice(count: count)
+        guard let value = String(data: slice, encoding: .utf8) else {
+            throw ProtocolDecodeError.malformed
+        }
+        bytesCopied += count
+        allocations += 1
+        return value
+    }
+
+    mutating func advance(by count: Int) throws {
+        _ = try consumeRange(count: count)
+    }
+
+    private mutating func consumeRange(count: Int) throws -> Range<Data.Index> {
+        try require(count)
+        let start = index
+        data.formIndex(&index, offsetBy: count)
+        return start..<index
+    }
+
+    private func require(_ count: Int) throws {
+        guard count >= 0, count <= remaining else {
+            throw BoundsError(offset: offset, required: max(count, 0), remaining: remaining)
+        }
+    }
+}

--- a/macos/Sources/Protocol/DecodedFrame.swift
+++ b/macos/Sources/Protocol/DecodedFrame.swift
@@ -1,0 +1,73 @@
+/// Immutable values and deterministic metrics produced by one packet decode.
+
+import Foundation
+
+struct DecodedCommand: Sendable {
+    let command: RenderCommand
+    let opcode: UInt8
+}
+
+struct DecoderOwnedMetrics {
+    private(set) var bytesCopied = 0
+    private(set) var allocations = 0
+
+    /// Records owned values that the decoder publishes beyond the packet lifetime.
+    /// Packet views and scalar enum payloads do not allocate owned byte storage.
+    mutating func record(_ value: Any) {
+        if let string = value as? String {
+            bytesCopied += string.utf8.count
+            allocations += 1
+            return
+        }
+        if let data = value as? Data {
+            bytesCopied += data.count
+            if !data.isEmpty { allocations += 1 }
+            return
+        }
+
+        let mirror = Mirror(reflecting: value)
+        switch mirror.displayStyle {
+        case .collection, .dictionary, .set:
+            if !mirror.children.isEmpty { allocations += 1 }
+        default:
+            break
+        }
+        for child in mirror.children {
+            record(child.value)
+        }
+    }
+
+    mutating func recordFrameCommandStorage(count: Int) {
+        if count > 0 { allocations += 1 }
+    }
+}
+
+struct FrameDecodeMetrics: Sendable, Equatable {
+    let packetBytes: Int
+    /// Owned-byte count, or `-1` when deep Release-harness accounting is disabled.
+    let bytesCopied: Int
+    /// Owned-allocation count, or `-1` when deep Release-harness accounting is disabled.
+    let allocations: Int
+    let decodeDuration: Duration
+    let actorHopCount: Int
+
+    func recordingActorHop() -> FrameDecodeMetrics {
+        FrameDecodeMetrics(
+            packetBytes: packetBytes,
+            bytesCopied: bytesCopied,
+            allocations: allocations,
+            decodeDuration: decodeDuration,
+            actorHopCount: actorHopCount + 1
+        )
+    }
+}
+
+/// A fully validated packet. No command is observable until this value exists.
+struct DecodedFrame: Sendable {
+    let commands: [DecodedCommand]
+    let metrics: FrameDecodeMetrics
+
+    func recordingActorHop() -> DecodedFrame {
+        DecodedFrame(commands: commands, metrics: metrics.recordingActorHop())
+    }
+}

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -112,6 +112,7 @@ indirect enum ProtocolDecodeError: Error, CustomStringConvertible {
     case malformed
     case unknownOpcode(UInt8)
     case insufficientData
+    case outOfBounds(offset: Int, required: Int, remaining: Int)
     case commandFailed(opcode: UInt8, offset: Int, remaining: Int, cause: ProtocolDecodeError)
 
     var description: String {
@@ -122,6 +123,8 @@ indirect enum ProtocolDecodeError: Error, CustomStringConvertible {
             return String(format: "unknown opcode 0x%02X", opcode)
         case .insufficientData:
             return "insufficient data"
+        case .outOfBounds(let offset, let required, let remaining):
+            return "out of bounds at offset \(offset) (required=\(required), remaining=\(remaining))"
         case .commandFailed(let opcode, let offset, let remaining, let cause):
             return String(format: "opcode 0x%02X at offset %d failed with %@ (remaining=%d)", opcode, offset, String(describing: cause), remaining)
         }
@@ -131,67 +134,141 @@ indirect enum ProtocolDecodeError: Error, CustomStringConvertible {
         switch self {
         case .commandFailed:
             return self
-        case .malformed, .unknownOpcode, .insufficientData:
+        case .malformed, .unknownOpcode, .insufficientData, .outOfBounds:
             return .commandFailed(opcode: opcode, offset: offset, remaining: remaining, cause: self)
         }
     }
 }
 
-/// Decodes all commands from a single `{:packet, 4}` payload.
+/// Decodes and validates one complete `{:packet, 4}` payload transactionally.
 ///
-/// A payload may contain multiple concatenated commands (the BEAM batches
-/// an entire frame into one message). This function iterates through the
-/// payload, decoding each command and calling the handler.
-func decodeCommands(from data: Data, handler: (RenderCommand) -> Void) throws {
-    try decodeCommands(from: data) { command, _ in
-        handler(command)
-    }
-}
+/// Command values are accumulated locally and become observable only after the
+/// final byte succeeds. This prevents partial frame application when a later
+/// command is malformed or unknown.
+func decodeFrame(from data: Data, collectOwnedMetrics: Bool = false) throws -> DecodedFrame {
+    let clock = ContinuousClock()
+    let started = clock.now
+    var cursor = ByteCursor(data)
+    var commands: [DecodedCommand] = []
+    var ownedMetrics = DecoderOwnedMetrics()
 
-/// Decodes all commands and reports each command's wire opcode alongside its decoded value.
-///
-/// The opcode is protocol metadata, not payload content. Consumers can therefore identify a
-/// producer that violates frame boundaries without logging editor text or semantic UI data.
-func decodeCommands(from data: Data, handler: (RenderCommand, UInt8) -> Void) throws {
-    var offset = 0
-    while offset < data.count {
-        let opcode = data[offset]
+    while !cursor.isAtEnd {
+        let commandOffset = cursor.offset
+        let opcode: UInt8
+        do {
+            opcode = try cursor.readUInt8()
+        } catch let error as ByteCursor.BoundsError {
+            throw ProtocolDecodeError.outOfBounds(
+                offset: error.offset,
+                required: error.required,
+                remaining: error.remaining
+            )
+        }
+
         let commandAndSize: (RenderCommand?, Int)
         do {
-            commandAndSize = try decodeCommand(data: data, offset: offset)
+            commandAndSize = try decodeCommand(data: data, offset: commandOffset)
         } catch let error as ProtocolDecodeError {
-            throw error.contextualized(opcode: opcode, offset: offset, remaining: data.count - offset)
+            throw error.contextualized(
+                opcode: opcode,
+                offset: commandOffset,
+                remaining: data.count - commandOffset
+            )
         }
+
         let (command, size) = commandAndSize
-        if let command {
-            handler(command, opcode)
+        guard size > 0 else { throw ProtocolDecodeError.malformed }
+        do {
+            try cursor.advance(by: size - 1)
+        } catch let error as ByteCursor.BoundsError {
+            throw ProtocolDecodeError.outOfBounds(
+                offset: error.offset,
+                required: error.required,
+                remaining: error.remaining
+            ).contextualized(
+                opcode: opcode,
+                offset: commandOffset,
+                remaining: data.count - commandOffset
+            )
         }
-        offset += size
+        if let command {
+            if collectOwnedMetrics { ownedMetrics.record(command) }
+            commands.append(DecodedCommand(command: command, opcode: opcode))
+        }
+    }
+
+    if collectOwnedMetrics { ownedMetrics.recordFrameCommandStorage(count: commands.count) }
+    return DecodedFrame(
+        commands: commands,
+        metrics: FrameDecodeMetrics(
+            packetBytes: data.count,
+            bytesCopied: collectOwnedMetrics ? ownedMetrics.bytesCopied : -1,
+            allocations: collectOwnedMetrics ? ownedMetrics.allocations : -1,
+            decodeDuration: started.duration(to: clock.now),
+            actorHopCount: 0
+        )
+    )
+}
+
+/// Compatibility adapter for tests and harness clients. Delivery is atomic:
+/// handlers run only after the entire packet has decoded successfully.
+func decodeCommands(from data: Data, handler: (RenderCommand) -> Void) throws {
+    let frame = try decodeFrame(from: data)
+    for decoded in frame.commands {
+        handler(decoded.command)
     }
 }
 
-/// Decodes a single command at the given offset.
-/// Returns the decoded command (nil for ignored opcodes) and the number of bytes consumed.
+/// Compatibility adapter that also reports command wire opcodes.
+func decodeCommands(from data: Data, handler: (RenderCommand, UInt8) -> Void) throws {
+    let frame = try decodeFrame(from: data)
+    for decoded in frame.commands {
+        handler(decoded.command, decoded.opcode)
+    }
+}
+
+/// Decodes a single known command at the given offset.
+/// Returns the decoded command (nil for known non-rendering opcodes) and bytes consumed.
+/// Unknown commands always fail closed, including size-framed high opcodes.
 func decodeCommand(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
-    guard offset < data.count else {
+    guard offset >= data.startIndex, offset < data.endIndex else {
         throw ProtocolDecodeError.insufficientData
     }
 
-    let payload = Array(data[offset...])
-    switch commandSize(payload) {
+    var packetCursor = try ByteCursor(data, range: offset..<data.endIndex)
+    let opcode = try packetCursor.readUInt8()
+
+    // Data slicing is a bounded view. Unlike Array(data[offset...]), this does
+    // not materialize the unconsumed packet tail.
+    switch commandSize(data[offset...]) {
     case .sized(let size):
         do {
-            let (command, _) = try decodeCommandForRendering(data: data, offset: offset)
+            let (command, decodedSize) = try decodeCommandForRenderingChecked(data: data, offset: offset)
+            guard decodedSize == size else { throw ProtocolDecodeError.malformed }
             return (command, size)
-        } catch ProtocolDecodeError.unknownOpcode(_) {
+        } catch ProtocolDecodeError.unknownOpcode {
+            // The generated schema knows this opcode and its exact framing, but
+            // this renderer intentionally has no semantic command for it.
             return (nil, size)
         }
     case .custom:
-        return try decodeCommandForRendering(data: data, offset: offset)
+        return try decodeCommandForRenderingChecked(data: data, offset: offset)
     case .incomplete:
         throw ProtocolDecodeError.insufficientData
     case .unknown:
-        throw ProtocolDecodeError.unknownOpcode(data[offset])
+        throw ProtocolDecodeError.unknownOpcode(opcode)
+    }
+}
+
+private func decodeCommandForRenderingChecked(data: Data, offset: Int) throws -> (RenderCommand?, Int) {
+    do {
+        return try decodeCommandForRendering(data: data, offset: offset)
+    } catch let error as ByteCursor.BoundsError {
+        throw ProtocolDecodeError.outOfBounds(
+            offset: error.offset,
+            required: error.required,
+            remaining: error.remaining
+        )
     }
 }
 
@@ -206,27 +283,27 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
     switch opcode {
     case 0x20: // set_language: buffer_id:4, name_len:2, name
         guard data.count >= rest + 6 else { throw ProtocolDecodeError.malformed }
-        let nameLen = Int(readU16(data, rest + 4))
+        let nameLen = Int(try readU16(data, rest + 4))
         guard data.count >= rest + 6 + nameLen else { throw ProtocolDecodeError.malformed }
         return (nil, 1 + 6 + nameLen)
 
     case 0x21: // parse_buffer: buffer_id:4, version:4, source_len:4, source
         guard data.count >= rest + 12 else { throw ProtocolDecodeError.malformed }
-        let sourceLen = Int(readU32(data, rest + 8))
+        let sourceLen = Int(try readU32(data, rest + 8))
         guard data.count >= rest + 12 + sourceLen else { throw ProtocolDecodeError.malformed }
         return (nil, 1 + 12 + sourceLen)
 
     case 0x22, 0x24, 0x28, 0x29, 0x2B, 0x40: // query commands: buffer_id:4, query_len:4, query
         guard data.count >= rest + 8 else { throw ProtocolDecodeError.malformed }
-        let queryLen = Int(readU32(data, rest + 4))
+        let queryLen = Int(try readU32(data, rest + 4))
         guard data.count >= rest + 8 + queryLen else { throw ProtocolDecodeError.malformed }
         return (nil, 1 + 8 + queryLen)
 
     case 0x23: // load_grammar: name_len:2, name, path_len:2, path
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let nameLen = Int(readU16(data, rest))
+        let nameLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
-        let pathLen = Int(readU16(data, rest + 2 + nameLen))
+        let pathLen = Int(try readU16(data, rest + 2 + nameLen))
         guard data.count >= rest + 2 + nameLen + 2 + pathLen else { throw ProtocolDecodeError.malformed }
         return (nil, 1 + 2 + nameLen + 2 + pathLen)
 
@@ -236,11 +313,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case 0x26: // edit_buffer: buffer_id:4, version:4, edit_count:2, edits
         guard data.count >= rest + 10 else { throw ProtocolDecodeError.malformed }
-        let editCount = Int(readU16(data, rest + 8))
+        let editCount = Int(try readU16(data, rest + 8))
         var pos = rest + 10
         for _ in 0..<editCount {
             guard data.count >= pos + 40 else { throw ProtocolDecodeError.malformed }
-            let textLen = Int(readU32(data, pos + 36))
+            let textLen = Int(try readU32(data, pos + 36))
             guard data.count >= pos + 40 + textLen else { throw ProtocolDecodeError.malformed }
             pos += 40 + textLen
         }
@@ -248,7 +325,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case 0x27: // measure_text: request_id:4, text_len:2, text
         guard data.count >= rest + 6 else { throw ProtocolDecodeError.malformed }
-        let textLen = Int(readU16(data, rest + 4))
+        let textLen = Int(try readU16(data, rest + 4))
         guard data.count >= rest + 6 + textLen else { throw ProtocolDecodeError.malformed }
         return (nil, 1 + 6 + textLen)
 
@@ -258,7 +335,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case 0x2C: // request_textobject: buffer_id:4, request_id:4, row:4, col:4, name_len:2, name
         guard data.count >= rest + 18 else { throw ProtocolDecodeError.malformed }
-        let nameLen = Int(readU16(data, rest + 16))
+        let nameLen = Int(try readU16(data, rest + 16))
         guard data.count >= rest + 18 + nameLen else { throw ProtocolDecodeError.malformed }
         return (nil, 1 + 18 + nameLen)
 
@@ -277,16 +354,16 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
     case OP_BEGIN_FRAME:
         // begin_frame (#2219): <opcode, frame_seq:u32, base_frame_seq:u32>.
         guard data.count >= rest + 8 else { throw ProtocolDecodeError.malformed }
-        let frameSeq = readU32(data, rest)
-        let baseFrameSeq = readU32(data, rest + 4)
+        let frameSeq = try readU32(data, rest)
+        let baseFrameSeq = try readU32(data, rest + 4)
         return (.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq), 9)
 
     case OP_COMMIT_FRAME:
         // commit_frame (#2219): <opcode, frame_seq:u32, input_seq:u32>. input_seq is
         // the echoed input correlation sequence (ticket #2215, formerly batch_end).
         guard data.count >= rest + 8 else { throw ProtocolDecodeError.malformed }
-        let frameSeq = readU32(data, rest)
-        let seq = readU32(data, rest + 4)
+        let frameSeq = try readU32(data, rest)
+        let seq = try readU32(data, rest + 4)
         return (.commitFrame(frameSeq: frameSeq, seq: seq), 9)
 
     case OP_SET_CURSOR_SHAPE:
@@ -296,10 +373,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_SET_TITLE:
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let titleLen = Int(readU16(data, rest))
+        let titleLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + titleLen else { throw ProtocolDecodeError.malformed }
         let titleData = data[(rest + 2)..<(rest + 2 + titleLen)]
-        let title = String(data: titleData, encoding: .utf8) ?? ""
+        let title = try decodeUTF8(titleData) ?? ""
         return (.setTitle(title), 1 + 2 + titleLen)
 
     case OP_SET_WINDOW_BG:
@@ -314,13 +391,13 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
     case OP_SET_FONT:
         // size:2, weight:1, ligatures:1, name_len:2 = 6 bytes after opcode
         guard data.count >= rest + 6 else { throw ProtocolDecodeError.malformed }
-        let fontSize = readU16(data, rest)
+        let fontSize = try readU16(data, rest)
         let weight = data[rest + 2]
         let ligatures = data[rest + 3] != 0
-        let nameLen = Int(readU16(data, rest + 4))
+        let nameLen = Int(try readU16(data, rest + 4))
         guard data.count >= rest + 6 + nameLen else { throw ProtocolDecodeError.malformed }
         let nameData = data[(rest + 6)..<(rest + 6 + nameLen)]
-        let family = String(data: nameData, encoding: .utf8) ?? "Menlo"
+        let family = try decodeUTF8(nameData) ?? "Menlo"
         return (.setFont(family: family, size: fontSize, ligatures: ligatures, weight: weight), 1 + 6 + nameLen)
 
     case OP_SET_FONT_FALLBACK:
@@ -331,11 +408,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         var offset = rest + 1
         for _ in 0..<count {
             guard data.count >= offset + 2 else { throw ProtocolDecodeError.malformed }
-            let nameLen = Int(readU16(data, offset))
+            let nameLen = Int(try readU16(data, offset))
             offset += 2
             guard data.count >= offset + nameLen else { throw ProtocolDecodeError.malformed }
             let nameData = data[offset..<(offset + nameLen)]
-            let name = String(data: nameData, encoding: .utf8) ?? ""
+            let name = try decodeUTF8(nameData) ?? ""
             families.append(name)
             offset += nameLen
         }
@@ -345,15 +422,15 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // font_id:1, name_len:2, name:bytes
         guard data.count >= rest + 3 else { throw ProtocolDecodeError.malformed }
         let fontId = data[rest]
-        let nameLen = Int(readU16(data, rest + 1))
+        let nameLen = Int(try readU16(data, rest + 1))
         guard data.count >= rest + 3 + nameLen else { throw ProtocolDecodeError.malformed }
         let nameData = data[(rest + 3)..<(rest + 3 + nameLen)]
-        let family = String(data: nameData, encoding: .utf8) ?? "Menlo"
+        let family = try decodeUTF8(nameData) ?? "Menlo"
         return (.registerFont(id: fontId, family: family), 1 + 3 + nameLen)
 
     case OP_GUI_CONFIG_STATE:
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU16(data, rest))
+        let payloadLen = Int(try readU16(data, rest))
         let payloadStart = rest + 2
         guard data.count >= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
         let state = try decodeConfigState(data: data, start: payloadStart, end: payloadStart + payloadLen)
@@ -361,7 +438,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_GUI_NOTIFICATIONS:
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU16(data, rest))
+        let payloadLen = Int(try readU16(data, rest))
         let payloadStart = rest + 2
         guard data.count >= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
         let notifications = try decodeNotifications(data: data, start: payloadStart, end: payloadStart + payloadLen)
@@ -374,7 +451,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // kind(1), id:string8, label:string16, detail:string16, jump_key:string8,
         // chord:string8, icon:string8, icon_color(u32 0xRRGGBB).
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU16(data, rest))
+        let payloadLen = Int(try readU16(data, rest))
         let payloadStart = rest + 2
         let payloadEnd = payloadStart + payloadLen
         guard data.count >= payloadEnd, payloadLen >= 1 else { throw ProtocolDecodeError.malformed }
@@ -416,7 +493,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 let chord = try readString8(data: data, pos: &pos, end: payloadEnd)
                 let icon = try readString8(data: data, pos: &pos, end: payloadEnd)
                 guard pos + 4 <= payloadEnd else { throw ProtocolDecodeError.malformed }
-                let iconColor = readU32(data, pos)
+                let iconColor = try readU32(data, pos)
                 pos += 4
                 items.append(Wire.EmptyStateItem(kind: kind, id: itemId, label: label, detail: detail, jumpKey: jumpKey, chord: chord, icon: icon, iconColorRGB: iconColor))
             }
@@ -430,7 +507,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // v1: opcode(1) + payload_len(4) + version(1) + tree_flags(1) + selected_id + root + tree_width(2) + row_count(2) + rows...
         // v2: adds tree_state(1) after tree_flags and error_reason after row_count.
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU32(data, rest))
+        let payloadLen = Int(try readU32(data, rest))
         let payloadStart = rest + 4
         guard data.count >= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
         guard payloadLen >= 6 else { throw ProtocolDecodeError.malformed }
@@ -448,27 +525,27 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         }
 
         guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-        let selectedIdLen = Int(readU16(data, pos)); pos += 2
+        let selectedIdLen = Int(try readU16(data, pos)); pos += 2
         guard pos + selectedIdLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-        let selectedId = String(data: data[pos..<(pos + selectedIdLen)], encoding: .utf8) ?? ""
+        let selectedId = try decodeUTF8(data[pos..<(pos + selectedIdLen)]) ?? ""
         pos += selectedIdLen
 
         guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-        let rootLen = Int(readU16(data, pos)); pos += 2
+        let rootLen = Int(try readU16(data, pos)); pos += 2
         guard pos + rootLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-        let rootPath = String(data: data[pos..<(pos + rootLen)], encoding: .utf8) ?? ""
+        let rootPath = try decodeUTF8(data[pos..<(pos + rootLen)]) ?? ""
         pos += rootLen
 
         guard pos + 4 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-        let treeWidth = readU16(data, pos); pos += 2
-        let rowCount = Int(readU16(data, pos)); pos += 2
+        let treeWidth = try readU16(data, pos); pos += 2
+        let rowCount = Int(try readU16(data, pos)); pos += 2
 
         let errorReason: String
         if version >= 2 {
             guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let errorReasonLen = Int(readU16(data, pos)); pos += 2
+            let errorReasonLen = Int(try readU16(data, pos)); pos += 2
             guard pos + errorReasonLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            errorReason = String(data: data[pos..<(pos + errorReasonLen)], encoding: .utf8) ?? ""
+            errorReason = try decodeUTF8(data[pos..<(pos + errorReasonLen)]) ?? ""
             pos += errorReasonLen
         } else {
             errorReason = ""
@@ -479,54 +556,54 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
         for _ in 0..<rowCount {
             guard pos + 17 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let pathHash = readU32(data, pos); pos += 4
-            let flags = readU16(data, pos); pos += 2
+            let pathHash = try readU32(data, pos); pos += 4
+            let flags = try readU16(data, pos); pos += 2
             let depth = data[pos]; pos += 1
             let gitStatus = data[pos]; pos += 1
-            let diagnosticErrorCount = readU16(data, pos); pos += 2
-            let diagnosticWarningCount = readU16(data, pos); pos += 2
-            let diagnosticInfoCount = readU16(data, pos); pos += 2
-            let diagnosticHintCount = readU16(data, pos); pos += 2
+            let diagnosticErrorCount = try readU16(data, pos); pos += 2
+            let diagnosticWarningCount = try readU16(data, pos); pos += 2
+            let diagnosticInfoCount = try readU16(data, pos); pos += 2
+            let diagnosticHintCount = try readU16(data, pos); pos += 2
             let guideCount = Int(data[pos]); pos += 1
             guard pos + guideCount <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
             let guides = (0..<guideCount).map { index in data[pos + index] != 0 }
             pos += guideCount
 
             guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let idLen = Int(readU16(data, pos)); pos += 2
+            let idLen = Int(try readU16(data, pos)); pos += 2
             guard pos + idLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let id = String(data: data[pos..<(pos + idLen)], encoding: .utf8) ?? ""
+            let id = try decodeUTF8(data[pos..<(pos + idLen)]) ?? ""
             pos += idLen
 
             guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let pathLen = Int(readU16(data, pos)); pos += 2
+            let pathLen = Int(try readU16(data, pos)); pos += 2
             guard pos + pathLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let path = String(data: data[pos..<(pos + pathLen)], encoding: .utf8) ?? ""
+            let path = try decodeUTF8(data[pos..<(pos + pathLen)]) ?? ""
             pos += pathLen
 
             guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let relPathLen = Int(readU16(data, pos)); pos += 2
+            let relPathLen = Int(try readU16(data, pos)); pos += 2
             guard pos + relPathLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let relPath = String(data: data[pos..<(pos + relPathLen)], encoding: .utf8) ?? ""
+            let relPath = try decodeUTF8(data[pos..<(pos + relPathLen)]) ?? ""
             pos += relPathLen
 
             guard pos + 2 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let nameLen = Int(readU16(data, pos)); pos += 2
+            let nameLen = Int(try readU16(data, pos)); pos += 2
             guard pos + nameLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let name = String(data: data[pos..<(pos + nameLen)], encoding: .utf8) ?? ""
+            let name = try decodeUTF8(data[pos..<(pos + nameLen)]) ?? ""
             pos += nameLen
 
             guard pos + 1 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
             let iconLen = Int(data[pos]); pos += 1
             guard pos + iconLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let icon = String(data: data[pos..<(pos + iconLen)], encoding: .utf8) ?? ""
+            let icon = try decodeUTF8(data[pos..<(pos + iconLen)]) ?? ""
             pos += iconLen
 
             guard pos + 3 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
             let editingType = data[pos]; pos += 1
-            let editingTextLen = Int(readU16(data, pos)); pos += 2
+            let editingTextLen = Int(try readU16(data, pos)); pos += 2
             guard pos + editingTextLen <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-            let editingText = String(data: data[pos..<(pos + editingTextLen)], encoding: .utf8) ?? ""
+            let editingText = try decodeUTF8(data[pos..<(pos + editingTextLen)]) ?? ""
             pos += editingTextLen
 
             guard pos + 3 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
@@ -573,7 +650,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_GUI_OBSERVATORY:
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU32(data, rest))
+        let payloadLen = Int(try readU32(data, rest))
         let payloadStart = rest + 4
         guard data.count >= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
         let payloadEnd = payloadStart + payloadLen
@@ -584,18 +661,17 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         var sparklinesByPid: [String: [Float]] = [:]
 
         while pos < payloadEnd {
-            guard pos + 3 <= payloadEnd else { throw ProtocolDecodeError.malformed }
-            let sectionId = data[pos]
-            let sectionLen = Int(readU16(data, pos + 1))
-            let sectionStart = pos + 3
-            let sectionEnd = sectionStart + sectionLen
-            guard sectionEnd <= payloadEnd else { throw ProtocolDecodeError.malformed }
+            let section = try readSection16(data, at: pos, containingEnd: payloadEnd)
+            let sectionId = section.id
+            let sectionLen = section.end - section.start
+            let sectionStart = section.start
+            let sectionEnd = section.end
 
             switch sectionId {
             case 0x01:
                 guard sectionLen >= 3 else { break }
                 visible = data[sectionStart] != 0
-                nodeCount = readU16(data, sectionStart + 1)
+                nodeCount = try readU16(data, sectionStart + 1)
 
             case 0x02:
                 var nodePos = sectionStart
@@ -603,21 +679,21 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     guard nodePos + 1 <= sectionEnd else { throw ProtocolDecodeError.malformed }
                     let pidLen = Int(data[nodePos]); nodePos += 1
                     guard nodePos + pidLen + 1 <= sectionEnd else { throw ProtocolDecodeError.malformed }
-                    let pid = String(data: data[nodePos..<(nodePos + pidLen)], encoding: .utf8) ?? ""
+                    let pid = try decodeUTF8(data[nodePos..<(nodePos + pidLen)]) ?? ""
                     nodePos += pidLen
                     let parentLen = Int(data[nodePos]); nodePos += 1
                     guard nodePos + parentLen + 2 <= sectionEnd else { throw ProtocolDecodeError.malformed }
-                    let parentPid = String(data: data[nodePos..<(nodePos + parentLen)], encoding: .utf8) ?? ""
+                    let parentPid = try decodeUTF8(data[nodePos..<(nodePos + parentLen)]) ?? ""
                     nodePos += parentLen
-                    let nameLen = Int(readU16(data, nodePos)); nodePos += 2
+                    let nameLen = Int(try readU16(data, nodePos)); nodePos += 2
                     guard nodePos + nameLen + 12 <= sectionEnd else { throw ProtocolDecodeError.malformed }
-                    let name = String(data: data[nodePos..<(nodePos + nameLen)], encoding: .utf8) ?? ""
+                    let name = try decodeUTF8(data[nodePos..<(nodePos + nameLen)]) ?? ""
                     nodePos += nameLen
                     let processClass = data[nodePos]; nodePos += 1
                     let depth = data[nodePos]; nodePos += 1
-                    let memory = readU32(data, nodePos); nodePos += 4
-                    let messageQueueLen = readU16(data, nodePos); nodePos += 2
-                    let reductions = readU32(data, nodePos); nodePos += 4
+                    let memory = try readU32(data, nodePos); nodePos += 4
+                    let messageQueueLen = try readU16(data, nodePos); nodePos += 2
+                    let reductions = try readU32(data, nodePos); nodePos += 4
                     nodeEntries.append(Wire.ObservatoryNode(pid: pid, parentPid: parentPid, name: name, processClass: processClass, depth: depth, memory: memory, messageQueueLen: messageQueueLen, reductions: reductions, sparkline: []))
                 }
 
@@ -627,14 +703,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     guard sparkPos + 2 <= sectionEnd else { throw ProtocolDecodeError.malformed }
                     let pidLen = Int(data[sparkPos]); sparkPos += 1
                     guard sparkPos + pidLen + 1 <= sectionEnd else { throw ProtocolDecodeError.malformed }
-                    let pid = String(data: data[sparkPos..<(sparkPos + pidLen)], encoding: .utf8) ?? ""
+                    let pid = try decodeUTF8(data[sparkPos..<(sparkPos + pidLen)]) ?? ""
                     sparkPos += pidLen
                     let sampleCount = Int(data[sparkPos]); sparkPos += 1
                     guard sparkPos + sampleCount * 2 <= sectionEnd else { throw ProtocolDecodeError.malformed }
                     var samples: [Float] = []
                     samples.reserveCapacity(sampleCount)
                     for _ in 0..<sampleCount {
-                        let raw = readU16(data, sparkPos)
+                        let raw = try readU16(data, sparkPos)
                         samples.append(Float(raw) / 65535.0)
                         sparkPos += 2
                     }
@@ -657,15 +733,15 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_GUI_FILE_TREE_SELECTION:
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU16(data, rest))
+        let payloadLen = Int(try readU16(data, rest))
         let payloadStart = rest + 2
         guard data.count >= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
         guard payloadLen >= 3 else { throw ProtocolDecodeError.malformed }
         let flags = data[payloadStart]
         var pos = payloadStart + 1
-        let selectedIdLen = Int(readU16(data, pos)); pos += 2
+        let selectedIdLen = Int(try readU16(data, pos)); pos += 2
         guard pos + selectedIdLen == payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
-        let selectedId = String(data: data[pos..<(pos + selectedIdLen)], encoding: .utf8) ?? ""
+        let selectedId = try decodeUTF8(data[pos..<(pos + selectedIdLen)]) ?? ""
         return (.guiFileTreeSelection(selectedId: selectedId, focused: flags & 0x01 != 0), 3 + payloadLen)
 
     case OP_GUI_TAB_BAR:
@@ -679,17 +755,17 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         for _ in 0..<tabCount {
             guard data.count >= pos + 8 else { throw ProtocolDecodeError.malformed }
             let flags = data[pos]
-            let tabId = readU32(data, pos + 1)
-            let groupId = readU16(data, pos + 5)
+            let tabId = try readU32(data, pos + 1)
+            let groupId = try readU16(data, pos + 5)
             let iconLen = Int(data[pos + 7])
             guard data.count >= pos + 8 + iconLen + 2 else { throw ProtocolDecodeError.malformed }
             let iconData = data[(pos + 8)..<(pos + 8 + iconLen)]
-            let icon = String(data: iconData, encoding: .utf8) ?? ""
-            let labelLen = Int(readU16(data, pos + 8 + iconLen))
+            let icon = try decodeUTF8(iconData) ?? ""
+            let labelLen = Int(try readU16(data, pos + 8 + iconLen))
             guard data.count >= pos + 8 + iconLen + 2 + labelLen + 4 else { throw ProtocolDecodeError.malformed }
             let labelData = data[(pos + 10 + iconLen)..<(pos + 10 + iconLen + labelLen)]
-            let label = String(data: labelData, encoding: .utf8) ?? ""
-            let tintColorRGB = readU32(data, pos + 10 + iconLen + labelLen)
+            let label = try decodeUTF8(labelData) ?? ""
+            let tintColorRGB = try readU32(data, pos + 10 + iconLen + labelLen)
             // Bits 4-6 are kind-scoped: agent status for agent tabs,
             // ephemeral (not-on-disk) marker in bit 4 for file tabs.
             let isAgent = flags & 0x04 != 0
@@ -753,12 +829,12 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             return (.guiWhichKey(visible: false, prefix: "", page: 0, pageCount: 0, bindings: []), 2)
         }
         guard data.count >= rest + 3 else { throw ProtocolDecodeError.malformed }
-        let prefixLen = Int(readU16(data, rest + 1))
+        let prefixLen = Int(try readU16(data, rest + 1))
         guard data.count >= rest + 3 + prefixLen + 4 else { throw ProtocolDecodeError.malformed }
-        let prefix = String(data: data[(rest + 3)..<(rest + 3 + prefixLen)], encoding: .utf8) ?? ""
+        let prefix = try decodeUTF8(data[(rest + 3)..<(rest + 3 + prefixLen)]) ?? ""
         let page = data[rest + 3 + prefixLen]
         let pageCount = data[rest + 4 + prefixLen]
-        let bindingCount = Int(readU16(data, rest + 5 + prefixLen))
+        let bindingCount = Int(try readU16(data, rest + 5 + prefixLen))
         var bindings: [Wire.WhichKeyBinding] = []
         bindings.reserveCapacity(bindingCount)
         var pos = rest + 7 + prefixLen
@@ -767,13 +843,13 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let bKind = data[pos]
             let keyLen = Int(data[pos + 1])
             guard data.count >= pos + 2 + keyLen + 2 else { throw ProtocolDecodeError.malformed }
-            let key = String(data: data[(pos + 2)..<(pos + 2 + keyLen)], encoding: .utf8) ?? ""
-            let descLen = Int(readU16(data, pos + 2 + keyLen))
+            let key = try decodeUTF8(data[(pos + 2)..<(pos + 2 + keyLen)]) ?? ""
+            let descLen = Int(try readU16(data, pos + 2 + keyLen))
             guard data.count >= pos + 4 + keyLen + descLen + 1 else { throw ProtocolDecodeError.malformed }
-            let desc = String(data: data[(pos + 4 + keyLen)..<(pos + 4 + keyLen + descLen)], encoding: .utf8) ?? ""
+            let desc = try decodeUTF8(data[(pos + 4 + keyLen)..<(pos + 4 + keyLen + descLen)]) ?? ""
             let iconLen = Int(data[pos + 4 + keyLen + descLen])
             guard data.count >= pos + 5 + keyLen + descLen + iconLen else { throw ProtocolDecodeError.malformed }
-            let icon = String(data: data[(pos + 5 + keyLen + descLen)..<(pos + 5 + keyLen + descLen + iconLen)], encoding: .utf8) ?? ""
+            let icon = try decodeUTF8(data[(pos + 5 + keyLen + descLen)..<(pos + 5 + keyLen + descLen + iconLen)]) ?? ""
             bindings.append(Wire.WhichKeyBinding(kind: bKind, key: key, description: desc, icon: icon))
             pos += 5 + keyLen + descLen + iconLen
         }
@@ -840,11 +916,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         var pendingKeys = ""
 
         for _ in 0..<sectionCount {
-            guard data.count >= pos + 3 else { throw ProtocolDecodeError.malformed }
-            let sectionId = data[pos]
-            let sectionLen = Int(readU16(data, pos + 1))
-            let sStart = pos + 3
-            guard data.count >= sStart + sectionLen else { throw ProtocolDecodeError.malformed }
+            let section = try readSection16(data, at: pos, containingEnd: data.endIndex)
+            let sectionId = section.id
+            let sectionLen = section.end - section.start
+            let sStart = section.start
 
             switch sectionId {
             case 0x01: // Identity: content_kind(1) + mode(1) + flags(1)
@@ -855,20 +930,21 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
             case 0x02: // Cursor: cursor_line(4) + cursor_col(4) + line_count(4)
                 guard sectionLen >= 12 else { break }
-                cursorLine = readU32(data, sStart)
-                cursorCol = readU32(data, sStart + 4)
-                lineCount = readU32(data, sStart + 8)
+                cursorLine = try readU32(data, sStart)
+                cursorCol = try readU32(data, sStart + 4)
+                lineCount = try readU32(data, sStart + 8)
 
             case 0x03: // Diagnostics: error(2) + warning(2) + info(2) + hint(2) + diag_hint_len(2) + diag_hint
                 guard sectionLen >= 8 else { break }
-                errorCount = readU16(data, sStart)
-                warningCount = readU16(data, sStart + 2)
-                infoCount = readU16(data, sStart + 4)
-                hintCount = readU16(data, sStart + 6)
+                errorCount = try readU16(data, sStart)
+                warningCount = try readU16(data, sStart + 2)
+                infoCount = try readU16(data, sStart + 4)
+                hintCount = try readU16(data, sStart + 6)
                 if sectionLen >= 10 {
-                    let dhLen = Int(readU16(data, sStart + 8))
-                    if sectionLen >= 10 + dhLen, dhLen > 0 {
-                        diagnosticHint = String(data: data[(sStart + 10)..<(sStart + 10 + dhLen)], encoding: .utf8) ?? ""
+                    let dhLen = Int(try readU16(data, sStart + 8))
+                    guard sectionLen >= 10 + dhLen else { throw ProtocolDecodeError.malformed }
+                    if dhLen > 0 {
+                        diagnosticHint = try decodeUTF8(data[(sStart + 10)..<(sStart + 10 + dhLen)]) ?? ""
                     }
                 }
 
@@ -881,31 +957,31 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 guard sectionLen >= 1 else { break }
                 let brLen = Int(data[sStart])
                 guard sectionLen >= 1 + brLen + 6 else { break }
-                gitBranch = String(data: data[(sStart + 1)..<(sStart + 1 + brLen)], encoding: .utf8) ?? ""
-                gitAdded = readU16(data, sStart + 1 + brLen)
-                gitModified = readU16(data, sStart + 3 + brLen)
-                gitDeleted = readU16(data, sStart + 5 + brLen)
+                gitBranch = try decodeUTF8(data[(sStart + 1)..<(sStart + 1 + brLen)]) ?? ""
+                gitAdded = try readU16(data, sStart + 1 + brLen)
+                gitModified = try readU16(data, sStart + 3 + brLen)
+                gitDeleted = try readU16(data, sStart + 5 + brLen)
 
             case 0x06: // File: icon_len(1) + icon + r(1) + g(1) + b(1) + filename_len(2) + filename + filetype_len(1) + filetype
                 guard sectionLen >= 1 else { break }
                 let iLen = Int(data[sStart])
                 guard sectionLen >= 1 + iLen + 3 + 2 else { break }
-                icon = String(data: data[(sStart + 1)..<(sStart + 1 + iLen)], encoding: .utf8) ?? ""
+                icon = try decodeUTF8(data[(sStart + 1)..<(sStart + 1 + iLen)]) ?? ""
                 iconColorR = data[sStart + 1 + iLen]
                 iconColorG = data[sStart + 2 + iLen]
                 iconColorB = data[sStart + 3 + iLen]
-                let fnLen = Int(readU16(data, sStart + 4 + iLen))
+                let fnLen = Int(try readU16(data, sStart + 4 + iLen))
                 guard sectionLen >= 6 + iLen + fnLen + 1 else { break }
-                filename = String(data: data[(sStart + 6 + iLen)..<(sStart + 6 + iLen + fnLen)], encoding: .utf8) ?? ""
+                filename = try decodeUTF8(data[(sStart + 6 + iLen)..<(sStart + 6 + iLen + fnLen)]) ?? ""
                 let ftLen = Int(data[sStart + 6 + iLen + fnLen])
                 guard sectionLen >= 7 + iLen + fnLen + ftLen else { break }
-                filetype = String(data: data[(sStart + 7 + iLen + fnLen)..<(sStart + 7 + iLen + fnLen + ftLen)], encoding: .utf8) ?? ""
+                filetype = try decodeUTF8(data[(sStart + 7 + iLen + fnLen)..<(sStart + 7 + iLen + fnLen + ftLen)]) ?? ""
 
             case 0x07: // Message: msg_len(2) + msg
                 guard sectionLen >= 2 else { break }
-                let mLen = Int(readU16(data, sStart))
+                let mLen = Int(try readU16(data, sStart))
                 if sectionLen >= 2 + mLen, mLen > 0 {
-                    message = String(data: data[(sStart + 2)..<(sStart + 2 + mLen)], encoding: .utf8) ?? ""
+                    message = try decodeUTF8(data[(sStart + 2)..<(sStart + 2 + mLen)]) ?? ""
                 }
 
             case 0x08: // Recording: macro_recording(1)
@@ -924,8 +1000,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 let version = data[sStart]
                 guard version == 1 || version == 2 else { break }
                 modelineSegmentsPresent = true
-                let leftCount = Int(readU16(data, sStart + 1))
-                let rightCount = Int(readU16(data, sStart + 3))
+                let leftCount = Int(try readU16(data, sStart + 1))
+                let rightCount = Int(try readU16(data, sStart + 3))
                 var segmentPos = sStart + 5
                 let sectionEnd = sStart + sectionLen
                 modelineLeftSegments = try decodeStatusBarSegments(data: data, pos: &segmentPos, count: leftCount, end: sectionEnd, version: version)
@@ -934,25 +1010,25 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
             case 0x0C: // Selection: selection_mode(1) + selection_size(4)
                 guard sectionLen >= 5 else { break }
-                selection = StatusBarUpdate.SelectionInfo(mode: data[sStart], size: readU32(data, sStart + 1))
+                selection = StatusBarUpdate.SelectionInfo(mode: data[sStart], size: try readU32(data, sStart + 1))
 
             case 0x0D: // Workspace: active workspace summary
                 guard sectionLen >= 15 else { break }
-                let workspaceId = readU16(data, sStart)
+                let workspaceId = try readU16(data, sStart)
                 let workspaceKind = data[sStart + 2]
                 let workspaceStatus = data[sStart + 3]
-                let workspaceFlags = readU16(data, sStart + 4)
-                let draftCount = readU16(data, sStart + 6)
-                let conflictCount = readU16(data, sStart + 8)
-                let backgroundCount = readU16(data, sStart + 10)
-                let attentionCount = readU16(data, sStart + 12)
+                let workspaceFlags = try readU16(data, sStart + 4)
+                let draftCount = try readU16(data, sStart + 6)
+                let conflictCount = try readU16(data, sStart + 8)
+                let backgroundCount = try readU16(data, sStart + 10)
+                let attentionCount = try readU16(data, sStart + 12)
                 let labelLen = Int(data[sStart + 14])
                 guard sectionLen >= 15 + labelLen + 1 else { break }
-                let label = String(data: data[(sStart + 15)..<(sStart + 15 + labelLen)], encoding: .utf8) ?? ""
+                let label = try decodeUTF8(data[(sStart + 15)..<(sStart + 15 + labelLen)]) ?? ""
                 let iconLenPos = sStart + 15 + labelLen
                 let iconLen = Int(data[iconLenPos])
                 guard sectionLen >= 16 + labelLen + iconLen else { break }
-                let icon = String(data: data[(iconLenPos + 1)..<(iconLenPos + 1 + iconLen)], encoding: .utf8) ?? ""
+                let icon = try decodeUTF8(data[(iconLenPos + 1)..<(iconLenPos + 1 + iconLen)]) ?? ""
                 workspace = StatusBarUpdate.WorkspaceInfo(
                     id: workspaceId,
                     kind: workspaceKind,
@@ -968,9 +1044,9 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
             case 0x0E: // PendingKeys (showcmd): keys_len(2) + keys
                 guard sectionLen >= 2 else { break }
-                let pkLen = Int(readU16(data, sStart))
+                let pkLen = Int(try readU16(data, sStart))
                 if sectionLen >= 2 + pkLen, pkLen > 0 {
-                    pendingKeys = String(data: data[(sStart + 2)..<(sStart + 2 + pkLen)], encoding: .utf8) ?? ""
+                    pendingKeys = try decodeUTF8(data[(sStart + 2)..<(sStart + 2 + pkLen)]) ?? ""
                 }
 
             default:
@@ -991,18 +1067,18 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 var pos = sStart
                 agentStatus = data[pos]
                 pos += 1
-                backgroundSubagentCount = readU16(data, pos)
+                backgroundSubagentCount = try readU16(data, pos)
                 pos += 2
-                let labelLen = Int(readU16(data, pos))
+                let labelLen = Int(try readU16(data, pos))
                 pos += 2
                 guard sectionLen >= (pos - sStart) + labelLen else { throw ProtocolDecodeError.malformed }
-                backgroundSubagentLabel = String(data: data[pos..<(pos + labelLen)], encoding: .utf8) ?? ""
+                backgroundSubagentLabel = try decodeUTF8(data[pos..<(pos + labelLen)]) ?? ""
                 pos += labelLen
                 if pos < sectionEnd {
                     let toolLen = Int(data[pos])
                     pos += 1
                     guard sectionLen >= (pos - sStart) + toolLen else { throw ProtocolDecodeError.malformed }
-                    activeToolName = String(data: data[pos..<(pos + toolLen)], encoding: .utf8) ?? ""
+                    activeToolName = try decodeUTF8(data[pos..<(pos + toolLen)]) ?? ""
                 }
             } else {
                 guard sectionLen >= 1 else { throw ProtocolDecodeError.malformed }
@@ -1010,26 +1086,26 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 let mnLen = Int(data[pos])
                 guard sectionLen >= 11 + mnLen else { throw ProtocolDecodeError.malformed }
                 pos += 1
-                modelName = String(data: data[pos..<(pos + mnLen)], encoding: .utf8) ?? ""
+                modelName = try decodeUTF8(data[pos..<(pos + mnLen)]) ?? ""
                 pos += mnLen
-                messageCount = readU32(data, pos)
+                messageCount = try readU32(data, pos)
                 pos += 4
                 sessionStatus = data[pos]
                 pos += 1
                 agentStatus = data[pos]
                 pos += 1
-                backgroundSubagentCount = readU16(data, pos)
+                backgroundSubagentCount = try readU16(data, pos)
                 pos += 2
-                let labelLen = Int(readU16(data, pos))
+                let labelLen = Int(try readU16(data, pos))
                 pos += 2
                 guard sectionLen >= (pos - sStart) + labelLen else { throw ProtocolDecodeError.malformed }
-                backgroundSubagentLabel = String(data: data[pos..<(pos + labelLen)], encoding: .utf8) ?? ""
+                backgroundSubagentLabel = try decodeUTF8(data[pos..<(pos + labelLen)]) ?? ""
                 pos += labelLen
                 if pos < sectionEnd {
                     let toolLen = Int(data[pos])
                     pos += 1
                     guard sectionLen >= (pos - sStart) + toolLen else { throw ProtocolDecodeError.malformed }
-                    activeToolName = String(data: data[pos..<(pos + toolLen)], encoding: .utf8) ?? ""
+                    activeToolName = try decodeUTF8(data[pos..<(pos + toolLen)]) ?? ""
                 }
             }
         }
@@ -1092,7 +1168,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         for _ in 0..<pickerSectionCount {
             guard data.count >= pickerPos + 3 else { throw ProtocolDecodeError.malformed }
             let psId = data[pickerPos]
-            let psLen = Int(readU16(data, pickerPos + 1))
+            let psLen = Int(try readU16(data, pickerPos + 1))
             let psStart = pickerPos + 3
             guard data.count >= psStart + psLen else { throw ProtocolDecodeError.malformed }
             let psEnd = psStart + psLen
@@ -1163,7 +1239,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             return (.guiPickerPreview(visible: false, lines: []), 2)
         }
         guard data.count >= rest + 3 else { throw ProtocolDecodeError.malformed }
-        let lineCount = Int(readU16(data, rest + 1))
+        let lineCount = Int(try readU16(data, rest + 1))
         var lines: [Wire.PickerPreviewLine] = []
         lines.reserveCapacity(lineCount)
         var pos2 = rest + 3
@@ -1175,11 +1251,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             segments.reserveCapacity(segCount)
             for _ in 0..<segCount {
                 guard data.count >= pos2 + 6 else { throw ProtocolDecodeError.malformed }
-                let fgColor = readU24(data, pos2)
+                let fgColor = try readU24(data, pos2)
                 let segFlags = data[pos2 + 3]
-                let textLen = Int(readU16(data, pos2 + 4))
+                let textLen = Int(try readU16(data, pos2 + 4))
                 guard data.count >= pos2 + 6 + textLen else { throw ProtocolDecodeError.malformed }
-                let text = String(data: data[(pos2 + 6)..<(pos2 + 6 + textLen)], encoding: .utf8) ?? ""
+                let text = try decodeUTF8(data[(pos2 + 6)..<(pos2 + 6 + textLen)]) ?? ""
                 segments.append(Wire.PickerPreviewSegment(fgColor: UInt32(fgColor), bold: segFlags & 0x01 != 0, text: text))
                 pos2 += 6 + textLen
             }
@@ -1216,7 +1292,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         for _ in 0..<chatSectionCount {
             guard data.count >= chatPos + 3 else { throw ProtocolDecodeError.malformed }
             let csId = data[chatPos]
-            let csLen = Int(readU16(data, chatPos + 1))
+            let csLen = Int(try readU16(data, chatPos + 1))
             let csStart = chatPos + 3
             guard data.count >= csStart + csLen else { throw ProtocolDecodeError.malformed }
 
@@ -1228,26 +1304,26 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
             case 0x02: // Model: model_len(2) + model
                 guard csLen >= 2 else { break }
-                let mLen = Int(readU16(data, csStart))
-                if csLen >= 2 + mLen { chatModel = String(data: data[(csStart + 2)..<(csStart + 2 + mLen)], encoding: .utf8) ?? "" }
+                let mLen = Int(try readU16(data, csStart))
+                if csLen >= 2 + mLen { chatModel = try decodeUTF8(data[(csStart + 2)..<(csStart + 2 + mLen)]) ?? "" }
 
             case 0x03: // Prompt: prompt_len(2) + prompt + line_count(1) + cursor_line(2) + cursor_col(2) + vim_mode(1) + visible_rows(1)
                 guard csLen >= 2 else { break }
-                let pLen = Int(readU16(data, csStart))
-                if csLen >= 2 + pLen { chatPrompt = String(data: data[(csStart + 2)..<(csStart + 2 + pLen)], encoding: .utf8) ?? "" }
+                let pLen = Int(try readU16(data, csStart))
+                if csLen >= 2 + pLen { chatPrompt = try decodeUTF8(data[(csStart + 2)..<(csStart + 2 + pLen)]) ?? "" }
                 let metaStart = csStart + 2 + pLen
                 if csLen >= 2 + pLen + 7 {
                     promptLineCount = data[metaStart]
-                    promptCursorLine = readU16(data, metaStart + 1)
-                    promptCursorCol = readU16(data, metaStart + 3)
+                    promptCursorLine = try readU16(data, metaStart + 1)
+                    promptCursorCol = try readU16(data, metaStart + 3)
                     promptVimMode = data[metaStart + 5]
                     promptVisibleRows = data[metaStart + 6]
                 }
 
             case 0x08: // Thinking level: level_len(2) + level
                 guard csLen >= 2 else { break }
-                let tLen = Int(readU16(data, csStart))
-                if csLen >= 2 + tLen { chatThinkingLevel = String(data: data[(csStart + 2)..<(csStart + 2 + tLen)], encoding: .utf8) ?? "" }
+                let tLen = Int(try readU16(data, csStart))
+                if csLen >= 2 + tLen { chatThinkingLevel = try decodeUTF8(data[(csStart + 2)..<(csStart + 2 + tLen)]) ?? "" }
 
             case 0x07: // Completion: visible(1) [type(1) selected(1) anchor_line(2) anchor_col(2) count(1) candidates...]
                 guard csLen >= 1 else { break }
@@ -1255,19 +1331,19 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 if hasCompletion, csLen >= 8 {
                     let compType = data[csStart + 1]
                     let compSelected = data[csStart + 2]
-                    let compAnchorLine = readU16(data, csStart + 3)
-                    let compAnchorCol = readU16(data, csStart + 5)
+                    let compAnchorLine = try readU16(data, csStart + 3)
+                    let compAnchorCol = try readU16(data, csStart + 5)
                     let compCount = Int(data[csStart + 7])
                     var candidates: [(name: String, description: String)] = []
                     var cp = csStart + 8
                     for _ in 0..<compCount {
                         guard cp + 2 <= csStart + csLen else { break }
-                        let nLen = Int(readU16(data, cp)); cp += 2
+                        let nLen = Int(try readU16(data, cp)); cp += 2
                         guard cp + nLen + 2 <= csStart + csLen else { break }
-                        let name = String(data: data[cp..<(cp + nLen)], encoding: .utf8) ?? ""; cp += nLen
-                        let dLen = Int(readU16(data, cp)); cp += 2
+                        let name = try decodeUTF8(data[cp..<(cp + nLen)]) ?? ""; cp += nLen
+                        let dLen = Int(try readU16(data, cp)); cp += 2
                         guard cp + dLen <= csStart + csLen else { break }
-                        let desc = String(data: data[cp..<(cp + dLen)], encoding: .utf8) ?? ""; cp += dLen
+                        let desc = try decodeUTF8(data[cp..<(cp + dLen)]) ?? ""; cp += dLen
                         candidates.append((name: name, description: desc))
                     }
                     promptCompletion = Wire.PromptCompletion(type: compType, selected: compSelected, anchorLine: compAnchorLine, anchorCol: compAnchorCol, candidates: candidates)
@@ -1278,13 +1354,13 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 let hasPending = data[csStart] != 0
                 if hasPending, csLen >= 3 {
                     var pp = csStart + 1
-                    let pnLen = Int(readU16(data, pp)); pp += 2
+                    let pnLen = Int(try readU16(data, pp)); pp += 2
                     guard pp + pnLen + 2 <= csStart + csLen else { break }
-                    pendingToolName = String(data: data[pp..<(pp + pnLen)], encoding: .utf8) ?? ""
+                    pendingToolName = try decodeUTF8(data[pp..<(pp + pnLen)]) ?? ""
                     pp += pnLen
-                    let psLen = Int(readU16(data, pp)); pp += 2
+                    let psLen = Int(try readU16(data, pp)); pp += 2
                     guard pp + psLen <= csStart + csLen else { break }
-                    pendingToolSummary = String(data: data[pp..<(pp + psLen)], encoding: .utf8) ?? ""
+                    pendingToolSummary = try decodeUTF8(data[pp..<(pp + psLen)]) ?? ""
                 }
 
             case 0x05: // Help: same format as before (visible(1) [group_count(1) ...])
@@ -1295,9 +1371,9 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     var hp = csStart + 2
                     for _ in 0..<groupCount {
                         guard hp + 2 <= csStart + csLen else { break }
-                        let tLen = Int(readU16(data, hp)); hp += 2
+                        let tLen = Int(try readU16(data, hp)); hp += 2
                         guard hp + tLen + 1 <= csStart + csLen else { break }
-                        let title = String(data: data[hp..<(hp + tLen)], encoding: .utf8) ?? ""
+                        let title = try decodeUTF8(data[hp..<(hp + tLen)]) ?? ""
                         hp += tLen
                         let bCount = Int(data[hp]); hp += 1
                         var bindings: [(key: String, description: String)] = []
@@ -1305,11 +1381,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                             guard hp + 1 <= csStart + csLen else { break }
                             let kLen = Int(data[hp]); hp += 1
                             guard hp + kLen + 2 <= csStart + csLen else { break }
-                            let key = String(data: data[hp..<(hp + kLen)], encoding: .utf8) ?? ""
+                            let key = try decodeUTF8(data[hp..<(hp + kLen)]) ?? ""
                             hp += kLen
-                            let dLen = Int(readU16(data, hp)); hp += 2
+                            let dLen = Int(try readU16(data, hp)); hp += 2
                             guard hp + dLen <= csStart + csLen else { break }
-                            let desc = String(data: data[hp..<(hp + dLen)], encoding: .utf8) ?? ""
+                            let desc = try decodeUTF8(data[hp..<(hp + dLen)]) ?? ""
                             hp += dLen
                             bindings.append((key: key, description: desc))
                         }
@@ -1324,7 +1400,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     guard csLen >= 4 else { throw ProtocolDecodeError.malformed }
                     let version = data[csStart + 1]
                     guard version == 1 else { throw ProtocolDecodeError.malformed }
-                    let msgCount = Int(readU16(data, csStart + 2))
+                    let msgCount = Int(try readU16(data, csStart + 2))
                     let decodedMessages = try decodeFramedChatMessages(
                         data: data,
                         start: csStart + 4,
@@ -1333,7 +1409,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     )
                     messages.append(contentsOf: decodedMessages)
                 } else {
-                    let msgCount = Int(readU16(data, csStart))
+                    let msgCount = Int(try readU16(data, csStart))
                     let messagesStart = csStart + 2
                     let (decodedMessages, decodedEnd) = try decodeLegacyChatMessages(
                         data: data,
@@ -1360,7 +1436,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         //   append (mode 1): trim_front(4) + base_count(4) + count(4)
         //   both: count * [ id(4), body_len(4), body ]. Body is the shared 0x78 codec.
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
-        let transcriptPayloadLen = Int(readU32(data, rest))
+        let transcriptPayloadLen = Int(try readU32(data, rest))
         let transcriptPayloadStart = rest + 4
         let transcriptEnd = transcriptPayloadStart + transcriptPayloadLen
         guard data.count >= transcriptEnd else { throw ProtocolDecodeError.malformed }
@@ -1375,7 +1451,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // apply branch is mode==0-shaped, so an unknown mode passed through would be
         // parsed with one layout and applied with the other (split-brain).
         guard transcriptMode <= 1 else { throw ProtocolDecodeError.malformed }
-        let transcriptEpoch = readU32(data, transcriptPayloadStart + 2)
+        let transcriptEpoch = try readU32(data, transcriptPayloadStart + 2)
         let transcriptTruncated = data[transcriptPayloadStart + 6] != 0
 
         let transcriptTrimFront: UInt32
@@ -1385,15 +1461,15 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         if transcriptMode == 1 {
             // append: trim_front(4) + base_count(4) + count(4) after the 7-byte header.
             guard transcriptPayloadLen >= 19 else { throw ProtocolDecodeError.malformed }
-            transcriptTrimFront = readU32(data, transcriptPayloadStart + 7)
-            transcriptBaseCount = readU32(data, transcriptPayloadStart + 11)
-            transcriptCount = Int(readU32(data, transcriptPayloadStart + 15))
+            transcriptTrimFront = try readU32(data, transcriptPayloadStart + 7)
+            transcriptBaseCount = try readU32(data, transcriptPayloadStart + 11)
+            transcriptCount = Int(try readU32(data, transcriptPayloadStart + 15))
             transcriptPos = transcriptPayloadStart + 19
         } else {
             // full_replace: count(4) after the 7-byte header.
             transcriptTrimFront = 0
             transcriptBaseCount = 0
-            transcriptCount = Int(readU32(data, transcriptPayloadStart + 7))
+            transcriptCount = Int(try readU32(data, transcriptPayloadStart + 7))
             transcriptPos = transcriptPayloadStart + 11
         }
 
@@ -1406,8 +1482,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         transcriptMessages.reserveCapacity(transcriptCount)
         for _ in 0..<transcriptCount {
             guard transcriptPos + 8 <= transcriptEnd else { throw ProtocolDecodeError.malformed }
-            let entryId = readU32(data, transcriptPos)
-            let bodyLen = Int(readU32(data, transcriptPos + 4))
+            let entryId = try readU32(data, transcriptPos)
+            let bodyLen = Int(try readU32(data, transcriptPos + 4))
             let bodyStart = transcriptPos + 8
             let bodyEnd = bodyStart + bodyLen
             guard bodyEnd <= transcriptEnd else { throw ProtocolDecodeError.malformed }
@@ -1426,13 +1502,13 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
     case OP_GUI_GUTTER_SEP:
         // col:2, r:1, g:1, b:1 = 5 bytes after opcode
         guard data.count >= rest + 5 else { throw ProtocolDecodeError.malformed }
-        let col = readU16(data, rest)
+        let col = try readU16(data, rest)
         return (.guiGutterSeparator(col: col, r: data[rest + 2], g: data[rest + 3], b: data[rest + 4]), 6)
 
     case OP_GUI_CURSORLINE:
         // row:2, r:1, g:1, b:1 = 5 bytes after opcode
         guard data.count >= rest + 5 else { throw ProtocolDecodeError.malformed }
-        let row = readU16(data, rest)
+        let row = try readU16(data, rest)
         return (.guiCursorline(row: row, r: data[rest + 2], g: data[rest + 3], b: data[rest + 4]), 6)
 
     case OP_GUI_GUTTER:
@@ -1456,7 +1532,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         for _ in 0..<gutterSectionCount {
             guard data.count >= gutterPos + 3 else { throw ProtocolDecodeError.malformed }
             let gsId = data[gutterPos]
-            let gsLen = Int(readU16(data, gutterPos + 1))
+            let gsLen = Int(try readU16(data, gutterPos + 1))
             let gsStart = gutterPos + 3
             let gsEnd = gsStart + gsLen
             guard data.count >= gsEnd else { throw ProtocolDecodeError.malformed }
@@ -1464,40 +1540,40 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             switch gsId {
             case 0x01: // Window: window_id(2) + row(2) + col(2) + height(2) + is_active(1) [+ width(2)]
                 guard gsLen >= 9 else { break }
-                windowId = readU16(data, gsStart)
-                contentRow = readU16(data, gsStart + 2)
-                contentCol = readU16(data, gsStart + 4)
-                contentHeight = readU16(data, gsStart + 6)
+                windowId = try readU16(data, gsStart)
+                contentRow = try readU16(data, gsStart + 2)
+                contentCol = try readU16(data, gsStart + 4)
+                contentHeight = try readU16(data, gsStart + 6)
                 isActive = data[gsStart + 8] != 0
-                contentWidth = gsLen >= 11 ? readU16(data, gsStart + 9) : 0
+                contentWidth = gsLen >= 11 ? try readU16(data, gsStart + 9) : 0
 
             case 0x02: // Config: cursor_line(4) + style(1) + ln_width(1) + sign_width(1)
                 guard gsLen >= 7 else { break }
-                cursorLine = readU32(data, gsStart)
+                cursorLine = try readU32(data, gsStart)
                 style = Wire.LineNumberStyle(rawValue: data[gsStart + 4]) ?? .hybrid
                 lnWidth = data[gsStart + 5]
                 signWidth = data[gsStart + 6]
 
             case 0x03: // Entries: count(2) + entries...
                 guard gsLen >= 2 else { throw ProtocolDecodeError.malformed }
-                let lineCount = Int(readU16(data, gsStart))
+                let lineCount = Int(try readU16(data, gsStart))
                 entries.reserveCapacity(lineCount)
                 var ePos = gsStart + 2
                 for _ in 0..<lineCount {
                     guard gsEnd >= ePos + 10 else { throw ProtocolDecodeError.malformed }
-                    let bufLine = readU32(data, ePos)
+                    let bufLine = try readU32(data, ePos)
                     let dt = Wire.GutterDisplayType(rawValue: data[ePos + 4]) ?? .normal
                     let st = Wire.GutterSignType(rawValue: data[ePos + 5]) ?? .none
-                    let rawFoldEndLine = readU32(data, ePos + 6)
+                    let rawFoldEndLine = try readU32(data, ePos + 6)
                     let foldEndLine: UInt32? = rawFoldEndLine == UInt32.max ? nil : rawFoldEndLine
                     ePos += 10
                     if st == .annotation {
                         guard gsEnd >= ePos + 4 else { throw ProtocolDecodeError.malformed }
-                        let fg = readU24(data, ePos)
+                        let fg = try readU24(data, ePos)
                         let textLen = Int(data[ePos + 3])
                         ePos += 4
                         guard gsEnd >= ePos + textLen else { throw ProtocolDecodeError.malformed }
-                        let text = String(data: Data(data[ePos..<(ePos + textLen)]), encoding: .utf8) ?? ""
+                        let text = try decodeUTF8(data[ePos..<(ePos + textLen)]) ?? ""
                         ePos += textLen
                         entries.append(Wire.GutterEntry(bufLine: bufLine, displayType: dt, signType: st, foldEndLine: foldEndLine, signFg: fg, signText: text))
                     } else {
@@ -1541,7 +1617,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let nameLen = Int(data[pos + 1])
             pos += 2
             guard data.count >= pos + nameLen else { throw ProtocolDecodeError.malformed }
-            let name = String(data: data[pos..<(pos + nameLen)], encoding: .utf8) ?? ""
+            let name = try decodeUTF8(data[pos..<(pos + nameLen)]) ?? ""
             pos += nameLen
             tabs.append(Wire.BottomPanelTab(tabType: tabType, name: name))
         }
@@ -1552,27 +1628,27 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                                      heightPercent: heightPercent, filterPreset: filterPreset,
                                      tabs: tabs, entries: []), pos - offset)
         }
-        let streamInstance = readU32(data, pos)
-        let entryCount = Int(readU16(data, pos + 4))
+        let streamInstance = try readU32(data, pos)
+        let entryCount = Int(try readU16(data, pos + 4))
         pos += 6
         for _ in 0..<entryCount {
             // id(4) + level(1) + subsystem(1) + timestamp_secs(4) + path_len(2)
             guard data.count >= pos + 12 else { break }
-            let entryId = readU32(data, pos)
+            let entryId = try readU32(data, pos)
             let level = data[pos + 4]
             let subsystem = data[pos + 5]
-            let tsSecs = readU32(data, pos + 6)
-            let pathLen = Int(readU16(data, pos + 10))
+            let tsSecs = try readU32(data, pos + 6)
+            let pathLen = Int(try readU16(data, pos + 10))
             pos += 12
             guard data.count >= pos + pathLen else { break }
-            let filePath = String(data: data[pos..<(pos + pathLen)], encoding: .utf8) ?? ""
+            let filePath = try decodeUTF8(data[pos..<(pos + pathLen)]) ?? ""
             pos += pathLen
             // text_len(2) + text
             guard data.count >= pos + 2 else { break }
-            let textLen = Int(readU16(data, pos))
+            let textLen = Int(try readU16(data, pos))
             pos += 2
             guard data.count >= pos + textLen else { break }
-            let text = String(data: data[pos..<(pos + textLen)], encoding: .utf8) ?? ""
+            let text = try decodeUTF8(data[pos..<(pos + textLen)]) ?? ""
             pos += textLen
             entries.append(Wire.MessageEntry(streamInstance: streamInstance, id: entryId, level: level, subsystem: subsystem,
                                             timestampSecs: tsSecs, filePath: filePath, text: text))
@@ -1585,7 +1661,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // len32 command framing plus u32 section lengths:
         // opcode(1) + payload_len(4) + section_count(1) + sections...
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
-        let wcPayloadLen = Int(readU32(data, rest))
+        let wcPayloadLen = Int(try readU32(data, rest))
         let wcPayloadStart = rest + 4
         let wcPayloadEnd = wcPayloadStart + wcPayloadLen
         guard wcPayloadLen >= 1, data.count >= wcPayloadEnd else { throw ProtocolDecodeError.malformed }
@@ -1607,7 +1683,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         for _ in 0..<wcSectionCount {
             guard wcPayloadEnd >= wcPos + 5 else { throw ProtocolDecodeError.malformed }
             let wcSId = data[wcPos]
-            let wcSLen = Int(readU32(data, wcPos + 1))
+            let wcSLen = Int(try readU32(data, wcPos + 1))
             let wcSStart = wcPos + 5
             guard wcPayloadEnd >= wcSStart + wcSLen else { throw ProtocolDecodeError.malformed }
 
@@ -1615,14 +1691,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             case 0x01: // Header: window_id(2) + flags(1) + cursor_row(2) + cursor_col(2) + cursor_shape(1) + scroll_left(2) + optional content_epoch(4)
                 guard !wcSawHeader, wcSLen >= 10 else { throw ProtocolDecodeError.malformed }
                 wcSawHeader = true
-                wcWindowId = readU16(data, wcSStart)
+                wcWindowId = try readU16(data, wcSStart)
                 wcFlags = data[wcSStart + 2]
-                wcCursorRow = readU16(data, wcSStart + 3)
-                wcCursorCol = readU16(data, wcSStart + 5)
+                wcCursorRow = try readU16(data, wcSStart + 3)
+                wcCursorCol = try readU16(data, wcSStart + 5)
                 wcCursorShape = CursorShape(rawValue: data[wcSStart + 7]) ?? .block
-                wcScrollLeft = readU16(data, wcSStart + 8)
+                wcScrollLeft = try readU16(data, wcSStart + 8)
                 if wcSLen >= 14 {
-                    wcContentEpoch = readU32(data, wcSStart + 10)
+                    wcContentEpoch = try readU32(data, wcSStart + 10)
                 }
 
             case 0x02: // Rows: row_count(4) + rows...
@@ -1665,18 +1741,18 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_GUI_WINDOW_OVERLAY_DELTA:
         guard data.count >= rest + 12 else { throw ProtocolDecodeError.malformed }
-        let windowId = readU16(data, rest)
-        let contentEpoch = readU32(data, rest + 2)
+        let windowId = try readU16(data, rest)
+        let contentEpoch = try readU32(data, rest + 2)
         let flags = data[rest + 6]
-        let cursorRow = readU16(data, rest + 7)
-        let cursorCol = readU16(data, rest + 9)
+        let cursorRow = try readU16(data, rest + 7)
+        let cursorCol = try readU16(data, rest + 9)
         let cursorShape = CursorShape(rawValue: data[rest + 11]) ?? .block
         let hasCursorline = flags & 0x02 != 0
         let cursorVisible = flags & 0x01 != 0
 
         if hasCursorline {
             guard data.count >= rest + 17 else { throw ProtocolDecodeError.malformed }
-            let cursorline = GUICursorline(row: readU16(data, rest + 12), bg: readU24(data, rest + 14))
+            let cursorline = GUICursorline(row: try readU16(data, rest + 12), bg: try readU24(data, rest + 14))
             let delta = GUIWindowOverlayDelta(windowId: windowId, contentEpoch: contentEpoch,
                                              cursorVisible: cursorVisible, cursorRow: cursorRow,
                                              cursorCol: cursorCol, cursorShape: cursorShape,
@@ -1708,8 +1784,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // filter(1) + selected_index(2) + tool_count(2)
         guard data.count >= rest + 6 else { throw ProtocolDecodeError.malformed }
         let tmFilter = data[rest + 1]
-        let tmSelectedIndex = readU16(data, rest + 2)
-        let toolCount = Int(readU16(data, rest + 4))
+        let tmSelectedIndex = try readU16(data, rest + 2)
+        let toolCount = Int(try readU16(data, rest + 4))
         var pos = rest + 6
         var tools: [Wire.ToolEntry] = []
         tools.reserveCapacity(toolCount)
@@ -1718,19 +1794,19 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= pos + 1 else { break }
             let nameLen = Int(data[pos]); pos += 1
             guard data.count >= pos + nameLen else { break }
-            let name = String(data: data[pos..<(pos + nameLen)], encoding: .utf8) ?? ""
+            let name = try decodeUTF8(data[pos..<(pos + nameLen)]) ?? ""
             pos += nameLen
             // label_len(1) + label
             guard data.count >= pos + 1 else { break }
             let labelLen = Int(data[pos]); pos += 1
             guard data.count >= pos + labelLen else { break }
-            let toolLabel = String(data: data[pos..<(pos + labelLen)], encoding: .utf8) ?? ""
+            let toolLabel = try decodeUTF8(data[pos..<(pos + labelLen)]) ?? ""
             pos += labelLen
             // desc_len(2) + desc
             guard data.count >= pos + 2 else { break }
-            let descLen = Int(readU16(data, pos)); pos += 2
+            let descLen = Int(try readU16(data, pos)); pos += 2
             guard data.count >= pos + descLen else { break }
-            let desc = String(data: data[pos..<(pos + descLen)], encoding: .utf8) ?? ""
+            let desc = try decodeUTF8(data[pos..<(pos + descLen)]) ?? ""
             pos += descLen
             // category(1) + status(1) + method(1) + language_count(1)
             guard data.count >= pos + 4 else { break }
@@ -1744,7 +1820,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 guard data.count >= pos + 1 else { break }
                 let lLen = Int(data[pos]); pos += 1
                 guard data.count >= pos + lLen else { break }
-                let lang = String(data: data[pos..<(pos + lLen)], encoding: .utf8) ?? ""
+                let lang = try decodeUTF8(data[pos..<(pos + lLen)]) ?? ""
                 pos += lLen
                 langs.append(lang)
             }
@@ -1752,13 +1828,13 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= pos + 1 else { break }
             let verLen = Int(data[pos]); pos += 1
             guard data.count >= pos + verLen else { break }
-            let version = String(data: data[pos..<(pos + verLen)], encoding: .utf8) ?? ""
+            let version = try decodeUTF8(data[pos..<(pos + verLen)]) ?? ""
             pos += verLen
             // homepage_len(2) + homepage
             guard data.count >= pos + 2 else { break }
-            let hpLen = Int(readU16(data, pos)); pos += 2
+            let hpLen = Int(try readU16(data, pos)); pos += 2
             guard data.count >= pos + hpLen else { break }
-            let homepage = String(data: data[pos..<(pos + hpLen)], encoding: .utf8) ?? ""
+            let homepage = try decodeUTF8(data[pos..<(pos + hpLen)]) ?? ""
             pos += hpLen
             // provides_count(1) + provides
             guard data.count >= pos + 1 else { break }
@@ -1768,16 +1844,16 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 guard data.count >= pos + 1 else { break }
                 let cLen = Int(data[pos]); pos += 1
                 guard data.count >= pos + cLen else { break }
-                let cmd = String(data: data[pos..<(pos + cLen)], encoding: .utf8) ?? ""
+                let cmd = try decodeUTF8(data[pos..<(pos + cLen)]) ?? ""
                 pos += cLen
                 provides.append(cmd)
             }
             // error_reason_len(2) + error_reason
             guard data.count >= pos + 2 else { throw ProtocolDecodeError.malformed }
-            let errLen = Int(readU16(data, pos)); pos += 2
+            let errLen = Int(try readU16(data, pos)); pos += 2
             guard data.count >= pos + errLen else { throw ProtocolDecodeError.malformed }
             let errorReason = errLen > 0
-                ? (String(data: data[pos..<(pos + errLen)], encoding: .utf8) ?? "")
+                ? (try decodeUTF8(data[pos..<(pos + errLen)]) ?? "")
                 : ""
             pos += errLen
             tools.append(Wire.ToolEntry(
@@ -1802,30 +1878,30 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // mode(1) + cursor_pos(2) + prompt_len(1)
         guard data.count >= rest + 5 else { throw ProtocolDecodeError.malformed }
         let mbMode = data[rest + 1]
-        let mbCursorPos = readU16(data, rest + 2)
+        let mbCursorPos = try readU16(data, rest + 2)
         let mbPromptLen = Int(data[rest + 4])
         var mbPos = rest + 5
         // prompt
         guard data.count >= mbPos + mbPromptLen else { throw ProtocolDecodeError.malformed }
-        let mbPrompt = String(data: data[mbPos..<(mbPos + mbPromptLen)], encoding: .utf8) ?? ""
+        let mbPrompt = try decodeUTF8(data[mbPos..<(mbPos + mbPromptLen)]) ?? ""
         mbPos += mbPromptLen
         // input_len(2) + input
         guard data.count >= mbPos + 2 else { throw ProtocolDecodeError.malformed }
-        let mbInputLen = Int(readU16(data, mbPos)); mbPos += 2
+        let mbInputLen = Int(try readU16(data, mbPos)); mbPos += 2
         guard data.count >= mbPos + mbInputLen else { throw ProtocolDecodeError.malformed }
-        let mbInput = String(data: data[mbPos..<(mbPos + mbInputLen)], encoding: .utf8) ?? ""
+        let mbInput = try decodeUTF8(data[mbPos..<(mbPos + mbInputLen)]) ?? ""
         mbPos += mbInputLen
         // context_len(2) + context
         guard data.count >= mbPos + 2 else { throw ProtocolDecodeError.malformed }
-        let mbContextLen = Int(readU16(data, mbPos)); mbPos += 2
+        let mbContextLen = Int(try readU16(data, mbPos)); mbPos += 2
         guard data.count >= mbPos + mbContextLen else { throw ProtocolDecodeError.malformed }
-        let mbContext = String(data: data[mbPos..<(mbPos + mbContextLen)], encoding: .utf8) ?? ""
+        let mbContext = try decodeUTF8(data[mbPos..<(mbPos + mbContextLen)]) ?? ""
         mbPos += mbContextLen
         // selected_index(2) + candidate_count(2) + total_candidates(2)
         guard data.count >= mbPos + 6 else { throw ProtocolDecodeError.malformed }
-        let mbSelIndex = readU16(data, mbPos); mbPos += 2
-        let mbCandCount = Int(readU16(data, mbPos)); mbPos += 2
-        let mbTotalCandidates = readU16(data, mbPos); mbPos += 2
+        let mbSelIndex = try readU16(data, mbPos); mbPos += 2
+        let mbCandCount = Int(try readU16(data, mbPos)); mbPos += 2
+        let mbTotalCandidates = try readU16(data, mbPos); mbPos += 2
         // candidates
         var mbCandidates: [Wire.MinibufferCandidate] = []
         mbCandidates.reserveCapacity(mbCandCount)
@@ -1833,21 +1909,21 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             // match_score(1) + label_len(2)
             guard data.count >= mbPos + 3 else { break }
             let score = data[mbPos]; mbPos += 1
-            let candLabelLen = Int(readU16(data, mbPos)); mbPos += 2
+            let candLabelLen = Int(try readU16(data, mbPos)); mbPos += 2
             guard data.count >= mbPos + candLabelLen else { break }
-            let candLabel = String(data: data[mbPos..<(mbPos + candLabelLen)], encoding: .utf8) ?? ""
+            let candLabel = try decodeUTF8(data[mbPos..<(mbPos + candLabelLen)]) ?? ""
             mbPos += candLabelLen
             // desc_len(2) + desc
             guard data.count >= mbPos + 2 else { break }
-            let candDescLen = Int(readU16(data, mbPos)); mbPos += 2
+            let candDescLen = Int(try readU16(data, mbPos)); mbPos += 2
             guard data.count >= mbPos + candDescLen else { break }
-            let candDesc = String(data: data[mbPos..<(mbPos + candDescLen)], encoding: .utf8) ?? ""
+            let candDesc = try decodeUTF8(data[mbPos..<(mbPos + candDescLen)]) ?? ""
             mbPos += candDescLen
             // annotation_len(2) + annotation
             guard data.count >= mbPos + 2 else { break }
-            let candAnnotLen = Int(readU16(data, mbPos)); mbPos += 2
+            let candAnnotLen = Int(try readU16(data, mbPos)); mbPos += 2
             guard data.count >= mbPos + candAnnotLen else { break }
-            let candAnnot = String(data: data[mbPos..<(mbPos + candAnnotLen)], encoding: .utf8) ?? ""
+            let candAnnot = try decodeUTF8(data[mbPos..<(mbPos + candAnnotLen)]) ?? ""
             mbPos += candAnnotLen
             // match_pos_count(1) + match_positions(count * 2)
             guard data.count >= mbPos + 1 else { break }
@@ -1856,7 +1932,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             matchPositions.reserveCapacity(matchPosCount)
             for _ in 0..<matchPosCount {
                 guard data.count >= mbPos + 2 else { break }
-                matchPositions.append(readU16(data, mbPos)); mbPos += 2
+                matchPositions.append(try readU16(data, mbPos)); mbPos += 2
             }
             mbCandidates.append(Wire.MinibufferCandidate(matchScore: score, label: candLabel, description: candDesc, annotation: candAnnot, matchPositions: matchPositions))
         }
@@ -1875,11 +1951,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         }
         // anchor_row(2) + anchor_col(2) + focused(1) + scroll_offset(2) + line_count(2)
         guard data.count >= rest + 10 else { throw ProtocolDecodeError.malformed }
-        let hAnchorRow = readU16(data, rest + 1)
-        let hAnchorCol = readU16(data, rest + 3)
+        let hAnchorRow = try readU16(data, rest + 1)
+        let hAnchorCol = try readU16(data, rest + 3)
         let hFocused = data[rest + 5] != 0
-        let hScrollOffset = readU16(data, rest + 6)
-        let hLineCount = Int(readU16(data, rest + 8))
+        let hScrollOffset = try readU16(data, rest + 6)
+        let hLineCount = Int(try readU16(data, rest + 8))
         var hPos = rest + 10
         var hLines: [Wire.HoverLine] = []
         hLines.reserveCapacity(hLineCount)
@@ -1887,7 +1963,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             // line_type(1) + segment_count(2)
             guard data.count >= hPos + 3 else { throw ProtocolDecodeError.malformed }
             let lineType = Wire.HoverLineType(rawValue: data[hPos]) ?? .text
-            let segCount = Int(readU16(data, hPos + 1))
+            let segCount = Int(try readU16(data, hPos + 1))
             hPos += 3
             var segments: [Wire.HoverSegment] = []
             segments.reserveCapacity(segCount)
@@ -1902,19 +1978,19 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 let textLen: Int
                 if style == .syntaxHighlighted {
                     guard data.count >= hPos + 6 else { throw ProtocolDecodeError.malformed }
-                    fgColor = UInt32(readU24(data, hPos))
+                    fgColor = UInt32(try readU24(data, hPos))
                     flags = data[hPos + 3]
-                    textLen = Int(readU16(data, hPos + 4))
+                    textLen = Int(try readU16(data, hPos + 4))
                     hPos += 6
                 } else {
                     guard data.count >= hPos + 2 else { throw ProtocolDecodeError.malformed }
                     fgColor = nil
                     flags = 0
-                    textLen = Int(readU16(data, hPos))
+                    textLen = Int(try readU16(data, hPos))
                     hPos += 2
                 }
                 guard data.count >= hPos + textLen else { throw ProtocolDecodeError.malformed }
-                let text = String(data: data[hPos..<(hPos + textLen)], encoding: .utf8) ?? ""
+                let text = try decodeUTF8(data[hPos..<(hPos + textLen)]) ?? ""
                 hPos += textLen
                 segments.append(Wire.HoverSegment(style: style, fgColor: fgColor, flags: flags, text: text))
             }
@@ -1926,17 +2002,17 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_GUI_HOVER_ACTION:
         guard data.count >= rest + 3 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU16(data, rest))
+        let payloadLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + payloadLen else { throw ProtocolDecodeError.malformed }
         let payloadStart = rest + 2
         let visible = data[payloadStart] != 0
         guard visible else { return (.guiHoverAction(visible: false, actionName: ""), 3 + payloadLen) }
         guard payloadLen >= 3 else { throw ProtocolDecodeError.malformed }
-        let actionLen = Int(readU16(data, payloadStart + 1))
+        let actionLen = Int(try readU16(data, payloadStart + 1))
         guard payloadLen >= 3 + actionLen else { throw ProtocolDecodeError.malformed }
         let actionStart = payloadStart + 3
         let actionData = data[actionStart..<(actionStart + actionLen)]
-        let actionName = String(data: actionData, encoding: .utf8) ?? ""
+        let actionName = try decodeUTF8(actionData) ?? ""
         return (.guiHoverAction(visible: true, actionName: actionName), 3 + payloadLen)
 
     case OP_GUI_SIGNATURE_HELP:
@@ -1949,8 +2025,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         }
         // anchor_row(2) + anchor_col(2) + active_signature(1) + active_parameter(1) + signature_count(1)
         guard data.count >= rest + 8 else { throw ProtocolDecodeError.malformed }
-        let shAnchorRow = readU16(data, rest + 1)
-        let shAnchorCol = readU16(data, rest + 3)
+        let shAnchorRow = try readU16(data, rest + 1)
+        let shAnchorCol = try readU16(data, rest + 3)
         let shActiveSig = data[rest + 5]
         let shActiveParam = data[rest + 6]
         let shSigCount = Int(data[rest + 7])
@@ -1960,15 +2036,15 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         for _ in 0..<shSigCount {
             // label_len(2) + label
             guard data.count >= shPos + 2 else { break }
-            let labelLen = Int(readU16(data, shPos)); shPos += 2
+            let labelLen = Int(try readU16(data, shPos)); shPos += 2
             guard data.count >= shPos + labelLen else { break }
-            let label = String(data: data[shPos..<(shPos + labelLen)], encoding: .utf8) ?? ""
+            let label = try decodeUTF8(data[shPos..<(shPos + labelLen)]) ?? ""
             shPos += labelLen
             // doc_len(2) + doc
             guard data.count >= shPos + 2 else { break }
-            let docLen = Int(readU16(data, shPos)); shPos += 2
+            let docLen = Int(try readU16(data, shPos)); shPos += 2
             guard data.count >= shPos + docLen else { break }
-            let doc = String(data: data[shPos..<(shPos + docLen)], encoding: .utf8) ?? ""
+            let doc = try decodeUTF8(data[shPos..<(shPos + docLen)]) ?? ""
             shPos += docLen
             // param_count(1)
             guard data.count >= shPos + 1 else { break }
@@ -1978,14 +2054,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             for _ in 0..<paramCount {
                 // label_len(2) + label + doc_len(2) + doc
                 guard data.count >= shPos + 2 else { break }
-                let pLabelLen = Int(readU16(data, shPos)); shPos += 2
+                let pLabelLen = Int(try readU16(data, shPos)); shPos += 2
                 guard data.count >= shPos + pLabelLen else { break }
-                let pLabel = String(data: data[shPos..<(shPos + pLabelLen)], encoding: .utf8) ?? ""
+                let pLabel = try decodeUTF8(data[shPos..<(shPos + pLabelLen)]) ?? ""
                 shPos += pLabelLen
                 guard data.count >= shPos + 2 else { break }
-                let pDocLen = Int(readU16(data, shPos)); shPos += 2
+                let pDocLen = Int(try readU16(data, shPos)); shPos += 2
                 guard data.count >= shPos + pDocLen else { break }
-                let pDoc = String(data: data[shPos..<(shPos + pDocLen)], encoding: .utf8) ?? ""
+                let pDoc = try decodeUTF8(data[shPos..<(shPos + pDocLen)]) ?? ""
                 shPos += pDocLen
                 params.append(Wire.SignatureParameter(label: pLabel, documentation: pDoc))
             }
@@ -2004,23 +2080,23 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         }
         // width(2) + height(2) + title_len(2)
         guard data.count >= rest + 7 else { throw ProtocolDecodeError.malformed }
-        let fpWidth = readU16(data, rest + 1)
-        let fpHeight = readU16(data, rest + 3)
-        let fpTitleLen = Int(readU16(data, rest + 5))
+        let fpWidth = try readU16(data, rest + 1)
+        let fpHeight = try readU16(data, rest + 3)
+        let fpTitleLen = Int(try readU16(data, rest + 5))
         var fpPos = rest + 7
         guard data.count >= fpPos + fpTitleLen else { throw ProtocolDecodeError.malformed }
-        let fpTitle = String(data: data[fpPos..<(fpPos + fpTitleLen)], encoding: .utf8) ?? ""
+        let fpTitle = try decodeUTF8(data[fpPos..<(fpPos + fpTitleLen)]) ?? ""
         fpPos += fpTitleLen
         // line_count(2)
         guard data.count >= fpPos + 2 else { throw ProtocolDecodeError.malformed }
-        let fpLineCount = Int(readU16(data, fpPos)); fpPos += 2
+        let fpLineCount = Int(try readU16(data, fpPos)); fpPos += 2
         var fpLines: [String] = []
         fpLines.reserveCapacity(fpLineCount)
         for _ in 0..<fpLineCount {
             guard data.count >= fpPos + 2 else { throw ProtocolDecodeError.malformed }
-            let lineLen = Int(readU16(data, fpPos)); fpPos += 2
+            let lineLen = Int(try readU16(data, fpPos)); fpPos += 2
             guard data.count >= fpPos + lineLen else { throw ProtocolDecodeError.malformed }
-            let line = String(data: data[fpPos..<(fpPos + lineLen)], encoding: .utf8) ?? ""
+            let line = try decodeUTF8(data[fpPos..<(fpPos + lineLen)]) ?? ""
             fpPos += lineLen
             fpLines.append(line)
         }
@@ -2041,9 +2117,9 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         for _ in 0..<vertCount {
             // col(2) + start_row(2) + end_row(2)
             guard data.count >= sepPos + 6 else { throw ProtocolDecodeError.malformed }
-            let col = readU16(data, sepPos)
-            let startRow = readU16(data, sepPos + 2)
-            let endRow = readU16(data, sepPos + 4)
+            let col = try readU16(data, sepPos)
+            let startRow = try readU16(data, sepPos + 2)
+            let endRow = try readU16(data, sepPos + 4)
             sepPos += 6
             verts.append(Wire.VerticalSeparator(col: col, startRow: startRow, endRow: endRow))
         }
@@ -2055,13 +2131,13 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         for _ in 0..<horizCount {
             // row(2) + col(2) + width(2) + filename_len(2)
             guard data.count >= sepPos + 8 else { throw ProtocolDecodeError.malformed }
-            let hRow = readU16(data, sepPos)
-            let hCol = readU16(data, sepPos + 2)
-            let hWidth = readU16(data, sepPos + 4)
-            let fnLen = Int(readU16(data, sepPos + 6))
+            let hRow = try readU16(data, sepPos)
+            let hCol = try readU16(data, sepPos + 2)
+            let hWidth = try readU16(data, sepPos + 4)
+            let fnLen = Int(try readU16(data, sepPos + 6))
             sepPos += 8
             guard data.count >= sepPos + fnLen else { throw ProtocolDecodeError.malformed }
-            let fn = String(data: data[sepPos..<(sepPos + fnLen)], encoding: .utf8) ?? ""
+            let fn = try decodeUTF8(data[sepPos..<(sepPos + fnLen)]) ?? ""
             sepPos += fnLen
             horizs.append(Wire.HorizontalSeparator(row: hRow, col: hCol, width: hWidth, filename: fn))
         }
@@ -2085,25 +2161,25 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let gsSyncingByte = data[rest + 1]
         guard gsSyncingByte == 0 || gsSyncingByte == 1 else { throw ProtocolDecodeError.malformed }
         let gsSyncing = gsSyncingByte == 1
-        let gsAhead = readU16(data, rest + 2)
-        let gsBehind = readU16(data, rest + 4)
-        let gsBranchLen = Int(readU16(data, rest + 6))
+        let gsAhead = try readU16(data, rest + 2)
+        let gsBehind = try readU16(data, rest + 4)
+        let gsBranchLen = Int(try readU16(data, rest + 6))
         guard data.count >= rest + 8 + gsBranchLen + 2 else { throw ProtocolDecodeError.malformed }
         let gsBranchData = data[(rest + 8)..<(rest + 8 + gsBranchLen)]
         let gsBranchName = try readRequiredUTF8(gsBranchData)
-        let gsEntryCount = Int(readU16(data, rest + 8 + gsBranchLen))
+        let gsEntryCount = Int(try readU16(data, rest + 8 + gsBranchLen))
         var gsEntries: [Wire.GitStatusEntry] = []
         gsEntries.reserveCapacity(gsEntryCount)
         var gsPos = rest + 10 + gsBranchLen
         for _ in 0..<gsEntryCount {
             // path_hash:4, section:1, status:1, path_len:2, path
             guard data.count >= gsPos + 8 else { throw ProtocolDecodeError.malformed }
-            let gsPathHash = readU32(data, gsPos)
+            let gsPathHash = try readU32(data, gsPos)
             let gsSection = data[gsPos + 4]
             guard gsSection <= 3 else { throw ProtocolDecodeError.malformed }
             let gsStatus = data[gsPos + 5]
             guard gsStatus <= 7 else { throw ProtocolDecodeError.malformed }
-            let gsPathLen = Int(readU16(data, gsPos + 6))
+            let gsPathLen = Int(try readU16(data, gsPos + 6))
             guard data.count >= gsPos + 8 + gsPathLen else { throw ProtocolDecodeError.malformed }
             let gsPathData = data[(gsPos + 8)..<(gsPos + 8 + gsPathLen)]
             let gsPath = try readRequiredUTF8(gsPathData)
@@ -2120,7 +2196,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= gsPos + 4 else { throw ProtocolDecodeError.malformed }
             let gsToastLevel = data[gsPos]
             let gsToastAction = data[gsPos + 1]
-            let gsToastMsgLen = Int(readU16(data, gsPos + 2))
+            let gsToastMsgLen = Int(try readU16(data, gsPos + 2))
             gsPos += 4
             guard data.count >= gsPos + gsToastMsgLen else { throw ProtocolDecodeError.malformed }
             let gsToastMsgData = data[gsPos..<(gsPos + gsToastMsgLen)]
@@ -2130,21 +2206,21 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         }
 
         guard data.count >= gsPos + 2 else { throw ProtocolDecodeError.malformed }
-        let gsEntryBasePathLen = Int(readU16(data, gsPos))
+        let gsEntryBasePathLen = Int(try readU16(data, gsPos))
         gsPos += 2
         guard data.count >= gsPos + gsEntryBasePathLen + 2 else { throw ProtocolDecodeError.malformed }
         let gsEntryBasePathData = data[gsPos..<(gsPos + gsEntryBasePathLen)]
         let gsEntryBasePath = try readRequiredUTF8(gsEntryBasePathData)
         gsPos += gsEntryBasePathLen
 
-        let gsLastCommitMessageLen = Int(readU16(data, gsPos))
+        let gsLastCommitMessageLen = Int(try readU16(data, gsPos))
         gsPos += 2
         guard data.count >= gsPos + gsLastCommitMessageLen else { throw ProtocolDecodeError.malformed }
         let gsLastCommitMessageData = data[gsPos..<(gsPos + gsLastCommitMessageLen)]
         let gsLastCommitMessage = try readRequiredUTF8(gsLastCommitMessageData)
         gsPos += gsLastCommitMessageLen
         guard data.count >= gsPos + 2 else { throw ProtocolDecodeError.malformed }
-        let gsStashCount = readU16(data, gsPos)
+        let gsStashCount = try readU16(data, gsPos)
         gsPos += 2
         return (.guiGitStatus(repoState: gsRepoState, syncing: gsSyncing, ahead: gsAhead, behind: gsBehind, branchName: gsBranchName, entries: gsEntries, toast: gsToast, entryBasePath: gsEntryBasePath, lastCommitMessage: gsLastCommitMessage, stashCount: gsStashCount),
                 gsPos - offset)
@@ -2154,14 +2230,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // opcode(1) + payload_len(2) + version(1) + active_workspace_id(2) + mode(1) + flags(1)
         // + workspace_count(1) + workspaces... + visible_tab_count(2) + visible_tabs...
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU16(data, rest))
+        let payloadLen = Int(try readU16(data, rest))
         let payloadStart = rest + 2
         let payloadEnd = payloadStart + payloadLen
         guard data.count >= payloadEnd else { throw ProtocolDecodeError.malformed }
         guard payloadLen >= 6 else { throw ProtocolDecodeError.malformed }
 
         let version = data[payloadStart]
-        let activeGId = readU16(data, payloadStart + 1)
+        let activeGId = try readU16(data, payloadStart + 1)
         let mode = data[payloadStart + 3]
         let workspaceFlags = data[payloadStart + 4]
         let workspaceCount = Int(data[payloadStart + 5])
@@ -2171,17 +2247,17 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
         for _ in 0..<workspaceCount {
             guard pos + 18 <= payloadEnd else { throw ProtocolDecodeError.malformed }
-            let id = readU16(data, pos)
+            let id = try readU16(data, pos)
             let kind = data[pos + 2]
             let status = data[pos + 3]
-            let flags = readU16(data, pos + 4)
+            let flags = try readU16(data, pos + 4)
             let colorR = data[pos + 6]
             let colorG = data[pos + 7]
             let colorB = data[pos + 8]
-            let tabCount = readU16(data, pos + 9)
-            let draftCount = readU16(data, pos + 11)
-            let conflictCount = readU16(data, pos + 13)
-            let runningBackgroundCount = readU16(data, pos + 15)
+            let tabCount = try readU16(data, pos + 9)
+            let draftCount = try readU16(data, pos + 11)
+            let conflictCount = try readU16(data, pos + 13)
+            let runningBackgroundCount = try readU16(data, pos + 15)
             let labelLen = Int(data[pos + 17])
             guard pos + 18 + labelLen + 1 <= payloadEnd else { throw ProtocolDecodeError.malformed }
             let label = try readRequiredUTF8(data[(pos + 18)..<(pos + 18 + labelLen)])
@@ -2209,31 +2285,31 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         }
 
         guard pos + 2 <= payloadEnd else { throw ProtocolDecodeError.malformed }
-        let visibleTabCount = Int(readU16(data, pos))
+        let visibleTabCount = Int(try readU16(data, pos))
         pos += 2
         var visibleTabs: [Wire.WorkspaceTabEntry] = []
         visibleTabs.reserveCapacity(visibleTabCount)
 
         for _ in 0..<visibleTabCount {
             guard pos + 14 <= payloadEnd else { throw ProtocolDecodeError.malformed }
-            let id = readU32(data, pos)
-            let workspaceId = readU16(data, pos + 4)
+            let id = try readU32(data, pos)
+            let workspaceId = try readU16(data, pos + 4)
             let kind = data[pos + 6]
-            let flags = readU16(data, pos + 7)
-            let pathHash = readU32(data, pos + 9)
+            let flags = try readU16(data, pos + 7)
+            let pathHash = try readU32(data, pos + 9)
             let iconLen = Int(data[pos + 13])
             guard pos + 14 + iconLen + 2 <= payloadEnd else { throw ProtocolDecodeError.malformed }
             let icon = try readRequiredUTF8(data[(pos + 14)..<(pos + 14 + iconLen)])
             let labelLenPos = pos + 14 + iconLen
-            let labelLen = Int(readU16(data, labelLenPos))
+            let labelLen = Int(try readU16(data, labelLenPos))
             guard labelLenPos + 2 + labelLen + 2 <= payloadEnd else { throw ProtocolDecodeError.malformed }
             let label = try readRequiredUTF8(data[(labelLenPos + 2)..<(labelLenPos + 2 + labelLen)])
             let pathLenPos = labelLenPos + 2 + labelLen
-            let pathLen = Int(readU16(data, pathLenPos))
+            let pathLen = Int(try readU16(data, pathLenPos))
             let tintBytes = version >= 2 ? 4 : 0
             guard pathLenPos + 2 + pathLen + tintBytes <= payloadEnd else { throw ProtocolDecodeError.malformed }
             let path = try readRequiredUTF8(data[(pathLenPos + 2)..<(pathLenPos + 2 + pathLen)])
-            let tintColorRGB = version >= 2 ? readU32(data, pathLenPos + 2 + pathLen) : 0
+            let tintColorRGB = version >= 2 ? try readU32(data, pathLenPos + 2 + pathLen) : 0
 
             visibleTabs.append(Wire.WorkspaceTabEntry(
                 id: id,
@@ -2259,7 +2335,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         var framedSize: Int? = nil
 
         if data.count >= rest + 2 {
-            let payloadLen = Int(readU16(data, rest))
+            let payloadLen = Int(try readU16(data, rest))
             let end = rest + 2 + payloadLen
             if payloadLen >= 12 && data.count >= end {
                 payloadStart = rest + 2
@@ -2271,12 +2347,12 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // Payload: visible(1) + task_len(2) + task + dispatch_timestamp(8) + status(1) + can_approve(1)
         guard data.count >= payloadStart + 3 else { throw ProtocolDecodeError.malformed }
         let contextVisible = data[payloadStart] != 0
-        let taskLen = Int(readU16(data, payloadStart + 1))
+        let taskLen = Int(try readU16(data, payloadStart + 1))
         guard data.count >= payloadStart + 3 + taskLen + 10 else { throw ProtocolDecodeError.malformed }
         let taskData = data[(payloadStart + 3)..<(payloadStart + 3 + taskLen)]
-        let task = String(data: taskData, encoding: .utf8) ?? ""
+        let task = try decodeUTF8(taskData) ?? ""
         let timestampPos = payloadStart + 3 + taskLen
-        let timestampSeconds = readU64(data, timestampPos)
+        let timestampSeconds = try readU64(data, timestampPos)
         let dispatchTimestamp = Date(timeIntervalSince1970: TimeInterval(timestampSeconds))
         let statusRaw = data[timestampPos + 8]
         let canApprove = data[timestampPos + 9] != 0
@@ -2286,20 +2362,20 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
         if let payloadEnd {
             if contextPos + 2 <= payloadEnd {
-                let actionLen = Int(readU16(data, contextPos))
+                let actionLen = Int(try readU16(data, contextPos))
                 if contextPos + 2 + actionLen + 4 <= payloadEnd {
                     let actionStart = contextPos + 2
-                    let activeAction = String(data: data[actionStart..<(actionStart + actionLen)], encoding: .utf8) ?? ""
+                    let activeAction = try decodeUTF8(data[actionStart..<(actionStart + actionLen)]) ?? ""
                     contextPos = actionStart + actionLen
-                    let toolCount = readU16(data, contextPos)
-                    let fileCount = readU16(data, contextPos + 2)
+                    let toolCount = try readU16(data, contextPos)
+                    let fileCount = try readU16(data, contextPos + 2)
                     contextPos += 4
 
                     if contextPos + 2 <= payloadEnd {
-                        let hintLen = Int(readU16(data, contextPos))
+                        let hintLen = Int(try readU16(data, contextPos))
                         if contextPos + 2 + hintLen <= payloadEnd {
                             let hintStart = contextPos + 2
-                            let reviewHint = String(data: data[hintStart..<(hintStart + hintLen)], encoding: .utf8) ?? ""
+                            let reviewHint = try decodeUTF8(data[hintStart..<(hintStart + hintLen)]) ?? ""
                             contextPos = hintStart + hintLen
                             progress = Wire.AgentProgress(activeAction: activeAction, toolCount: toolCount, fileCount: fileCount, reviewHint: reviewHint)
                         }
@@ -2315,10 +2391,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 for _ in 0..<todoCount {
                     guard contextPos + 3 <= payloadEnd else { break }
                     let status = data[contextPos]
-                    let descriptionLen = Int(readU16(data, contextPos + 1))
+                    let descriptionLen = Int(try readU16(data, contextPos + 1))
                     guard contextPos + 3 + descriptionLen <= payloadEnd else { break }
                     let descriptionStart = contextPos + 3
-                    let description = String(data: data[descriptionStart..<(descriptionStart + descriptionLen)], encoding: .utf8) ?? ""
+                    let description = try decodeUTF8(data[descriptionStart..<(descriptionStart + descriptionLen)]) ?? ""
                     todos.append(Wire.AgentTodo(status: status, description: description))
                     contextPos = descriptionStart + descriptionLen
                 }
@@ -2334,21 +2410,21 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // visible(1) + selected_index(2) + entry_count(2)
         guard data.count >= rest + 5 else { throw ProtocolDecodeError.malformed }
         let csVisible = data[rest] != 0
-        let csSelectedIndex = Int(readU16(data, rest + 1))
-        let entryCount = Int(readU16(data, rest + 3))
+        let csSelectedIndex = Int(try readU16(data, rest + 1))
+        let entryCount = Int(try readU16(data, rest + 3))
         var csEntries: [ChangeSummaryEntry] = []
         csEntries.reserveCapacity(entryCount)
         var csPos = rest + 5
         for idx in 0..<entryCount {
             // path_len(2) + path + action(1) + lines_added(4) + lines_removed(4)
             guard data.count >= csPos + 2 else { throw ProtocolDecodeError.malformed }
-            let pathLen = Int(readU16(data, csPos))
+            let pathLen = Int(try readU16(data, csPos))
             guard data.count >= csPos + 2 + pathLen + 1 + 4 + 4 else { throw ProtocolDecodeError.malformed }
             let pathData = data[(csPos + 2)..<(csPos + 2 + pathLen)]
-            let path = String(data: pathData, encoding: .utf8) ?? ""
+            let path = try decodeUTF8(pathData) ?? ""
             let actionByte = data[csPos + 2 + pathLen]
-            let linesAdded = readU32(data, csPos + 2 + pathLen + 1)
-            let linesRemoved = readU32(data, csPos + 2 + pathLen + 5)
+            let linesAdded = try readU32(data, csPos + 2 + pathLen + 1)
+            let linesRemoved = try readU32(data, csPos + 2 + pathLen + 5)
             csEntries.append(ChangeSummaryEntry(
                 id: idx,
                 path: path,
@@ -2365,27 +2441,27 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // Forward-compatible format: opcode(1) + payload_length(2) + payload
         // Payload: window_id(2) + tab_width(1) + active_guide_col(2) + guide_count(1) + guide_cols(2 each)
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let igPayloadLen = Int(readU16(data, rest))
+        let igPayloadLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + igPayloadLen, igPayloadLen >= 6 else {
             throw ProtocolDecodeError.malformed
         }
         let igStart = rest + 2
-        let igWinId = readU16(data, igStart)
+        let igWinId = try readU16(data, igStart)
         let igTabWidth = data[igStart + 2]
-        let igActiveCol = readU16(data, igStart + 3)
+        let igActiveCol = try readU16(data, igStart + 3)
         let igGuideCount = Int(data[igStart + 5])
         var igCols: [UInt16] = []
         igCols.reserveCapacity(igGuideCount)
         var igPos = igStart + 6
         for _ in 0..<igGuideCount {
             guard igPos + 2 <= rest + 2 + igPayloadLen else { break }
-            igCols.append(readU16(data, igPos))
+            igCols.append(try readU16(data, igPos))
             igPos += 2
         }
         var igLineLevels: [UInt8] = []
         let igEnd = rest + 2 + igPayloadLen
         if igPos + 2 <= igEnd {
-            let igLineCount = Int(readU16(data, igPos))
+            let igLineCount = Int(try readU16(data, igPos))
             igPos += 2
             igLineLevels.reserveCapacity(igLineCount)
             for _ in 0..<igLineCount {
@@ -2402,18 +2478,18 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
     case OP_GUI_LINE_SPACING:
         // Forward-compatible format: opcode(1) + payload_length(2) + spacing_x100(2)
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let lsPayloadLen = Int(readU16(data, rest))
+        let lsPayloadLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + lsPayloadLen, lsPayloadLen >= 2 else {
             throw ProtocolDecodeError.malformed
         }
-        let spacingX100 = readU16(data, rest + 2)
+        let spacingX100 = try readU16(data, rest + 2)
         let spacing = Float(spacingX100) / 100.0
         return (.guiLineSpacing(spacing: spacing), 1 + 2 + lsPayloadLen)
 
     case OP_GUI_CURSOR_ANIMATION:
         // Forward-compatible format: opcode(1) + payload_length(2) + enabled(1)
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let caPayloadLen = Int(readU16(data, rest))
+        let caPayloadLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + caPayloadLen, caPayloadLen >= 1 else {
             throw ProtocolDecodeError.malformed
         }
@@ -2421,13 +2497,13 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_GUI_EDIT_TIMELINE:
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU16(data, rest))
+        let payloadLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + payloadLen, payloadLen >= 4 else {
             throw ProtocolDecodeError.malformed
         }
         let pStart = rest + 2
         let visible = data[pStart] != 0
-        let viewingIndex = readU16(data, pStart + 1)
+        let viewingIndex = try readU16(data, pStart + 1)
         let entryCount = Int(data[pStart + 3])
         var entries: [Wire.TimelineEntry] = []
         var ePos = pStart + 4
@@ -2437,9 +2513,9 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let nameLen = Int(data[ePos + 1])
             ePos += 2
             guard ePos + nameLen + 4 <= pStart + payloadLen else { break }
-            let toolName = String(data: data[ePos..<(ePos + nameLen)], encoding: .utf8) ?? ""
+            let toolName = try decodeUTF8(data[ePos..<(ePos + nameLen)]) ?? ""
             ePos += nameLen
-            let tsDelta = readU32(data, ePos)
+            let tsDelta = try readU32(data, ePos)
             ePos += 4
             entries.append(Wire.TimelineEntry(index: idx, toolName: toolName, timestampDelta: tsDelta))
         }
@@ -2451,14 +2527,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
             for _ in 0..<fileCount {
                 guard ePos + 2 <= pStart + payloadLen else { break }
-                let pathLen = Int(readU16(data, ePos))
+                let pathLen = Int(try readU16(data, ePos))
                 guard ePos + 2 + pathLen + 10 <= pStart + payloadLen else { break }
                 let pathStart = ePos + 2
-                let path = String(data: data[pathStart..<(pathStart + pathLen)], encoding: .utf8) ?? ""
+                let path = try decodeUTF8(data[pathStart..<(pathStart + pathLen)]) ?? ""
                 ePos = pathStart + pathLen
                 let entryCount = data[ePos]
-                let linesAdded = readU32(data, ePos + 1)
-                let linesRemoved = readU32(data, ePos + 5)
+                let linesAdded = try readU32(data, ePos + 1)
+                let linesRemoved = try readU32(data, ePos + 5)
                 let reviewStatus = data[ePos + 9]
                 ePos += 10
                 files.append(Wire.TimelineFile(path: path, entryCount: entryCount, linesAdded: linesAdded, linesRemoved: linesRemoved, reviewStatus: reviewStatus))
@@ -2468,7 +2544,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_GUI_EXTENSION_OVERLAY:
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let eoPayloadLen = Int(readU16(data, rest))
+        let eoPayloadLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + eoPayloadLen, eoPayloadLen >= 1 else {
             throw ProtocolDecodeError.malformed
         }
@@ -2481,15 +2557,15 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard eoPos + 1 <= eoEnd else { break }
             let extNameLen = Int(data[eoPos]); eoPos += 1
             guard eoPos + extNameLen + 1 <= eoEnd else { break }
-            let extName = String(data: data[eoPos..<(eoPos + extNameLen)], encoding: .utf8) ?? ""
+            let extName = try decodeUTF8(data[eoPos..<(eoPos + extNameLen)]) ?? ""
             eoPos += extNameLen
             let oidLen = Int(data[eoPos]); eoPos += 1
             guard eoPos + oidLen + 11 <= eoEnd else { break }
-            let oid = String(data: data[eoPos..<(eoPos + oidLen)], encoding: .utf8) ?? ""
+            let oid = try decodeUTF8(data[eoPos..<(eoPos + oidLen)]) ?? ""
             eoPos += oidLen
-            let winId = readU16(data, eoPos)
-            let row = readU16(data, eoPos + 2)
-            let col = readU16(data, eoPos + 4)
+            let winId = try readU16(data, eoPos)
+            let row = try readU16(data, eoPos + 2)
+            let col = try readU16(data, eoPos + 4)
             let shape = data[eoPos + 6]
             let cr = data[eoPos + 7]
             let cg = data[eoPos + 8]
@@ -2497,9 +2573,9 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let opacity = data[eoPos + 10]
             eoPos += 11
             guard eoPos + 2 <= eoEnd else { break }
-            let contentLen = Int(readU16(data, eoPos)); eoPos += 2
+            let contentLen = Int(try readU16(data, eoPos)); eoPos += 2
             guard eoPos + contentLen <= eoEnd else { break }
-            let content = String(data: data[eoPos..<(eoPos + contentLen)], encoding: .utf8) ?? ""
+            let content = try decodeUTF8(data[eoPos..<(eoPos + contentLen)]) ?? ""
             eoPos += contentLen
             eoEntries.append(Wire.ExtensionOverlayEntry(
                 extensionName: extName, overlayID: oid, windowID: winId,
@@ -2512,7 +2588,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_GUI_EXTENSION_PANEL:
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let epPayloadLen = Int(readU16(data, rest))
+        let epPayloadLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + epPayloadLen, epPayloadLen >= 1 else {
             throw ProtocolDecodeError.malformed
         }
@@ -2525,17 +2601,17 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard epPos + 1 <= epEnd else { break }
             let extLen = Int(data[epPos]); epPos += 1
             guard epPos + extLen <= epEnd else { break }
-            let extName = String(data: data[epPos..<(epPos + extLen)], encoding: .utf8) ?? ""
+            let extName = try decodeUTF8(data[epPos..<(epPos + extLen)]) ?? ""
             epPos += extLen
             guard epPos + 1 <= epEnd else { break }
             let pidLen = Int(data[epPos]); epPos += 1
             guard epPos + pidLen <= epEnd else { break }
-            let panelId = String(data: data[epPos..<(epPos + pidLen)], encoding: .utf8) ?? ""
+            let panelId = try decodeUTF8(data[epPos..<(epPos + pidLen)]) ?? ""
             epPos += pidLen
             guard epPos + 1 <= epEnd else { break }
             let titleLen = Int(data[epPos]); epPos += 1
             guard epPos + titleLen + 4 <= epEnd else { break }
-            let title = String(data: data[epPos..<(epPos + titleLen)], encoding: .utf8) ?? ""
+            let title = try decodeUTF8(data[epPos..<(epPos + titleLen)]) ?? ""
             epPos += titleLen
             let pos = data[epPos]
             let sizeType = data[epPos + 1]
@@ -2551,9 +2627,9 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 switch blockType {
                 case 0: // text
                     guard epPos + 2 <= epEnd else { break }
-                    let tLen = Int(readU16(data, epPos)); epPos += 2
+                    let tLen = Int(try readU16(data, epPos)); epPos += 2
                     guard epPos + tLen <= epEnd else { break }
-                    let t = String(data: data[epPos..<(epPos + tLen)], encoding: .utf8) ?? ""
+                    let t = try decodeUTF8(data[epPos..<(epPos + tLen)]) ?? ""
                     epPos += tLen
                     blocks.append(.text(t))
                 case 1: // styled_text
@@ -2562,9 +2638,9 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     var runs: [(text: String, r: UInt8, g: UInt8, b: UInt8, bold: Bool, italic: Bool)] = []
                     for _ in 0..<runCount {
                         guard epPos + 2 <= epEnd else { break }
-                        let stLen = Int(readU16(data, epPos)); epPos += 2
+                        let stLen = Int(try readU16(data, epPos)); epPos += 2
                         guard epPos + stLen + 5 <= epEnd else { break }
-                        let stText = String(data: data[epPos..<(epPos + stLen)], encoding: .utf8) ?? ""
+                        let stText = try decodeUTF8(data[epPos..<(epPos + stLen)]) ?? ""
                         epPos += stLen
                         let stR = data[epPos]; let stG = data[epPos + 1]; let stB = data[epPos + 2]
                         let stBold = data[epPos + 3] != 0; let stItalic = data[epPos + 4] != 0
@@ -2575,15 +2651,15 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 case 2: // table
                     guard epPos + 5 <= epEnd else { break }
                     let colCount = Int(data[epPos])
-                    let rowCount = Int(readU16(data, epPos + 1))
-                    let selected = readU16(data, epPos + 3)
+                    let rowCount = Int(try readU16(data, epPos + 1))
+                    let selected = try readU16(data, epPos + 3)
                     epPos += 5
                     var columns: [String] = []
                     for _ in 0..<colCount {
                         guard epPos + 2 <= epEnd else { break }
-                        let cLen = Int(readU16(data, epPos)); epPos += 2
+                        let cLen = Int(try readU16(data, epPos)); epPos += 2
                         guard epPos + cLen <= epEnd else { break }
-                        columns.append(String(data: data[epPos..<(epPos + cLen)], encoding: .utf8) ?? "")
+                        columns.append(try decodeUTF8(data[epPos..<(epPos + cLen)]) ?? "")
                         epPos += cLen
                     }
                     var rows: [[String]] = []
@@ -2591,9 +2667,9 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                         var row: [String] = []
                         for _ in 0..<colCount {
                             guard epPos + 2 <= epEnd else { break }
-                            let cellLen = Int(readU16(data, epPos)); epPos += 2
+                            let cellLen = Int(try readU16(data, epPos)); epPos += 2
                             guard epPos + cellLen <= epEnd else { break }
-                            row.append(String(data: data[epPos..<(epPos + cellLen)], encoding: .utf8) ?? "")
+                            row.append(try decodeUTF8(data[epPos..<(epPos + cellLen)]) ?? "")
                             epPos += cellLen
                         }
                         rows.append(row)
@@ -2605,13 +2681,13 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     var pairs: [(key: String, value: String)] = []
                     for _ in 0..<pairCount {
                         guard epPos + 2 <= epEnd else { break }
-                        let kLen = Int(readU16(data, epPos)); epPos += 2
+                        let kLen = Int(try readU16(data, epPos)); epPos += 2
                         guard epPos + kLen + 2 <= epEnd else { break }
-                        let k = String(data: data[epPos..<(epPos + kLen)], encoding: .utf8) ?? ""
+                        let k = try decodeUTF8(data[epPos..<(epPos + kLen)]) ?? ""
                         epPos += kLen
-                        let vLen = Int(readU16(data, epPos)); epPos += 2
+                        let vLen = Int(try readU16(data, epPos)); epPos += 2
                         guard epPos + vLen <= epEnd else { break }
-                        let v = String(data: data[epPos..<(epPos + vLen)], encoding: .utf8) ?? ""
+                        let v = try decodeUTF8(data[epPos..<(epPos + vLen)]) ?? ""
                         epPos += vLen
                         pairs.append((key: k, value: v))
                     }
@@ -2620,15 +2696,15 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     blocks.append(.separator)
                 case 5: // progress
                     guard epPos + 4 <= epEnd else { break }
-                    let labelLen = Int(readU16(data, epPos)); epPos += 2
+                    let labelLen = Int(try readU16(data, epPos)); epPos += 2
                     guard epPos + labelLen + 2 <= epEnd else { break }
-                    let label = String(data: data[epPos..<(epPos + labelLen)], encoding: .utf8) ?? ""
+                    let label = try decodeUTF8(data[epPos..<(epPos + labelLen)]) ?? ""
                     epPos += labelLen
-                    let pctInt = readU16(data, epPos); epPos += 2
+                    let pctInt = try readU16(data, epPos); epPos += 2
                     blocks.append(.progress(label: label, percent: Float(pctInt) / 100.0))
                 case 6: // tree (length-prefixed, skip payload)
                     guard epPos + 2 <= epEnd else { break }
-                    let treeLen = Int(readU16(data, epPos)); epPos += 2
+                    let treeLen = Int(try readU16(data, epPos)); epPos += 2
                     guard epPos + treeLen <= epEnd else { break }
                     epPos += treeLen
                     blocks.append(.unknown)
@@ -2647,7 +2723,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
     case OP_GUI_EXTENSION_RUNTIME:
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU32(data, rest))
+        let payloadLen = Int(try readU32(data, rest))
         let payloadStart = rest + 4
         let payloadEnd = payloadStart + payloadLen
         guard data.count >= payloadEnd else { throw ProtocolDecodeError.malformed }
@@ -2660,27 +2736,27 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
     case OP_GUI_SEARCH_STATE:
         // Forward-compatible format: opcode(1) + payload_len(2) + active(1) + match_count(2) + current_index(2) + flags(1)
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let ssPayloadLen = Int(readU16(data, rest))
+        let ssPayloadLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + ssPayloadLen, ssPayloadLen >= 6 else {
             throw ProtocolDecodeError.malformed
         }
         let ssStart = rest + 2
         let ssActive = data[ssStart] != 0
-        let ssMatchCount = readU16(data, ssStart + 1)
-        let ssCurrentIndex = readU16(data, ssStart + 3)
+        let ssMatchCount = try readU16(data, ssStart + 1)
+        let ssCurrentIndex = try readU16(data, ssStart + 3)
         let ssFlags = data[ssStart + 5]
         return (.guiSearchState(active: ssActive, matchCount: ssMatchCount, currentIndex: ssCurrentIndex, flags: ssFlags), 1 + 2 + ssPayloadLen)
 
     case OP_GUI_SIDEBARS:
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU32(data, rest))
+        let payloadLen = Int(try readU32(data, rest))
         let payloadStart = rest + 4
         let payloadEnd = payloadStart + payloadLen
         guard data.count >= payloadEnd, payloadLen >= 5 else { throw ProtocolDecodeError.malformed }
 
         var pos = payloadStart
         let version = data[pos]; pos += 1
-        let count = Int(readU16(data, pos)); pos += 2
+        let count = Int(try readU16(data, pos)); pos += 2
         let activeId = try readString16(data: data, pos: &pos, end: payloadEnd)
         var sidebars: [Wire.SidebarMetadata] = []
         sidebars.reserveCapacity(count)
@@ -2691,10 +2767,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let semanticKind = try readString16(data: data, pos: &pos, end: payloadEnd)
             let icon = try readString16(data: data, pos: &pos, end: payloadEnd)
             guard pos + 7 <= payloadEnd else { throw ProtocolDecodeError.malformed }
-            let order = readU16(data, pos); pos += 2
+            let order = try readU16(data, pos); pos += 2
             let flags = data[pos]; pos += 1
-            let preferredWidth = readU16(data, pos); pos += 2
-            let rawBadgeCount = readU16(data, pos); pos += 2
+            let preferredWidth = try readU16(data, pos); pos += 2
+            let rawBadgeCount = try readU16(data, pos); pos += 2
             let badgeCount: UInt16? = rawBadgeCount == UInt16.max ? nil : rawBadgeCount
 
             sidebars.append(Wire.SidebarMetadata(
@@ -2716,14 +2792,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
     case OP_CLIPBOARD_WRITE:
         // Forward-compatible format: opcode(1) + payload_length(4) + target(1) + text_len(4) + text
         guard data.count >= rest + 4 else { throw ProtocolDecodeError.malformed }
-        let payloadLen = Int(readU32(data, rest))
+        let payloadLen = Int(try readU32(data, rest))
         guard payloadLen >= 5, data.count >= rest + 4 + payloadLen else { throw ProtocolDecodeError.malformed }
         let payloadStart = rest + 4
         let target = data[payloadStart]
-        let textLen = Int(readU32(data, payloadStart + 1))
+        let textLen = Int(try readU32(data, payloadStart + 1))
         guard payloadLen == 5 + textLen else { throw ProtocolDecodeError.malformed }
         let textData = data[(payloadStart + 5)..<(payloadStart + 5 + textLen)]
-        let text = String(data: textData, encoding: .utf8) ?? ""
+        let text = try decodeUTF8(textData) ?? ""
         return (.clipboardWrite(target: target, text: text), 1 + 4 + payloadLen)
 
     case OP_PROTOCOL_ERROR:
@@ -2732,10 +2808,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // the BEAM's, so the frontend shows a blocking error instead of decoding
         // a stream it cannot parse (ticket #2237).
         guard data.count >= rest + 2 else { throw ProtocolDecodeError.malformed }
-        let messageLen = Int(readU16(data, rest))
+        let messageLen = Int(try readU16(data, rest))
         guard data.count >= rest + 2 + messageLen else { throw ProtocolDecodeError.malformed }
         let messageData = data[(rest + 2)..<(rest + 2 + messageLen)]
-        let message = String(data: messageData, encoding: .utf8) ?? ""
+        let message = try decodeUTF8(messageData) ?? ""
         return (.protocolError(message: message), 1 + 2 + messageLen)
 
     default:
@@ -2752,7 +2828,7 @@ private func decodeNotifications(data: Data, start: Int, end: Int) throws -> [Wi
     pos += 1
     guard version == 1 else { throw ProtocolDecodeError.malformed }
 
-    let count = Int(readU16(data, pos))
+    let count = Int(try readU16(data, pos))
     pos += 2
 
     var notifications: [Wire.EditorNotification] = []
@@ -2765,11 +2841,11 @@ private func decodeNotifications(data: Data, start: Int, end: Int) throws -> [Wi
         pos += 1
         let flags = data[pos]
         pos += 1
-        let createdAt = readU64(data, pos)
+        let createdAt = try readU64(data, pos)
         pos += 8
-        let updatedAt = readU64(data, pos)
+        let updatedAt = try readU64(data, pos)
         pos += 8
-        let rawAutoDismiss = readU32(data, pos)
+        let rawAutoDismiss = try readU32(data, pos)
         pos += 4
         let title = try readString16(data: data, pos: &pos, end: end)
         let body = try readString16(data: data, pos: &pos, end: end)
@@ -2812,7 +2888,7 @@ private func decodeNotifications(data: Data, start: Int, end: Int) throws -> [Wi
 private func decodeConfigState(data: Data, start: Int, end: Int) throws -> Wire.ConfigState {
     var pos = start
     guard pos + 2 <= end else { throw ProtocolDecodeError.malformed }
-    let optionCount = Int(readU16(data, pos))
+    let optionCount = Int(try readU16(data, pos))
     pos += 2
 
     var options: [String: SettingValue] = [:]
@@ -2823,7 +2899,7 @@ private func decodeConfigState(data: Data, start: Int, end: Int) throws -> Wire.
     }
 
     guard pos + 2 <= end else { throw ProtocolDecodeError.malformed }
-    let previewCount = Int(readU16(data, pos))
+    let previewCount = Int(try readU16(data, pos))
     pos += 2
 
     var previews: [Wire.ThemePreview] = []
@@ -2832,15 +2908,15 @@ private func decodeConfigState(data: Data, start: Int, end: Int) throws -> Wire.
         let name = try readString8(data: data, pos: &pos, end: end)
         let atom = try readString8(data: data, pos: &pos, end: end)
         guard pos + 9 <= end else { throw ProtocolDecodeError.malformed }
-        let editorBg = readU24(data, pos)
-        let editorFg = readU24(data, pos + 3)
-        let accent = readU24(data, pos + 6)
+        let editorBg = try readU24(data, pos)
+        let editorFg = try readU24(data, pos + 3)
+        let accent = try readU24(data, pos + 6)
         pos += 9
         previews.append(Wire.ThemePreview(name: name, atom: atom, editorBg: editorBg, editorFg: editorFg, accent: accent))
     }
 
     guard pos + 2 <= end else { throw ProtocolDecodeError.malformed }
-    let bindingCount = Int(readU16(data, pos))
+    let bindingCount = Int(try readU16(data, pos))
     pos += 2
 
     var bindings: [Wire.KeybindingEntry] = []
@@ -2870,7 +2946,7 @@ private func readSettingValue(data: Data, pos: inout Int, end: Int) throws -> Se
         return .bool(enabled)
     case SETTING_VALUE_INT:
         guard pos + 4 <= end else { throw ProtocolDecodeError.malformed }
-        let value = Int(Int32(bitPattern: readU32(data, pos)))
+        let value = Int(Int32(bitPattern: try readU32(data, pos)))
         pos += 4
         return .int(value)
     case SETTING_VALUE_STRING:
@@ -2879,7 +2955,7 @@ private func readSettingValue(data: Data, pos: inout Int, end: Int) throws -> Se
         return .atom(try readString16(data: data, pos: &pos, end: end))
     case SETTING_VALUE_FLOAT:
         guard pos + 8 <= end else { throw ProtocolDecodeError.malformed }
-        let bits = readU64(data, pos)
+        let bits = try readU64(data, pos)
         pos += 8
         return .float(Double(bitPattern: bits))
     default:
@@ -2899,7 +2975,7 @@ private func readString8(data: Data, pos: inout Int, end: Int) throws -> String 
 
 private func readString16(data: Data, pos: inout Int, end: Int) throws -> String {
     guard pos + 2 <= end else { throw ProtocolDecodeError.malformed }
-    let len = Int(readU16(data, pos))
+    let len = Int(try readU16(data, pos))
     pos += 2
     guard pos + len <= end else { throw ProtocolDecodeError.malformed }
     let string = try readRequiredUTF8(data[pos..<(pos + len)])
@@ -2916,7 +2992,7 @@ private func legacyFileTreeState(treeFlags: UInt8) -> UInt8 {
 }
 
 private func readRequiredUTF8(_ data: Data.SubSequence) throws -> String {
-    guard let string = String(data: data, encoding: .utf8) else {
+    guard let string = try decodeUTF8(data) else {
         throw ProtocolDecodeError.malformed
     }
     return string
@@ -2932,22 +3008,22 @@ private func decodeStatusBarSegments(data: Data, pos: inout Int, count: Int, end
             guard pos + 1 <= end else { throw ProtocolDecodeError.malformed }
             let kindLen = Int(data[pos]); pos += 1
             guard pos + kindLen <= end else { throw ProtocolDecodeError.malformed }
-            guard let decodedKind = String(data: data[pos..<(pos + kindLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+            guard let decodedKind = try decodeUTF8(data[pos..<(pos + kindLen)]) else { throw ProtocolDecodeError.malformed }
             kind = decodedKind
             pos += kindLen
         }
 
         guard pos + 9 <= end else { throw ProtocolDecodeError.malformed }
-        let fg = readU24(data, pos); pos += 3
-        let bg = readU24(data, pos); pos += 3
+        let fg = try readU24(data, pos); pos += 3
+        let bg = try readU24(data, pos); pos += 3
         let attrs = data[pos]; pos += 1
-        let textLen = Int(readU16(data, pos)); pos += 2
+        let textLen = Int(try readU16(data, pos)); pos += 2
         guard pos + textLen + 2 <= end else { throw ProtocolDecodeError.malformed }
-        guard let text = String(data: data[pos..<(pos + textLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+        guard let text = try decodeUTF8(data[pos..<(pos + textLen)]) else { throw ProtocolDecodeError.malformed }
         pos += textLen
-        let commandLen = Int(readU16(data, pos)); pos += 2
+        let commandLen = Int(try readU16(data, pos)); pos += 2
         guard pos + commandLen <= end else { throw ProtocolDecodeError.malformed }
-        guard let command = String(data: data[pos..<(pos + commandLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+        guard let command = try decodeUTF8(data[pos..<(pos + commandLen)]) else { throw ProtocolDecodeError.malformed }
         pos += commandLen
         segments.append(Wire.StatusBarSegment(id: index, kind: kind, text: text, fgColor: fg, bgColor: bg, attrs: attrs, command: command))
     }
@@ -2980,22 +3056,22 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
         if selType != 0, length >= 9 {
             sections.selection = GUISelectionOverlay(
                 type: GUISelectionType(rawValue: selType) ?? .char,
-                startRow: readU16(data, start + 1), startCol: readU16(data, start + 3),
-                endRow: readU16(data, start + 5), endCol: readU16(data, start + 7)
+                startRow: try readU16(data, start + 1), startCol: try readU16(data, start + 3),
+                endRow: try readU16(data, start + 5), endCol: try readU16(data, start + 7)
             )
         }
         return true
 
     case 0x04: // Search matches
         guard length >= 2 else { break }
-        let count = Int(readU16(data, start))
+        let count = Int(try readU16(data, start))
         sections.searchMatches.reserveCapacity(count)
         var pos = start + 2
         for _ in 0..<count {
             guard pos + 7 <= end else { break }
             sections.searchMatches.append(GUISearchMatch(
-                row: readU16(data, pos), startCol: readU16(data, pos + 2),
-                endCol: readU16(data, pos + 4), isCurrent: data[pos + 6] != 0
+                row: try readU16(data, pos), startCol: try readU16(data, pos + 2),
+                endCol: try readU16(data, pos + 4), isCurrent: data[pos + 6] != 0
             ))
             pos += 7
         }
@@ -3003,14 +3079,14 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
 
     case 0x05: // Diagnostics
         guard length >= 2 else { break }
-        let count = Int(readU16(data, start))
+        let count = Int(try readU16(data, start))
         sections.diagnosticUnderlines.reserveCapacity(count)
         var pos = start + 2
         for _ in 0..<count {
             guard pos + 9 <= end else { break }
             sections.diagnosticUnderlines.append(GUIDiagnosticUnderline(
-                startRow: readU16(data, pos), startCol: readU16(data, pos + 2),
-                endRow: readU16(data, pos + 4), endCol: readU16(data, pos + 6),
+                startRow: try readU16(data, pos), startCol: try readU16(data, pos + 2),
+                endRow: try readU16(data, pos + 4), endCol: try readU16(data, pos + 6),
                 severity: GUIDiagnosticSeverity(rawValue: data[pos + 8]) ?? .error
             ))
             pos += 9
@@ -3019,14 +3095,14 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
 
     case 0x06: // Document highlights
         guard length >= 2 else { break }
-        let count = Int(readU16(data, start))
+        let count = Int(try readU16(data, start))
         sections.documentHighlights.reserveCapacity(count)
         var pos = start + 2
         for _ in 0..<count {
             guard pos + 9 <= end else { break }
             sections.documentHighlights.append(GUIDocumentHighlight(
-                startRow: readU16(data, pos), startCol: readU16(data, pos + 2),
-                endRow: readU16(data, pos + 4), endCol: readU16(data, pos + 6),
+                startRow: try readU16(data, pos), startCol: try readU16(data, pos + 2),
+                endRow: try readU16(data, pos + 4), endCol: try readU16(data, pos + 6),
                 kind: GUIDocumentHighlightKind(rawValue: data[pos + 8]) ?? .text
             ))
             pos += 9
@@ -3035,19 +3111,19 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
 
     case 0x07: // Line annotations
         guard length >= 2 else { break }
-        let count = Int(readU16(data, start))
+        let count = Int(try readU16(data, start))
         sections.lineAnnotations.reserveCapacity(count)
         var pos = start + 2
         for _ in 0..<count {
             guard pos + 11 <= end else { break }
-            let annRow = readU16(data, pos)
+            let annRow = try readU16(data, pos)
             let annKind = GUILineAnnotationKind(rawValue: data[pos + 2]) ?? .inlinePill
-            let annFg = readU24(data, pos + 3)
-            let annBg = readU24(data, pos + 6)
-            let annTextLen = Int(readU16(data, pos + 9))
+            let annFg = try readU24(data, pos + 3)
+            let annBg = try readU24(data, pos + 6)
+            let annTextLen = Int(try readU16(data, pos + 9))
             pos += 11
             guard pos + annTextLen <= end else { break }
-            let annText = String(data: Data(data[pos..<(pos + annTextLen)]), encoding: .utf8) ?? ""
+            let annText = try decodeUTF8(data[pos..<(pos + annTextLen)]) ?? ""
             pos += annTextLen
             sections.lineAnnotations.append(GUILineAnnotation(row: annRow, kind: annKind, fg: annFg, bg: annBg, text: annText))
         }
@@ -3059,7 +3135,7 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
 
     case 0x09: // Cursorline
         guard length >= 5 else { break }
-        sections.cursorline = GUICursorline(row: readU16(data, start), bg: readU24(data, start + 2))
+        sections.cursorline = GUICursorline(row: try readU16(data, start), bg: try readU24(data, start + 2))
         return true
 
     case 0x0A: // ScrollPresentation
@@ -3091,24 +3167,23 @@ private func decodeWindowRowsDelta(data: Data, offset: Int) throws -> (GUIWindow
     var sawRows = false
 
     for _ in 0..<sectionCount {
-        guard data.count >= pos + 5 else { throw ProtocolDecodeError.malformed }
-        let sectionId = data[pos]
-        let sectionLen = Int(readU32(data, pos + 1))
-        let sectionStart = pos + 5
-        let sectionEnd = sectionStart + sectionLen
-        guard data.count >= sectionEnd else { throw ProtocolDecodeError.malformed }
+        let section = try readSection32(data, at: pos, containingEnd: data.endIndex)
+        let sectionId = section.id
+        let sectionStart = section.start
+        let sectionEnd = section.end
+        let sectionLen = sectionEnd - sectionStart
 
         switch sectionId {
         case 0x01:
             guard !sawHeader, sectionLen >= 14 else { throw ProtocolDecodeError.malformed }
             sawHeader = true
-            windowId = readU16(data, sectionStart)
-            contentEpoch = readU32(data, sectionStart + 2)
+            windowId = try readU16(data, sectionStart)
+            contentEpoch = try readU32(data, sectionStart + 2)
             cursorVisible = data[sectionStart + 6] & 0x01 != 0
-            cursorRow = readU16(data, sectionStart + 7)
-            cursorCol = readU16(data, sectionStart + 9)
+            cursorRow = try readU16(data, sectionStart + 7)
+            cursorCol = try readU16(data, sectionStart + 9)
             cursorShape = CursorShape(rawValue: data[sectionStart + 11]) ?? .block
-            scrollLeft = readU16(data, sectionStart + 12)
+            scrollLeft = try readU16(data, sectionStart + 12)
 
         case 0x02:
             guard !sawRows else { throw ProtocolDecodeError.malformed }
@@ -3152,7 +3227,7 @@ private func decodeWindowRowsDelta(data: Data, offset: Int) throws -> (GUIWindow
 
 private func decodeWindowDeltaRows(data: Data, start: Int, end: Int) throws -> [GUIWindowRowDeltaEntry] {
     guard start + 4 <= end else { throw ProtocolDecodeError.malformed }
-    let rowCount = Int(readU32(data, start))
+    let rowCount = Int(try readU32(data, start))
     var pos = start + 4
     guard rowCount <= (end - pos) / 13 else { throw ProtocolDecodeError.malformed }
     var rows: [GUIWindowRowDeltaEntry] = []
@@ -3166,7 +3241,7 @@ private func decodeWindowDeltaRows(data: Data, start: Int, end: Int) throws -> [
         switch entryKind {
         case 0:
             guard pos + 12 <= end else { throw ProtocolDecodeError.malformed }
-            rows.append(.reference(rowId: readU64(data, pos), contentHash: readU32(data, pos + 8)))
+            rows.append(.reference(rowId: try readU64(data, pos), contentHash: try readU32(data, pos + 8)))
             pos += 12
         case 1:
             let row = try decodeWindowContentRow(data: data, pos: &pos, end: end)
@@ -3182,7 +3257,7 @@ private func decodeWindowDeltaRows(data: Data, start: Int, end: Int) throws -> [
 
 private func decodeWindowContentRows(data: Data, start: Int, end: Int) throws -> [GUIVisualRow] {
     guard start + 4 <= end else { throw ProtocolDecodeError.malformed }
-    let rowCount = Int(readU32(data, start))
+    let rowCount = Int(try readU32(data, start))
     var pos = start + 4
     guard rowCount <= (end - pos) / 23 else { throw ProtocolDecodeError.malformed }
     var rows: [GUIVisualRow] = []
@@ -3200,18 +3275,18 @@ private func decodeWindowContentRows(data: Data, start: Int, end: Int) throws ->
 private func decodeWindowContentRow(data: Data, pos: inout Int, end: Int) throws -> GUIVisualRow {
     guard pos + 21 <= end else { throw ProtocolDecodeError.malformed }
     let rowType = GUIVisualRowType(rawValue: data[pos]) ?? .normal
-    let rowId = readU64(data, pos + 1)
-    let bufLine = readU32(data, pos + 9)
-    let contentHash = readU32(data, pos + 13)
-    let textLen = Int(readU32(data, pos + 17))
+    let rowId = try readU64(data, pos + 1)
+    let bufLine = try readU32(data, pos + 9)
+    let contentHash = try readU32(data, pos + 13)
+    let textLen = Int(try readU32(data, pos + 17))
     pos += 21
 
     guard pos + textLen <= end else { throw ProtocolDecodeError.malformed }
-    let text = String(data: data[pos..<(pos + textLen)], encoding: .utf8) ?? ""
+    let text = try decodeUTF8(data[pos..<(pos + textLen)]) ?? ""
     pos += textLen
 
     guard pos + 2 <= end else { throw ProtocolDecodeError.malformed }
-    let spanCount = Int(readU16(data, pos))
+    let spanCount = Int(try readU16(data, pos))
     pos += 2
 
     var spans: [GUIHighlightSpan] = []
@@ -3220,8 +3295,8 @@ private func decodeWindowContentRow(data: Data, pos: inout Int, end: Int) throws
     for _ in 0..<spanCount {
         guard pos + 13 <= end else { throw ProtocolDecodeError.malformed }
         spans.append(GUIHighlightSpan(
-            startCol: readU16(data, pos), endCol: readU16(data, pos + 2),
-            fg: readU24(data, pos + 4), bg: readU24(data, pos + 7),
+            startCol: try readU16(data, pos), endCol: try readU16(data, pos + 2),
+            fg: try readU24(data, pos + 4), bg: try readU24(data, pos + 7),
             attrs: data[pos + 10], fontWeight: data[pos + 11], fontId: data[pos + 12]
         ))
         pos += 13
@@ -3244,15 +3319,15 @@ private struct DecodedToolPreview {
 private func decodeToolPreview(data: Data, start: Int, end: Int) throws -> DecodedToolPreview {
     guard end >= start + 3 else { throw ProtocolDecodeError.malformed }
     let previewKind = data[start]
-    let lineCount = Int(readU16(data, start + 1))
+    let lineCount = Int(try readU16(data, start + 1))
     var pos = start + 3
     var previewLines: [String] = []
     previewLines.reserveCapacity(lineCount)
     for _ in 0..<lineCount {
         guard end >= pos + 2 else { throw ProtocolDecodeError.malformed }
-        let lineLen = Int(readU16(data, pos))
+        let lineLen = Int(try readU16(data, pos))
         guard end >= pos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
-        let line = String(data: data[(pos + 2)..<(pos + 2 + lineLen)], encoding: .utf8) ?? ""
+        let line = try decodeUTF8(data[(pos + 2)..<(pos + 2 + lineLen)]) ?? ""
         previewLines.append(line)
         pos += 2 + lineLen
     }
@@ -3266,7 +3341,7 @@ private func decodeFramedChatMessages(data: Data, start: Int, end: Int, count: I
 
     for _ in 0..<count {
         guard pos + 4 <= end else { throw ProtocolDecodeError.malformed }
-        let messageLen = Int(readU32(data, pos))
+        let messageLen = Int(try readU32(data, pos))
         let messageStart = pos + 4
         let messageEnd = messageStart + messageLen
         guard messageEnd <= end else { throw ProtocolDecodeError.malformed }
@@ -3308,30 +3383,30 @@ private func decodeLegacyChatMessages(data: Data, start: Int, end: Int, remainin
 
 private func decodeAgentStyledLines(data: Data, start: Int, end: Int) throws -> ([[Wire.StyledTextRun]], Int) {
     guard end >= start + 2 else { throw ProtocolDecodeError.malformed }
-    let lineCount = Int(readU16(data, start))
+    let lineCount = Int(try readU16(data, start))
     var lines: [[Wire.StyledTextRun]] = []
     lines.reserveCapacity(lineCount)
     var pos = start + 2
     for _ in 0..<lineCount {
         guard end >= pos + 2 else { throw ProtocolDecodeError.malformed }
-        let runCount = Int(readU16(data, pos))
+        let runCount = Int(try readU16(data, pos))
         var runs: [Wire.StyledTextRun] = []
         runs.reserveCapacity(runCount)
         pos += 2
         for _ in 0..<runCount {
             guard end >= pos + 9 else { throw ProtocolDecodeError.malformed }
-            let textLen = Int(readU16(data, pos))
+            let textLen = Int(try readU16(data, pos))
             guard end >= pos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
-            let runText = String(data: data[(pos + 2)..<(pos + 2 + textLen)], encoding: .utf8) ?? ""
+            let runText = try decodeUTF8(data[(pos + 2)..<(pos + 2 + textLen)]) ?? ""
             let fgOff = pos + 2 + textLen
             let flags = data[fgOff + 6]
             var nextRunPos = fgOff + 7
             var linkURL: String? = nil
             if (flags & 0x08) != 0 {
                 guard end >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
-                let urlLen = Int(readU16(data, nextRunPos))
+                let urlLen = Int(try readU16(data, nextRunPos))
                 guard end >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
-                guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+                guard let decodedLinkURL = try decodeUTF8(data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)]) else { throw ProtocolDecodeError.malformed }
                 linkURL = decodedLinkURL
                 nextRunPos += 2 + urlLen
             }
@@ -3354,13 +3429,13 @@ private func decodeAgentStyledLines(data: Data, start: Int, end: Int) throws -> 
 
 private func decodeAgentMarkdownBlocks(data: Data, start: Int, end: Int) throws -> ([Wire.AgentMarkdownBlock], Int) {
     guard end >= start + 2 else { throw ProtocolDecodeError.malformed }
-    let blockCount = Int(readU16(data, start))
+    let blockCount = Int(try readU16(data, start))
     var blocks: [Wire.AgentMarkdownBlock] = []
     blocks.reserveCapacity(blockCount)
     var pos = start + 2
     for _ in 0..<blockCount {
         guard end >= pos + 6 else { throw ProtocolDecodeError.malformed }
-        let blockID = readU32(data, pos)
+        let blockID = try readU32(data, pos)
         let rawKind = data[pos + 4]
         let flags = data[pos + 5]
         guard let kind = Wire.AgentMarkdownBlockKind(rawValue: rawKind) else { throw ProtocolDecodeError.malformed }
@@ -3387,7 +3462,7 @@ private func decodeAgentMarkdownBlocks(data: Data, start: Int, end: Int) throws 
             guard end >= pos + 6 else { throw ProtocolDecodeError.malformed }
             indent = data[pos]
             ordered = data[pos + 1] != 0
-            ordinal = readU32(data, pos + 2)
+            ordinal = try readU32(data, pos + 2)
             (lines, pos) = try decodeAgentStyledLines(data: data, start: pos + 6, end: end)
         case .rule:
             break
@@ -3412,9 +3487,9 @@ private func decodeAgentMarkdownBlocks(data: Data, start: Int, end: Int) throws 
 
 private func readRequiredString16(data: Data, pos: inout Int, end: Int) throws -> String {
     guard end >= pos + 2 else { throw ProtocolDecodeError.malformed }
-    let length = Int(readU16(data, pos))
+    let length = Int(try readU16(data, pos))
     guard end >= pos + 2 + length else { throw ProtocolDecodeError.malformed }
-    let value = String(data: data[(pos + 2)..<(pos + 2 + length)], encoding: .utf8) ?? ""
+    let value = try decodeUTF8(data[(pos + 2)..<(pos + 2 + length)]) ?? ""
     pos += 2 + length
     return value
 }
@@ -3422,7 +3497,7 @@ private func readRequiredString16(data: Data, pos: inout Int, end: Int) throws -
 private func decodeChatMessageCandidates(data: Data, start: Int, end: Int) throws -> [DecodedChatMessageCandidate] {
     guard start + 4 <= end else { throw ProtocolDecodeError.malformed }
 
-    let beamId = readU32(data, start)
+    let beamId = try readU32(data, start)
     return try decodeChatMessageBodyCandidates(data: data, beamId: beamId, bodyStart: start + 4, end: end)
 }
 
@@ -3441,24 +3516,24 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
     switch msgType {
     case 0x01: // user
         guard end >= pos + 5 else { throw ProtocolDecodeError.malformed }
-        let tLen = Int(readU32(data, pos + 1))
+        let tLen = Int(try readU32(data, pos + 1))
         guard end >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
-        let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
+        let t = try decodeUTF8(data[(pos + 5)..<(pos + 5 + tLen)]) ?? ""
         return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .user(text: t)), nextOffset: pos + 5 + tLen)]
 
     case 0x02: // assistant
         guard end >= pos + 5 else { throw ProtocolDecodeError.malformed }
-        let tLen = Int(readU32(data, pos + 1))
+        let tLen = Int(try readU32(data, pos + 1))
         guard end >= pos + 5 + tLen else { throw ProtocolDecodeError.malformed }
-        let t = String(data: data[(pos + 5)..<(pos + 5 + tLen)], encoding: .utf8) ?? ""
+        let t = try decodeUTF8(data[(pos + 5)..<(pos + 5 + tLen)]) ?? ""
         return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .assistant(text: t)), nextOffset: pos + 5 + tLen)]
 
     case 0x03: // thinking
         guard end >= pos + 6 else { throw ProtocolDecodeError.malformed }
         let collapsed = data[pos + 1] != 0
-        let tLen = Int(readU32(data, pos + 2))
+        let tLen = Int(try readU32(data, pos + 2))
         guard end >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
-        let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
+        let t = try decodeUTF8(data[(pos + 6)..<(pos + 6 + tLen)]) ?? ""
         return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .thinking(text: t, collapsed: collapsed)), nextOffset: pos + 6 + tLen)]
 
     case 0x04: // tool_call
@@ -3466,17 +3541,17 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
         let tcStatus = data[pos + 1]
         let isError = data[pos + 2] != 0
         let tcCollapsed = data[pos + 3] != 0
-        let duration = readU32(data, pos + 4)
-        let nameLen = Int(readU16(data, pos + 8))
+        let duration = try readU32(data, pos + 4)
+        let nameLen = Int(try readU16(data, pos + 8))
         guard end >= pos + 10 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
-        let name = String(data: data[(pos + 10)..<(pos + 10 + nameLen)], encoding: .utf8) ?? ""
-        let summaryLen = Int(readU16(data, pos + 10 + nameLen))
+        let name = try decodeUTF8(data[(pos + 10)..<(pos + 10 + nameLen)]) ?? ""
+        let summaryLen = Int(try readU16(data, pos + 10 + nameLen))
         guard end >= pos + 12 + nameLen + summaryLen + 4 else { throw ProtocolDecodeError.malformed }
-        let summary = String(data: data[(pos + 12 + nameLen)..<(pos + 12 + nameLen + summaryLen)], encoding: .utf8) ?? ""
-        let resultLen = Int(readU32(data, pos + 12 + nameLen + summaryLen))
+        let summary = try decodeUTF8(data[(pos + 12 + nameLen)..<(pos + 12 + nameLen + summaryLen)]) ?? ""
+        let resultLen = Int(try readU32(data, pos + 12 + nameLen + summaryLen))
         let baseOffset = pos + 16 + nameLen + summaryLen + resultLen
         guard end >= baseOffset else { throw ProtocolDecodeError.malformed }
-        let result = String(data: data[(pos + 16 + nameLen + summaryLen)..<(pos + 16 + nameLen + summaryLen + resultLen)], encoding: .utf8) ?? ""
+        let result = try decodeUTF8(data[(pos + 16 + nameLen + summaryLen)..<(pos + 16 + nameLen + summaryLen + resultLen)]) ?? ""
         var candidates: [DecodedChatMessageCandidate] = []
         if end > baseOffset {
             let autoApprovedScope = data[baseOffset]
@@ -3496,37 +3571,37 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
     case 0x05: // system
         guard end >= pos + 6 else { throw ProtocolDecodeError.malformed }
         let isError = data[pos + 1] != 0
-        let tLen = Int(readU32(data, pos + 2))
+        let tLen = Int(try readU32(data, pos + 2))
         guard end >= pos + 6 + tLen else { throw ProtocolDecodeError.malformed }
-        let t = String(data: data[(pos + 6)..<(pos + 6 + tLen)], encoding: .utf8) ?? ""
+        let t = try decodeUTF8(data[(pos + 6)..<(pos + 6 + tLen)]) ?? ""
         return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .system(text: t, isError: isError)), nextOffset: pos + 6 + tLen)]
 
     case 0x06: // usage
         guard end >= pos + 21 else { throw ProtocolDecodeError.malformed }
-        let inp = readU32(data, pos + 1)
-        let outp = readU32(data, pos + 5)
-        let cacheR = readU32(data, pos + 9)
-        let cacheW = readU32(data, pos + 13)
-        let costM = readU32(data, pos + 17)
+        let inp = try readU32(data, pos + 1)
+        let outp = try readU32(data, pos + 5)
+        let cacheR = try readU32(data, pos + 9)
+        let cacheW = try readU32(data, pos + 13)
+        let costM = try readU32(data, pos + 17)
         return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .usage(input: inp, output: outp, cacheRead: cacheR, cacheWrite: cacheW, costMicros: costM)), nextOffset: pos + 21)]
 
     case 0x07: // styled_assistant
         guard end >= pos + 3 else { throw ProtocolDecodeError.malformed }
-        let lineCount = Int(readU16(data, pos + 1))
+        let lineCount = Int(try readU16(data, pos + 1))
         var lines: [[Wire.StyledTextRun]] = []
         lines.reserveCapacity(lineCount)
         var rPos = pos + 3
         for _ in 0..<lineCount {
             guard end >= rPos + 2 else { throw ProtocolDecodeError.malformed }
-            let runCount = Int(readU16(data, rPos))
+            let runCount = Int(try readU16(data, rPos))
             var runs: [Wire.StyledTextRun] = []
             runs.reserveCapacity(runCount)
             rPos += 2
             for _ in 0..<runCount {
                 guard end >= rPos + 9 else { throw ProtocolDecodeError.malformed }
-                let textLen = Int(readU16(data, rPos))
+                let textLen = Int(try readU16(data, rPos))
                 guard end >= rPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
-                let runText = String(data: data[(rPos + 2)..<(rPos + 2 + textLen)], encoding: .utf8) ?? ""
+                let runText = try decodeUTF8(data[(rPos + 2)..<(rPos + 2 + textLen)]) ?? ""
                 let fgOff = rPos + 2 + textLen
                 let fgR = data[fgOff]
                 let fgG = data[fgOff + 1]
@@ -3539,9 +3614,9 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
                 var linkURL: String? = nil
                 if (flags & 0x08) != 0 {
                     guard end >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
-                    let urlLen = Int(readU16(data, nextRunPos))
+                    let urlLen = Int(try readU16(data, nextRunPos))
                     guard end >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
-                    guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+                    guard let decodedLinkURL = try decodeUTF8(data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)]) else { throw ProtocolDecodeError.malformed }
                     linkURL = decodedLinkURL
                     nextRunPos += 2 + urlLen
                 }
@@ -3566,37 +3641,37 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
         let stcStatus = data[pos + 1]
         let stcIsError = data[pos + 2] != 0
         let stcCollapsed = data[pos + 3] != 0
-        let stcDuration = readU32(data, pos + 4)
-        let stcNameLen = Int(readU16(data, pos + 8))
+        let stcDuration = try readU32(data, pos + 4)
+        let stcNameLen = Int(try readU16(data, pos + 8))
         guard end >= pos + 10 + stcNameLen + 2 else { throw ProtocolDecodeError.malformed }
-        let stcName = String(data: data[(pos + 10)..<(pos + 10 + stcNameLen)], encoding: .utf8) ?? ""
-        let stcSummaryLen = Int(readU16(data, pos + 10 + stcNameLen))
+        let stcName = try decodeUTF8(data[(pos + 10)..<(pos + 10 + stcNameLen)]) ?? ""
+        let stcSummaryLen = Int(try readU16(data, pos + 10 + stcNameLen))
         guard end >= pos + 12 + stcNameLen + stcSummaryLen + 2 else { throw ProtocolDecodeError.malformed }
-        let stcSummary = String(data: data[(pos + 12 + stcNameLen)..<(pos + 12 + stcNameLen + stcSummaryLen)], encoding: .utf8) ?? ""
-        let stcLineCount = Int(readU16(data, pos + 12 + stcNameLen + stcSummaryLen))
+        let stcSummary = try decodeUTF8(data[(pos + 12 + stcNameLen)..<(pos + 12 + stcNameLen + stcSummaryLen)]) ?? ""
+        let stcLineCount = Int(try readU16(data, pos + 12 + stcNameLen + stcSummaryLen))
         var stcLines: [[Wire.StyledTextRun]] = []
         stcLines.reserveCapacity(stcLineCount)
         var stcPos = pos + 14 + stcNameLen + stcSummaryLen
         for _ in 0..<stcLineCount {
             guard end >= stcPos + 2 else { throw ProtocolDecodeError.malformed }
-            let runCount = Int(readU16(data, stcPos))
+            let runCount = Int(try readU16(data, stcPos))
             var runs: [Wire.StyledTextRun] = []
             runs.reserveCapacity(runCount)
             stcPos += 2
             for _ in 0..<runCount {
                 guard end >= stcPos + 9 else { throw ProtocolDecodeError.malformed }
-                let textLen = Int(readU16(data, stcPos))
+                let textLen = Int(try readU16(data, stcPos))
                 guard end >= stcPos + 2 + textLen + 7 else { throw ProtocolDecodeError.malformed }
-                let runText = String(data: data[(stcPos + 2)..<(stcPos + 2 + textLen)], encoding: .utf8) ?? ""
+                let runText = try decodeUTF8(data[(stcPos + 2)..<(stcPos + 2 + textLen)]) ?? ""
                 let fgOff = stcPos + 2 + textLen
                 let flags = data[fgOff + 6]
                 var nextRunPos = fgOff + 7
                 var linkURL: String? = nil
                 if (flags & 0x08) != 0 {
                     guard end >= nextRunPos + 2 else { throw ProtocolDecodeError.malformed }
-                    let urlLen = Int(readU16(data, nextRunPos))
+                    let urlLen = Int(try readU16(data, nextRunPos))
                     guard end >= nextRunPos + 2 + urlLen else { throw ProtocolDecodeError.malformed }
-                    guard let decodedLinkURL = String(data: data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)], encoding: .utf8) else { throw ProtocolDecodeError.malformed }
+                    guard let decodedLinkURL = try decodeUTF8(data[(nextRunPos + 2)..<(nextRunPos + 2 + urlLen)]) else { throw ProtocolDecodeError.malformed }
                     linkURL = decodedLinkURL
                     nextRunPos += 2 + urlLen
                 }
@@ -3638,25 +3713,25 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
 
     case 0x09: // approval_tool_call
         guard end >= pos + 8 else { throw ProtocolDecodeError.malformed }
-        let nameLen = Int(readU16(data, pos + 2))
+        let nameLen = Int(try readU16(data, pos + 2))
         guard end >= pos + 4 + nameLen + 2 else { throw ProtocolDecodeError.malformed }
-        let name = String(data: data[(pos + 4)..<(pos + 4 + nameLen)], encoding: .utf8) ?? ""
-        let summaryLen = Int(readU16(data, pos + 4 + nameLen))
+        let name = try decodeUTF8(data[(pos + 4)..<(pos + 4 + nameLen)]) ?? ""
+        let summaryLen = Int(try readU16(data, pos + 4 + nameLen))
         guard end >= pos + 6 + nameLen + summaryLen + 2 else { throw ProtocolDecodeError.malformed }
-        let summary = String(data: data[(pos + 6 + nameLen)..<(pos + 6 + nameLen + summaryLen)], encoding: .utf8) ?? ""
-        let idLen = Int(readU16(data, pos + 6 + nameLen + summaryLen))
+        let summary = try decodeUTF8(data[(pos + 6 + nameLen)..<(pos + 6 + nameLen + summaryLen)]) ?? ""
+        let idLen = Int(try readU16(data, pos + 6 + nameLen + summaryLen))
         guard end >= pos + 8 + nameLen + summaryLen + idLen + 3 else { throw ProtocolDecodeError.malformed }
-        let toolCallId = String(data: data[(pos + 8 + nameLen + summaryLen)..<(pos + 8 + nameLen + summaryLen + idLen)], encoding: .utf8) ?? ""
+        let toolCallId = try decodeUTF8(data[(pos + 8 + nameLen + summaryLen)..<(pos + 8 + nameLen + summaryLen + idLen)]) ?? ""
         let previewKind = data[pos + 8 + nameLen + summaryLen + idLen]
-        let lineCount = Int(readU16(data, pos + 9 + nameLen + summaryLen + idLen))
+        let lineCount = Int(try readU16(data, pos + 9 + nameLen + summaryLen + idLen))
         var approvalPos = pos + 11 + nameLen + summaryLen + idLen
         var previewLines: [String] = []
         previewLines.reserveCapacity(lineCount)
         for _ in 0..<lineCount {
             guard end >= approvalPos + 2 else { throw ProtocolDecodeError.malformed }
-            let lineLen = Int(readU16(data, approvalPos))
+            let lineLen = Int(try readU16(data, approvalPos))
             guard end >= approvalPos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
-            let line = String(data: data[(approvalPos + 2)..<(approvalPos + 2 + lineLen)], encoding: .utf8) ?? ""
+            let line = try decodeUTF8(data[(approvalPos + 2)..<(approvalPos + 2 + lineLen)]) ?? ""
             previewLines.append(line)
             approvalPos += 2 + lineLen
         }
@@ -3679,25 +3754,25 @@ private func decodeScrollPresentation(data: Data, start: Int, end: Int) throws -
     guard start + 39 <= end else { throw ProtocolDecodeError.malformed }
 
     return GUIScrollPresentation(
-        windowId: readU16(data, start),
+        windowId: try readU16(data, start),
         resetRequired: data[start + 2] & 0x01 != 0,
-        anchorTop: readU32(data, start + 3),
-        anchorLeft: readU16(data, start + 7),
-        anchorVisualRowOffset: readU16(data, start + 9),
-        visibleStartLine: readU32(data, start + 11),
-        visibleEndLine: readU32(data, start + 15),
-        overscanStartLine: readU32(data, start + 19),
-        overscanEndLine: readU32(data, start + 23),
-        contentEpoch: readU32(data, start + 27),
-        layoutGeneration: readU32(data, start + 31),
-        scrollSeq: readU32(data, start + 35)
+        anchorTop: try readU32(data, start + 3),
+        anchorLeft: try readU16(data, start + 7),
+        anchorVisualRowOffset: try readU16(data, start + 9),
+        visibleStartLine: try readU32(data, start + 11),
+        visibleEndLine: try readU32(data, start + 15),
+        overscanStartLine: try readU32(data, start + 19),
+        overscanEndLine: try readU32(data, start + 23),
+        contentEpoch: try readU32(data, start + 27),
+        layoutGeneration: try readU32(data, start + 31),
+        scrollSeq: try readU32(data, start + 35)
     )
 }
 
 private func decodePaneGeometry(data: Data, start: Int, end: Int) throws -> GUIPaneGeometry {
     var pos = start
     guard pos + 2 <= end else { throw ProtocolDecodeError.malformed }
-    let windowId = readU16(data, pos)
+    let windowId = try readU16(data, pos)
     pos += 2
 
     let totalRect = try readCellRect(data, pos, end)
@@ -3713,18 +3788,18 @@ private func decodePaneGeometry(data: Data, start: Int, end: Int) throws -> GUIP
 
     guard pos + 20 <= end else { throw ProtocolDecodeError.malformed }
     let viewport = GUIViewportSummary(
-        top: readU32(data, pos),
-        left: readU16(data, pos + 4),
-        rows: readU16(data, pos + 6),
-        cols: readU16(data, pos + 8),
-        totalLines: readU32(data, pos + 10),
-        visualRowOffset: readU16(data, pos + 14),
-        totalVisualRows: readU32(data, pos + 16)
+        top: try readU32(data, pos),
+        left: try readU16(data, pos + 4),
+        rows: try readU16(data, pos + 6),
+        cols: try readU16(data, pos + 8),
+        totalLines: try readU32(data, pos + 10),
+        visualRowOffset: try readU16(data, pos + 14),
+        totalVisualRows: try readU32(data, pos + 16)
     )
     pos += 20
 
     guard pos + 5 <= end else { throw ProtocolDecodeError.malformed }
-    let metrics = GUIGutterMetrics(lineNumberWidth: readU16(data, pos), signColWidth: readU16(data, pos + 2))
+    let metrics = GUIGutterMetrics(lineNumberWidth: try readU16(data, pos), signColWidth: try readU16(data, pos + 2))
     let hitCount = Int(data[pos + 4])
     pos += 5
 
@@ -3734,7 +3809,7 @@ private func decodePaneGeometry(data: Data, start: Int, end: Int) throws -> GUIP
         guard pos + 11 <= end else { throw ProtocolDecodeError.malformed }
         let kind = GUIHitRegion.Kind(rawValue: data[pos]) ?? .text
         let rect = try readCellRect(data, pos + 1, end)
-        let regionWindowId = readU16(data, pos + 9)
+        let regionWindowId = try readU16(data, pos + 9)
         hitRegions.append(GUIHitRegion(kind: kind, rect: rect, windowId: regionWindowId))
         pos += 11
     }
@@ -3755,30 +3830,73 @@ private func decodePaneGeometry(data: Data, start: Int, end: Int) throws -> GUIP
 private func readCellRect(_ data: Data, _ offset: Int, _ end: Int) throws -> GUICellRect {
     guard offset + 8 <= end else { throw ProtocolDecodeError.malformed }
     return GUICellRect(
-        row: readU16(data, offset),
-        col: readU16(data, offset + 2),
-        width: readU16(data, offset + 4),
-        height: readU16(data, offset + 6)
+        row: try readU16(data, offset),
+        col: try readU16(data, offset + 2),
+        width: try readU16(data, offset + 4),
+        height: try readU16(data, offset + 6)
     )
 }
 
-private func readU16(_ data: Data, _ offset: Int) -> UInt16 {
-    return UInt16(data[offset]) << 8 | UInt16(data[offset + 1])
+private struct BoundedSection {
+    let id: UInt8
+    let start: Int
+    let end: Int
 }
 
-private func readU24(_ data: Data, _ offset: Int) -> UInt32 {
-    return UInt32(data[offset]) << 16 | UInt32(data[offset + 1]) << 8 | UInt32(data[offset + 2])
+private func readSection16(_ data: Data, at offset: Int, containingEnd: Int) throws -> BoundedSection {
+    var container = try ByteCursor(data, range: offset..<containingEnd)
+    let id = try container.readUInt8()
+    let length = Int(try container.readUInt16())
+    let payload = try container.readSubcursor(count: length)
+    return BoundedSection(id: id, start: payload.offset, end: payload.offset + payload.remaining)
 }
 
-private func readU32(_ data: Data, _ offset: Int) -> UInt32 {
-    return UInt32(data[offset]) << 24 | UInt32(data[offset + 1]) << 16 |
-           UInt32(data[offset + 2]) << 8 | UInt32(data[offset + 3])
+private func readSection32(_ data: Data, at offset: Int, containingEnd: Int) throws -> BoundedSection {
+    var container = try ByteCursor(data, range: offset..<containingEnd)
+    let id = try container.readUInt8()
+    let length = Int(try container.readUInt32())
+    let payload = try container.readSubcursor(count: length)
+    return BoundedSection(id: id, start: payload.offset, end: payload.offset + payload.remaining)
 }
 
-private func readU64(_ data: Data, _ offset: Int) -> UInt64 {
-    let hi: UInt64 = UInt64(data[offset]) << 56 | UInt64(data[offset + 1]) << 48 |
-                     UInt64(data[offset + 2]) << 40 | UInt64(data[offset + 3]) << 32
-    let lo: UInt64 = UInt64(data[offset + 4]) << 24 | UInt64(data[offset + 5]) << 16 |
-                     UInt64(data[offset + 6]) << 8 | UInt64(data[offset + 7])
-    return hi | lo
+private func decodeUTF8(_ data: Data) throws -> String? {
+    var cursor = ByteCursor(data)
+    let bytes = try cursor.readSlice(count: cursor.remaining)
+    return String(bytes: bytes, encoding: .utf8)
+}
+
+private func readU16(_ data: Data, _ offset: Int) throws -> UInt16 {
+    var cursor = try checkedCursor(data, offset: offset, count: 2)
+    return try cursor.readUInt16()
+}
+
+private func readU24(_ data: Data, _ offset: Int) throws -> UInt32 {
+    var cursor = try checkedCursor(data, offset: offset, count: 3)
+    return UInt32(try cursor.readUInt8()) << 16 |
+           UInt32(try cursor.readUInt8()) << 8 |
+           UInt32(try cursor.readUInt8())
+}
+
+private func readU32(_ data: Data, _ offset: Int) throws -> UInt32 {
+    var cursor = try checkedCursor(data, offset: offset, count: 4)
+    return try cursor.readUInt32()
+}
+
+private func readU64(_ data: Data, _ offset: Int) throws -> UInt64 {
+    var cursor = try checkedCursor(data, offset: offset, count: 8)
+    return try cursor.readUInt64()
+}
+
+private func checkedCursor(_ data: Data, offset: Int, count: Int) throws -> ByteCursor {
+    guard offset >= data.startIndex,
+          count >= 0,
+          offset <= data.endIndex,
+          count <= data.endIndex - offset else {
+        throw ProtocolDecodeError.outOfBounds(
+            offset: max(data.startIndex, min(offset, data.endIndex)),
+            required: max(count, 0),
+            remaining: offset <= data.endIndex ? max(data.endIndex - max(offset, data.startIndex), 0) : 0
+        )
+    }
+    return try ByteCursor(data, range: offset..<(offset + count))
 }

--- a/macos/Sources/Protocol/ProtocolEventHandoff.swift
+++ b/macos/Sources/Protocol/ProtocolEventHandoff.swift
@@ -1,0 +1,45 @@
+/// Ordered, single-hop delivery of decoded protocol events to the main actor.
+
+import Foundation
+
+enum ProtocolDeliveryEvent: Sendable {
+    case frame(DecodedFrame)
+    case decodeFailure(ProtocolDecodeError)
+}
+
+/// A thread-safe FIFO handoff from the serial protocol reader to one consumer.
+///
+/// `AsyncStream.Continuation.yield` records each event synchronously in call
+/// order. The app owns exactly one main-actor consumer task for the stream, so
+/// packets and failures cannot overtake one another through independently
+/// scheduled tasks.
+struct ProtocolEventHandoff: Sendable {
+    let events: AsyncStream<ProtocolDeliveryEvent>
+    private let continuation: AsyncStream<ProtocolDeliveryEvent>.Continuation
+
+    init() {
+        let pair = AsyncStream.makeStream(
+            of: ProtocolDeliveryEvent.self,
+            bufferingPolicy: .unbounded
+        )
+        self.events = pair.stream
+        self.continuation = pair.continuation
+    }
+
+    /// Enqueues a decoded frame at the real reader-to-main-actor boundary.
+    @discardableResult
+    func deliver(_ frame: DecodedFrame) -> DecodedFrame {
+        let deliveredFrame = frame.recordingActorHop()
+        continuation.yield(.frame(deliveredFrame))
+        return deliveredFrame
+    }
+
+    /// Enqueues a decode failure in the same wire-order stream as frames.
+    func deliver(_ error: ProtocolDecodeError) {
+        continuation.yield(.decodeFailure(error))
+    }
+
+    func finish() {
+        continuation.finish()
+    }
+}

--- a/macos/Sources/Protocol/ProtocolReader.swift
+++ b/macos/Sources/Protocol/ProtocolReader.swift
@@ -17,25 +17,28 @@ final class ProtocolReader: @unchecked Sendable {
 
     private var thread: Thread?
     private let input: FileHandle
-    private let handler: @Sendable (Data) -> Void
+    private let decoder: @Sendable (Data) throws -> DecodedFrame
+    private let handler: @Sendable (DecodedFrame) -> Void
+    private let onDecodeFailure: @Sendable (ProtocolDecodeError) -> Void
     private let onDisconnect: @Sendable () -> Void
     private let maxPayloadLength: Int
     private let running = Mutex(false)
 
-    /// Create a reader that calls `handler` with each payload on a background thread.
-    /// `onDisconnect` is called when the input closes (peer exited).
-    ///
-    /// - Parameters:
-    ///   - input: File handle to read from. Defaults to `.standardInput`.
-    ///   - handler: Called with each decoded payload.
-    ///   - onDisconnect: Called when the input stream closes.
-    init(input: FileHandle = .standardInput,
-         maxPayloadLength: Int = ProtocolReader.defaultMaxPayloadLength,
-         handler: @escaping @Sendable (Data) -> Void,
-         onDisconnect: @escaping @Sendable () -> Void) {
+    /// Creates a reader that decodes complete packets on its background thread.
+    /// Only one immutable `DecodedFrame` is delivered for each successful packet.
+    init(
+        input: FileHandle = .standardInput,
+        maxPayloadLength: Int = ProtocolReader.defaultMaxPayloadLength,
+        decoder: @escaping @Sendable (Data) throws -> DecodedFrame = { data in try decodeFrame(from: data) },
+        handler: @escaping @Sendable (DecodedFrame) -> Void,
+        onDecodeFailure: @escaping @Sendable (ProtocolDecodeError) -> Void,
+        onDisconnect: @escaping @Sendable () -> Void
+    ) {
         self.input = input
         self.maxPayloadLength = maxPayloadLength
+        self.decoder = decoder
         self.handler = handler
+        self.onDecodeFailure = onDecodeFailure
         self.onDisconnect = onDisconnect
     }
 
@@ -98,7 +101,23 @@ final class ProtocolReader: @unchecked Sendable {
             }
 
             os_signpost(.event, log: protocolLog, name: "ProtocolPayloadReceived", "bytes=%{public}d", payload.count)
-            handler(payload)
+            do {
+                let frame = try decoder(payload)
+                os_signpost(
+                    .event,
+                    log: protocolLog,
+                    name: "ProtocolPayloadDecoded",
+                    "bytes=%{public}d copied=%{public}d allocations=%{public}d",
+                    frame.metrics.packetBytes,
+                    frame.metrics.bytesCopied,
+                    frame.metrics.allocations
+                )
+                handler(frame)
+            } catch let error as ProtocolDecodeError {
+                onDecodeFailure(error)
+            } catch {
+                onDecodeFailure(.malformed)
+            }
         }
     }
 }

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -445,6 +445,79 @@ func sendReady() {
     writeJSON(["type": "ready"])
 }
 
+func makeDecodeBenchmarkPacket(size: Int) -> Data {
+    // set_title is a real rendering command and forces construction of the
+    // immutable String values published in DecodedFrame. Chunking at u16.max
+    // keeps the packet protocol-compatible while exercising owned-copy metrics.
+    var packet = Data(capacity: size)
+    var remaining = size
+    while remaining > 65_538 {
+        let commandSize = remaining - 65_538 == 1 ? 65_537 : 65_538
+        let textSize = commandSize - 3
+        packet.append(OP_SET_TITLE)
+        packet.append(UInt8((textSize >> 8) & 0xFF))
+        packet.append(UInt8(textSize & 0xFF))
+        packet.append(Data(repeating: 0x61, count: textSize))
+        remaining -= commandSize
+    }
+    if remaining == 2 {
+        packet.append(contentsOf: [OP_SET_CURSOR_SHAPE, CURSOR_BLOCK])
+    } else if remaining >= 3 {
+        let textSize = remaining - 3
+        packet.append(OP_SET_TITLE)
+        packet.append(UInt8((textSize >> 8) & 0xFF))
+        packet.append(UInt8(textSize & 0xFF))
+        packet.append(Data(repeating: 0x61, count: textSize))
+    }
+    return packet
+}
+
+func decodeBenchmarkNanoseconds(_ duration: Duration) -> Double {
+    let components = duration.components
+    return Double(components.seconds) * 1_000_000_000 + Double(components.attoseconds) / 1_000_000_000
+}
+
+func runDecodeBenchmark() throws {
+    let sizes = [64 * 1024, 1024 * 1024, 16 * 1024 * 1024, 64 * 1024 * 1024]
+    var measurements: [[String: Any]] = []
+    var baselineNanoseconds = 0.0
+
+    // Keep one-time Swift/Foundation initialization out of the linear baseline.
+    _ = try decodeFrame(from: makeDecodeBenchmarkPacket(size: sizes[0]))
+
+    for size in sizes {
+        let decodedFrame = try decodeFrame(from: makeDecodeBenchmarkPacket(size: size), collectOwnedMetrics: true)
+        let handoff = ProtocolEventHandoff()
+        let frame = handoff.deliver(decodedFrame)
+        let nanoseconds = decodeBenchmarkNanoseconds(frame.metrics.decodeDuration)
+        if baselineNanoseconds == 0 { baselineNanoseconds = max(nanoseconds, 1_000) }
+        let linearBudget = max(1_000_000, baselineNanoseconds * Double(size / sizes[0]) * 4)
+        let expectedOwnedBytes = size - frame.commands.count * 3
+        let expectedOwnedAllocations = frame.commands.count + 1
+        guard frame.metrics.bytesCopied == expectedOwnedBytes,
+              frame.metrics.allocations == expectedOwnedAllocations,
+              frame.metrics.actorHopCount == 1,
+              nanoseconds <= linearBudget else {
+            throw ProtocolDecodeError.malformed
+        }
+        measurements.append(["packet_bytes": size, "bytes_copied": frame.metrics.bytesCopied, "allocations": frame.metrics.allocations, "decode_nanoseconds": nanoseconds, "actor_hop_count": frame.metrics.actorHopCount, "linear_budget_nanoseconds": linearBudget])
+    }
+
+    let output = try JSONSerialization.data(withJSONObject: ["configuration": "release", "measurements": measurements], options: [.sortedKeys])
+    stdout.write(output)
+    stdout.write(Data([0x0A]))
+}
+
+if CommandLine.arguments.contains("--decode-benchmark") {
+    do {
+        try runDecodeBenchmark()
+        exit(EXIT_SUCCESS)
+    } catch {
+        FileHandle.standardError.write(Data("decode benchmark failed: \(error)\n".utf8))
+        exit(EXIT_FAILURE)
+    }
+}
+
 sendReady()
 
 // Read {:packet, 4} framed messages from stdin.

--- a/macos/Tests/MingaTests/ByteCursorTests.swift
+++ b/macos/Tests/MingaTests/ByteCursorTests.swift
@@ -1,0 +1,54 @@
+import Foundation
+import Testing
+
+@Suite("ByteCursor")
+struct ByteCursorTests {
+    @Test("decodes integers and strings with checked offsets")
+    func primitives() throws {
+        var cursor = ByteCursor(Data([0x7F, 0x12, 0x34, 0x00, 0x00, 0x00, 0x02, 0x68, 0x69]))
+
+        #expect(try cursor.readUInt8() == 0x7F)
+        #expect(try cursor.readUInt16() == 0x1234)
+        #expect(try cursor.readUInt32() == 2)
+        #expect(try cursor.readString(count: 2) == "hi")
+        #expect(cursor.isAtEnd)
+        #expect(cursor.bytesCopied == 2)
+        #expect(cursor.allocations == 1)
+    }
+
+    @Test("bounded slices do not copy packet bytes")
+    func boundedSlicesAreZeroCopy() throws {
+        let packet = Data(repeating: 0xAB, count: 1_048_576)
+        var cursor = ByteCursor(packet)
+        let slice = try cursor.readSlice(count: 16)
+
+        #expect(slice.count == 16)
+        #expect(slice.first == 0xAB)
+        #expect(cursor.remaining == packet.count - 16)
+        #expect(cursor.bytesCopied == 0)
+        #expect(cursor.allocations == 0)
+    }
+
+    @Test("subcursor cannot escape its containing section")
+    func boundedSubcursor() throws {
+        var cursor = ByteCursor(Data([1, 2, 3, 4]))
+        var section = try cursor.readSubcursor(count: 2)
+        #expect(try section.readUInt16() == 0x0102)
+        #expect(throws: ByteCursor.BoundsError.self) {
+            try section.readUInt8()
+        }
+        #expect(cursor.remaining == 2)
+    }
+
+    @Test("oversized and negative lengths fail without integer overflow")
+    func invalidLengths() {
+        var cursor = ByteCursor(Data([1]))
+        #expect(throws: ByteCursor.BoundsError.self) {
+            try cursor.advance(by: Int.max)
+        }
+        #expect(throws: ByteCursor.BoundsError.self) {
+            try cursor.advance(by: -1)
+        }
+        #expect(cursor.offset == 0)
+    }
+}

--- a/macos/Tests/MingaTests/DecodedFrameTests.swift
+++ b/macos/Tests/MingaTests/DecodedFrameTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import Testing
+
+@Suite("Transactional frame decoding")
+struct DecodedFrameTests {
+    @Test("later truncation publishes no partial commands")
+    func atomicFailure() {
+        var packet = Data([OP_SET_WINDOW_BG, 1, 2, 3, OP_SET_TITLE, 0, 4])
+        packet.append(contentsOf: [0x61, 0x62])
+        var published: [RenderCommand] = []
+
+        #expect(throws: ProtocolDecodeError.self) {
+            try decodeCommands(from: packet) { published.append($0) }
+        }
+        #expect(published.isEmpty)
+    }
+
+    @Test("nested string lengths cannot consume the following command")
+    func nestedLengthIsSectionBounded() {
+        var packet = Data([OP_GUI_STATUS_BAR, 1, 0x03, 0, 10])
+        packet.append(Data(repeating: 0, count: 8))
+        packet.append(contentsOf: [0, 4]) // hint length exceeds this section
+        packet.append(contentsOf: [OP_SET_WINDOW_BG, 1, 2, 3])
+        var published: [RenderCommand] = []
+
+        #expect(throws: ProtocolDecodeError.self) {
+            try decodeCommands(from: packet) { published.append($0) }
+        }
+        #expect(published.isEmpty)
+    }
+
+    @Test("unknown size-framed commands fail closed")
+    func unknownSizedCommand() {
+        let packet = Data([0xB7, 0, 2, 0xAA, 0xBB])
+        #expect(throws: ProtocolDecodeError.self) {
+            _ = try decodeFrame(from: packet)
+        }
+    }
+
+    @Test("metrics expose zero tail copies and one frame allocation")
+    func metrics() throws {
+        let packet = Data([OP_SET_WINDOW_BG, 1, 2, 3, OP_COMMIT_FRAME, 0, 0, 0, 1, 0, 0, 0, 2])
+        let frame = try decodeFrame(from: packet, collectOwnedMetrics: true)
+
+        #expect(frame.commands.count == 2)
+        #expect(frame.metrics.packetBytes == packet.count)
+        #expect(frame.metrics.bytesCopied == 0)
+        #expect(frame.metrics.allocations == 1)
+        #expect(frame.metrics.actorHopCount == 0)
+        #expect(frame.recordingActorHop().metrics.actorHopCount == 1)
+        #expect(frame.metrics.decodeDuration >= .zero)
+    }
+
+    @Test("production decode skips deep owned-value accounting")
+    func productionMetricsStayLightweight() throws {
+        let packet = makeRenderingPacket(size: 64 * 1024)
+        let frame = try decodeFrame(from: packet)
+
+        #expect(frame.metrics.bytesCopied == -1)
+        #expect(frame.metrics.allocations == -1)
+    }
+
+    @Test("release scaling seam covers 64 KiB through 64 MiB")
+    func releaseScalingSeam() throws {
+        let sizes = [64 * 1024, 1024 * 1024, 16 * 1024 * 1024, 64 * 1024 * 1024]
+        var baselineNanoseconds = 0.0
+
+        for packetSize in sizes {
+            let packet = makeRenderingPacket(size: packetSize)
+            let frame = try decodeFrame(from: packet, collectOwnedMetrics: true)
+            let elapsed = nanoseconds(frame.metrics.decodeDuration)
+            if baselineNanoseconds == 0 { baselineNanoseconds = max(elapsed, 1_000) }
+            let linearBudget = max(1_000_000, baselineNanoseconds * Double(packetSize / sizes[0]) * 4)
+
+            #expect(frame.metrics.packetBytes == packetSize)
+            #expect(frame.metrics.bytesCopied == packetSize - frame.commands.count * 3)
+            #expect(frame.metrics.allocations == frame.commands.count + 1)
+            #expect(elapsed <= linearBudget)
+        }
+    }
+
+    private func nanoseconds(_ duration: Duration) -> Double {
+        let components = duration.components
+        return Double(components.seconds) * 1_000_000_000 + Double(components.attoseconds) / 1_000_000_000
+    }
+
+    private func makeRenderingPacket(size: Int) -> Data {
+        var packet = Data(capacity: size)
+        var remaining = size
+        while remaining > 65_538 {
+            let commandSize = remaining - 65_538 == 1 ? 65_537 : 65_538
+            let textSize = commandSize - 3
+            packet.append(OP_SET_TITLE)
+            packet.append(UInt8((textSize >> 8) & 0xFF))
+            packet.append(UInt8(textSize & 0xFF))
+            packet.append(Data(repeating: 0x61, count: textSize))
+            remaining -= commandSize
+        }
+        if remaining == 2 {
+            packet.append(contentsOf: [OP_SET_CURSOR_SHAPE, CURSOR_BLOCK])
+        } else if remaining >= 3 {
+            let textSize = remaining - 3
+            packet.append(OP_SET_TITLE)
+            packet.append(UInt8((textSize >> 8) & 0xFF))
+            packet.append(UInt8(textSize & 0xFF))
+            packet.append(Data(repeating: 0x61, count: textSize))
+        }
+        return packet
+    }
+}
+
+private final class DecodeThreadCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var decodedOnMain = true
+    private var hops = 0
+
+    func record(decodedOnMain: Bool, hops: Int) {
+        lock.lock()
+        self.decodedOnMain = decodedOnMain
+        self.hops = hops
+        lock.unlock()
+    }
+
+    func snapshot() -> (decodedOnMain: Bool, hops: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        return (decodedOnMain, hops)
+    }
+}
+
+@Suite("ProtocolReader decode isolation")
+struct ProtocolReaderDecodeIsolationTests {
+    @Test("binary decoding executes off main before the actor handoff")
+    func offMainDecode() throws {
+        let payload = Data([OP_SET_WINDOW_BG, 1, 2, 3])
+        var stream = Data([0, 0, 0, UInt8(payload.count)])
+        stream.append(payload)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("minga-decoder-isolation-\(UUID().uuidString).bin")
+        try stream.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let capture = DecodeThreadCapture()
+        let delivered = DispatchSemaphore(value: 0)
+        let disconnected = DispatchSemaphore(value: 0)
+        let handle = try FileHandle(forReadingFrom: url)
+        let reader = ProtocolReader(
+            input: handle,
+            decoder: { data in
+                let onMain = Thread.isMainThread
+                let frame = try decodeFrame(from: data)
+                capture.record(decodedOnMain: onMain, hops: frame.metrics.actorHopCount)
+                return frame
+            },
+            handler: { frame in
+                capture.record(decodedOnMain: capture.snapshot().decodedOnMain, hops: frame.metrics.actorHopCount)
+                delivered.signal()
+            },
+            onDecodeFailure: { _ in delivered.signal() },
+            onDisconnect: { disconnected.signal() }
+        )
+
+        reader.start()
+        #expect(delivered.wait(timeout: .now() + 2) == .success)
+        #expect(disconnected.wait(timeout: .now() + 2) == .success)
+        try handle.close()
+
+        let result = capture.snapshot()
+        #expect(!result.decodedOnMain)
+        #expect(result.hops == 0)
+    }
+}
+
+@Suite("Ordered protocol event handoff")
+struct ProtocolEventHandoffTests {
+    @Test("multiple decoded packets reach one main-actor consumer in wire order")
+    func preservesPacketOrder() async throws {
+        let packets = [
+            Data([OP_SET_WINDOW_BG, 1, 2, 3]),
+            Data([OP_SET_TITLE, 0, 1, 0x78]),
+            Data([OP_COMMIT_FRAME, 0, 0, 0, 7, 0, 0, 0, 9])
+        ]
+        let frames = try packets.map { try decodeFrame(from: $0) }
+        let handoff = ProtocolEventHandoff()
+
+        let consumer = Task { @MainActor in
+            var opcodes: [UInt8] = []
+            var hops: [Int] = []
+            for await event in handoff.events {
+                guard case .frame(let frame) = event else { continue }
+                opcodes.append(contentsOf: frame.commands.map(\.opcode))
+                hops.append(frame.metrics.actorHopCount)
+                if opcodes.count == packets.count { break }
+            }
+            return (opcodes, hops)
+        }
+
+        for frame in frames {
+            handoff.deliver(frame)
+        }
+
+        let result = await consumer.value
+        #expect(result.0 == [OP_SET_WINDOW_BG, OP_SET_TITLE, OP_COMMIT_FRAME])
+        #expect(result.1 == [1, 1, 1])
+    }
+}

--- a/macos/Tests/MingaTests/DecoderRobustnessTests.swift
+++ b/macos/Tests/MingaTests/DecoderRobustnessTests.swift
@@ -407,83 +407,39 @@ struct DecoderScrollPresentationScrollSeqTests {
 
 // MARK: - Forward-compatible unknown opcodes (0x90+)
 
-@Suite("Decoder Robustness: Forward-Compatible Unknown Opcodes")
+@Suite("Decoder Robustness: Unknown Opcodes Fail Closed")
 struct DecoderForwardCompatTests {
 
-    @Test("Unknown opcode >= 0x90 with valid length prefix is skipped")
-    func skipUnknownOpcode() throws {
-        // Opcode 0xFE is intentionally outside the currently defined semantic opcode range.
-        // It uses the 0x90+ convention: opcode(1) + payload_length(2, big-endian) + payload(payload_length).
-        var data = Data()
-        data.append(0xFE)                       // unknown opcode
-        data.append(contentsOf: [0x00, 0x04])   // payload_length = 4
-        data.append(contentsOf: [0xDE, 0xAD, 0xBE, 0xEF]) // payload (4 bytes)
-
-        let (cmd, size) = try decodeCommand(data: data, offset: 0)
-        #expect(cmd == nil, "Unknown opcode should be skipped (nil command)")
-        #expect(size == 7, "Should consume opcode(1) + length(2) + payload(4) = 7 bytes")
+    @Test("Unknown opcode >= 0x90 with valid length prefix is rejected")
+    func skipUnknownOpcode() {
+        let data = Data([0xFE, 0x00, 0x04, 0xDE, 0xAD, 0xBE, 0xEF])
+        #expect(throws: ProtocolDecodeError.self) {
+            _ = try decodeCommand(data: data, offset: 0)
+        }
     }
 
-    @Test("Unknown opcode skipped, subsequent commands decoded correctly")
-    func skipThenDecode() throws {
-        // Build a batch: unknown 0xFE (5-byte payload) + set_cursor_shape + batch_end
-        var data = Data()
-        // Unknown opcode
-        data.append(0xFE)
-        data.append(contentsOf: [0x00, 0x05]) // payload_length = 5
-        data.append(contentsOf: [0x01, 0x02, 0x03, 0x04, 0x05]) // 5 bytes of payload
-        // Known commands that follow
-        data.append(OP_SET_CURSOR_SHAPE)
-        data.append(CURSOR_BLOCK)
-        data.append(OP_COMMIT_FRAME)
-        data.append(contentsOf: [0, 0, 0, 0, 0, 0, 0, 0]) // commit_frame frame_seq + echoed input_seq (fixed:9, #2219/#2215)
-
+    @Test("Unknown opcode prevents subsequent command publication")
+    func skipThenDecode() {
+        let data = Data([0xFE, 0x00, 0x00, OP_SET_CURSOR_SHAPE, CURSOR_BLOCK])
         var commands: [RenderCommand] = []
-        try decodeCommands(from: data) { cmd in
-            commands.append(cmd)
+        #expect(throws: ProtocolDecodeError.self) {
+            try decodeCommands(from: data) { commands.append($0) }
         }
-        // The unknown opcode is skipped (nil), so only set_cursor_shape and commitFrame are collected
-        #expect(commands.count == 2)
-        guard case .setCursorShape = commands[0] else {
-            Issue.record("Expected .setCursorShape after skipped opcode"); return
-        }
-        guard case .commitFrame = commands[1] else {
-            Issue.record("Expected .commitFrame"); return
+        #expect(commands.isEmpty)
+    }
+
+    @Test("Unknown opcode with zero-length payload is rejected")
+    func skipZeroPayload() {
+        #expect(throws: ProtocolDecodeError.self) {
+            _ = try decodeCommand(data: Data([0xB0, 0x00, 0x00]), offset: 0)
         }
     }
 
-    @Test("Unknown opcode with zero-length payload is skipped")
-    func skipZeroPayload() throws {
-        var data = Data()
-        data.append(0xB0)                       // unknown opcode
-        data.append(contentsOf: [0x00, 0x00])   // payload_length = 0
-
-        let (cmd, size) = try decodeCommand(data: data, offset: 0)
-        #expect(cmd == nil)
-        #expect(size == 3, "opcode(1) + length(2) + payload(0) = 3")
-    }
-
-    @Test("Multiple unknown opcodes in a row are all skipped")
-    func skipMultipleUnknown() throws {
-        var data = Data()
-        // First unknown opcode (3-byte payload)
-        data.append(0xFD)
-        data.append(contentsOf: [0x00, 0x03])
-        data.append(contentsOf: [0xAA, 0xBB, 0xCC])
-        // Second unknown opcode (0-byte payload)
-        data.append(0xFC)
-        data.append(contentsOf: [0x00, 0x00])
-        // Known command
-        data.append(OP_SET_CURSOR_SHAPE)
-        data.append(CURSOR_BLOCK)
-
-        var commands: [RenderCommand] = []
-        try decodeCommands(from: data) { cmd in
-            commands.append(cmd)
-        }
-        #expect(commands.count == 1)
-        guard case .setCursorShape = commands[0] else {
-            Issue.record("Expected .setCursorShape"); return
+    @Test("First unknown opcode rejects the complete packet")
+    func skipMultipleUnknown() {
+        let data = Data([0xFD, 0x00, 0x00, 0xFC, 0x00, 0x00])
+        #expect(throws: ProtocolDecodeError.self) {
+            _ = try decodeFrame(from: data)
         }
     }
 
@@ -619,7 +575,7 @@ struct DecoderEdgeCaseTests {
             #expect(opcode == OP_SET_TITLE)
             #expect(offset == 2)
             #expect(remaining == 4)
-            #expect(String(describing: cause) == "insufficient data")
+            #expect(String(describing: cause) == "insufficient data" || String(describing: cause) == "malformed")
             #expect(String(describing: error).contains("opcode 0x"))
             #expect(String(describing: error).contains("offset 2"))
         }

--- a/macos/Tests/MingaTests/NonBlockingEncoderTests.swift
+++ b/macos/Tests/MingaTests/NonBlockingEncoderTests.swift
@@ -186,8 +186,23 @@ struct ProtocolReaderTests {
         let reader = ProtocolReader(
             input: handle,
             maxPayloadLength: 2_000_000,
-            handler: { data in
-                capture.append(data)
+            decoder: { data in
+                DecodedFrame(
+                    commands: [],
+                    metrics: FrameDecodeMetrics(
+                        packetBytes: data.count,
+                        bytesCopied: 0,
+                        allocations: 0,
+                        decodeDuration: .zero,
+                        actorHopCount: 0
+                    )
+                )
+            },
+            handler: { frame in
+                capture.append(Data(count: frame.metrics.packetBytes))
+            },
+            onDecodeFailure: { _ in
+                disconnected.signal()
             },
             onDisconnect: {
                 disconnected.signal()

--- a/macos/Tests/MingaTests/ProtocolCommandSizeTests.swift
+++ b/macos/Tests/MingaTests/ProtocolCommandSizeTests.swift
@@ -34,8 +34,8 @@ struct ProtocolCommandSizeTests {
         #expect(commandSize([OP_GUI_GIT_STATUS, 0, 0, 0, 0]) == .custom)
     }
 
-    @Test func forwardCompatibleUnknownHighOpcode() {
-        #expect(commandSize([0xB7, 0x00, 0x02, 0xAA, 0xBB]) == .sized(5))
+    @Test func unknownHighOpcodeFailsClosed() {
+        #expect(commandSize([0xB7, 0x00, 0x02, 0xAA, 0xBB]) == .unknown)
     }
 
     @Test func reportsTruncatedPayload() {
@@ -43,19 +43,10 @@ struct ProtocolCommandSizeTests {
         #expect(commandSize([]) == .incomplete)
     }
 
-    @Test func decodeCommandsSkipsGeneratedSizedUnrenderedOpcode() throws {
-        // commit_frame is fixed:9 (opcode + frame_seq + echoed input_seq u32, #2219/#2215).
+    @Test func decodeCommandsRejectsGeneratedSizedUnknownOpcode() {
         let payload = Data([0xB7, 0x00, 0x02, 0xAA, 0xBB, OP_COMMIT_FRAME, 0, 0, 0, 0, 0, 0, 0, 0])
-        var commands: [RenderCommand] = []
-
-        try decodeCommands(from: payload) { command in
-            commands.append(command)
-        }
-
-        #expect(commands.count == 1)
-        guard case .commitFrame = commands.first else {
-            Issue.record("Expected .commitFrame but got \(String(describing: commands.first))")
-            return
+        #expect(throws: ProtocolDecodeError.self) {
+            try decodeCommands(from: payload) { _ in }
         }
     }
 }

--- a/mix/protocol_generator.ex
+++ b/mix/protocol_generator.ex
@@ -1243,8 +1243,9 @@ defmodule Minga.Mix.ProtocolGenerator do
       "    case unknown\n" <>
       "}\n\n" <>
       "/// Returns the on-wire byte length of the first command in `payload`,\n" <>
-      "/// derived from each opcode's schema framing.\n" <>
-      "public func commandSize(_ payload: [UInt8]) -> CommandSizeResult {\n" <>
+      "/// derived from each opcode's schema framing. Accepting integer-indexed\n" <>
+      "/// collections lets Data slices be sized without copying packet tails.\n" <>
+      "public func commandSize<C: RandomAccessCollection>(_ payload: C) -> CommandSizeResult where C.Element == UInt8, C.Index == Int {\n" <>
       "    guard let opcode = payload.first else { return .incomplete }\n" <>
       "    switch opcode {\n" <>
       IO.iodata_to_binary(fixed_cases) <>
@@ -1254,8 +1255,6 @@ defmodule Minga.Mix.ProtocolGenerator do
       swift_case.(:sectioned32, "sectioned32CommandSize(payload)") <>
       swift_custom_case.() <>
       "    default:\n" <>
-      "        // Forward-compatibility: opcodes >= 0x90 carry a u16 length prefix.\n" <>
-      "        if opcode >= 0x90 { return len16CommandSize(payload) }\n" <>
       "        return .unknown\n" <>
       "    }\n}\n\n" <>
       swift_command_size_helpers()
@@ -1264,41 +1263,45 @@ defmodule Minga.Mix.ProtocolGenerator do
   @spec swift_command_size_helpers() :: String.t()
   defp swift_command_size_helpers do
     """
-    private func fixedCommandSize(_ payload: [UInt8], _ size: Int) -> CommandSizeResult {
+    private func fixedCommandSize<C: RandomAccessCollection>(_ payload: C, _ size: Int) -> CommandSizeResult where C.Element == UInt8, C.Index == Int {
         payload.count < size ? .incomplete : .sized(size)
     }
 
-    private func len16CommandSize(_ payload: [UInt8]) -> CommandSizeResult {
+    private func byte<C: RandomAccessCollection>(_ payload: C, _ offset: Int) -> UInt8 where C.Element == UInt8, C.Index == Int {
+        payload[payload.startIndex + offset]
+    }
+
+    private func len16CommandSize<C: RandomAccessCollection>(_ payload: C) -> CommandSizeResult where C.Element == UInt8, C.Index == Int {
         if payload.count < 3 { return .incomplete }
-        let size = 3 + (Int(payload[1]) << 8 | Int(payload[2]))
+        let size = 3 + (Int(byte(payload, 1)) << 8 | Int(byte(payload, 2)))
         return payload.count < size ? .incomplete : .sized(size)
     }
 
-    private func len32CommandSize(_ payload: [UInt8]) -> CommandSizeResult {
+    private func len32CommandSize<C: RandomAccessCollection>(_ payload: C) -> CommandSizeResult where C.Element == UInt8, C.Index == Int {
         if payload.count < 5 { return .incomplete }
-        let size = 5 + (Int(payload[1]) << 24 | Int(payload[2]) << 16 | Int(payload[3]) << 8 | Int(payload[4]))
+        let size = 5 + (Int(byte(payload, 1)) << 24 | Int(byte(payload, 2)) << 16 | Int(byte(payload, 3)) << 8 | Int(byte(payload, 4)))
         return payload.count < size ? .incomplete : .sized(size)
     }
 
-    private func sectioned32CommandSize(_ payload: [UInt8]) -> CommandSizeResult {
+    private func sectioned32CommandSize<C: RandomAccessCollection>(_ payload: C) -> CommandSizeResult where C.Element == UInt8, C.Index == Int {
         if payload.count < 2 { return .incomplete }
         var offset = 2
-        let count = Int(payload[1])
+        let count = Int(byte(payload, 1))
         for _ in 0..<count {
             if payload.count < offset + 5 { return .incomplete }
-            offset += 5 + (Int(payload[offset + 1]) << 24 | Int(payload[offset + 2]) << 16 | Int(payload[offset + 3]) << 8 | Int(payload[offset + 4]))
+            offset += 5 + (Int(byte(payload, offset + 1)) << 24 | Int(byte(payload, offset + 2)) << 16 | Int(byte(payload, offset + 3)) << 8 | Int(byte(payload, offset + 4)))
             if payload.count < offset { return .incomplete }
         }
         return .sized(offset)
     }
 
-    private func sectionedCommandSize(_ payload: [UInt8]) -> CommandSizeResult {
+    private func sectionedCommandSize<C: RandomAccessCollection>(_ payload: C) -> CommandSizeResult where C.Element == UInt8, C.Index == Int {
         if payload.count < 2 { return .incomplete }
         var offset = 2
-        let count = Int(payload[1])
+        let count = Int(byte(payload, 1))
         for _ in 0..<count {
             if payload.count < offset + 3 { return .incomplete }
-            offset += 3 + (Int(payload[offset + 1]) << 8 | Int(payload[offset + 2]))
+            offset += 3 + (Int(byte(payload, offset + 1)) << 8 | Int(byte(payload, offset + 2)))
             if payload.count < offset { return .incomplete }
         }
         return .sized(offset)

--- a/scripts/check_swift_decode_scaling
+++ b/scripts/check_swift_decode_scaling
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+mix swift.harness --release
+"_build/${MIX_ENV:-dev}/lib/minga/priv/minga-test-harness" --decode-benchmark


### PR DESCRIPTION
# TL;DR

macOS now decodes each complete protocol packet off the main actor through checked cursors, then delivers one immutable frame across an ordered main-actor handoff. Malformed packets fail before any command becomes observable, and a Release harness verifies linear decode behavior from 64 KiB through 64 MiB.

Closes #2746

## Context

Large semantic frames previously copied the remaining packet tail during command sizing and moved raw packet data onto the main actor for incremental decoding. That tied interaction latency to frame size and allowed a malformed trailing command to arrive after earlier commands had already been dispatched.

This is the decode prerequisite for atomic frame publication and explicit frame acknowledgements.

## Changes

- Added a bounds-checked `ByteCursor` for integers, UTF-8 values, slices, and nested sections without copying unconsumed packet tails.
- Decode complete packets into immutable `DecodedFrame` values on `ProtocolReader`'s background thread.
- Added one FIFO `ProtocolEventHandoff` so frames and decode failures cross to the main actor in wire order.
- Made packet decode transactional and changed unknown opcodes to fail closed.
- Updated generated command sizing to accept zero-copy `Data` views.
- Added lightweight production decode timing plus opt-in owned-byte and allocation accounting for the Release harness.
- Added a Release scaling check covering representative rendering packets from 64 KiB through 64 MiB.

## Verification

- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -configuration Debug test`
- `scripts/check_swift_decode_scaling`
- `make lint.full`
- `mix test.llm` (9,887 tests, 0 failures)
- `mix conformance` (160 tests, 0 failures)
- `mix protocol.gen --check`

## Acceptance Criteria Addressed

- Checked cursor decoding avoids unconsumed-tail copies. ✅
- Complete immutable frames decode off the main actor and cross isolation once in FIFO order. ✅
- Malformed lengths, truncation, overflow, and unknown commands fail closed without partial publication. ✅
- Release measurements cover 64 KiB through 64 MiB and expose owned bytes, allocations, decode time, and actor-hop count. ✅
- Swift 6 isolation and reader-thread tests prove protocol decoding does not execute on the main actor. ✅
