### PR TITLE
fix(editor): recover stalled frontend frames

### DIFF
--- a/lib/minga/runtime/supervisor.ex
+++ b/lib/minga/runtime/supervisor.ex
@@ -5,7 +5,7 @@ defmodule Minga.Runtime.Supervisor do
   Uses `one_for_one` so that each child restarts independently:
 
       Runtime.Supervisor (one_for_one)
-      ├── MingaEditor.Watchdog      SIGUSR1 recovery (independent leaf)
+      ├── MingaEditor.Watchdog      SIGUSR2 recovery (independent leaf)
       ├── Minga.FileWatcher          FSEvents/inotify watcher (independent leaf)
       └── MingaEditor.Supervisor    Parser → Port → Renderer → Editor (rest_for_one)
 
@@ -37,7 +37,7 @@ defmodule Minga.Runtime.Supervisor do
     backend = Keyword.get(opts, :backend, :tui)
 
     children = [
-      # Watchdog starts first so it's ready to receive SIGUSR1 from the
+      # Watchdog starts first so it's ready to receive SIGUSR2 from the
       # moment the Editor boots. It's an independent leaf: its crash
       # restarts only itself under one_for_one.
       MingaEditor.Watchdog,

--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -82,13 +82,24 @@ defmodule MingaEditor.Renderer.Server do
   @typedoc "Editor process reference used for renderer writebacks."
   @type editor_ref :: pid() | atom() | nil
 
+  @typedoc "Generation-scoped lease for one frame awaiting frontend acknowledgement."
+  @type ack_lease :: %{
+          required(:generation) => non_neg_integer(),
+          required(:seq) => non_neg_integer(),
+          required(:timer_ref) => reference(),
+          required(:output) => render_output(),
+          required(:snapshot) => Input.t(),
+          required(:pushed_at) => integer()
+        }
+
   @typedoc "Renderer server state."
   @type t :: %__MODULE__{
           editor_pid: editor_ref(),
           rendering?: boolean(),
           pending: {Input.t(), non_neg_integer(), integer()} | nil,
           in_flight: {Input.t(), non_neg_integer(), integer()} | nil,
-          awaiting_ack: {render_output(), Input.t(), non_neg_integer(), integer()} | nil,
+          awaiting_ack: ack_lease() | nil,
+          ack_timeout_ms: pos_integer(),
           font_registry: FontRegistry.t(),
           caches: Caches.t(),
           message_store: MessageStore.t() | nil,
@@ -101,6 +112,7 @@ defmodule MingaEditor.Renderer.Server do
             pending: nil,
             in_flight: nil,
             awaiting_ack: nil,
+            ack_timeout_ms: 2_000,
             font_registry: FontRegistry.new(),
             caches: Caches.new(),
             message_store: nil,
@@ -175,7 +187,15 @@ defmodule MingaEditor.Renderer.Server do
     editor_pid = Keyword.get(opts, :editor_pid, MingaEditor)
     pipeline = Keyword.get(opts, :pipeline, &RenderPipeline.run/1)
     require_ack? = Keyword.get(opts, :require_ack?, not Keyword.has_key?(opts, :pipeline))
-    {:ok, %__MODULE__{editor_pid: editor_pid, pipeline: pipeline, require_ack?: require_ack?}}
+    ack_timeout_ms = Keyword.get(opts, :ack_timeout_ms, 2_000)
+
+    {:ok,
+     %__MODULE__{
+       editor_pid: editor_pid,
+       pipeline: pipeline,
+       require_ack?: require_ack?,
+       ack_timeout_ms: ack_timeout_ms
+     }}
   end
 
   @impl true
@@ -188,6 +208,7 @@ defmodule MingaEditor.Renderer.Server do
   end
 
   def handle_call({:reset_connection, snap, seq, pushed_at}, _from, state) do
+    cancel_ack_timer(state.awaiting_ack)
     caches = Caches.reset_frontend_state(state.caches)
 
     # The Editor snapshot has already reset all frontend-retained cursors for
@@ -262,11 +283,25 @@ defmodule MingaEditor.Renderer.Server do
     # Port write is not proof of commit. Keep the prepared output private until
     # the matching generation/sequence acknowledgement returns the single credit.
     if state.require_ack? do
+      generation = output.caches.recovery_generation
+
+      timer_ref =
+        Process.send_after(self(), {:frame_ack_timeout, generation, seq}, state.ack_timeout_ms)
+
+      lease = %{
+        generation: generation,
+        seq: seq,
+        timer_ref: timer_ref,
+        output: output,
+        snapshot: snap,
+        pushed_at: pushed_at
+      }
+
       state = %{
         state
         | font_registry: output.font_registry,
           in_flight: nil,
-          awaiting_ack: {output, snap, seq, pushed_at}
+          awaiting_ack: lease
       }
 
       {:noreply, state}
@@ -297,9 +332,10 @@ defmodule MingaEditor.Renderer.Server do
 
   def handle_info(
         {:frame_status, {:frame_applied, generation, seq}},
-        %__MODULE__{awaiting_ack: {output, _snap, seq, _pushed_at}} = state
-      )
-      when generation == state.caches.recovery_generation do
+        %__MODULE__{awaiting_ack: %{generation: generation, seq: seq, output: output} = lease} =
+          state
+      ) do
+    cancel_ack_timer(lease)
     acknowledged = Caches.acknowledge_frame(output.caches, seq, generation)
 
     output = %{output | caches: acknowledged}
@@ -317,20 +353,32 @@ defmodule MingaEditor.Renderer.Server do
 
   def handle_info(
         {:frame_status, {:frame_rejected, generation, seq, last_applied, reason}},
-        %__MODULE__{awaiting_ack: {_output, snap, seq, pushed_at}} = state
+        %__MODULE__{
+          awaiting_ack: %{
+            generation: generation,
+            seq: seq,
+            snapshot: snap,
+            pushed_at: pushed_at
+          }
+        } = state
       )
-      when generation == state.caches.recovery_generation and
-             last_applied == state.caches.last_acknowledged_frame_seq do
+      when last_applied == state.caches.last_acknowledged_frame_seq do
     Minga.Log.warning(:render, "Frontend rejected frame #{seq}: #{reason}")
     recover_transaction(state, snap, seq, pushed_at)
   end
 
   def handle_info(
         {:frame_status, {:window_ref_miss, generation, seq, last_applied, window_id}},
-        %__MODULE__{awaiting_ack: {_output, snap, seq, pushed_at}} = state
+        %__MODULE__{
+          awaiting_ack: %{
+            generation: generation,
+            seq: seq,
+            snapshot: snap,
+            pushed_at: pushed_at
+          }
+        } = state
       )
-      when generation == state.caches.recovery_generation and
-             last_applied == state.caches.last_acknowledged_frame_seq do
+      when last_applied == state.caches.last_acknowledged_frame_seq do
     Minga.Log.warning(:render, "Frontend missed window #{window_id} in frame #{seq}")
     recover_window(state, snap, seq, pushed_at, window_id)
   end
@@ -340,8 +388,25 @@ defmodule MingaEditor.Renderer.Server do
   def handle_info({:frame_status, _status}, state), do: {:noreply, state}
 
   def handle_info(
+        {:frame_ack_timeout, generation, seq},
+        %__MODULE__{
+          awaiting_ack: %{
+            generation: generation,
+            seq: seq,
+            snapshot: snap,
+            pushed_at: pushed_at
+          }
+        } = state
+      ) do
+    Minga.Log.warning(:render, "Frontend acknowledgement timed out for frame #{seq}")
+    recover_transaction(state, snap, seq, pushed_at)
+  end
+
+  def handle_info({:frame_ack_timeout, _generation, _seq}, state), do: {:noreply, state}
+
+  def handle_info(
         :request_recovery,
-        %__MODULE__{awaiting_ack: {_output, snap, seq, pushed_at}} = state
+        %__MODULE__{awaiting_ack: %{snapshot: snap, seq: seq, pushed_at: pushed_at}} = state
       ) do
     recover_transaction(state, snap, seq, pushed_at)
   end
@@ -418,6 +483,8 @@ defmodule MingaEditor.Renderer.Server do
 
   @spec recover_transaction(t(), Input.t(), non_neg_integer(), integer()) :: {:noreply, t()}
   defp recover_transaction(state, rejected_snap, rejected_seq, rejected_pushed_at) do
+    cancel_ack_timer(state.awaiting_ack)
+
     {latest_snap, latest_seq, latest_pushed_at} =
       latest_intent(state.pending, rejected_snap, rejected_seq, rejected_pushed_at)
 
@@ -437,6 +504,8 @@ defmodule MingaEditor.Renderer.Server do
   @spec recover_window(t(), Input.t(), non_neg_integer(), integer(), non_neg_integer()) ::
           {:noreply, t()}
   defp recover_window(state, rejected_snap, rejected_seq, rejected_pushed_at, window_id) do
+    cancel_ack_timer(state.awaiting_ack)
+
     {latest_snap, latest_seq, latest_pushed_at} =
       latest_intent(state.pending, rejected_snap, rejected_seq, rejected_pushed_at)
 
@@ -455,6 +524,14 @@ defmodule MingaEditor.Renderer.Server do
       :error ->
         recover_transaction(state, latest_snap, latest_seq, latest_pushed_at)
     end
+  end
+
+  @spec cancel_ack_timer(ack_lease() | nil) :: :ok
+  defp cancel_ack_timer(nil), do: :ok
+
+  defp cancel_ack_timer(%{timer_ref: timer_ref}) do
+    _ = Process.cancel_timer(timer_ref)
+    :ok
   end
 
   @spec latest_intent(

--- a/lib/minga_editor/watchdog.ex
+++ b/lib/minga_editor/watchdog.ex
@@ -2,11 +2,7 @@ defmodule MingaEditor.Watchdog do
   @moduledoc """
   Out-of-band recovery process for the Editor GenServer.
 
-  Registers for SIGUSR1 via `:os.set_signal/2`. When the Zig
-  renderer (or macOS GUI) detects that the BEAM is unresponsive, it sends
-  SIGUSR1 to the parent BEAM OS process. The Watchdog receives the signal
-  as a `{:signal, :sigusr1}` message and kills the Editor GenServer,
-  letting the supervisor restart it.
+  Registers for SIGUSR2 via `:os.set_signal/2` and `erl_signal_server`. When the renderer or macOS GUI detects that the BEAM is unresponsive, it sends SIGUSR2 to the parent BEAM OS process. The signal handler forwards it to the Watchdog as a `{:signal, :sigusr2}` message, which kills the Editor GenServer and lets the supervisor restart it.
 
   This process has no periodic work. It exists solely to receive the
   out-of-band kill signal when the normal protocol channel is blocked.
@@ -29,6 +25,7 @@ defmodule MingaEditor.Watchdog do
 
   use GenServer
   alias Minga.Log
+  alias MingaEditor.Watchdog.SignalHandler
 
   @typedoc "Options for starting the watchdog."
   @type start_opt :: {:name, GenServer.name()} | {:editor_name, GenServer.name()}
@@ -53,19 +50,20 @@ defmodule MingaEditor.Watchdog do
   def init(opts) do
     editor_name = Keyword.get(opts, :editor_name, MingaEditor)
 
-    # Register for SIGUSR1. OTP 26+ delivers signals as messages
-    # to the calling process: {:signal, :sigusr1}
-    :os.set_signal(:sigusr1, :handle)
+    # OTP's built-in erl_signal_handler reserves SIGUSR1 for crash-dump shutdown.
+    # SIGUSR2 is otherwise ignored, so Minga handles it through erl_signal_server.
+    :ok = :os.set_signal(:sigusr2, :handle)
+    :ok = :gen_event.add_sup_handler(:erl_signal_server, {SignalHandler, self()}, self())
 
-    Log.info(:editor, "Watchdog started, listening for SIGUSR1")
+    Log.info(:editor, "Watchdog started, listening for SIGUSR2")
 
     {:ok, %{editor_name: editor_name}}
   end
 
   @impl true
   @spec handle_info(term(), state()) :: {:noreply, state()}
-  def handle_info({:signal, :sigusr1}, state) do
-    Log.warning(:editor, "Watchdog received SIGUSR1, killing Editor for recovery")
+  def handle_info({:signal, :sigusr2}, state) do
+    Log.warning(:editor, "Watchdog received SIGUSR2, killing Editor for recovery")
 
     case Process.whereis(state.editor_name) do
       nil ->

--- a/lib/minga_editor/watchdog/signal_handler.ex
+++ b/lib/minga_editor/watchdog/signal_handler.ex
@@ -1,0 +1,40 @@
+defmodule MingaEditor.Watchdog.SignalHandler do
+  @moduledoc """
+  Forwards the BEAM's recovery signal from `erl_signal_server` to the Watchdog.
+
+  SIGUSR1 cannot be used here because OTP's built-in signal handler reserves it for an immediate crash-dump shutdown. SIGUSR2 is otherwise ignored by OTP and is safe for Minga's out-of-band editor recovery path.
+  """
+
+  @behaviour :gen_event
+
+  @type state :: pid()
+
+  @impl true
+  @spec init(pid()) :: {:ok, state()}
+  def init(watchdog) when is_pid(watchdog), do: {:ok, watchdog}
+
+  @impl true
+  @spec handle_event(term(), state()) :: {:ok, state()}
+  def handle_event(:sigusr2, watchdog) do
+    send(watchdog, {:signal, :sigusr2})
+    {:ok, watchdog}
+  end
+
+  def handle_event(_signal, watchdog), do: {:ok, watchdog}
+
+  @impl true
+  @spec handle_call(term(), state()) :: {:ok, :ok, state()}
+  def handle_call(_request, watchdog), do: {:ok, :ok, watchdog}
+
+  @impl true
+  @spec handle_info(term(), state()) :: {:ok, state()}
+  def handle_info(_message, watchdog), do: {:ok, watchdog}
+
+  @impl true
+  @spec terminate(term(), state()) :: :ok
+  def terminate(_reason, _watchdog), do: :ok
+
+  @impl true
+  @spec code_change(term(), state(), term()) :: {:ok, state()}
+  def code_change(_old_version, watchdog, _extra), do: {:ok, watchdog}
+end

--- a/macos/Sources/BEAMProcessManager.swift
+++ b/macos/Sources/BEAMProcessManager.swift
@@ -244,10 +244,10 @@ final class BEAMProcessManager {
         return urls
     }
 
-    /// Sends SIGUSR1 to the BEAM so the Watchdog restarts the editor core while preserving buffers.
+    /// Sends SIGUSR2 to the BEAM so the Watchdog restarts the editor core while preserving buffers.
     func sendRecoveryRestartSignal() {
         guard let proc = process, proc.isRunning else { return }
-        kill(proc.processIdentifier, SIGUSR1)
+        kill(proc.processIdentifier, SIGUSR2)
     }
 
     /// Re-spawns the BEAM after the automatic restart budget was exhausted.

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -311,7 +311,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 manager.sendRecoveryRestartSignal()
             } else {
                 let parentPid = getppid()
-                if parentPid > 1 { kill(parentPid, SIGUSR1) }
+                if parentPid > 1 { kill(parentPid, SIGUSR2) }
             }
         }
         self.recoveryManager = recovery

--- a/macos/Sources/Recovery/RecoveryManager.swift
+++ b/macos/Sources/Recovery/RecoveryManager.swift
@@ -110,6 +110,6 @@ final class RecoveryManager {
     private static func sendRestartSignalToParent() {
         let parentPid = getppid()
         guard parentPid > 1 else { return }
-        kill(parentPid, SIGUSR1)
+        kill(parentPid, SIGUSR2)
     }
 }

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -188,6 +188,55 @@ defmodule MingaEditor.Renderer.ServerTest do
       refute_receive {:render_done, %{frame_seq: 12}}, 50
     end
 
+    test "acknowledgement timeout retries the latest pending frame as a fresh-generation keyframe" do
+      renderer = start_ack_renderer(self())
+
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 10)
+      assert_receive {:ack_pipeline, 10, 1, 0, true}, @async_render_timeout
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 11)
+
+      send(renderer, {:frame_ack_timeout, 1, 10})
+
+      assert_receive {:ack_pipeline, 11, 2, 0, true}, @async_render_timeout
+      assert RendererServer.acknowledgement_state(renderer) == {2, 0}
+      refute_receive {:render_done, %{frame_seq: 10}}, 50
+    end
+
+    test "late acknowledgement from a timed-out generation cannot release current credit" do
+      renderer = start_ack_renderer(self())
+
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 20)
+      assert_receive {:ack_pipeline, 20, 1, 0, true}, @async_render_timeout
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 21)
+      send(renderer, {:frame_ack_timeout, 1, 20})
+      assert_receive {:ack_pipeline, 21, 2, 0, true}, @async_render_timeout
+
+      RendererServer.frame_status(renderer, {:frame_applied, 1, 20})
+      assert RendererServer.acknowledgement_state(renderer) == {2, 0}
+      refute_receive {:render_done, %{frame_seq: 20}}, 50
+
+      RendererServer.frame_status(renderer, {:frame_applied, 2, 21})
+      assert_receive {:render_done, %{frame_seq: 21}}, @async_render_timeout
+      assert RendererServer.acknowledgement_state(renderer) == {2, 21}
+    end
+
+    test "normal acknowledgement makes its queued timeout message harmless" do
+      renderer = start_ack_renderer(self())
+
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 30)
+      assert_receive {:ack_pipeline, 30, 1, 0, true}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 1, 30})
+      assert_receive {:render_done, %{frame_seq: 30}}, @async_render_timeout
+
+      send(renderer, {:frame_ack_timeout, 1, 30})
+      refute RendererServer.rendering?(renderer)
+      assert RendererServer.acknowledgement_state(renderer) == {1, 30}
+      refute_receive {:ack_pipeline, _, _, _, _}, 50
+
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 31)
+      assert_receive {:ack_pipeline, 31, 1, 30, false}, @async_render_timeout
+    end
+
     test "rejected frame N renders only latest pending N+1 as a fresh-generation keyframe" do
       renderer = start_ack_renderer(self())
 

--- a/test/minga_editor/watchdog_test.exs
+++ b/test/minga_editor/watchdog_test.exs
@@ -1,18 +1,23 @@
 defmodule MingaEditor.WatchdogTest do
-  use ExUnit.Case, async: true
+  # erl_signal_server is VM-global, and the recovery contract sends a real OS signal.
+  use ExUnit.Case, async: false
 
   alias MingaEditor.Watchdog
+  alias MingaEditor.Watchdog.SignalHandler
 
   describe "init" do
-    test "starts and registers for SIGUSR1" do
+    test "registers a supervised SIGUSR2 handler" do
       assert {:ok, pid} = Watchdog.start_link(name: :test_watchdog, editor_name: :fake_editor)
-      assert Process.alive?(pid)
+      assert {SignalHandler, pid} in :gen_event.which_handlers(:erl_signal_server)
+
       GenServer.stop(pid)
+      refute {SignalHandler, pid} in :gen_event.which_handlers(:erl_signal_server)
     end
   end
 
-  describe "SIGUSR1 handling" do
-    test "kills the editor process on SIGUSR1" do
+  describe "SIGUSR2 handling" do
+    @tag timeout: 5_000
+    test "a real SIGUSR2 kills the editor process without terminating the BEAM" do
       editor_name = :"test_editor_for_watchdog_#{System.unique_integer([:positive])}"
 
       editor =
@@ -32,38 +37,38 @@ defmodule MingaEditor.WatchdogTest do
         )
 
       ref = Process.monitor(editor)
-
-      send(watchdog, {:signal, :sigusr1})
-
+      kill = System.find_executable("kill") || raise "kill executable not found"
+      assert {_output, 0} = System.cmd(kill, ["-USR2", System.pid()], stderr_to_stdout: true)
       assert_receive {:DOWN, ^ref, :process, ^editor, :killed}, 1000
+      assert Process.alive?(watchdog)
 
       GenServer.stop(watchdog)
     end
 
-    test "handles SIGUSR1 gracefully when editor is not running" do
+    test "handles SIGUSR2 gracefully when editor is not running" do
       {:ok, watchdog} =
         Watchdog.start_link(
           name: :test_watchdog_no_editor,
           editor_name: :nonexistent_editor_process
         )
 
-      send(watchdog, {:signal, :sigusr1})
+      :ok = :gen_event.notify(:erl_signal_server, :sigusr2)
       _ = :sys.get_state(watchdog)
       assert Process.alive?(watchdog)
 
       GenServer.stop(watchdog)
     end
 
-    test "survives multiple SIGUSR1 signals" do
+    test "survives multiple SIGUSR2 signals" do
       {:ok, watchdog} =
         Watchdog.start_link(
           name: :test_watchdog_multi,
           editor_name: :nonexistent_editor_multi
         )
 
-      send(watchdog, {:signal, :sigusr1})
-      send(watchdog, {:signal, :sigusr1})
-      send(watchdog, {:signal, :sigusr1})
+      send(watchdog, {:signal, :sigusr2})
+      send(watchdog, {:signal, :sigusr2})
+      send(watchdog, {:signal, :sigusr2})
       _ = :sys.get_state(watchdog)
       assert Process.alive?(watchdog)
 
@@ -77,7 +82,7 @@ defmodule MingaEditor.WatchdogTest do
         Watchdog.start_link(name: :test_watchdog_unknown, editor_name: :fake_editor_unknown)
 
       send(watchdog, :random_message)
-      send(watchdog, {:signal, :sigusr2})
+      send(watchdog, {:signal, :sigusr1})
       send(watchdog, {:some, :tuple})
       _ = :sys.get_state(watchdog)
       assert Process.alive?(watchdog)


### PR DESCRIPTION
# TL;DR
Minga now recovers automatically when a frontend frame acknowledgement is lost instead of leaving every later render update blocked. The macOS out-of-band recovery path also uses SIGUSR2, avoiding OTP's SIGUSR1 crash-dump handler.

## Context
A restored session could display its buffers but stop publishing later state changes. Tab clicks, sidebar actions, editor clicks, and parser highlighting all appeared broken because `Renderer.Server` held its single frame credit forever after one acknowledgement was lost.

The existing Watchdog recovery path had a separate defect: OTP reserves SIGUSR1 for immediate crash-dump shutdown, so invoking recovery terminated the BEAM instead of restarting the supervised editor.

## Changes
- Add a generation-and-sequence-scoped acknowledgement lease to `Renderer.Server` with a two-second timeout.
- Retry the latest pending render as a fresh-generation keyframe when a lease expires.
- Cancel acknowledgement timers on apply, rejection, targeted recovery, manual recovery, and frontend reconnection while treating queued stale timeout messages as harmless.
- Route SIGUSR2 through OTP's existing `erl_signal_server` to the existing Watchdog GenServer.
- Update all macOS recovery signal call sites from SIGUSR1 to SIGUSR2.
- Add deterministic tests for timeout recovery, late acknowledgements, stale timeout delivery, supervised signal-handler cleanup, and a real OS signal that leaves the BEAM alive.

## Compatibility
No protocol opcode or payload changes. Frame identity continues to use the existing recovery generation and frame sequence.

## Verification
- `make lint` passed.
- `mix test.debug test/minga_editor/renderer/server_test.exs test/minga_editor/watchdog_test.exs` passed, 23 tests.
- `mix test.llm test/minga_editor/commands/buffer_management_test.exs:130` passed, confirming the one unrelated full-suite timeout passes focused.
- `mix swift.build` passed.
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga test CODE_SIGNING_ALLOWED=NO` passed, 1,087 Swift tests.
- `make lint.full` was interrupted before completion and was not rerun.
- The full `mix test.llm` run reached 9,857 tests with one unrelated timeout; its exact test passed on focused rerun.

## Acceptance Criteria Addressed
- Lost frontend acknowledgements no longer stall all subsequent rendering. ✅
- Late or stale acknowledgement events cannot release current frame credit. ✅
- Restored-session interactions and syntax-highlight updates can publish after a lost acknowledgement. ✅
- macOS recovery restarts the supervised editor without terminating the BEAM. ✅
