### PR TITLE
fix(parser): narrow synchronization result contracts

### DIFF
--- a/lib/minga/parser/event_router.ex
+++ b/lib/minga/parser/event_router.ex
@@ -22,8 +22,6 @@ defmodule Minga.Parser.EventRouter do
 
   @type route_result ::
           {:noreply, BufferRegistry.t(), ParseScheduler.t(), RequestState.t(), SnippetState.t()}
-          | {:port_write_failed, BufferRegistry.t(), ParseScheduler.t(), RequestState.t(),
-             SnippetState.t()}
   @type highlight_start_result ::
           {:noreply, SnippetState.t()} | {:reply, :unsupported, SnippetState.t()}
   @type route_context ::
@@ -315,9 +313,6 @@ defmodule Minga.Parser.EventRouter do
 
         noreply(buffers, scheduler, requests, snippets)
 
-      {:port_write_failed, buffers, scheduler, requests} ->
-        {:port_write_failed, buffers, scheduler, requests, snippets}
-
       :stale ->
         noreply(buffers, scheduler, requests, snippets)
     end
@@ -463,13 +458,10 @@ defmodule Minga.Parser.EventRouter do
   defp recover_parser_buffer(port, buffers, scheduler, requests, snippets, buffer_id) do
     case BufferRegistry.resolve(buffers, buffer_id) do
       buffer_pid when is_pid(buffer_pid) ->
-        case ParseSync.force_parse(port, buffers, scheduler, requests, buffer_pid) do
-          {:ok, buffers, scheduler, requests} ->
-            noreply(buffers, scheduler, requests, snippets)
+        {:ok, buffers, scheduler, requests} =
+          ParseSync.force_parse(port, buffers, scheduler, requests, buffer_pid)
 
-          {:port_write_failed, buffers, scheduler, requests} ->
-            {:port_write_failed, buffers, scheduler, requests, snippets}
-        end
+        noreply(buffers, scheduler, requests, snippets)
 
       nil ->
         noreply(buffers, scheduler, requests, snippets)

--- a/lib/minga/parser/manager.ex
+++ b/lib/minga/parser/manager.ex
@@ -722,18 +722,6 @@ defmodule Minga.Parser.Manager do
         snippets: snippets
     }
 
-  defp install_route_result(state, {:port_write_failed, buffers, scheduler, requests, snippets}) do
-    state = %{
-      state
-      | buffers: buffers,
-        parse_scheduler: scheduler,
-        requests: requests,
-        snippets: snippets
-    }
-
-    recover_write_failure(state)
-  end
-
   @spec handle_manual_restart(t()) :: {:reply, :ok | {:error, :binary_not_found}, t()}
   defp handle_manual_restart(state) do
     port_state = PortState.reset_restart_policy(state.port)

--- a/lib/minga/parser/parse_sync.ex
+++ b/lib/minga/parser/parse_sync.ex
@@ -19,12 +19,12 @@ defmodule Minga.Parser.ParseSync do
 
   @parse_admission_timeout_ms 10_000
 
+  @type ok_result :: {:ok, BufferRegistry.t(), ParseScheduler.t(), RequestState.t()}
   @type result ::
-          {:ok, BufferRegistry.t(), ParseScheduler.t(), RequestState.t()}
+          ok_result()
           | {:port_write_failed, BufferRegistry.t(), ParseScheduler.t(), RequestState.t()}
   @type completion_result ::
           {:ok, BufferRegistry.t(), ParseScheduler.t(), RequestState.t(), BufferRegistration.t()}
-          | {:port_write_failed, BufferRegistry.t(), ParseScheduler.t(), RequestState.t()}
           | :stale
   @type timeout_result ::
           :ok | {:drop_buffer, RequestState.t()} | :restart_port
@@ -36,7 +36,7 @@ defmodule Minga.Parser.ParseSync do
           ParseScheduler.t(),
           RequestState.t(),
           pid()
-        ) :: result()
+        ) :: ok_result()
   def force_parse(port, buffers, scheduler, requests, buffer_pid) do
     case BufferRegistry.fetch(buffers, buffer_pid) do
       {:ok, registration} ->
@@ -59,7 +59,7 @@ defmodule Minga.Parser.ParseSync do
           RequestState.t(),
           pid(),
           non_neg_integer()
-        ) :: result()
+        ) :: ok_result()
   def mark_dirty(port, buffers, scheduler, requests, buffer_pid, sequence) do
     case BufferRegistry.fetch(buffers, buffer_pid) do
       {:ok, registration} ->
@@ -82,7 +82,7 @@ defmodule Minga.Parser.ParseSync do
           ParseScheduler.t(),
           RequestState.t(),
           pid()
-        ) :: result()
+        ) :: ok_result()
   def pump(nil, buffers, scheduler, requests, _buffer_pid), do: ok(buffers, scheduler, requests)
 
   def pump(port, buffers, scheduler, requests, buffer_pid) do
