### PR TITLE
feat(macos): publish prepared frame transactions

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		00F5A6B58392069C8645B12C /* PresentationScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */; };
 		01EA03A621B455B253E6C7B3 /* MingaUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		03C97AFD225BCEA6E7A8E0BF /* PreparedFrameTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */; };
 		058481A528AFB6C7225A067D /* MouseInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */; };
 		05EC70C811170EE160C5E4D9 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
 		067369CB702835E93D254606 /* PipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */; };
@@ -105,6 +106,7 @@
 		615049EC1AF720C119D63438 /* ExtensionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C089C5163F2C513D3DC21E7C /* ExtensionPanelView.swift */; };
 		619712AD984E8EA2ED68AE2C /* PreviewRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17B2A4D2BADE64E249073E1 /* PreviewRegistry.swift */; };
 		61CF67858355FFF4962D9D99 /* ThemeColorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */; };
+		61D00C1763BF9CE0587A9A5F /* PreparedFrameTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */; };
 		62628D5EAC0BCF980D2C59A3 /* PreviewRegistry+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6904499C06BDDEDCECC5D364 /* PreviewRegistry+AgentChat.swift */; };
 		637E93B9C1D6B5DBF0E29F05 /* MessagesContentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4867C8EE01AF6ACFB27DB7C /* MessagesContentStateTests.swift */; };
 		63F3CF3A4746901FDF1C3356 /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
@@ -205,6 +207,7 @@
 		AB6380E87DD09C5259E74DE3 /* SignatureHelpState.swift in Sources */ = {isa = PBXBuildFile; fileRef = E1E4036EB5EED196E5F367CC /* SignatureHelpState.swift */; };
 		AB804A6366BEFE62E30C929B /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		ABE7AA8517D1D7FBD7CC1816 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */; };
+		ADF5C83FD9AB775E025493AC /* PreparedFrameTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */; };
 		AECCB78BD5A8934BB64A3C52 /* PreviewRegistry+FileTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305F0E7D9158C236803224AA /* PreviewRegistry+FileTree.swift */; };
 		AFE31388980EE451C8F734A3 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
 		B00499E91B66E7A6E167D808 /* WhichKeyState.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEEC828C1445B3314C8989E1 /* WhichKeyState.swift */; };
@@ -530,6 +533,7 @@
 		9D721181E284AD8BA34F0354 /* SparklineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SparklineView.swift; sourceTree = "<group>"; };
 		9E1D0E05FBEEC550591460C7 /* PreviewSnapshotPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewSnapshotPolicy.swift; sourceTree = "<group>"; };
 		9E27E6D9ACEB7DCD7F98FB0F /* PowerThermalPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerThermalPolicyTests.swift; sourceTree = "<group>"; };
+		9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreparedFrameTransaction.swift; sourceTree = "<group>"; };
 		9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotAllocatorTests.swift; sourceTree = "<group>"; };
 		A38E8668FFBC3522674AE29C /* HoverPopupOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HoverPopupOverlay.swift; sourceTree = "<group>"; };
 		A583EB0DCE480D1A5FC7E440 /* BottomPanelState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelState.swift; sourceTree = "<group>"; };
@@ -719,6 +723,7 @@
 				D2D59D9EEB390C8DF351D595 /* FrameState.swift */,
 				4742DDE225F256A140177301 /* LineTextureAtlas.swift */,
 				3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */,
+				9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */,
 				371C61E78D4BB39467516BA7 /* SlotAllocator.swift */,
 				790F7E20F30FEEFC552B3685 /* WindowContent.swift */,
 				CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */,
@@ -1347,6 +1352,7 @@
 				4B2CF3C29FD0F4B63C7E7027 /* MingaWindow.swift in Sources */,
 				067369CB702835E93D254606 /* PipelineCache.swift in Sources */,
 				B7203DF9CF85663B0A266580 /* PowerThermalPolicy.swift in Sources */,
+				ADF5C83FD9AB775E025493AC /* PreparedFrameTransaction.swift in Sources */,
 				00F5A6B58392069C8645B12C /* PresentationScrollAnimator.swift in Sources */,
 				62628D5EAC0BCF980D2C59A3 /* PreviewRegistry+AgentChat.swift in Sources */,
 				77668ADDD66C267D11ACF44C /* PreviewRegistry+Chrome.swift in Sources */,
@@ -1398,6 +1404,7 @@
 				8DBD574DB36A054FBCFC5DD8 /* MingaWindow.swift in Sources */,
 				E3B2DB94D802E1831C17474E /* PipelineCache.swift in Sources */,
 				68886327B4EB9F0766EB7DCD /* PowerThermalPolicy.swift in Sources */,
+				03C97AFD225BCEA6E7A8E0BF /* PreparedFrameTransaction.swift in Sources */,
 				E0F2C0021D714788A404E845 /* PresentationScrollAnimator.swift in Sources */,
 				077AF22C34E2851B1F975C78 /* PreviewHostApp.swift in Sources */,
 				28E5444432A6B3AF05FE9762 /* PreviewRegistry+AgentChat.swift in Sources */,
@@ -1592,6 +1599,7 @@
 				4E1EEFA65935DCE58528E02B /* PipelineCacheTests.swift in Sources */,
 				05EC70C811170EE160C5E4D9 /* PowerThermalPolicy.swift in Sources */,
 				BA72343308BCD0E078452868 /* PowerThermalPolicyTests.swift in Sources */,
