### PR TITLE
feat(macos): gate native render latency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,9 @@ jobs:
       - name: Verify Release optimization
         run: scripts/check_macos_release_optimization
 
+      - name: Gate optimized native render preparation
+        run: scripts/check_render_performance
+
       - name: Build
         run: |
           cd macos

--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,0 +1,48 @@
+# Rendering performance gates
+
+The macOS renderer has two independent production gates: deterministic work-count gates (completed as their resident-rendering dependencies land) and an optimized native wall-clock gate. Wall-clock numbers diagnose native preparation; they do not replace deterministic complexity assertions.
+
+## Optimized native harness
+
+Run:
+
+```sh
+scripts/check_render_performance
+```
+
+The script always compiles `macos/Tests/Performance/main.swift` with `swiftc -O`. It warms the fixed `native-visible-v1` fixture for 200 iterations, measures 1,000 iterations, and prints p50/p95 for:
+
+- protocol-shaped decode plus semantic application;
+- visible-range command preparation;
+- the combined preparation path.
+
+The checked-in, versioned references are in `performance/baselines/macos_render_release.json`. Production policy is hard-coded in `RenderPerformanceGate`: each stage must be at or below **4.00 ms p95**, the combined path at or below **8.00 ms p95**, and each value at or below **1.20x** its reference. The JSON schema deliberately has no policy fields, so a baseline update cannot relax those ceilings. The comparator treats each exact boundary as passing and the next representable value as failing.
+
+The `native-visible-v1` references were calibrated on 2026-07-12 using the GitHub-hosted `macos-15` arm64 runner on macOS 15.7.7 (24G720), its default Xcode toolchain, and `swiftc -O`. After 200 warmups and 1,000 measured iterations, CI run `29176725578` reported p95 references of **0.762125 ms decode/apply**, **0.026 ms command preparation**, and **1.362917 ms combined**. Calibrating on the enforced CI environment makes the 20 percent regression policy meaningful where it runs, while the hard-coded 4 ms stage and 8 ms combined ceilings remain unchanged.
+
+Baseline changes are never generated in CI. A baseline change must include the explicit JSON diff plus provenance and a PR rationale naming the fixture/toolchain change and measurements that justify it. Unsupported schema versions or fixtures and non-finite/non-positive references or measurements fail closed.
+
+## Native latency milestones
+
+`LatencyRecorder` tracks these milestones separately:
+
+1. input received (`stamp`);
+2. frontend semantic state applied (`markApplied`);
+3. Metal command buffer submitted (`markSubmitted`);
+4. successful command-buffer completion after a drawable was scheduled (`markPresented`).
+
+GPU completion is the closest reliable native callback currently used; it is later and more honest than semantic apply, but is not a claim about photon timing. Screen-sleep, hidden, occluded, nil-drawable, superseded, scheduling-impossible, renderer-dropped, and GPU-failed samples are discarded with typed reasons. Hidden and occluded surfaces are rejected before drawable acquisition or presentation-sequence selection, so a retained occluded drawable cannot resolve as presented. The HUD labels `apply` and `present` separately. A frame acknowledgement updates apply only and cannot resolve presentation.
+
+## #2743 remaining integration ledger
+
+The following acceptance work is deliberately **not** implemented by this dependency-independent slice:
+
+- **AC 1:** production conformance corpus for sections larger than 65,535 bytes, the 65,536-line resident document, structural edits near row zero, reference misses, stale content epochs/generations, and reset recovery across BEAM/Swift/Go. This requires #2740 content epochs and #2741 resident storage.
+- **AC 2:** final deterministic ordinary-edit counters and limits: zero resets, exactly one ChangeLog consumption, at most eight lines fetched/composed, at most four Swift chunks touched, visible-plus-overscan rows visited, and separate decoration work. This requires #2741 and #2742.
+- **AC 3:** 256 KiB request/receipt assertions on the 65,536-line fixture. This requires the resident-store fixture and renderer-owned measurement points from #2741/#2742.
+- **AC 4:** replace the independent fixed benchmark fixture's semantic store/preparation operations with the final #2740-#2742 production resident decode/apply and renderer command-preparation path while retaining this harness, percentile, baseline, and comparator framework.
+- **AC 5:** add a distinct BEAM-frame-emitted timestamp if the cross-process protocol gains that milestone; this slice covers native receipt/apply/submission/completion and discard semantics.
+- **AC 6:** wire the final deterministic complexity and message-size gates after their counters and corpus exist. The optimized absolute/relative native gate is wired now.
+- **AC 7:** presentation labels and non-resolution from apply are complete; final overlay-specific consumption should be checked with #2735 when that work lands.
+
+Do not satisfy this ledger with placeholder counters, synthetic 65,536-row assertions, or stale-epoch fixtures that bypass the owning dependency implementations.

--- a/lib/mix/tasks/swift_harness.ex
+++ b/lib/mix/tasks/swift_harness.ex
@@ -28,6 +28,7 @@ defmodule Mix.Tasks.Swift.Harness do
     "macos/Sources/Renderer/WindowContent.swift",
     "macos/Sources/Protocol/AgentSurfaceTypes.swift",
     "macos/Sources/Protocol/LatencyRecorder.swift",
+    "macos/Sources/Protocol/RenderPerformanceGate.swift",
     "macos/Sources/Protocol/FrontendExtensionRuntimeMessage.swift"
   ]
 

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -142,6 +142,7 @@
 		78F06B9BFB553B50D9BDD50F /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		798E677ABC34C730785559B4 /* PickerStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EC9D6E3E77B85DF13841B4 /* PickerStateTests.swift */; };
 		79E8353F67F7638721A02A54 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
+		7A3FC2E0792930DDBA783042 /* RenderPerformanceGateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31E6BD3E6A84E3117BD3C7AF /* RenderPerformanceGateTests.swift */; };
 		7AFD153489353DC030087B75 /* NotificationCenterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44FF59E5F1800200A69FB8FB /* NotificationCenterView.swift */; };
 		7BA75B36E9A9573C57571C53 /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D118F59FBCA463A52B84FA /* AgentContextBar.swift */; };
 		7BCDF8E63FDADFCADFCA5276 /* ByteCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D220B640A214311083EE8B4 /* ByteCursorTests.swift */; };
@@ -190,6 +191,7 @@
 		A23A42248D022DE42E122D0B /* WorkspaceIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BD32DD25D2C6C5A90D898 /* WorkspaceIndicatorView.swift */; };
 		A29BB96B8F84AA489CBA0C5F /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
 		A30B81F2A7DAA0C2AEF54DB3 /* LiveResizeDebounceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63680361FC590F8BD01FE061 /* LiveResizeDebounceTests.swift */; };
+		A3B27DBFF9C2D200BEEE3B89 /* RenderPerformanceGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D563A97B0CB496D7906B53D /* RenderPerformanceGate.swift */; };
 		A409AE210CBAE48D4DCE47F7 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
 		A4329C17518FA82F5049A8EF /* PresentationScrollAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DADB6D964450D692B37217 /* PresentationScrollAnimatorTests.swift */; };
 		A4E838B0B19ED0B8F9CC4654 /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
@@ -424,6 +426,7 @@
 		1BA08D322A0BCE2491D4489D /* MessagesContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentView.swift; sourceTree = "<group>"; };
 		1BB45C5B630FDEDFD0BD6BE0 /* EditTimelineState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTimelineState.swift; sourceTree = "<group>"; };
 		1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewTests.swift; sourceTree = "<group>"; };
+		1D563A97B0CB496D7906B53D /* RenderPerformanceGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderPerformanceGate.swift; sourceTree = "<group>"; };
 		1E1059DF5F524F5FC2B697EC /* LatencyHUDOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyHUDOverlay.swift; sourceTree = "<group>"; };
 		1F2A06C5BA9E3F53A59E202F /* BEAMProcessManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BEAMProcessManagerTests.swift; sourceTree = "<group>"; };
 		202B9FAA0B926E0B23C0BA88 /* FileTreeState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeState.swift; sourceTree = "<group>"; };
@@ -439,6 +442,7 @@
 		2BAB83B99298DE01101D3C60 /* PreviewFixtures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewFixtures.swift; sourceTree = "<group>"; };
 		305F0E7D9158C236803224AA /* PreviewRegistry+FileTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreviewRegistry+FileTree.swift"; sourceTree = "<group>"; };
 		31DA375DF5D4047E01761926 /* AgentChatView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatView.swift; sourceTree = "<group>"; };
+		31E6BD3E6A84E3117BD3C7AF /* RenderPerformanceGateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderPerformanceGateTests.swift; sourceTree = "<group>"; };
 		321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineCacheTests.swift; sourceTree = "<group>"; };
 		371C61E78D4BB39467516BA7 /* SlotAllocator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SlotAllocator.swift; sourceTree = "<group>"; };
 		37AA0E8F5D7D411B92E9E3FA /* FloatPopupOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FloatPopupOverlay.swift; sourceTree = "<group>"; };
@@ -876,6 +880,7 @@
 				BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */,
 				4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */,
 				08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */,
+				1D563A97B0CB496D7906B53D /* RenderPerformanceGate.swift */,
 				8D450D75A36486FD84AD6BB8 /* StatusBarUpdate.swift */,
 			);
 			path = Protocol;
@@ -1033,6 +1038,7 @@
 				3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */,
 				F220A60775A252A728477659 /* ProtocolTests.swift */,
 				E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */,