@@ -97,7 +97,7 @@ defmodule Minga.Parser.ParseSync do
 
   @doc "Activates the next queued parse synchronization operation."
   @spec dispatch_next(port() | nil, BufferRegistry.t(), ParseScheduler.t(), RequestState.t()) ::
-          result()
+          ok_result()
   def dispatch_next(nil, buffers, scheduler, requests), do: ok(buffers, scheduler, requests)
 
   def dispatch_next(port, buffers, scheduler, requests) do
@@ -219,7 +219,7 @@ defmodule Minga.Parser.ParseSync do
           BufferRegistry.t(),
           ParseScheduler.t(),
           RequestState.t()
-        ) :: result()
+        ) :: ok_result()
   def restart_pumps(port, buffers, scheduler, requests) do
     buffer_count = BufferRegistry.count(buffers)
 
@@ -233,11 +233,8 @@ defmodule Minga.Parser.ParseSync do
     buffers
     |> BufferRegistry.entries()
     |> Map.keys()
-    |> Enum.reduce_while(ok(buffers, scheduler, requests), fn buffer_pid, {:ok, b, s, r} ->
-      case pump(port, b, s, r, buffer_pid) do
-        {:ok, _b, _s, _r} = result -> {:cont, result}
-        failed -> {:halt, failed}
-      end
+    |> Enum.reduce(ok(buffers, scheduler, requests), fn buffer_pid, {:ok, b, s, r} ->
+      pump(port, b, s, r, buffer_pid)
     end)
   end
 
@@ -259,7 +256,7 @@ defmodule Minga.Parser.ParseSync do
           RequestState.t(),
           pid(),
           BufferRegistration.t()
-        ) :: result()
+        ) :: ok_result()
   defp enqueue_pumpable(port, buffers, scheduler, requests, buffer_pid, registration) do
     if BufferRegistration.pumpable?(registration) do
       dispatch_next(port, buffers, ParseScheduler.enqueue(scheduler, buffer_pid), requests)
@@ -274,7 +271,7 @@ defmodule Minga.Parser.ParseSync do
           ParseScheduler.t(),
           RequestState.t(),
           pid()
-        ) :: result()
+        ) :: ok_result()
   defp dispatch_activated(port, buffers, scheduler, requests, buffer_pid) do
     case BufferRegistry.fetch(buffers, buffer_pid) do
       {:ok, registration} ->
@@ -295,7 +292,7 @@ defmodule Minga.Parser.ParseSync do
           ParseScheduler.t(),
           RequestState.t(),
           pid()
-        ) :: result()
+        ) :: ok_result()
   defp continue_dispatch(port, buffers, scheduler, requests, buffer_pid) do
     scheduler = release_admission(scheduler, buffer_pid)
     dispatch_next(port, buffers, scheduler, requests)
@@ -307,7 +304,7 @@ defmodule Minga.Parser.ParseSync do
           RequestState.t(),
           pid(),
           BufferRegistration.t()
-        ) :: result()
+        ) :: ok_result()
   defp request_snapshot(buffers, scheduler, requests, buffer_pid, registration) do
     token = make_ref()
     cursor = BufferRegistration.snapshot_cursor(registration)
@@ -445,7 +442,7 @@ defmodule Minga.Parser.ParseSync do
     end
   end
 
-  @spec ok(BufferRegistry.t(), ParseScheduler.t(), RequestState.t()) :: result()
+  @spec ok(BufferRegistry.t(), ParseScheduler.t(), RequestState.t()) :: ok_result()
   defp ok(buffers, scheduler, requests), do: {:ok, buffers, scheduler, requests}
 
   @spec monotonic_ms() :: integer()


### PR DESCRIPTION
# TL;DR

Fixes main's OTP 29 Dialyzer failure by narrowing parser synchronization result contracts to the outcomes each operation can actually produce.

## Context

The parser state refactor merged in #2795 modeled synchronous port write failures across all parser synchronization operations. Only snapshot application writes to the parser Port. Queueing snapshots, restarting pumps, completing parse events, and routing parser events cannot return `:port_write_failed`, so Dialyzer correctly reported their recovery branches as unreachable.

Failed CI job: https://github.com/jsmestad/minga/actions/runs/29210432521/job/86697170728

## Changes

- Add an `ok_result` type for parser operations that only update scheduling state or request snapshots.
- Keep `:port_write_failed` on snapshot application, where `PortLifecycle.send_batch/2` actually runs.
- Remove unreachable write-failure propagation from event routing and manager result installation.
- Replace `restart_pumps/4` error-short-circuiting with a regular reduction because pumping cannot write to the Port.

## Verification

- `mix dialyzer --format short`
- `make lint`
- `mix test.llm test/minga/parser/` (21 tests, 0 failures)
- `mix test.llm` (9,171 tests, 0 failures)
- Final reviewer verdict: PASS