+				61D00C1763BF9CE0587A9A5F /* PreparedFrameTransaction.swift in Sources */,
 				3A296C1AF0FDD2A0FDF83E7A /* PresentationScrollAnimator.swift in Sources */,
 				A4329C17518FA82F5049A8EF /* PresentationScrollAnimatorTests.swift in Sources */,
 				CE8489B606217C3889536EBD /* PreviewRegistry+AgentChat.swift in Sources */,

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -462,7 +462,12 @@ public struct ContentView<EditorSurface: View>: View {
     }
 
     public var body: some View {
-        ZStack {
+        // Protocol-driven child State objects publish through these aggregate
+        // swaps, never through independent nested observation notifications.
+        _ = gui.framePublication
+        _ = gui.outOfBandPublication
+
+        return ZStack {
             VStack(spacing: 0) {
                 unifiedToolbar
                 HStack(spacing: 0) {

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -818,9 +818,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
             frame.metrics.actorHopCount
         )
         guard let dispatcher else { return }
-        for decoded in frame.commands {
-            dispatcher.dispatch(decoded.command, opcode: decoded.opcode)
-        }
+        dispatcher.dispatch(frame)
     }
 
     private func handleProtocolDecodeFailure(_ error: ProtocolDecodeError) {

--- a/macos/Sources/Protocol/DecodedFrame.swift
+++ b/macos/Sources/Protocol/DecodedFrame.swift
@@ -63,6 +63,9 @@ struct FrameDecodeMetrics: Sendable, Equatable {
 }
 
 /// A fully validated packet. No command is observable until this value exists.
+/// The main-actor dispatcher consumes the whole value and compiles its commands
+/// directly into a `PreparedFrameTransactionBuilder`; it never stores packet views
+/// or publishes commands individually.
 struct DecodedFrame: Sendable {
     let commands: [DecodedCommand]
     let metrics: FrameDecodeMetrics

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -4,23 +4,18 @@
 /// and the dedicated gui_* opcodes. The cell-paradigm commands (draw_text,
 /// set_cursor, clear, region tracking) were retired in protocol_version 2.
 ///
-/// ## Frame transactions (#2219 child D)
+/// ## Frame transactions (#2747)
 ///
 /// Every BEAM frame is bracketed by `begin_frame` and `commit_frame`. Between
-/// the two, transaction-scoped commands are *buffered* in `stagedCommands`
-/// rather than mutating the presented `FrameState`/`GUIState`, so SwiftUI never
-/// renders a half-applied frame. At `commit_frame` the dispatcher validates the
-/// transaction (frame_seq matches the open begin; base_frame_seq is 0 or the
-/// last committed seq) and *replays* the buffered commands through the same
-/// `apply(_:)` switch that drives non-transactional dispatch. This is the
-/// buffered-commands design from the AC-1 consult: one mutation path, no shadow
-/// state, no per-field staging twins. The replay happens synchronously inside
-/// `commit_frame` before `onFrameReady`, so the SwiftUI render pass observes the
-/// whole frame as one consistent update.
+/// the two, commands compile into typed domain updates in a value-semantic
+/// `PreparedFrameTransactionBuilder`; presented state remains untouched.
+/// Window deltas and resource references resolve while staging. Commit validates
+/// ordering and freezes the builder before entering one focused GUI publication
+/// boundary, so an invalid frame cannot partially publish.
 ///
-/// Invalidation (truncation via double-begin, seq mismatch, base mismatch, or a
-/// decode failure surfaced while a transaction is open) discards the staged
-/// buffer and requests a fresh keyframe via `onRequestKeyframe`. A subtle
+/// Rejection (truncation via double-begin, seq mismatch, base mismatch, or a
+/// decode failure surfaced while a transaction is open) discards the builder
+/// and requests a fresh keyframe via `onRequestKeyframe`. A subtle
 /// resync-pending hint (`GUIState.resyncState`) is raised until the next clean
 /// commit lands.
 
@@ -143,9 +138,21 @@ final class CommandDispatcher {
     /// Validated against `lastCommittedFrameSeq` at commit.
     private var openBaseFrameSeq: UInt32 = 0
 
-    /// Commands buffered since the open `begin_frame`. Replayed through
-    /// `apply(_:)` at `commit_frame` so the presented state changes in one batch.
-    private var stagedCommands: [RenderCommand] = []
+    /// Value-semantic builder for the open frame. Commands are classified and
+    /// window deltas are resolved during staging; commit only freezes and publishes.
+    private var transactionBuilder: PreparedFrameTransactionBuilder?
+
+    /// Font resources known to the publisher. Font id 0 is the primary font.
+    private var registeredFontIds: Set<UInt8> = [0]
+
+    /// Typed result boundary consumed by the frame acknowledgement work in #2739.
+    var onTransactionResult: ((FrameTransactionResult) -> Void)?
+
+    /// Number of focused publication-boundary entries, exposed for instrumentation.
+    private(set) var publicationCount = 0
+
+    /// Cost of the most recently published frame in changed-domain operations.
+    private(set) var lastPublicationOperationCounts: PreparedFrameOperationCounts?
 
     /// frame_seq of the last transaction this dispatcher committed cleanly.
     /// Doubles as the delta base validator and the `last_good_frame_seq` carried
@@ -187,7 +194,7 @@ final class CommandDispatcher {
 
     /// Entry point from the protocol reader. Routes a decoded command through the
     /// frame-transaction state machine: frame markers open/close transactions,
-    /// transaction-scoped commands buffer into `stagedCommands`, and explicitly
+    /// transaction-scoped commands compile into the prepared builder, and explicitly
     /// sanctioned out-of-band commands apply immediately (or stage if inside a
     /// transaction). Everything else outside a transaction triggers active
     /// recovery: invalidation and a keyframe request.
@@ -198,6 +205,14 @@ final class CommandDispatcher {
     /// active recovery rather than silent drop. Contrast the old positive-allowlist
     /// design where a missing entry caused an unnecessary keyframe request with no
     /// application of the command.
+    /// Stages every immutable command from one decoded packet through the same
+    /// prepared-transaction builder. Packet decoding itself remains off-main.
+    func dispatch(_ frame: DecodedFrame) {
+        for decoded in frame.commands {
+            dispatch(decoded.command, opcode: decoded.opcode)
+        }
+    }
+
     func dispatch(_ command: RenderCommand, opcode: UInt8? = nil) {
         switch command {
         case .beginFrame(let frameSeq, let baseFrameSeq):
@@ -208,7 +223,7 @@ final class CommandDispatcher {
 
         // Sanctioned out-of-band commands: the BEAM legitimately emits these
         // outside a begin/commit bracket. If one arrives inside an open
-        // transaction it stages for atomic replay; outside one it applies
+        // transaction it compiles for atomic publication; outside one it applies
         // immediately. Mirrors Go's explicit match arms at model.go:444-450.
         //
         // setTitle / setWindowBg / setLinkCursor / clipboardWrite: post-commit
@@ -217,26 +232,39 @@ final class CommandDispatcher {
         // setFont / setFontFallback / registerFont / guiConfigState: startup
         //   config emitted before the first frame (equivalent to Go's CommandNoop
         //   for font commands, but Swift actually applies them).
-        case .setTitle, .setWindowBg, .setLinkCursor, .protocolError,
-             .setFont, .setFontFallback, .registerFont,
-             .guiConfigState, .clipboardWrite:
-            if openFrameSeq != nil {
-                stagedCommands.append(command)
-            } else {
+        case .guiConfigState:
+            // Settings is an independently interactive scene. Its config stream
+            // is startup/out-of-band state and never participates in a render frame.
+            guiState.performOutOfBandPublication {
                 apply(command)
+            }
+
+        case .setTitle, .setWindowBg, .setLinkCursor, .protocolError,
+             .setFont, .setFontFallback, .registerFont, .clipboardWrite:
+            if openFrameSeq != nil {
+                transactionBuilder?.stage(command)
+            } else {
+                guiState.performOutOfBandPublication {
+                    apply(command)
+                }
             }
 
         default:
             if openFrameSeq != nil {
-                // Inside a transaction: buffer for atomic replay at commit.
-                stagedCommands.append(command)
+                // Inside a transaction: compile into typed domain updates.
+                transactionBuilder?.stage(command)
             } else {
                 // A command arrived with no open transaction and no sanctioned
                 // out-of-band match above. Either a new BEAM out-of-band command
                 // was added to the protocol without a corresponding explicit arm
                 // here, or the byte stream is desynced. Active recovery: discard
                 // staged state and request a keyframe. Mirrors Go model.go:454-456.
-                invalidate(reason: "out-of-transaction command", sourceOpcode: opcode)
+                reject(
+                    .outOfTransactionCommand(opcode: opcode),
+                    frameSeq: nil,
+                    logReason: "out-of-transaction command",
+                    sourceOpcode: opcode
+                )
             }
         }
     }
@@ -245,89 +273,91 @@ final class CommandDispatcher {
     /// `commit_frame` is truncation: the prior frame never closed, so its staged
     /// commands are discarded and we resync before opening the new transaction.
     private func beginTransaction(frameSeq: UInt32, baseFrameSeq: UInt32) {
-        if openFrameSeq != nil {
+        if let openFrameSeq {
             // Double-begin = truncation of the previous frame.
-            invalidate(reason: "begin_frame while a transaction was open")
+            reject(
+                .beginWhileOpen(openFrameSeq: openFrameSeq, incomingFrameSeq: frameSeq),
+                frameSeq: openFrameSeq,
+                logReason: "begin_frame while a transaction was open"
+            )
         }
         openFrameSeq = frameSeq
         openBaseFrameSeq = baseFrameSeq
-        stagedCommands.removeAll(keepingCapacity: true)
+        transactionBuilder = PreparedFrameTransactionBuilder(
+            frameSeq: frameSeq,
+            baseFrameSeq: baseFrameSeq,
+            committedWindows: guiState.windowContents,
+            registeredFontIds: registeredFontIds,
+            committedTranscript: guiState.agentChatState.transcriptSnapshot
+        )
         if baseFrameSeq == 0 && resyncRecoveryState == .awaitingKeyframe {
             resyncRecoveryState = .keyframeInFlight
         }
     }
 
-    /// Closes a frame transaction. Validates frame_seq against the open begin and
-    /// base_frame_seq against the last clean commit, then replays the buffered
-    /// commands through `apply(_:)` in one batch and presents. Any validation
-    /// failure discards staging and requests a keyframe without partial promotion.
+    /// Closes, freezes, and publishes the open transaction. Validation completes
+    /// before `publish(_:)` is entered, so a rejected frame has no observable writes.
     private func commitTransaction(frameSeq: UInt32, inputSeq: UInt32) {
         guard let open = openFrameSeq else {
-            // commit_frame with no open begin: truncation/desync.
-            invalidate(reason: "commit_frame with no open transaction")
+            reject(
+                .commitWithoutBegin(frameSeq: frameSeq),
+                frameSeq: frameSeq,
+                logReason: "commit_frame with no open transaction"
+            )
             return
         }
-
         guard frameSeq == open else {
-            invalidate(reason: "commit_frame seq \(frameSeq) != open begin seq \(open)")
+            reject(
+                .commitSequenceMismatch(openFrameSeq: open, commitFrameSeq: frameSeq),
+                frameSeq: open,
+                logReason: "commit_frame seq \(frameSeq) != open begin seq \(open)"
+            )
+            return
+        }
+        guard !hasCommitted || frameSeq > lastCommittedFrameSeq else {
+            reject(
+                .frameSequenceNotIncreasing(lastFrameSeq: lastCommittedFrameSeq, incomingFrameSeq: frameSeq),
+                frameSeq: frameSeq,
+                logReason: "frame_seq \(frameSeq) is not newer than \(lastCommittedFrameSeq)"
+            )
             return
         }
 
-        // base_frame_seq == 0 is a keyframe (depends on nothing). Otherwise the
-        // base must name the frame_seq this client last committed cleanly.
         let baseValid = openBaseFrameSeq == 0 ||
             (hasCommitted && openBaseFrameSeq == lastCommittedFrameSeq)
         guard baseValid else {
-            invalidate(reason: "base_frame_seq \(openBaseFrameSeq) != last committed \(lastCommittedFrameSeq)")
+            reject(
+                .baseSequenceMismatch(expectedFrameSeq: lastCommittedFrameSeq, actualBaseFrameSeq: openBaseFrameSeq),
+                frameSeq: frameSeq,
+                logReason: "base_frame_seq \(openBaseFrameSeq) != last committed \(lastCommittedFrameSeq)"
+            )
+            return
+        }
+        guard let transactionBuilder else {
+            reject(.decodeFailure(frameSeq: frameSeq), frameSeq: frameSeq, logReason: "missing frame builder")
             return
         }
 
-        let validation = stagedThemeValidation()
-        if validation.found {
-            if !validation.missingSlots.isEmpty {
-                let missingSlots = CommandDispatcher.formatMissingThemeSlots(validation.missingSlots)
-                if openBaseFrameSeq == 0 {
-                    PortLogger.warn("Keyframe committed with incomplete gui_theme, missing slots: \(missingSlots)")
-                    apply(.protocolError(message: "missing gui_theme slots in keyframe: \(missingSlots)"))
-                    return invalidate(reason: "missing gui_theme slots in keyframe: \(missingSlots)")
-                }
-
-                PortLogger.warn("Frame committed with incomplete gui_theme, missing slots: \(missingSlots)")
-                apply(.protocolError(message: "missing gui_theme slots: \(missingSlots)"))
-                return invalidate(reason: "missing gui_theme slots: \(missingSlots)")
+        switch transactionBuilder.freeze(requiredThemeSlots: Self.requiredThemeSlots) {
+        case .failure(let rejection):
+            reject(rejection, frameSeq: frameSeq, logReason: rejection.logDescription)
+            return
+        case .success(let transaction):
+            if openBaseFrameSeq == 0 && resyncRecoveryState == .keyframeInFlight {
+                resyncRecoveryState = .clean
+                guiState.resyncState.clear()
             }
-        } else if openBaseFrameSeq == 0 {
-            PortLogger.warn("Keyframe committed without gui_theme; refusing to present unthemed frame")
-            apply(.protocolError(message: "missing gui_theme in keyframe"))
-            return invalidate(reason: "missing gui_theme in keyframe")
+            publish(transaction)
         }
 
-        // Promote: replay the staged commands through the single mutation path.
-        // This whole loop runs synchronously before onFrameReady, so SwiftUI's
-        // render pass observes one consistent update rather than each step.
-        for staged in stagedCommands {
-            apply(staged)
-        }
-
-        if openBaseFrameSeq == 0 {
-            pruneAuthoritativeFrameState(liveWindowIds: liveWindowIds(from: stagedCommands))
-        }
-
-        // Record the clean commit and clear the transaction.
         lastCommittedFrameSeq = frameSeq
         hasCommitted = true
         openFrameSeq = nil
-        stagedCommands.removeAll(keepingCapacity: true)
-        if openBaseFrameSeq == 0 && resyncRecoveryState == .keyframeInFlight {
-            resyncRecoveryState = .clean
-            guiState.resyncState.clear()
-        }
+        self.transactionBuilder = nil
 
-        // Resolve the keystroke-to-present latency sample for the echoed input
-        // correlation sequence (ticket #2215). The frame is fully promoted here
-        // and about to be presented by the Metal renderer.
         os_signpost(.event, log: renderLog, name: "CommitFrame", "frame=%{public}u input=%{public}u", frameSeq, inputSeq)
         latency.resolve(seq: inputSeq)
+        onTransactionResult?(.published(frameSeq: frameSeq))
         if let firstRender = onFirstRender {
             firstRender()
             onFirstRender = nil
@@ -336,20 +366,42 @@ final class CommandDispatcher {
         onFrameReady?()
     }
 
-    private func stagedThemeValidation() -> (found: Bool, missingSlots: [UInt8]) {
-        var found = false
-
-        for command in stagedCommands {
-            if case .guiTheme(let slots) = command {
-                found = true
-                let missingSlots = CommandDispatcher.missingThemeSlots(in: slots)
-                if !missingSlots.isEmpty {
-                    return (true, missingSlots)
+    /// The sole committed-GUI publication boundary.
+    private func publish(_ transaction: PreparedFrameTransaction) {
+        guiState.performFramePublication(frameSeq: transaction.frameSeq) {
+            if let theme = transaction.theme { apply(.guiTheme(slots: theme.slots)) }
+            if let resources = transaction.resources { resources.commands.forEach(apply) }
+            if let windows = transaction.windows { apply(windows) }
+            if let metadata = transaction.metadata { metadata.commands.forEach(apply) }
+            if let chrome = transaction.chrome {
+                if let transcript = chrome.transcript {
+                    guiState.agentChatState.publishTranscript(transcript)
                 }
+                chrome.commands.forEach(apply)
             }
+            if let overlays = transaction.overlays { overlays.commands.forEach(apply) }
+            if let focus = transaction.focus { focus.commands.forEach(apply) }
         }
+        publicationCount += 1
+        lastPublicationOperationCounts = transaction.operationCounts
+    }
 
-        return (found, [])
+    private func apply(_ updates: PreparedWindowUpdates) {
+        for (windowId, content) in updates.replacements {
+            let previousScroll = guiState.windowContents[windowId]?.scrollPresentation
+            guiState.windowContents[windowId] = content
+            if shouldResetScrollPresentation(previous: previousScroll, next: content.scrollPresentation) {
+                discardLocalPresentation(.offset, windowId: windowId)
+            }
+            frameState.cursorVisible = content.cursorVisible
+            frameState.dirty = true
+        }
+        updates.commands.forEach(apply)
+        if let authoritativeWindowIds = updates.authoritativeWindowIds {
+            pruneAuthoritativeFrameState(liveWindowIds: authoritativeWindowIds)
+        } else {
+            currentFrameWindowIds.formUnion(updates.touchedWindowIds)
+        }
     }
 
     private func pruneAuthoritativeFrameState(liveWindowIds: Set<UInt16>) {
@@ -371,55 +423,25 @@ final class CommandDispatcher {
         frameState.viewportTopLine = activeGutter.entries.first?.bufLine ?? 0xFFFF_FFFF
     }
 
-    private func liveWindowIds(from commands: [RenderCommand]) -> Set<UInt16> {
-        var ids = Set<UInt16>()
-        ids.reserveCapacity(commands.count)
-
-        for command in commands {
-            switch command {
-            case .guiWindowContent(let data):
-                ids.insert(data.windowId)
-            case .guiWindowOverlayDelta(let data):
-                ids.insert(data.windowId)
-            case .guiWindowViewportDelta(let data):
-                ids.insert(data.windowId)
-            case .guiWindowRowsDelta(let data):
-                ids.insert(data.windowId)
-            case .guiGutter(let data):
-                ids.insert(data.windowId)
-            case .guiIndentGuides(let data):
-                ids.insert(data.windowId)
-            default:
-                continue
-            }
-        }
-
-        return ids
-    }
-
-    private static func missingThemeSlots(in slots: [(UInt8, UInt8, UInt8, UInt8)]) -> [UInt8] {
-        let present = Set(slots.map { $0.0 })
-        return requiredThemeSlots.filter { !present.contains($0) }
-    }
-
-    private static func formatMissingThemeSlots(_ slots: [UInt8]) -> String {
-        slots.map { String(format: "0x%02X", $0) }.joined(separator: ", ")
-    }
-
-    /// Discards the open transaction's staged commands without promoting any of
-    /// them and asks the BEAM for a fresh keyframe (#2219 child D). The presented
-    /// state is left exactly as the last clean commit left it, so the screen
-    /// holds the last good frame until the keyframe arrives. Raises a subtle
-    /// resync-pending hint in the meantime.
-    private func invalidate(reason: String, sourceOpcode: UInt8? = nil) {
+    /// Rejects one frame, leaves the last-good publication untouched, and emits
+    /// exactly one typed result for the acknowledgement layer in #2739.
+    private func reject(
+        _ rejection: PreparedFrameRejection,
+        frameSeq: UInt32?,
+        logReason: String,
+        sourceOpcode: UInt8? = nil
+    ) {
         let opcodeContext = sourceOpcode.map { String(format: ", opcode=0x%02X", $0) } ?? ""
         let shouldRequestKeyframe = resyncRecoveryState != .awaitingKeyframe
         resyncRecoveryState = .awaitingKeyframe
-        PortLogger.warn("Frame transaction invalidated (\(reason)\(opcodeContext)); \(shouldRequestKeyframe ? "requesting" : "awaiting") keyframe from \(lastCommittedFrameSeq)")
+        PortLogger.warn("Frame transaction rejected (\(logReason)\(opcodeContext)); \(shouldRequestKeyframe ? "requesting" : "awaiting") keyframe from \(lastCommittedFrameSeq)")
         openFrameSeq = nil
         openBaseFrameSeq = 0
-        stagedCommands.removeAll(keepingCapacity: false)
-        guiState.resyncState.markPending(lastGoodFrameSeq: lastCommittedFrameSeq)
+        transactionBuilder = nil
+        guiState.performOutOfBandPublication {
+            guiState.resyncState.markPending(lastGoodFrameSeq: lastCommittedFrameSeq)
+        }
+        onTransactionResult?(.rejected(frameSeq: frameSeq, reason: rejection))
         if shouldRequestKeyframe {
             onRequestKeyframe?(lastCommittedFrameSeq)
         }
@@ -432,8 +454,12 @@ final class CommandDispatcher {
     /// a transaction there is nothing staged to discard, so the reader keeps its
     /// existing log-and-continue behavior.
     func decodeFailed() {
-        guard openFrameSeq != nil else { return }
-        invalidate(reason: "decode failure inside an open transaction")
+        guard let openFrameSeq else { return }
+        reject(
+            .decodeFailure(frameSeq: openFrameSeq),
+            frameSeq: openFrameSeq,
+            logReason: "decode failure inside an open transaction"
+        )
     }
 
     /// Test seam: apply a single command directly to the presented state,
@@ -441,6 +467,17 @@ final class CommandDispatcher {
     /// this; it routes through `dispatch`. Routing/setup tests use it to assert a
     /// command's mutation without bracketing every call in begin/commit.
     func applyForTesting(_ command: RenderCommand) {
+        if case .guiAgentTranscript(let mode, let epoch, let truncated, let trimFront, let baseCount, let messages) = command {
+            _ = guiState.agentChatState.applyTranscript(
+                mode: mode,
+                epoch: epoch,
+                truncated: truncated,
+                trimFront: Int(trimFront),
+                baseCount: Int(baseCount),
+                messages: messages
+            )
+            return
+        }
         apply(command)
     }
 
@@ -471,14 +508,17 @@ final class CommandDispatcher {
     func previewFileTreeNavigation(codepoint: UInt32, modifiers: UInt8) -> Bool {
         guard modifiers == 0 else { return false }
 
+        let changed: Bool
         switch codepoint {
         case FileTreeNavigationCodepoints.downKey, FileTreeNavigationCodepoints.downArrow:
-            return guiState.fileTreeState.previewNavigation(delta: 1)
+            changed = guiState.fileTreeState.previewNavigation(delta: 1)
         case FileTreeNavigationCodepoints.upKey, FileTreeNavigationCodepoints.upArrow:
-            return guiState.fileTreeState.previewNavigation(delta: -1)
+            changed = guiState.fileTreeState.previewNavigation(delta: -1)
         default:
             return false
         }
+        if changed { guiState.performOutOfBandPublication {} }
+        return changed
     }
 
     @discardableResult
@@ -505,26 +545,31 @@ final class CommandDispatcher {
         } else {
             return false
         }
-        return guiState.completionState.previewNavigation(delta: delta)
+        let changed = guiState.completionState.previewNavigation(delta: delta)
+        if changed { guiState.performOutOfBandPublication {} }
+        return changed
     }
 
     @discardableResult
     func previewPickerNavigation(codepoint: UInt32, modifiers: UInt8) -> Bool {
         guard modifiers == 0 else { return false }
 
+        let changed: Bool
         switch codepoint {
         case PickerNavigationCodepoints.downKey, PickerNavigationCodepoints.downArrow:
-            return guiState.pickerState.previewNavigation(delta: 1)
+            changed = guiState.pickerState.previewNavigation(delta: 1)
         case PickerNavigationCodepoints.upKey, PickerNavigationCodepoints.upArrow:
-            return guiState.pickerState.previewNavigation(delta: -1)
+            changed = guiState.pickerState.previewNavigation(delta: -1)
         default:
             return false
         }
+        if changed { guiState.performOutOfBandPublication {} }
+        return changed
     }
 
-    /// Apply a single render command to the presented FrameState/GUIState. This
-    /// is the single mutation path: called directly for out-of-band commands and
-    /// replayed for every staged command at commit. It must NOT handle the frame
+    /// Apply one domain command to the presented FrameState/GUIState. This is
+    /// called directly for out-of-band commands and from the focused prepared
+    /// publication boundary for committed domain updates. It must NOT handle frame
     /// markers (begin/commit) — those drive the transaction state machine in
     /// `dispatch`/`commitTransaction`, not the presented state.
     private func apply(_ command: RenderCommand) {
@@ -535,7 +580,7 @@ final class CommandDispatcher {
         case .beginFrame, .commitFrame:
             // Frame markers drive the transaction state machine in `dispatch`,
             // not the presented state. They are intercepted before `apply` is
-            // called and are never buffered into `stagedCommands`, so reaching
+            // called and are never staged into a prepared transaction, so reaching
             // here means a routing bug.
             PortLogger.warn("Frame marker reached apply(_:); transaction routing bug")
 
@@ -572,6 +617,7 @@ final class CommandDispatcher {
 
         case .registerFont(let id, let family):
             fontManager?.registerFont(id: id, name: family)
+            registeredFontIds.insert(id)
 
         case .guiConfigState(let configState):
             guiState.settingsState.apply(configState: configState)
@@ -583,7 +629,7 @@ final class CommandDispatcher {
             guiState.editTimelineState.update(visible: visible, viewingIndex: viewingIndex, wireEntries: entries, wireFiles: files)
 
         case .guiTheme(let slots):
-            guiState.themeColors.applySlots(slots)
+            guiState.replaceTheme(slots: slots)
             let tc = guiState.themeColors
             frameState.gutterColors = GutterThemeColors(
                 fg: tc.gutterFgRGB,
@@ -714,8 +760,10 @@ final class CommandDispatcher {
                 onAgentChatVisibilityChanged?(guiState.agentChatState.visible)
             }
 
-        case .guiAgentTranscript(let mode, let epoch, let truncated, let trimFront, let baseCount, let messages):
-            guiState.agentChatState.applyTranscript(mode: mode, epoch: epoch, truncated: truncated, trimFront: Int(trimFront), baseCount: Int(baseCount), messages: messages)
+        case .guiAgentTranscript:
+            // Prepared transactions publish the validated value snapshot directly.
+            // Reaching this path would bypass all-or-nothing transcript validation.
+            assertionFailure("guiAgentTranscript must be prepared before publication")
 
         case .guiGutterSeparator(let col, let r, let g, let b):
             let rgb: UInt32 = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -1,0 +1,454 @@
+/// Value-semantic frame preparation and validation.
+///
+/// Commands are classified while a frame is staged. Window deltas are resolved
+/// against the last-good snapshot immediately, so publication never has to scan
+/// the command stream or look up a live reference that was not validated first.
+
+import Foundation
+import MingaProtocol
+import MingaUI
+
+/// The single typed result consumed by the frame-status protocol in #2739.
+enum FrameTransactionResult: Sendable, Equatable {
+    case published(frameSeq: UInt32)
+    case rejected(frameSeq: UInt32?, reason: PreparedFrameRejection)
+}
+
+/// A rejection is complete and stable before any observable state is changed.
+enum PreparedFrameRejection: Error, Sendable, Equatable {
+    case beginWhileOpen(openFrameSeq: UInt32, incomingFrameSeq: UInt32)
+    case commitWithoutBegin(frameSeq: UInt32)
+    case commitSequenceMismatch(openFrameSeq: UInt32, commitFrameSeq: UInt32)
+    case frameSequenceNotIncreasing(lastFrameSeq: UInt32, incomingFrameSeq: UInt32)
+    case baseSequenceMismatch(expectedFrameSeq: UInt32, actualBaseFrameSeq: UInt32)
+    case missingTheme
+    case incompleteTheme(missingSlots: [UInt8])
+    case missingWindowReference(windowId: UInt16)
+    case windowEpochMismatch(windowId: UInt16, expected: UInt32, actual: UInt32)
+    case invalidRetainedRows(windowId: UInt16, contentEpoch: UInt32)
+    case missingFontResource(fontId: UInt8)
+    case transcriptBeforeSeed
+    case transcriptEpochMismatch
+    case transcriptDesynced
+    case decodeFailure(frameSeq: UInt32)
+    case outOfTransactionCommand(opcode: UInt8?)
+
+    var logDescription: String {
+        switch self {
+        case .beginWhileOpen(let open, let incoming):
+            return "begin_frame \(incoming) while frame \(open) was open"
+        case .commitWithoutBegin(let frameSeq):
+            return "commit_frame \(frameSeq) with no open transaction"
+        case .commitSequenceMismatch(let open, let commit):
+            return "commit_frame seq \(commit) != open begin seq \(open)"
+        case .frameSequenceNotIncreasing(let last, let incoming):
+            return "frame_seq \(incoming) is not newer than \(last)"
+        case .baseSequenceMismatch(let expected, let actual):
+            return "base_frame_seq \(actual) != last committed \(expected)"
+        case .missingTheme:
+            return "missing gui_theme in keyframe"
+        case .incompleteTheme(let slots):
+            let formatted = slots.map { String(format: "0x%02X", $0) }.joined(separator: ", ")
+            return "missing gui_theme slots: \(formatted)"
+        case .missingWindowReference(let windowId):
+            return "missing live window reference \(windowId)"
+        case .windowEpochMismatch(let windowId, let expected, let actual):
+            return "window \(windowId) epoch \(actual) != \(expected)"
+        case .invalidRetainedRows(let windowId, let epoch):
+            return "window \(windowId) has invalid retained rows for epoch \(epoch)"
+        case .missingFontResource(let fontId):
+            return "missing font resource \(fontId)"
+        case .transcriptBeforeSeed:
+            return "agent transcript append before seed"
+        case .transcriptEpochMismatch:
+            return "agent transcript epoch mismatch"
+        case .transcriptDesynced:
+            return "agent transcript append desynced"
+        case .decodeFailure(let frameSeq):
+            return "decode failure in frame \(frameSeq)"
+        case .outOfTransactionCommand:
+            return "out-of-transaction command"
+        }
+    }
+}
+
+/// Instrumentation describes publication cost in domain operations, not commands.
+struct PreparedFrameOperationCounts: Sendable, Equatable {
+    let theme: Int
+    let windows: Int
+    let chrome: Int
+    let overlays: Int
+    let resources: Int
+    let focus: Int
+    let metadata: Int
+
+    var total: Int { theme + windows + chrome + overlays + resources + focus + metadata }
+}
+
+struct PreparedThemeUpdate: Sendable {
+    let slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)]
+}
+
+struct PreparedWindowUpdates: Sendable {
+    let replacements: [UInt16: GUIWindowContent]
+    let touchedWindowIds: Set<UInt16>
+    let authoritativeWindowIds: Set<UInt16>?
+    let commands: [RenderCommand]
+}
+
+struct PreparedChromeUpdates {
+    let commands: [RenderCommand]
+    let transcript: AgentTranscriptSnapshot?
+}
+struct PreparedOverlayUpdates: Sendable { let commands: [RenderCommand] }
+struct PreparedResourceUpdates: Sendable { let commands: [RenderCommand] }
+struct PreparedFocusUpdates: Sendable { let commands: [RenderCommand] }
+struct PreparedMetadataUpdates: Sendable { let commands: [RenderCommand] }
+
+/// Frozen transaction. All references, epochs, resources, and keyframe
+/// requirements have been validated before this value can be created.
+struct PreparedFrameTransaction {
+    let frameSeq: UInt32
+    let baseFrameSeq: UInt32
+    let theme: PreparedThemeUpdate?
+    let windows: PreparedWindowUpdates?
+    let chrome: PreparedChromeUpdates?
+    let overlays: PreparedOverlayUpdates?
+    let resources: PreparedResourceUpdates?
+    let focus: PreparedFocusUpdates?
+    let metadata: PreparedMetadataUpdates?
+    let operationCounts: PreparedFrameOperationCounts
+}
+
+/// Coalesces repeated updates to the same semantic state during staging. This is
+/// what makes commit independent of decoded command count: each affected state
+/// appears at most once in its prepared domain (per window/resource where keyed).
+private enum PreparedWindowCommandKind: Hashable {
+    case gutter
+    case indentGuides
+}
+
+private enum PreparedCoalescingKey: Hashable {
+    case command(Int)
+    case window(kind: PreparedWindowCommandKind, id: UInt16)
+    case font(UInt8)
+    case appended(Int)
+}
+
+private struct PreparedDomainBuffer {
+    private var order: [PreparedCoalescingKey] = []
+    private var commandsByKey: [PreparedCoalescingKey: RenderCommand] = [:]
+    private var nextAppendKey = 0
+
+    var isEmpty: Bool { order.isEmpty }
+    var commands: [RenderCommand] { order.compactMap { commandsByKey[$0] } }
+
+    mutating func replace(_ command: RenderCommand, key: PreparedCoalescingKey) {
+        if commandsByKey[key] == nil { order.append(key) }
+        commandsByKey[key] = command
+    }
+
+    mutating func append(_ command: RenderCommand) {
+        let key = PreparedCoalescingKey.appended(nextAppendKey)
+        order.append(key)
+        commandsByKey[key] = command
+        nextAppendKey += 1
+    }
+}
+
+/// Mutable value builder owned only by CommandDispatcher while a frame is open.
+@MainActor
+struct PreparedFrameTransactionBuilder {
+    let frameSeq: UInt32
+    let baseFrameSeq: UInt32
+
+    private var theme: PreparedThemeUpdate?
+    private var workingWindows: [UInt16: GUIWindowContent]
+    private var changedWindows: [UInt16: GUIWindowContent] = [:]
+    private var referencedWindowIds: Set<UInt16> = []
+    private var touchedWindowIds: Set<UInt16> = []
+    private var windowCommands = PreparedDomainBuffer()
+    private var chromeCommands = PreparedDomainBuffer()
+    private var overlayCommands = PreparedDomainBuffer()
+    private var resourceCommands = PreparedDomainBuffer()
+    private var focusCommands = PreparedDomainBuffer()
+    private var metadataCommands = PreparedDomainBuffer()
+    private var registeredFontIds: Set<UInt8>
+    private var requiredFontIds: Set<UInt8> = []
+    private var workingTranscript: AgentTranscriptSnapshot
+    private var changedTranscript: AgentTranscriptSnapshot?
+    private var rejection: PreparedFrameRejection?
+
+    init(
+        frameSeq: UInt32,
+        baseFrameSeq: UInt32,
+        committedWindows: [UInt16: GUIWindowContent],
+        registeredFontIds: Set<UInt8>,
+        committedTranscript: AgentTranscriptSnapshot
+    ) {
+        self.frameSeq = frameSeq
+        self.baseFrameSeq = baseFrameSeq
+        self.workingWindows = baseFrameSeq == 0 ? [:] : committedWindows
+        self.registeredFontIds = registeredFontIds
+        self.registeredFontIds.insert(0)
+        self.workingTranscript = committedTranscript
+    }
+
+    mutating func stage(_ command: RenderCommand) {
+        switch command {
+        case .guiTheme(let slots):
+            theme = PreparedThemeUpdate(slots: slots)
+
+        case .guiWindowContent(let content):
+            workingWindows[content.windowId] = content
+            changedWindows[content.windowId] = content
+            touchedWindowIds.insert(content.windowId)
+            recordFontResources(in: content)
+
+        case .guiWindowOverlayDelta(let delta):
+            resolveOverlayDelta(delta)
+
+        case .guiWindowViewportDelta(let delta), .guiWindowRowsDelta(let delta):
+            resolveRowsDelta(delta)
+
+        case .guiGutter(let data):
+            referencedWindowIds.insert(data.windowId)
+            touchedWindowIds.insert(data.windowId)
+            windowCommands.replace(command, key: .window(kind: .gutter, id: data.windowId))
+
+        case .guiIndentGuides(let data):
+            referencedWindowIds.insert(data.windowId)
+            touchedWindowIds.insert(data.windowId)
+            windowCommands.replace(command, key: .window(kind: .indentGuides, id: data.windowId))
+
+        case .setFont, .setFontFallback, .guiConfigState:
+            resourceCommands.replace(command, key: .command(command.preparedUpdateKey))
+
+        case .registerFont(let id, _):
+            registeredFontIds.insert(id)
+            resourceCommands.replace(command, key: .font(id))
+
+        case .setCursorShape, .setLinkCursor, .guiFileTreeSelection:
+            focusCommands.replace(command, key: .command(command.preparedUpdateKey))
+
+        case .guiCompletion, .guiWhichKey, .guiPicker, .guiPickerPreview,
+             .guiAgentChat, .guiMinibuffer, .guiHoverPopup, .guiHoverAction,
+             .guiSignatureHelp, .guiFloatPopup, .guiExtensionOverlay,
+             .guiSearchState, .guiEmptyState, .protocolError:
+            overlayCommands.replace(command, key: .command(command.preparedUpdateKey))
+
+        case .setTitle, .setWindowBg, .guiGutterSeparator, .guiCursorline,
+             .guiLineSpacing, .guiCursorAnimation, .guiSplitSeparators,
+             .guiStatusBar, .clipboardWrite:
+            metadataCommands.replace(command, key: .command(command.preparedUpdateKey))
+
+        case .guiAgentTranscript(let mode, let epoch, let truncated, let trimFront, let baseCount, let messages):
+            guard rejection == nil else { return }
+            switch AgentChatState.prepareTranscript(
+                from: workingTranscript,
+                mode: mode,
+                epoch: epoch,
+                truncated: truncated,
+                trimFront: Int(trimFront),
+                baseCount: Int(baseCount),
+                messages: messages
+            ) {
+            case .success(let prepared):
+                workingTranscript = prepared
+                changedTranscript = prepared
+            case .failure(.beforeSeed):
+                rejection = .transcriptBeforeSeed
+            case .failure(.epochMismatch):
+                rejection = .transcriptEpochMismatch
+            case .failure(.desynced):
+                rejection = .transcriptDesynced
+            }
+
+        case .guiBottomPanel, .guiExtensionRuntime:
+            // These carry append/upsert semantics; every payload is meaningful.
+            chromeCommands.append(command)
+
+        case .guiTabBar, .guiFileTree, .guiObservatory, .guiBreadcrumb,
+             .guiToolManager, .guiGitStatus, .guiWorkspaces, .guiAgentContext,
+             .guiChangeSummary, .guiNotifications, .guiEditTimeline,
+             .guiExtensionPanel, .guiSidebars:
+            chromeCommands.replace(command, key: .command(command.preparedUpdateKey))
+
+        case .beginFrame, .commitFrame:
+            break
+        }
+    }
+
+    func freeze(requiredThemeSlots: [UInt8]) -> Result<PreparedFrameTransaction, PreparedFrameRejection> {
+        if let rejection { return .failure(rejection) }
+
+        if baseFrameSeq == 0, theme == nil { return .failure(.missingTheme) }
+        if let theme {
+            let present = Set(theme.slots.map(\.slotId))
+            let missing = requiredThemeSlots.filter { !present.contains($0) }
+            if !missing.isEmpty { return .failure(.incompleteTheme(missingSlots: missing)) }
+        }
+
+        let liveWindowIds = Set(workingWindows.keys)
+        if let missingReference = referencedWindowIds.subtracting(liveWindowIds).min() {
+            return .failure(.missingWindowReference(windowId: missingReference))
+        }
+        if let missingFont = requiredFontIds.subtracting(registeredFontIds).min() {
+            return .failure(.missingFontResource(fontId: missingFont))
+        }
+
+        let windowsChanged = !changedWindows.isEmpty || !windowCommands.isEmpty || baseFrameSeq == 0
+        let transaction = PreparedFrameTransaction(
+            frameSeq: frameSeq,
+            baseFrameSeq: baseFrameSeq,
+            theme: theme,
+            windows: windowsChanged ? PreparedWindowUpdates(
+                replacements: changedWindows,
+                touchedWindowIds: touchedWindowIds,
+                authoritativeWindowIds: baseFrameSeq == 0 ? liveWindowIds : nil,
+                commands: windowCommands.commands
+            ) : nil,
+            chrome: chromeCommands.isEmpty && changedTranscript == nil ? nil : PreparedChromeUpdates(
+                commands: chromeCommands.commands,
+                transcript: changedTranscript
+            ),
+            overlays: overlayCommands.isEmpty ? nil : PreparedOverlayUpdates(commands: overlayCommands.commands),
+            resources: resourceCommands.isEmpty ? nil : PreparedResourceUpdates(commands: resourceCommands.commands),
+            focus: focusCommands.isEmpty ? nil : PreparedFocusUpdates(commands: focusCommands.commands),
+            metadata: metadataCommands.isEmpty ? nil : PreparedMetadataUpdates(commands: metadataCommands.commands),
+            operationCounts: PreparedFrameOperationCounts(
+                theme: theme == nil ? 0 : 1,
+                windows: windowsChanged ? 1 : 0,
+                chrome: chromeCommands.isEmpty && changedTranscript == nil ? 0 : 1,
+                overlays: overlayCommands.isEmpty ? 0 : 1,
+                resources: resourceCommands.isEmpty ? 0 : 1,
+                focus: focusCommands.isEmpty ? 0 : 1,
+                metadata: metadataCommands.isEmpty ? 0 : 1
+            )
+        )
+        return .success(transaction)
+    }
+
+    private mutating func resolveOverlayDelta(_ delta: GUIWindowOverlayDelta) {
+        touchedWindowIds.insert(delta.windowId)
+        guard rejection == nil else { return }
+        guard let current = workingWindows[delta.windowId] else {
+            rejection = .missingWindowReference(windowId: delta.windowId)
+            return
+        }
+        guard current.contentEpoch == delta.contentEpoch else {
+            rejection = .windowEpochMismatch(
+                windowId: delta.windowId,
+                expected: current.contentEpoch,
+                actual: delta.contentEpoch
+            )
+            return
+        }
+        guard let updated = current.applyingOverlayDelta(delta) else {
+            rejection = .windowEpochMismatch(
+                windowId: delta.windowId,
+                expected: current.contentEpoch,
+                actual: delta.contentEpoch
+            )
+            return
+        }
+        workingWindows[delta.windowId] = updated
+        changedWindows[delta.windowId] = updated
+    }
+
+    private mutating func resolveRowsDelta(_ delta: GUIWindowRowsDelta) {
+        touchedWindowIds.insert(delta.windowId)
+        guard rejection == nil else { return }
+        guard let current = workingWindows[delta.windowId] else {
+            rejection = .missingWindowReference(windowId: delta.windowId)
+            return
+        }
+        guard current.contentEpoch == delta.contentEpoch else {
+            rejection = .windowEpochMismatch(
+                windowId: delta.windowId,
+                expected: current.contentEpoch,
+                actual: delta.contentEpoch
+            )
+            return
+        }
+        guard let updated = current.applyingRowsDelta(delta) else {
+            rejection = .invalidRetainedRows(windowId: delta.windowId, contentEpoch: delta.contentEpoch)
+            return
+        }
+        workingWindows[delta.windowId] = updated
+        changedWindows[delta.windowId] = updated
+        recordFontResources(in: updated)
+    }
+
+    private mutating func recordFontResources(in content: GUIWindowContent) {
+        for row in content.rows {
+            for span in row.spans where span.fontId != 0 {
+                requiredFontIds.insert(span.fontId)
+            }
+        }
+    }
+}
+
+private extension RenderCommand {
+    /// Stable semantic key used only within a prepared domain. Repeated payloads
+    /// for the same state replace earlier payloads while staging.
+    var preparedUpdateKey: Int {
+        switch self {
+        case .beginFrame: 1
+        case .commitFrame: 2
+        case .setCursorShape: 3
+        case .setTitle: 4
+        case .setWindowBg: 5
+        case .setLinkCursor: 6
+        case .protocolError: 7
+        case .setFont: 8
+        case .setFontFallback: 9
+        case .registerFont: 10
+        case .guiTheme: 11
+        case .guiTabBar: 12
+        case .guiFileTree: 13
+        case .guiFileTreeSelection: 14
+        case .guiObservatory: 15
+        case .guiCompletion: 16
+        case .guiWhichKey: 17
+        case .guiBreadcrumb: 18
+        case .guiStatusBar: 19
+        case .guiPicker: 20
+        case .guiPickerPreview: 21
+        case .guiAgentChat: 22
+        case .guiAgentTranscript: 23
+        case .guiGutterSeparator: 24
+        case .guiCursorline: 25
+        case .guiGutter: 26
+        case .guiBottomPanel: 27
+        case .guiWindowContent: 28
+        case .guiWindowOverlayDelta: 29
+        case .guiWindowViewportDelta: 30
+        case .guiWindowRowsDelta: 31
+        case .guiToolManager: 32
+        case .guiMinibuffer: 33
+        case .guiHoverPopup: 34
+        case .guiHoverAction: 35
+        case .guiSignatureHelp: 36
+        case .guiFloatPopup: 37
+        case .clipboardWrite: 38
+        case .guiIndentGuides: 39
+        case .guiLineSpacing: 40
+        case .guiCursorAnimation: 41
+        case .guiSplitSeparators: 42
+        case .guiGitStatus: 43
+        case .guiWorkspaces: 44
+        case .guiAgentContext: 45
+        case .guiChangeSummary: 46
+        case .guiConfigState: 47
+        case .guiNotifications: 48
+        case .guiEditTimeline: 49
+        case .guiExtensionOverlay: 50
+        case .guiExtensionPanel: 51
+        case .guiExtensionRuntime: 52
+        case .guiSearchState: 53
+        case .guiSidebars: 54
+        case .guiEmptyState: 55
+        }
+    }
+}

--- a/macos/Sources/Views/Agent/AgentChatState.swift
+++ b/macos/Sources/Views/Agent/AgentChatState.swift
@@ -45,8 +45,24 @@ public struct HelpGroup: Identifiable {
     public var id: String { title }
 }
 
+/// Value-semantic resident transcript used to validate and prepare a complete
+/// frame before any GUI state is published.
+public struct AgentTranscriptSnapshot {
+    let messages: [ChatMessageEntry]
+    let epoch: UInt32
+    let hasTranscript: Bool
+    let truncated: Bool
+    let promptVersion: Int
+}
+
+/// Stable reason that a transcript operation cannot join the resident transcript snapshot.
+public enum AgentTranscriptPreparationFailure: Error, Equatable {
+    case beforeSeed
+    case epochMismatch
+    case desynced
+}
+
 @MainActor
-@Observable
 public final class AgentChatState {
     public init(visible: Bool = false, status: UInt8 = 0, model: String = "", thinkingLevel: String = "medium", prompt: String = "", messages: [ChatMessageEntry] = [], helpVisible: Bool = false, helpGroups: [HelpGroup] = [], promptVersion: Int = 0, promptLineCount: UInt8 = 1, promptCursorLine: UInt16 = 0, promptCursorCol: UInt16 = 0, promptVimMode: UInt8 = 0, promptVisibleRows: UInt8 = 1, promptCompletion: Wire.PromptCompletion? = nil) {
         self.visible = visible
@@ -220,40 +236,85 @@ public final class AgentChatState {
 
     @discardableResult
     public func applyTranscript(mode: UInt8, epoch: UInt32, truncated: Bool = false, trimFront: Int = 0, baseCount: Int, messages rawMessages: [Wire.ChatMessage]) -> TranscriptApplyOutcome {
-        let mapped = rawMessages.map(Self.mapMessage)
-
-        if mode == 0 {
-            self.messages = mapped
-            self.transcriptEpoch = epoch
-            self.hasTranscript = true
-            self.transcriptTruncated = truncated
-            self.promptVersion += 1
-            return .appliedFullReplace
-        }
-
-        // Drop conditions (await the next full_replace), per GUI_PROTOCOL.md 0x86.
-        // Each is named and logged: a drop means the transcript stops updating until
-        // the next full_replace, and an invisible freeze is the worst failure mode
-        // this stream can have.
-        guard hasTranscript else {
+        switch Self.prepareTranscript(
+            from: transcriptSnapshot,
+            mode: mode,
+            epoch: epoch,
+            truncated: truncated,
+            trimFront: trimFront,
+            baseCount: baseCount,
+            messages: rawMessages
+        ) {
+        case .success(let prepared):
+            publishTranscript(prepared)
+            return mode == 0 ? .appliedFullReplace : .appliedAppend
+        case .failure(.beforeSeed):
             PortLogger.warn("transcript append before seed dropped (epoch \(epoch))")
             return .droppedBeforeSeed
-        }
-        guard epoch == transcriptEpoch else {
+        case .failure(.epochMismatch):
             PortLogger.warn("transcript append epoch mismatch dropped (frame \(epoch), store \(transcriptEpoch))")
             return .droppedEpochMismatch
-        }
-        guard trimFront >= 0, baseCount >= 0, messages.count >= trimFront + baseCount else {
+        case .failure(.desynced):
             PortLogger.warn("transcript append desynced dropped (resident \(messages.count), trimFront \(trimFront), baseCount \(baseCount), epoch \(epoch))")
             return .droppedDesynced
         }
+    }
 
-        // Evict trim_front from the front, keep [0, base_count) of the remainder, upsert.
-        let kept = messages[trimFront ..< (trimFront + baseCount)]
-        self.messages = Array(kept) + mapped
-        self.transcriptTruncated = truncated
-        self.promptVersion += 1
-        return .appliedAppend
+    /// Captures the resident transcript as a value for frame-level validation.
+    public var transcriptSnapshot: AgentTranscriptSnapshot {
+        AgentTranscriptSnapshot(
+            messages: messages,
+            epoch: transcriptEpoch,
+            hasTranscript: hasTranscript,
+            truncated: transcriptTruncated,
+            promptVersion: promptVersion
+        )
+    }
+
+    /// Validates and applies one full or append transcript operation without mutating presented state.
+    public static func prepareTranscript(
+        from current: AgentTranscriptSnapshot,
+        mode: UInt8,
+        epoch: UInt32,
+        truncated: Bool,
+        trimFront: Int,
+        baseCount: Int,
+        messages rawMessages: [Wire.ChatMessage]
+    ) -> Result<AgentTranscriptSnapshot, AgentTranscriptPreparationFailure> {
+        let mapped = rawMessages.map(Self.mapMessage)
+        if mode == 0 {
+            return .success(AgentTranscriptSnapshot(
+                messages: mapped,
+                epoch: epoch,
+                hasTranscript: true,
+                truncated: truncated,
+                promptVersion: current.promptVersion + 1
+            ))
+        }
+        guard current.hasTranscript else { return .failure(.beforeSeed) }
+        guard epoch == current.epoch else { return .failure(.epochMismatch) }
+        guard trimFront >= 0,
+              baseCount >= 0,
+              current.messages.count >= trimFront + baseCount else {
+            return .failure(.desynced)
+        }
+        let kept = current.messages[trimFront ..< (trimFront + baseCount)]
+        return .success(AgentTranscriptSnapshot(
+            messages: Array(kept) + mapped,
+            epoch: current.epoch,
+            hasTranscript: true,
+            truncated: truncated,
+            promptVersion: current.promptVersion + 1
+        ))
+    }
+
+    /// Installs a transcript snapshot that was fully validated before frame publication.
+    public func publishTranscript(_ snapshot: AgentTranscriptSnapshot) {
+        messages = snapshot.messages
+        transcriptEpoch = snapshot.epoch
+        hasTranscript = snapshot.hasTranscript
+        transcriptTruncated = snapshot.truncated
+        promptVersion = snapshot.promptVersion
     }
 
     /// Maps a decoded wire message onto its displayable `ChatMessageEntry`.

--- a/macos/Sources/Views/Agent/AgentContextBarState.swift
+++ b/macos/Sources/Views/Agent/AgentContextBarState.swift
@@ -10,7 +10,6 @@ import MingaProtocol
 ///
 /// Updated by the BEAM via the `gui_agent_context` opcode (0x88).
 @MainActor
-@Observable
 public final class AgentContextBarState {
     public init(visible: Bool = false, task: String = "", dispatchTimestamp: Date = Date(), status: CardStatus = .idle, canApprove: Bool = false, progress: Wire.AgentProgress = .init(activeAction: "", toolCount: 0, fileCount: 0, reviewHint: ""), todos: [Wire.AgentTodo] = []) {
         self.visible = visible

--- a/macos/Sources/Views/EditorChrome/BottomPanelState.swift
+++ b/macos/Sources/Views/EditorChrome/BottomPanelState.swift
@@ -19,7 +19,6 @@ public struct BottomPanelTab: Identifiable, Equatable {
 }
 
 @MainActor
-@Observable
 public final class BottomPanelState {
     public init(visible: Bool = false, activeTabIndex: Int = 0, heightPercent: Int = 30, filterPreset: UInt8 = 0, tabs: [BottomPanelTab] = []) {
         self.visible = visible

--- a/macos/Sources/Views/EditorChrome/BottomPanelView.swift
+++ b/macos/Sources/Views/EditorChrome/BottomPanelView.swift
@@ -12,7 +12,7 @@ public struct BottomPanelView: View {
         self.encoder = encoder
         self.availableHeight = availableHeight
     }
-    @Bindable public var state: BottomPanelState
+    public let state: BottomPanelState
     @Environment(\.themeColors) private var theme
     public let encoder: InputEncoder?
     /// Total height of the right pane (tab bar + editor + panel + status bar).

--- a/macos/Sources/Views/EditorChrome/BreadcrumbBar.swift
+++ b/macos/Sources/Views/EditorChrome/BreadcrumbBar.swift
@@ -6,7 +6,6 @@
 import SwiftUI
 
 @MainActor
-@Observable
 public final class BreadcrumbState {
     public init(segments: [String] = []) {
         self.segments = segments

--- a/macos/Sources/Views/EditorChrome/EmptyStateState.swift
+++ b/macos/Sources/Views/EditorChrome/EmptyStateState.swift
@@ -79,7 +79,6 @@ public struct EmptyStateSectionModel: Identifiable, Equatable {
 
 /// Observable state for the launchpad, driven by BEAM protocol messages.
 @MainActor
-@Observable
 public final class EmptyStateState {
     public init(visible: Bool = false, crashed: Bool = false, version: String = "", focusedId: String = "", sections: [EmptyStateSectionModel] = []) {
         self.visible = visible

--- a/macos/Sources/Views/EditorChrome/FeedbackState.swift
+++ b/macos/Sources/Views/EditorChrome/FeedbackState.swift
@@ -8,13 +8,17 @@ public final class FeedbackState {
         self.holdTask = holdTask
         self.spinnerOnTime = spinnerOnTime
     }
-    public private(set) var isPending = false
-    public private(set) var showingSpinner = false
+    @ObservationIgnored public private(set) var isPending = false
+    @ObservationIgnored public private(set) var showingSpinner = false
 
-    private var showTask: Task<Void, Never>?
-    private var holdTask: Task<Void, Never>?
-    private var spinnerOnTime: ContinuousClock.Instant?
-    private var lastMessage = ""
+    /// GUIState installs this to republish delayed local presentation changes
+    /// through its aggregate out-of-band token.
+    @ObservationIgnored public var onPresentationChanged: (() -> Void)?
+
+    @ObservationIgnored private var showTask: Task<Void, Never>?
+    @ObservationIgnored private var holdTask: Task<Void, Never>?
+    @ObservationIgnored private var spinnerOnTime: ContinuousClock.Instant?
+    @ObservationIgnored private var lastMessage = ""
 
     nonisolated static let spinnerDelay: Duration = .milliseconds(100)
     nonisolated static let spinnerHold: Duration = .milliseconds(500)
@@ -36,6 +40,7 @@ public final class FeedbackState {
                 guard !Task.isCancelled, isPending else { return }
                 showingSpinner = true
                 spinnerOnTime = .now
+                notifyPresentationChanged()
             }
         } else {
             let wasSpinning = showingSpinner
@@ -53,10 +58,12 @@ public final class FeedbackState {
                         guard !Task.isCancelled else { return }
                         showingSpinner = false
                         spinnerOnTime = nil
+                        notifyPresentationChanged()
                     }
                 } else {
                     showingSpinner = false
                     spinnerOnTime = nil
+                    notifyPresentationChanged()
                 }
             }
         }
@@ -71,6 +78,12 @@ public final class FeedbackState {
         holdTask = nil
         spinnerOnTime = nil
         lastMessage = ""
+    }
+
+    private func notifyPresentationChanged() {
+        Task { @MainActor [weak self] in
+            self?.onPresentationChanged?()
+        }
     }
 
     nonisolated static func isInflight(_ message: String) -> Bool {

--- a/macos/Sources/Views/EditorChrome/SearchState.swift
+++ b/macos/Sources/Views/EditorChrome/SearchState.swift
@@ -14,7 +14,6 @@ public enum SearchFlags {
 }
 
 @MainActor
-@Observable
 public final class SearchState {
     public init(visible: Bool = false, matchCount: UInt16 = 0, currentIndex: UInt16 = 0, replaceMode: Bool = false, caseSensitive: Bool = false, wholeWord: Bool = false, regex: Bool = false) {
         self.visible = visible

--- a/macos/Sources/Views/EditorChrome/StatusBarState.swift
+++ b/macos/Sources/Views/EditorChrome/StatusBarState.swift
@@ -2,7 +2,6 @@ import SwiftUI
 import MingaProtocol
 
 @MainActor
-@Observable
 public final class StatusBarState {
     public init(contentKind: UInt8 = 0, mode: UInt8 = 0, cursorLine: UInt32 = 1, cursorCol: UInt32 = 1, lineCount: UInt32 = 1, flags: UInt8 = 0, safeMode: Bool = false, lspStatus: UInt8 = 0, gitBranch: String = "", message: String = "", filetype: String = "", errorCount: UInt16 = 0, warningCount: UInt16 = 0, modelName: String = "", messageCount: UInt32 = 0, sessionStatus: UInt8 = 0, infoCount: UInt16 = 0, hintCount: UInt16 = 0, macroRecording: UInt8 = 0, parserStatus: UInt8 = 0, agentStatus: UInt8 = 0, activeToolName: String = "", gitAdded: UInt16 = 0, gitModified: UInt16 = 0, gitDeleted: UInt16 = 0, icon: String = "", iconColorR: UInt8 = 0, iconColorG: UInt8 = 0, iconColorB: UInt8 = 0, filename: String = "", diagnosticHint: String = "", backgroundSubagentCount: UInt16 = 0, backgroundSubagentLabel: String = "", indent: StatusBarUpdate.IndentInfo = .init(kind: 0, size: 2), modelineSegmentsPresent: Bool = false, modelineLeftSegments: [Wire.StatusBarSegment] = [], modelineRightSegments: [Wire.StatusBarSegment] = [], selection: StatusBarUpdate.SelectionInfo = .init(mode: 0, size: 0), pendingKeys: String = "") {
         self.contentKind = contentKind

--- a/macos/Sources/Views/EditorChrome/TabBarState.swift
+++ b/macos/Sources/Views/EditorChrome/TabBarState.swift
@@ -98,7 +98,6 @@ public struct WorkspaceTabEntry: Identifiable {
 
 /// Observable state for the tab bar, driven by BEAM protocol messages.
 @MainActor
-@Observable
 public final class TabBarState {
     public init(tabs: [TabEntry] = [], activeIndex: UInt8 = 0, workspaces: [WorkspaceEntry] = [], workspaceTabs: [WorkspaceTabEntry] = [], activeWorkspaceId: UInt16 = 0, workspaceMode: UInt8 = 0, workspaceFlags: UInt8 = 0, hasCanonicalWorkspaceTabs: Bool = false) {
         self.tabs = tabs

--- a/macos/Sources/Views/EditorChrome/WorkspaceState.swift
+++ b/macos/Sources/Views/EditorChrome/WorkspaceState.swift
@@ -64,7 +64,6 @@ public struct WorkspaceFileTabEntry: Identifiable {
 
 /// Observable state for the workspace header and active-workspace file tabs.
 @MainActor
-@Observable
 public final class WorkspaceState {
     public init(workspaces: [WorkspaceSummaryEntry] = [], visibleTabs: [WorkspaceFileTabEntry] = [], activeWorkspaceId: UInt16 = 0, viewMode: UInt8 = 0, flags: UInt8 = 0, hasCanonicalPayload: Bool = false) {
         self.workspaces = workspaces

--- a/macos/Sources/Views/Extensions/ExtensionOverlayState.swift
+++ b/macos/Sources/Views/Extensions/ExtensionOverlayState.swift
@@ -5,7 +5,7 @@ import MingaProtocol
 ///
 /// Updated by `CommandDispatcher` from `gui_extension_overlay` (0x9C) opcode.
 /// Read by `ExtensionOverlayView` to render positioned overlays.
-@MainActor @Observable
+@MainActor
 public final class ExtensionOverlayState {
     public init() {}
     /// Active overlay entries from all extensions.

--- a/macos/Sources/Views/Extensions/ExtensionPanelState.swift
+++ b/macos/Sources/Views/Extensions/ExtensionPanelState.swift
@@ -5,7 +5,7 @@ import MingaProtocol
 ///
 /// Updated by `CommandDispatcher` from `gui_extension_panel` (0x9D) opcode.
 /// Read by `ExtensionPanelView` to render structured content with native widgets.
-@MainActor @Observable
+@MainActor
 public final class ExtensionPanelState {
     public init() {}
     /// Active panel entries from all extensions.

--- a/macos/Sources/Views/Extensions/ToolManagerState.swift
+++ b/macos/Sources/Views/Extensions/ToolManagerState.swift
@@ -129,7 +129,6 @@ public struct ToolEntry: Identifiable {
 // MARK: - Observable state
 
 @MainActor
-@Observable
 public final class ToolManagerState {
     public init(visible: Bool = false, filter: ToolFilter = .all, selectedIndex: Int = 0, tools: [ToolEntry] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/CompletionState.swift
+++ b/macos/Sources/Views/Overlays/CompletionState.swift
@@ -17,7 +17,6 @@ public struct CompletionItem: Identifiable {
 }
 
 @MainActor
-@Observable
 public final class CompletionState {
     public init(visible: Bool = false, anchorRow: Int = 0, anchorCol: Int = 0, selectedIndex: Int = 0, previewSelectedIndex: Int? = nil, items: [CompletionItem] = [], documentation: String = "") {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/FloatPopupState.swift
+++ b/macos/Sources/Views/Overlays/FloatPopupState.swift
@@ -8,7 +8,6 @@
 import SwiftUI
 
 @MainActor
-@Observable
 public final class FloatPopupState {
     public init(visible: Bool = false, title: String = "", width: Int = 0, height: Int = 0, lines: [String] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/HoverPopupState.swift
+++ b/macos/Sources/Views/Overlays/HoverPopupState.swift
@@ -32,7 +32,6 @@ public struct HoverLine: Identifiable {
 }
 
 @MainActor
-@Observable
 public final class HoverPopupState {
     public init(visible: Bool = false, anchorRow: Int = 0, anchorCol: Int = 0, focused: Bool = false, scrollOffset: Int = 0, lines: [HoverLine] = [], openActionName: String? = nil) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/MessagesContentState.swift
+++ b/macos/Sources/Views/Overlays/MessagesContentState.swift
@@ -150,11 +150,11 @@ public final class MessagesContentState {
         self.activeSubsystems = activeSubsystems
         self.searchText = searchText
     }
-    public var entries: [MessageEntry] = []
+    @ObservationIgnored public var entries: [MessageEntry] = []
     /// Whether the view should auto-scroll to the latest entry.
-    public var isAutoScrolling: Bool = true
+    @ObservationIgnored public var isAutoScrolling: Bool = true
     /// Set to true when new entries arrive while scrolled up (shows "jump to latest").
-    public var hasNewEntries: Bool = false
+    @ObservationIgnored public var hasNewEntries: Bool = false
 
     // MARK: - Filters
 

--- a/macos/Sources/Views/Overlays/MinibufferState.swift
+++ b/macos/Sources/Views/Overlays/MinibufferState.swift
@@ -42,7 +42,6 @@ public enum MinibufferMode: UInt8 {
 }
 
 @MainActor
-@Observable
 public final class MinibufferState {
     public init(visible: Bool = false, mode: UInt8 = 0, cursorPos: UInt16 = 0xFFFF, prompt: String = "", input: String = "", context: String = "", selectedIndex: UInt16 = 0, candidates: [MinibufferCandidate] = [], totalCandidates: UInt16 = 0, inputVersion: Int = 0) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/NotificationCenterState.swift
+++ b/macos/Sources/Views/Overlays/NotificationCenterState.swift
@@ -42,7 +42,6 @@ public struct EditorNotification: Identifiable, Equatable {
 
 /// Stores the current notification stack sent by the BEAM.
 @MainActor
-@Observable
 public final class NotificationCenterState {
     public init(notifications: [EditorNotification] = []) {
         self.notifications = notifications

--- a/macos/Sources/Views/Overlays/PickerState.swift
+++ b/macos/Sources/Views/Overlays/PickerState.swift
@@ -94,7 +94,6 @@ public struct PreviewSegment: Identifiable {
 }
 
 @MainActor
-@Observable
 public final class PickerState {
     public init(visible: Bool = false, selectedIndex: Int = 0, previewSelectedIndex: Int? = nil, filteredCount: Int = 0, totalCount: Int = 0, markedCount: Int = 0, title: String = "", query: String = "", modePrefix: String = "", hasPreview: Bool = false, loadStatus: Wire.PickerLoadStatus = .ready, items: [PickerItem] = [], previewLines: [PreviewLine] = [], actionMenu: PickerActionMenu? = nil) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/ProtocolErrorState.swift
+++ b/macos/Sources/Views/Overlays/ProtocolErrorState.swift
@@ -10,7 +10,6 @@
 import SwiftUI
 
 @MainActor
-@Observable
 public final class ProtocolErrorState {
     public init() {}
     /// The BEAM-supplied reason, or nil when no protocol_error has arrived.

--- a/macos/Sources/Views/Overlays/ResyncState.swift
+++ b/macos/Sources/Views/Overlays/ResyncState.swift
@@ -15,7 +15,6 @@
 import SwiftUI
 
 @MainActor
-@Observable
 public final class ResyncState {
     public init() {}
     /// True between an invalidation and the next clean commit. Drives a small

--- a/macos/Sources/Views/Overlays/SignatureHelpState.swift
+++ b/macos/Sources/Views/Overlays/SignatureHelpState.swift
@@ -30,7 +30,6 @@ public struct SignatureInfo: Identifiable {
 }
 
 @MainActor
-@Observable
 public final class SignatureHelpState {
     public init(visible: Bool = false, anchorRow: Int = 0, anchorCol: Int = 0, activeSignature: Int = 0, activeParameter: Int = 0, signatures: [SignatureInfo] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/WhichKeyState.swift
+++ b/macos/Sources/Views/Overlays/WhichKeyState.swift
@@ -19,7 +19,6 @@ public struct WhichKeyBinding: Identifiable {
 }
 
 @MainActor
-@Observable
 public final class WhichKeyState {
     public init(visible: Bool = false, prefix: String = "", page: Int = 0, pageCount: Int = 0, bindings: [WhichKeyBinding] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Shared/EditTimelineState.swift
+++ b/macos/Sources/Views/Shared/EditTimelineState.swift
@@ -2,7 +2,6 @@ import Foundation
 import MingaProtocol
 
 @MainActor
-@Observable
 public final class EditTimelineState {
     public init(visible: Bool = false, viewingIndex: Int = -1, entries: [TimelineEntry] = [], files: [TimelineFile] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Shared/GUIState.swift
+++ b/macos/Sources/Views/Shared/GUIState.swift
@@ -1,6 +1,8 @@
 /// Container for all GUI chrome sub-states.
 ///
-/// Holds every `@Observable` state object that SwiftUI chrome views need.
+/// Owns the protocol-driven State + View objects behind one observable aggregate
+/// publication value. The child states are deliberately non-observable: a frame
+/// mutates them while hidden, then swaps `framePublication` exactly once.
 /// Injected once into `CommandDispatcher` and `ContentView`, eliminating
 /// the 9 optional property wiring that previously required individual
 /// assignment in `AppDelegate`.
@@ -8,14 +10,67 @@
 /// All sub-states are initialized at creation time; no optional nil-checks
 /// needed in dispatch handlers.
 import MingaProtocol
+import Observation
+
+/// Immutable observation token published after one complete GUI state transition.
+public struct GUIStatePublication: Equatable, Sendable {
+    public let generation: UInt64
+    public let frameSeq: UInt32?
+}
 
 @MainActor
+@Observable
 public final class GUIState {
     public init(windowContents: [UInt16: GUIWindowContent] = [:]) {
         self.windowContents = windowContents
+        feedbackState.onPresentationChanged = { [weak self] in
+            self?.performOutOfBandPublication {}
+        }
     }
-    /// Theme colors for SwiftUI chrome views.
-    public let themeColors = ThemeColors()
+
+    /// Immutable aggregate token swapped after every complete prepared frame.
+    /// Reading this token is the only observation dependency views need for
+    /// protocol-driven child state.
+    public private(set) var framePublication = GUIStatePublication(generation: 0, frameSeq: nil)
+
+    /// Out-of-band/recovery state has a separate publication stream so rejecting
+    /// a frame never masquerades as a committed frame publication.
+    public private(set) var outOfBandPublication = GUIStatePublication(generation: 0, frameSeq: nil)
+
+    /// Number of complete prepared frames published since this GUI state was created.
+    public var framePublicationCount: UInt64 { framePublication.generation }
+
+    /// Child state cannot notify while this closure runs because protocol-driven
+    /// State objects are non-observable. The immutable aggregate swap is therefore
+    /// the sole frame observation point.
+    public func performFramePublication(frameSeq: UInt32, _ mutation: () -> Void) {
+        mutation()
+        framePublication = GUIStatePublication(
+            generation: framePublication.generation + 1,
+            frameSeq: frameSeq
+        )
+    }
+
+    /// Applies one recovery or local-presentation mutation and publishes it separately from committed frames.
+    public func performOutOfBandPublication(_ mutation: () -> Void) {
+        mutation()
+        outOfBandPublication = GUIStatePublication(
+            generation: outOfBandPublication.generation + 1,
+            frameSeq: nil
+        )
+    }
+
+    /// Theme remains Observable because SwiftUI environment injection requires
+    /// that conformance. Frame publication replaces the whole instance, so the
+    /// published instance is never mutated under active observers.
+    @ObservationIgnored public private(set) var themeColors = ThemeColors()
+
+    /// Builds and installs a complete theme value without mutating the observed prior instance.
+    public func replaceTheme(slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)]) {
+        let replacement = ThemeColors()
+        replacement.applySlots(slots)
+        themeColors = replacement
+    }
 
     /// Native settings panel state.
     public let settingsState = SettingsState()
@@ -119,6 +174,6 @@ public final class GUIState {
     /// Keyed by windowId. NOT cleared between frames; the guiWindowContent
     /// dispatch overwrites per-window data each frame. Stale entries serve
     /// as fallback to prevent blank viewport flashes.
-    public var windowContents: [UInt16: GUIWindowContent] = [:]
+    @ObservationIgnored public var windowContents: [UInt16: GUIWindowContent] = [:]
 
 }

--- a/macos/Sources/Views/Sidebar/ChangeSummaryState.swift
+++ b/macos/Sources/Views/Sidebar/ChangeSummaryState.swift
@@ -7,7 +7,6 @@ import MingaProtocol
 /// stats. Drives `ChangeSummaryView` which renders a list of changed files
 /// with their status and line counts.
 @MainActor
-@Observable
 public final class ChangeSummaryState {
     public init(visible: Bool = false, entries: [ChangeSummaryEntry] = [], selectedIndex: Int = 0) {
         self.visible = visible

--- a/macos/Sources/Views/Sidebar/FileTreeState.swift
+++ b/macos/Sources/Views/Sidebar/FileTreeState.swift
@@ -220,7 +220,6 @@ extension FileTreeEntry {
 
 /// Observable state for the file tree sidebar, driven by BEAM protocol messages.
 @MainActor
-@Observable
 public final class FileTreeState {
     public init(entries: [FileTreeEntry] = [], version: UInt8 = 1, selectedId: String = "", selectedIndex: Int = 0, treeWidth: Int = 30, visible: Bool = false, focused: Bool = false, localNavigationEnabled: Bool = false, treeState: FileTreeVisibilityState = .hidden, errorReason: String = "", projectRoot: String = "", editingIndex: Int? = nil) {
         self.entries = entries

--- a/macos/Sources/Views/Sidebar/GitStatusState.swift
+++ b/macos/Sources/Views/Sidebar/GitStatusState.swift
@@ -105,41 +105,41 @@ public final class GitStatusState {
         self.amendMode = amendMode
         self.entriesRevision = entriesRevision
     }
-    public var visible: Bool = false
-    public var repoState: GitRepoState = .notARepo
-    public var syncing: Bool = false
+    @ObservationIgnored public var visible: Bool = false
+    @ObservationIgnored public var repoState: GitRepoState = .notARepo
+    @ObservationIgnored public var syncing: Bool = false
 
     // Branch info
-    public var branchName: String = ""
-    public var ahead: UInt16 = 0
-    public var behind: UInt16 = 0
-    public var entryBasePath: String = ""
-    public var stashCount: UInt16 = 0
+    @ObservationIgnored public var branchName: String = ""
+    @ObservationIgnored public var ahead: UInt16 = 0
+    @ObservationIgnored public var behind: UInt16 = 0
+    @ObservationIgnored public var entryBasePath: String = ""
+    @ObservationIgnored public var stashCount: UInt16 = 0
 
     // Toast notification (shown after remote operations)
-    public var toastMessage: String? = nil
-    public var toastLevel: ToastLevel = .success
-    public var toastAction: ToastAction = .none
+    @ObservationIgnored public var toastMessage: String? = nil
+    @ObservationIgnored public var toastLevel: ToastLevel = .success
+    @ObservationIgnored public var toastAction: ToastAction = .none
 
     // File entries grouped by section
-    public var stagedEntries: [GitStatusEntry] = []
-    public var changedEntries: [GitStatusEntry] = []
-    public var untrackedEntries: [GitStatusEntry] = []
-    public var conflictedEntries: [GitStatusEntry] = []
-    public var duplicatePathHashes: Set<UInt32> = []
+    @ObservationIgnored public var stagedEntries: [GitStatusEntry] = []
+    @ObservationIgnored public var changedEntries: [GitStatusEntry] = []
+    @ObservationIgnored public var untrackedEntries: [GitStatusEntry] = []
+    @ObservationIgnored public var conflictedEntries: [GitStatusEntry] = []
+    @ObservationIgnored public var duplicatePathHashes: Set<UInt32> = []
 
     // Section collapsed state (local UI state, not sent by BEAM)
     public var collapsedSections: Set<GitStatusSection> = []
 
     // Commit message (local UI state, typed by the user)
     public var commitMessage: String = ""
-    public var previousCommitMessage: String = ""
+    @ObservationIgnored public var previousCommitMessage: String = ""
 
     // Amend mode (local UI state, toggled by the user)
     public var amendMode: Bool = false
 
     // Changes whenever BEAM-provided entries update. Views use this to animate moves between sections.
-    public var entriesRevision: UInt64 = 0
+    @ObservationIgnored public var entriesRevision: UInt64 = 0
 
     /// Total number of entries across all sections.
     public var totalCount: Int {

--- a/macos/Sources/Views/Sidebar/ObservatoryState.swift
+++ b/macos/Sources/Views/Sidebar/ObservatoryState.swift
@@ -4,7 +4,6 @@ import MingaProtocol
 
 /// Observable state for the BEAM Observatory sidebar.
 @MainActor
-@Observable
 public final class ObservatoryState {
     public init(visible: Bool = false, nodes: [ObservatoryNode] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Sidebar/SidebarHostState.swift
+++ b/macos/Sources/Views/Sidebar/SidebarHostState.swift
@@ -30,7 +30,6 @@ public struct SidebarItem: Identifiable, Equatable {
 
 /// Stores the BEAM-selected sidebar identities and validates semantic kinds against the native registry.
 @MainActor
-@Observable
 public final class SidebarHostState {
     public init(warnedUnknownKinds: Set<String> = []) {
         self.warnedUnknownKinds = warnedUnknownKinds

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -5,6 +5,8 @@
 /// routed to the wrong state or not routed at all.
 
 import MingaUI
+import Observation
+import Synchronization
 import Testing
 import Foundation
 import AppKit
@@ -1366,50 +1368,62 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.themeColors.hasAppliedTheme)
     }
 
-    @Test("keyframe with content but no guiTheme presents protocol error")
+    @Test("keyframe with content but no guiTheme returns a typed rejection")
     @MainActor func keyframeWithoutThemeErrors() {
         let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "unthemed.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        #expect(gui.protocolErrorState.isPresented)
-        #expect(gui.protocolErrorState.message == "missing gui_theme in keyframe")
+        #expect(gui.protocolErrorState.isPresented == false)
         #expect(gui.tabBarState.tabs.isEmpty)
+        #expect(results == [.rejected(frameSeq: 1, reason: .missingTheme)])
     }
 
     @Test("keyframe with empty guiTheme rejects promotion")
     @MainActor func keyframeWithEmptyThemeErrors() {
         let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
         dispatcher.dispatch(.guiTheme(slots: []))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "empty.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
 
-        #expect(gui.protocolErrorState.isPresented)
-        #expect(gui.protocolErrorState.message?.contains("missing gui_theme slots in keyframe") == true)
-        #expect(gui.protocolErrorState.message?.contains("0x01") == true)
+        #expect(gui.protocolErrorState.isPresented == false)
         #expect(gui.themeColors.hasAppliedTheme == false)
         #expect(gui.tabBarState.tabs.isEmpty)
+        guard case .rejected(frameSeq: 2, reason: .incompleteTheme(let missing)) = results.first else {
+            Issue.record("expected incomplete-theme rejection")
+            return
+        }
+        #expect(missing.contains(0x01))
     }
 
     @Test("keyframe with partial guiTheme rejects promotion")
     @MainActor func keyframeWithPartialThemeErrors() {
         let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
         dispatcher.dispatch(.guiTheme(slots: [(GUI_COLOR_EDITOR_BG, 0x00, 0x00, 0x00)]))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "partial.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
 
-        #expect(gui.protocolErrorState.isPresented)
-        #expect(gui.protocolErrorState.message?.contains("missing gui_theme slots in keyframe") == true)
-        #expect(gui.protocolErrorState.message?.contains("0x02") == true)
-        #expect(gui.protocolErrorState.message?.contains("0xA0") == true)
+        #expect(gui.protocolErrorState.isPresented == false)
         #expect(gui.themeColors.hasAppliedTheme == false)
         #expect(gui.tabBarState.tabs.isEmpty)
+        guard case .rejected(frameSeq: 3, reason: .incompleteTheme(let missing)) = results.first else {
+            Issue.record("expected incomplete-theme rejection")
+            return
+        }
+        #expect(missing.contains(0x02))
+        #expect(missing.contains(0xA0))
     }
 }
 
@@ -1433,6 +1447,30 @@ struct CommandDispatcherStagingTests {
         Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false,
                       hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0,
                       icon: "", label: label)
+    }
+
+    private func windowContent(windowId: UInt16 = 7, epoch: UInt32 = 42, fontId: UInt8 = 0) -> GUIWindowContent {
+        let span = GUIHighlightSpan(
+            startCol: 0, endCol: 3, fg: 0xFFFFFF, bg: 0,
+            attrs: 0, fontWeight: 0, fontId: fontId
+        )
+        let row = GUIVisualRow(
+            rowType: .normal, rowId: 1, bufLine: 0,
+            contentHash: 11, text: "old", spans: [span]
+        )
+        return GUIWindowContent(
+            windowId: windowId, fullRefresh: true, contentEpoch: epoch,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [row], selection: nil, searchMatches: [],
+            diagnosticUnderlines: [], documentHighlights: []
+        )
+    }
+
+    private func overlayDelta(windowId: UInt16 = 7, epoch: UInt32 = 42) -> GUIWindowOverlayDelta {
+        GUIWindowOverlayDelta(
+            windowId: windowId, contentEpoch: epoch, cursorVisible: true,
+            cursorRow: 0, cursorCol: 1, cursorShape: .beam, cursorline: nil
+        )
     }
 
     // MARK: - Nothing paints between begin and commit
@@ -1532,6 +1570,8 @@ struct CommandDispatcherStagingTests {
     @Test("delta frame with empty guiTheme rejects promotion")
     @MainActor func deltaFrameWithEmptyThemeErrors() {
         let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
@@ -1544,17 +1584,23 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("empty-delta.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 6, seq: 0))
 
-        #expect(gui.protocolErrorState.isPresented)
-        #expect(gui.protocolErrorState.message?.contains("missing gui_theme slots: ") == true)
-        #expect(gui.protocolErrorState.message?.contains("0x01") == true)
-        #expect(gui.protocolErrorState.message?.contains("0xA0") == true)
+        #expect(gui.protocolErrorState.isPresented == false)
         #expect(gui.themeColors.editorBg == baselineThemeBg)
         #expect(gui.tabBarState.tabs.first?.label == "base.ex")
+        #expect(results.count == 2)
+        guard case .rejected(frameSeq: 6, reason: .incompleteTheme(let missing)) = results.last else {
+            Issue.record("expected incomplete-theme rejection")
+            return
+        }
+        #expect(missing.contains(0x01))
+        #expect(missing.contains(0xA0))
     }
 
     @Test("delta frame with partial guiTheme rejects promotion")
     @MainActor func deltaFrameWithPartialThemeErrors() {
         let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
@@ -1567,12 +1613,16 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("partial-delta.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 6, seq: 0))
 
-        #expect(gui.protocolErrorState.isPresented)
-        #expect(gui.protocolErrorState.message?.contains("missing gui_theme slots: ") == true)
-        #expect(gui.protocolErrorState.message?.contains("0x02") == true)
-        #expect(gui.protocolErrorState.message?.contains("0xA0") == true)
+        #expect(gui.protocolErrorState.isPresented == false)
         #expect(gui.themeColors.editorBg == baselineThemeBg)
         #expect(gui.tabBarState.tabs.first?.label == "base.ex")
+        #expect(results.count == 2)
+        guard case .rejected(frameSeq: 6, reason: .incompleteTheme(let missing)) = results.last else {
+            Issue.record("expected incomplete-theme rejection")
+            return
+        }
+        #expect(missing.contains(0x02))
+        #expect(missing.contains(0xA0))
     }
 
     // MARK: - Invalidation requests a keyframe with no partial promotion
@@ -1770,6 +1820,254 @@ struct CommandDispatcherStagingTests {
         #expect(gui.resyncState.pending == false)
         #expect(gui.resyncState.lastGoodFrameSeq == 0)
         #expect(gui.tabBarState.tabs.first?.label == "recovered.ex")
+    }
+
+    // MARK: - Prepared transaction publication contract (#2747)
+
+    @Test("prepared publication is equivalent to the direct command fixture")
+    @MainActor func preparedPublicationEquivalence() {
+        let (direct, directGUI) = makeDispatcher()
+        let (prepared, preparedGUI) = makeDispatcher()
+        let content = windowContent()
+        let commands: [RenderCommand] = [
+            .guiTheme(slots: completeThemeSlots()),
+            .guiWindowContent(data: content),
+            .guiTabBar(activeIndex: 0, tabs: [tab("equivalent.ex")]),
+            .setCursorShape(.beam),
+        ]
+
+        for command in commands { direct.applyForTesting(command) }
+        prepared.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        for command in commands { prepared.dispatch(command) }
+        prepared.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(preparedGUI.themeColors.editorBg == directGUI.themeColors.editorBg)
+        #expect(preparedGUI.windowContents[7]?.rows.map(\.text) == directGUI.windowContents[7]?.rows.map(\.text))
+        #expect(preparedGUI.tabBarState.tabs.map(\.label) == directGUI.tabBarState.tabs.map(\.label))
+        #expect(prepared.frameState.cursorShape == direct.frameState.cursorShape)
+    }
+
+    @Test("one valid frame enters the publication boundary exactly once")
+    @MainActor func onePublicationPerFrame() {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: windowContent()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("prepared.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(gui.framePublicationCount == 1)
+        #expect(dispatcher.publicationCount == 1)
+        #expect(results == [.published(frameSeq: 1)])
+        #expect(gui.windowContents[7]?.rows.first?.text == "old")
+        #expect(gui.tabBarState.tabs.first?.label == "prepared.ex")
+    }
+
+    @Test("one aggregate observation callback sees all sibling domains committed")
+    @MainActor func aggregateObservationIsAtomic() {
+        let (dispatcher, gui) = makeDispatcher()
+        let notificationCount = Mutex(0)
+
+        withObservationTracking {
+            _ = gui.framePublication
+            // Reading the siblings documents the observation's consistency contract.
+            _ = gui.tabBarState.tabs
+            _ = gui.agentChatState.model
+        } onChange: {
+            notificationCount.withLock { $0 += 1 }
+        }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("atomic.ex")]))
+        dispatcher.dispatch(.guiAgentChat(
+            visible: true, status: 0, model: "prepared-model", thinkingLevel: "medium",
+            prompt: "", promptLineCount: 1, promptCursorLine: 0, promptCursorCol: 0,
+            promptVimMode: 1, promptVisibleRows: 1, promptCompletion: nil,
+            pendingToolName: nil, pendingToolSummary: "", helpVisible: false,
+            helpGroups: [], messages: []
+        ))
+        #expect(notificationCount.withLock { $0 } == 0)
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(notificationCount.withLock { $0 } == 1)
+        #expect(gui.tabBarState.tabs.first?.label == "atomic.ex")
+        #expect(gui.agentChatState.model == "prepared-model")
+    }
+
+    @Test("gutter and indent guide keys cannot collide across window ids")
+    @MainActor func typedWindowCoalescingKeysDoNotCollide() {
+        let (dispatcher, _) = makeDispatcher()
+        let gutter = Wire.WindowGutter(
+            windowId: 1001, contentRow: 0, contentCol: 4, contentHeight: 1,
+            isActive: false, contentWidth: 40, cursorLine: 0, lineNumberStyle: .absolute,
+            lineNumberWidth: 3, signColWidth: 1, entries: []
+        )
+        let guides = IndentGuideData(
+            windowId: 1, tabWidth: 4, activeGuideCol: 4,
+            guideCols: [4, 8], lineIndentLevels: [2]
+        )
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: windowContent(windowId: 1001)))
+        dispatcher.dispatch(.guiWindowContent(data: windowContent(windowId: 1)))
+        dispatcher.dispatch(.guiGutter(data: gutter))
+        dispatcher.dispatch(.guiIndentGuides(data: guides))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(dispatcher.frameState.windowGutters[1001]?.lineNumberWidth == 3)
+        #expect(dispatcher.frameState.windowIndentGuides[1]?.guideCols == [4, 8])
+    }
+
+    @Test("a later invalid domain rejects the whole frame without publication")
+    @MainActor func partialFrameRejectionPublishesNothing() {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("must-not-publish.ex")]))
+        dispatcher.dispatch(.guiWindowOverlayDelta(data: overlayDelta(windowId: 99)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(gui.framePublicationCount == 0)
+        #expect(gui.tabBarState.tabs.isEmpty)
+        #expect(results == [.rejected(frameSeq: 1, reason: .missingWindowReference(windowId: 99))])
+    }
+
+    @Test("invalid transcript operations reject without publishing sibling state")
+    @MainActor func invalidTranscriptRejectsWholeTransaction() {
+        let invalidCommands: [(RenderCommand, PreparedFrameRejection)] = [
+            (
+                .guiAgentTranscript(mode: 1, epoch: 1, truncated: false, trimFront: 0, baseCount: 0, messages: []),
+                .transcriptBeforeSeed
+            ),
+            (
+                .guiAgentTranscript(mode: 1, epoch: 2, truncated: false, trimFront: 0, baseCount: 1, messages: []),
+                .transcriptEpochMismatch
+            ),
+            (
+                .guiAgentTranscript(mode: 1, epoch: 1, truncated: false, trimFront: 0, baseCount: 9, messages: []),
+                .transcriptDesynced
+            ),
+        ]
+
+        for (index, invalid) in invalidCommands.enumerated() {
+            let (dispatcher, gui) = makeDispatcher()
+            var results: [FrameTransactionResult] = []
+            dispatcher.onTransactionResult = { results.append($0) }
+
+            if index > 0 {
+                dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+                dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+                dispatcher.dispatch(.guiAgentTranscript(
+                    mode: 0, epoch: 1, truncated: false, trimFront: 0, baseCount: 0,
+                    messages: [Wire.ChatMessage(beamId: 1, content: .user(text: "seed"))]
+                ))
+                dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("baseline.ex")]))
+                dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+            }
+
+            let baselinePublications = gui.framePublicationCount
+            let frameSeq = UInt32(index > 0 ? 2 : 1)
+            let baseSeq = UInt32(index > 0 ? 1 : 0)
+            dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseSeq))
+            if baseSeq == 0 { dispatcher.dispatch(.guiTheme(slots: completeThemeSlots())) }
+            dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("must-not-publish.ex")]))
+            dispatcher.dispatch(invalid.0)
+            dispatcher.dispatch(.commitFrame(frameSeq: frameSeq, seq: 0))
+
+            #expect(gui.framePublicationCount == baselinePublications)
+            #expect(gui.tabBarState.tabs.first?.label == (index > 0 ? "baseline.ex" : nil))
+            #expect(results.last == .rejected(frameSeq: frameSeq, reason: invalid.1))
+            #expect(gui.agentChatState.messages.map(\.id) == (index > 0 ? [1] : []))
+        }
+    }
+
+    @Test("duplicate and out-of-order frame sequences return typed rejections")
+    @MainActor func duplicateAndOutOfOrderFramesReject() {
+        for incoming: UInt32 in [5, 4] {
+            let (dispatcher, _) = makeDispatcher()
+            var results: [FrameTransactionResult] = []
+            dispatcher.onTransactionResult = { results.append($0) }
+            dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
+            dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+            dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
+
+            dispatcher.dispatch(.beginFrame(frameSeq: incoming, baseFrameSeq: 0))
+            dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+            dispatcher.dispatch(.commitFrame(frameSeq: incoming, seq: 0))
+
+            #expect(results.last == .rejected(
+                frameSeq: incoming,
+                reason: .frameSequenceNotIncreasing(lastFrameSeq: 5, incomingFrameSeq: incoming)
+            ))
+            #expect(dispatcher.publicationCount == 1)
+        }
+    }
+
+    @Test("missing window references and stale epochs reject before publication")
+    @MainActor func windowReferenceAndEpochValidation() {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: windowContent()))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1))
+        dispatcher.dispatch(.guiWindowOverlayDelta(data: overlayDelta(epoch: 41)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+
+        #expect(gui.framePublicationCount == 1)
+        #expect(results.last == .rejected(
+            frameSeq: 2,
+            reason: .windowEpochMismatch(windowId: 7, expected: 42, actual: 41)
+        ))
+        #expect(gui.windowContents[7]?.cursorShape == .block)
+    }
+
+    @Test("unregistered font resources reject a prepared frame")
+    @MainActor func missingFontResourceRejects() {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: windowContent(fontId: 3)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(gui.framePublicationCount == 0)
+        #expect(results == [.rejected(frameSeq: 1, reason: .missingFontResource(fontId: 3))])
+    }
+
+    @Test("publication operation count depends on changed domains, not command count")
+    @MainActor func changedDomainOperationCount() {
+        let (dispatcher, gui) = makeDispatcher()
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1))
+        for index in 0..<100 {
+            dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("\(index).ex")]))
+        }
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+
+        #expect(dispatcher.lastPublicationOperationCounts == PreparedFrameOperationCounts(
+            theme: 0, windows: 0, chrome: 1, overlays: 0,
+            resources: 0, focus: 0, metadata: 0
+        ))
+        #expect(gui.framePublicationCount == 2)
+        #expect(gui.tabBarState.tabs.first?.label == "99.ex")
     }
 
     // MARK: - Negative-guard dispatch (#2634)


### PR DESCRIPTION
# TL;DR

macOS now validates each decoded frame into a value-semantic `PreparedFrameTransaction` and publishes all protocol-driven GUI state through one aggregate observation swap. Invalid window, resource, theme, or transcript updates publish nothing and return one typed rejection for the acknowledgement stack.

Part of #2747

## Context

The old commit path replayed staged commands directly into observable state. That repeated work at commit time and allowed failures discovered late in one domain to leave sibling domains partially visible.

This PR establishes the atomic publication boundary required by #2739. The stacked acknowledgement PR will encode `FrameTransactionResult` as `frame_applied` or `frame_rejected`; this PR deliberately does not attach status to the removed replay loop.

## Changes

- Added a typed prepared transaction builder for theme, windows, chrome, overlays, resources, focus, metadata, and resident agent transcripts.
- Resolve retained rows, epochs, window references, fonts, complete themes, and transcript append bases before publication.
- Coalesce repeated state replacements with typed keys while preserving append and upsert commands.
- Publish protocol-driven child state through one immutable aggregate observation token.
- Keep recovery and local-presentation changes on a separate out-of-band publication token.
- Added typed operation counts, rejection reasons, and a `FrameTransactionResult` callback for #2739.
- Added regression coverage for real observation atomicity, sequence/base rejection, missing resources, coalescing collisions, transcript desync, and keyframe/delta equivalence.

## Verification

- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -configuration Debug test` (1,072 tests passed)
- `make lint.full`
- `mix test.llm` (9,864 tests, 0 failures)
- LSP diagnostics on changed Swift files (0 diagnostics)
- `git diff --check`

## Acceptance Criteria Addressed

- Decoding produces typed domain updates and validation state in one prepared transaction. ✅
- Frame invariants and references validate before committed GUI state changes. ✅
- A valid transaction has one aggregate publication; an invalid transaction publishes nothing and returns one typed result. ✅
- Commit work is coalesced by changed semantic domain rather than replaying every decoded command. ✅
- Keyframe, delta, and last-good recovery semantics remain covered by regression tests. ✅

## Remaining Stack Work

- #2739 will encode and send the prepared boundary's typed applied/rejected status events. That stacked commit completes #2747's wire-reporting clause without rebuilding acknowledgement on the old replay path.
