### PR TITLE
chore(editor): prefer Expert for Elixir LSP

### DIFF
--- a/.pi-lens/lsp.json
+++ b/.pi-lens/lsp.json
@@ -1,0 +1,3 @@
+{
+  "disabledServers": ["elixir"]
+}


### PR DESCRIPTION
# TL;DR
Configure pi-lens to use Expert as Minga's default Elixir language server instead of ElixirLS.

## Context
pi-lens 3.8.69 added Expert as an alternate Elixir LSP. Disabling the `elixir` server ID selects Expert for project diagnostics and navigation.

## Changes
- Add `.pi-lens/lsp.json`.
- Disable the ElixirLS `elixir` server entry so pi-lens selects Expert.

## Verification
- Parsed `.pi-lens/lsp.json` with `python3 -m json.tool`.
- Ran `git diff --check`.
- Ran LSP diagnostics against the configuration with no findings.
- Started a fresh isolated Pi process from this worktree and ran `lsp_diagnostics` on `lib/minga.ex`. Telemetry showed two attempted servers, `expert` and `ast-grep`, with no ElixirLS attempt. Expert returned zero diagnostics.
- Reviewer verdict: PASS.