### PR TITLE
feat(port): acknowledge applied frontend frames

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -27,7 +27,7 @@ The frontend runs as a child process of the BEAM. Communication uses stdin (BEAM
 
 **Text encoding:** All text fields (titles, language names, query source, semantic content) are UTF-8 encoded.
 
-**Protocol version:** The schema carries a `protocol_version` integer (currently 6). The BEAM and every frontend compile against it and exchange it in the `ready` handshake. The BEAM rejects a frontend whose version does not match and sends an explicit `protocol_error` instead of streaming frames the frontend cannot decode. Version 6 bumps the semantic agent chrome contract so `gui_agent_context` is length-framed and `gui_edit_timeline` appends file summaries after the entry list. See "Protocol Version Negotiation" below.
+**Protocol version:** The schema carries a `protocol_version` integer (currently 11). The BEAM and every frontend compile against it and exchange it in the `ready` handshake. The BEAM rejects a frontend whose version does not match and sends an explicit `protocol_error` instead of streaming frames the frontend cannot decode. Version 11 makes frame transactions generation-aware and adds explicit applied, rejected, and targeted window-reference-miss status. See "Protocol Version Negotiation" below.
 
 ---
 
@@ -39,7 +39,7 @@ The cell-paradigm render opcodes (`draw_text`, `set_cursor`, `clear`, and the re
 
 | Opcode | Name | Size | Description |
 |--------|------|------|-------------|
-| `0x10` | begin_frame | 9 | Open a frame transaction (frame_seq + base_frame_seq); see Frame Transactions |
+| `0x10` | begin_frame | 13 | Open a generation-aware frame transaction (frame_seq + base_frame_seq + generation); see Frame Transactions |
 | `0x11` | commit_frame | 9 | Close a frame transaction; promote staging and present (frame_seq + input_seq) |
 | `0x13` | _(reserved)_ | — | Freed by retiring batch_end in v3; do not reassign before a version bump past 3 |
 | `0x15` | set_cursor_shape | 2 | Change cursor appearance |
@@ -83,7 +83,10 @@ The cell-paradigm render opcodes (`draw_text`, `set_cursor`, `clear`, and the re
 | `0x03` | ready | 5, 13, or 15+ | Frontend is initialized and ready (15+ carries a u16 protocol_version) |
 | `0x04` | mouse_event | 9 | Mouse button, wheel, or motion (8-byte legacy also accepted) |
 | `0x05` | capabilities_updated | 9 | Updated capabilities after async detection |
-| `0x08` | request_keyframe | 5 | Ask the BEAM for a full keyframe after an invalidation (last_good_frame_seq) |
+| `0x08` | request_keyframe | 9 | Ask the BEAM to start a fresh recovery generation (last_good_frame_seq + failed generation) |
+| `0x0A` | frame_applied | 9 | Report semantic publication of a complete frame |
+| `0x0B` | frame_rejected | 14 | Reject a frame with generation, last applied frame, and stable reason |
+| `0x0C` | window_ref_miss | 15 | Reject a missing row/window reference and identify the affected window |
 
 ### Frontend → BEAM (Highlight Responses)
 
@@ -211,18 +214,19 @@ Between frames, the frontend must not mutate committed editor state or present n
 
 ## Frame Transactions
 
-> Status: protocol_version 4 keeps the transaction vocabulary introduced in protocol_version 3 (#2219 child A) and the BEAM now brackets every emitted frame with `begin_frame`/`commit_frame` (#2219 child B). Both frontends decode the markers and gate frames and latency on `commit_frame` exactly as they did `batch_end`; they ignore `base_frame_seq` for now. Children C/D move the frontends onto real staging/commit (paint nothing until the matching `commit_frame`, resync on truncation). This section is the authoritative spec those children build against.
+> Status: protocol_version 11 makes every transaction recovery-generation-aware. Frontends stage and validate the complete semantic transaction, publish it atomically on `commit_frame`, and then report whether it was applied, rejected, or missed a window reference. The BEAM grants one in-flight frame credit per frontend connection and uses only an applied frame from the current generation as a later delta base.
 
 A frame transaction makes a frame atomic: the BEAM brackets a frame's semantic commands between `begin_frame` and `commit_frame`, and a frontend paints nothing until it sees the matching `commit_frame`. This replaces the single `batch_end` terminator with an explicit open/close pair so a truncated or out-of-order stream can never paint a partial frame.
 
 ### Wire shapes
 
-`begin_frame` (0x10), fixed 9 bytes:
+`begin_frame` (0x10), fixed 13 bytes:
 
 ```
 opcode:         u8  = 0x10
-frame_seq:      u32           strictly monotonic global frame sequence
-base_frame_seq: u32           the frame these deltas assume; 0 = keyframe
+frame_seq:      u32           strictly monotonic frame sequence for this connection
+base_frame_seq: u32           acknowledged frame these deltas assume; 0 = keyframe
+generation:     u32           BEAM-owned recovery generation
 ```
 
 `commit_frame` (0x11), fixed 9 bytes:
@@ -233,11 +237,12 @@ frame_seq: u32                must equal the open begin_frame's frame_seq
 input_seq: u32                echoed input correlation sequence (#2215); 0 = no correlation
 ```
 
-`request_keyframe` (0x08, Frontend → BEAM), fixed 5 bytes:
+`request_keyframe` (0x08, Frontend → BEAM), fixed 9 bytes:
 
 ```
 opcode:              u8  = 0x08
-last_good_frame_seq: u32      last frame_seq the frontend committed cleanly; 0 if none
+last_good_frame_seq: u32      last frame_seq the frontend applied cleanly; 0 if none
+failed_generation:   u32      generation whose recovery is being retried
 ```
 
 A frame is therefore: `begin_frame ++ gui_* semantic/chrome commands ++ gui_surface_layout ++ commit_frame`. The placement envelope (`gui_surface_layout` 0xA4) is sent inside the transaction; see GUI_PROTOCOL.md for its section layout.
@@ -266,7 +271,9 @@ Four conditions invalidate the in-flight frame. In every case the frontend disca
 
 ### request_keyframe flow
 
-After any invalidation, the frontend emits `request_keyframe(last_good_frame_seq)`. The BEAM responds by sending the next frame as a full keyframe (`base_frame_seq == 0`), which re-establishes a known base for subsequent deltas. `last_good_frame_seq` is informational for the BEAM (the cleanly committed frame the client last held); the recovery action is the same regardless of its value: send a full keyframe. In the child-B single-client prototype, an inbound `request_keyframe` simply forces the next frame full.
+After any invalidation the frontend emits a typed rejection status. `window_ref_miss` identifies the affected window so the BEAM can preserve the acknowledged surrounding frame and emit a full replacement only for that window. Transaction-level rejection starts a fresh generation and sends the latest coalesced render intent as a full keyframe (`base_frame_seq == 0`). A manual `request_keyframe` also starts a fresh generation; it never merely repeats the failed generation.
+
+The BEAM keeps one frame credit **per frontend connection**. A Port write consumes the credit but does not advance the delta base. While status is outstanding, newer render requests replace the single pending intent. Only a matching `frame_applied` returns the credit and advances the acknowledged base. Rejected, duplicate, stale, out-of-order, wrong-generation, and inconsistent-last-applied statuses cannot advance the base or clear recovery. Recovery clears only when the requested base-zero keyframe is semantically published and its matching applied status reaches the BEAM. Metal/GPU presentation is deliberately outside this contract.
 
 ---
 
@@ -381,18 +388,17 @@ Total size: 9 bytes.
 | `0x02` | Motion (no button held) |
 | `0x03` | Drag (button held during motion) |
 
-### `0x08` request_keyframe
+### Frame recovery status (`0x08`, `0x0A`–`0x0C`)
 
-Ask the BEAM to send the next frame as a full keyframe. A frontend emits this after a frame transaction is invalidated (see "Frame Transactions"). Decoders ship in protocol_version 3; nothing on either frontend emits it until the staging/commit children (#2219 C/D) land.
+`request_keyframe` has the 9-byte generation-aware shape documented under Frame Transactions. It is the manual/general retry control and causes the BEAM to advance generation.
 
-```
-opcode:              u8  = 0x08
-last_good_frame_seq: u32      last frame_seq the frontend committed cleanly; 0 if none
-```
+`frame_applied` (0x0A), fixed 9 bytes: `generation:u32, frame_seq:u32`. Emit it only after the complete transaction has validated and its semantic state has been published atomically. Do not wait for Metal submission, terminal drawing, visibility, or vsync.
 
-Total size: 5 bytes.
+`frame_rejected` (0x0B), fixed 14 bytes: `generation:u32, frame_seq:u32, last_applied_frame_seq:u32, reason:u8`.
 
-**Behavior:** The BEAM forces the next frame full (`base_frame_seq == 0`), re-establishing a known delta base. See "Frame Transactions" for the full recovery flow.
+`window_ref_miss` (0x0C), fixed 15 bytes: `generation:u32, frame_seq:u32, last_applied_frame_seq:u32, window_id:u16`. It is the targeted form for a missing retained row/window reference; sibling windows and chrome remain committed at `last_applied_frame_seq`.
+
+Stable rejection reasons are: 1 truncation, 2 commit sequence mismatch, 3 non-increasing frame sequence, 4 base sequence mismatch, 5 missing theme, 6 incomplete theme, 7 missing window reference, 8 window epoch mismatch, 9 invalid retained rows, 10 missing font resource, 11 transcript desync, 12 decode failure, 13 out-of-transaction command, and 255 unknown.
 
 ---
 
@@ -764,7 +770,7 @@ Total size: 4 + msg_len bytes.
 
 ## Protocol Version Negotiation
 
-The schema (`docs/protocol_schema.toml`) carries a `protocol_version` integer (currently 10). `mix protocol.gen` emits it as a constant on every side: `Minga.Protocol.Opcodes.protocol_version()` (Elixir), `generated.ProtocolVersion` (Go), `PROTOCOL_VERSION` (Swift), `PROTOCOL_VERSION` (Zig parser). Bump it whenever the wire contract changes incompatibly; protocol_version 2 retired the 9 cell-paradigm render opcodes, protocol_version 3 (#2219) added the frame-transaction vocabulary (`begin_frame`, `commit_frame`, `request_keyframe`) and authoritative layout (`surface_placement`, `gui_surface_layout`), protocol_version 4 added the `gui_file_tree` row `heat_level` byte, protocol_version 5 added producer-assigned `stream_instance` identity to the Messages stream, protocol_version 6 frames `gui_agent_context` and appends `gui_edit_timeline` file summaries, protocol_version 7 established the current baseline, protocol_version 8 added `set_link_cursor`, protocol_version 9 widened `gui_window_content` framing and section lengths, and protocol_version 10 widens clipboard and retained-window delta framing. A frontend built against an older protocol handshakes with its old version and receives the `protocol_error` blocking surface instead of a desynced stream.
+The schema (`docs/protocol_schema.toml`) carries a `protocol_version` integer (currently 11). `mix protocol.gen` emits it as a constant on every side: `Minga.Protocol.Opcodes.protocol_version()` (Elixir), `generated.ProtocolVersion` (Go), `PROTOCOL_VERSION` (Swift), `PROTOCOL_VERSION` (Zig parser). Bump it whenever the wire contract changes incompatibly; protocol_version 2 retired the 9 cell-paradigm render opcodes, protocol_version 3 (#2219) added the frame-transaction vocabulary (`begin_frame`, `commit_frame`, `request_keyframe`) and authoritative layout (`surface_placement`, `gui_surface_layout`), protocol_version 4 added the `gui_file_tree` row `heat_level` byte, protocol_version 5 added producer-assigned `stream_instance` identity to the Messages stream, protocol_version 6 frames `gui_agent_context` and appends `gui_edit_timeline` file summaries, protocol_version 7 established the current baseline, protocol_version 8 added `set_link_cursor`, protocol_version 9 widened `gui_window_content` framing and section lengths, and protocol_version 10 widens clipboard and retained-window delta framing, and protocol_version 11 makes `begin_frame` generation-aware and adds explicit frame status/retry events. A frontend built against an older protocol handshakes with its old version and receives the `protocol_error` blocking surface instead of a desynced stream.
 
 **Handshake.** A frontend appends its compiled-in `protocol_version` as a u16 tail on the extended `ready` event (after `caps_data`). A frontend that omits the tail (short ready, or extended ready without the tail) is treated as protocol_version 0.
 

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -24,7 +24,9 @@ version = "2.0.0"
 # to len32 command framing with u32 inner section lengths.
 # protocol_version 10 widens clipboard_write and the A1/A2 window delta section
 # carriers and row counts to u32 so large payloads cannot silently wrap.
-protocol_version = 10
+# protocol_version 11 makes frame transactions generation-aware and adds explicit
+# applied/rejected/window-reference-miss acknowledgements (#2739).
+protocol_version = 11
 description = "Minga port protocol opcode registry"
 
 # Directions:
@@ -80,15 +82,15 @@ direction = "frontend_to_beam"
 # keyframe (a transaction with base_frame_seq == 0). A frontend emits it after any
 # invalidation (truncation, seq mismatch, in-transaction sizing failure, base
 # mismatch) carrying last_good_frame_seq:u32 — the last frame_seq it committed
-# cleanly (0 if it has none). fixed:5 = opcode(1) + last_good_frame_seq(u32).
-# The BEAM decodes it and forces the next frame to a keyframe (base_frame_seq 0,
-# full snapshots) since #2219 child B. Frontends do not emit it until #2219 child C/D.
+# cleanly (0 if it has none), plus the generation that failed. fixed:9 =
+# opcode(1) + last_good_frame_seq(u32) + generation(u32). The BEAM always starts a
+# fresh generation before publishing the recovery keyframe.
 [[opcodes]]
 category = "input"
 name = "request_keyframe"
 value = 0x08
 direction = "frontend_to_beam"
-framing = "fixed:5"
+framing = "fixed:9"
 
 [[opcodes]]
 category = "input"
@@ -96,6 +98,33 @@ name = "scroll_batch"
 value = 0x09
 direction = "frontend_to_beam"
 framing = "fixed:6"
+
+# Frame status events (#2739). Rejection reasons are stable wire values:
+# 1 truncation, 2 commit_sequence_mismatch, 3 frame_sequence_not_increasing,
+# 4 base_sequence_mismatch, 5 missing_theme, 6 incomplete_theme,
+# 7 missing_window_reference, 8 window_epoch_mismatch, 9 invalid_retained_rows,
+# 10 missing_font_resource, 11 transcript_desync, 12 decode_failure,
+# 13 out_of_transaction_command, 255 unknown.
+[[opcodes]]
+category = "input"
+name = "frame_applied"
+value = 0x0A
+direction = "frontend_to_beam"
+framing = "fixed:9"
+
+[[opcodes]]
+category = "input"
+name = "frame_rejected"
+value = 0x0B
+direction = "frontend_to_beam"
+framing = "fixed:14"
+
+[[opcodes]]
+category = "input"
+name = "window_ref_miss"
+value = 0x0C
+direction = "frontend_to_beam"
+framing = "fixed:15"
 
 [[opcodes]]
 category = "input"
@@ -120,7 +149,7 @@ direction = "frontend_to_beam"
 # (0x10) and set_cursor (0x11) slots.
 
 # begin_frame (#2219 child A) opens a frame transaction. fixed:9 = opcode(1) +
-# frame_seq(u32) + base_frame_seq(u32). frame_seq is the strictly monotonic global
+# frame_seq(u32) + base_frame_seq(u32) + generation(u32). frame_seq is the strictly monotonic global
 # frame sequence (reuses Renderer.Server's seq) used for resync/attach ordering.
 # base_frame_seq names the frame this transaction's deltas assume; base_frame_seq
 # == 0 means keyframe (full snapshots, no deltas — also the multi-client attach
@@ -131,7 +160,7 @@ category = "render"
 name = "begin_frame"
 value = 0x10
 direction = "beam_to_frontend"
-framing = "fixed:9"
+framing = "fixed:13"
 
 # commit_frame (#2219 child A) closes a frame transaction; a frontend promotes its
 # staged commands and presents the frame on this opcode. fixed:9 = opcode(1) +

--- a/go/tui/internal/generated/command_size.go
+++ b/go/tui/internal/generated/command_size.go
@@ -30,8 +30,10 @@ func CommandSize(payload []byte) (int, CommandSizeStatus) {
 		return fixedCommandSize(payload, 4)
 	case OPGuiGutterSep, OPGuiCursorline:
 		return fixedCommandSize(payload, 6)
-	case OPBeginFrame, OPCommitFrame:
+	case OPCommitFrame:
 		return fixedCommandSize(payload, 9)
+	case OPBeginFrame:
+		return fixedCommandSize(payload, 13)
 	case OPSetTitle, OPProtocolError, OPGuiIndentGuides, OPGuiLineSpacing, OPGuiFileTreeSelection, OPGuiCursorAnimation, OPGuiHoverAction, OPGuiConfigState, OPGuiWorkspaces, OPGuiNotifications, OPGuiEditTimeline, OPGuiExtensionOverlay, OPGuiExtensionPanel, OPGuiSearchState, OPGuiEmptyState:
 		return len16CommandSize(payload)
 	case OPGuiWindowContent, OPGuiAgentTranscript, OPClipboardWrite, OPGuiFileTree, OPGuiObservatory, OPGuiSidebars, OPGuiExtensionRuntime:

--- a/go/tui/internal/generated/command_size_test.go
+++ b/go/tui/internal/generated/command_size_test.go
@@ -12,9 +12,8 @@ func TestCommandSizeFramings(t *testing.T) {
 		{"fixed set_cursor_shape", []byte{OPSetCursorShape, 0}, 2, CommandSizeOK},
 		{"fixed set_window_bg", []byte{OPSetWindowBg, 0x28, 0x2C, 0x34}, 4, CommandSizeOK},
 		{"fixed gutter_sep", []byte{OPGuiGutterSep, 0, 0, 0, 0, 0}, 6, CommandSizeOK},
-		// Frame-transaction markers (#2219 child A): begin_frame/commit_frame are
-		// fixed:9 = opcode + two u32 fields.
-		{"fixed begin_frame", []byte{OPBeginFrame, 0, 0, 0, 7, 0, 0, 0, 0}, 9, CommandSizeOK},
+		// begin_frame adds a generation u32 in protocol v11; commit_frame stays fixed:9.
+		{"fixed begin_frame", []byte{OPBeginFrame, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 1}, 13, CommandSizeOK},
 		{"fixed commit_frame", []byte{OPCommitFrame, 0, 0, 0, 7, 0, 0, 0, 5}, 9, CommandSizeOK},
 		{"incomplete begin_frame", []byte{OPBeginFrame, 0, 0, 0}, 0, CommandSizeIncomplete},
 		// gui_indent_guides: the opcode that previously desynced the Go reader.

--- a/go/tui/internal/generated/opcodes.go
+++ b/go/tui/internal/generated/opcodes.go
@@ -4,7 +4,7 @@ package generated
 
 // ProtocolVersion is the wire-contract version the frontend exchanges with
 // the BEAM in the ready handshake. A mismatch yields an explicit protocol_error.
-const ProtocolVersion uint16 = 10
+const ProtocolVersion uint16 = 11
 
 const (
 	// Input
@@ -17,6 +17,9 @@ const (
 	OPGuiAction           byte = 0x07
 	OPRequestKeyframe     byte = 0x08
 	OPScrollBatch         byte = 0x09
+	OPFrameApplied        byte = 0x0A
+	OPFrameRejected       byte = 0x0B
+	OPWindowRefMiss       byte = 0x0C
 	OPLogMessage          byte = 0x60
 
 	// Render

--- a/go/tui/internal/port/reader_test.go
+++ b/go/tui/internal/port/reader_test.go
@@ -76,9 +76,9 @@ func TestDecodePacketDoesNotSwallowAfterOverlayDelta(t *testing.T) {
 // The model uses the marker to abort an open frame transaction and resync.
 func TestDecodePacketSurfacesStreamErrorOnUnknownOpcode(t *testing.T) {
 	var batch []byte
-	batch = append(batch, generated.OPBeginFrame, 0, 0, 0, 5, 0, 0, 0, 0) // open transaction (seq 5, base 0)
-	batch = append(batch, generated.OPSetCursorShape, 0)                  // a valid command before the failure
-	batch = append(batch, 0x6F)                                           // unknown opcode (below chrome range, no schema size)
+	batch = append(batch, generated.OPBeginFrame, 0, 0, 0, 5, 0, 0, 0, 0, 0, 0, 0, 1) // seq 5, base 0, generation 1
+	batch = append(batch, generated.OPSetCursorShape, 0)                              // a valid command before the failure
+	batch = append(batch, 0x6F)                                                       // unknown opcode (below chrome range, no schema size)
 
 	var warnings []string
 	cmds := decodePacket(batch, func(_ byte, text string) { warnings = append(warnings, text) })

--- a/go/tui/internal/protocol/commands.go
+++ b/go/tui/internal/protocol/commands.go
@@ -47,6 +47,8 @@ type Command struct {
 	// keyframe (#2219). A non-zero base must equal the last committed frame_seq or
 	// the transaction is invalidated.
 	BaseFrameSeq uint32
+	// Generation is the BEAM-owned recovery generation echoed by frame status.
+	Generation uint32
 	// InputSeq is the echoed input correlation sequence carried by a
 	// CommandCommitFrame (ticket #2215, wire field input_seq). 0 means "no correlation".
 	InputSeq         uint32
@@ -175,16 +177,16 @@ func DecodeCommand(payload []byte) (Command, error) {
 
 	switch payload[0] {
 	case generated.OPBeginFrame:
-		// begin_frame opens a frame transaction (#2219): <opcode, frame_seq:u32,
-		// base_frame_seq:u32>. Decoded but ignored for rendering today.
-		if len(payload) < 9 {
+		// begin_frame (#2739): frame_seq:u32 + base_frame_seq:u32 + generation:u32.
+		if len(payload) < 13 {
 			return Command{}, fmt.Errorf("short begin_frame")
 		}
 		return Command{
 			Kind:         CommandBeginFrame,
-			Size:         9,
+			Size:         13,
 			FrameSeq:     binary.BigEndian.Uint32(payload[1:5]),
 			BaseFrameSeq: binary.BigEndian.Uint32(payload[5:9]),
+			Generation:   binary.BigEndian.Uint32(payload[9:13]),
 		}, nil
 	case generated.OPCommitFrame:
 		// commit_frame closes a frame transaction (#2219): <opcode, frame_seq:u32,

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -60,8 +60,8 @@ func TestDecodeProtocolError(t *testing.T) {
 }
 
 func TestDecodeBeginFrame(t *testing.T) {
-	// begin_frame (#2219): opcode + frame_seq:u32 + base_frame_seq:u32.
-	packet := []byte{generated.OPBeginFrame, 0, 0, 0, 7, 0, 0, 0, 3}
+	// begin_frame (#2739): opcode + frame_seq:u32 + base_frame_seq:u32 + generation:u32.
+	packet := []byte{generated.OPBeginFrame, 0, 0, 0, 7, 0, 0, 0, 3, 0, 0, 0, 9}
 	cmd, err := DecodeCommand(packet)
 	if err != nil {
 		t.Fatalf("DecodeCommand returned error: %v", err)
@@ -69,11 +69,11 @@ func TestDecodeBeginFrame(t *testing.T) {
 	if cmd.Kind != CommandBeginFrame {
 		t.Fatalf("kind = %v, want begin frame", cmd.Kind)
 	}
-	if cmd.Size != 9 {
-		t.Fatalf("size = %d, want 9", cmd.Size)
+	if cmd.Size != 13 {
+		t.Fatalf("size = %d, want 13", cmd.Size)
 	}
-	if cmd.FrameSeq != 7 || cmd.BaseFrameSeq != 3 {
-		t.Fatalf("frame_seq/base = %d/%d, want 7/3", cmd.FrameSeq, cmd.BaseFrameSeq)
+	if cmd.FrameSeq != 7 || cmd.BaseFrameSeq != 3 || cmd.Generation != 9 {
+		t.Fatalf("frame_seq/base/generation = %d/%d/%d, want 7/3/9", cmd.FrameSeq, cmd.BaseFrameSeq, cmd.Generation)
 	}
 }
 

--- a/go/tui/internal/protocol/events.go
+++ b/go/tui/internal/protocol/events.go
@@ -66,17 +66,55 @@ func EncodeResize(width, height uint16) []byte {
 	return []byte{generated.OPResize, byte(width >> 8), byte(width), byte(height >> 8), byte(height)}
 }
 
-// EncodeRequestKeyframe asks the BEAM to send the next frame as a full keyframe
-// after the frontend invalidated its staged/committed state (#2219). The frontend
-// emits it when a frame transaction is truncated, carries a mismatched seq/base,
-// or fails to size/decode mid-transaction. last_good_frame_seq is the last frame
-// the frontend committed cleanly (informational under single-client scope; the
-// BEAM forces the next frame full regardless). Wire format: fixed:5 =
+// EncodeRequestKeyframe asks the BEAM to manually retry with a full keyframe.
+// Automatic invalidation recovery uses frame_rejected alone; emitting both would
+// advance the BEAM recovery generation twice. last_good_frame_seq is the last
+// frame the frontend committed cleanly (informational under single-client scope;
+// the BEAM forces the next frame full regardless). Wire format: fixed:5 =
 // opcode(1) + last_good_frame_seq(u32), matching protocol.ex decode_event/1.
-func EncodeRequestKeyframe(lastGoodFrameSeq uint32) []byte {
+func EncodeRequestKeyframe(lastGoodFrameSeq, generation uint32) []byte {
 	return []byte{
 		generated.OPRequestKeyframe,
 		byte(lastGoodFrameSeq >> 24), byte(lastGoodFrameSeq >> 16), byte(lastGoodFrameSeq >> 8), byte(lastGoodFrameSeq),
+		byte(generation >> 24), byte(generation >> 16), byte(generation >> 8), byte(generation),
+	}
+}
+
+const (
+	RejectTruncation             byte = 1
+	RejectCommitSequence         byte = 2
+	RejectFrameSequence          byte = 3
+	RejectBaseSequence           byte = 4
+	RejectMissingTheme           byte = 5
+	RejectIncompleteTheme        byte = 6
+	RejectMissingWindowReference byte = 7
+	RejectWindowEpoch            byte = 8
+	RejectInvalidRetainedRows    byte = 9
+	RejectMissingFont            byte = 10
+	RejectTranscriptDesync       byte = 11
+	RejectDecodeFailure          byte = 12
+	RejectOutOfTransaction       byte = 13
+)
+
+func EncodeFrameApplied(generation, frameSeq uint32) []byte {
+	return encodeFrameStatus(generated.OPFrameApplied, generation, frameSeq)
+}
+
+func EncodeFrameRejected(generation, frameSeq, lastApplied uint32, reason byte) []byte {
+	out := encodeFrameStatus(generated.OPFrameRejected, generation, frameSeq)
+	out = append(out, byte(lastApplied>>24), byte(lastApplied>>16), byte(lastApplied>>8), byte(lastApplied), reason)
+	return out
+}
+
+func EncodeWindowRefMiss(generation, frameSeq, lastApplied uint32, windowID uint16) []byte {
+	out := encodeFrameStatus(generated.OPWindowRefMiss, generation, frameSeq)
+	return append(out, byte(lastApplied>>24), byte(lastApplied>>16), byte(lastApplied>>8), byte(lastApplied), byte(windowID>>8), byte(windowID))
+}
+
+func encodeFrameStatus(op byte, generation, frameSeq uint32) []byte {
+	return []byte{op,
+		byte(generation >> 24), byte(generation >> 16), byte(generation >> 8), byte(generation),
+		byte(frameSeq >> 24), byte(frameSeq >> 16), byte(frameSeq >> 8), byte(frameSeq),
 	}
 }
 

--- a/go/tui/internal/protocol/frame_status_test.go
+++ b/go/tui/internal/protocol/frame_status_test.go
@@ -1,0 +1,23 @@
+package protocol
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+)
+
+func TestFrameStatusWireLayouts(t *testing.T) {
+	applied := EncodeFrameApplied(3, 9)
+	if len(applied) != 9 || applied[0] != generated.OPFrameApplied || binary.BigEndian.Uint32(applied[1:5]) != 3 || binary.BigEndian.Uint32(applied[5:9]) != 9 {
+		t.Fatalf("bad frame_applied layout: %v", applied)
+	}
+	rejected := EncodeFrameRejected(3, 9, 7, RejectBaseSequence)
+	if len(rejected) != 14 || rejected[0] != generated.OPFrameRejected || binary.BigEndian.Uint32(rejected[9:13]) != 7 || rejected[13] != RejectBaseSequence {
+		t.Fatalf("bad frame_rejected layout: %v", rejected)
+	}
+	miss := EncodeWindowRefMiss(3, 9, 7, 12)
+	if len(miss) != 15 || miss[0] != generated.OPWindowRefMiss || binary.BigEndian.Uint16(miss[13:15]) != 12 {
+		t.Fatalf("bad window_ref_miss layout: %v", miss)
+	}
+}

--- a/go/tui/internal/ui/frame_status_test.go
+++ b/go/tui/internal/ui/frame_status_test.go
@@ -1,0 +1,75 @@
+package ui
+
+import (
+	"encoding/binary"
+	"testing"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+func TestCommitEmitsAppliedOnlyAfterCompletePublication(t *testing.T) {
+	out := make(chan []byte, 16)
+	m := New(40, 8, out, nil)
+	m = applyTo(t, m, beginFrame(1, 0), testThemeCommand(), windowRowsCommand(1, "committed"), commitFrame(1))
+	packets := drainOutboundPackets(out)
+	if len(packets) == 0 {
+		t.Fatal("missing frame_applied")
+	}
+	last := packets[len(packets)-1]
+	if len(last) != 9 || last[0] != generated.OPFrameApplied || binary.BigEndian.Uint32(last[1:5]) != 1 || binary.BigEndian.Uint32(last[5:9]) != 1 {
+		t.Fatalf("last packet should acknowledge committed generation/frame: %v", last)
+	}
+	if got := renderedBody(m); got == "" {
+		t.Fatal("frame must be published before applied is emitted")
+	}
+}
+
+func TestRejectedTransactionEmitsOnlyTypedRejectionAndDoesNotPublish(t *testing.T) {
+	out := make(chan []byte, 16)
+	m := New(40, 8, out, nil)
+	beforeWindows := len(m.windows)
+	beforeCommitted := m.lastCommittedSeq
+	m = applyTo(t, m, beginFrame(9, 4), commitFrame(9))
+	packets := drainOutboundPackets(out)
+	if len(packets) != 2 || packets[0][0] != generated.OPFrameRejected || packets[1][0] != generated.OPLogMessage {
+		t.Fatalf("automatic recovery must emit one rejection plus diagnostics only: %v", packets)
+	}
+	for _, packet := range packets {
+		if packet[0] == generated.OPRequestKeyframe {
+			t.Fatalf("automatic rejection must not also request a keyframe: %v", packets)
+		}
+	}
+	if len(m.windows) != beforeWindows || m.lastCommittedSeq != beforeCommitted {
+		t.Fatal("rejected frame partially published semantic state")
+	}
+}
+
+func TestWindowReferenceMissReportsTargetWithoutPublishingSiblingState(t *testing.T) {
+	out := make(chan []byte, 16)
+	m := New(40, 8, out, nil)
+	m = applyTo(t, m, beginFrame(1, 0), testThemeCommand(), windowRowsCommand(1, "baseline"), commitFrame(1))
+	drainOutboundPackets(out)
+
+	missing := protocol.Command{Kind: protocol.CommandWindowDelta, Window: protocol.WindowContent{
+		ID: 2, ContentEpoch: 1,
+		Rows: []protocol.WindowRow{{Ref: true, ID: 999, ContentHash: 999}},
+	}}
+	m = applyTo(t, m, beginFrame(2, 1), missing, commitFrame(2))
+	packets := drainOutboundPackets(out)
+	if len(packets) != 1 || len(packets[0]) != 15 || packets[0][0] != generated.OPWindowRefMiss {
+		t.Fatalf("expected one targeted window_ref_miss, got %v", packets)
+	}
+	if got := binary.BigEndian.Uint16(packets[0][13:15]); got != 2 {
+		t.Fatalf("window id = %d, want 2", got)
+	}
+	if _, ok := m.windows[2]; ok {
+		t.Fatal("missing-window delta must not publish")
+	}
+	if m.resyncPending {
+		t.Fatal("targeted ref recovery must not enter global base-zero resync")
+	}
+	if got := m.windows[1].Rows[0].Text; got != "baseline" {
+		t.Fatalf("sibling window changed: %q", got)
+	}
+}

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"sort"
+	"strings"
 	"time"
 
 	"charm.land/bubbles/v2/viewport"
@@ -97,9 +98,9 @@ type Model struct {
 	// last_good_frame_seq carried by request_keyframe. 0 means no frame committed
 	// yet (only a base-0 keyframe is valid until then).
 	lastCommittedSeq uint32
-	// resyncPending is set when the model discarded a transaction and asked the
-	// BEAM for a keyframe (#2219). It drives a subtle footer indicator while the
-	// frontend waits, and clears when a valid commit applies.
+	// resyncPending is set when the model rejected a transaction. It drives a
+	// subtle footer indicator while the BEAM performs typed-status recovery, and
+	// clears when a valid commit applies.
 	resyncPending bool
 	// surfacePlacements is the BEAM's authoritative per-frame surface layout from
 	// gui_surface_layout (0xA4, #2268): one rect+z list. Compositing reads the z
@@ -128,8 +129,9 @@ type frameStaging struct {
 	// base is the begin_frame's base_frame_seq; 0 means keyframe (always valid),
 	// otherwise it must equal lastCommittedSeq.
 	base uint32
-	// commands are the buffered semantic/chrome commands in arrival order,
-	// replayed through the live mutation switch at a valid commit.
+	// generation is echoed on every status event.
+	generation uint32
+	// commands are the buffered semantic/chrome commands in arrival order.
 	commands []protocol.Command
 }
 
@@ -517,7 +519,7 @@ func (m Model) cursorStyleSequence() string {
 // accumulate in it without touching the live model; commit_frame validates and
 // replays the buffer atomically. Out-of-band commands (set_title/set_window_bg, clipboard writes, no-op compatibility commands, protocol_error, transport survivors) apply directly with no open transaction; the same command inside a transaction stages and applies at commit. A semantic/chrome command with NO open transaction, or any stream
 // error / invalidation, is a protocol violation under the staged model and
-// triggers request_keyframe instead of a partial paint.
+// triggers typed frame rejection instead of a partial paint.
 func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 	cmds := make([]tea.Cmd, 0, 1)
 	for _, command := range commands {
@@ -529,9 +531,10 @@ func (m *Model) applyCommands(commands []protocol.Command) tea.Cmd {
 				cmds = m.invalidateStaging(cmds, "truncated frame transaction (begin while open)")
 			}
 			m.staging = &frameStaging{
-				seq:      command.FrameSeq,
-				base:     command.BaseFrameSeq,
-				commands: make([]protocol.Command, 0, 16),
+				seq:        command.FrameSeq,
+				base:       command.BaseFrameSeq,
+				generation: command.Generation,
+				commands:   make([]protocol.Command, 0, 16),
 			}
 		case protocol.CommandCommitFrame:
 			cmds = m.commitStaging(cmds, command)
@@ -591,7 +594,7 @@ func stagingThemeValidation(commands []protocol.Command) (found bool, missing []
 // commitStaging validates the open transaction against the commit and, if valid,
 // replays its buffered commands through the live mutation switch in one shot,
 // then fires the commit-gated behaviors (latency resolve). An invalid or missing
-// transaction discards staging and requests a keyframe (#2219), except a missing theme on a keyframe latches a protocol error because the BEAM must own theme selection.
+// transaction discards staging and emits typed rejection (#2219), except a missing theme on a keyframe latches a protocol error because the BEAM must own theme selection.
 func (m *Model) commitStaging(cmds []tea.Cmd, command protocol.Command) []tea.Cmd {
 	if m.staging == nil {
 		// commit with no open begin: the begin was lost or truncated. Resync.
@@ -627,11 +630,21 @@ func (m *Model) commitStaging(cmds []tea.Cmd, command protocol.Command) []tea.Cm
 		m.lineCache.reset()
 	}
 
+	// Validate every window reference against a temporary snapshot before any
+	// publication. A miss returns targeted status and leaves surrounding state live.
+	if windowID, missed := m.validateWindowReferences(); missed {
+		generation, seq := m.staging.generation, m.staging.seq
+		m.send(protocol.EncodeWindowRefMiss(generation, seq, m.lastCommittedSeq, windowID))
+		m.staging = nil
+		return cmds
+	}
+
 	// Valid: replay the buffer atomically through the live mutation path.
+	generation, seq := m.staging.generation, m.staging.seq
 	for _, staged := range m.staging.commands {
 		m.applyMutation(staged)
 	}
-	m.lastCommittedSeq = m.staging.seq
+	m.lastCommittedSeq = seq
 	m.staging = nil
 	// A clean commit clears any pending resync indicator: the frontend is back
 	// in sync with the BEAM (#2219).
@@ -641,29 +654,81 @@ func (m *Model) commitStaging(cmds []tea.Cmd, command protocol.Command) []tea.Cm
 	// to the terminal, so resolve the keystroke-to-write latency sample now for
 	// the echoed correlation sequence (ticket #2215, resolved on commit).
 	m.latency.Resolve(command.InputSeq)
+	m.send(protocol.EncodeFrameApplied(generation, seq))
 	return cmds
 }
 
-// invalidateStaging discards any open transaction and emits a request_keyframe
-// carrying the last cleanly committed frame_seq (#2219). It is the single sink
-// for every invalidation: truncation, seq mismatch, base mismatch, a stream
-// error inside a transaction, and an out-of-transaction semantic command. The
-// live model keeps the last committed frame, so View() never paints a partial.
+// invalidateStaging discards any open transaction and emits one typed
+// frame_rejected status. It is the single sink for every invalidation: truncation,
+// seq mismatch, base mismatch, a stream error inside a transaction, and an
+// out-of-transaction semantic command. The live model keeps the last committed
+// frame, so View() never paints a partial. request_keyframe remains reserved for
+// an explicit manual retry rather than duplicating automatic typed recovery.
 func (m *Model) invalidateStaging(cmds []tea.Cmd, reason string) []tea.Cmd {
+	generation, frameSeq := uint32(0), uint32(0)
+	if m.staging != nil {
+		generation, frameSeq = m.staging.generation, m.staging.seq
+	}
+	m.send(protocol.EncodeFrameRejected(generation, frameSeq, m.lastCommittedSeq, rejectionCode(reason)))
 	m.staging = nil
-	// Debounce the keyframe request: after an invalidation, every stale
-	// in-flight frame also fails its base check (the BEAM advances
-	// base_frame_seq for frames we discarded), and re-requesting per frame
-	// would force a duplicate BEAM render each. One request per resync
-	// window; the pending flag clears when a valid commit applies. The diagnostic
-	// follows the same debounce and is sent to BEAM's *Messages* log instead of
-	// raw stderr, because stderr writes can corrupt the terminal renderer.
+	// Typed rejection is the automatic recovery trigger. Keep diagnostics and
+	// the visible resync state debounced while stale frames from the old credit
+	// drain, but never send a second recovery trigger automatically.
 	if !m.resyncPending {
 		m.resyncPending = true
-		m.logToMessages(protocol.LogLevelWarn, "Go TUI frame invalidated (%s), requesting keyframe from %d", reason, m.lastCommittedSeq)
-		m.send(protocol.EncodeRequestKeyframe(m.lastCommittedSeq))
+		m.logToMessages(protocol.LogLevelWarn, "Go TUI frame invalidated (%s), awaiting recovery from %d", reason, m.lastCommittedSeq)
 	}
 	return cmds
+}
+
+func rejectionCode(reason string) byte {
+	switch {
+	case strings.Contains(reason, "begin while open"):
+		return protocol.RejectTruncation
+	case strings.Contains(reason, "commit_frame"):
+		return protocol.RejectCommitSequence
+	case strings.Contains(reason, "base mismatch"):
+		return protocol.RejectBaseSequence
+	case strings.Contains(reason, "missing gui_theme slots"):
+		return protocol.RejectIncompleteTheme
+	case strings.Contains(reason, "missing gui_theme"):
+		return protocol.RejectMissingTheme
+	case strings.Contains(reason, "stream error"):
+		return protocol.RejectDecodeFailure
+	case strings.Contains(reason, "outside frame transaction"):
+		return protocol.RejectOutOfTransaction
+	default:
+		return 255
+	}
+}
+
+// validateWindowReferences resolves deltas against a temporary window snapshot.
+// It performs no observable writes, so a miss can be reported before publication.
+func (m *Model) validateWindowReferences() (uint16, bool) {
+	working := make(map[uint16]protocol.WindowContent, len(m.windows))
+	for id, window := range m.windows {
+		working[id] = window
+	}
+	for _, command := range m.staging.commands {
+		switch command.Kind {
+		case protocol.CommandWindowContent:
+			working[command.Window.ID] = command.Window
+		case protocol.CommandWindowDelta:
+			previous, ok := working[command.Window.ID]
+			if !ok || previous.ContentEpoch != command.Window.ContentEpoch {
+				return command.Window.ID, true
+			}
+			if command.Window.Rows != nil {
+				rows, err := resolveWindowRows(previous.Rows, command.Window.Rows)
+				if err != nil {
+					return command.Window.ID, true
+				}
+				previous.Rows = rows
+			}
+			working[command.Window.ID] = previous
+		}
+	}
+	return 0, false
 }
 
 // applyMutation runs a single command through the live per-command mutation
@@ -960,7 +1025,7 @@ func (m Model) send(payload []byte) {
 	}
 }
 
-func (m Model) logToMessages(level byte, format string, args ...any) {
+func (m Model) logToMessages(level byte, format string, args ...interface{}) {
 	m.send(protocol.EncodeLogMessage(level, fmt.Sprintf(format, args...)))
 }
 

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -275,10 +275,16 @@ func TestProtocolErrorRendersBlockingSurfaceAndTakesPrecedence(t *testing.T) {
 	}
 
 	packets := drainOutboundPackets(out)
-	if len(packets) != 1 {
-		t.Fatalf("protocol error should send one log_message packet, got %d", len(packets))
+	var logPacket []byte
+	for _, packet := range packets {
+		if _, _, ok := decodeLogMessage(packet); ok {
+			logPacket = packet
+		}
 	}
-	level, text, ok := decodeLogMessage(packets[0])
+	if logPacket == nil {
+		t.Fatalf("protocol error should send a log_message packet, got %d packets", len(packets))
+	}
+	level, text, ok := decodeLogMessage(logPacket)
 	if !ok {
 		t.Fatalf("protocol error packet should be log_message, got %v", packets[0])
 	}

--- a/go/tui/internal/ui/staging_test.go
+++ b/go/tui/internal/ui/staging_test.go
@@ -12,7 +12,7 @@ import (
 
 // beginFrame builds a begin_frame command for a transaction (#2219).
 func beginFrame(seq, base uint32) protocol.Command {
-	return protocol.Command{Kind: protocol.CommandBeginFrame, FrameSeq: seq, BaseFrameSeq: base}
+	return protocol.Command{Kind: protocol.CommandBeginFrame, FrameSeq: seq, BaseFrameSeq: base, Generation: 1}
 }
 
 // commitFrame builds a commit_frame command for a transaction (#2219).
@@ -60,7 +60,7 @@ func drainOutboundPackets(out chan []byte) [][]byte {
 }
 
 func decodeKeyframeRequest(packet []byte) (uint32, bool) {
-	if len(packet) != 5 || packet[0] != generated.OPRequestKeyframe {
+	if len(packet) != 9 || packet[0] != generated.OPRequestKeyframe {
 		return 0, false
 	}
 	return uint32(packet[1])<<24 | uint32(packet[2])<<16 | uint32(packet[3])<<8 | uint32(packet[4]), true
@@ -83,17 +83,16 @@ func applyTo(t *testing.T, model Model, commands ...protocol.Command) Model {
 	return updated.(Model)
 }
 
-// Stale in-flight frames after an invalidation each fail their base check,
-// but only the FIRST invalidation sends request_keyframe; the rest discard
-// silently until a valid commit clears the pending flag (#2266 review).
-func TestInvalidationDebouncesKeyframeRequests(t *testing.T) {
+// Automatic invalidation emits typed rejection only. Stale in-flight frames may
+// reject too, but none may duplicate recovery with request_keyframe.
+func TestInvalidationNeverAutomaticallyRequestsKeyframe(t *testing.T) {
 	out := make(chan []byte, 8)
 	m := New(80, 24, out, nil)
 
 	// First invalidation: commit with no open transaction.
 	m = applyTo(t, m, commitFrame(7))
-	if seqs := drainKeyframeRequests(t, out); len(seqs) != 1 {
-		t.Fatalf("first invalidation should send one request_keyframe, got %d", len(seqs))
+	if seqs := drainKeyframeRequests(t, out); len(seqs) != 0 {
+		t.Fatalf("automatic invalidation must not request_keyframe, got %d", len(seqs))
 	}
 
 	// Stale in-flight frame: base mismatch while resync is already pending.
@@ -133,8 +132,8 @@ func TestInvalidationLogsToMessagesAndDebouncesDiagnostics(t *testing.T) {
 		}
 	}
 
-	if len(keyframes) != 1 || keyframes[0] != 0 {
-		t.Fatalf("first invalidation should request keyframe from last good seq 0, got %v", keyframes)
+	if len(keyframes) != 0 {
+		t.Fatalf("automatic invalidation must not request a keyframe, got %v", keyframes)
 	}
 	if len(logs) != 1 {
 		t.Fatalf("first invalidation should send one log_message, got %d", len(logs))
@@ -144,8 +143,14 @@ func TestInvalidationLogsToMessagesAndDebouncesDiagnostics(t *testing.T) {
 	}
 
 	m = applyTo(t, m, beginFrame(8, 7), windowRowsCommand(1, "stale"), commitFrame(8))
-	if packets := drainOutboundPackets(out); len(packets) != 0 {
-		t.Fatalf("pending resync should debounce duplicate keyframe requests and logs, got %d packets", len(packets))
+	packets = drainOutboundPackets(out)
+	for _, packet := range packets {
+		if _, ok := decodeKeyframeRequest(packet); ok {
+			t.Fatal("pending resync must debounce duplicate keyframe recovery")
+		}
+		if _, _, ok := decodeLogMessage(packet); ok {
+			t.Fatal("pending resync must debounce duplicate diagnostics")
+		}
 	}
 }
 
@@ -202,9 +207,9 @@ func TestStagingAppliesAtomicallyOnCommit(t *testing.T) {
 	}
 }
 
-// AC-3: a truncated transaction (new begin before commit) requests a keyframe and
-// does NOT partially paint; the prior committed frame stays on screen.
-func TestTruncatedTransactionRequestsKeyframeAndKeepsPriorFrame(t *testing.T) {
+// AC-3: a truncated transaction does not partially paint or automatically ask
+// for a keyframe; the prior committed frame stays on screen.
+func TestTruncatedTransactionRejectsAndKeepsPriorFrame(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out, nil)
 	model = applyTo(t, model, beginFrame(7, 0), testThemeCommand(), windowRowsCommand(1, "good frame"), commitFrame(7))
@@ -220,18 +225,17 @@ func TestTruncatedTransactionRequestsKeyframeAndKeepsPriorFrame(t *testing.T) {
 	if !strings.Contains(got, "good frame") {
 		t.Fatalf("prior committed frame should remain on screen: %q", got)
 	}
-	reqs := drainKeyframeRequests(t, out)
-	if len(reqs) != 1 || reqs[0] != 7 {
-		t.Fatalf("truncation should request a keyframe from last good seq 7, got %v", reqs)
+	if reqs := drainKeyframeRequests(t, out); len(reqs) != 0 {
+		t.Fatalf("truncation must not automatically request a keyframe, got %v", reqs)
 	}
 	if !model.resyncPending {
 		t.Fatal("model should mark resync pending after truncation")
 	}
 }
 
-// AC-3: a malformed transaction (stream error inside it) requests a keyframe and
-// keeps the prior frame.
-func TestStreamErrorInsideTransactionRequestsKeyframe(t *testing.T) {
+// AC-3: a malformed transaction is rejected without an automatic keyframe
+// request and keeps the prior frame.
+func TestStreamErrorInsideTransactionRejects(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out, nil)
 	model = applyTo(t, model, beginFrame(3, 0), testThemeCommand(), windowRowsCommand(1, "stable"), commitFrame(3))
@@ -252,9 +256,8 @@ func TestStreamErrorInsideTransactionRequestsKeyframe(t *testing.T) {
 	if !strings.Contains(got, "stable") {
 		t.Fatalf("prior committed frame should remain: %q", got)
 	}
-	reqs := drainKeyframeRequests(t, out)
-	if len(reqs) != 1 || reqs[0] != 3 {
-		t.Fatalf("stream error should request keyframe from seq 3, got %v", reqs)
+	if reqs := drainKeyframeRequests(t, out); len(reqs) != 0 {
+		t.Fatalf("stream error must not automatically request a keyframe, got %v", reqs)
 	}
 }
 
@@ -269,8 +272,8 @@ func TestStreamErrorOutsideTransactionIsHarmless(t *testing.T) {
 	}
 }
 
-// AC-2: a commit whose seq does not match the open begin requests a keyframe.
-func TestCommitSeqMismatchRequestsKeyframe(t *testing.T) {
+// AC-2: a commit whose seq does not match the open begin is rejected.
+func TestCommitSeqMismatchRejects(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out, nil)
 	model = applyTo(t, model, beginFrame(10, 0), testThemeCommand(), windowRowsCommand(1, "base"), commitFrame(10))
@@ -281,9 +284,8 @@ func TestCommitSeqMismatchRequestsKeyframe(t *testing.T) {
 	if got := renderedBody(model); strings.Contains(got, "mismatch") {
 		t.Fatalf("a seq-mismatched commit must not apply staged content: %q", got)
 	}
-	reqs := drainKeyframeRequests(t, out)
-	if len(reqs) != 1 || reqs[0] != 10 {
-		t.Fatalf("seq mismatch should request keyframe from seq 10, got %v", reqs)
+	if reqs := drainKeyframeRequests(t, out); len(reqs) != 0 {
+		t.Fatalf("seq mismatch must not automatically request a keyframe, got %v", reqs)
 	}
 	if model.lastCommittedSeq != 10 {
 		t.Fatalf("lastCommittedSeq should stay at 10 after a rejected commit, got %d", model.lastCommittedSeq)
@@ -291,8 +293,8 @@ func TestCommitSeqMismatchRequestsKeyframe(t *testing.T) {
 }
 
 // AC-2: a delta transaction whose base does not match the last committed frame
-// requests a keyframe.
-func TestBaseMismatchRequestsKeyframe(t *testing.T) {
+// is rejected without a second automatic recovery trigger.
+func TestBaseMismatchRejects(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out, nil)
 	model = applyTo(t, model, beginFrame(20, 0), testThemeCommand(), windowRowsCommand(1, "committed"), commitFrame(20))
@@ -304,9 +306,8 @@ func TestBaseMismatchRequestsKeyframe(t *testing.T) {
 	if got := renderedBody(model); strings.Contains(got, "bad base") {
 		t.Fatalf("a base-mismatched transaction must not apply: %q", got)
 	}
-	reqs := drainKeyframeRequests(t, out)
-	if len(reqs) != 1 || reqs[0] != 20 {
-		t.Fatalf("base mismatch should request keyframe from seq 20, got %v", reqs)
+	if reqs := drainKeyframeRequests(t, out); len(reqs) != 0 {
+		t.Fatalf("base mismatch must not automatically request a keyframe, got %v", reqs)
 	}
 }
 
@@ -382,8 +383,8 @@ func TestOutOfBandSideChannelsApplyWithoutTransaction(t *testing.T) {
 }
 
 // A semantic command with no open transaction is a protocol violation under the
-// staged model: it must NOT apply and must request a keyframe.
-func TestSemanticCommandOutsideTransactionRequestsKeyframe(t *testing.T) {
+// staged model: it must NOT apply and is reported by typed rejection only.
+func TestSemanticCommandOutsideTransactionRejects(t *testing.T) {
 	out := make(chan []byte, 16)
 	model := New(40, 8, out, nil)
 	model = applyTo(t, model, beginFrame(50, 0), testThemeCommand(), windowRowsCommand(1, "committed"), commitFrame(50))
@@ -394,9 +395,8 @@ func TestSemanticCommandOutsideTransactionRequestsKeyframe(t *testing.T) {
 	if got := renderedBody(model); strings.Contains(got, "stray semantic") {
 		t.Fatalf("a stray out-of-transaction semantic command must not paint: %q", got)
 	}
-	reqs := drainKeyframeRequests(t, out)
-	if len(reqs) != 1 || reqs[0] != 50 {
-		t.Fatalf("stray semantic command should request keyframe from seq 50, got %v", reqs)
+	if reqs := drainKeyframeRequests(t, out); len(reqs) != 0 {
+		t.Fatalf("stray semantic command must not automatically request a keyframe, got %v", reqs)
 	}
 }
 

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -407,7 +407,7 @@ defmodule MingaEditor do
 
     Startup.send_font_config(new_state)
     new_state = refresh_gui_config_state(new_state)
-    new_state = Renderer.render_or_async(new_state)
+    new_state = Renderer.reset_connection(new_state)
     StartupTimer.mark(:first_render_dispatched)
     StartupTimer.report()
 
@@ -520,10 +520,40 @@ defmodule MingaEditor do
     {:noreply, new_state}
   end
 
+  # Legacy in-process fixtures omit generation; treat them as an explicit retry.
   def handle_info({:minga_input, {:request_keyframe, last_good_frame_seq}}, state) do
-    Minga.Log.warning(:render, "Frontend requested keyframe from frame #{last_good_frame_seq}")
+    handle_info({:minga_input, {:request_keyframe, last_good_frame_seq, 0}}, state)
+  end
+
+  def handle_info(
+        {:minga_input, {:request_keyframe, last_good_frame_seq, failed_generation}},
+        %{renderer: renderer} = state
+      )
+      when is_pid(renderer) do
+    Minga.Log.warning(
+      :render,
+      "Frontend requested recovery from frame #{last_good_frame_seq} generation #{failed_generation}"
+    )
+
+    MingaEditor.Renderer.Server.request_recovery(renderer)
+    {:noreply, state}
+  end
+
+  def handle_info({:minga_input, {:request_keyframe, _last_good, _generation}}, state) do
     new_state = %{state | keyframe_pending?: true}
     {:noreply, Renderer.render_or_async(new_state)}
+  end
+
+  def handle_info({:minga_input, {kind, _, _} = status}, %{renderer: renderer} = state)
+      when kind == :frame_applied and is_pid(renderer) do
+    MingaEditor.Renderer.Server.frame_status(renderer, status)
+    {:noreply, state}
+  end
+
+  def handle_info({:minga_input, {kind, _, _, _, _} = status}, %{renderer: renderer} = state)
+      when kind in [:frame_rejected, :window_ref_miss] and is_pid(renderer) do
+    MingaEditor.Renderer.Server.frame_status(renderer, status)
+    {:noreply, state}
   end
 
   # ── GUI action events (semantic commands from SwiftUI chrome) ────────────

--- a/lib/minga_editor/frontend.ex
+++ b/lib/minga_editor/frontend.ex
@@ -93,7 +93,7 @@ defmodule MingaEditor.Frontend do
         ) :: :ok
   def send_frame_boundary(port, frame_seq, base_frame_seq, input_seq \\ 0) do
     send_commands(port, [
-      Protocol.encode_begin_frame(frame_seq, base_frame_seq),
+      Protocol.encode_begin_frame(frame_seq, base_frame_seq, 1),
       Protocol.encode_commit_frame(frame_seq, input_seq)
     ])
   end

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -48,8 +48,14 @@ defmodule MingaEditor.Frontend.Emit do
     # adapter delta caches so every window emits full content and every chrome
     # surface re-emits, and brackets the frame with base_frame_seq 0.
     frame_seq = frame_seq(ctx)
-    keyframe? = ctx.force_keyframe? or caches.last_emitted_frame_seq == 0
-    base_frame_seq = if keyframe?, do: 0, else: caches.last_emitted_frame_seq
+
+    acknowledged_base =
+      if ctx.acknowledgement_required?,
+        do: caches.last_acknowledged_frame_seq,
+        else: caches.last_emitted_frame_seq
+
+    keyframe? = ctx.force_keyframe? or acknowledged_base == 0
+    base_frame_seq = if keyframe?, do: 0, else: acknowledged_base
 
     caches =
       if keyframe? do
@@ -72,11 +78,7 @@ defmodule MingaEditor.Frontend.Emit do
       {:error, error} ->
         Minga.Log.warning(:render, "Discarded invalid GUI frame: #{Exception.message(error)}")
 
-        {%{
-           caches
-           | adapter_gui_caches: Minga.Frontend.Adapter.GUI.Caches.new(),
-             last_emitted_frame_seq: 0
-         }, ctx}
+        {Caches.reset_frontend_state(caches), ctx}
 
       {:ok, encoded_frame} ->
         emit_encoded_frame(
@@ -130,7 +132,7 @@ defmodule MingaEditor.Frontend.Emit do
       Minga.Frontend.Adapter.GUI.SurfaceLayoutEncoder.encode_command(ctx.surface_placements)
 
     commands =
-      [Protocol.encode_begin_frame(frame_seq, base_frame_seq)] ++
+      [Protocol.encode_begin_frame(frame_seq, base_frame_seq, caches.recovery_generation)] ++
         flush_font_registration_commands() ++
         encoded_frame.metal_commands ++
         encoded_frame.chrome_commands ++
@@ -145,6 +147,12 @@ defmodule MingaEditor.Frontend.Emit do
 
     caches = update_tracking(ctx, caches)
     caches = %{caches | last_emitted_frame_seq: frame_seq, last_frame_keyframe?: keyframe?}
+
+    caches =
+      if ctx.acknowledgement_required?,
+        do: caches,
+        else: Caches.acknowledge_frame(caches, frame_seq, caches.recovery_generation)
+
     byte_count = IO.iodata_length(commands)
 
     Telemetry.span(
@@ -161,11 +169,7 @@ defmodule MingaEditor.Frontend.Emit do
     error in [Minga.Protocol.EncodingError, Minga.Frontend.Adapter.GUI.EncodingError] ->
       Minga.Log.warning(:render, "Discarded invalid GUI frame: #{Exception.message(error)}")
 
-      {%{
-         caches
-         | adapter_gui_caches: Minga.Frontend.Adapter.GUI.Caches.new(),
-           last_emitted_frame_seq: 0
-       }, ctx}
+      {Caches.reset_frontend_state(caches), ctx}
   end
 
   # The async render path threads Renderer.Server's monotonic seq through the

--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -26,7 +26,7 @@ defmodule MingaEditor.Frontend.Emit.Context do
   alias MingaEditor.State
 
   @type t :: %__MODULE__{
-          port_manager: pid(),
+          port_manager: GenServer.server() | nil,
           capabilities: Capabilities.t(),
           theme: Theme.t() | nil,
           font_registry: FontRegistry.t(),
@@ -56,6 +56,7 @@ defmodule MingaEditor.Frontend.Emit.Context do
           last_input_seq: non_neg_integer(),
           frame_seq: non_neg_integer() | nil,
           force_keyframe?: boolean(),
+          acknowledgement_required?: boolean(),
           surface_placements: [MingaEditor.Layout.SurfaceRegistry.wire_placement()],
           gui?: boolean(),
           line_spacing: number() | nil,
@@ -95,6 +96,7 @@ defmodule MingaEditor.Frontend.Emit.Context do
             last_input_seq: 0,
             frame_seq: nil,
             force_keyframe?: false,
+            acknowledgement_required?: false,
             surface_placements: [],
             gui?: false,
             line_spacing: nil,
@@ -141,6 +143,8 @@ defmodule MingaEditor.Frontend.Emit.Context do
       last_input_seq: Map.get(state, :last_input_seq, 0),
       frame_seq: Map.get(state, :frame_seq),
       force_keyframe?: Map.get(state, :force_keyframe?, false),
+      acknowledgement_required?:
+        Map.get(state, :backend) != :headless and not is_nil(state.port_manager),
       # The single per-frame surface layout authority (#2268), already projected
       # to wire shape by the registry. Derived from the same focus tree mouse
       # routing hit-tests against, so the emitted placement rect for every surface

--- a/lib/minga_editor/frontend/frame_transaction.ex
+++ b/lib/minga_editor/frontend/frame_transaction.ex
@@ -59,11 +59,14 @@ defmodule MingaEditor.Frontend.FrameTransaction do
   defp validate([], {:inside, frame_seq}), do: {:error, {:unterminated_frame, frame_seq}}
   defp validate([<<>> | _commands], _state), do: {:error, :malformed_command}
 
-  defp validate([<<@op_begin_frame, frame_seq::32, _base_frame_seq::32>> | commands], :outside),
-    do: validate(commands, {:inside, frame_seq})
+  defp validate(
+         [<<@op_begin_frame, frame_seq::32, _base_frame_seq::32, _generation::32>> | commands],
+         :outside
+       ),
+       do: validate(commands, {:inside, frame_seq})
 
   defp validate(
-         [<<@op_begin_frame, _frame_seq::32, _base_frame_seq::32>> | _commands],
+         [<<@op_begin_frame, _frame_seq::32, _base_frame_seq::32, _generation::32>> | _commands],
          {:inside, open_frame_seq}
        ),
        do: {:error, {:begin_while_open, open_frame_seq}}

--- a/lib/minga_editor/frontend/protocol.ex
+++ b/lib/minga_editor/frontend/protocol.ex
@@ -45,6 +45,9 @@ defmodule MingaEditor.Frontend.Protocol do
   @op_begin_frame Opcodes.begin_frame()
   @op_commit_frame Opcodes.commit_frame()
   @op_request_keyframe Opcodes.request_keyframe()
+  @op_frame_applied Opcodes.frame_applied()
+  @op_frame_rejected Opcodes.frame_rejected()
+  @op_window_ref_miss Opcodes.window_ref_miss()
   @op_scroll_batch Opcodes.scroll_batch()
   @op_set_title Opcodes.set_title()
   @op_set_window_bg Opcodes.set_window_bg()
@@ -131,7 +134,24 @@ defmodule MingaEditor.Frontend.Protocol do
   """
   @type input_seq :: non_neg_integer()
 
-  @typedoc "An input event decoded from Zig."
+  @typedoc "Stable frontend frame-transaction rejection reason."
+  @type frame_rejection_reason ::
+          :truncation
+          | :commit_sequence_mismatch
+          | :frame_sequence_not_increasing
+          | :base_sequence_mismatch
+          | :missing_theme
+          | :incomplete_theme
+          | :missing_window_reference
+          | :window_epoch_mismatch
+          | :invalid_retained_rows
+          | :missing_font_resource
+          | :transcript_desync
+          | :decode_failure
+          | :out_of_transaction_command
+          | :unknown
+
+  @typedoc "An input event decoded from a frontend."
   @type input_event ::
           {:key_press, codepoint :: non_neg_integer(), modifiers(), input_seq()}
           | {:resize, width :: pos_integer(), height :: pos_integer()}
@@ -167,7 +187,13 @@ defmodule MingaEditor.Frontend.Protocol do
           | {:request_reparse, buffer_id :: non_neg_integer()}
           | {:log_message, level :: String.t(), text :: String.t()}
           | {:gui_action, ProtocolGUI.gui_action()}
-          | {:request_keyframe, last_good_frame_seq :: non_neg_integer()}
+          | {:request_keyframe, last_good_frame_seq :: non_neg_integer(),
+             generation :: non_neg_integer()}
+          | {:frame_applied, generation :: non_neg_integer(), frame_seq :: non_neg_integer()}
+          | {:frame_rejected, generation :: non_neg_integer(), frame_seq :: non_neg_integer(),
+             last_applied_frame_seq :: non_neg_integer(), frame_rejection_reason()}
+          | {:window_ref_miss, generation :: non_neg_integer(), frame_seq :: non_neg_integer(),
+             last_applied_frame_seq :: non_neg_integer(), window_id :: non_neg_integer()}
           | {:scroll_batch, window_id :: non_neg_integer(), delta_lines :: integer(),
              direction :: :down | :up}
 
@@ -217,6 +243,11 @@ defmodule MingaEditor.Frontend.Protocol do
     <<@op_protocol_error, byte_size(message)::16, message::binary>>
   end
 
+  @doc "Encodes a begin-frame command in the initial recovery generation."
+  @spec encode_begin_frame(non_neg_integer(), non_neg_integer()) :: binary()
+  def encode_begin_frame(frame_seq, base_frame_seq),
+    do: encode_begin_frame(frame_seq, base_frame_seq, 1)
+
   @doc """
   Encodes a begin_frame command that opens a frame transaction (#2219).
 
@@ -224,13 +255,14 @@ defmodule MingaEditor.Frontend.Protocol do
   Renderer.Server's seq) used for resync/attach ordering. `base_frame_seq` names
   the frame this transaction's deltas assume; `base_frame_seq == 0` means keyframe
   (full snapshots, no deltas). Both fields are masked to u32 so a large monotonic
-  `frame_seq` stays wire-safe. fixed:9 = opcode(1) + frame_seq(u32) + base(u32).
+  `frame_seq` stays wire-safe. `generation` identifies the BEAM-owned recovery
+  attempt. fixed:13 = opcode(1) + frame_seq(u32) + base(u32) + generation(u32).
   """
-  @spec encode_begin_frame(non_neg_integer(), non_neg_integer()) :: binary()
-  def encode_begin_frame(frame_seq, base_frame_seq)
+  @spec encode_begin_frame(non_neg_integer(), non_neg_integer(), non_neg_integer()) :: binary()
+  def encode_begin_frame(frame_seq, base_frame_seq, generation)
       when is_integer(frame_seq) and frame_seq >= 0 and is_integer(base_frame_seq) and
-             base_frame_seq >= 0 do
-    <<@op_begin_frame, u32(frame_seq)::32, u32(base_frame_seq)::32>>
+             base_frame_seq >= 0 and is_integer(generation) and generation >= 0 do
+    <<@op_begin_frame, u32(frame_seq)::32, u32(base_frame_seq)::32, u32(generation)::32>>
   end
 
   @doc """
@@ -506,11 +538,26 @@ defmodule MingaEditor.Frontend.Protocol do
     {:ok, {:paste_event, text}}
   end
 
-  # request_keyframe (#2219): a frontend asks the BEAM to send the next frame as a
-  # full keyframe after an invalidation. fixed:5 = opcode(1) + last_good_frame_seq(u32).
-  # The BEAM forces the next frame to base_frame_seq 0 + full snapshots.
-  def decode_event(<<@op_request_keyframe, last_good_frame_seq::32>>) do
-    {:ok, {:request_keyframe, last_good_frame_seq}}
+  # Generation-aware frame status (#2739). All values are fixed-width so malformed
+  # statuses fail closed in the generic decoder rather than partially advancing state.
+  def decode_event(<<@op_request_keyframe, last_good_frame_seq::32, generation::32>>) do
+    {:ok, {:request_keyframe, last_good_frame_seq, generation}}
+  end
+
+  def decode_event(<<@op_frame_applied, generation::32, frame_seq::32>>) do
+    {:ok, {:frame_applied, generation, frame_seq}}
+  end
+
+  def decode_event(
+        <<@op_frame_rejected, generation::32, frame_seq::32, last_applied::32, reason::8>>
+      ) do
+    {:ok, {:frame_rejected, generation, frame_seq, last_applied, decode_rejection_reason(reason)}}
+  end
+
+  def decode_event(
+        <<@op_window_ref_miss, generation::32, frame_seq::32, last_applied::32, window_id::16>>
+      ) do
+    {:ok, {:window_ref_miss, generation, frame_seq, last_applied, window_id}}
   end
 
   def decode_event(<<@op_scroll_batch, window_id::16, delta_lines::16-signed, direction::8>>) do
@@ -544,6 +591,10 @@ defmodule MingaEditor.Frontend.Protocol do
              @op_ready,
              @op_mouse_event,
              @op_capabilities_updated,
+             @op_request_keyframe,
+             @op_frame_applied,
+             @op_frame_rejected,
+             @op_window_ref_miss,
              @op_scroll_batch
            ] do
     {:error, :malformed}
@@ -560,6 +611,22 @@ defmodule MingaEditor.Frontend.Protocol do
   @type conceal_span :: Minga.Parser.Protocol.conceal_span()
 
   # ── Mouse helpers ──
+
+  @spec decode_rejection_reason(non_neg_integer()) :: frame_rejection_reason()
+  defp decode_rejection_reason(1), do: :truncation
+  defp decode_rejection_reason(2), do: :commit_sequence_mismatch
+  defp decode_rejection_reason(3), do: :frame_sequence_not_increasing
+  defp decode_rejection_reason(4), do: :base_sequence_mismatch
+  defp decode_rejection_reason(5), do: :missing_theme
+  defp decode_rejection_reason(6), do: :incomplete_theme
+  defp decode_rejection_reason(7), do: :missing_window_reference
+  defp decode_rejection_reason(8), do: :window_epoch_mismatch
+  defp decode_rejection_reason(9), do: :invalid_retained_rows
+  defp decode_rejection_reason(10), do: :missing_font_resource
+  defp decode_rejection_reason(11), do: :transcript_desync
+  defp decode_rejection_reason(12), do: :decode_failure
+  defp decode_rejection_reason(13), do: :out_of_transaction_command
+  defp decode_rejection_reason(_), do: :unknown
 
   @spec decode_mouse_button(non_neg_integer()) :: mouse_button()
   defp decode_mouse_button(@mouse_left), do: :left

--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -291,80 +291,12 @@ defmodule MingaEditor.Input.Router do
     :exit, _ -> nil
   end
 
-  # Skips the full render when entering operator-pending mode with no buffer
-  # change. This prevents the visible flicker between keystrokes of compound
-  # operators like `dd`, `cc`, `yy`, etc. The first keystroke is a zero-cost
-  # state flag, not a mode change that warrants a screen redraw.
-  #
-  # A bare frame transaction (begin_frame + commit_frame, no content) is still
-  # emitted so frame-synchronization contracts (HeadlessPort in tests, future
-  # frame-pacing in production) and keystroke-latency correlation remain satisfied
-  # (#2219). A pending keyframe request forces a real render so the keyframe carries
-  # full content rather than an empty boundary.
+  # Every action produces a normal render intent. In production, including for
+  # operator-pending transitions with no buffer mutation, Renderer.Server owns
+  # emission so its single credit, recovery generation, and acknowledged delta
+  # base remain authoritative (#2739).
   @spec maybe_render(EditorState.t(), non_neg_integer()) :: EditorState.t()
-  defp maybe_render(state, buf_version_before) do
-    if Editing.mode(state) == :operator_pending and
-         buffer_version(state) == buf_version_before and not state.keyframe_pending? do
-      emit_operator_pending_frame(state)
-    else
-      MingaEditor.do_render(state)
-    end
-  end
-
-  # Frame-emission ORDERING INVARIANT (#2219): on-wire frame_seq must be strictly
-  # monotonic. The bare boundary mints its seq and writes the port directly from the
-  # Editor process, while async real frames are emitted by Renderer.Server. If a
-  # lower-seq render is still in-flight there, emitting a higher-seq boundary straight
-  # to the port would put a decreasing frame_seq on the wire (and duplicate the
-  # base_frame_seq, since last_emitted_frame_seq only advances on writeback).
-  #
-  # To serialize ordering at one process without losing the latency-correlation
-  # contract (every input_seq is eventually echoed), fall back to a full async render
-  # whenever the Renderer.Server is busy: that frame is emitted in order by the server
-  # and still echoes the current last_input_seq on its commit_frame. The bare-boundary
-  # shortcut is only taken when nothing else can be writing the port concurrently:
-  # either there is no async renderer (sync/headless paths), or the renderer is idle.
-  @spec emit_operator_pending_frame(EditorState.t()) :: EditorState.t()
-  defp emit_operator_pending_frame(%EditorState{rendering: :disabled} = state) do
-    MingaEditor.do_render(state)
-  end
-
-  defp emit_operator_pending_frame(state) do
-    if async_renderer_busy?(state) do
-      MingaEditor.do_render(state)
-    else
-      emit_bare_frame_boundary(state)
-    end
-  end
-
-  @spec async_renderer_busy?(EditorState.t()) :: boolean()
-  defp async_renderer_busy?(%{renderer: pid}) when is_pid(pid) do
-    MingaEditor.Renderer.Server.rendering?(pid)
-  catch
-    # A dead or unresponsive renderer can't be writing the port; the bare boundary
-    # is safe and we must not crash the Editor on its hot path.
-    :exit, _ -> false
-  end
-
-  defp async_renderer_busy?(_state), do: false
-
-  # Emits a content-free frame transaction and advances the emitter's frame_seq so
-  # the next real frame names this one as its delta base (#2219). Only safe when the
-  # Editor is the sole writer of the port (see emit_operator_pending_frame/1).
-  @spec emit_bare_frame_boundary(EditorState.t()) :: EditorState.t()
-  defp emit_bare_frame_boundary(state) do
-    frame_seq = System.unique_integer([:positive, :monotonic])
-    base_frame_seq = state.caches.last_emitted_frame_seq
-
-    MingaEditor.Frontend.send_frame_boundary(
-      state.port_manager,
-      frame_seq,
-      base_frame_seq,
-      state.last_input_seq
-    )
-
-    %{state | caches: %{state.caches | last_emitted_frame_seq: frame_seq}}
-  end
+  defp maybe_render(state, _buf_version_before), do: MingaEditor.do_render(state)
 
   @doc """
   Dispatches a mouse event through the focus tree.

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -105,6 +105,8 @@ defmodule MingaEditor.RenderPipeline.Input do
     # Renderer.Server's seq here; sync/headless paths default to a fresh monotonic
     # value so every emit still carries a unique, advancing frame_seq.
     frame_seq: nil,
+    # BEAM-owned recovery generation carried by begin_frame and echoed by statuses.
+    recovery_generation: 1,
     # When true, the emitter forces this frame to a keyframe (base_frame_seq 0,
     # full window snapshots, every chrome surface re-emitted). Set by the BEAM
     # after an inbound request_keyframe (#2219).
@@ -165,6 +167,7 @@ defmodule MingaEditor.RenderPipeline.Input do
           terminal_viewport: Viewport.t(),
           last_input_seq: non_neg_integer(),
           frame_seq: non_neg_integer() | nil,
+          recovery_generation: non_neg_integer(),
           force_keyframe?: boolean(),
           line_spacing: number() | nil,
           cursor_animate: boolean() | nil,
@@ -241,6 +244,19 @@ defmodule MingaEditor.RenderPipeline.Input do
   @spec with_font_registry(t(), FontRegistry.t()) :: t()
   def with_font_registry(%__MODULE__{} = input, %FontRegistry{} = font_registry) do
     %{input | font_registry: font_registry}
+  end
+
+  @doc "Invalidates one window in the owned render snapshot for targeted recovery."
+  @spec invalidate_window(t(), non_neg_integer()) :: {:ok, t()} | :error
+  def invalidate_window(%__MODULE__{workspace: workspace} = input, window_id) do
+    case MingaEditor.Session.State.update_snapshot_window(
+           workspace,
+           window_id,
+           &MingaEditor.Window.invalidate/1
+         ) do
+      {:ok, updated_workspace} -> {:ok, %{input | workspace: updated_workspace}}
+      :error -> :error
+    end
   end
 
   # ── Chrome dirty tracking ──────────────────────────────────────────────────

--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -75,6 +75,32 @@ defmodule MingaEditor.Renderer do
 
   def render_or_async(state), do: render(state)
 
+  @doc """
+  Renders the first frame for a newly ready frontend connection.
+
+  Async renderers synchronously abandon credit owned by the replaced connection
+  before preparing a base-zero keyframe in a fresh recovery generation. Other
+  rendering paths keep their normal synchronous behavior.
+  """
+  @spec reset_connection(state()) :: state()
+  def reset_connection(%EditorState{rendering: :disabled} = state), do: state
+  def reset_connection(%{backend: :headless} = state), do: render(state)
+
+  def reset_connection(%{renderer: pid} = state) when is_pid(pid) do
+    state = EditorState.ensure_shell_available(state)
+
+    if async_render?(state) do
+      snapshot = Input.from_editor_state(state)
+      seq = System.unique_integer([:positive, :monotonic])
+      :ok = RendererServer.reset_connection(pid, snapshot, seq)
+      state
+    else
+      render(state)
+    end
+  end
+
+  def reset_connection(state), do: render(state)
+
   @spec async_render?(state()) :: boolean()
   defp async_render?(state), do: EditorState.active_shell_module(state).async_render?(state)
 

--- a/lib/minga_editor/renderer/caches.ex
+++ b/lib/minga_editor/renderer/caches.ex
@@ -54,10 +54,11 @@ defmodule MingaEditor.Renderer.Caches do
     last_link_cursor: nil,
 
     # ── Frame transaction (#2219) ────────────────────────────────────────────
-    # The frame_seq of the last successfully-emitted frame. A delta frame names
-    # it as its begin_frame base_frame_seq; a keyframe forces base 0. Starts at 0
-    # so the very first frame is a keyframe by construction.
+    # The last frame written and the last frame explicitly acknowledged by the
+    # current frontend generation. Only the acknowledged value may be a delta base.
     last_emitted_frame_seq: 0,
+    last_acknowledged_frame_seq: 0,
+    recovery_generation: 1,
 
     # Whether the most recently emitted frame was a keyframe (base_frame_seq 0,
     # full window snapshots). The Editor reads this to clear `keyframe_pending?`
@@ -88,6 +89,8 @@ defmodule MingaEditor.Renderer.Caches do
           last_window_bg: non_neg_integer() | nil,
           last_link_cursor: boolean() | nil,
           last_emitted_frame_seq: non_neg_integer(),
+          last_acknowledged_frame_seq: non_neg_integer(),
+          recovery_generation: non_neg_integer(),
           last_frame_keyframe?: boolean(),
           adapter_gui_caches: Minga.Frontend.Adapter.GUI.Caches.t()
         }
@@ -95,6 +98,13 @@ defmodule MingaEditor.Renderer.Caches do
   @doc "Creates a fresh Caches struct with first-frame defaults."
   @spec new() :: t()
   def new, do: %__MODULE__{}
+
+  @doc "Records the frame explicitly applied by the current frontend generation."
+  @spec acknowledge_frame(t(), non_neg_integer(), non_neg_integer()) :: t()
+  def acknowledge_frame(%__MODULE__{} = caches, frame_seq, generation)
+      when is_integer(frame_seq) and frame_seq >= 0 and is_integer(generation) and generation >= 0 do
+    %{caches | last_acknowledged_frame_seq: frame_seq, recovery_generation: generation}
+  end
 
   @doc "Clears frontend-retained state tracking after the frontend reports ready again."
   @spec reset_frontend_state(t()) :: t()
@@ -105,9 +115,10 @@ defmodule MingaEditor.Renderer.Caches do
         last_title: nil,
         last_window_bg: nil,
         last_link_cursor: nil,
-        # A reconnecting frontend has no committed base, so force the next frame to
-        # a keyframe (base_frame_seq 0) by clearing the last-emitted frame_seq.
-        last_emitted_frame_seq: 0
+        # A reconnecting frontend has no acknowledged base in the fresh generation.
+        last_emitted_frame_seq: 0,
+        last_acknowledged_frame_seq: 0,
+        recovery_generation: caches.recovery_generation + 1
     }
   end
 end

--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -18,12 +18,11 @@ defmodule MingaEditor.Renderer.Server do
   snapshot is dropped (most-recent-wins coalescing) and a
   `[:minga, :render, :coalesced]` telemetry event fires. Each snapshot
   is normalized against the renderer-owned cache state before it renders.
-  After each render emit completes, the Renderer stores the emitted
-  cache state and threads it into any pending snapshot before starting
-  the next frame; otherwise it goes idle. If the Editor emits a direct
-  bare frame boundary, that newer snapshot cache wins instead. That keeps
-  delta frame bases aligned with what the frontend just received, even
-  when the Editor has not yet processed the prior render writeback.
+  After each acknowledged render completes, the Renderer stores the committed
+  cache state and threads it into any pending snapshot before starting the next
+  frame; otherwise it goes idle. The Renderer is the sole production frame
+  emitter, keeping delta bases aligned with the frontend's acknowledged state
+  even when the Editor has not yet processed the prior render writeback.
 
   ## Click-region writeback
 
@@ -89,20 +88,24 @@ defmodule MingaEditor.Renderer.Server do
           rendering?: boolean(),
           pending: {Input.t(), non_neg_integer(), integer()} | nil,
           in_flight: {Input.t(), non_neg_integer(), integer()} | nil,
+          awaiting_ack: {render_output(), Input.t(), non_neg_integer(), integer()} | nil,
           font_registry: FontRegistry.t(),
           caches: Caches.t(),
           message_store: MessageStore.t() | nil,
-          pipeline: pipeline()
+          pipeline: pipeline(),
+          require_ack?: boolean()
         }
 
   defstruct editor_pid: nil,
             rendering?: false,
             pending: nil,
             in_flight: nil,
+            awaiting_ack: nil,
             font_registry: FontRegistry.new(),
             caches: Caches.new(),
             message_store: nil,
-            pipeline: &RenderPipeline.run/1
+            pipeline: &RenderPipeline.run/1,
+            require_ack?: true
 
   # ── API ────────────────────────────────────────────────────────────────────
 
@@ -127,10 +130,41 @@ defmodule MingaEditor.Renderer.Server do
     GenServer.cast(server, {:render, snapshot, frame_seq, monotonic_now()})
   end
 
-  @doc "Returns true while a render pass is in progress."
+  @doc "Returns true while rendering or waiting for the frontend's one frame credit."
   @spec rendering?(GenServer.server()) :: boolean()
   def rendering?(server \\ __MODULE__) do
     GenServer.call(server, :rendering?)
+  end
+
+  @doc "Returns the current recovery generation and acknowledged frame for diagnostics."
+  @spec acknowledgement_state(GenServer.server()) :: {non_neg_integer(), non_neg_integer()}
+  def acknowledgement_state(server \\ __MODULE__) do
+    GenServer.call(server, :acknowledgement_state)
+  end
+
+  @doc "Returns one frame credit after a typed frontend status."
+  @spec frame_status(GenServer.server(), MingaEditor.Frontend.Protocol.input_event()) :: :ok
+  def frame_status(server \\ __MODULE__, status) do
+    send(server, {:frame_status, status})
+    :ok
+  end
+
+  @doc "Starts a fresh recovery generation for automatic or manual retry."
+  @spec request_recovery(GenServer.server()) :: :ok
+  def request_recovery(server \\ __MODULE__) do
+    send(server, :request_recovery)
+    :ok
+  end
+
+  @doc """
+  Replaces all work tied to the previous frontend connection with the latest
+  editor intent. The replacement starts at base zero in a fresh recovery
+  generation and owns the connection's single frame credit.
+  """
+  @spec reset_connection(GenServer.server(), Input.t(), non_neg_integer()) :: :ok
+  def reset_connection(server \\ __MODULE__, %Input{} = snapshot, frame_seq)
+      when is_integer(frame_seq) and frame_seq >= 0 do
+    GenServer.call(server, {:reset_connection, snapshot, frame_seq, monotonic_now()})
   end
 
   # ── GenServer callbacks ───────────────────────────────────────────────────
@@ -140,12 +174,41 @@ defmodule MingaEditor.Renderer.Server do
   def init(opts) do
     editor_pid = Keyword.get(opts, :editor_pid, MingaEditor)
     pipeline = Keyword.get(opts, :pipeline, &RenderPipeline.run/1)
-    {:ok, %__MODULE__{editor_pid: editor_pid, pipeline: pipeline}}
+    require_ack? = Keyword.get(opts, :require_ack?, not Keyword.has_key?(opts, :pipeline))
+    {:ok, %__MODULE__{editor_pid: editor_pid, pipeline: pipeline, require_ack?: require_ack?}}
   end
 
   @impl true
   def handle_call(:rendering?, _from, state) do
     {:reply, state.rendering?, state}
+  end
+
+  def handle_call(:acknowledgement_state, _from, state) do
+    {:reply, {state.caches.recovery_generation, state.caches.last_acknowledged_frame_seq}, state}
+  end
+
+  def handle_call({:reset_connection, snap, seq, pushed_at}, _from, state) do
+    caches = Caches.reset_frontend_state(state.caches)
+
+    # The Editor snapshot has already reset all frontend-retained cursors for
+    # this connection (including MessageStore). Do not merge state from the
+    # replaced frontend back into it.
+    retry = %{snap | caches: caches, force_keyframe?: true}
+
+    # Every queued or awaiting frame belongs to the replaced connection. Abandon
+    # that credit and render only the latest Editor snapshot for the new one.
+    send(self(), :do_render)
+
+    state = %{
+      state
+      | rendering?: true,
+        pending: nil,
+        in_flight: {retry, seq, pushed_at},
+        awaiting_ack: nil,
+        caches: caches
+    }
+
+    {:reply, :ok, state}
   end
 
   @impl true
@@ -196,15 +259,30 @@ defmodule MingaEditor.Renderer.Server do
       %{frame_seq: seq}
     )
 
-    state = %{
-      state
-      | font_registry: output.font_registry,
-        caches: output.caches,
-        message_store: output.message_store
-    }
+    # Port write is not proof of commit. Keep the prepared output private until
+    # the matching generation/sequence acknowledgement returns the single credit.
+    if state.require_ack? do
+      state = %{
+        state
+        | font_registry: output.font_registry,
+          in_flight: nil,
+          awaiting_ack: {output, snap, seq, pushed_at}
+      }
 
-    send_writeback(state.editor_pid, output, seq)
-    advance_pending(state, output.caches, output.message_store)
+      {:noreply, state}
+    else
+      # Injected pure pipelines are used by legacy server unit tests and have no
+      # frontend transport. Their return is the commit boundary.
+      state = %{
+        state
+        | font_registry: output.font_registry,
+          caches: output.caches,
+          message_store: output.message_store
+      }
+
+      send_writeback(state.editor_pid, output, seq)
+      advance_pending(state, output.caches, output.message_store)
+    end
   rescue
     e ->
       trace = Exception.format_stacktrace(__STACKTRACE__) |> String.slice(0, 500)
@@ -217,6 +295,62 @@ defmodule MingaEditor.Renderer.Server do
       advance_pending(state, state.caches, state.message_store)
   end
 
+  def handle_info(
+        {:frame_status, {:frame_applied, generation, seq}},
+        %__MODULE__{awaiting_ack: {output, _snap, seq, _pushed_at}} = state
+      )
+      when generation == state.caches.recovery_generation do
+    acknowledged = Caches.acknowledge_frame(output.caches, seq, generation)
+
+    output = %{output | caches: acknowledged}
+    send_writeback(state.editor_pid, output, seq)
+
+    state = %{
+      state
+      | caches: acknowledged,
+        message_store: output.message_store,
+        awaiting_ack: nil
+    }
+
+    advance_pending(state, acknowledged, output.message_store)
+  end
+
+  def handle_info(
+        {:frame_status, {:frame_rejected, generation, seq, last_applied, reason}},
+        %__MODULE__{awaiting_ack: {_output, snap, seq, pushed_at}} = state
+      )
+      when generation == state.caches.recovery_generation and
+             last_applied == state.caches.last_acknowledged_frame_seq do
+    Minga.Log.warning(:render, "Frontend rejected frame #{seq}: #{reason}")
+    recover_transaction(state, snap, seq, pushed_at)
+  end
+
+  def handle_info(
+        {:frame_status, {:window_ref_miss, generation, seq, last_applied, window_id}},
+        %__MODULE__{awaiting_ack: {_output, snap, seq, pushed_at}} = state
+      )
+      when generation == state.caches.recovery_generation and
+             last_applied == state.caches.last_acknowledged_frame_seq do
+    Minga.Log.warning(:render, "Frontend missed window #{window_id} in frame #{seq}")
+    recover_window(state, snap, seq, pushed_at, window_id)
+  end
+
+  # Stale, duplicate, out-of-order, wrong-generation, and unsolicited statuses
+  # are intentionally side-effect free: they cannot return credit or retrigger recovery.
+  def handle_info({:frame_status, _status}, state), do: {:noreply, state}
+
+  def handle_info(
+        :request_recovery,
+        %__MODULE__{awaiting_ack: {_output, snap, seq, pushed_at}} = state
+      ) do
+    recover_transaction(state, snap, seq, pushed_at)
+  end
+
+  def handle_info(:request_recovery, %__MODULE__{pending: {snap, seq, pushed_at}} = state) do
+    recover_transaction(state, snap, seq, pushed_at)
+  end
+
+  def handle_info(:request_recovery, state), do: {:noreply, state}
   def handle_info(_other, state), do: {:noreply, state}
 
   # ── Helpers ────────────────────────────────────────────────────────────────
@@ -282,6 +416,67 @@ defmodule MingaEditor.Renderer.Server do
     end
   end
 
+  @spec recover_transaction(t(), Input.t(), non_neg_integer(), integer()) :: {:noreply, t()}
+  defp recover_transaction(state, rejected_snap, rejected_seq, rejected_pushed_at) do
+    {latest_snap, latest_seq, latest_pushed_at} =
+      latest_intent(state.pending, rejected_snap, rejected_seq, rejected_pushed_at)
+
+    caches = Caches.reset_frontend_state(state.caches)
+    retry = %{latest_snap | caches: caches, force_keyframe?: true}
+
+    state = %{
+      state
+      | caches: caches,
+        awaiting_ack: nil,
+        pending: {retry, latest_seq, latest_pushed_at}
+    }
+
+    advance_pending(state, caches, state.message_store)
+  end
+
+  @spec recover_window(t(), Input.t(), non_neg_integer(), integer(), non_neg_integer()) ::
+          {:noreply, t()}
+  defp recover_window(state, rejected_snap, rejected_seq, rejected_pushed_at, window_id) do
+    {latest_snap, latest_seq, latest_pushed_at} =
+      latest_intent(state.pending, rejected_snap, rejected_seq, rejected_pushed_at)
+
+    latest_snap = %{latest_snap | caches: state.caches}
+
+    case Input.invalidate_window(latest_snap, window_id) do
+      {:ok, retry} ->
+        state = %{
+          state
+          | awaiting_ack: nil,
+            pending: {retry, latest_seq, latest_pushed_at}
+        }
+
+        advance_pending(state, state.caches, state.message_store)
+
+      :error ->
+        recover_transaction(state, latest_snap, latest_seq, latest_pushed_at)
+    end
+  end
+
+  @spec latest_intent(
+          {Input.t(), non_neg_integer(), integer()} | nil,
+          Input.t(),
+          non_neg_integer(),
+          integer()
+        ) :: {Input.t(), non_neg_integer(), integer()}
+  defp latest_intent(
+         {%Input{} = snap, seq, pushed_at},
+         _fallback,
+         rejected_seq,
+         _fallback_pushed_at
+       )
+       when seq > rejected_seq,
+       do: {snap, seq, pushed_at}
+
+  defp latest_intent(_pending, %Input{} = fallback, rejected_seq, fallback_pushed_at) do
+    unique_seq = System.unique_integer([:positive, :monotonic])
+    {fallback, max(unique_seq, rejected_seq + 1), fallback_pushed_at}
+  end
+
   @spec use_latest_renderer_state(Input.t(), Caches.t(), MessageStore.t() | nil) :: Input.t()
   defp use_latest_renderer_state(%Input{} = snap, %Caches{} = latest_caches, latest_message_store) do
     snap
@@ -291,10 +486,10 @@ defmodule MingaEditor.Renderer.Server do
 
   @spec use_latest_caches(Input.t(), Caches.t()) :: Input.t()
   defp use_latest_caches(
-         %Input{caches: %Caches{last_emitted_frame_seq: 0}} = snap,
-         %Caches{last_emitted_frame_seq: latest_seq}
+         %Input{caches: %Caches{recovery_generation: snap_generation}} = snap,
+         %Caches{recovery_generation: latest_generation}
        )
-       when latest_seq > 0 do
+       when snap_generation > latest_generation do
     snap
   end
 

--- a/lib/minga_editor/session/state.ex
+++ b/lib/minga_editor/session/state.ex
@@ -143,6 +143,17 @@ defmodule MingaEditor.Session.State do
     %{wspace | windows: Windows.update(ws, id, fun)}
   end
 
+  @doc "Updates one window in a render-pipeline workspace snapshot."
+  @spec update_snapshot_window(map(), Window.id(), (Window.t() -> Window.t())) ::
+          {:ok, map()} | :error
+  def update_snapshot_window(%{windows: %Windows{} = windows} = snapshot, id, fun)
+      when is_function(fun, 1) do
+    case Windows.fetch(windows, id) do
+      {:ok, _window} -> {:ok, %{snapshot | windows: Windows.update(windows, id, fun)}}
+      :error -> :error
+    end
+  end
+
   @doc "Updates every window that shows the given buffer via a mapper function."
   @spec update_windows_for_buffer(t(), pid(), (Window.t() -> Window.t())) :: t()
   def update_windows_for_buffer(%__MODULE__{windows: ws} = wspace, buffer, fun)

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -1073,8 +1073,8 @@ public struct ContentView<EditorSurface: View>: View {
         // If recovery stalls, the badge becomes a small manual retry control.
         ResyncOverlay(
             state: gui.resyncState,
-            onRetry: { lastGoodFrameSeq in
-                encoder?.sendRequestKeyframe(lastGoodFrameSeq: lastGoodFrameSeq)
+            onRetry: { lastGoodFrameSeq, generation in
+                encoder?.sendRequestKeyframe(lastGoodFrameSeq: lastGoodFrameSeq, generation: generation)
             }
         )
 

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -358,11 +358,28 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         disp.onFramePresented = { [weak recovery] in
             recovery?.onRenderReceived()
         }
-        // Route through the app delegate's live encoder, not the encoder captured
-        // at startup: a BEAM crash restart swaps `self.encoder` for a new pipe, so
-        // a resync request must reach the current process, not the dead one.
-        disp.onRequestKeyframe = { [weak self] lastGoodFrameSeq in
-            self?.encoder?.sendRequestKeyframe(lastGoodFrameSeq: lastGoodFrameSeq)
+        // #2739 status is emitted at semantic publication/rejection, never from
+        // the old replay loop and never delayed until Metal presentation.
+        disp.onTransactionResult = { [weak self] result in
+            guard let encoder = self?.encoder else { return }
+            switch result {
+            case .applied(let generation, let frameSeq):
+                encoder.sendFrameApplied(generation: generation, frameSeq: frameSeq)
+            case .rejected(let generation, let frameSeq, let lastApplied, let reason):
+                encoder.sendFrameRejected(
+                    generation: generation,
+                    frameSeq: frameSeq,
+                    lastAppliedFrameSeq: lastApplied,
+                    reason: reason.wireCode
+                )
+            case .windowRefMiss(let generation, let frameSeq, let lastApplied, let windowId):
+                encoder.sendWindowRefMiss(
+                    generation: generation,
+                    frameSeq: frameSeq,
+                    lastAppliedFrameSeq: lastApplied,
+                    windowId: windowId
+                )
+            }
         }
         disp.onFrameReady = { [weak nsView] in
             nsView?.renderFrame()

--- a/macos/Sources/Protocol/InputEncoder.swift
+++ b/macos/Sources/Protocol/InputEncoder.swift
@@ -20,9 +20,11 @@ public protocol InputEncoder: AnyObject, Sendable {
     func sendKeyPress(codepoint: UInt32, modifiers: UInt8, seq: UInt32)
     func sendResize(cols: UInt16, rows: UInt16)
     /// Ask the BEAM to send the next frame as a full keyframe (#2219 child D).
-    /// Emitted by `CommandDispatcher` after a frame-transaction invalidation,
-    /// carrying the last frame_seq this frontend committed cleanly (0 if none).
-    func sendRequestKeyframe(lastGoodFrameSeq: UInt32)
+    /// Manual recovery request carrying the failed BEAM generation.
+    func sendRequestKeyframe(lastGoodFrameSeq: UInt32, generation: UInt32)
+    func sendFrameApplied(generation: UInt32, frameSeq: UInt32)
+    func sendFrameRejected(generation: UInt32, frameSeq: UInt32, lastAppliedFrameSeq: UInt32, reason: UInt8)
+    func sendWindowRefMiss(generation: UInt32, frameSeq: UInt32, lastAppliedFrameSeq: UInt32, windowId: UInt16)
     func sendMouseEvent(row: Int16, col: Int16, button: UInt8, modifiers: UInt8, eventType: UInt8, clickCount: UInt8)
     func sendPasteEvent(text: String)
     func sendLog(level: UInt8, message: String)
@@ -170,9 +172,11 @@ public extension InputEncoder {
         sendKeyPress(codepoint: codepoint, modifiers: modifiers)
     }
 
-    /// Default no-op so existing test spies do not need to implement the
-    /// frame-transaction resync request (#2219 child D).
-    func sendRequestKeyframe(lastGoodFrameSeq: UInt32) {}
+    /// Default no-ops so existing test spies need not implement frame status.
+    func sendRequestKeyframe(lastGoodFrameSeq: UInt32, generation: UInt32) {}
+    func sendFrameApplied(generation: UInt32, frameSeq: UInt32) {}
+    func sendFrameRejected(generation: UInt32, frameSeq: UInt32, lastAppliedFrameSeq: UInt32, reason: UInt8) {}
+    func sendWindowRefMiss(generation: UInt32, frameSeq: UInt32, lastAppliedFrameSeq: UInt32, windowId: UInt16) {}
 
     /// Default no-op so existing test spies do not need to implement settings actions.
     func sendConfigQuery() {}

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -26,7 +26,7 @@ enum RenderCommand: Sendable {
     /// set_cursor, and the region commands) were retired in protocol_version 2;
     /// all content now flows through gui_window_content (0x80) and the dedicated
     /// gui_* semantic opcodes.
-    case beginFrame(frameSeq: UInt32, baseFrameSeq: UInt32)
+    case beginFrame(frameSeq: UInt32, baseFrameSeq: UInt32, generation: UInt32)
     /// Closes a frame transaction (#2219): frameSeq matches the open begin_frame;
     /// seq is the echoed input correlation sequence (ticket #2215, formerly carried
     /// by batch_end). The frontend presents the frame and resolves keystroke latency
@@ -352,11 +352,12 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         return (nil, 18)
 
     case OP_BEGIN_FRAME:
-        // begin_frame (#2219): <opcode, frame_seq:u32, base_frame_seq:u32>.
-        guard data.count >= rest + 8 else { throw ProtocolDecodeError.malformed }
+        // begin_frame (#2739): <opcode, frame_seq:u32, base_frame_seq:u32, generation:u32>.
+        guard data.count >= rest + 12 else { throw ProtocolDecodeError.malformed }
         let frameSeq = try readU32(data, rest)
         let baseFrameSeq = try readU32(data, rest + 4)
-        return (.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq), 9)
+        let generation = try readU32(data, rest + 8)
+        return (.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: generation), 13)
 
     case OP_COMMIT_FRAME:
         // commit_frame (#2219): <opcode, frame_seq:u32, input_seq:u32>. input_seq is

--- a/macos/Sources/Protocol/ProtocolEncoder.swift
+++ b/macos/Sources/Protocol/ProtocolEncoder.swift
@@ -147,14 +147,41 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
         writeFrame(buf)
     }
 
-    /// Send a request_keyframe event (#2219 child D).
-    /// Layout: opcode(1) + last_good_frame_seq(4, big-endian). Asks the BEAM to
-    /// emit the next frame as a keyframe (base_frame_seq == 0, full snapshots)
-    /// after this frontend invalidated an in-flight frame transaction.
-    func sendRequestKeyframe(lastGoodFrameSeq: UInt32) {
-        var buf = Data(count: 5)
+    /// Request a fresh BEAM recovery generation.
+    func sendRequestKeyframe(lastGoodFrameSeq: UInt32, generation: UInt32) {
+        var buf = Data(count: 9)
         buf[0] = OP_REQUEST_KEYFRAME
         writeU32(&buf, 1, lastGoodFrameSeq)
+        writeU32(&buf, 5, generation)
+        writeFrame(buf)
+    }
+
+    /// Report semantic publication, deliberately independent of Metal presentation.
+    func sendFrameApplied(generation: UInt32, frameSeq: UInt32) {
+        var buf = Data(count: 9)
+        buf[0] = OP_FRAME_APPLIED
+        writeU32(&buf, 1, generation)
+        writeU32(&buf, 5, frameSeq)
+        writeFrame(buf)
+    }
+
+    func sendFrameRejected(generation: UInt32, frameSeq: UInt32, lastAppliedFrameSeq: UInt32, reason: UInt8) {
+        var buf = Data(count: 14)
+        buf[0] = OP_FRAME_REJECTED
+        writeU32(&buf, 1, generation)
+        writeU32(&buf, 5, frameSeq)
+        writeU32(&buf, 9, lastAppliedFrameSeq)
+        buf[13] = reason
+        writeFrame(buf)
+    }
+
+    func sendWindowRefMiss(generation: UInt32, frameSeq: UInt32, lastAppliedFrameSeq: UInt32, windowId: UInt16) {
+        var buf = Data(count: 15)
+        buf[0] = OP_WINDOW_REF_MISS
+        writeU32(&buf, 1, generation)
+        writeU32(&buf, 5, frameSeq)
+        writeU32(&buf, 9, lastAppliedFrameSeq)
+        writeU16(&buf, 13, windowId)
         writeFrame(buf)
     }
 

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -134,9 +134,9 @@ final class CommandDispatcher {
     /// is open. Set on `begin_frame`, cleared on `commit_frame` or invalidation.
     private(set) var openFrameSeq: UInt32?
 
-    /// base_frame_seq of the currently open transaction (0 means keyframe).
-    /// Validated against `lastCommittedFrameSeq` at commit.
+    /// base_frame_seq and BEAM-owned generation of the open transaction.
     private var openBaseFrameSeq: UInt32 = 0
+    private var openGeneration: UInt32 = 0
 
     /// Value-semantic builder for the open frame. Commands are classified and
     /// window deltas are resolved during staging; commit only freezes and publishes.
@@ -215,8 +215,8 @@ final class CommandDispatcher {
 
     func dispatch(_ command: RenderCommand, opcode: UInt8? = nil) {
         switch command {
-        case .beginFrame(let frameSeq, let baseFrameSeq):
-            beginTransaction(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq)
+        case .beginFrame(let frameSeq, let baseFrameSeq, let generation):
+            beginTransaction(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: generation)
 
         case .commitFrame(let frameSeq, let seq):
             commitTransaction(frameSeq: frameSeq, inputSeq: seq)
@@ -272,7 +272,7 @@ final class CommandDispatcher {
     /// Opens a frame transaction. A second `begin_frame` before its matching
     /// `commit_frame` is truncation: the prior frame never closed, so its staged
     /// commands are discarded and we resync before opening the new transaction.
-    private func beginTransaction(frameSeq: UInt32, baseFrameSeq: UInt32) {
+    private func beginTransaction(frameSeq: UInt32, baseFrameSeq: UInt32, generation: UInt32) {
         if let openFrameSeq {
             // Double-begin = truncation of the previous frame.
             reject(
@@ -283,9 +283,11 @@ final class CommandDispatcher {
         }
         openFrameSeq = frameSeq
         openBaseFrameSeq = baseFrameSeq
+        openGeneration = generation
         transactionBuilder = PreparedFrameTransactionBuilder(
             frameSeq: frameSeq,
             baseFrameSeq: baseFrameSeq,
+            generation: generation,
             committedWindows: guiState.windowContents,
             registeredFontIds: registeredFontIds,
             committedTranscript: guiState.agentChatState.transcriptSnapshot
@@ -357,7 +359,7 @@ final class CommandDispatcher {
 
         os_signpost(.event, log: renderLog, name: "CommitFrame", "frame=%{public}u input=%{public}u", frameSeq, inputSeq)
         latency.resolve(seq: inputSeq)
-        onTransactionResult?(.published(frameSeq: frameSeq))
+        onTransactionResult?(.applied(generation: openGeneration, frameSeq: frameSeq))
         if let firstRender = onFirstRender {
             firstRender()
             onFirstRender = nil
@@ -432,19 +434,46 @@ final class CommandDispatcher {
         sourceOpcode: UInt8? = nil
     ) {
         let opcodeContext = sourceOpcode.map { String(format: ", opcode=0x%02X", $0) } ?? ""
-        let shouldRequestKeyframe = resyncRecoveryState != .awaitingKeyframe
-        resyncRecoveryState = .awaitingKeyframe
-        PortLogger.warn("Frame transaction rejected (\(logReason)\(opcodeContext)); \(shouldRequestKeyframe ? "requesting" : "awaiting") keyframe from \(lastCommittedFrameSeq)")
+        let rejectedFrameSeq = frameSeq ?? 0
         openFrameSeq = nil
         openBaseFrameSeq = 0
         transactionBuilder = nil
-        guiState.performOutOfBandPublication {
-            guiState.resyncState.markPending(lastGoodFrameSeq: lastCommittedFrameSeq)
+
+        if case .missingWindowReference(let windowId) = rejection {
+            // A row/window reference miss has a targeted BEAM recovery path. Keep
+            // unrelated committed surfaces live and do not enter global base-zero
+            // resync; the replacement window arrives on the acknowledged base.
+            PortLogger.warn("Frame transaction missed window \(windowId) (\(logReason)\(opcodeContext)); awaiting targeted replacement")
+            onTransactionResult?(.windowRefMiss(
+                generation: openGeneration,
+                frameSeq: rejectedFrameSeq,
+                lastAppliedFrameSeq: lastCommittedFrameSeq,
+                windowId: windowId
+            ))
+            return
         }
-        onTransactionResult?(.rejected(frameSeq: frameSeq, reason: rejection))
+
+        let shouldRequestKeyframe = resyncRecoveryState != .awaitingKeyframe
+        resyncRecoveryState = .awaitingKeyframe
+        PortLogger.warn("Frame transaction rejected (\(logReason)\(opcodeContext)); awaiting BEAM recovery from \(lastCommittedFrameSeq)")
+        guiState.performOutOfBandPublication {
+            guiState.resyncState.markPending(
+                lastGoodFrameSeq: lastCommittedFrameSeq,
+                generation: openGeneration,
+                rejection: rejection.logDescription
+            )
+        }
         if shouldRequestKeyframe {
+            // Compatibility/test seam only. Production recovery is driven by the
+            // typed onTransactionResult status wired in MingaApp.
             onRequestKeyframe?(lastCommittedFrameSeq)
         }
+        onTransactionResult?(.rejected(
+            generation: openGeneration,
+            frameSeq: rejectedFrameSeq,
+            lastAppliedFrameSeq: lastCommittedFrameSeq,
+            reason: rejection
+        ))
     }
 
     /// Surfaced by the protocol reader when `decodeCommands` throws mid-stream.

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -10,8 +10,9 @@ import MingaUI
 
 /// The single typed result consumed by the frame-status protocol in #2739.
 enum FrameTransactionResult: Sendable, Equatable {
-    case published(frameSeq: UInt32)
-    case rejected(frameSeq: UInt32?, reason: PreparedFrameRejection)
+    case applied(generation: UInt32, frameSeq: UInt32)
+    case rejected(generation: UInt32, frameSeq: UInt32, lastAppliedFrameSeq: UInt32, reason: PreparedFrameRejection)
+    case windowRefMiss(generation: UInt32, frameSeq: UInt32, lastAppliedFrameSeq: UInt32, windowId: UInt16)
 }
 
 /// A rejection is complete and stable before any observable state is changed.
@@ -32,6 +33,25 @@ enum PreparedFrameRejection: Error, Sendable, Equatable {
     case transcriptDesynced
     case decodeFailure(frameSeq: UInt32)
     case outOfTransactionCommand(opcode: UInt8?)
+
+    /// Stable wire value shared with docs/protocol_schema.toml and Go.
+    var wireCode: UInt8 {
+        switch self {
+        case .beginWhileOpen: return 1
+        case .commitWithoutBegin, .commitSequenceMismatch: return 2
+        case .frameSequenceNotIncreasing: return 3
+        case .baseSequenceMismatch: return 4
+        case .missingTheme: return 5
+        case .incompleteTheme: return 6
+        case .missingWindowReference: return 7
+        case .windowEpochMismatch: return 8
+        case .invalidRetainedRows: return 9
+        case .missingFontResource: return 10
+        case .transcriptBeforeSeed, .transcriptEpochMismatch, .transcriptDesynced: return 11
+        case .decodeFailure: return 12
+        case .outOfTransactionCommand: return 13
+        }
+    }
 
     var logDescription: String {
         switch self {
@@ -110,6 +130,7 @@ struct PreparedMetadataUpdates: Sendable { let commands: [RenderCommand] }
 struct PreparedFrameTransaction {
     let frameSeq: UInt32
     let baseFrameSeq: UInt32
+    let generation: UInt32
     let theme: PreparedThemeUpdate?
     let windows: PreparedWindowUpdates?
     let chrome: PreparedChromeUpdates?
@@ -161,6 +182,7 @@ private struct PreparedDomainBuffer {
 struct PreparedFrameTransactionBuilder {
     let frameSeq: UInt32
     let baseFrameSeq: UInt32
+    let generation: UInt32
 
     private var theme: PreparedThemeUpdate?
     private var workingWindows: [UInt16: GUIWindowContent]
@@ -182,12 +204,14 @@ struct PreparedFrameTransactionBuilder {
     init(
         frameSeq: UInt32,
         baseFrameSeq: UInt32,
+        generation: UInt32,
         committedWindows: [UInt16: GUIWindowContent],
         registeredFontIds: Set<UInt8>,
         committedTranscript: AgentTranscriptSnapshot
     ) {
         self.frameSeq = frameSeq
         self.baseFrameSeq = baseFrameSeq
+        self.generation = generation
         self.workingWindows = baseFrameSeq == 0 ? [:] : committedWindows
         self.registeredFontIds = registeredFontIds
         self.registeredFontIds.insert(0)
@@ -301,6 +325,7 @@ struct PreparedFrameTransactionBuilder {
         let transaction = PreparedFrameTransaction(
             frameSeq: frameSeq,
             baseFrameSeq: baseFrameSeq,
+            generation: generation,
             theme: theme,
             windows: windowsChanged ? PreparedWindowUpdates(
                 replacements: changedWindows,

--- a/macos/Sources/Views/Overlays/ResyncOverlay.swift
+++ b/macos/Sources/Views/Overlays/ResyncOverlay.swift
@@ -10,12 +10,12 @@
 import SwiftUI
 
 public struct ResyncOverlay: View {
-    public init(state: ResyncState, onRetry: ((UInt32) -> Void)? = nil) {
+    public init(state: ResyncState, onRetry: ((UInt32, UInt32) -> Void)? = nil) {
         self.state = state
         self.onRetry = onRetry
     }
     public var state: ResyncState
-    public var onRetry: ((UInt32) -> Void)?
+    public var onRetry: ((UInt32, UInt32) -> Void)?
     @Environment(\.themeColors) private var theme
     @State private var retryVisible = false
 
@@ -46,7 +46,7 @@ public struct ResyncOverlay: View {
     private var badge: some View {
         if retryVisible, let onRetry {
             Button {
-                onRetry(state.lastGoodFrameSeq)
+                onRetry(state.lastGoodFrameSeq, state.generation)
             } label: {
                 badgeContent(showRetryIcon: true)
             }
@@ -62,7 +62,7 @@ public struct ResyncOverlay: View {
         HStack(spacing: 6) {
             ProgressView()
                 .controlSize(.small)
-            Text("Resyncing…")
+            Text(state.rejection.map { "Resyncing generation \(state.generation): \($0)" } ?? "Resyncing generation \(state.generation)…")
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(theme.tabActiveFg)
             if showRetryIcon {

--- a/macos/Sources/Views/Overlays/ResyncState.swift
+++ b/macos/Sources/Views/Overlays/ResyncState.swift
@@ -24,10 +24,14 @@ public final class ResyncState {
     /// Most recent frame_seq that committed cleanly before recovery began.
     /// Manual retry uses this to ask the BEAM for the same keyframe recovery the automatic path requested.
     public private(set) var lastGoodFrameSeq: UInt32 = 0
+    public private(set) var generation: UInt32 = 0
+    public private(set) var rejection: String?
 
-    /// Raise the resync-pending hint. Called by `CommandDispatcher.invalidate`.
-    public func markPending(lastGoodFrameSeq: UInt32) {
+    /// Raise the resync-pending hint and expose the active generation/rejection.
+    public func markPending(lastGoodFrameSeq: UInt32, generation: UInt32, rejection: String) {
         self.lastGoodFrameSeq = lastGoodFrameSeq
+        self.generation = generation
+        self.rejection = rejection
         pending = true
     }
 
@@ -36,5 +40,6 @@ public final class ResyncState {
     public func clear() {
         pending = false
         lastGoodFrameSeq = 0
+        rejection = nil
     }
 }

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -242,8 +242,8 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
                 "height_percent": Int(heightPercent), "filter_preset": Int(filterPreset),
                 "tabs": tabList, "entries": entryList]
 
-    case .beginFrame(let frameSeq, let baseFrameSeq):
-        return ["type": "begin_frame", "frame_seq": Int(frameSeq), "base_frame_seq": Int(baseFrameSeq)]
+    case .beginFrame(let frameSeq, let baseFrameSeq, let generation):
+        return ["type": "begin_frame", "frame_seq": Int(frameSeq), "base_frame_seq": Int(baseFrameSeq), "generation": Int(generation)]
 
     case .commitFrame(let frameSeq, let seq):
         return ["type": "commit_frame", "frame_seq": Int(frameSeq), "input_seq": Int(seq)]

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -55,7 +55,7 @@ struct CommandDispatcherRoutingTests {
         #expect(dispatcher.frameState.gutterCol == 7)
         #expect(dispatcher.frameState.viewportTopLine == 9)
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
@@ -87,7 +87,7 @@ struct CommandDispatcherRoutingTests {
             guideCols: [], lineIndentLevels: []
         )))
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiWindowContent(data: GUIWindowContent(
             windowId: 1, fullRefresh: false,
@@ -1339,13 +1339,13 @@ struct CommandDispatcherRoutingTests {
         dispatcher.onFirstRender = { callCount += 1 }
 
         // Two well-formed keyframe transactions; onFirstRender fires only once.
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
         #expect(callCount == 1)
         #expect(dispatcher.onFirstRender == nil)
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
         #expect(callCount == 1)
@@ -1374,13 +1374,13 @@ struct CommandDispatcherRoutingTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "unthemed.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
         #expect(gui.protocolErrorState.isPresented == false)
         #expect(gui.tabBarState.tabs.isEmpty)
-        #expect(results == [.rejected(frameSeq: 1, reason: .missingTheme)])
+        #expect(results == [.rejected(generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0, reason: .missingTheme)])
     }
 
     @Test("keyframe with empty guiTheme rejects promotion")
@@ -1389,7 +1389,7 @@ struct CommandDispatcherRoutingTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: []))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "empty.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
@@ -1397,7 +1397,7 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.protocolErrorState.isPresented == false)
         #expect(gui.themeColors.hasAppliedTheme == false)
         #expect(gui.tabBarState.tabs.isEmpty)
-        guard case .rejected(frameSeq: 2, reason: .incompleteTheme(let missing)) = results.first else {
+        guard case .rejected(generation: 1, frameSeq: 2, lastAppliedFrameSeq: _, reason: .incompleteTheme(let missing)) = results.first else {
             Issue.record("expected incomplete-theme rejection")
             return
         }
@@ -1410,7 +1410,7 @@ struct CommandDispatcherRoutingTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: [(GUI_COLOR_EDITOR_BG, 0x00, 0x00, 0x00)]))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false, hasAttention: false, agentStatus: 0, isPinned: false, tintColorRGB: 0, icon: "", label: "partial.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
@@ -1418,7 +1418,7 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.protocolErrorState.isPresented == false)
         #expect(gui.themeColors.hasAppliedTheme == false)
         #expect(gui.tabBarState.tabs.isEmpty)
-        guard case .rejected(frameSeq: 3, reason: .incompleteTheme(let missing)) = results.first else {
+        guard case .rejected(generation: 1, frameSeq: 3, lastAppliedFrameSeq: _, reason: .incompleteTheme(let missing)) = results.first else {
             Issue.record("expected incomplete-theme rejection")
             return
         }
@@ -1480,14 +1480,14 @@ struct CommandDispatcherStagingTests {
         let (dispatcher, gui) = makeDispatcher()
 
         // Establish a committed baseline so we have a "presented" tab bar.
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("old.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
         #expect(gui.tabBarState.tabs.first?.label == "old.ex")
 
         // Open a new transaction and stage a different tab bar, but do NOT commit.
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("new.ex")]))
 
         // The presented state still shows the last committed frame.
@@ -1498,14 +1498,14 @@ struct CommandDispatcherStagingTests {
     @MainActor func frameStateUnchangedMidTransaction() {
         let (dispatcher, _) = makeDispatcher()
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.setCursorShape(.block))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
         #expect(dispatcher.frameState.cursorShape == .block)
 
         // Stage a shape change without committing; the presented shape holds.
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
         dispatcher.dispatch(.setCursorShape(.beam))
         #expect(dispatcher.frameState.cursorShape == .block)
     }
@@ -1516,7 +1516,7 @@ struct CommandDispatcherStagingTests {
     @MainActor func commitPromotesStagedCommands() {
         let (dispatcher, gui) = makeDispatcher()
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("a.ex")]))
         dispatcher.dispatch(.setCursorShape(.beam))
@@ -1538,7 +1538,7 @@ struct CommandDispatcherStagingTests {
         var readyCount = 0
         dispatcher.onFrameReady = { readyCount += 1 }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("a.ex")]))
         #expect(readyCount == 0)
@@ -1553,13 +1553,13 @@ struct CommandDispatcherStagingTests {
     @MainActor func deltaBaseMatchesCommits() {
         let (dispatcher, gui) = makeDispatcher()
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("base.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
 
         // Next frame is a delta whose base names the frame we just committed.
-        dispatcher.dispatch(.beginFrame(frameSeq: 6, baseFrameSeq: 5))
+        dispatcher.dispatch(.beginFrame(frameSeq: 6, baseFrameSeq: 5, generation: 1))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("delta.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 6, seq: 0))
 
@@ -1573,13 +1573,13 @@ struct CommandDispatcherStagingTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("base.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
         let baselineThemeBg = gui.themeColors.editorBg
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 6, baseFrameSeq: 5))
+        dispatcher.dispatch(.beginFrame(frameSeq: 6, baseFrameSeq: 5, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: []))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("empty-delta.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 6, seq: 0))
@@ -1588,7 +1588,7 @@ struct CommandDispatcherStagingTests {
         #expect(gui.themeColors.editorBg == baselineThemeBg)
         #expect(gui.tabBarState.tabs.first?.label == "base.ex")
         #expect(results.count == 2)
-        guard case .rejected(frameSeq: 6, reason: .incompleteTheme(let missing)) = results.last else {
+        guard case .rejected(generation: 1, frameSeq: 6, lastAppliedFrameSeq: _, reason: .incompleteTheme(let missing)) = results.last else {
             Issue.record("expected incomplete-theme rejection")
             return
         }
@@ -1602,13 +1602,13 @@ struct CommandDispatcherStagingTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("base.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
         let baselineThemeBg = gui.themeColors.editorBg
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 6, baseFrameSeq: 5))
+        dispatcher.dispatch(.beginFrame(frameSeq: 6, baseFrameSeq: 5, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: [(GUI_COLOR_EDITOR_BG, 0x00, 0x00, 0x00)]))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("partial-delta.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 6, seq: 0))
@@ -1617,7 +1617,7 @@ struct CommandDispatcherStagingTests {
         #expect(gui.themeColors.editorBg == baselineThemeBg)
         #expect(gui.tabBarState.tabs.first?.label == "base.ex")
         #expect(results.count == 2)
-        guard case .rejected(frameSeq: 6, reason: .incompleteTheme(let missing)) = results.last else {
+        guard case .rejected(generation: 1, frameSeq: 6, lastAppliedFrameSeq: _, reason: .incompleteTheme(let missing)) = results.last else {
             Issue.record("expected incomplete-theme rejection")
             return
         }
@@ -1634,13 +1634,13 @@ struct CommandDispatcherStagingTests {
         dispatcher.onRequestKeyframe = { requested.append($0) }
 
         // Commit a clean baseline so lastCommittedFrameSeq is known.
-        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("good.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
 
         // Open a frame, stage a change, then commit with the WRONG seq.
-        dispatcher.dispatch(.beginFrame(frameSeq: 4, baseFrameSeq: 3))
+        dispatcher.dispatch(.beginFrame(frameSeq: 4, baseFrameSeq: 3, generation: 1))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("bad.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 99, seq: 0))
 
@@ -1668,13 +1668,13 @@ struct CommandDispatcherStagingTests {
         // It must discard silently without re-requesting (#2267 review: every
         // stale frame after an invalidation fails its base check; re-requesting
         // per frame would force a duplicate BEAM render each).
-        dispatcher.dispatch(.beginFrame(frameSeq: 8, baseFrameSeq: 7))
+        dispatcher.dispatch(.beginFrame(frameSeq: 8, baseFrameSeq: 7, generation: 1))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("stale.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 8, seq: 0))
         #expect(requested == [0])
 
         // The keyframe arrives: pending clears and content promotes.
-        dispatcher.dispatch(.beginFrame(frameSeq: 9, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 9, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("fresh.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 9, seq: 0))
@@ -1688,7 +1688,7 @@ struct CommandDispatcherStagingTests {
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("rogue.ex")]))
@@ -1696,12 +1696,12 @@ struct CommandDispatcherStagingTests {
 
         // This delta is valid against our retained baseline, but it is not the
         // requested base-0 recovery frame and must not dismiss the pending hint.
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("stale.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
         #expect(gui.resyncState.pending == true)
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
         #expect(gui.resyncState.pending == false)
@@ -1719,13 +1719,13 @@ struct CommandDispatcherStagingTests {
 
         // A base-0 frame has answered the request, but fails validation before it
         // can commit. It must reopen the request window instead of hanging forever.
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: []))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
         #expect(requested == [0, 0])
         #expect(gui.resyncState.pending == true)
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
         #expect(gui.resyncState.pending == false)
@@ -1737,11 +1737,11 @@ struct CommandDispatcherStagingTests {
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("staged.ex")]))
         // A new begin before commit: the first frame was truncated.
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
 
         // The truncated frame promoted nothing.
@@ -1756,13 +1756,13 @@ struct CommandDispatcherStagingTests {
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 10, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 10, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("base.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 10, seq: 0))
 
         // Delta whose base names a frame this client never committed (7, not 10).
-        dispatcher.dispatch(.beginFrame(frameSeq: 11, baseFrameSeq: 7))
+        dispatcher.dispatch(.beginFrame(frameSeq: 11, baseFrameSeq: 7, generation: 1))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("orphan.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 11, seq: 0))
 
@@ -1788,7 +1788,7 @@ struct CommandDispatcherStagingTests {
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("partial.ex")]))
         dispatcher.decodeFailed()
@@ -1812,7 +1812,7 @@ struct CommandDispatcherStagingTests {
         #expect(gui.resyncState.pending == true)
 
         // The recovering keyframe arrives and commits cleanly.
-        dispatcher.dispatch(.beginFrame(frameSeq: 7, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 7, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("recovered.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 7, seq: 0))
@@ -1837,7 +1837,7 @@ struct CommandDispatcherStagingTests {
         ]
 
         for command in commands { direct.applyForTesting(command) }
-        prepared.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        prepared.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         for command in commands { prepared.dispatch(command) }
         prepared.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
@@ -1853,7 +1853,7 @@ struct CommandDispatcherStagingTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiWindowContent(data: windowContent()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("prepared.ex")]))
@@ -1861,9 +1861,30 @@ struct CommandDispatcherStagingTests {
 
         #expect(gui.framePublicationCount == 1)
         #expect(dispatcher.publicationCount == 1)
-        #expect(results == [.published(frameSeq: 1)])
+        #expect(results == [.applied(generation: 1, frameSeq: 1)])
         #expect(gui.windowContents[7]?.rows.first?.text == "old")
         #expect(gui.tabBarState.tabs.first?.label == "prepared.ex")
+    }
+
+    @Test("applied follows semantic publication and does not wait for Metal presentation")
+    @MainActor func appliedAtSemanticBoundary() {
+        let (dispatcher, gui) = makeDispatcher()
+        var readyCount = 0
+        var publicationSeenByApplied = false
+        dispatcher.onFrameReady = { readyCount += 1 }
+        dispatcher.onTransactionResult = { result in
+            guard case .applied(generation: 4, frameSeq: 8) = result else { return }
+            publicationSeenByApplied = gui.framePublicationCount == 1 &&
+                gui.tabBarState.tabs.first?.label == "semantic.ex" && readyCount == 0
+        }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 8, baseFrameSeq: 0, generation: 4))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("semantic.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 8, seq: 0))
+
+        #expect(publicationSeenByApplied)
+        #expect(readyCount == 1)
     }
 
     @Test("one aggregate observation callback sees all sibling domains committed")
@@ -1880,7 +1901,7 @@ struct CommandDispatcherStagingTests {
             notificationCount.withLock { $0 += 1 }
         }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("atomic.ex")]))
         dispatcher.dispatch(.guiAgentChat(
@@ -1911,7 +1932,7 @@ struct CommandDispatcherStagingTests {
             guideCols: [4, 8], lineIndentLevels: [2]
         )
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiWindowContent(data: windowContent(windowId: 1001)))
         dispatcher.dispatch(.guiWindowContent(data: windowContent(windowId: 1)))
@@ -1929,7 +1950,7 @@ struct CommandDispatcherStagingTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("must-not-publish.ex")]))
         dispatcher.dispatch(.guiWindowOverlayDelta(data: overlayDelta(windowId: 99)))
@@ -1937,7 +1958,8 @@ struct CommandDispatcherStagingTests {
 
         #expect(gui.framePublicationCount == 0)
         #expect(gui.tabBarState.tabs.isEmpty)
-        #expect(results == [.rejected(frameSeq: 1, reason: .missingWindowReference(windowId: 99))])
+        #expect(gui.resyncState.pending == false)
+        #expect(results == [.windowRefMiss(generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0, windowId: 99)])
     }
 
     @Test("invalid transcript operations reject without publishing sibling state")
@@ -1963,7 +1985,7 @@ struct CommandDispatcherStagingTests {
             dispatcher.onTransactionResult = { results.append($0) }
 
             if index > 0 {
-                dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+                dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
                 dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
                 dispatcher.dispatch(.guiAgentTranscript(
                     mode: 0, epoch: 1, truncated: false, trimFront: 0, baseCount: 0,
@@ -1976,7 +1998,7 @@ struct CommandDispatcherStagingTests {
             let baselinePublications = gui.framePublicationCount
             let frameSeq = UInt32(index > 0 ? 2 : 1)
             let baseSeq = UInt32(index > 0 ? 1 : 0)
-            dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseSeq))
+            dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseSeq, generation: 1))
             if baseSeq == 0 { dispatcher.dispatch(.guiTheme(slots: completeThemeSlots())) }
             dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("must-not-publish.ex")]))
             dispatcher.dispatch(invalid.0)
@@ -1984,7 +2006,7 @@ struct CommandDispatcherStagingTests {
 
             #expect(gui.framePublicationCount == baselinePublications)
             #expect(gui.tabBarState.tabs.first?.label == (index > 0 ? "baseline.ex" : nil))
-            #expect(results.last == .rejected(frameSeq: frameSeq, reason: invalid.1))
+            #expect(results.last == .rejected(generation: 1, frameSeq: frameSeq, lastAppliedFrameSeq: UInt32(index > 0 ? 1 : 0), reason: invalid.1))
             #expect(gui.agentChatState.messages.map(\.id) == (index > 0 ? [1] : []))
         }
     }
@@ -1995,18 +2017,15 @@ struct CommandDispatcherStagingTests {
             let (dispatcher, _) = makeDispatcher()
             var results: [FrameTransactionResult] = []
             dispatcher.onTransactionResult = { results.append($0) }
-            dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0))
+            dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0, generation: 1))
             dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
             dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
 
-            dispatcher.dispatch(.beginFrame(frameSeq: incoming, baseFrameSeq: 0))
+            dispatcher.dispatch(.beginFrame(frameSeq: incoming, baseFrameSeq: 0, generation: 1))
             dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
             dispatcher.dispatch(.commitFrame(frameSeq: incoming, seq: 0))
 
-            #expect(results.last == .rejected(
-                frameSeq: incoming,
-                reason: .frameSequenceNotIncreasing(lastFrameSeq: 5, incomingFrameSeq: incoming)
-            ))
+            #expect(results.last == .rejected(generation: 1, frameSeq: incoming, lastAppliedFrameSeq: 5, reason: .frameSequenceNotIncreasing(lastFrameSeq: 5, incomingFrameSeq: incoming)))
             #expect(dispatcher.publicationCount == 1)
         }
     }
@@ -2017,20 +2036,17 @@ struct CommandDispatcherStagingTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiWindowContent(data: windowContent()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
         dispatcher.dispatch(.guiWindowOverlayDelta(data: overlayDelta(epoch: 41)))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
 
         #expect(gui.framePublicationCount == 1)
-        #expect(results.last == .rejected(
-            frameSeq: 2,
-            reason: .windowEpochMismatch(windowId: 7, expected: 42, actual: 41)
-        ))
+        #expect(results.last == .rejected(generation: 1, frameSeq: 2, lastAppliedFrameSeq: 1, reason: .windowEpochMismatch(windowId: 7, expected: 42, actual: 41)))
         #expect(gui.windowContents[7]?.cursorShape == .block)
     }
 
@@ -2040,23 +2056,23 @@ struct CommandDispatcherStagingTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiWindowContent(data: windowContent(fontId: 3)))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
         #expect(gui.framePublicationCount == 0)
-        #expect(results == [.rejected(frameSeq: 1, reason: .missingFontResource(fontId: 3))])
+        #expect(results == [.rejected(generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0, reason: .missingFontResource(fontId: 3))])
     }
 
     @Test("publication operation count depends on changed domains, not command count")
     @MainActor func changedDomainOperationCount() {
         let (dispatcher, gui) = makeDispatcher()
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
         for index in 0..<100 {
             dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("\(index).ex")]))
         }

--- a/macos/Tests/MingaTests/ProtocolCommandSizeTests.swift
+++ b/macos/Tests/MingaTests/ProtocolCommandSizeTests.swift
@@ -24,8 +24,8 @@ struct ProtocolCommandSizeTests {
     }
 
     @Test func sizesFrameTransactionMarkers() {
-        // begin_frame/commit_frame (#2219 child A) are fixed:9 = opcode + two u32.
-        #expect(commandSize([OP_BEGIN_FRAME, 0, 0, 0, 7, 0, 0, 0, 0]) == .sized(9))
+        // begin_frame adds generation in protocol v11; commit_frame remains fixed:9.
+        #expect(commandSize([OP_BEGIN_FRAME, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 1]) == .sized(13))
         #expect(commandSize([OP_COMMIT_FRAME, 0, 0, 0, 7, 0, 0, 0, 5]) == .sized(9))
         #expect(commandSize([OP_BEGIN_FRAME, 0, 0, 0]) == .incomplete)
     }

--- a/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
+++ b/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
@@ -80,21 +80,56 @@ struct EncoderReadyTests {
 struct EncoderRequestKeyframeTests {
     @Test("request_keyframe encodes opcode and last_good_frame_seq (#2219 child D)")
     func requestKeyframeLayout() {
-        let payload = captureFrame { $0.sendRequestKeyframe(lastGoodFrameSeq: 0x0A0B_0C0D) }
+        let payload = captureFrame { $0.sendRequestKeyframe(lastGoodFrameSeq: 0x0A0B_0C0D, generation: 7) }
 
-        // fixed:5 = opcode(1) + last_good_frame_seq(u32, big-endian).
-        #expect(payload.count == 5)
+        #expect(payload.count == 9)
         #expect(payload[0] == OP_REQUEST_KEYFRAME)
         #expect(readU32(payload, 1) == 0x0A0B_0C0D)
+        #expect(readU32(payload, 5) == 7)
     }
 
     @Test("request_keyframe carries a zero seq when the frontend has no good frame")
     func requestKeyframeZeroSeq() {
-        let payload = captureFrame { $0.sendRequestKeyframe(lastGoodFrameSeq: 0) }
+        let payload = captureFrame { $0.sendRequestKeyframe(lastGoodFrameSeq: 0, generation: 0) }
 
-        #expect(payload.count == 5)
+        #expect(payload.count == 9)
         #expect(payload[0] == OP_REQUEST_KEYFRAME)
         #expect(readU32(payload, 1) == 0)
+    }
+
+    @Test("frame_applied encodes generation and frame")
+    func frameAppliedLayout() {
+        let payload = captureFrame { $0.sendFrameApplied(generation: 3, frameSeq: 9) }
+        #expect(payload.count == 9)
+        #expect(payload[0] == OP_FRAME_APPLIED)
+        #expect(readU32(payload, 1) == 3)
+        #expect(readU32(payload, 5) == 9)
+    }
+
+    @Test("frame_rejected encodes stable status fields")
+    func frameRejectedLayout() {
+        let payload = captureFrame {
+            $0.sendFrameRejected(generation: 3, frameSeq: 9, lastAppliedFrameSeq: 7, reason: 4)
+        }
+        #expect(payload.count == 14)
+        #expect(payload[0] == OP_FRAME_REJECTED)
+        #expect(readU32(payload, 1) == 3)
+        #expect(readU32(payload, 5) == 9)
+        #expect(readU32(payload, 9) == 7)
+        #expect(payload[13] == 4)
+    }
+
+    @Test("window_ref_miss encodes the targeted window")
+    func windowRefMissLayout() {
+        let payload = captureFrame {
+            $0.sendWindowRefMiss(generation: 3, frameSeq: 9, lastAppliedFrameSeq: 7, windowId: 12)
+        }
+        #expect(payload.count == 15)
+        #expect(payload[0] == OP_WINDOW_REF_MISS)
+        #expect(readU32(payload, 1) == 3)
+        #expect(readU32(payload, 5) == 9)
+        #expect(readU32(payload, 9) == 7)
+        #expect(readU16(payload, 13) == 12)
     }
 }
 

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -133,16 +133,17 @@ struct ProtocolDecoderTests {
 
     @Test("Decode begin_frame command")
     func decodeBeginFrame() throws {
-        // begin_frame (#2219): frame_seq:u32 + base_frame_seq:u32.
-        let data = Data([OP_BEGIN_FRAME, 0x00, 0x00, 0x00, 0x07, 0x00, 0x00, 0x00, 0x03])
+        // begin_frame (#2739): frame_seq:u32 + base_frame_seq:u32 + generation:u32.
+        let data = Data([OP_BEGIN_FRAME, 0, 0, 0, 7, 0, 0, 0, 3, 0, 0, 0, 9])
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
-        #expect(size == 9)
-        guard case .beginFrame(let frameSeq, let baseFrameSeq) = cmd else {
+        #expect(size == 13)
+        guard case .beginFrame(let frameSeq, let baseFrameSeq, let generation) = cmd else {
             Issue.record("Expected .beginFrame, got \(String(describing: cmd))")
             return
         }
         #expect(frameSeq == 7)
         #expect(baseFrameSeq == 3)
+        #expect(generation == 9)
     }
 
     @Test("Decode framed gui_agent_context payload")

--- a/test/minga_editor/frontend/emit/keyframe_side_channel_test.exs
+++ b/test/minga_editor/frontend/emit/keyframe_side_channel_test.exs
@@ -42,8 +42,10 @@ defmodule MingaEditor.Frontend.Emit.KeyframeSideChannelTest do
     # Establish populated side-channel caches via two frames. The first frame is a
     # keyframe (no committed base) and sends both side channels; flush them.
     {_c1, caches} = emit_and_capture(frame, state, %Caches{}, frame_seq: 11)
+    caches = Caches.acknowledge_frame(caches, 11, caches.recovery_generation)
     flush_side_channels(title_op, bg_op)
     {_c2, caches} = emit_and_capture(frame, state, caches, frame_seq: 22)
+    caches = Caches.acknowledge_frame(caches, 22, caches.recovery_generation)
 
     assert is_binary(caches.last_title)
     assert is_integer(caches.last_window_bg)

--- a/test/minga_editor/frontend/emit_test.exs
+++ b/test/minga_editor/frontend/emit_test.exs
@@ -39,7 +39,7 @@ defmodule MingaEditor.Frontend.EmitTest do
       # transaction (#2219): every frame opens with begin_frame (0x10) and closes
       # with commit_frame (0x11). The frame no longer starts with a cell-grid clear.
       refute Enum.any?(commands, &match?(<<0x12, _::binary>>, &1))
-      assert [<<first_opcode, frame_seq::32, base_frame_seq::32>> | _] = commands
+      assert [<<first_opcode, frame_seq::32, base_frame_seq::32, _generation::32>> | _] = commands
       assert first_opcode == Opcodes.begin_frame()
       # First frame is a keyframe (no committed base), so base_frame_seq is 0.
       assert base_frame_seq == 0
@@ -110,11 +110,11 @@ defmodule MingaEditor.Frontend.EmitTest do
       {commands1, _caches} = emit_and_capture(frame, state, caches, frame_seq: 100)
       {commands2, _caches} = emit_and_capture(frame, state, caches, frame_seq: 200)
 
-      assert [<<op_begin, fs1::32, _base::32>> | _] = commands1
+      assert [<<op_begin, fs1::32, _base::32, _generation::32>> | _] = commands1
       assert op_begin == Opcodes.begin_frame()
       assert Enum.at(commands1, -1) == <<Opcodes.commit_frame(), fs1::32, 0::32>>
 
-      assert [<<_, fs2::32, _::32>> | _] = commands2
+      assert [<<_, fs2::32, _base::32, _generation::32>> | _] = commands2
       # frame_seq advances per emit even though the snapshot is identical.
       assert fs2 > fs1
     end
@@ -125,11 +125,36 @@ defmodule MingaEditor.Frontend.EmitTest do
 
       {commands, _caches} = emit_and_capture(frame, state, %Caches{}, frame_seq: 7)
 
-      assert [<<_, 7::32, base_frame_seq::32>> | _] = commands
+      assert [<<_, 7::32, base_frame_seq::32, _generation::32>> | _] = commands
       assert base_frame_seq == 0
 
       assert Enum.any?(commands, &match?(<<0x80, _::binary>>, &1)),
              "keyframe carries full window content"
+    end
+
+    test "a successful Port write does not become a delta base without acknowledgement" do
+      frame = window_frame_with_content()
+      state = semantic_state()
+
+      {_commands, unacknowledged} = emit_and_capture(frame, state, %Caches{}, frame_seq: 11)
+      {commands, _caches} = emit_and_capture(frame, state, unacknowledged, frame_seq: 22)
+
+      assert [<<_, 22::32, 0::32, _generation::32>> | _] = commands
+      assert Enum.any?(commands, &match?(<<0x80, _::binary>>, &1))
+    end
+
+    test "a renderer without a frontend treats synchronous emission as the commit boundary" do
+      frame = window_frame_with_content()
+      ctx = %{Context.from_editor_state(semantic_state()) | port_manager: nil, frame_seq: 11}
+
+      {caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, %Caches{})
+      assert caches.last_acknowledged_frame_seq == 11
+      assert caches.last_frame_keyframe?
+
+      ctx = %{ctx | frame_seq: 22}
+      {caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches)
+      assert caches.last_acknowledged_frame_seq == 22
+      refute caches.last_frame_keyframe?
     end
 
     test "a later frame names the previous frame_seq as its delta base" do
@@ -137,10 +162,11 @@ defmodule MingaEditor.Frontend.EmitTest do
       state = semantic_state()
 
       {_c1, caches} = emit_and_capture(frame, state, %Caches{}, frame_seq: 11)
+      caches = acknowledge(caches, 11)
       {commands, _c2} = emit_and_capture(frame, state, caches, frame_seq: 22)
 
-      assert [<<_, 22::32, base_frame_seq::32>> | _] = commands
-      assert base_frame_seq == 11, "non-keyframe bases on the previously emitted frame_seq"
+      assert [<<_, 22::32, base_frame_seq::32, _generation::32>> | _] = commands
+      assert base_frame_seq == 11, "non-keyframe bases on the previously acknowledged frame_seq"
     end
 
     test "an invalid late window field writes nothing and the next valid frame recovers with a keyframe" do
@@ -148,6 +174,7 @@ defmodule MingaEditor.Frontend.EmitTest do
       state = semantic_state()
 
       {_commands, caches} = emit_and_capture(frame, state, %Caches{}, frame_seq: 11)
+      caches = acknowledge(caches, 11)
       invalid_frame = frame_with_invalid_indent_level(frame)
       ctx = %{Context.from_editor_state(state) | frame_seq: 22}
 
@@ -160,7 +187,7 @@ defmodule MingaEditor.Frontend.EmitTest do
 
       {commands, _caches} = emit_and_capture(frame, state, recovered_caches, frame_seq: 33)
 
-      assert [<<_, 33::32, 0::32>> | _] = commands
+      assert [<<_, 33::32, 0::32, _generation::32>> | _] = commands
       assert Enum.any?(commands, &match?(<<0x80, _::binary>>, &1))
     end
 
@@ -170,6 +197,7 @@ defmodule MingaEditor.Frontend.EmitTest do
 
       # Establish a delta base: frame two bases on frame one and skips full content.
       {_c1, caches} = emit_and_capture(frame, state, %Caches{}, frame_seq: 11)
+      caches = acknowledge(caches, 11)
       {delta_commands, caches} = emit_and_capture(frame, state, caches, frame_seq: 22)
 
       refute Enum.any?(delta_commands, &match?(<<0x80, _::binary>>, &1)),
@@ -179,7 +207,7 @@ defmodule MingaEditor.Frontend.EmitTest do
       {key_commands, _caches} =
         emit_and_capture(frame, state, caches, frame_seq: 33, force_keyframe?: true)
 
-      assert [<<_, 33::32, 0::32>> | _] = key_commands
+      assert [<<_, 33::32, 0::32, _generation::32>> | _] = key_commands
 
       assert Enum.any?(key_commands, &match?(<<0x80, _::binary>>, &1)),
              "forced keyframe resends full window content"
@@ -204,7 +232,8 @@ defmodule MingaEditor.Frontend.EmitTest do
       seeded = %Caches{
         last_title: "stale title",
         last_window_bg: 0x123456,
-        last_emitted_frame_seq: 22
+        last_emitted_frame_seq: 22,
+        last_acknowledged_frame_seq: 22
       }
 
       {_key, key_caches} =
@@ -375,11 +404,16 @@ defmodule MingaEditor.Frontend.EmitTest do
 
   # Drives Emit.emit/4 with an explicit frame_seq and optional keyframe forcing,
   # capturing the single send_commands cast (port_manager is self()).
+  defp acknowledge(caches, frame_seq) do
+    Caches.acknowledge_frame(caches, frame_seq, caches.recovery_generation)
+  end
+
   defp emit_and_capture(frame, state, caches, opts) do
     ctx = %{
       Context.from_editor_state(state)
       | frame_seq: Keyword.fetch!(opts, :frame_seq),
-        force_keyframe?: Keyword.get(opts, :force_keyframe?, false)
+        force_keyframe?: Keyword.get(opts, :force_keyframe?, false),
+        acknowledgement_required?: true
     }
 
     {new_caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches)

--- a/test/minga_editor/frontend/manager_test.exs
+++ b/test/minga_editor/frontend/manager_test.exs
@@ -77,11 +77,11 @@ defmodule MingaEditor.Frontend.ManagerTest do
       pid = start_manager(name)
       :ok = Manager.subscribe(name)
 
-      # opcode 0x08 + last_good_frame_seq:u32. The Manager stays opaque transport
+      # opcode 0x08 + last_good_frame_seq:u32 + generation:u32. The Manager stays opaque transport
       # and only broadcasts the decoded event; the BEAM owns keyframe forcing.
-      send_port_data(pid, nil, <<0x08, 42::32>>)
+      send_port_data(pid, nil, <<0x08, 42::32, 7::32>>)
 
-      assert_receive {:minga_input, {:request_keyframe, 42}}
+      assert_receive {:minga_input, {:request_keyframe, 42, 7}}
     end
 
     test "duplicate subscriptions receive one copy of each event" do

--- a/test/minga_editor/frontend/protocol_schema_test.exs
+++ b/test/minga_editor/frontend/protocol_schema_test.exs
@@ -55,6 +55,9 @@ defmodule MingaEditor.Frontend.ProtocolSchemaTest do
       gui_action: 0x07,
       request_keyframe: 0x08,
       scroll_batch: 0x09,
+      frame_applied: 0x0A,
+      frame_rejected: 0x0B,
+      window_ref_miss: 0x0C,
       log_message: 0x60
     )
   end

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -269,16 +269,16 @@ defmodule MingaEditor.Frontend.ProtocolTest do
 
   describe "encode_begin_frame/2" do
     test "encodes begin_frame with frame_seq and base_frame_seq (#2219)" do
-      assert <<0x10, 7::32, 6::32>> = Protocol.encode_begin_frame(7, 6)
+      assert <<0x10, 7::32, 6::32, 1::32>> = Protocol.encode_begin_frame(7, 6)
     end
 
     test "encodes a keyframe as base_frame_seq 0" do
-      assert <<0x10, 9::32, 0::32>> = Protocol.encode_begin_frame(9, 0)
+      assert <<0x10, 9::32, 0::32, 1::32>> = Protocol.encode_begin_frame(9, 0)
     end
 
     test "masks large monotonic frame_seq values to u32" do
       big = 0x1_0000_0001
-      assert <<0x10, 1::32, 0::32>> = Protocol.encode_begin_frame(big, 0)
+      assert <<0x10, 1::32, 0::32, 1::32>> = Protocol.encode_begin_frame(big, 0)
     end
   end
 
@@ -303,12 +303,12 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       assert <<0x11, 0::32, 0::32>> = Protocol.encode_commit_frame(0)
     end
 
-    test "begin_frame carries frame_seq + base_frame_seq (opcode + 8 bytes)" do
-      assert <<0x10, 0::32, 0::32>> = Protocol.encode_begin_frame(0, 0)
+    test "begin_frame carries frame_seq + base_frame_seq + generation" do
+      assert <<0x10, 0::32, 0::32, 1::32>> = Protocol.encode_begin_frame(0, 0)
     end
 
-    test "request_keyframe decodes last_good_frame_seq (#2219)" do
-      assert {:ok, {:request_keyframe, 12}} = Protocol.decode_event(<<0x08, 12::32>>)
+    test "request_keyframe decodes last_good_frame_seq and generation" do
+      assert {:ok, {:request_keyframe, 12, 3}} = Protocol.decode_event(<<0x08, 12::32, 3::32>>)
     end
 
     test "key_press event has correct byte layout" do
@@ -424,14 +424,15 @@ defmodule MingaEditor.Frontend.ProtocolTest do
     end
   end
 
-  # The scroll_prefetch_hint opcode (0x0A) and its decode were deleted with the
-  # velocity-aware overscan prefetch (#2680, epic #2652); 0x0A is now an unknown
-  # opcode.
-  describe "decode_event/1 — retired scroll_prefetch_hint opcode" do
-    test "former scroll_prefetch_hint opcode (0x0A) is unknown" do
-      payload = <<0x0A, 1::16, 100::32, 0, 42::32>>
+  describe "decode_event/1 — frame status" do
+    test "decodes generation-aware applied, rejected, and window ref miss statuses" do
+      assert {:ok, {:frame_applied, 3, 9}} = Protocol.decode_event(<<0x0A, 3::32, 9::32>>)
 
-      assert {:error, :unknown_opcode} = Protocol.decode_event(payload)
+      assert {:ok, {:frame_rejected, 3, 9, 7, :base_sequence_mismatch}} =
+               Protocol.decode_event(<<0x0B, 3::32, 9::32, 7::32, 4>>)
+
+      assert {:ok, {:window_ref_miss, 3, 9, 7, 12}} =
+               Protocol.decode_event(<<0x0C, 3::32, 9::32, 7::32, 12::16>>)
     end
   end
 

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -161,20 +161,15 @@ defmodule MingaEditor.Input.RouterTest do
       _new_state = Router.dispatch(state, ?j, 0)
     end
 
-    test "entering operator_pending mode skips full render but emits a bare frame transaction" do
+    test "entering operator_pending mode still renders a committed frame" do
       state = base_state()
-      # Flush any startup messages
       flush_mailbox()
 
-      # Press 'd' to enter operator_pending mode (no buffer mutation)
       new_state = Router.dispatch(state, ?d, 0)
       assert new_state.workspace.editing.mode == :operator_pending
 
-      # A single no-op frame boundary (begin_frame + commit_frame in one
-      # send_commands cast) is sent, not a full render (#2219). port_manager is
-      # self(), so GenServer.cast sends one $gen_cast message.
       msg_count = flush_mailbox()
-      assert msg_count == 1, "Expected exactly 1 frame-boundary message, got #{msg_count}"
+      assert msg_count > 0, "Expected render messages for operator-pending transition"
     end
 
     test "normal motion triggers full render (more than one message)" do
@@ -234,24 +229,9 @@ defmodule MingaEditor.Input.RouterTest do
     end
   end
 
-  describe "operator-pending frame ordering (#2219)" do
+  describe "operator-pending frame acknowledgement (#2739)" do
     alias MingaEditor.Renderer.Server, as: RendererServer
     alias MingaEditor.Viewport
-    alias Minga.Protocol.Opcodes
-
-    # A bare boundary is exactly two commands in one send_commands cast:
-    # begin_frame then commit_frame, no content between.
-    defp bare_boundary_cast? do
-      begin_op = Opcodes.begin_frame()
-      commit_op = Opcodes.commit_frame()
-
-      receive do
-        {:"$gen_cast", {:send_commands, [<<^begin_op, _::binary>>, <<^commit_op, _::binary>>]}} ->
-          true
-      after
-        0 -> false
-      end
-    end
 
     defp async_state(renderer_pid) do
       buf = start_supervised!({BufferProcess, content: "hello\nworld\nthird"})
@@ -277,65 +257,49 @@ defmodule MingaEditor.Input.RouterTest do
       }
     end
 
-    defp park_busy(renderer) do
-      :sys.replace_state(renderer, fn s ->
+    defp acknowledged_probe(parent) do
+      fn input ->
+        send(parent, {
+          :acknowledged_render,
+          input.frame_seq,
+          input.caches.recovery_generation,
+          input.caches.last_acknowledged_frame_seq
+        })
+
         %{
-          s
-          | rendering?: true,
-            in_flight:
-              {%MingaEditor.RenderPipeline.Input{
-                 port_manager: self(),
-                 theme: MingaEditor.UI.Theme.get!(:doom_one),
-                 capabilities: %MingaEditor.Frontend.Capabilities{},
-                 shell_id: :traditional,
-                 shell: MingaEditor.Shell.Traditional,
-                 workspace: %{
-                   windows: %MingaEditor.State.Windows{},
-                   viewport: Viewport.new(24, 80)
-                 }
-               }, 0, 0}
+          input
+          | caches: %{
+              input.caches
+              | last_emitted_frame_seq: input.frame_seq,
+                last_frame_keyframe?: input.caches.last_acknowledged_frame_seq == 0
+            }
         }
-      end)
+      end
     end
 
-    test "an operator-pending no-op emits a bare boundary when the renderer is idle" do
+    test "operator-pending followed by a normal render uses only the acknowledged renderer base" do
       renderer =
-        start_supervised!({RendererServer, name: nil, editor_pid: self(), pipeline: & &1})
+        start_supervised!(
+          {RendererServer,
+           name: nil, editor_pid: self(), pipeline: acknowledged_probe(self()), require_ack?: true}
+        )
 
       state = async_state(renderer)
       flush_mailbox()
 
-      new_state = Router.dispatch(state, ?d, 0)
-      assert new_state.workspace.editing.mode == :operator_pending
+      pending_state = Router.dispatch(state, ?d, 0)
+      assert pending_state.workspace.editing.mode == :operator_pending
+      assert_receive {:acknowledged_render, first_seq, 1, 0}
+      refute_receive {:"$gen_cast", {:send_commands, _commands}}, 20
 
-      # The idle renderer is the sole writer, so the boundary is emitted directly and
-      # the editor's last_emitted_frame_seq advances.
-      assert bare_boundary_cast?(), "idle path emits a bare frame boundary"
-      assert new_state.caches.last_emitted_frame_seq > state.caches.last_emitted_frame_seq
-    end
+      RendererServer.frame_status(renderer, {:frame_applied, 1, first_seq})
+      assert_receive {:render_done, %{frame_seq: ^first_seq}}
 
-    test "an operator-pending no-op routes through the renderer (no bare boundary) when busy" do
-      renderer =
-        start_supervised!({RendererServer, name: nil, editor_pid: self(), pipeline: & &1})
-
-      state = async_state(renderer)
-      park_busy(renderer)
-      flush_mailbox()
-
-      new_state = Router.dispatch(state, ?d, 0)
-      assert new_state.workspace.editing.mode == :operator_pending
-
-      # Ordering invariant: while a lower-seq render is in-flight, the boundary must
-      # NOT be written straight to the port (that would put a decreasing frame_seq on
-      # the wire). It is serialized through the renderer instead.
-      refute bare_boundary_cast?(),
-             "busy path must not emit a bare boundary straight to the port"
-
-      # The async render was cast to the parked-busy renderer, which holds it as the
-      # pending snapshot (most-recent-wins) instead of writing the port out of order.
-      assert {_snap, _seq, _pushed_at} = :sys.get_state(renderer).pending
-      # last_emitted_frame_seq is NOT advanced at cast time; it advances on writeback.
-      assert new_state.caches.last_emitted_frame_seq == state.caches.last_emitted_frame_seq
+      normal_state = Router.dispatch(pending_state, ?w, 0)
+      assert normal_state.workspace.editing.mode == :normal
+      assert_receive {:acknowledged_render, second_seq, 1, ^first_seq}
+      assert second_seq > first_seq
+      assert RendererServer.acknowledgement_state(renderer) == {1, first_seq}
     end
   end
 

--- a/test/minga_editor/integration/attach_keyframe_test.exs
+++ b/test/minga_editor/integration/attach_keyframe_test.exs
@@ -316,7 +316,7 @@ defmodule Minga.Integration.AttachKeyframeTest do
   #   * closes with commit_frame whose frame_seq matches the begin
   #   * carries at least one full gui_window_content (full snapshot, no deltas)
   defp assert_keyframe_transaction!(commands) do
-    [<<@op_begin_frame, frame_seq::32, base_frame_seq::32>> | _] = commands
+    [<<@op_begin_frame, frame_seq::32, base_frame_seq::32, _generation::32>> | _] = commands
 
     assert base_frame_seq == 0,
            "attach handshake must produce a keyframe (base_frame_seq 0), got #{base_frame_seq}"

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -143,7 +143,11 @@ defmodule MingaEditor.Renderer.ServerTest do
   test "frontend reset snapshots keep their reset caches" do
     parent = self()
     renderer = start_renderer(parent, pipeline: cache_probe_pipeline(parent))
-    reset_snapshot = %{stub_snapshot() | caches: %Caches{last_emitted_frame_seq: 0}}
+
+    reset_snapshot = %{
+      stub_snapshot()
+      | caches: %Caches{last_emitted_frame_seq: 0, recovery_generation: 2}
+    }
 
     :sys.replace_state(renderer, fn state ->
       %{state | caches: %Caches{last_emitted_frame_seq: 11}}
@@ -157,21 +161,124 @@ defmodule MingaEditor.Renderer.ServerTest do
                    @async_render_timeout
   end
 
-  test "direct editor-emitted frame boundaries can advance beyond renderer caches" do
-    parent = self()
-    renderer = start_renderer(parent, pipeline: cache_probe_pipeline(parent))
-    boundary_advanced_snapshot = %{stub_snapshot() | caches: %Caches{last_emitted_frame_seq: 12}}
+  describe "frame acknowledgement credit" do
+    test "apply advances the base while duplicate, out-of-order, stale, and wrong-generation statuses do not" do
+      renderer = start_ack_renderer(self())
 
-    :sys.replace_state(renderer, fn state ->
-      %{state | caches: %Caches{last_emitted_frame_seq: 11}}
-    end)
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 10)
+      assert_receive {:ack_pipeline, 10, 1, 0, true}, @async_render_timeout
 
-    RendererServer.cast_snapshot(renderer, boundary_advanced_snapshot, 13)
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 11)
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 12)
 
-    assert_receive {:pipeline_input, 13, 12}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 2, 10})
+      RendererServer.frame_status(renderer, {:frame_applied, 1, 9})
+      RendererServer.frame_status(renderer, {:frame_rejected, 1, 10, 99, :base_sequence_mismatch})
+      assert RendererServer.acknowledgement_state(renderer) == {1, 0}
+      refute_receive {:ack_pipeline, _, _, _, _}, 50
 
-    assert_receive {:render_done, %{frame_seq: 13, caches: %Caches{last_emitted_frame_seq: 13}}},
-                   @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 1, 10})
+      assert_receive {:render_done, %{frame_seq: 10, keyframe?: true}}, @async_render_timeout
+      assert_receive {:ack_pipeline, 12, 1, 10, false}, @async_render_timeout
+      assert RendererServer.acknowledgement_state(renderer) == {1, 10}
+
+      RendererServer.frame_status(renderer, {:frame_applied, 1, 10})
+      RendererServer.frame_status(renderer, {:frame_rejected, 0, 12, 10, :base_sequence_mismatch})
+      assert RendererServer.acknowledgement_state(renderer) == {1, 10}
+      refute_receive {:render_done, %{frame_seq: 12}}, 50
+    end
+
+    test "rejected frame N renders only latest pending N+1 as a fresh-generation keyframe" do
+      renderer = start_ack_renderer(self())
+
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 20)
+      assert_receive {:ack_pipeline, 20, 1, 0, true}, @async_render_timeout
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 21)
+
+      RendererServer.frame_status(renderer, {:frame_rejected, 1, 20, 0, :base_sequence_mismatch})
+      assert_receive {:ack_pipeline, 21, 2, 0, true}, @async_render_timeout
+      assert RendererServer.acknowledgement_state(renderer) == {2, 0}
+      refute_receive {:ack_pipeline, _, 3, _, _}, 50
+      refute_receive {:render_done, %{frame_seq: 20}}, 50
+    end
+
+    test "manual retry returns the credit and advances recovery generation every time" do
+      renderer = start_ack_renderer(self())
+
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 30)
+      assert_receive {:ack_pipeline, 30, 1, 0, true}, @async_render_timeout
+
+      RendererServer.request_recovery(renderer)
+      assert_receive {:ack_pipeline, first_retry, 2, 0, true}, @async_render_timeout
+      assert RendererServer.acknowledgement_state(renderer) == {2, 0}
+
+      RendererServer.request_recovery(renderer)
+      assert_receive {:ack_pipeline, second_retry, 3, 0, true}, @async_render_timeout
+      assert second_retry > first_retry
+      assert RendererServer.acknowledgement_state(renderer) == {3, 0}
+    end
+
+    test "connection reset abandons outstanding credit and resumes from a base-zero keyframe" do
+      renderer = start_ack_renderer(self())
+
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 50)
+      assert_receive {:ack_pipeline, 50, 1, 0, true}, @async_render_timeout
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 51)
+
+      :ok = RendererServer.reset_connection(renderer, stub_snapshot(), 60)
+      assert_receive {:ack_pipeline, 60, 2, 0, true}, @async_render_timeout
+      refute_receive {:ack_pipeline, 51, _, _, _}, 50
+
+      RendererServer.frame_status(renderer, {:frame_applied, 1, 50})
+      assert RendererServer.acknowledgement_state(renderer) == {2, 0}
+      refute_receive {:render_done, %{frame_seq: 50}}, 50
+
+      RendererServer.frame_status(renderer, {:frame_applied, 2, 60})
+      assert_receive {:render_done, %{frame_seq: 60}}, @async_render_timeout
+
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 61)
+      assert_receive {:ack_pipeline, 61, 2, 60, false}, @async_render_timeout
+      assert RendererServer.acknowledgement_state(renderer) == {2, 60}
+    end
+
+    test "window ref miss keeps the acknowledged generation/base and invalidates only its window" do
+      renderer = start_ack_renderer(self(), pipeline: targeted_probe_pipeline(self()))
+      state = build_editor_state(:tui, nil)
+      snapshot = Input.from_editor_state(state)
+
+      RendererServer.cast_snapshot(renderer, snapshot, 40)
+      assert_receive {:targeted_pipeline, 40, 1, 0, true, [1]}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 1, 40})
+      assert_receive {:render_done, %{frame_seq: 40}}, @async_render_timeout
+
+      clean_snapshot =
+        snapshot
+        |> Map.update!(:caches, fn caches ->
+          %{caches | last_emitted_frame_seq: 40, last_acknowledged_frame_seq: 40}
+        end)
+        |> update_in(
+          [
+            Access.key!(:workspace),
+            Access.key!(:windows),
+            Access.key!(:map),
+            1,
+            Access.key!(:render_cache)
+          ],
+          fn cache ->
+            %{cache | dirty_lines: %{}, reset_pending: false}
+          end
+        )
+
+      RendererServer.cast_snapshot(renderer, clean_snapshot, 41)
+      assert_receive {:targeted_pipeline, 41, 1, 40, false, []}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:window_ref_miss, 1, 41, 40, 1})
+
+      assert_receive {:targeted_pipeline, targeted_retry, 1, 40, false, [1]},
+                     @async_render_timeout
+
+      assert targeted_retry > 41
+      assert RendererServer.acknowledgement_state(renderer) == {1, 40}
+    end
   end
 
   describe "render_or_async dispatch" do
@@ -211,6 +318,64 @@ defmodule MingaEditor.Renderer.ServerTest do
   defp start_renderer(editor_pid, opts \\ []) do
     opts = Keyword.merge([name: nil, editor_pid: editor_pid], opts)
     start_supervised!({RendererServer, opts})
+  end
+
+  defp start_ack_renderer(editor_pid, opts \\ []) do
+    pipeline = Keyword.get(opts, :pipeline, acknowledgement_probe_pipeline(editor_pid))
+    start_renderer(editor_pid, Keyword.merge(opts, pipeline: pipeline, require_ack?: true))
+  end
+
+  defp acknowledgement_probe_pipeline(parent) do
+    fn input ->
+      keyframe? = input.force_keyframe? or input.caches.last_acknowledged_frame_seq == 0
+
+      send(parent, {
+        :ack_pipeline,
+        input.frame_seq,
+        input.caches.recovery_generation,
+        input.caches.last_acknowledged_frame_seq,
+        keyframe?
+      })
+
+      %{
+        input
+        | caches: %{
+            input.caches
+            | last_emitted_frame_seq: input.frame_seq,
+              last_frame_keyframe?: keyframe?
+          }
+      }
+    end
+  end
+
+  defp targeted_probe_pipeline(parent) do
+    fn input ->
+      reset_windows =
+        input.workspace.windows.map
+        |> Enum.filter(fn {_id, window} -> window.render_cache.reset_pending end)
+        |> Enum.map(&elem(&1, 0))
+        |> Enum.sort()
+
+      keyframe? = input.force_keyframe? or input.caches.last_acknowledged_frame_seq == 0
+
+      send(parent, {
+        :targeted_pipeline,
+        input.frame_seq,
+        input.caches.recovery_generation,
+        input.caches.last_acknowledged_frame_seq,
+        keyframe?,
+        reset_windows
+      })
+
+      %{
+        input
+        | caches: %{
+            input.caches
+            | last_emitted_frame_seq: input.frame_seq,
+              last_frame_keyframe?: keyframe?
+          }
+      }
+    end
   end
 
   defp emit_commit_frame(input) do

--- a/zig/src/protocol.zig
+++ b/zig/src/protocol.zig
@@ -13,7 +13,7 @@
 /// Render commands (BEAM → frontend), transport survivors only. The
 /// cell-paradigm opcodes (draw_text, set_cursor, clear, region commands,
 /// draw_styled_text) were retired in protocol_version 2 with the Zig renderer:
-///   0x10 begin_frame:      frame_seq:u32, base_frame_seq:u32
+///   0x10 begin_frame:      frame_seq:u32, base_frame_seq:u32, generation:u32
 ///   0x11 commit_frame:     frame_seq:u32, input_seq:u32
 ///   0x15 set_cursor_shape: shape:u8
 ///
@@ -35,6 +35,9 @@ pub const OP_PASTE_EVENT = opcodes.OP_PASTE_EVENT;
 pub const OP_GUI_ACTION = opcodes.OP_GUI_ACTION;
 pub const OP_REQUEST_KEYFRAME = opcodes.OP_REQUEST_KEYFRAME;
 pub const OP_SCROLL_BATCH = opcodes.OP_SCROLL_BATCH;
+pub const OP_FRAME_APPLIED = opcodes.OP_FRAME_APPLIED;
+pub const OP_FRAME_REJECTED = opcodes.OP_FRAME_REJECTED;
+pub const OP_WINDOW_REF_MISS = opcodes.OP_WINDOW_REF_MISS;
 pub const OP_LOG_MESSAGE = opcodes.OP_LOG_MESSAGE;
 
 // Render
@@ -835,8 +838,14 @@ pub fn decodeCommand(data: []const u8) DecodeError!RenderCommand {
     const rest = data[1..];
 
     switch (opcode) {
-        OP_BEGIN_FRAME => return .begin_frame,
-        OP_COMMIT_FRAME => return .commit_frame,
+        OP_BEGIN_FRAME => {
+            if (rest.len < 12) return error.Malformed;
+            return .begin_frame;
+        },
+        OP_COMMIT_FRAME => {
+            if (rest.len < 8) return error.Malformed;
+            return .commit_frame;
+        },
         OP_SET_CURSOR_SHAPE => {
             if (rest.len < 1) return error.Malformed;
             switch (rest[0]) {
@@ -1095,7 +1104,7 @@ fn decodeStructuralNavAction(action: u8) !StructuralNavAction {
 /// each command.
 ///
 /// Fixed sizes:
-///   0x10 begin_frame:      9 bytes (opcode + frame_seq:4 + base_frame_seq:4)
+///   0x10 begin_frame:     13 bytes (opcode + frame_seq:4 + base_frame_seq:4 + generation:4)
 ///   0x11 commit_frame:     9 bytes (opcode + frame_seq:4 + input_seq:4)
 ///   0x15 set_cursor_shape: 2 bytes (opcode + shape:1)
 pub fn commandSize(payload: []const u8) usize {
@@ -1939,10 +1948,15 @@ test "encode and verify resize" {
     try std.testing.expectEqual(@as(u8, OP_RESIZE), buf[0]);
 }
 
-test "decode begin_frame command" {
-    const data = [_]u8{ OP_BEGIN_FRAME, 0, 0, 0, 7, 0, 0, 0, 0 };
+test "decode generation-aware begin_frame command" {
+    const data = [_]u8{ OP_BEGIN_FRAME, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 3 };
     const cmd = try decodeCommand(&data);
     try std.testing.expect(cmd == .begin_frame);
+}
+
+test "reject legacy truncated begin_frame command" {
+    const data = [_]u8{ OP_BEGIN_FRAME, 0, 0, 0, 7, 0, 0, 0, 0 };
+    try std.testing.expectError(error.Malformed, decodeCommand(&data));
 }
 
 test "decode commit_frame command" {
@@ -2369,9 +2383,9 @@ test "commandSize: commit_frame is 9 bytes when complete" {
     try std.testing.expectEqual(@as(usize, 9), commandSize(&data));
 }
 
-test "commandSize: begin_frame is 9 bytes when complete" {
-    const data = [_]u8{ OP_BEGIN_FRAME, 0, 0, 0, 7, 0, 0, 0, 0 };
-    try std.testing.expectEqual(@as(usize, 9), commandSize(&data));
+test "commandSize: generation-aware begin_frame is 13 bytes when complete" {
+    const data = [_]u8{ OP_BEGIN_FRAME, 0, 0, 0, 7, 0, 0, 0, 0, 0, 0, 0, 3 };
+    try std.testing.expectEqual(@as(usize, 13), commandSize(&data));
 }
 
 test "commandSize: fixed-size commands clamp to available payload" {
@@ -3540,8 +3554,8 @@ test "generated commandSize matches protocol.commandSize" {
 
 test "generated-sized unrendered opcode does not consume following command" {
     const cases = [_][]const u8{
-        &[_]u8{ opcodes.OP_GUI_INDENT_GUIDES, 0x00, 0x06, 1, 2, 3, 4, 5, 6, OP_COMMIT_FRAME },
-        &[_]u8{ 0xB7, 0x00, 0x02, 0xAA, 0xBB, OP_COMMIT_FRAME },
+        &[_]u8{ opcodes.OP_GUI_INDENT_GUIDES, 0x00, 0x06, 1, 2, 3, 4, 5, 6, OP_COMMIT_FRAME, 0, 0, 0, 1, 0, 0, 0, 0 },
+        &[_]u8{ 0xB7, 0x00, 0x02, 0xAA, 0xBB, OP_COMMIT_FRAME, 0, 0, 0, 1, 0, 0, 0, 0 },
     };
 
     for (cases) |packet| {


### PR DESCRIPTION
# TL;DR

Frontends now report whether each semantic frame was applied, rejected, or missed a window reference. The renderer grants one frame credit at a time, bases deltas only on the acknowledged frame in the current recovery generation, and recovers deterministically with latest-intent coalescing.

Closes #2739
Closes #2747

## Context

A successful Port write only proves that bytes entered the transport. It does not prove the frontend validated and committed the frame. Advancing delta state at write time allowed the BEAM and frontend to diverge indefinitely after a rejection or reference miss.

This PR builds on #2788’s atomic `PreparedFrameTransaction` boundary. Swift reports status from that boundary after semantic publication, not from the removed replay loop and not from Metal presentation.

## Changes

- Added recovery generations to frame transactions and bumped the generated protocol contract.
- Added typed `frame_applied`, `frame_rejected`, and `window_ref_miss` events across BEAM, Swift, Go, and Zig sizing/decoding.
- Made acknowledged current-generation state the only legal delta base.
- Added one in-flight frame credit with most-recent pending-intent replacement.
- Ignore stale, duplicate, out-of-order, wrong-generation, and inconsistent-last-applied statuses without returning credit or retriggering recovery.
- Make manual retry advance the recovery generation and force a base-zero keyframe.
- Recover a missed window with a targeted full replacement while preserving unrelated window and chrome state.
- Reset stranded credit on frontend reconnect and rehydrate the latest intent in a fresh generation.
- Removed the operator-pending frame-boundary bypass so every production frame participates in acknowledgement state.
- Keep synchronous/headless rendering bounded by treating its local return as the commit boundary.
- Updated the resync UI with generation and rejection progress.

## Verification

- `make lint.full`
- `mix test.llm` (9,869 tests, 0 failures)
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -configuration Debug test` (1,076 tests passed)
- `cd go/tui && go test ./...` (620 tests passed)
- `mix zig.lint`
- `mix protocol.gen --check`
- Focused acknowledgement, reconnect, retry, coalescing, router, and targeted-recovery tests

## Acceptance Criteria Addressed

- Swift and Go report applied status only after complete semantic commit. ✅
- Rejections and reference misses identify generation, frame, last applied frame, stable reason, and affected window where applicable. ✅
- The BEAM uses only acknowledged current-generation frames as delta bases. ✅
- Each frontend connection has one credit and one latest pending intent. ✅
- Invalid statuses cannot advance state or repeatedly trigger recovery. ✅
- Resync clears only after an applied requested base-zero keyframe; retry advances generation. ✅
- Window reference misses recover the affected window without globally resetting unrelated surfaces. ✅
- #2747’s prepared publication result now emits the wire status required to close that ticket. ✅