+				31E6BD3E6A84E3117BD3C7AF /* RenderPerformanceGateTests.swift */,
 				211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */,
 				8E15F1EAA861D1AAC8832D56 /* ScrollSettleReconcileTests.swift */,
 				26C02007D4036FC9C7D0FB71 /* SettingsStateTests.swift */,
@@ -1439,6 +1445,7 @@
 				581390BB65F36B77E59F6D9F /* GUIColorSlots.swift in Sources */,
 				D394B6B62354CC4ADD76DB74 /* LatencyRecorder.swift in Sources */,
 				C2FC62BE435E26A8E579F8AD /* ProtocolTypes.swift in Sources */,
+				A3B27DBFF9C2D200BEEE3B89 /* RenderPerformanceGate.swift in Sources */,
 				1EE1BE95F948B359F08BC48A /* StatusBarUpdate.swift in Sources */,
 				2F0A0D75FA309989C48B32EF /* WindowContent.swift in Sources */,
 			);
@@ -1624,6 +1631,7 @@
 				686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */,
 				9C0676A96179F6068B85CCA1 /* RecoveryManager.swift in Sources */,
 				A9EE5F81AE818C176D03A6E3 /* RecoveryManagerTests.swift in Sources */,
+				7A3FC2E0792930DDBA783042 /* RenderPerformanceGateTests.swift in Sources */,
 				DCCC540FD702D8D37013173F /* ScrollAccumulator.swift in Sources */,
 				D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */,
 				AB445AD42EF996DC400DC5BF /* ScrollSettleReconcileTests.swift in Sources */,

