### PR TITLE
fix(render): preserve bounded retry state

### DIFF
--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -421,9 +421,12 @@ defmodule Minga.Buffer do
           Minga.Buffer.RenderSnapshot.t()
   defdelegate render_snapshot(server, first_line, count), to: BufferProcess
 
-  @doc "Atomically consumes renderer deltas with the current version/count/sequence."
-  @spec renderer_consume(t()) :: Minga.Buffer.RendererConsume.t()
-  defdelegate renderer_consume(server), to: BufferProcess
+  @doc "Atomically consumes renderer deltas and snapshots their bounded affected range."
+  @spec renderer_consume(
+          t(),
+          {non_neg_integer(), non_neg_integer()} | nil
+        ) :: Minga.Buffer.RendererConsume.t()
+  defdelegate renderer_consume(server, prior_affected_range \\ nil), to: BufferProcess
 
   @doc "Returns a bounded line range only when the expected version is still current."
   @spec render_lines(t(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::

--- a/lib/minga/buffer/edit_delta.ex
+++ b/lib/minga/buffer/edit_delta.ex
@@ -38,6 +38,8 @@ defmodule Minga.Buffer.EditDelta do
     :inserted_text
   ]
 
+  @type line_range :: {non_neg_integer(), non_neg_integer()}
+
   @type t :: %__MODULE__{
           start_byte: non_neg_integer(),
           old_end_byte: non_neg_integer(),
@@ -47,6 +49,16 @@ defmodule Minga.Buffer.EditDelta do
           new_end_position: {non_neg_integer(), non_neg_integer()},
           inserted_text: String.t()
         }
+
+  @doc "Returns the current-coordinate line range affected by ordered deltas."
+  @spec affected_line_range([t()], line_range() | nil) :: line_range() | nil
+  def affected_line_range(deltas, prior_range \\ nil) when is_list(deltas) do
+    Enum.reduce(deltas, prior_range, fn delta, range ->
+      range
+      |> transform_line_range(delta)
+      |> union_line_range(delta_range(delta))
+    end)
+  end
 
   @doc "Creates a delta for an insertion at a position (no text removed)."
   @spec insertion(
@@ -85,6 +97,50 @@ defmodule Minga.Buffer.EditDelta do
       inserted_text: ""
     }
   end
+
+  @spec transform_line_range(line_range() | nil, t()) :: line_range() | nil
+  defp transform_line_range(nil, _delta), do: nil
+
+  defp transform_line_range({_first, last} = range, %__MODULE__{start_position: {start, _}})
+       when last < start,
+       do: range
+
+  defp transform_line_range(
+         {first, last},
+         %__MODULE__{
+           old_end_position: {old_end, _},
+           new_end_position: {new_end, _}
+         }
+       )
+       when first > old_end do
+    shift = new_end - old_end
+    {first + shift, last + shift}
+  end
+
+  defp transform_line_range(
+         {first, last},
+         %__MODULE__{
+           start_position: {start, _},
+           old_end_position: {old_end, _},
+           new_end_position: {new_end, _}
+         }
+       ) do
+    shifted_last = if last > old_end, do: last + new_end - old_end, else: new_end
+    {min(first, start), max(new_end, shifted_last)}
+  end
+
+  @spec delta_range(t()) :: line_range()
+  defp delta_range(%__MODULE__{
+         start_position: {start, _},
+         new_end_position: {new_end, _}
+       }),
+       do: {start, max(start, new_end)}
+
+  @spec union_line_range(line_range() | nil, line_range()) :: line_range()
+  defp union_line_range(nil, range), do: range
+
+  defp union_line_range({first, last}, {new_first, new_last}),
+    do: {min(first, new_first), max(last, new_last)}
 
   @doc "Creates a delta for a replacement (text removed and text inserted)."
   @spec replacement(

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -592,9 +592,14 @@ defmodule Minga.Buffer.Process do
     GenServer.call(server, {:render_snapshot, first_line, count})
   end
 
-  @doc "Atomically advances the renderer ChangeLog cursor and observes its version/count."
-  @spec renderer_consume(GenServer.server()) :: RendererConsume.t()
-  def renderer_consume(server), do: GenServer.call(server, :renderer_consume)
+  @doc "Atomically consumes renderer changes and snapshots their affected line range."
+  @spec renderer_consume(
+          GenServer.server(),
+          {non_neg_integer(), non_neg_integer()} | nil
+        ) :: RendererConsume.t()
+  def renderer_consume(server, prior_affected_range \\ nil) do
+    GenServer.call(server, {:renderer_consume, prior_affected_range})
+  end
 
   @doc "Fetches only a requested line range when the buffer is still at `expected_version`."
   @spec render_lines(GenServer.server(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
@@ -1363,17 +1368,19 @@ defmodule Minga.Buffer.Process do
     {:reply, result, %{state | change_log: change_log}}
   end
 
-  def handle_call(:renderer_consume, _from, state) do
+  def handle_call({:renderer_consume, prior_affected_range}, _from, state) do
     {changes, change_log} = ChangeLog.take_unseen_changes(state.change_log, :renderer)
+    state = %{state | change_log: change_log}
 
-    result = %Minga.Buffer.RendererConsume{
+    result = %RendererConsume{
       version: BufState.version(state),
       line_count: Document.line_count(state.document),
       change_sequence: ChangeLog.sequence(change_log),
-      changes: changes
+      changes: changes,
+      snapshot: renderer_changed_snapshot(state, changes, prior_affected_range)
     }
 
-    {:reply, result, %{state | change_log: change_log}}
+    {:reply, result, state}
   end
 
   def handle_call({:changes_since, sequence}, _from, state) do
@@ -2373,6 +2380,26 @@ defmodule Minga.Buffer.Process do
   end
 
   # ── move_if_possible helpers ──
+
+  @spec renderer_changed_snapshot(
+          BufState.t(),
+          {:ok, [Minga.Buffer.EditDelta.t()]} | :reset_required,
+          {non_neg_integer(), non_neg_integer()} | nil
+        ) :: RenderSnapshot.t() | nil
+  defp renderer_changed_snapshot(_state, :reset_required, _prior_range), do: nil
+
+  defp renderer_changed_snapshot(state, {:ok, changes}, prior_range) do
+    case EditDelta.affected_line_range(changes, prior_range) do
+      nil ->
+        nil
+
+      {first_line, last_line} ->
+        line_count = Document.line_count(state.document)
+        bounded_first = min(first_line, line_count - 1)
+        bounded_last = min(max(last_line, bounded_first), line_count - 1)
+        bounded_render_snapshot(state, bounded_first, bounded_last - bounded_first + 1)
+    end
+  end
 
   @spec snapshot_lines(Document.t(), non_neg_integer(), non_neg_integer()) :: [String.t()]
   @spec bounded_render_snapshot(BufState.t(), non_neg_integer(), non_neg_integer()) ::

--- a/lib/minga/buffer/renderer_consume.ex
+++ b/lib/minga/buffer/renderer_consume.ex
@@ -3,19 +3,22 @@ defmodule Minga.Buffer.RendererConsume do
   Atomic renderer ChangeLog observation.
 
   The buffer creates this value in the same GenServer call that advances the
-  `:renderer` consumer. It deliberately contains no document or line payload.
+  `:renderer` consumer. `snapshot` is an optional bounded line payload for the
+  affected range; it never contains a document.
   """
 
   alias Minga.Buffer.ChangeLog
   alias Minga.Buffer.EditDelta
+  alias Minga.Buffer.RenderSnapshot
 
-  @enforce_keys [:version, :line_count, :change_sequence, :changes]
+  @enforce_keys [:version, :line_count, :change_sequence, :changes, :snapshot]
   defstruct @enforce_keys
 
   @type t :: %__MODULE__{
           version: non_neg_integer(),
           line_count: pos_integer(),
           change_sequence: ChangeLog.sequence(),
-          changes: {:ok, [EditDelta.t()]} | :reset_required
+          changes: {:ok, [EditDelta.t()]} | :reset_required,
+          snapshot: RenderSnapshot.t() | nil
         }
 end

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   """
 
   alias Minga.Buffer
+  alias Minga.Buffer.EditDelta
   alias Minga.Buffer.RenderSnapshot
   alias Minga.Config
   alias Minga.Core.Decorations
@@ -204,8 +205,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         do: Window.scroll_follow_cursor?(window, {cursor_line, cursor_byte_col}, now),
         else: {window, true}
 
-    expected_version = Window.expected_buffer_version(window) || Buffer.version(window.buffer)
-    base_snapshot = fetch_at_version!(window.buffer, expected_version, 0, 0)
+    {expected_version, changed_snapshot, base_snapshot} = render_observation!(window)
 
     window = Window.sync_line_identity(window, base_snapshot)
     line_count = base_snapshot.line_count
@@ -302,7 +302,15 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         wrap_on: wrap_on
       })
 
-    snapshot = fetch_at_version!(window.buffer, expected_version, fetch_first, fetch_count)
+    snapshot =
+      fetch_snapshot!(
+        window.buffer,
+        expected_version,
+        fetch_first,
+        fetch_count,
+        changed_snapshot
+      )
+
     lines = snapshot.lines
 
     Minga.Telemetry.execute(
@@ -397,6 +405,41 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     }
   end
 
+  @spec render_observation!(Window.t()) ::
+          {non_neg_integer(), RenderSnapshot.t() | nil, RenderSnapshot.t()}
+  defp render_observation!(window) do
+    expected_version = Window.expected_buffer_version(window) || Buffer.version(window.buffer)
+    changed_snapshot = Window.changed_snapshot(window)
+    base_snapshot = changed_snapshot || fetch_at_version!(window.buffer, expected_version, 0, 0)
+    {expected_version, changed_snapshot, base_snapshot}
+  end
+
+  @spec fetch_snapshot!(
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer(),
+          RenderSnapshot.t() | nil
+        ) :: RenderSnapshot.t()
+  defp fetch_snapshot!(
+         buffer,
+         expected_version,
+         first_line,
+         count,
+         %RenderSnapshot{
+           version: expected_version,
+           first_line: first_line,
+           lines: lines
+         } = snapshot
+       ) do
+    if length(lines) == count,
+      do: snapshot,
+      else: fetch_at_version!(buffer, expected_version, first_line, count)
+  end
+
+  defp fetch_snapshot!(buffer, expected_version, first_line, count, _changed_snapshot),
+    do: fetch_at_version!(buffer, expected_version, first_line, count)
+
   @spec fetch_at_version!(pid(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
           RenderSnapshot.t()
   defp fetch_at_version!(buffer, expected_version, first_line, count) do
@@ -445,11 +488,19 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   end
 
   defp resolve_fetch_range(%{visible_line_map: nil, full_residence?: true} = params) do
-    # A hydrated resident store needs only the lines touched by renderer-consumed
-    # deltas. Initial/reset/global-context hydration still fetches the whole file.
-    case resident_delta_fetch_range(params.window, params.line_count) do
-      nil -> {0, params.line_count, params.first_line}
-      {fetch_first, fetch_count} -> {fetch_first, fetch_count, params.first_line}
+    # A hydrated resident store needs only changed rows. A no-edit warm frame
+    # reuses the store and fetches only bounded visible presentation data.
+    case {resident_delta_fetch_range(params.window, params.line_count),
+          Window.resident_build(params.window)} do
+      {{fetch_first, fetch_count}, _resident_build} ->
+        {fetch_first, fetch_count, params.first_line}
+
+      {nil, %ResidentBuild{}} ->
+        count = min(params.visible_rows, max(params.line_count - params.first_line, 1))
+        {params.first_line, count, 0}
+
+      {nil, nil} ->
+        {0, params.line_count, params.first_line}
     end
   end
 
@@ -489,8 +540,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     deltas = Window.pending_edit_deltas(window)
 
     if Window.resident_build(window) != nil and deltas != [] do
-      first = deltas |> Enum.map(&elem(&1.start_position, 0)) |> Enum.min()
-      last = deltas |> Enum.map(&elem(&1.new_end_position, 0)) |> Enum.max()
+      {first, last} = EditDelta.affected_line_range(deltas)
       bounded_first = min(first, max(line_count - 1, 0))
       {bounded_first, max(min(last, line_count - 1) - bounded_first + 1, 1)}
     else

--- a/lib/minga_editor/render_pipeline/intent.ex
+++ b/lib/minga_editor/render_pipeline/intent.ex
@@ -12,6 +12,8 @@ defmodule MingaEditor.RenderPipeline.Intent do
   alias MingaEditor.RenderPipeline.WindowIntent
   alias MingaEditor.RenderPipeline.WorkspaceIntent
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Window
+  alias MingaEditor.Window.RenderCache
 
   @enforce_keys [:frame, :workspace, :windows, :window_layout, :buffer_versions, :revision]
   defstruct @enforce_keys
@@ -39,7 +41,7 @@ defmodule MingaEditor.RenderPipeline.Intent do
       workspace: WorkspaceIntent.from_workspace(input.workspace),
       windows: carriers,
       window_layout: %{tree: windows.tree, active: windows.active, next_id: windows.next_id},
-      buffer_versions: buffer_versions(carriers),
+      buffer_versions: buffer_versions(windows.map),
       revision: revision
     }
   end
@@ -49,20 +51,24 @@ defmodule MingaEditor.RenderPipeline.Intent do
   def force_keyframe(%__MODULE__{} = intent),
     do: %{intent | frame: FrameIntent.force_keyframe(intent.frame)}
 
-  @spec buffer_versions(map()) :: map()
+  @spec buffer_versions(%{optional(Window.id()) => Window.t()}) ::
+          %{optional(pid()) => non_neg_integer()}
   defp buffer_versions(windows) do
     Enum.reduce(windows, %{}, fn
-      {_id, %WindowIntent{buffer: buffer}}, acc when is_pid(buffer) ->
-        Map.put_new_lazy(acc, buffer, fn -> safe_version(buffer) end)
+      {_id,
+       %Window{
+         buffer: buffer,
+         render_cache: %RenderCache{buffer_version: observed_version}
+       }},
+      acc
+      when is_pid(buffer) and is_integer(observed_version) and observed_version >= 0 ->
+        Map.update(acc, buffer, observed_version, &max(&1, observed_version))
+
+      {_id, %Window{buffer: buffer}}, acc when is_pid(buffer) ->
+        Map.put_new(acc, buffer, 0)
 
       _, acc ->
         acc
     end)
-  end
-
-  defp safe_version(buffer) do
-    Minga.Buffer.version(buffer)
-  catch
-    :exit, _ -> 0
   end
 end

--- a/lib/minga_editor/renderer/buffer_changes.ex
+++ b/lib/minga_editor/renderer/buffer_changes.ex
@@ -7,6 +7,8 @@ defmodule MingaEditor.Renderer.BufferChanges do
   to every resident window showing that PID.
   """
 
+  alias Minga.Buffer.EditDelta
+  alias Minga.Buffer.RenderSnapshot
   alias Minga.Buffer.RendererConsume
   alias Minga.Telemetry
   alias MingaEditor.RenderPipeline.Intent
@@ -28,12 +30,12 @@ defmodule MingaEditor.Renderer.BufferChanges do
 
   @doc "Commits renderer-owned per-window cache state after a successful pipeline frame."
   @spec commit(State.t(), Input.t(), Intent.t()) :: State.t()
-  def commit(%State{} = state, %Input{} = output, %Intent{} = intent) do
+  def commit(%State{} = state, %Input{} = output, %Intent{}) do
     residents =
       Enum.reduce(output.workspace.windows.map, state.resident_windows, fn {id, window}, acc ->
         case Map.get(acc, id) do
           %ResidentWindowState{} = resident ->
-            version = Map.get(intent.buffer_versions, resident.buffer)
+            version = Map.get(state.buffer_versions, resident.buffer)
             Map.put(acc, id, ResidentWindowState.commit_window(resident, window, version))
 
           nil ->
@@ -41,7 +43,7 @@ defmodule MingaEditor.Renderer.BufferChanges do
         end
       end)
 
-    %{state | resident_windows: residents, buffer_versions: intent.buffer_versions}
+    %{state | resident_windows: residents}
   end
 
   @doc "Invalidates one renderer-owned window for targeted frontend recovery."
@@ -78,7 +80,8 @@ defmodule MingaEditor.Renderer.BufferChanges do
   defp consume_buffer_if_changed(%State{} = state, buffer, observed_version) do
     # This call is intentionally unconditional. Besides advancing changed buffers,
     # it closes the consume/fetch race when a retry reuses an older editor intent.
-    consumed = safe_consume(buffer, observed_version)
+    prior_range = pending_affected_range(state.resident_windows, buffer)
+    consumed = safe_consume(buffer, observed_version, prior_range)
     residents = fanout(state.resident_windows, buffer, consumed)
 
     delta_count =
@@ -104,16 +107,21 @@ defmodule MingaEditor.Renderer.BufferChanges do
     }
   end
 
-  @spec safe_consume(pid(), non_neg_integer()) :: RendererConsume.t()
-  defp safe_consume(buffer, fallback_version) do
-    Minga.Buffer.renderer_consume(buffer)
+  @spec safe_consume(
+          pid(),
+          non_neg_integer(),
+          {non_neg_integer(), non_neg_integer()} | nil
+        ) :: RendererConsume.t()
+  defp safe_consume(buffer, fallback_version, prior_range) do
+    Minga.Buffer.renderer_consume(buffer, prior_range)
   catch
     :exit, _ ->
       %RendererConsume{
         version: fallback_version,
         line_count: 1,
         change_sequence: 0,
-        changes: :reset_required
+        changes: :reset_required,
+        snapshot: nil
       }
   end
 
@@ -131,6 +139,7 @@ defmodule MingaEditor.Renderer.BufferChanges do
               ResidentWindowState.apply_deltas(
                 resident,
                 deltas,
+                consumed.snapshot,
                 consumed.version,
                 consumed.line_count,
                 consumed.change_sequence
@@ -152,6 +161,63 @@ defmodule MingaEditor.Renderer.BufferChanges do
         pair
     end)
   end
+
+  @spec pending_affected_range(
+          %{optional(MingaEditor.Window.id()) => ResidentWindowState.t()},
+          pid()
+        ) :: {non_neg_integer(), non_neg_integer()} | nil
+  defp pending_affected_range(residents, buffer) do
+    snapshots =
+      Enum.flat_map(residents, fn
+        {_id, %ResidentWindowState{buffer: ^buffer, render_cache: cache}} ->
+          case MingaEditor.Renderer.WindowCache.changed_snapshot(cache) do
+            %RenderSnapshot{} = snapshot -> [snapshot]
+            nil -> []
+          end
+
+        _ ->
+          []
+      end)
+
+    pending_range_from_snapshots(snapshots, residents, buffer)
+  end
+
+  @spec pending_range_from_snapshots(
+          [RenderSnapshot.t()],
+          %{optional(MingaEditor.Window.id()) => ResidentWindowState.t()},
+          pid()
+        ) :: {non_neg_integer(), non_neg_integer()} | nil
+  defp pending_range_from_snapshots([_ | _] = snapshots, _residents, _buffer) do
+    Enum.reduce(snapshots, nil, fn snapshot, range ->
+      last = snapshot.first_line + max(length(snapshot.lines) - 1, 0)
+      union_range(range, {snapshot.first_line, last})
+    end)
+  end
+
+  defp pending_range_from_snapshots([], residents, buffer) do
+    deltas =
+      Enum.find_value(residents, [], fn
+        {_id, %ResidentWindowState{buffer: ^buffer, render_cache: cache}} ->
+          case MingaEditor.Renderer.WindowCache.pending_edit_deltas(cache) do
+            [] -> nil
+            pending -> pending
+          end
+
+        _ ->
+          nil
+      end)
+
+    EditDelta.affected_line_range(deltas)
+  end
+
+  @spec union_range(
+          {non_neg_integer(), non_neg_integer()} | nil,
+          {non_neg_integer(), non_neg_integer()}
+        ) :: {non_neg_integer(), non_neg_integer()}
+  defp union_range(nil, range), do: range
+
+  defp union_range({first, last}, {new_first, new_last}),
+    do: {min(first, new_first), max(last, new_last)}
 
   @spec materialize(State.t(), Intent.t()) :: Input.t()
   defp materialize(%State{} = state, %Intent{} = intent) do

--- a/lib/minga_editor/renderer/frame_handler.ex
+++ b/lib/minga_editor/renderer/frame_handler.ex
@@ -143,7 +143,7 @@ defmodule MingaEditor.Renderer.FrameHandler do
       end)
 
     committed = BufferChanges.commit(state, output, intent)
-    emit_frame_telemetry(output, intent, seq, pushed_at)
+    emit_frame_telemetry(output, seq, pushed_at)
     {:ok, committed, output}
   rescue
     _error in [StaleBufferError] -> {:stale, state}
@@ -193,12 +193,7 @@ defmodule MingaEditor.Renderer.FrameHandler do
   defp receipt(output, seq, intent) do
     receipt = RenderReceipt.from_output(output, seq, monotonic_now(), intent.revision)
 
-    Telemetry.execute(
-      [:minga, :render, :boundary],
-      %{receipt_bytes: :erlang.external_size(receipt)},
-      %{}
-    )
-
+    emit_boundary_sizes(intent, receipt)
     receipt
   end
 
@@ -212,8 +207,8 @@ defmodule MingaEditor.Renderer.FrameHandler do
     })
   end
 
-  @spec emit_frame_telemetry(Input.t(), Intent.t(), non_neg_integer(), integer()) :: :ok
-  defp emit_frame_telemetry(output, intent, seq, pushed_at) do
+  @spec emit_frame_telemetry(Input.t(), non_neg_integer(), integer()) :: :ok
+  defp emit_frame_telemetry(output, seq, pushed_at) do
     Telemetry.execute(
       [:minga, :render, :frame_latency],
       %{microseconds: monotonic_now() - pushed_at},
@@ -222,12 +217,29 @@ defmodule MingaEditor.Renderer.FrameHandler do
 
     Telemetry.execute(
       [:minga, :render, :work],
-      %{
-        rows_composed: output.caches.frame_rows_rasterized,
-        request_bytes: :erlang.external_size(intent)
-      },
+      %{rows_composed: output.caches.frame_rows_rasterized},
       %{frame_seq: seq, path: output.caches.frame_render_path}
     )
+  end
+
+  @spec emit_boundary_sizes(Intent.t(), RenderReceipt.t()) :: :ok
+  defp emit_boundary_sizes(intent, receipt) do
+    event = [:minga, :render, :boundary]
+
+    case :telemetry.list_handlers(event) do
+      [] ->
+        :ok
+
+      _handlers ->
+        Telemetry.execute(
+          event,
+          %{
+            request_bytes: :erlang.external_size(intent),
+            receipt_bytes: :erlang.external_size(receipt)
+          },
+          %{}
+        )
+    end
   end
 
   @spec schedule_render() :: reference()

--- a/lib/minga_editor/renderer/render_window.ex
+++ b/lib/minga_editor/renderer/render_window.ex
@@ -694,6 +694,11 @@ defmodule MingaEditor.Renderer.RenderWindow do
   def pending_edit_deltas(%__MODULE__{render_cache: cache}),
     do: RenderCache.pending_edit_deltas(cache)
 
+  @doc "Returns the atomic bounded snapshot for pending resident deltas."
+  @spec changed_snapshot(t()) :: Minga.Buffer.RenderSnapshot.t() | nil
+  def changed_snapshot(%__MODULE__{render_cache: cache}),
+    do: RenderCache.changed_snapshot(cache)
+
   @doc "Returns the persistent full-document residence build state (#2658)."
   @spec resident_build(t()) :: MingaEditor.RenderModel.Window.ResidentBuild.t() | nil
   def resident_build(%__MODULE__{render_cache: cache}), do: RenderCache.resident_build(cache)

--- a/lib/minga_editor/renderer/resident_window_state.ex
+++ b/lib/minga_editor/renderer/resident_window_state.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Renderer.ResidentWindowState do
   """
 
   alias Minga.Buffer.EditDelta
+  alias Minga.Buffer.RenderSnapshot
   alias MingaEditor.Renderer.RenderWindow
   alias MingaEditor.Window
   alias MingaEditor.Renderer.WindowCache, as: RenderCache
@@ -62,11 +63,31 @@ defmodule MingaEditor.Renderer.ResidentWindowState do
   end
 
   @doc "Applies newly consumed deltas exactly once and retains them until a frame commits."
-  @spec apply_deltas(t(), [EditDelta.t()], non_neg_integer(), pos_integer(), non_neg_integer()) ::
-          t()
-  def apply_deltas(%__MODULE__{} = state, deltas, version, line_count, change_sequence)
+  @spec apply_deltas(
+          t(),
+          [EditDelta.t()],
+          RenderSnapshot.t() | nil,
+          non_neg_integer(),
+          pos_integer(),
+          non_neg_integer()
+        ) :: t()
+  def apply_deltas(
+        %__MODULE__{} = state,
+        deltas,
+        changed_snapshot,
+        version,
+        line_count,
+        change_sequence
+      )
       when is_list(deltas) do
-    cache = RenderCache.apply_edit_deltas(state.render_cache, state.buffer, deltas)
+    cache =
+      RenderCache.apply_edit_deltas(
+        state.render_cache,
+        state.buffer,
+        deltas,
+        changed_snapshot
+      )
+
     dirty = dirty_lines(deltas)
 
     %{

--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -9,7 +9,6 @@ defmodule MingaEditor.Renderer.Server do
 
   use GenServer
 
-  alias Minga.Telemetry
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.Renderer.FrameHandler
@@ -33,7 +32,6 @@ defmodule MingaEditor.Renderer.Server do
 
   def cast_snapshot(server, %Intent{} = intent, frame_seq)
       when is_integer(frame_seq) and frame_seq >= 0 do
-    emit_request_size(intent)
     GenServer.cast(server, {:render, intent, frame_seq, monotonic_now()})
   end
 
@@ -47,7 +45,6 @@ defmodule MingaEditor.Renderer.Server do
 
   def render_sync(server, %Intent{} = intent, frame_seq)
       when is_integer(frame_seq) and frame_seq >= 0 do
-    emit_request_size(intent)
     GenServer.call(server, {:render_sync, intent, frame_seq, monotonic_now()}, :infinity)
   end
 
@@ -56,7 +53,6 @@ defmodule MingaEditor.Renderer.Server do
           {:ok, MingaEditor.Renderer.RenderReceipt.t()} | {:error, Exception.t()}
   def reset_sync(server, %Intent{} = intent, frame_seq)
       when is_integer(frame_seq) and frame_seq >= 0 do
-    emit_request_size(intent)
     GenServer.call(server, {:reset_sync, intent, frame_seq, monotonic_now()}, :infinity)
   end
 
@@ -121,15 +117,6 @@ defmodule MingaEditor.Renderer.Server do
 
   @impl true
   def handle_info(message, state), do: FrameHandler.dispatch(message, state)
-
-  @spec emit_request_size(Intent.t()) :: :ok
-  defp emit_request_size(intent) do
-    Telemetry.execute(
-      [:minga, :render, :boundary],
-      %{request_bytes: :erlang.external_size(intent)},
-      %{}
-    )
-  end
 
   @spec monotonic_now() :: integer()
   defp monotonic_now, do: System.monotonic_time(:microsecond)

--- a/lib/minga_editor/renderer/window_cache.ex
+++ b/lib/minga_editor/renderer/window_cache.ex
@@ -90,6 +90,7 @@ defmodule MingaEditor.Renderer.WindowCache do
           row_slot_allocator: RowSlotAllocator.t(),
           resident_build: MingaEditor.RenderModel.Window.ResidentBuild.t() | nil,
           pending_edit_deltas: [Minga.Buffer.EditDelta.t()],
+          changed_snapshot: RenderSnapshot.t() | nil,
           hydration_reason: atom() | nil,
           resident: boolean(),
           residence_armed: boolean(),
@@ -119,6 +120,7 @@ defmodule MingaEditor.Renderer.WindowCache do
             row_slot_allocator: RowSlotAllocator.new(),
             resident_build: nil,
             pending_edit_deltas: [],
+            changed_snapshot: nil,
             hydration_reason: nil,
             resident: false,
             residence_armed: false,
@@ -169,6 +171,7 @@ defmodule MingaEditor.Renderer.WindowCache do
         retained_wrap_lines: %{},
         resident_build: nil,
         pending_edit_deltas: [],
+        changed_snapshot: nil,
         residence_armed: false
     }
   end
@@ -399,12 +402,27 @@ defmodule MingaEditor.Renderer.WindowCache do
     %{cache | row_slot_allocator: allocator}
   end
 
-  @doc "Applies renderer-consumed ordered edit deltas without a full buffer snapshot."
-  @spec apply_edit_deltas(t(), pid(), [Minga.Buffer.EditDelta.t()]) :: t()
-  def apply_edit_deltas(%__MODULE__{line_identity: nil} = cache, _buffer, deltas),
-    do: %{cache | pending_edit_deltas: cache.pending_edit_deltas ++ deltas}
+  @doc "Applies renderer-consumed deltas and retains their atomic changed snapshot."
+  @spec apply_edit_deltas(
+          t(),
+          pid(),
+          [Minga.Buffer.EditDelta.t()],
+          RenderSnapshot.t() | nil
+        ) :: t()
+  def apply_edit_deltas(
+        %__MODULE__{line_identity: nil} = cache,
+        _buffer,
+        deltas,
+        changed_snapshot
+      ) do
+    %{
+      cache
+      | pending_edit_deltas: cache.pending_edit_deltas ++ deltas,
+        changed_snapshot: changed_snapshot || cache.changed_snapshot
+    }
+  end
 
-  def apply_edit_deltas(%__MODULE__{} = cache, buffer, deltas)
+  def apply_edit_deltas(%__MODULE__{} = cache, buffer, deltas, changed_snapshot)
       when is_pid(buffer) and is_list(deltas) do
     case LineIdentity.apply_edits(cache.line_identity, deltas) do
       {:ok, identity} ->
@@ -413,7 +431,8 @@ defmodule MingaEditor.Renderer.WindowCache do
           | line_identity: identity,
             identity_buffer: buffer,
             applied_change_sequence: cache.applied_change_sequence + length(deltas),
-            pending_edit_deltas: cache.pending_edit_deltas ++ deltas
+            pending_edit_deltas: cache.pending_edit_deltas ++ deltas,
+            changed_snapshot: changed_snapshot || cache.changed_snapshot
         }
 
       :reset_required ->
@@ -450,6 +469,7 @@ defmodule MingaEditor.Renderer.WindowCache do
         row_slot_allocator: RowSlotAllocator.new(),
         resident_build: nil,
         pending_edit_deltas: [],
+        changed_snapshot: nil,
         hydration_reason: :identity_reset,
         reset_pending: true
     }
@@ -636,10 +656,20 @@ defmodule MingaEditor.Renderer.WindowCache do
   @spec pending_edit_deltas(t()) :: [Minga.Buffer.EditDelta.t()]
   def pending_edit_deltas(%__MODULE__{pending_edit_deltas: deltas}), do: deltas
 
+  @doc "Returns the atomic bounded snapshot for pending resident deltas."
+  @spec changed_snapshot(t()) :: RenderSnapshot.t() | nil
+  def changed_snapshot(%__MODULE__{changed_snapshot: snapshot}), do: snapshot
+
   @doc "Replaces the persistent residence build state captured by the last frame."
   @spec put_resident_build(t(), MingaEditor.RenderModel.Window.ResidentBuild.t() | nil) :: t()
   def put_resident_build(%__MODULE__{} = cache, state) do
-    %{cache | resident_build: state, pending_edit_deltas: [], hydration_reason: nil}
+    %{
+      cache
+      | resident_build: state,
+        pending_edit_deltas: [],
+        changed_snapshot: nil,
+        hydration_reason: nil
+    }
   end
 
   @doc "Returns the explicit reason for the next full resident hydration."

--- a/test/minga/buffer/renderer_api_test.exs
+++ b/test/minga/buffer/renderer_api_test.exs
@@ -21,6 +21,68 @@ defmodule Minga.Buffer.RendererAPITest do
     assert {:ok, []} = Buffer.consume_edit_deltas(buffer, :renderer)
   end
 
+  test "renderer consume returns one bounded changed snapshot with no Document" do
+    buffer = start_supervised!({Buffer, content: "zero\none\ntwo\nthree"})
+    _initial = Buffer.renderer_consume(buffer)
+
+    :ok = Buffer.move_to(buffer, {2, 0})
+    :ok = Buffer.insert_text(buffer, "changed ")
+
+    assert %RendererConsume{
+             version: 1,
+             changes: {:ok, [_]},
+             snapshot:
+               %RenderSnapshot{first_line: 2, lines: ["changed two"], version: 1} = snapshot
+           } = Buffer.renderer_consume(buffer)
+
+    refute Map.has_key?(Map.from_struct(snapshot), :document)
+  end
+
+  test "retry consume snapshots the union of a prior pending range and a second edit" do
+    buffer = start_supervised!({Buffer, content: "zero\none\ntwo\nthree\nfour"})
+    _initial = Buffer.renderer_consume(buffer)
+
+    :ok = Buffer.move_to(buffer, {1, 0})
+    :ok = Buffer.insert_text(buffer, "A")
+
+    assert %RendererConsume{snapshot: %RenderSnapshot{first_line: 1, lines: ["Aone"]}} =
+             Buffer.renderer_consume(buffer)
+
+    :ok = Buffer.move_to(buffer, {3, 0})
+    :ok = Buffer.insert_text(buffer, "B")
+
+    assert %RendererConsume{
+             version: 2,
+             changes: {:ok, [_]},
+             snapshot: %RenderSnapshot{
+               first_line: 1,
+               lines: ["Aone", "two", "Bthree"],
+               version: 2
+             }
+           } = Buffer.renderer_consume(buffer, {1, 1})
+  end
+
+  test "retry range follows pending content shifted by a structural edit" do
+    buffer = start_supervised!({Buffer, content: "zero\none\ntwo\nthree\nfour"})
+    _initial = Buffer.renderer_consume(buffer)
+
+    :ok = Buffer.move_to(buffer, {3, 0})
+    :ok = Buffer.insert_text(buffer, "X")
+
+    assert %RendererConsume{snapshot: %RenderSnapshot{first_line: 3, lines: ["Xthree"]}} =
+             Buffer.renderer_consume(buffer)
+
+    :ok = Buffer.move_to(buffer, {0, 0})
+    :ok = Buffer.insert_text(buffer, "new\n")
+
+    assert %RendererConsume{
+             snapshot: %RenderSnapshot{
+               first_line: 0,
+               lines: ["new", "zero", "one", "two", "Xthree"]
+             }
+           } = Buffer.renderer_consume(buffer, {3, 3})
+  end
+
   test "version-checked range fetch returns no Document and rejects an intervening edit" do
     buffer = start_supervised!({Buffer, content: "zero\none\ntwo\nthree"})
     consume = Buffer.renderer_consume(buffer)

--- a/test/minga/system_observer_test.exs
+++ b/test/minga/system_observer_test.exs
@@ -84,9 +84,7 @@ defmodule Minga.SystemObserverTest do
       Minga.Events.subscribe(:supervisor_restarted)
       dummy_pid = spawn(fn -> receive do: (:stop -> :ok) end)
       on_exit(fn -> if Process.alive?(dummy_pid), do: Process.exit(dummy_pid, :kill) end)
-      monitor_as_supervisor(name, dummy_pid, :dummy_supervisor)
-
-      Process.exit(dummy_pid, :kill)
+      monitor_and_kill_as_supervisor(name, dummy_pid, :dummy_supervisor)
 
       assert_receive {:minga_event, :supervisor_restarted, payload}, 1_000
       assert payload.name == :dummy_supervisor
@@ -205,9 +203,10 @@ defmodule Minga.SystemObserverTest do
     :ok
   end
 
-  defp monitor_as_supervisor(name, pid, supervisor_name) do
+  defp monitor_and_kill_as_supervisor(name, pid, supervisor_name) do
     :sys.replace_state(name, fn state ->
       ref = Process.monitor(pid)
+      Process.exit(pid, :kill)
       %{state | monitors: Map.put(state.monitors, ref, supervisor_name)}
     end)
   end

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -83,10 +83,10 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
     cache = renderer_cache(existing)
 
     case consumed.changes do
-      {:ok, deltas} -> WindowCache.apply_edit_deltas(cache, buffer, deltas)
+      {:ok, deltas} -> WindowCache.apply_edit_deltas(cache, buffer, deltas, consumed.snapshot)
       :reset_required -> WindowCache.mark_identity_reset(cache)
     end
-    |> WindowCache.with_fetch_version(Buffer.render_snapshot(buffer, 0, 1).version)
+    |> WindowCache.with_fetch_version(consumed.version)
   end
 
   defp renderer_cache(%WindowCache{} = cache), do: cache

--- a/test/minga_editor/render_pipeline/resident_incremental_test.exs
+++ b/test/minga_editor/render_pipeline/resident_incremental_test.exs
@@ -94,6 +94,37 @@ defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
       assert after_model.row_delta.result_row_count == 300
     end
 
+    test "a warm no-edit frame never fetches the full resident document" do
+      state = warm(resident_state(300))
+      buffer = state.editor.workspace.buffers.active
+
+      calls = trace_buffer_calls(buffer, fn -> build_frame(state) end)
+
+      refute Enum.any?(calls.messages, fn
+               {:render_lines, _version, 0, 300} -> true
+               _ -> false
+             end)
+
+      assert Enum.all?(calls.messages, fn
+               {:render_lines, _version, _first, count} -> count <= 12
+               _ -> true
+             end)
+    end
+
+    test "an ordinary resident edit uses one atomic consume snapshot and no render_lines" do
+      state = warm(resident_state(300))
+      buffer = state.editor.workspace.buffers.active
+
+      BufferProcess.move_to(buffer, {150, 0})
+      BufferProcess.insert_text(buffer, "Z")
+
+      calls = trace_buffer_calls(buffer, fn -> build_frame(state) end)
+
+      assert Enum.count(calls.messages, &match?({:renderer_consume, _}, &1)) == 1
+      refute Enum.any?(calls.messages, &match?({:render_lines, _, _, _}, &1))
+      refute Enum.any?(calls.messages, &match?(:version, &1))
+    end
+
     test "a pure cursor move reuses the resident rows and leaves the digest unchanged" do
       state = warm(resident_state(300))
       buffer = state.editor.workspace.buffers.active
@@ -108,8 +139,8 @@ defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
     end
   end
 
-  describe "stale consume/fetch retry" do
-    test "two ordered edits survive a forced stale fetch and compose once on both rows" do
+  describe "uncommitted consume retry" do
+    test "two ordered edits union their snapshots and compose once on both rows" do
       state = warm(resident_state(300))
       buffer = state.editor.workspace.buffers.active
 
@@ -126,9 +157,11 @@ defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
       stale_input = RenderPipeline.compute_layout(stale_input)
       stale_layout = Layout.get(stale_input)
 
-      assert_raise MingaEditor.Renderer.StaleBufferError, fn ->
-        Scroll.scroll_windows(stale_input, stale_layout)
-      end
+      # The resident fast path owns an atomic version-qualified snapshot, so
+      # this frame can finish consistently without a second buffer fetch even
+      # though another edit landed after consume. We intentionally do not
+      # commit it; the retry must retain its pending range and union edit B.
+      {_stale_scrolls, _stale_input} = Scroll.scroll_windows(stale_input, stale_layout)
 
       {renderer, input} = BufferChanges.prepare(renderer, intent)
       input = Content.reset_rows_rasterized(input)
@@ -151,6 +184,31 @@ defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
       assert first.row_id != second.row_id
       assert model.row_delta.base_row_count == 300
       assert model.row_delta.result_row_count == 300
+    end
+  end
+
+  defp trace_buffer_calls(buffer, fun) do
+    :erlang.trace(buffer, true, [:receive, {:tracer, self()}])
+
+    try do
+      result = fun.()
+      delivery_ref = :erlang.trace_delivered(buffer)
+      assert_receive {:trace_delivered, ^buffer, ^delivery_ref}
+      %{result: result, messages: drain_buffer_calls(buffer, [])}
+    after
+      :erlang.trace(buffer, false, [:receive])
+    end
+  end
+
+  defp drain_buffer_calls(buffer, acc) do
+    receive do
+      {:trace, ^buffer, :receive, {:"$gen_call", _from, message}} ->
+        drain_buffer_calls(buffer, [message | acc])
+
+      {:trace, ^buffer, :receive, _message} ->
+        drain_buffer_calls(buffer, acc)
+    after
+      0 -> Enum.reverse(acc)
     end
   end
 

--- a/test/minga_editor/renderer/buffer_changes_test.exs
+++ b/test/minga_editor/renderer/buffer_changes_test.exs
@@ -23,13 +23,68 @@ defmodule MingaEditor.Renderer.BufferChangesTest do
     :ok = Minga.Buffer.insert_text(buffer, "changed ")
     changed = %{intent | buffer_versions: %{buffer => Minga.Buffer.version(buffer)}}
 
-    {state, _input} = BufferChanges.prepare(state, changed)
+    calls = trace_buffer_calls(buffer, fn -> BufferChanges.prepare(state, changed) end)
+    {state, _input} = calls.result
+
+    assert Enum.count(calls.messages, &match?({:renderer_consume, _}, &1)) == 1
+    refute Enum.any?(calls.messages, &match?(:version, &1))
 
     first_pending = state.resident_windows[1].render_cache.pending_edit_deltas
     second_pending = state.resident_windows[2].render_cache.pending_edit_deltas
+    first_snapshot = state.resident_windows[1].render_cache.changed_snapshot
+    second_snapshot = state.resident_windows[2].render_cache.changed_snapshot
+
     assert first_pending != []
     assert first_pending == second_pending
+    assert first_snapshot == second_snapshot
+    assert first_snapshot.lines == ["changed two"]
+    refute Map.has_key?(Map.from_struct(first_snapshot), :document)
     assert {:ok, []} = Minga.Buffer.consume_edit_deltas(buffer, :renderer)
+  end
+
+  test "a third uncommitted consume preserves a pending range shifted by structural edits" do
+    buffer = start_supervised!({Minga.Buffer, content: "zero\none\ntwo\nthree\nfour"})
+    intent = intent(buffer, 0)
+    {state, _input} = BufferChanges.prepare(State.new([]), intent)
+
+    :ok = Minga.Buffer.move_to(buffer, {3, 0})
+    :ok = Minga.Buffer.insert_text(buffer, "X")
+    {state, _input} = BufferChanges.prepare(state, intent)
+
+    :ok = Minga.Buffer.move_to(buffer, {0, 0})
+    :ok = Minga.Buffer.insert_text(buffer, "new\n")
+    {state, _input} = BufferChanges.prepare(state, intent)
+
+    :ok = Minga.Buffer.move_to(buffer, {0, 0})
+    :ok = Minga.Buffer.insert_text(buffer, "Y")
+    {state, _input} = BufferChanges.prepare(state, intent)
+
+    first_snapshot = state.resident_windows[1].render_cache.changed_snapshot
+    second_snapshot = state.resident_windows[2].render_cache.changed_snapshot
+
+    assert first_snapshot == second_snapshot
+    assert first_snapshot.first_line == 0
+    assert first_snapshot.lines == ["Ynew", "zero", "one", "two", "Xthree"]
+  end
+
+  test "intent derives typed observed versions without calling the buffer" do
+    buffer = start_supervised!({Minga.Buffer, content: "one"})
+    one = Window.new(1, buffer, 24, 80)
+    windows = %Windows{map: %{1 => one}, active: 1, tree: {:leaf, 1}, next_id: 2}
+
+    input = %Input{
+      port_manager: nil,
+      theme: Fallback.theme(),
+      capabilities: %Capabilities{},
+      shell_id: :traditional,
+      shell: MingaEditor.Shell.Traditional,
+      message_store: %MingaEditor.UI.Panel.MessageStore{},
+      workspace: %{windows: windows}
+    }
+
+    calls = trace_buffer_calls(buffer, fn -> Intent.from_input(input) end)
+    assert calls.result.buffer_versions == %{buffer => 0}
+    assert calls.messages == []
   end
 
   test "window close, buffer replacement, and exact buffer DOWN share centralized cleanup" do
@@ -137,6 +192,31 @@ defmodule MingaEditor.Renderer.BufferChangesTest do
     assert Enum.all?(bounded.windows, fn {_id, carrier} ->
              carrier.__struct__ == MingaEditor.RenderPipeline.WindowIntent
            end)
+  end
+
+  defp trace_buffer_calls(buffer, fun) do
+    :erlang.trace(buffer, true, [:receive, {:tracer, self()}])
+
+    try do
+      result = fun.()
+      delivery_ref = :erlang.trace_delivered(buffer)
+      assert_receive {:trace_delivered, ^buffer, ^delivery_ref}
+      %{result: result, messages: drain_buffer_calls(buffer, [])}
+    after
+      :erlang.trace(buffer, false, [:receive])
+    end
+  end
+
+  defp drain_buffer_calls(buffer, acc) do
+    receive do
+      {:trace, ^buffer, :receive, {:"$gen_call", _from, message}} ->
+        drain_buffer_calls(buffer, [message | acc])
+
+      {:trace, ^buffer, :receive, _message} ->
+        drain_buffer_calls(buffer, acc)
+    after
+      0 -> Enum.reverse(acc)
+    end
   end
 
   defp intent(buffer, version) do

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -455,7 +455,7 @@ defmodule MingaEditor.Renderer.ServerTest do
 
       RendererServer.cast_snapshot(renderer, snapshot, 20)
       assert_receive {:resident_probe, 20, 1, false, 0, [], ^epoch}, @async_render_timeout
-      assert_receive {:line_fetch, %{lines_fetched: 130}, %{full_residence?: true}}
+      assert_receive {:line_fetch, %{lines_fetched: 24}, %{full_residence?: true}}
 
       RendererServer.frame_status(
         renderer,


### PR DESCRIPTION
## Summary

- preserve current-coordinate changed snapshots across repeated stale consume/fetch retries, including structural line shifts
- fold changed-line capture into the atomic renderer consume so ordinary resident edits avoid separate version and line-fetch calls
- materialize full resident rows whenever adapter recovery requires a full snapshot
- compute request/receipt term-size telemetry only when the boundary event has observers, removing unconditional serialization from every frame
- make headless reset use the persistent renderer recovery path and isolate two timing-sensitive tests

## Performance

No benchmark threshold, fixture, or baseline changed. Three local rounds improved median p50 versus merged #2741:

- small frame: ~1.38 ms vs ~1.52 ms
- large frame: ~1.63 ms vs ~1.74 ms
- agent stream: ~1.67 ms vs ~1.83 ms

## Validation

- `make lint`
- `mix test.llm` (9,150 tests, 97 properties, 0 failures)
- `mix conformance` (160 transcripts)
- focused renderer/retry/buffer suites (89 tests, 0 failures)
- complete local keystroke benchmark, all scenarios

Follow-up to #2742 and #2797.