--- a/macos/Sources/PreviewRegistry+Overlays.swift
+++ b/macos/Sources/PreviewRegistry+Overlays.swift
@@ -248,7 +248,12 @@ extension PreviewRegistry {
     static func latencyHUDPreview() -> some View {
         let theme = PreviewFixtures.theme()
         let state = LatencyHUDState(environment: ["MINGA_LATENCY_HUD": "1"])
-        state.stats = LatencyRecorder.Stats(count: 128, p50Micros: 812, p99Micros: 2450, maxMicros: 5100)
+        state.stats = LatencyRecorder.Stats(
+            apply: .init(count: 128, p50Micros: 812, p95Micros: 1_200),
+            present: .init(count: 120, p50Micros: 2_450, p95Micros: 5_100),
+            submittedCount: 120,
+            discardCounts: [.superseded: 8]
+        )
 
         return LatencyHUDOverlay(state: state)
             .frame(width: 520, height: 120)

--- a/macos/Sources/Protocol/LatencyRecorder.swift
+++ b/macos/Sources/Protocol/LatencyRecorder.swift
@@ -1,129 +1,205 @@
 import Foundation
 
-/// Records end-to-end keystroke-to-present latency for the macOS GUI (ticket
-/// #2215).
-///
-/// The renderer stamps a monotonically increasing correlation sequence into each
-/// key packet at input time (``stamp()``). The BEAM echoes that sequence back on
-/// the `commit_frame` of the resulting frame; the renderer resolves the sample when
-/// the frame is presented (``resolve(seq:)``). Samples live in a fixed-size ring
-/// buffer so the recorder never grows unbounded.
-///
-/// This is the minimal sample recorder for the GUI. The on-screen latency HUD is
-/// a deliberate follow-up (see the ticket report); the BEAM telemetry spans and
-/// the bench harness already capture the BEAM-side numbers, and this recorder
-/// makes the GUI keystroke-to-present sample available for a future overlay or
-/// log dump.
-public final class LatencyRecorder: @unchecked Sendable {
-    /// Bounds the in-flight stamps and recorded samples.
-    private let ringSize = 4096
+/// Pure preflight used before requesting a drawable or claiming a presentation sequence.
+public enum PresentationSamplePreflight {
+    /// Returns why a view cannot schedule a presentation sample, or nil when it may draw.
+    public static func discardReason(screenAsleep: Bool, hidden: Bool,
+                                     occluded: Bool) -> LatencyRecorder.DiscardReason? {
+        if screenAsleep { return .screenSleep }
+        if hidden { return .hidden }
+        if occluded { return .occluded }
+        return nil
+    }
+}
 
+/// Records honest native input latency milestones without treating semantic apply
+/// as presentation. Input sequences remain pending after apply until Metal submits
+/// and completes the matching drawable, or until an explicit discard reason wins.
+public final class LatencyRecorder: @unchecked Sendable {
+    private let ringSize = 4096
     private let lock = NSLock()
     private let now: () -> DispatchTime
 
-    private var nextSeq: UInt32 = 0
-    private var pending: [UInt32: DispatchTime] = [:]
-    private var pendingOrder: [UInt32] = []
-
-    private var samples: [Double]  // nanoseconds
-    private var head = 0
-    private var count = 0
-
-    public private(set) var resolvedCount: UInt64 = 0
-    public private(set) var droppedCount: UInt64 = 0
-
-    public init(now: @escaping () -> DispatchTime = { DispatchTime.now() }) {
-        self.now = now
-        self.samples = [Double](repeating: 0, count: ringSize)
+    private struct Pending {
+        let received: DispatchTime
+        var applied: DispatchTime?
+        var submitted: DispatchTime?
     }
 
-    /// Allocates the next correlation sequence and records the current time.
-    /// Sequences start at 1 so 0 stays the "no correlation" sentinel.
-    public func stamp() -> UInt32 {
-        lock.lock()
-        defer { lock.unlock() }
-
-        nextSeq &+= 1
-        if nextSeq == 0 { nextSeq = 1 }
-        let seq = nextSeq
-
-        pending[seq] = now()
-        pendingOrder.append(seq)
-        while pendingOrder.count > ringSize {
-            let oldest = pendingOrder.removeFirst()
-            if pending.removeValue(forKey: oldest) != nil {
-                droppedCount &+= 1
-            }
-        }
-        return seq
+    /// Stable reason that a pending presentation sample could not reach the display path.
+    public enum DiscardReason: String, CaseIterable, Sendable {
+        case screenSleep = "screen_sleep"
+        case hidden
+        case occluded
+        case nilDrawable = "nil_drawable"
+        case superseded
+        case schedulingImpossible = "scheduling_impossible"
+        case dropped
+        case gpuFailure = "gpu_failure"
     }
 
-    /// Resolves the elapsed time for a sequence echoed on a frame boundary.
-    /// Sequence 0 (no correlation) and unknown sequences are ignored; the BEAM
-    /// coalesces rapid keystrokes into one frame, so only the latest sequence in
-    /// a frame resolves and earlier ones fall out of `pending` naturally.
-    public func resolve(seq: UInt32) {
-        guard seq != 0 else { return }
-
-        lock.lock()
-        defer { lock.unlock() }
-
-        guard let stampedAt = pending.removeValue(forKey: seq) else { return }
-        if let index = pendingOrder.firstIndex(of: seq) {
-            pendingOrder.remove(at: index)
-        }
-
-        let elapsed = Double(now().uptimeNanoseconds &- stampedAt.uptimeNanoseconds)
-        samples[head] = elapsed
-        head = (head + 1) % ringSize
-        if count < ringSize { count += 1 }
-        resolvedCount &+= 1
-    }
-
-    /// Percentile statistics over the buffered samples, in microseconds.
-    public struct Stats: Equatable, Sendable {
+    /// Percentile summary for one latency milestone.
+    public struct StageStats: Equatable, Sendable {
+        /// Number of retained samples.
         public var count: Int = 0
+        /// Median latency in microseconds.
         public var p50Micros: Double = 0
+        /// P95 latency in microseconds.
+        public var p95Micros: Double = 0
+        /// P99 latency in microseconds.
         public var p99Micros: Double = 0
+        /// Maximum retained latency in microseconds.
         public var maxMicros: Double = 0
 
-        public init(count: Int = 0, p50Micros: Double = 0, p99Micros: Double = 0, maxMicros: Double = 0) {
+        /// Creates a stage summary from its count and percentile values.
+        public init(count: Int = 0, p50Micros: Double = 0, p95Micros: Double = 0,
+                    p99Micros: Double = 0, maxMicros: Double = 0) {
             self.count = count
             self.p50Micros = p50Micros
+            self.p95Micros = p95Micros
             self.p99Micros = p99Micros
             self.maxMicros = maxMicros
         }
     }
 
-    /// Returns percentile statistics over the buffered samples. Copies the live
-    /// window before sorting so the hot path never blocks on a sort of the
-    /// shared buffer.
+    /// Snapshot of apply, presentation, submission, and discard telemetry.
+    public struct Stats: Equatable, Sendable {
+        /// Semantic-apply latency summary.
+        public var apply: StageStats = StageStats()
+        /// GPU-completion presentation latency summary.
+        public var present: StageStats = StageStats()
+        /// Number of matching Metal command buffers submitted.
+        public var submittedCount: UInt64 = 0
+        /// Number of samples discarded for each stable reason.
+        public var discardCounts: [DiscardReason: UInt64] = [:]
+
+        /// Creates a complete recorder snapshot.
+        public init(apply: StageStats = StageStats(), present: StageStats = StageStats(),
+                    submittedCount: UInt64 = 0,
+                    discardCounts: [DiscardReason: UInt64] = [:]) {
+            self.apply = apply
+            self.present = present
+            self.submittedCount = submittedCount
+            self.discardCounts = discardCounts
+        }
+    }
+
+    private var nextSeq: UInt32 = 0
+    private var pending: [UInt32: Pending] = [:]
+    private var pendingOrder: [UInt32] = []
+    private var applySamples: [Double] = []
+    private var presentSamples: [Double] = []
+    private var submittedCount: UInt64 = 0
+    private var discardCounts: [DiscardReason: UInt64] = [:]
+
+    /// Creates a recorder using the supplied monotonic clock.
+    public init(now: @escaping () -> DispatchTime = { DispatchTime.now() }) {
+        self.now = now
+    }
+
+    /// Marks input receipt and returns a non-zero correlation sequence.
+    public func stamp() -> UInt32 {
+        lock.lock()
+        defer { lock.unlock() }
+        nextSeq &+= 1
+        if nextSeq == 0 { nextSeq = 1 }
+        let seq = nextSeq
+        pending[seq] = Pending(received: now())
+        pendingOrder.append(seq)
+        while pendingOrder.count > ringSize {
+            let oldest = pendingOrder.removeFirst()
+            if pending.removeValue(forKey: oldest) != nil {
+                discardCounts[.dropped, default: 0] &+= 1
+            }
+        }
+        return seq
+    }
+
+    /// Marks frontend semantic publication. This records apply latency but does
+    /// not resolve or remove the presentation sample.
+    public func markApplied(seq: UInt32) {
+        guard seq != 0 else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        guard var entry = pending[seq], entry.applied == nil else { return }
+        let applied = now()
+        entry.applied = applied
+        pending[seq] = entry
+        append(Double(applied.uptimeNanoseconds &- entry.received.uptimeNanoseconds), to: &applySamples)
+    }
+
+    /// Marks command-buffer submission for a semantically applied sequence.
+    public func markSubmitted(seq: UInt32) {
+        guard seq != 0 else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        guard var entry = pending[seq], entry.applied != nil, entry.submitted == nil else { return }
+        entry.submitted = now()
+        pending[seq] = entry
+        submittedCount &+= 1
+    }
+
+    /// Resolves presentation only after the submitted Metal command buffer
+    /// completes successfully. Apply acknowledgement alone never calls this.
+    public func markPresented(seq: UInt32) {
+        guard seq != 0 else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        guard let entry = pending[seq], entry.submitted != nil else { return }
+        _ = removePending(seq)
+        append(Double(now().uptimeNanoseconds &- entry.received.uptimeNanoseconds), to: &presentSamples)
+    }
+
+    /// Removes an unpresentable sample with a typed diagnostic reason.
+    public func discard(seq: UInt32, reason: DiscardReason) {
+        guard seq != 0 else { return }
+        lock.lock()
+        defer { lock.unlock() }
+        guard removePending(seq) != nil else { return }
+        discardCounts[reason, default: 0] &+= 1
+    }
+
+    /// Returns an immutable percentile and discard-count snapshot.
     public func snapshot() -> Stats {
         lock.lock()
-        var window = [Double]()
-        window.reserveCapacity(count)
-        for i in 0..<count {
-            let idx = (head - count + i + ringSize) % ringSize
-            window.append(samples[idx])
-        }
+        let apply = applySamples
+        let present = presentSamples
+        let submissions = submittedCount
+        let discards = discardCounts
         lock.unlock()
-
-        guard !window.isEmpty else { return Stats() }
-        window.sort()
         return Stats(
-            count: window.count,
-            p50Micros: percentile(window, 0.50) / 1000.0,
-            p99Micros: percentile(window, 0.99) / 1000.0,
-            maxMicros: (window.last ?? 0) / 1000.0
+            apply: stageStats(apply),
+            present: stageStats(present),
+            submittedCount: submissions,
+            discardCounts: discards
         )
     }
 
-    /// Nearest-rank percentile over a pre-sorted slice, matching the BEAM bench.
+    private func removePending(_ seq: UInt32) -> Pending? {
+        guard let entry = pending.removeValue(forKey: seq) else { return nil }
+        if let index = pendingOrder.firstIndex(of: seq) { pendingOrder.remove(at: index) }
+        return entry
+    }
+
+    private func append(_ sample: Double, to samples: inout [Double]) {
+        if samples.count == ringSize { samples.removeFirst() }
+        samples.append(sample)
+    }
+
+    private func stageStats(_ samples: [Double]) -> StageStats {
+        guard !samples.isEmpty else { return StageStats() }
+        let sorted = samples.sorted()
+        return StageStats(
+            count: sorted.count,
+            p50Micros: percentile(sorted, 0.50) / 1000.0,
+            p95Micros: percentile(sorted, 0.95) / 1000.0,
+            p99Micros: percentile(sorted, 0.99) / 1000.0,
+            maxMicros: (sorted.last ?? 0) / 1000.0
+        )
+    }
+
     private func percentile(_ sorted: [Double], _ ratio: Double) -> Double {
         guard !sorted.isEmpty else { return 0 }
-        var index = Int((Double(sorted.count) * ratio).rounded(.up)) - 1
-        if index < 0 { index = 0 }
-        if index >= sorted.count { index = sorted.count - 1 }
-        return sorted[index]
+        return sorted[min(max(Int((Double(sorted.count) * ratio).rounded(.up)) - 1, 0), sorted.count - 1)]
     }
 }

--- a/macos/Sources/Protocol/RenderPerformanceGate.swift
+++ b/macos/Sources/Protocol/RenderPerformanceGate.swift
@@ -1,0 +1,150 @@
+import Foundation
+
+/// Provenance for a checked-in optimized-harness calibration.
+public struct RenderPerformanceProvenance: Codable, Equatable, Sendable {
+    /// Date when the calibration was recorded.
+    public let measuredAt: String
+    /// Hardware and operating-system description for the calibration host.
+    public let environment: String
+    /// Optimized compiler and toolchain description.
+    public let toolchain: String
+    /// Human-reviewed reason for the baseline update.
+    public let rationale: String
+
+    /// Creates provenance for one checked-in optimized-harness calibration.
+    public init(measuredAt: String, environment: String, toolchain: String, rationale: String) {
+        self.measuredAt = measuredAt
+        self.environment = environment
+        self.toolchain = toolchain
+        self.rationale = rationale
+    }
+}
+
+/// Versioned p95 references for the optimized native harness.
+///
+/// Policy ceilings intentionally do not belong to this schema. A baseline update
+/// can recalibrate relative references, but cannot relax production policy.
+public struct RenderPerformanceBaseline: Codable, Equatable, Sendable {
+    /// Baseline schema version.
+    public let version: Int
+    /// Fixed benchmark fixture identity.
+    public let fixtureVersion: String
+    /// Reference p95 for decode plus semantic apply.
+    public let decodeApplyP95Ms: Double
+    /// Reference p95 for visible-range command preparation.
+    public let commandPreparationP95Ms: Double
+    /// Reference p95 for the combined native preparation path.
+    public let combinedP95Ms: Double
+    /// Calibration provenance reviewed with the baseline diff.
+    public let provenance: RenderPerformanceProvenance
+
+    /// Creates one versioned set of measured p95 references.
+    public init(version: Int, fixtureVersion: String, decodeApplyP95Ms: Double,
+                commandPreparationP95Ms: Double, combinedP95Ms: Double,
+                provenance: RenderPerformanceProvenance) {
+        self.version = version
+        self.fixtureVersion = fixtureVersion
+        self.decodeApplyP95Ms = decodeApplyP95Ms
+        self.commandPreparationP95Ms = commandPreparationP95Ms
+        self.combinedP95Ms = combinedP95Ms
+        self.provenance = provenance
+    }
+}
+
+/// Percentile measurements emitted by one optimized native harness run.
+public struct RenderPerformanceMeasurement: Codable, Equatable, Sendable {
+    /// Median decode plus semantic-apply duration.
+    public let decodeApplyP50Ms: Double
+    /// P95 decode plus semantic-apply duration.
+    public let decodeApplyP95Ms: Double
+    /// Median visible-range command-preparation duration.
+    public let commandPreparationP50Ms: Double
+    /// P95 visible-range command-preparation duration.
+    public let commandPreparationP95Ms: Double
+    /// Median combined native-preparation duration.
+    public let combinedP50Ms: Double
+    /// P95 combined native-preparation duration.
+    public let combinedP95Ms: Double
+
+    /// Creates the stage and combined percentile measurements for one run.
+    public init(decodeApplyP50Ms: Double, decodeApplyP95Ms: Double,
+                commandPreparationP50Ms: Double, commandPreparationP95Ms: Double,
+                combinedP50Ms: Double, combinedP95Ms: Double) {
+        self.decodeApplyP50Ms = decodeApplyP50Ms
+        self.decodeApplyP95Ms = decodeApplyP95Ms
+        self.commandPreparationP50Ms = commandPreparationP50Ms
+        self.commandPreparationP95Ms = commandPreparationP95Ms
+        self.combinedP50Ms = combinedP50Ms
+        self.combinedP95Ms = combinedP95Ms
+    }
+}
+
+/// Fail-closed production policy for optimized native rendering measurements.
+public enum RenderPerformanceGate {
+    /// Baseline schema version accepted by the gate.
+    public static let supportedBaselineVersion = 1
+    /// Fixture identity accepted by the gate.
+    public static let supportedFixtureVersion = "native-visible-v1"
+    /// Absolute p95 ceiling for each measured stage.
+    public static let stageAbsoluteBudgetMs = 4.0
+    /// Absolute p95 ceiling for the combined native preparation path.
+    public static let combinedAbsoluteBudgetMs = 8.0
+    /// Largest allowed ratio between a measurement and its checked-in reference.
+    public static let maximumRegressionRatio = 1.20
+
+    /// Returns every policy or baseline validation failure for one measurement.
+    public static func failures(measurement: RenderPerformanceMeasurement,
+                                baseline: RenderPerformanceBaseline) -> [String] {
+        var failures = validationFailures(measurement: measurement, baseline: baseline)
+        guard failures.isEmpty else { return failures }
+
+        check("decode_apply", measurement.decodeApplyP95Ms, baseline.decodeApplyP95Ms,
+              stageAbsoluteBudgetMs, &failures)
+        check("command_preparation", measurement.commandPreparationP95Ms,
+              baseline.commandPreparationP95Ms, stageAbsoluteBudgetMs, &failures)
+        check("combined", measurement.combinedP95Ms, baseline.combinedP95Ms,
+              combinedAbsoluteBudgetMs, &failures)
+        return failures
+    }
+
+    private static func validationFailures(measurement: RenderPerformanceMeasurement,
+                                           baseline: RenderPerformanceBaseline) -> [String] {
+        var failures: [String] = []
+        if baseline.version != supportedBaselineVersion {
+            failures.append("unsupported baseline version \(baseline.version); expected \(supportedBaselineVersion)")
+        }
+        if baseline.fixtureVersion != supportedFixtureVersion {
+            failures.append("unsupported fixture \(baseline.fixtureVersion); expected \(supportedFixtureVersion)")
+        }
+
+        validate("baseline decode_apply p95", baseline.decodeApplyP95Ms, &failures)
+        validate("baseline command_preparation p95", baseline.commandPreparationP95Ms, &failures)
+        validate("baseline combined p95", baseline.combinedP95Ms, &failures)
+        validate("measurement decode_apply p50", measurement.decodeApplyP50Ms, &failures)
+        validate("measurement decode_apply p95", measurement.decodeApplyP95Ms, &failures)
+        validate("measurement command_preparation p50", measurement.commandPreparationP50Ms, &failures)
+        validate("measurement command_preparation p95", measurement.commandPreparationP95Ms, &failures)
+        validate("measurement combined p50", measurement.combinedP50Ms, &failures)
+        validate("measurement combined p95", measurement.combinedP95Ms, &failures)
+        return failures
+    }
+
+    private static func validate(_ name: String, _ value: Double, _ failures: inout [String]) {
+        if !value.isFinite || value <= 0 {
+            failures.append("\(name) must be finite and greater than zero")
+        }
+    }
+
+    private static func check(_ stage: String, _ measured: Double, _ baseline: Double,
+                              _ absolute: Double, _ failures: inout [String]) {
+        if measured > absolute {
+            failures.append("\(stage) p95 \(format(measured))ms exceeds absolute \(format(absolute))ms")
+        }
+        let relative = baseline * maximumRegressionRatio
+        if measured > relative {
+            failures.append("\(stage) p95 \(format(measured))ms exceeds \(format(maximumRegressionRatio))x baseline \(format(relative))ms")
+        }
+    }
+
+    private static func format(_ value: Double) -> String { String(format: "%.2f", value) }
+}

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -116,10 +116,26 @@ final class CommandDispatcher {
     /// Non-optional: forgetting to wire this is a compile-time error.
     let guiState: GUIState
 
-    /// Records end-to-end keystroke-to-present latency (ticket #2215). The input
-    /// path stamps a correlation sequence into each key packet; this dispatcher
-    /// resolves the sample when the echoed sequence arrives on `commit_frame`.
+    /// Records input-to-apply and input-to-presentation as separate milestones.
+    /// A committed transaction marks apply only; Metal owns submission/completion.
     let latency = LatencyRecorder()
+
+    /// Input sequence attached to the newest applied frame awaiting a draw.
+    private var pendingPresentationInputSeq: UInt32 = 0
+
+    /// Claims the newest applied input sequence for one Metal submission.
+    func takePresentationInputSeq() -> UInt32 {
+        let seq = pendingPresentationInputSeq
+        pendingPresentationInputSeq = 0
+        return seq
+    }
+
+    /// Discards an applied frame that cannot acquire a drawable/presentation path.
+    func discardPendingPresentation(reason: LatencyRecorder.DiscardReason) {
+        guard pendingPresentationInputSeq != 0 else { return }
+        latency.discard(seq: pendingPresentationInputSeq, reason: reason)
+        pendingPresentationInputSeq = 0
+    }
 
     /// Window ids that arrived in the current frame batch. Used for input hit testing so stale
     /// retained pane geometry can still render without being clickable.
@@ -357,8 +373,12 @@ final class CommandDispatcher {
         openFrameSeq = nil
         self.transactionBuilder = nil
 
-        os_signpost(.event, log: renderLog, name: "CommitFrame", "frame=%{public}u input=%{public}u", frameSeq, inputSeq)
-        latency.resolve(seq: inputSeq)
+        os_signpost(.event, log: renderLog, name: "SemanticApply", "frame=%{public}u input=%{public}u", frameSeq, inputSeq)
+        if pendingPresentationInputSeq != 0, pendingPresentationInputSeq != inputSeq {
+            latency.discard(seq: pendingPresentationInputSeq, reason: .superseded)
+        }
+        latency.markApplied(seq: inputSeq)
+        pendingPresentationInputSeq = inputSeq
         onTransactionResult?(.applied(generation: openGeneration, frameSeq: frameSeq))
         if let firstRender = onFirstRender {
             firstRender()

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -375,7 +375,9 @@ final class CoreTextMetalRenderer {
                 gutterHoverRow: UInt16? = nil,
                 drawable: CAMetalDrawable, viewportSize: CGSize,
                 contentScale: Float, scrollOffset: SIMD2<Float> = .zero,
-                presentationWindowId: UInt16? = nil) {
+                presentationWindowId: UInt16? = nil,
+                presentationInputSeq: UInt32 = 0,
+                latencyRecorder: LatencyRecorder? = nil) {
         // The window that owns the current presentation scroll offset. During a live gesture this
         // is the gesture target; during a settle / spring-back / discrete ease the gesture target
         // is already nil, so the view resolves this from the settle/elastic window instead. The
@@ -797,7 +799,10 @@ final class CoreTextMetalRenderer {
         renderDesc.colorAttachments[0].clearColor = clearColor
 
         guard let cmdBuf = commandQueue.makeCommandBuffer(),
-              let encoder = cmdBuf.makeRenderCommandEncoder(descriptor: renderDesc) else { return }
+              let encoder = cmdBuf.makeRenderCommandEncoder(descriptor: renderDesc) else {
+            latencyRecorder?.discard(seq: presentationInputSeq, reason: .schedulingImpossible)
+            return
+        }
 
         // Triple-buffered quad uploads: wait until a quad buffer is free (at most
         // `quadBufferFrameCount` frames in flight), then rotate to it and reset
@@ -1249,6 +1254,15 @@ final class CoreTextMetalRenderer {
         let quadFrameSemaphore = self.quadFrameSemaphore
         cmdBuf.addCompletedHandler { completedBuffer in
             quadFrameSemaphore.signal()
+            if completedBuffer.status == .completed {
+                latencyRecorder?.markPresented(seq: presentationInputSeq)
+                os_signpost(.event, log: renderLog, name: "PresentationComplete", signpostID: renderSignpostID,
+                            "input=%{public}u", presentationInputSeq)
+            } else {
+                latencyRecorder?.discard(seq: presentationInputSeq, reason: .gpuFailure)
+                os_signpost(.event, log: renderLog, name: "PresentationDropped", signpostID: renderSignpostID,
+                            "input=%{public}u status=%{public}d", presentationInputSeq, completedBuffer.status.rawValue)
+            }
             let completionLatencyMs = (CACurrentMediaTime() - commitTime) * 1000.0
             let gpuStart = completedBuffer.gpuStartTime
             let gpuEnd = completedBuffer.gpuEndTime
@@ -1259,6 +1273,9 @@ final class CoreTextMetalRenderer {
                 os_signpost(.event, log: renderLog, name: "GPU Timing", signpostID: renderSignpostID, "gpu_ms=%{public}.3f commit_to_complete_ms=%{public}.3f", 0.0, completionLatencyMs)
             }
         }
+        latencyRecorder?.markSubmitted(seq: presentationInputSeq)
+        os_signpost(.event, log: renderLog, name: "MetalSubmit", signpostID: renderSignpostID,
+                    "input=%{public}u", presentationInputSeq)
         cmdBuf.commit()
     }
 

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -254,6 +254,7 @@ final class EditorNSView: MTKView {
 
     /// Cleans up window-bound observers and monitors.
     private func cleanupWindowResources() {
+        dispatcher.discardPendingPresentation(reason: .hidden)
         cleanupBlinkResources()
         cancelThumbDragWithFlush()
         resetSmoothScrollState()
@@ -337,6 +338,7 @@ final class EditorNSView: MTKView {
     /// Pauses Metal rendering and cursor blinking while the screens are asleep.
     func pauseForScreenSleep() {
         isScreenAsleep = true
+        dispatcher.discardPendingPresentation(reason: .screenSleep)
         blinkTask?.cancel()
         cursorBlinkVisible = true
     }
@@ -498,8 +500,16 @@ final class EditorNSView: MTKView {
 
     /// Called by MTKView's display link at vsync when needsDisplay is true.
     override func draw(_ dirtyRect: NSRect) {
-        guard !isScreenAsleep else { return }
-        guard let drawable = currentDrawable else { return }
+        // Fail before currentDrawable can vend a retained surface and before an input
+        // sequence is claimed. In particular, an occluded drawable is not presentation.
+        if let reason = presentationPreflightDiscardReason() {
+            dispatcher.discardPendingPresentation(reason: reason)
+            return
+        }
+        guard let drawable = currentDrawable else {
+            dispatcher.discardPendingPresentation(reason: .nilDrawable)
+            return
+        }
         let scale = Float(window?.backingScaleFactor ?? 2.0)
 
         // Check for cursor movement to post accessibility notifications.
@@ -531,6 +541,7 @@ final class EditorNSView: MTKView {
         let validGutterHoverRow = validGutterHoverWindowId == nil ? nil : gutterHoverRow
         let validMouseInGutter = isMouseInGutter && validGutterHoverWindowId != nil
         let cursorAnimationGeneration = coreTextRenderer.cursorAnimationGeneration
+        let presentationInputSeq = dispatcher.takePresentationInputSeq()
         coreTextRenderer.render(frameState: fs, fontManager: fontManager,
                                 cursorBlinkVisible: cursorBlinkVisible,
                                 windowContents: guiState?.windowContents ?? [:],
@@ -541,7 +552,9 @@ final class EditorNSView: MTKView {
                                 drawable: drawable, viewportSize: drawableSize,
                                 contentScale: scale,
                                 scrollOffset: SIMD2<Float>(Float(scrollPixelOffset.x), Float(scrollPixelOffset.y + scrollElasticOffsetY)),
-                                presentationWindowId: presentationScrollWindowId)
+                                presentationWindowId: presentationScrollWindowId,
+                                presentationInputSeq: presentationInputSeq,
+                                latencyRecorder: dispatcher.latency)
         if coreTextRenderer.cursorAnimationGeneration != cursorAnimationGeneration {
             resetCursorBlink()
         }
@@ -646,6 +659,11 @@ final class EditorNSView: MTKView {
         displayConfigurationChanged(newScale: window.backingScaleFactor)
     }
 
+    override func viewDidHide() {
+        super.viewDidHide()
+        dispatcher.discardPendingPresentation(reason: .hidden)
+    }
+
     /// Applies a live display configuration update to the Metal surface.
     func displayConfigurationChanged(newScale: CGFloat, forceResizeEvent: Bool = false, sendDimensions: Bool = true) {
         updateMetalBackingScale(newScale)
@@ -729,6 +747,18 @@ final class EditorNSView: MTKView {
             name: NSWindow.didExitFullScreenNotification,
             object: window
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowPresentationAvailabilityDidChange),
+            name: NSWindow.didChangeOcclusionStateNotification,
+            object: window
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(windowPresentationAvailabilityDidChange),
+            name: NSWindow.didMiniaturizeNotification,
+            object: window
+        )
         onFullScreenChanged?(window.styleMask.contains(.fullScreen))
 
         firstResponderGuard = FirstResponderGuard(window: window, editorView: self)
@@ -755,6 +785,16 @@ final class EditorNSView: MTKView {
         NotificationCenter.default.removeObserver(
             self,
             name: NSWindow.didExitFullScreenNotification,
+            object: observedWindow
+        )
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.didChangeOcclusionStateNotification,
+            object: observedWindow
+        )
+        NotificationCenter.default.removeObserver(
+            self,
+            name: NSWindow.didMiniaturizeNotification,
             object: observedWindow
         )
         onFullScreenChanged?(false)
@@ -800,6 +840,20 @@ final class EditorNSView: MTKView {
         // Control): no mouseUp is guaranteed, so discard the drag with its final target flushed
         // rather than leave the reconcile gate stuck open (Critical 1b / Critical 2, policy b).
         cancelThumbDragWithFlush()
+    }
+
+    @objc private func windowPresentationAvailabilityDidChange(_ notification: Notification) {
+        if let reason = presentationPreflightDiscardReason() {
+            dispatcher.discardPendingPresentation(reason: reason)
+        }
+    }
+
+    private func presentationPreflightDiscardReason() -> LatencyRecorder.DiscardReason? {
+        let hidden = isHiddenOrHasHiddenAncestor || window?.isVisible == false || window?.isMiniaturized == true
+        let occluded = window.map { !$0.occlusionState.contains(.visible) } ?? false
+        return PresentationSamplePreflight.discardReason(
+            screenAsleep: isScreenAsleep, hidden: hidden, occluded: occluded
+        )
     }
 
     override func becomeFirstResponder() -> Bool {

--- a/macos/Sources/Views/Overlays/LatencyHUDState.swift
+++ b/macos/Sources/Views/Overlays/LatencyHUDState.swift
@@ -1,13 +1,7 @@
-/// Observable state for the on-screen keystroke-to-present latency HUD (ticket
-/// #2215).
+/// Observable state for honest native input latency milestones.
 ///
-/// The macOS GUI's `LatencyRecorder` (owned by `CommandDispatcher`) records
-/// keystroke-to-present samples: the input path stamps a correlation sequence
-/// into each key packet, and `commit_frame` resolves the sample when the frame is
-/// presented. This state object is the client-local, ephemeral display layer for
-/// those numbers, mirroring the Go TUI's HUD: it shows live p50/p99/max and the
-/// sample count, refreshed on a coarse timer so reading the recorder never
-/// happens inside the measured critical sections.
+/// Semantic apply and Metal completion/presentation are displayed separately;
+/// a frame acknowledgement can update apply statistics but never presentation.
 ///
 /// `visible` is enabled at boot when `MINGA_LATENCY_HUD=1` and toggled at runtime
 /// from the View menu (cmd-ctrl-l). This is a frontend-local debug surface in the
@@ -127,23 +121,20 @@ public struct LatencyHUDModel: Sendable, Equatable {
     }
     public let stats: LatencyRecorder.Stats
 
-    /// True when there are no resolved samples yet.
-    public var isEmpty: Bool { stats.count == 0 }
+    /// True when neither milestone has samples yet.
+    public var isEmpty: Bool { stats.apply.count == 0 && stats.present.count == 0 }
 
-    /// p50 formatted as a duration string (e.g. `812µs`, `1.20ms`).
-    public var p50: String { LatencyHUDModel.formatMicros(stats.p50Micros) }
-    /// p99 formatted as a duration string.
-    public var p99: String { LatencyHUDModel.formatMicros(stats.p99Micros) }
-    /// max formatted as a duration string.
-    public var max: String { LatencyHUDModel.formatMicros(stats.maxMicros) }
-    /// Resolved sample count backing the percentiles.
-    public var sampleCount: Int { stats.count }
-
-    /// One-line badge text, matching the Go HUD layout. Shows a placeholder until
-    /// the first sample resolves.
     public var line: String {
-        guard !isEmpty else { return "lat: (no samples)" }
-        return "lat p50 \(p50)  p99 \(p99)  max \(max)  n=\(sampleCount)"
+        guard !isEmpty else { return "lat: (no apply/present samples)" }
+        let apply = stageLine(label: "apply", stats: stats.apply)
+        let present = stageLine(label: "present", stats: stats.present)
+        let discarded = stats.discardCounts.values.reduce(0, +)
+        return "\(apply)  \(present)  discarded=\(discarded)"
+    }
+
+    private func stageLine(label: String, stats: LatencyRecorder.StageStats) -> String {
+        guard stats.count > 0 else { return "\(label) —" }
+        return "\(label) p50 \(Self.formatMicros(stats.p50Micros)) p95 \(Self.formatMicros(stats.p95Micros)) n=\(stats.count)"
     }
 
     /// Formats a microsecond value as `µs` below 1ms and `ms` at or above, with

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -2266,3 +2266,45 @@ private func wireFileTreeEntry(
         editingText: editingText
     )
 }
+
+@Suite("CommandDispatcher presentation samples")
+struct CommandDispatcherPresentationSampleTests {
+    @MainActor
+    private func makeDispatcher() -> CommandDispatcher {
+        CommandDispatcher(cols: 80, rows: 24, guiState: GUIState())
+    }
+
+    @MainActor
+    private func commit(_ dispatcher: CommandDispatcher, frameSeq: UInt32,
+                        baseFrameSeq: UInt32, inputSeq: UInt32) {
+        dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: 1))
+        if frameSeq == 1 {
+            dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        }
+        dispatcher.dispatch(.commitFrame(frameSeq: frameSeq, seq: inputSeq))
+    }
+
+    @Test("a newer semantic frame discards the unsubmitted sample as superseded")
+    @MainActor func supersededSampleIsDiscarded() {
+        let dispatcher = makeDispatcher()
+        let first = dispatcher.latency.stamp()
+        commit(dispatcher, frameSeq: 1, baseFrameSeq: 0, inputSeq: first)
+        let second = dispatcher.latency.stamp()
+        commit(dispatcher, frameSeq: 2, baseFrameSeq: 1, inputSeq: second)
+
+        #expect(dispatcher.latency.snapshot().discardCounts[.superseded] == 1)
+        #expect(dispatcher.takePresentationInputSeq() == second)
+    }
+
+    @Test("an unavailable surface discards rather than selects the pending sample")
+    @MainActor func unavailableSurfaceDiscardsPendingSample() {
+        let dispatcher = makeDispatcher()
+        let seq = dispatcher.latency.stamp()
+        commit(dispatcher, frameSeq: 1, baseFrameSeq: 0, inputSeq: seq)
+
+        dispatcher.discardPendingPresentation(reason: .occluded)
+
+        #expect(dispatcher.takePresentationInputSeq() == 0)
+        #expect(dispatcher.latency.snapshot().discardCounts[.occluded] == 1)
+    }
+}

--- a/macos/Tests/MingaTests/LatencyHUDStateTests.swift
+++ b/macos/Tests/MingaTests/LatencyHUDStateTests.swift
@@ -16,8 +16,7 @@ struct LatencyHUDStateTests {
     func emptyPlaceholder() {
         let model = LatencyHUDModel(stats: LatencyRecorder.Stats())
         #expect(model.isEmpty)
-        #expect(model.sampleCount == 0)
-        #expect(model.line == "lat: (no samples)")
+        #expect(model.line == "lat: (no apply/present samples)")
     }
 
     @Test("sub-millisecond values format as microseconds")
@@ -38,14 +37,15 @@ struct LatencyHUDStateTests {
 
     @Test("populated stats render the full badge line")
     func populatedLine() {
-        let stats = LatencyRecorder.Stats(count: 128, p50Micros: 812, p99Micros: 2450, maxMicros: 5100)
+        let stats = LatencyRecorder.Stats(
+            apply: .init(count: 128, p50Micros: 812, p95Micros: 1_200),
+            present: .init(count: 120, p50Micros: 2_450, p95Micros: 5_100),
+            submittedCount: 120,
+            discardCounts: [.superseded: 8]
+        )
         let model = LatencyHUDModel(stats: stats)
         #expect(!model.isEmpty)
-        #expect(model.p50 == "812µs")
-        #expect(model.p99 == "2.45ms")
-        #expect(model.max == "5.10ms")
-        #expect(model.sampleCount == 128)
-        #expect(model.line == "lat p50 812µs  p99 2.45ms  max 5.10ms  n=128")
+        #expect(model.line == "apply p50 812µs p95 1.20ms n=128  present p50 2.45ms p95 5.10ms n=120  discarded=8")
     }
 
     // MARK: - Boot visibility (MINGA_LATENCY_HUD)
@@ -90,15 +90,17 @@ struct LatencyHUDStateTests {
     func connectRefreshesWhenVisible() {
         let recorder = LatencyRecorder()
         let seq = recorder.stamp()
-        recorder.resolve(seq: seq)
+        recorder.markApplied(seq: seq)
+        recorder.markSubmitted(seq: seq)
+        recorder.markPresented(seq: seq)
 
         let state = LatencyHUDState(
             environment: ["MINGA_LATENCY_HUD": "1"],
             refreshInterval: .seconds(60)
         )
-        #expect(state.stats.count == 0)
+        #expect(state.stats.present.count == 0)
         state.connect { recorder.snapshot() }
-        #expect(state.stats.count == 1)
+        #expect(state.stats.present.count == 1)
     }
 
     @MainActor
@@ -110,9 +112,11 @@ struct LatencyHUDStateTests {
         #expect(state.model.isEmpty)
 
         let seq = recorder.stamp()
-        recorder.resolve(seq: seq)
+        recorder.markApplied(seq: seq)
+        recorder.markSubmitted(seq: seq)
+        recorder.markPresented(seq: seq)
         state.refresh()
-        #expect(state.stats.count == 1)
+        #expect(state.stats.present.count == 1)
         #expect(!state.model.isEmpty)
     }
 }

--- a/macos/Tests/MingaTests/LatencyRecorderTests.swift
+++ b/macos/Tests/MingaTests/LatencyRecorderTests.swift
@@ -2,65 +2,105 @@ import MingaProtocol
 import Foundation
 import Testing
 
-@testable import Minga
-
-/// Verifies the GUI latency recorder (ticket #2215): stamping, resolution, and
-/// percentile statistics over a controllable clock.
 @Suite("Latency Recorder")
 struct LatencyRecorderTests {
-    /// A controllable clock backing DispatchTime so durations are exact.
     private final class Clock: @unchecked Sendable {
         private let lock = NSLock()
         private var nanos: UInt64
-        init(start: UInt64 = 1_000_000_000) { self.nanos = start }
-        func advance(_ d: UInt64) { lock.lock(); nanos &+= d; lock.unlock() }
+        init(start: UInt64 = 1_000_000_000) { nanos = start }
+        func advance(_ duration: UInt64) { lock.lock(); nanos &+= duration; lock.unlock() }
         func now() -> DispatchTime { lock.lock(); defer { lock.unlock() }; return DispatchTime(uptimeNanoseconds: nanos) }
     }
 
-    @Test("stamp returns monotonic non-zero sequences")
-    func stampMonotonic() {
-        let r = LatencyRecorder()
-        let a = r.stamp()
-        let b = r.stamp()
-        #expect(a != 0)
-        #expect(b == a + 1)
-    }
-
-    @Test("resolve records elapsed duration")
-    func resolveRecords() {
+    @Test("semantic apply records apply but does not resolve presentation")
+    func applyIsNotPresentation() {
         let clock = Clock()
-        let r = LatencyRecorder(now: clock.now)
-        let seq = r.stamp()
-        clock.advance(750_000) // 750µs
-        r.resolve(seq: seq)
+        let recorder = LatencyRecorder(now: clock.now)
+        let seq = recorder.stamp()
+        clock.advance(750_000)
+        recorder.markApplied(seq: seq)
 
-        let stats = r.snapshot()
-        #expect(stats.count == 1)
-        #expect(abs(stats.p50Micros - 750.0) < 0.001)
-        #expect(r.resolvedCount == 1)
+        let stats = recorder.snapshot()
+        #expect(stats.apply.count == 1)
+        #expect(stats.apply.p50Micros == 750)
+        #expect(stats.present.count == 0)
+        #expect(stats.submittedCount == 0)
     }
 
-    @Test("resolve ignores zero and unknown sequences")
-    func resolveIgnores() {
-        let r = LatencyRecorder()
-        r.resolve(seq: 0)
-        r.resolve(seq: 999)
-        #expect(r.snapshot().count == 0)
+    @Test("submission and GPU completion resolve presentation")
+    func completionResolvesPresentation() {
+        let clock = Clock()
+        let recorder = LatencyRecorder(now: clock.now)
+        let seq = recorder.stamp()
+        clock.advance(1_000_000)
+        recorder.markApplied(seq: seq)
+        clock.advance(500_000)
+        recorder.markSubmitted(seq: seq)
+        clock.advance(500_000)
+        recorder.markPresented(seq: seq)
+
+        let stats = recorder.snapshot()
+        #expect(stats.apply.p50Micros == 1_000)
+        #expect(stats.present.p50Micros == 2_000)
+        #expect(stats.submittedCount == 1)
     }
 
-    @Test("percentiles use nearest rank over 1..100µs")
+    @Test("presentation before submission is ignored")
+    func completionRequiresSubmission() {
+        let recorder = LatencyRecorder()
+        let seq = recorder.stamp()
+        recorder.markApplied(seq: seq)
+        recorder.markPresented(seq: seq)
+        #expect(recorder.snapshot().present.count == 0)
+    }
+
+    @Test("unpresentable samples retain typed discard reasons", arguments: LatencyRecorder.DiscardReason.allCases)
+    func discardReasons(reason: LatencyRecorder.DiscardReason) {
+        let recorder = LatencyRecorder()
+        let seq = recorder.stamp()
+        recorder.markApplied(seq: seq)
+        recorder.discard(seq: seq, reason: reason)
+        recorder.markSubmitted(seq: seq)
+        recorder.markPresented(seq: seq)
+        let stats = recorder.snapshot()
+        #expect(stats.present.count == 0)
+        #expect(stats.discardCounts[reason] == 1)
+    }
+
+    @Test("presentation preflight rejects sleep, hidden, and occluded surfaces")
+    func presentationPreflight() {
+        #expect(PresentationSamplePreflight.discardReason(
+            screenAsleep: true, hidden: false, occluded: false) == .screenSleep)
+        #expect(PresentationSamplePreflight.discardReason(
+            screenAsleep: false, hidden: true, occluded: false) == .hidden)
+        #expect(PresentationSamplePreflight.discardReason(
+            screenAsleep: false, hidden: false, occluded: true) == .occluded)
+        #expect(PresentationSamplePreflight.discardReason(
+            screenAsleep: false, hidden: false, occluded: false) == nil)
+    }
+
+    @Test("preflight prioritizes screen sleep and hidden state over retained occluded drawables")
+    func presentationPreflightPrecedence() {
+        #expect(PresentationSamplePreflight.discardReason(
+            screenAsleep: true, hidden: true, occluded: true) == .screenSleep)
+        #expect(PresentationSamplePreflight.discardReason(
+            screenAsleep: false, hidden: true, occluded: true) == .hidden)
+    }
+
+    @Test("percentiles use nearest rank")
     func percentiles() {
         let clock = Clock()
-        let r = LatencyRecorder(now: clock.now)
-        for i in 1...100 {
-            let seq = r.stamp()
-            clock.advance(UInt64(i) * 1000) // i µs
-            r.resolve(seq: seq)
+        let recorder = LatencyRecorder(now: clock.now)
+        for value in 1...100 {
+            let seq = recorder.stamp()
+            clock.advance(UInt64(value) * 1_000)
+            recorder.markApplied(seq: seq)
+            recorder.markSubmitted(seq: seq)
+            recorder.markPresented(seq: seq)
         }
-        let stats = r.snapshot()
-        #expect(stats.count == 100)
-        #expect(abs(stats.p50Micros - 50.0) < 0.001)
-        #expect(abs(stats.p99Micros - 99.0) < 0.001)
-        #expect(abs(stats.maxMicros - 100.0) < 0.001)
+        let stats = recorder.snapshot()
+        #expect(stats.apply.p50Micros == 50)
+        #expect(stats.apply.p95Micros == 95)
+        #expect(stats.present.p99Micros == 99)
     }
 }

--- a/macos/Tests/MingaTests/RenderPerformanceGateTests.swift
+++ b/macos/Tests/MingaTests/RenderPerformanceGateTests.swift
@@ -1,0 +1,119 @@
+import Foundation
+import MingaProtocol
+import Testing
+
+@Suite("Render performance comparator")
+struct RenderPerformanceGateTests {
+    private let provenance = RenderPerformanceProvenance(
+        measuredAt: "2026-07-11", environment: "test", toolchain: "swiftc -O", rationale: "test"
+    )
+
+    private var baseline: RenderPerformanceBaseline {
+        RenderPerformanceBaseline(
+            version: 1,
+            fixtureVersion: "native-visible-v1",
+            decodeApplyP95Ms: 1.0,
+            commandPreparationP95Ms: 1.0,
+            combinedP95Ms: 2.0,
+            provenance: provenance
+        )
+    }
+
+    @Test("exact relative boundary passes and the next representable value fails")
+    func relativeBoundary() {
+        #expect(failures(stage: 1.20, combined: 2.40).isEmpty)
+        #expect(failures(stage: 1.20.nextUp, combined: 2.40).contains { $0.contains("1.20x baseline") })
+    }
+
+    @Test("exact absolute boundaries pass and the next representable values fail")
+    func absoluteBoundaries() {
+        let absoluteBaseline = RenderPerformanceBaseline(
+            version: 1, fixtureVersion: "native-visible-v1", decodeApplyP95Ms: 4.0,
+            commandPreparationP95Ms: 4.0, combinedP95Ms: 8.0, provenance: provenance)
+
+        let pass = measurement(stage: 4.0, combined: 8.0)
+        #expect(RenderPerformanceGate.failures(measurement: pass, baseline: absoluteBaseline).isEmpty)
+
+        let stageFail = measurement(stage: 4.0.nextUp, combined: 8.0)
+        #expect(RenderPerformanceGate.failures(measurement: stageFail, baseline: absoluteBaseline)
+            .contains { $0.contains("absolute 4.00ms") })
+
+        let combinedFail = measurement(stage: 4.0, combined: 8.0.nextUp)
+        #expect(RenderPerformanceGate.failures(measurement: combinedFail, baseline: absoluteBaseline)
+            .contains { $0.contains("absolute 8.00ms") })
+    }
+
+    @Test("baseline JSON cannot redefine hard-coded policy ceilings")
+    func baselineCannotRedefinePolicy() throws {
+        let json = """
+        {
+          "version": 1,
+          "fixtureVersion": "native-visible-v1",
+          "decodeApplyP95Ms": 4.0,
+          "commandPreparationP95Ms": 4.0,
+          "combinedP95Ms": 8.0,
+          "stageAbsoluteBudgetMs": 999.0,
+          "combinedAbsoluteBudgetMs": 999.0,
+          "maximumRegressionRatio": 999.0,
+          "provenance": {
+            "measuredAt": "2026-07-11",
+            "environment": "test",
+            "toolchain": "swiftc -O",
+            "rationale": "test"
+          }
+        }
+        """
+        let decoded = try JSONDecoder().decode(RenderPerformanceBaseline.self, from: Data(json.utf8))
+        let failures = RenderPerformanceGate.failures(
+            measurement: measurement(stage: 4.01, combined: 8.01), baseline: decoded)
+        #expect(failures.contains { $0.contains("absolute 4.00ms") })
+        #expect(failures.contains { $0.contains("absolute 8.00ms") })
+    }
+
+    @Test("unsupported baseline versions and fixtures fail closed")
+    func unsupportedBaselineIdentity() {
+        let unsupported = RenderPerformanceBaseline(
+            version: 2, fixtureVersion: "other-fixture", decodeApplyP95Ms: 1,
+            commandPreparationP95Ms: 1, combinedP95Ms: 2, provenance: provenance)
+        let failures = RenderPerformanceGate.failures(
+            measurement: measurement(stage: 1, combined: 2), baseline: unsupported)
+        #expect(failures.contains { $0.contains("unsupported baseline version") })
+        #expect(failures.contains { $0.contains("unsupported fixture") })
+    }
+
+    @Test("non-finite, zero, and negative references fail closed", arguments: [
+        Double.nan, Double.infinity, -Double.infinity, 0.0, -0.01
+    ])
+    func invalidReference(value: Double) {
+        let invalid = RenderPerformanceBaseline(
+            version: 1, fixtureVersion: "native-visible-v1", decodeApplyP95Ms: value,
+            commandPreparationP95Ms: 1, combinedP95Ms: 2, provenance: provenance)
+        #expect(RenderPerformanceGate.failures(
+            measurement: measurement(stage: 1, combined: 2), baseline: invalid
+        ).contains { $0.contains("baseline decode_apply p95 must be finite and greater than zero") })
+    }
+
+    @Test("non-finite, zero, and negative measurements fail closed", arguments: [
+        Double.nan, Double.infinity, -Double.infinity, 0.0, -0.01
+    ])
+    func invalidMeasurement(value: Double) {
+        let invalid = RenderPerformanceMeasurement(
+            decodeApplyP50Ms: 1, decodeApplyP95Ms: 1,
+            commandPreparationP50Ms: 1, commandPreparationP95Ms: value,
+            combinedP50Ms: 2, combinedP95Ms: 2)
+        #expect(RenderPerformanceGate.failures(measurement: invalid, baseline: baseline)
+            .contains { $0.contains("measurement command_preparation p95 must be finite and greater than zero") })
+    }
+
+    private func failures(stage: Double, combined: Double) -> [String] {
+        RenderPerformanceGate.failures(measurement: measurement(stage: stage, combined: combined), baseline: baseline)
+    }
+
+    private func measurement(stage: Double, combined: Double) -> RenderPerformanceMeasurement {
+        RenderPerformanceMeasurement(
+            decodeApplyP50Ms: stage, decodeApplyP95Ms: stage,
+            commandPreparationP50Ms: min(stage, 1), commandPreparationP95Ms: min(stage, 1),
+            combinedP50Ms: combined, combinedP95Ms: combined
+        )
+    }
+}

--- a/macos/Tests/Performance/main.swift
+++ b/macos/Tests/Performance/main.swift
@@ -1,0 +1,117 @@
+import Foundation
+
+private let warmupIterations = 200
+private let measuredIterations = 1_000
+private let fixtureRows = 4_096
+private let visibleRows = 160
+
+private struct Fixture {
+    let payload: Data
+
+    static func make() -> Fixture {
+        var data = Data()
+        data.reserveCapacity(fixtureRows * 48)
+        for row in 0..<fixtureRows {
+            var id = UInt32(row).bigEndian
+            withUnsafeBytes(of: &id) { data.append(contentsOf: $0) }
+            let text = Data(String(format: "row-%04d let value = fixture[%04d]\n", row, row).utf8)
+            var length = UInt16(text.count).bigEndian
+            withUnsafeBytes(of: &length) { data.append(contentsOf: $0) }
+            data.append(text)
+        }
+        return Fixture(payload: data)
+    }
+}
+
+private func decodeAndApply(_ fixture: Fixture) -> [UInt32: Data] {
+    var store: [UInt32: Data] = [:]
+    store.reserveCapacity(fixtureRows)
+    fixture.payload.withUnsafeBytes { raw in
+        guard let base = raw.baseAddress?.assumingMemoryBound(to: UInt8.self) else { return }
+        var offset = 0
+        while offset < raw.count {
+            let id = UInt32(base[offset]) << 24 | UInt32(base[offset + 1]) << 16 |
+                UInt32(base[offset + 2]) << 8 | UInt32(base[offset + 3])
+            let length = Int(base[offset + 4]) << 8 | Int(base[offset + 5])
+            offset += 6
+            store[id] = Data(bytes: base + offset, count: length)
+            offset += length
+        }
+    }
+    return store
+}
+
+private func prepareVisibleCommands(_ store: [UInt32: Data]) -> Int {
+    var checksum = 0
+    var commands: [(Float, Float, Int)] = []
+    commands.reserveCapacity(visibleRows)
+    for row in 0..<visibleRows {
+        let bytes = store[UInt32(row)] ?? Data()
+        checksum &+= bytes.count
+        commands.append((Float(row * 18), Float(bytes.count * 8), bytes.hashValue))
+    }
+    return commands.reduce(checksum) { $0 &+ Int($1.0) &+ Int($1.1) &+ $1.2 }
+}
+
+private func elapsedMs(_ body: () -> Void) -> Double {
+    let start = DispatchTime.now().uptimeNanoseconds
+    body()
+    return Double(DispatchTime.now().uptimeNanoseconds - start) / 1_000_000.0
+}
+
+private func percentile(_ samples: [Double], _ ratio: Double) -> Double {
+    let sorted = samples.sorted()
+    let index = min(max(Int((Double(sorted.count) * ratio).rounded(.up)) - 1, 0), sorted.count - 1)
+    return sorted[index]
+}
+
+guard CommandLine.arguments.count == 2 else {
+    FileHandle.standardError.write(Data("usage: minga-render-performance <baseline.json>\n".utf8))
+    exit(2)
+}
+
+private let fixture = Fixture.make()
+for _ in 0..<warmupIterations {
+    let store = decodeAndApply(fixture)
+    _ = prepareVisibleCommands(store)
+}
+
+var decodeSamples: [Double] = []
+var preparationSamples: [Double] = []
+var combinedSamples: [Double] = []
+decodeSamples.reserveCapacity(measuredIterations)
+preparationSamples.reserveCapacity(measuredIterations)
+combinedSamples.reserveCapacity(measuredIterations)
+var sink = 0
+
+for _ in 0..<measuredIterations {
+    var store: [UInt32: Data] = [:]
+    decodeSamples.append(elapsedMs { store = decodeAndApply(fixture) })
+    preparationSamples.append(elapsedMs { sink &+= prepareVisibleCommands(store) })
+    combinedSamples.append(elapsedMs {
+        let combinedStore = decodeAndApply(fixture)
+        sink &+= prepareVisibleCommands(combinedStore)
+    })
+}
+
+let measurement = RenderPerformanceMeasurement(
+    decodeApplyP50Ms: percentile(decodeSamples, 0.50),
+    decodeApplyP95Ms: percentile(decodeSamples, 0.95),
+    commandPreparationP50Ms: percentile(preparationSamples, 0.50),
+    commandPreparationP95Ms: percentile(preparationSamples, 0.95),
+    combinedP50Ms: percentile(combinedSamples, 0.50),
+    combinedP95Ms: percentile(combinedSamples, 0.95)
+)
+let baselineURL = URL(fileURLWithPath: CommandLine.arguments[1])
+let baseline = try JSONDecoder().decode(RenderPerformanceBaseline.self, from: Data(contentsOf: baselineURL))
+let output = try JSONEncoder().encode(measurement)
+print(String(decoding: output, as: UTF8.self))
+print(String(format: "decode+apply p50 %.3fms p95 %.3fms | command-prep p50 %.3fms p95 %.3fms | combined p50 %.3fms p95 %.3fms",
+             measurement.decodeApplyP50Ms, measurement.decodeApplyP95Ms,
+             measurement.commandPreparationP50Ms, measurement.commandPreparationP95Ms,
+             measurement.combinedP50Ms, measurement.combinedP95Ms))
+print("fixture=native-visible-v1 rows=\(fixtureRows) visible=\(visibleRows) warmup=\(warmupIterations) iterations=\(measuredIterations) os=\(ProcessInfo.processInfo.operatingSystemVersionString) sink=\(sink)")
+
+let failures = RenderPerformanceGate.failures(measurement: measurement, baseline: baseline)
+for failure in failures { FileHandle.standardError.write(Data("error: \(failure)\n".utf8)) }
+if !failures.isEmpty { exit(1) }

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -37,6 +37,8 @@ targets:
         type: file
       - path: Sources/Protocol/LatencyRecorder.swift
         type: file
+      - path: Sources/Protocol/RenderPerformanceGate.swift
+        type: file
       - path: Sources/Protocol/FrontendExtensionRuntimeMessage.swift
         type: file
     settings:
@@ -111,6 +113,7 @@ targets:
           - "Renderer/WindowContent.swift"
           - "Protocol/AgentSurfaceTypes.swift"
           - "Protocol/LatencyRecorder.swift"
+          - "Protocol/RenderPerformanceGate.swift"
           - "Protocol/FrontendExtensionRuntimeMessage.swift"
           # MingaUI-owned (Slice 3)
           - "Protocol/InputEncoder.swift"
@@ -213,6 +216,8 @@ targets:
           # Snapshot test outputs are gitignored local artifacts; never bundle
           # them as test resources or the checked-in project fails on missing inputs.
           - "Snapshots/**"
+          # Standalone optimized executable; unit tests cover its comparator separately.
+          - "Performance/**"
       - path: Sources
         type: group
         excludes:
@@ -226,6 +231,7 @@ targets:
           - "Renderer/WindowContent.swift"
           - "Protocol/AgentSurfaceTypes.swift"
           - "Protocol/LatencyRecorder.swift"
+          - "Protocol/RenderPerformanceGate.swift"
           - "Protocol/FrontendExtensionRuntimeMessage.swift"
           # MingaUI-owned (Slice 3)
           - "Protocol/InputEncoder.swift"
@@ -298,6 +304,7 @@ targets:
           - "Renderer/WindowContent.swift"
           - "Protocol/AgentSurfaceTypes.swift"
           - "Protocol/LatencyRecorder.swift"
+          - "Protocol/RenderPerformanceGate.swift"
           - "Protocol/FrontendExtensionRuntimeMessage.swift"
           # MingaUI-owned (Slice 3)
           - "Protocol/InputEncoder.swift"

--- a/performance/baselines/macos_render_release.json
+++ b/performance/baselines/macos_render_release.json
@@ -1,0 +1,13 @@
+{
+  "version": 1,
+  "fixtureVersion": "native-visible-v1",
+  "decodeApplyP95Ms": 0.762125,
+  "commandPreparationP95Ms": 0.026,
+  "combinedP95Ms": 1.362917,
+  "provenance": {
+    "measuredAt": "2026-07-12",
+    "environment": "GitHub-hosted macos-15 arm64 runner, macOS 15.7.7 (24G720)",
+    "toolchain": "GitHub Actions macos-15 default Xcode toolchain, swiftc -O",
+    "rationale": "Initial CI calibration for native-visible-v1 from the optimized 200-warmup/1000-measurement gate in run 29176725578; the references are the measured CI p95 values, while hard-coded 4 ms stage and 8 ms combined ceilings remain unchanged."
+  }
+}

--- a/scripts/check_render_performance
+++ b/scripts/check_render_performance
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="${ROOT}/_build/render-performance"
+BINARY="${BUILD_DIR}/minga-render-performance"
+BASELINE="${1:-${ROOT}/performance/baselines/macos_render_release.json}"
+
+if [[ "$(uname -s)" != "Darwin" ]]; then
+  echo "error: optimized native render gate requires macOS" >&2
+  exit 2
+fi
+if [[ ! -f "${BASELINE}" ]]; then
+  echo "error: baseline not found: ${BASELINE}" >&2
+  exit 2
+fi
+
+mkdir -p "${BUILD_DIR}"
+swiftc --version
+swiftc -O \
+  "${ROOT}/macos/Sources/Protocol/RenderPerformanceGate.swift" \
+  "${ROOT}/macos/Tests/Performance/main.swift" \
+  -o "${BINARY}"
+
+"${BINARY}" "${BASELINE}"


### PR DESCRIPTION
# TL;DR

macOS now measures semantic apply and GPU-completion presentation as separate latency milestones, and CI runs an optimized native benchmark with hard-coded absolute and relative regression policies. This establishes the production gate framework without claiming the resident-store and renderer-counter work that still depends on #2740 through #2742.

Part of #2743

## Context

Semantic frame commit is not presentation. The previous latency path could report success before Metal submitted or completed the matching command buffer, while native performance checks lacked an optimized, versioned baseline comparator.

This PR is the dependency-independent #2743 slice. The issue remains open for the production-size corpus, resident-store complexity counters, renderer message-size bounds, and final production-path benchmark fixture.

## Changes

- Added explicit input, semantic-apply, Metal-submission, GPU-completion, and typed discard milestones.
- Keep presentation samples pending after apply and resolve them only from the matching successful command-buffer completion.
- Discard hidden, occluded, sleeping, nil-drawable, superseded, unschedulable, dropped, and GPU-failed samples.
- Split the latency HUD and diagnostic labels into apply and present percentiles.
- Added a Release-only benchmark harness with warm-up, fixed fixtures, p50/p95 output, and environment metadata.
- Hard-coded 4 ms stage, 8 ms combined, and 1.20 relative-regression policies so a baseline edit cannot relax them.
- Added fail-closed baseline version, fixture, and finite-positive value validation.
- Checked in measured p95 references with hardware, toolchain, date, and rationale provenance.
- Added exact comparator boundary tests and CI/script/documentation wiring.

## Verification

- `scripts/check_render_performance`
- `scripts/check_macos_release_optimization`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -configuration Debug test` (1,087 tests passed)
- `MIX_ENV=test mix swift.harness --release`
- `mix test.llm` (9,897 tests, 0 failures)
- `make lint.full`
- Swift protocol integration (27 tests passed)

## Acceptance Criteria Addressed

- Native telemetry distinguishes input, semantic apply, Metal submission, GPU completion/presentation, and typed dropped samples. ✅
- HUD and logs label apply and presentation separately; apply acknowledgement never resolves presentation. ✅
- Optimized benchmark, baseline comparator, absolute budgets, relative policy, and CI framework are in place. Partial, pending final resident production paths.

## Remaining #2743 Work

- Add the >65,535-byte and 65,536-row cross-language corpus after #2740/#2741.
- Add final ChangeLog, hydration, composition, chunk, and visible-row counters after #2741/#2742.
- Enforce 256 KiB request and receipt bounds against the final resident fixture.
- Replace scaffold benchmark operations with the final resident protocol/apply and renderer-owned command-preparation paths.
- Add the BEAM-frame-emitted timestamp and final deterministic complexity/message-size CI gates.
