### PR TITLE
feat(port): classify frontend rejection dispositions

### DIFF
--- a/docs/PROTOCOL.md
+++ b/docs/PROTOCOL.md
@@ -80,12 +80,12 @@ The cell-paradigm render opcodes (`draw_text`, `set_cursor`, `clear`, and the re
 |--------|------|------|-------------|
 | `0x01` | key_press | 6 | A key was pressed |
 | `0x02` | resize | 5 | Terminal/window was resized |
-| `0x03` | ready | 5, 13, or 15+ | Frontend is initialized and ready (15+ carries a u16 protocol_version) |
+| `0x03` | ready | 5, 13, or 29 | Frontend is initialized and ready (29 carries capability format 2 and protocol version) |
 | `0x04` | mouse_event | 9 | Mouse button, wheel, or motion (8-byte legacy also accepted) |
-| `0x05` | capabilities_updated | 9 | Updated capabilities after async detection |
+| `0x05` | capabilities_updated | 9 or 23 | Updated versioned capabilities after async detection |
 | `0x08` | request_keyframe | 9 | Ask the BEAM to start a fresh recovery generation (last_good_frame_seq + failed generation) |
 | `0x0A` | frame_applied | 9 | Report semantic publication of a complete frame |
-| `0x0B` | frame_rejected | 14 | Reject a frame with generation, last applied frame, and stable reason |
+| `0x0B` | frame_rejected | 15 | Reject a correlated frame with stable reason and disposition |
 | `0x0C` | window_ref_miss | 15 | Reject a missing row/window reference and identify the affected window |
 
 ### Frontend → BEAM (Highlight Responses)
@@ -338,7 +338,7 @@ height: u16           initial content rows available at current presentation met
 opcode:           u8  = 0x03
 width:            u16           initial content columns available at current presentation metrics
 height:           u16           initial content rows available at current presentation metrics
-caps_version:     u8            capability format version (currently 1)
+caps_version:     u8            capability format version (currently 2)
 caps_len:         u8            length of capability data
 caps_data:        [caps_len]u8  capability fields (see "Capability Negotiation" section)
 protocol_version: u16           OPTIONAL: the wire-contract version the frontend was generated against
@@ -394,11 +394,13 @@ Total size: 9 bytes.
 
 `frame_applied` (0x0A), fixed 9 bytes: `generation:u32, frame_seq:u32`. Emit it only after the complete transaction has validated and its semantic state has been published atomically. Do not wait for Metal submission, terminal drawing, visibility, or vsync.
 
-`frame_rejected` (0x0B), fixed 14 bytes: `generation:u32, frame_seq:u32, last_applied_frame_seq:u32, reason:u8`.
+`frame_rejected` (0x0B), fixed 15 bytes: `generation:u32, frame_seq:u32, last_applied_frame_seq:u32, reason:u8, disposition:u8`. The disposition byte is appended, so generation, frame sequence, last-good base, and reason retain their protocol-version-11 positions.
 
 `window_ref_miss` (0x0C), fixed 15 bytes: `generation:u32, frame_seq:u32, last_applied_frame_seq:u32, window_id:u16`. It is the targeted form for a missing retained row/window reference; sibling windows and chrome remain committed at `last_applied_frame_seq`.
 
-Stable rejection reasons are: 1 truncation, 2 commit sequence mismatch, 3 non-increasing frame sequence, 4 base sequence mismatch, 5 missing theme, 6 incomplete theme, 7 missing window reference, 8 window epoch mismatch, 9 invalid retained rows, 10 missing font resource, 11 transcript desync, 12 decode failure, 13 out-of-transaction command, 14 invalid row splice, and 255 unknown.
+Stable rejection reasons are: 1 truncation, 2 commit sequence mismatch, 3 non-increasing frame sequence, 4 base sequence mismatch, 5 missing theme, 6 incomplete theme, 7 missing window reference, 8 window epoch mismatch, 9 invalid retained rows, 10 missing font resource, 11 transcript desync, 12 decode failure, 13 out-of-transaction command, 14 invalid row splice, 15 resource policy, and 255 unknown.
+
+Disposition values are generated from the shared schema: 1 retryable recovery, 2 targeted replacement, 3 adapted retry, and 4 terminal frontend failure. Ordinary lineage failures remain retryable. Missing retained references use `window_ref_miss` and stay scoped. Resource-policy rejection defaults terminal. An adapted retry is valid only when the producer has one-shot local evidence bound to the rejected generation and frame, a non-zero advertised dimension (`frame_bytes`, `frame_commands`, or `window_rows`), distinct rejected/adapted values, and a concrete adapted intent distinct from the rejected intent; the evidence is deliberately not sent because detailed resource usage belongs only in privacy-safe telemetry. Terminal failure preserves `last_applied_frame_seq`, cancels outstanding credit, and must not emit or request the unchanged frame again. Current macOS and TUI frontends enforce and advertise only the 64 MiB packet-byte ceiling; command-count and window-row dimensions remain zero (unadvertised) until their hard admission checks exist.
 
 ---
 
@@ -806,7 +808,7 @@ The `ready` event supports an extended format with capability fields. This lets 
 0x03 ready (extended):
   width:          u16
   height:         u16
-  caps_version:   u8    (currently 1)
+  caps_version:   u8    (currently 2)
   caps_len:       u8    (length of remaining fields)
   frontend_type:  u8    (0=tui, 1=native_gui, 2=web)
   color_depth:    u8    (0=mono, 1=256color, 2=rgb)
@@ -814,9 +816,14 @@ The `ready` event supports an extended format with capability fields. This lets 
   image_support:  u8    (0=none, 1=kitty, 2=sixel, 3=native)
   float_support:  u8    (0=emulated, 1=native)
   text_rendering: u8    (0=monospace, 1=proportional)
+  semantic_ui:    u8    (0=disabled, 1=enabled)
+  resource_policy_version: u8
+  max_frame_bytes:        u32
+  max_frame_commands:     u32
+  max_window_rows:        u32
 ```
 
-Total size: 13 bytes.
+Capability format 2 carries 20 capability bytes and the complete ready event is 29 bytes including the protocol-version tail. Format 1's original fields remain in the same positions.
 
 Frontends that send the short 5-byte `ready` format are assumed to have default capabilities: `{tui, rgb, wcwidth, none, emulated, monospace}`.
 
@@ -826,7 +833,7 @@ Sent after the initial `ready` event when the frontend detects additional capabi
 
 ```
 opcode:         u8  = 0x05
-caps_version:   u8    (currently 1)
+caps_version:   u8    (currently 2)
 caps_len:       u8    (length of remaining fields)
 frontend_type:  u8
 color_depth:    u8
@@ -834,9 +841,14 @@ unicode_width:  u8
 image_support:  u8
 float_support:  u8
 text_rendering: u8
+semantic_ui:    u8
+resource_policy_version: u8
+max_frame_bytes:        u32
+max_frame_commands:     u32
+max_window_rows:        u32
 ```
 
-Total size: 9 bytes.
+Capability format 2 has 20 payload bytes (23 bytes including opcode/version/length).
 
 **Behavior:** The BEAM updates its stored capabilities for this frontend. No re-render is triggered; the updated caps take effect on the next frame.
 
@@ -850,6 +862,11 @@ Total size: 9 bytes.
 | `image_support` | 0=none, 1=kitty, 2=sixel, 3=native | Inline image protocol |
 | `float_support` | 0=emulated, 1=native | Floating window support |
 | `text_rendering` | 0=monospace, 1=proportional | Font rendering model |
+| `semantic_ui` | 0=disabled, 1=enabled | Semantic render-model support |
+| `resource_policy_version` | 0=unadvertised, 1=current | Version of hard-dimension policy |
+| `max_frame_bytes` | u32; 0=unadvertised | Maximum admitted encoded frame bytes |
+| `max_frame_commands` | u32; 0=unadvertised | Maximum admitted commands in one frame |
+| `max_window_rows` | u32; 0=unadvertised | Maximum admitted rows for one semantic window |
 
 ### Implementation Notes
 

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -28,7 +28,9 @@ version = "2.0.0"
 # applied/rejected/window-reference-miss acknowledgements (#2739), and evolves
 # A2 row updates from legacy complete section 0x02 snapshots to immutable-base
 # RowSplices section 0x0B (#2741).
-protocol_version = 11
+# protocol_version 12 appends a disposition byte to frame_rejected and appends
+# the versioned hard-dimension resource policy to frontend capabilities (#2801).
+protocol_version = 12
 description = "Minga port protocol opcode registry"
 
 # Directions:
@@ -101,12 +103,11 @@ value = 0x09
 direction = "frontend_to_beam"
 framing = "fixed:6"
 
-# Frame status events (#2739). Rejection reasons are stable wire values:
-# 1 truncation, 2 commit_sequence_mismatch, 3 frame_sequence_not_increasing,
-# 4 base_sequence_mismatch, 5 missing_theme, 6 incomplete_theme,
-# 7 missing_window_reference, 8 window_epoch_mismatch, 9 invalid_retained_rows,
-# 10 missing_font_resource, 11 transcript_desync, 12 decode_failure,
-# 13 out_of_transaction_command, 14 invalid_row_splice, 255 unknown.
+# Frame status events (#2739, #2801). Rejection reasons and dispositions are
+# generated from the enum vocabularies below. frame_rejected appends disposition
+# after the original correlated fields, preserving generation, frame sequence,
+# last-good base, and reason positions. Resource-policy rejection is terminal by
+# default; an adapted retry requires a producer-local named-dimension descriptor.
 [[opcodes]]
 category = "input"
 name = "frame_applied"
@@ -119,7 +120,7 @@ category = "input"
 name = "frame_rejected"
 value = 0x0B
 direction = "frontend_to_beam"
-framing = "fixed:14"
+framing = "fixed:15"
 
 [[opcodes]]
 category = "input"
@@ -1178,6 +1179,36 @@ value = 0x5C
 name = "chat_returned_to_bottom"
 value = 0x5D
 
+# ── Versioned frontend resource policy (#2801) ─────────────────────────────
+#
+# Capability payload version 2 appends these fields after the original seven
+# bytes. Zero means that the dimension is not advertised and must not be used as
+# evidence for adapted retry. Non-zero limits are hard admission dimensions.
+# The BEAM may retry an adapted frame only with one-shot evidence bound to the
+# rejected generation/frame, a non-zero advertised dimension with distinct
+# values, and a concrete adapted intent distinct from the rejected intent.
+# Evidence stays producer-local and telemetry-safe.
+
+[[capability_fields]]
+name = "resource_policy_version"
+type = "u8"
+introduced_in = 2
+
+[[capability_fields]]
+name = "max_frame_bytes"
+type = "u32"
+introduced_in = 2
+
+[[capability_fields]]
+name = "max_frame_commands"
+type = "u32"
+introduced_in = 2
+
+[[capability_fields]]
+name = "max_window_rows"
+type = "u32"
+introduced_in = 2
+
 # ── Enum vocabularies ─────────────────────────────────────────────────────
 #
 # An [[enums]] entry names a closed set of wire byte values with a stable
@@ -1187,6 +1218,51 @@ value = 0x5D
 # a bare integer. The optional `default` is the byte value an encoder emits for
 # an unmapped atom (it must appear in `values`). Validation requires unique
 # value bytes, every byte in range for the repr, and a resolvable `default`.
+
+[[enums]]
+name = "frame_rejection_reason"
+repr = "u8"
+default = "unknown"
+values = [
+  { name = "truncation", value = 1 },
+  { name = "commit_sequence_mismatch", value = 2 },
+  { name = "frame_sequence_not_increasing", value = 3 },
+  { name = "base_sequence_mismatch", value = 4 },
+  { name = "missing_theme", value = 5 },
+  { name = "incomplete_theme", value = 6 },
+  { name = "missing_window_reference", value = 7 },
+  { name = "window_epoch_mismatch", value = 8 },
+  { name = "invalid_retained_rows", value = 9 },
+  { name = "missing_font_resource", value = 10 },
+  { name = "transcript_desync", value = 11 },
+  { name = "decode_failure", value = 12 },
+  { name = "out_of_transaction_command", value = 13 },
+  { name = "invalid_row_splice", value = 14 },
+  { name = "resource_policy", value = 15 },
+  { name = "unknown", value = 255 },
+]
+
+[[enums]]
+name = "frame_rejection_disposition"
+repr = "u8"
+default = "terminal_frontend_failure"
+values = [
+  { name = "retryable_recovery", value = 1 },
+  { name = "targeted_replacement", value = 2 },
+  { name = "adapted_retry", value = 3 },
+  { name = "terminal_frontend_failure", value = 4 },
+]
+
+[[enums]]
+name = "resource_policy_dimension"
+repr = "u8"
+default = "unknown"
+values = [
+  { name = "unknown", value = 0 },
+  { name = "frame_bytes", value = 1 },
+  { name = "frame_commands", value = 2 },
+  { name = "window_rows", value = 3 },
+]
 
 [[enums]]
 name = "completion_kind"

--- a/go/tui/internal/generated/opcodes.go
+++ b/go/tui/internal/generated/opcodes.go
@@ -4,7 +4,7 @@ package generated
 
 // ProtocolVersion is the wire-contract version the frontend exchanges with
 // the BEAM in the ready handshake. A mismatch yields an explicit protocol_error.
-const ProtocolVersion uint16 = 11
+const ProtocolVersion uint16 = 12
 
 const (
 	// Input

--- a/go/tui/internal/generated/semantic_types.go
+++ b/go/tui/internal/generated/semantic_types.go
@@ -2,6 +2,48 @@
 
 package generated
 
+// FrameRejectionReason is a generated enum (repr u8).
+type FrameRejectionReason uint8
+
+const (
+	FrameRejectionReasonTruncation                 FrameRejectionReason = 1
+	FrameRejectionReasonCommitSequenceMismatch     FrameRejectionReason = 2
+	FrameRejectionReasonFrameSequenceNotIncreasing FrameRejectionReason = 3
+	FrameRejectionReasonBaseSequenceMismatch       FrameRejectionReason = 4
+	FrameRejectionReasonMissingTheme               FrameRejectionReason = 5
+	FrameRejectionReasonIncompleteTheme            FrameRejectionReason = 6
+	FrameRejectionReasonMissingWindowReference     FrameRejectionReason = 7
+	FrameRejectionReasonWindowEpochMismatch        FrameRejectionReason = 8
+	FrameRejectionReasonInvalidRetainedRows        FrameRejectionReason = 9
+	FrameRejectionReasonMissingFontResource        FrameRejectionReason = 10
+	FrameRejectionReasonTranscriptDesync           FrameRejectionReason = 11
+	FrameRejectionReasonDecodeFailure              FrameRejectionReason = 12
+	FrameRejectionReasonOutOfTransactionCommand    FrameRejectionReason = 13
+	FrameRejectionReasonInvalidRowSplice           FrameRejectionReason = 14
+	FrameRejectionReasonResourcePolicy             FrameRejectionReason = 15
+	FrameRejectionReasonUnknown                    FrameRejectionReason = 255
+)
+
+// FrameRejectionDisposition is a generated enum (repr u8).
+type FrameRejectionDisposition uint8
+
+const (
+	FrameRejectionDispositionRetryableRecovery       FrameRejectionDisposition = 1
+	FrameRejectionDispositionTargetedReplacement     FrameRejectionDisposition = 2
+	FrameRejectionDispositionAdaptedRetry            FrameRejectionDisposition = 3
+	FrameRejectionDispositionTerminalFrontendFailure FrameRejectionDisposition = 4
+)
+
+// ResourcePolicyDimension is a generated enum (repr u8).
+type ResourcePolicyDimension uint8
+
+const (
+	ResourcePolicyDimensionUnknown       ResourcePolicyDimension = 0
+	ResourcePolicyDimensionFrameBytes    ResourcePolicyDimension = 1
+	ResourcePolicyDimensionFrameCommands ResourcePolicyDimension = 2
+	ResourcePolicyDimensionWindowRows    ResourcePolicyDimension = 3
+)
+
 // CompletionKind is a generated enum (repr u8).
 type CompletionKind uint8
 

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -9,20 +9,29 @@ import (
 
 func TestEncodeReadyReportsSemanticTUI(t *testing.T) {
 	packet := EncodeReady(120, 40)
-	// 14 caps bytes + a u16 protocol_version tail (protocol_version 2).
-	if len(packet) != 16 {
-		t.Fatalf("ready packet length = %d, want 16", len(packet))
+	// Capability format 2 carries 20 fields plus a u16 protocol-version tail.
+	if len(packet) != 29 {
+		t.Fatalf("ready packet length = %d, want 29", len(packet))
 	}
 	if packet[0] != generated.OPReady {
 		t.Fatalf("opcode = 0x%02X, want ready", packet[0])
 	}
-	if packet[5] != 1 || packet[6] != 7 {
-		t.Fatalf("capability header = {%d,%d}, want {1,7}", packet[5], packet[6])
+	if packet[5] != 2 || packet[6] != 20 {
+		t.Fatalf("capability header = {%d,%d}, want {2,20}", packet[5], packet[6])
 	}
-	if packet[7] != 0 || packet[13] != 1 {
-		t.Fatalf("capabilities should report tui with semantic_ui=true: %#v", packet[7:])
+	if packet[7] != 0 || packet[13] != 1 || packet[14] != 1 {
+		t.Fatalf("capabilities should report semantic TUI resource policy: %#v", packet[7:])
 	}
-	version := uint16(packet[14])<<8 | uint16(packet[15])
+	if got := binary.BigEndian.Uint32(packet[15:19]); got != 64*1024*1024 {
+		t.Fatalf("max_frame_bytes = %d", got)
+	}
+	if got := binary.BigEndian.Uint32(packet[19:23]); got != 0 {
+		t.Fatalf("max_frame_commands = %d, want unadvertised", got)
+	}
+	if got := binary.BigEndian.Uint32(packet[23:27]); got != 0 {
+		t.Fatalf("max_window_rows = %d, want unadvertised", got)
+	}
+	version := uint16(packet[27])<<8 | uint16(packet[28])
 	if version != generated.ProtocolVersion {
 		t.Fatalf("protocol_version tail = %d, want %d", version, generated.ProtocolVersion)
 	}

--- a/go/tui/internal/protocol/events.go
+++ b/go/tui/internal/protocol/events.go
@@ -47,15 +47,19 @@ func EncodeReady(width, height uint16) []byte {
 		generated.OPReady,
 		byte(width >> 8), byte(width),
 		byte(height >> 8), byte(height),
-		1,
-		7,
-		0, // frontend_type: tui
-		2, // color_depth: rgb
-		1, // unicode_width: unicode_15
-		0, // image_support: none
-		0, // float_support: emulated
-		0, // text_rendering: monospace
-		1, // semantic_ui: true
+		2,          // capability format version
+		20,         // original 7 fields plus resource-policy tail
+		0,          // frontend_type: tui
+		2,          // color_depth: rgb
+		1,          // unicode_width: unicode_15
+		0,          // image_support: none
+		0,          // float_support: emulated
+		0,          // text_rendering: monospace
+		1,          // semantic_ui: true
+		1,          // resource_policy_version
+		4, 0, 0, 0, // max_frame_bytes: 64 MiB, enforced by ReadPacket
+		0, 0, 0, 0, // max_frame_commands: unadvertised
+		0, 0, 0, 0, // max_window_rows: unadvertised
 		// protocol_version (u16): the wire contract this frontend was generated
 		// against. The BEAM rejects a mismatch with an explicit protocol_error.
 		byte(generated.ProtocolVersion >> 8), byte(generated.ProtocolVersion),
@@ -94,17 +98,36 @@ const (
 	RejectTranscriptDesync       byte = 11
 	RejectDecodeFailure          byte = 12
 	RejectOutOfTransaction       byte = 13
-	RejectInvalidRowSplice       byte = 14
+	RejectInvalidRowSplice       byte = byte(generated.FrameRejectionReasonInvalidRowSplice)
+	RejectResourcePolicy         byte = byte(generated.FrameRejectionReasonResourcePolicy)
+)
+
+// RejectionDisposition is generated from the shared schema vocabulary.
+type RejectionDisposition = generated.FrameRejectionDisposition
+
+const (
+	DispositionRetryable = generated.FrameRejectionDispositionRetryableRecovery
+	DispositionTargeted  = generated.FrameRejectionDispositionTargetedReplacement
+	DispositionAdapted   = generated.FrameRejectionDispositionAdaptedRetry
+	DispositionTerminal  = generated.FrameRejectionDispositionTerminalFrontendFailure
 )
 
 func EncodeFrameApplied(generation, frameSeq uint32) []byte {
 	return encodeFrameStatus(generated.OPFrameApplied, generation, frameSeq)
 }
 
-func EncodeFrameRejected(generation, frameSeq, lastApplied uint32, reason byte) []byte {
+func EncodeFrameRejected(generation, frameSeq, lastApplied uint32, reason byte, disposition RejectionDisposition) []byte {
 	out := encodeFrameStatus(generated.OPFrameRejected, generation, frameSeq)
-	out = append(out, byte(lastApplied>>24), byte(lastApplied>>16), byte(lastApplied>>8), byte(lastApplied), reason)
+	out = append(out, byte(lastApplied>>24), byte(lastApplied>>16), byte(lastApplied>>8), byte(lastApplied), reason, byte(disposition))
 	return out
+}
+
+// DefaultRejectionDisposition makes deterministic resource-policy failure terminal.
+func DefaultRejectionDisposition(reason byte) RejectionDisposition {
+	if reason == RejectResourcePolicy {
+		return DispositionTerminal
+	}
+	return DispositionRetryable
 }
 
 func EncodeWindowRefMiss(generation, frameSeq, lastApplied uint32, windowID uint16) []byte {

--- a/go/tui/internal/protocol/frame_status_test.go
+++ b/go/tui/internal/protocol/frame_status_test.go
@@ -12,9 +12,13 @@ func TestFrameStatusWireLayouts(t *testing.T) {
 	if len(applied) != 9 || applied[0] != generated.OPFrameApplied || binary.BigEndian.Uint32(applied[1:5]) != 3 || binary.BigEndian.Uint32(applied[5:9]) != 9 {
 		t.Fatalf("bad frame_applied layout: %v", applied)
 	}
-	rejected := EncodeFrameRejected(3, 9, 7, RejectBaseSequence)
-	if len(rejected) != 14 || rejected[0] != generated.OPFrameRejected || binary.BigEndian.Uint32(rejected[9:13]) != 7 || rejected[13] != RejectBaseSequence {
+	rejected := EncodeFrameRejected(3, 9, 7, RejectBaseSequence, DispositionRetryable)
+	if len(rejected) != 15 || rejected[0] != generated.OPFrameRejected || binary.BigEndian.Uint32(rejected[9:13]) != 7 || rejected[13] != RejectBaseSequence || rejected[14] != byte(DispositionRetryable) {
 		t.Fatalf("bad frame_rejected layout: %v", rejected)
+	}
+	terminal := EncodeFrameRejected(4, 10, 9, RejectResourcePolicy, DispositionTerminal)
+	if terminal[13] != byte(generated.FrameRejectionReasonResourcePolicy) || terminal[14] != byte(generated.FrameRejectionDispositionTerminalFrontendFailure) {
+		t.Fatalf("bad terminal resource rejection layout: %v", terminal)
 	}
 	miss := EncodeWindowRefMiss(3, 9, 7, 12)
 	if len(miss) != 15 || miss[0] != generated.OPWindowRefMiss || binary.BigEndian.Uint16(miss[13:15]) != 12 {

--- a/go/tui/internal/ui/frame_status_test.go
+++ b/go/tui/internal/ui/frame_status_test.go
@@ -45,6 +45,33 @@ func TestRejectedTransactionEmitsOnlyTypedRejectionAndDoesNotPublish(t *testing.
 	}
 }
 
+func TestTerminalResourcePolicyRejectionPreservesLastGoodAndEmitsOnce(t *testing.T) {
+	out := make(chan []byte, 16)
+	m := New(40, 8, out, nil)
+	m = applyTo(t, m, beginFrame(1, 0), testThemeCommand(), windowRowsCommand(1, "baseline"), commitFrame(1))
+	drainOutboundPackets(out)
+
+	m = applyTo(t, m, beginFrame(2, 1), windowRowsCommand(1, "must not publish"))
+	m.rejectStagingWithDisposition(nil, protocol.RejectResourcePolicy, protocol.DispositionTerminal, "resource policy")
+	packets := drainOutboundPackets(out)
+	if len(packets) != 2 || packets[0][0] != generated.OPFrameRejected || packets[0][13] != protocol.RejectResourcePolicy || packets[0][14] != byte(protocol.DispositionTerminal) {
+		t.Fatalf("expected terminal resource rejection plus one diagnostic: %v", packets)
+	}
+	if m.lastCommittedSeq != 1 || m.lastCommittedGeneration != 1 {
+		t.Fatalf("terminal rejection changed last-good frame: generation=%d seq=%d", m.lastCommittedGeneration, m.lastCommittedSeq)
+	}
+	if got := m.windows[1].Rows[0].Text; got != "baseline" {
+		t.Fatalf("terminal rejection partially published %q", got)
+	}
+
+	// Re-processing the same correlated terminal intent must not emit again.
+	m.staging = &frameStaging{generation: 1, seq: 2}
+	m.rejectStagingWithDisposition(nil, protocol.RejectResourcePolicy, protocol.DispositionTerminal, "resource policy")
+	if duplicate := drainOutboundPackets(out); len(duplicate) != 0 {
+		t.Fatalf("duplicate terminal rejection emitted again: %v", duplicate)
+	}
+}
+
 func TestWrongWindowEpochRejectsTransactionWithoutPartialApply(t *testing.T) {
 	out := make(chan []byte, 16)
 	m := New(40, 8, out, nil)

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -111,7 +111,8 @@ type Model struct {
 	resyncPending bool
 	// lastFrameOutcome is set by the production transaction gate itself. Corpus
 	// tests observe it after submission; they never infer or pre-populate status.
-	lastFrameOutcome frameOutcome
+	lastFrameOutcome      frameOutcome
+	lastTerminalRejection *terminalRejection
 	// surfacePlacements is the BEAM's authoritative per-frame surface layout from
 	// gui_surface_layout (0xA4, #2268): one rect+z list. Compositing reads the z
 	// of a placed surface to order it instead of the old hand-coded
@@ -127,6 +128,14 @@ type Model struct {
 	// a pointer so it persists across the value-copied Update loop (same lifetime
 	// trick as lineCache/latency).
 	transcript *residentTranscript
+}
+
+// terminalRejection deduplicates an identical deterministic terminal status.
+type terminalRejection struct {
+	generation uint32
+	frameSeq   uint32
+	lastGood   uint32
+	reason     byte
 }
 
 // frameStaging is the open frame transaction buffer (#2219). It lives only
@@ -677,6 +686,7 @@ func (m *Model) commitStaging(cmds []tea.Cmd, command protocol.Command) []tea.Cm
 	m.lastCommittedSeq = seq
 	m.lastCommittedGeneration = generation
 	m.staging = nil
+	m.lastTerminalRejection = nil
 	// A clean commit clears any pending resync indicator: the frontend is back
 	// in sync with the BEAM (#2219).
 	m.resyncPending = false
@@ -701,12 +711,22 @@ func (m *Model) invalidateStaging(cmds []tea.Cmd, reason string) []tea.Cmd {
 }
 
 func (m *Model) rejectStaging(cmds []tea.Cmd, reason byte, description string) []tea.Cmd {
+	return m.rejectStagingWithDisposition(cmds, reason, protocol.DefaultRejectionDisposition(reason), description)
+}
+
+func (m *Model) rejectStagingWithDisposition(cmds []tea.Cmd, reason byte, disposition protocol.RejectionDisposition, description string) []tea.Cmd {
 	m.lastFrameOutcome = frameOutcomeRejected
 	generation, frameSeq := uint32(0), uint32(0)
 	if m.staging != nil {
 		generation, frameSeq = m.staging.generation, m.staging.seq
 	}
-	m.send(protocol.EncodeFrameRejected(generation, frameSeq, m.lastCommittedSeq, reason))
+	terminal := terminalRejection{generation: generation, frameSeq: frameSeq, lastGood: m.lastCommittedSeq, reason: reason}
+	if disposition != protocol.DispositionTerminal || m.lastTerminalRejection == nil || *m.lastTerminalRejection != terminal {
+		m.send(protocol.EncodeFrameRejected(generation, frameSeq, m.lastCommittedSeq, reason, disposition))
+	}
+	if disposition == protocol.DispositionTerminal {
+		m.lastTerminalRejection = &terminal
+	}
 	m.staging = nil
 	// Typed rejection is the automatic recovery trigger. Keep diagnostics and
 	// the visible resync state debounced while stale frames from the old credit

--- a/lib/minga_editor/frontend/capabilities.ex
+++ b/lib/minga_editor/frontend/capabilities.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.Frontend.Capabilities do
   alias Minga.Core.WidthOracle
   alias Minga.Core.WidthOracle.Measured
   alias Minga.Core.WidthOracle.Monospace
+  alias MingaEditor.Frontend.ResourcePolicy
 
   defstruct frontend_type: :tui,
             color_depth: :rgb,
@@ -21,7 +22,8 @@ defmodule MingaEditor.Frontend.Capabilities do
             image_support: :none,
             float_support: :emulated,
             text_rendering: :monospace,
-            semantic_ui: false
+            semantic_ui: false,
+            resource_policy: ResourcePolicy.unadvertised()
 
   @type frontend_type :: :tui | :native_gui | :web
   @type color_depth :: :mono | :color_256 | :rgb
@@ -37,18 +39,48 @@ defmodule MingaEditor.Frontend.Capabilities do
           image_support: image_support(),
           float_support: float_support(),
           text_rendering: text_rendering(),
-          semantic_ui: boolean()
+          semantic_ui: boolean(),
+          resource_policy: ResourcePolicy.t()
         }
 
   @doc "Returns the default capabilities (TUI with full RGB, monospace)."
   @spec default() :: t()
   def default, do: %__MODULE__{}
 
-  @doc "Decodes capability fields from the binary payload (7 bytes with semantic_ui; 6- and 5-byte legacy forms decode with semantic_ui false)."
+  @doc "Decodes capability fields, including the capability-format-2 resource-policy tail."
   @spec from_binary(binary()) :: t()
+  def from_binary(data), do: from_binary(data, inferred_version(data))
+
+  @doc "Decodes capability fields under the explicitly reported capability format version."
+  @spec from_binary(binary(), non_neg_integer()) :: t()
   def from_binary(
         <<frontend_type::8, color_depth::8, unicode_width::8, image_support::8, float_support::8,
-          text_rendering::8, semantic_ui::8>>
+          text_rendering::8, semantic_ui::8, policy_version::8, max_frame_bytes::32,
+          max_frame_commands::32, max_window_rows::32>>,
+        version
+      )
+      when version >= 2 do
+    from_fields(
+      frontend_type,
+      color_depth,
+      unicode_width,
+      image_support,
+      float_support,
+      text_rendering,
+      semantic_ui,
+      ResourcePolicy.new(
+        policy_version,
+        max_frame_bytes,
+        max_frame_commands,
+        max_window_rows
+      )
+    )
+  end
+
+  def from_binary(
+        <<frontend_type::8, color_depth::8, unicode_width::8, image_support::8, float_support::8,
+          text_rendering::8, semantic_ui::8>>,
+        _version
       ) do
     from_fields(
       frontend_type,
@@ -57,13 +89,15 @@ defmodule MingaEditor.Frontend.Capabilities do
       image_support,
       float_support,
       text_rendering,
-      semantic_ui
+      semantic_ui,
+      ResourcePolicy.unadvertised()
     )
   end
 
   def from_binary(
         <<frontend_type::8, color_depth::8, unicode_width::8, image_support::8, float_support::8,
-          text_rendering::8>>
+          text_rendering::8>>,
+        _version
       ) do
     from_fields(
       frontend_type,
@@ -72,11 +106,12 @@ defmodule MingaEditor.Frontend.Capabilities do
       image_support,
       float_support,
       text_rendering,
-      0
+      0,
+      ResourcePolicy.unadvertised()
     )
   end
 
-  def from_binary(_), do: default()
+  def from_binary(_data, _version), do: default()
 
   @spec from_fields(
           non_neg_integer(),
@@ -85,7 +120,8 @@ defmodule MingaEditor.Frontend.Capabilities do
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
-          non_neg_integer()
+          non_neg_integer(),
+          ResourcePolicy.t()
         ) :: t()
   defp from_fields(
          frontend_type,
@@ -94,7 +130,8 @@ defmodule MingaEditor.Frontend.Capabilities do
          image_support,
          float_support,
          text_rendering,
-         semantic_ui
+         semantic_ui,
+         resource_policy
        ) do
     %__MODULE__{
       frontend_type: decode_frontend_type(frontend_type),
@@ -103,7 +140,8 @@ defmodule MingaEditor.Frontend.Capabilities do
       image_support: decode_image_support(image_support),
       float_support: decode_float_support(float_support),
       text_rendering: decode_text_rendering(text_rendering),
-      semantic_ui: semantic_ui != 0
+      semantic_ui: semantic_ui != 0,
+      resource_policy: resource_policy
     }
   end
 
@@ -151,6 +189,10 @@ defmodule MingaEditor.Frontend.Capabilities do
   def width_oracle(%__MODULE__{}, _cache), do: %Monospace{}
 
   # ── Decoders ──
+
+  @spec inferred_version(binary()) :: non_neg_integer()
+  defp inferred_version(data) when byte_size(data) == 20, do: 2
+  defp inferred_version(_data), do: 1
 
   @spec decode_frontend_type(non_neg_integer()) :: frontend_type()
   defp decode_frontend_type(0), do: :tui

--- a/lib/minga_editor/frontend/protocol.ex
+++ b/lib/minga_editor/frontend/protocol.ex
@@ -150,7 +150,15 @@ defmodule MingaEditor.Frontend.Protocol do
           | :transcript_desync
           | :decode_failure
           | :out_of_transaction_command
+          | :resource_policy
           | :unknown
+
+  @typedoc "Shared disposition for a rejected frontend frame."
+  @type frame_rejection_disposition ::
+          :retryable_recovery
+          | :targeted_replacement
+          | :adapted_retry
+          | :terminal_frontend_failure
 
   @typedoc "An input event decoded from a frontend."
   @type input_event ::
@@ -192,7 +200,8 @@ defmodule MingaEditor.Frontend.Protocol do
              generation :: non_neg_integer()}
           | {:frame_applied, generation :: non_neg_integer(), frame_seq :: non_neg_integer()}
           | {:frame_rejected, generation :: non_neg_integer(), frame_seq :: non_neg_integer(),
-             last_applied_frame_seq :: non_neg_integer(), frame_rejection_reason()}
+             last_applied_frame_seq :: non_neg_integer(), frame_rejection_reason(),
+             frame_rejection_disposition()}
           | {:window_ref_miss, generation :: non_neg_integer(), frame_seq :: non_neg_integer(),
              last_applied_frame_seq :: non_neg_integer(), window_id :: non_neg_integer()}
           | {:scroll_batch, window_id :: non_neg_integer(), delta_lines :: integer(),
@@ -483,10 +492,10 @@ defmodule MingaEditor.Frontend.Protocol do
   # (protocol_version 2+). The frontend stamps the wire-contract version it was
   # generated against so the BEAM can reject a mismatch before streaming frames.
   def decode_event(
-        <<@op_ready, width::16, height::16, _caps_version::8, caps_len::8,
+        <<@op_ready, width::16, height::16, caps_version::8, caps_len::8,
           caps_data::binary-size(caps_len), protocol_version::16>>
       ) do
-    caps = Capabilities.from_binary(caps_data)
+    caps = Capabilities.from_binary(caps_data, caps_version)
     {:ok, {:ready, width, height, caps, protocol_version}}
   end
 
@@ -494,10 +503,10 @@ defmodule MingaEditor.Frontend.Protocol do
   # + width(2) + height(2) + caps_version(1) + caps_len(1) + caps_data. Surfaced
   # as protocol_version 0 ("unversioned") so the Manager can reject it explicitly.
   def decode_event(
-        <<@op_ready, width::16, height::16, _caps_version::8, caps_len::8,
+        <<@op_ready, width::16, height::16, caps_version::8, caps_len::8,
           caps_data::binary-size(caps_len)>>
       ) do
-    caps = Capabilities.from_binary(caps_data)
+    caps = Capabilities.from_binary(caps_data, caps_version)
     {:ok, {:ready, width, height, caps, 0}}
   end
 
@@ -508,10 +517,10 @@ defmodule MingaEditor.Frontend.Protocol do
 
   # Capabilities updated event (sent after async capability detection).
   def decode_event(
-        <<@op_capabilities_updated, _caps_version::8, caps_len::8,
+        <<@op_capabilities_updated, caps_version::8, caps_len::8,
           caps_data::binary-size(caps_len)>>
       ) do
-    caps = Capabilities.from_binary(caps_data)
+    caps = Capabilities.from_binary(caps_data, caps_version)
     {:ok, {:capabilities_updated, caps}}
   end
 
@@ -550,9 +559,21 @@ defmodule MingaEditor.Frontend.Protocol do
   end
 
   def decode_event(
+        <<@op_frame_rejected, generation::32, frame_seq::32, last_applied::32, reason::8,
+          disposition::8>>
+      ) do
+    {:ok,
+     {:frame_rejected, generation, frame_seq, last_applied, decode_rejection_reason(reason),
+      decode_rejection_disposition(disposition)}}
+  end
+
+  # Compatibility for a protocol-version-11 status already draining on reconnect.
+  def decode_event(
         <<@op_frame_rejected, generation::32, frame_seq::32, last_applied::32, reason::8>>
       ) do
-    {:ok, {:frame_rejected, generation, frame_seq, last_applied, decode_rejection_reason(reason)}}
+    {:ok,
+     {:frame_rejected, generation, frame_seq, last_applied, decode_rejection_reason(reason),
+      :retryable_recovery}}
   end
 
   def decode_event(
@@ -628,7 +649,15 @@ defmodule MingaEditor.Frontend.Protocol do
   defp decode_rejection_reason(12), do: :decode_failure
   defp decode_rejection_reason(13), do: :out_of_transaction_command
   defp decode_rejection_reason(14), do: :invalid_row_splice
+  defp decode_rejection_reason(15), do: :resource_policy
   defp decode_rejection_reason(_), do: :unknown
+
+  @spec decode_rejection_disposition(non_neg_integer()) :: frame_rejection_disposition()
+  defp decode_rejection_disposition(1), do: :retryable_recovery
+  defp decode_rejection_disposition(2), do: :targeted_replacement
+  defp decode_rejection_disposition(3), do: :adapted_retry
+  defp decode_rejection_disposition(4), do: :terminal_frontend_failure
+  defp decode_rejection_disposition(_), do: :terminal_frontend_failure
 
   @spec decode_mouse_button(non_neg_integer()) :: mouse_button()
   defp decode_mouse_button(@mouse_left), do: :left

--- a/lib/minga_editor/frontend/resource_policy.ex
+++ b/lib/minga_editor/frontend/resource_policy.ex
@@ -1,0 +1,70 @@
+defmodule MingaEditor.Frontend.ResourcePolicy do
+  @moduledoc """
+  Versioned frontend hard-dimension policy advertised during capability negotiation.
+
+  Zero-valued dimensions are unadvertised. Limits describe admission boundaries
+  only; payload-derived usage stays local to the producer and privacy-safe telemetry.
+  """
+
+  @type dimension :: :frame_bytes | :frame_commands | :window_rows
+  @type adaptation_descriptor :: %{
+          required(:dimension) => dimension(),
+          required(:rejected_value) => pos_integer(),
+          required(:adapted_value) => pos_integer()
+        }
+
+  @enforce_keys [:version, :max_frame_bytes, :max_frame_commands, :max_window_rows]
+  defstruct [:version, :max_frame_bytes, :max_frame_commands, :max_window_rows]
+
+  @type t :: %__MODULE__{
+          version: non_neg_integer(),
+          max_frame_bytes: non_neg_integer(),
+          max_frame_commands: non_neg_integer(),
+          max_window_rows: non_neg_integer()
+        }
+
+  @doc "Returns the legacy policy with no advertised hard dimensions."
+  @spec unadvertised() :: t()
+  def unadvertised do
+    %__MODULE__{
+      version: 0,
+      max_frame_bytes: 0,
+      max_frame_commands: 0,
+      max_window_rows: 0
+    }
+  end
+
+  @doc "Builds the version-one resource policy appended by capability format 2."
+  @spec new(non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: t()
+  def new(version, max_frame_bytes, max_frame_commands, max_window_rows)
+      when version >= 0 and max_frame_bytes >= 0 and max_frame_commands >= 0 and
+             max_window_rows >= 0 do
+    %__MODULE__{
+      version: version,
+      max_frame_bytes: max_frame_bytes,
+      max_frame_commands: max_frame_commands,
+      max_window_rows: max_window_rows
+    }
+  end
+
+  @doc "Validates an explicit adapted-retry descriptor for one named bounded dimension."
+  @spec adaptation(dimension(), integer(), integer()) :: {:ok, adaptation_descriptor()} | :error
+  def adaptation(dimension, rejected_value, adapted_value)
+      when dimension in [:frame_bytes, :frame_commands, :window_rows] and rejected_value > 0 and
+             adapted_value > 0 and rejected_value != adapted_value do
+    {:ok, %{dimension: dimension, rejected_value: rejected_value, adapted_value: adapted_value}}
+  end
+
+  def adaptation(_dimension, _rejected_value, _adapted_value), do: :error
+
+  @doc "Returns whether a frontend advertises a hard limit for the named dimension."
+  @spec advertised?(t(), dimension()) :: boolean()
+  def advertised?(%__MODULE__{version: version, max_frame_bytes: limit}, :frame_bytes),
+    do: version > 0 and limit > 0
+
+  def advertised?(%__MODULE__{version: version, max_frame_commands: limit}, :frame_commands),
+    do: version > 0 and limit > 0
+
+  def advertised?(%__MODULE__{version: version, max_window_rows: limit}, :window_rows),
+    do: version > 0 and limit > 0
+end

--- a/lib/minga_editor/renderer/ack_handler.ex
+++ b/lib/minga_editor/renderer/ack_handler.ex
@@ -28,11 +28,41 @@ defmodule MingaEditor.Renderer.AckHandler do
         %State{
           awaiting_ack: %{generation: generation, seq: seq, intent: intent, pushed_at: pushed_at}
         } = state,
-        {:frame_rejected, generation, seq, last_applied, reason}
+        {:frame_rejected, generation, seq, last_applied, reason, :retryable_recovery}
       )
-      when last_applied == state.caches.last_acknowledged_frame_seq do
+      when reason != :resource_policy and last_applied == state.caches.last_acknowledged_frame_seq do
     Minga.Log.warning(:render, "Frontend rejected frame #{seq}: #{reason}")
     RecoveryHandler.transaction(state, intent, seq, pushed_at)
+  end
+
+  def handle(
+        %State{awaiting_ack: %{generation: generation, seq: seq}} = state,
+        {:frame_rejected, generation, seq, last_applied, reason, :adapted_retry}
+      )
+      when last_applied == state.caches.last_acknowledged_frame_seq do
+    Minga.Log.warning(:render, "Frontend requested adapted retry for frame #{seq}: #{reason}")
+    RecoveryHandler.adapted(state, last_applied, reason)
+  end
+
+  def handle(
+        %State{awaiting_ack: %{generation: generation, seq: seq}} = state,
+        {:frame_rejected, generation, seq, last_applied, reason, disposition}
+      )
+      when last_applied == state.caches.last_acknowledged_frame_seq and
+             disposition in [
+               :retryable_recovery,
+               :targeted_replacement,
+               :terminal_frontend_failure
+             ] do
+    terminal(state, last_applied, reason, disposition)
+  end
+
+  # Keep direct callers from the protocol-version-11 contract retryable.
+  def handle(state, {:frame_rejected, generation, seq, last_applied, reason}) do
+    handle(
+      state,
+      {:frame_rejected, generation, seq, last_applied, reason, :retryable_recovery}
+    )
   end
 
   def handle(
@@ -61,4 +91,16 @@ defmodule MingaEditor.Renderer.AckHandler do
   end
 
   def timeout(state, _generation, _seq), do: {:noreply, state}
+
+  @spec terminal(State.t(), non_neg_integer(), atom(), atom()) :: {:noreply, State.t()}
+  defp terminal(state, last_applied, reason, disposition) do
+    RecoveryHandler.cancel_timer(state.awaiting_ack)
+
+    Minga.Log.warning(
+      :render,
+      "Frontend terminally rejected frame #{state.awaiting_ack.seq}: #{reason} (#{disposition})"
+    )
+
+    {:noreply, State.terminal_failure(state, last_applied, reason)}
+  end
 end

--- a/lib/minga_editor/renderer/frame_handler.ex
+++ b/lib/minga_editor/renderer/frame_handler.ex
@@ -14,13 +14,21 @@ defmodule MingaEditor.Renderer.FrameHandler do
   @max_stale_retries 3
 
   @spec enqueue(State.t(), Intent.t(), non_neg_integer(), integer()) :: result()
-  def enqueue(%State{rendering?: true} = state, intent, seq, pushed_at) do
+  def enqueue(%State{} = state, %Intent{} = intent, seq, pushed_at) do
+    case State.accept_intent(state, intent) do
+      {:accepted, accepted} -> enqueue_accepted(accepted, intent, seq, pushed_at)
+      {:blocked, blocked} -> {:noreply, blocked}
+    end
+  end
+
+  @spec enqueue_accepted(State.t(), Intent.t(), non_neg_integer(), integer()) :: result()
+  defp enqueue_accepted(%State{rendering?: true} = state, intent, seq, pushed_at) do
     Telemetry.hop_latency(:cast_snapshot, pushed_at)
     emit_coalesced(state.pending, seq)
     {:noreply, %{state | pending: {intent, seq, pushed_at}}}
   end
 
-  def enqueue(%State{rendering?: false} = state, intent, seq, pushed_at) do
+  defp enqueue_accepted(%State{rendering?: false} = state, intent, seq, pushed_at) do
     Telemetry.hop_latency(:cast_snapshot, pushed_at)
     token = schedule_render()
 

--- a/lib/minga_editor/renderer/recovery_handler.ex
+++ b/lib/minga_editor/renderer/recovery_handler.ex
@@ -9,7 +9,7 @@ defmodule MingaEditor.Renderer.RecoveryHandler do
   @spec reset(State.t(), Intent.t(), non_neg_integer(), integer()) :: {:reply, :ok, State.t()}
   def reset(state, intent, seq, pushed_at) do
     cancel_timer(state.awaiting_ack)
-    state = State.reset_frontend(state, :renderer_restart)
+    state = state |> State.reset_frontend(:renderer_restart) |> State.clear_rejection()
     token = schedule_render()
 
     {:reply, :ok,
@@ -33,6 +33,7 @@ defmodule MingaEditor.Renderer.RecoveryHandler do
 
     state
     |> State.reset_frontend(:renderer_restart)
+    |> State.clear_rejection()
     |> FrameHandler.render_sync(Intent.force_keyframe(intent), seq, pushed_at)
   end
 
@@ -45,6 +46,40 @@ defmodule MingaEditor.Renderer.RecoveryHandler do
 
   def request(state), do: {:noreply, state}
 
+  @doc "Starts one fresh-generation retry only after consuming explicit adaptation evidence."
+  @spec adapted(State.t(), non_neg_integer(), atom()) :: {:noreply, State.t()}
+  def adapted(
+        %State{
+          awaiting_ack: %{
+            generation: generation,
+            seq: rejected_seq,
+            pushed_at: pushed_at
+          }
+        } = state,
+        last_applied,
+        reason
+      ) do
+    case State.consume_adaptation(state, generation, rejected_seq) do
+      {:ok, adapted_state, adapted_intent} ->
+        adapted_transaction(adapted_state, adapted_intent, rejected_seq, pushed_at)
+
+      :error ->
+        terminal_without_adaptation(state, last_applied, reason)
+    end
+  end
+
+  @spec adapted_transaction(State.t(), Intent.t(), non_neg_integer(), integer()) ::
+          {:noreply, State.t()}
+  defp adapted_transaction(state, adapted_intent, rejected_seq, pushed_at) do
+    cancel_timer(state.awaiting_ack)
+    retry_seq = max(System.unique_integer([:positive, :monotonic]), rejected_seq + 1)
+
+    state
+    |> State.reset_frontend()
+    |> State.queue_frame({adapted_intent, retry_seq, pushed_at})
+    |> FrameHandler.advance()
+  end
+
   @doc "Starts transaction recovery from the latest semantic intent."
   @spec transaction(State.t(), Intent.t(), non_neg_integer(), integer()) ::
           {:noreply, State.t()}
@@ -56,8 +91,7 @@ defmodule MingaEditor.Renderer.RecoveryHandler do
 
     state
     |> State.reset_frontend()
-    |> Map.put(:awaiting_ack, nil)
-    |> Map.put(:pending, {Intent.force_keyframe(latest), seq, pushed_at})
+    |> State.queue_frame({Intent.force_keyframe(latest), seq, pushed_at})
     |> FrameHandler.advance()
   end
 
@@ -94,12 +128,18 @@ defmodule MingaEditor.Renderer.RecoveryHandler do
     if Map.has_key?(intent.windows, window_id) do
       state
       |> BufferChanges.invalidate_window(window_id)
-      |> Map.put(:awaiting_ack, nil)
-      |> Map.put(:pending, {intent, seq, pushed_at})
+      |> State.queue_frame({intent, seq, pushed_at})
       |> FrameHandler.advance()
     else
       transaction(state, intent, seq, pushed_at)
     end
+  end
+
+  @spec terminal_without_adaptation(State.t(), non_neg_integer(), atom()) ::
+          {:noreply, State.t()}
+  defp terminal_without_adaptation(state, last_applied, reason) do
+    cancel_timer(state.awaiting_ack)
+    {:noreply, State.terminal_failure(state, last_applied, reason)}
   end
 
   @spec latest(State.frame_work() | nil, Intent.t(), non_neg_integer(), integer()) ::

--- a/lib/minga_editor/renderer/rejection_state.ex
+++ b/lib/minga_editor/renderer/rejection_state.ex
@@ -1,0 +1,76 @@
+defmodule MingaEditor.Renderer.RejectionState do
+  @moduledoc "Terminal frontend failure and one-shot adapted-retry evidence."
+
+  alias MingaEditor.Frontend.ResourcePolicy
+  alias MingaEditor.RenderPipeline.Intent
+
+  @type terminal :: %{
+          required(:generation) => non_neg_integer(),
+          required(:frame_seq) => non_neg_integer(),
+          required(:last_good_frame_seq) => non_neg_integer(),
+          required(:reason) => atom(),
+          required(:intent) => Intent.t()
+        }
+
+  @type adaptation :: %{
+          required(:generation) => non_neg_integer(),
+          required(:frame_seq) => non_neg_integer(),
+          required(:dimension) => ResourcePolicy.dimension(),
+          required(:rejected_value) => pos_integer(),
+          required(:adapted_value) => pos_integer(),
+          required(:intent) => Intent.t()
+        }
+
+  defstruct terminal: nil, adaptation: nil
+
+  @type t :: %__MODULE__{
+          terminal: terminal() | nil,
+          adaptation: adaptation() | nil
+        }
+
+  @doc "Returns empty rejection state."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Records a terminal failure while retaining the rejected semantic intent."
+  @spec terminal(t(), non_neg_integer(), non_neg_integer(), non_neg_integer(), atom(), Intent.t()) ::
+          t()
+  def terminal(%__MODULE__{} = state, generation, frame_seq, last_good, reason, intent) do
+    %{
+      state
+      | terminal: %{
+          generation: generation,
+          frame_seq: frame_seq,
+          last_good_frame_seq: last_good,
+          reason: reason,
+          intent: intent
+        },
+        adaptation: nil
+    }
+  end
+
+  @doc "Records producer-local evidence bound to one rejected transaction and adapted intent."
+  @spec adapt(
+          t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          ResourcePolicy.adaptation_descriptor(),
+          Intent.t()
+        ) :: t()
+  def adapt(%__MODULE__{} = state, generation, frame_seq, descriptor, intent) do
+    evidence =
+      descriptor
+      |> Map.merge(%{generation: generation, frame_seq: frame_seq, intent: intent})
+
+    %{state | adaptation: evidence}
+  end
+
+  @doc "Clears terminal visibility and adaptation evidence after a material state change."
+  @spec clear(t()) :: t()
+  def clear(%__MODULE__{}), do: new()
+
+  @doc "Returns whether an intent is byte-for-byte the same semantic intent that failed terminally."
+  @spec blocks?(t(), Intent.t()) :: boolean()
+  def blocks?(%__MODULE__{terminal: %{intent: intent}}, intent), do: true
+  def blocks?(%__MODULE__{}, %Intent{}), do: false
+end

--- a/lib/minga_editor/renderer/server.ex
+++ b/lib/minga_editor/renderer/server.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Renderer.Server do
 
   use GenServer
 
+  alias MingaEditor.Frontend.ResourcePolicy
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.Renderer.FrameHandler
@@ -65,6 +66,37 @@ defmodule MingaEditor.Renderer.Server do
   def acknowledgement_state(server \\ __MODULE__),
     do: GenServer.call(server, :acknowledgement_state)
 
+  @doc "Returns the visible terminal frontend failure, if one has stopped frame credit."
+  @spec terminal_failure(GenServer.server()) ::
+          MingaEditor.Renderer.RejectionState.terminal() | nil
+  def terminal_failure(server \\ __MODULE__), do: GenServer.call(server, :terminal_failure)
+
+  @doc "Records one-shot adaptation evidence bound to an outstanding rejected transaction."
+  @spec record_adaptation(
+          GenServer.server(),
+          non_neg_integer(),
+          non_neg_integer(),
+          ResourcePolicy.dimension(),
+          integer(),
+          integer(),
+          Intent.t()
+        ) :: :ok | :error
+  def record_adaptation(
+        server \\ __MODULE__,
+        generation,
+        frame_seq,
+        dimension,
+        rejected_value,
+        adapted_value,
+        %Intent{} = adapted_intent
+      ) do
+    GenServer.call(
+      server,
+      {:record_adaptation, generation, frame_seq, dimension, rejected_value, adapted_value,
+       adapted_intent}
+    )
+  end
+
   @doc "Routes a typed frontend frame status to the renderer."
   @spec frame_status(GenServer.server(), MingaEditor.Frontend.Protocol.input_event()) :: :ok
   def frame_status(server \\ __MODULE__, status) do
@@ -101,6 +133,25 @@ defmodule MingaEditor.Renderer.Server do
     do:
       {:reply, {state.caches.recovery_generation, state.caches.last_acknowledged_frame_seq},
        state}
+
+  def handle_call(:terminal_failure, _from, state),
+    do: {:reply, State.terminal_failure(state), state}
+
+  def handle_call(
+        {:record_adaptation, generation, frame_seq, dimension, rejected_value, adapted_value,
+         adapted_intent},
+        _from,
+        state
+      ) do
+    with {:ok, descriptor} <- ResourcePolicy.adaptation(dimension, rejected_value, adapted_value),
+         {:ok, adapted_state} <-
+           State.record_adaptation(state, generation, frame_seq, descriptor, adapted_intent) do
+      {:reply, :ok, adapted_state}
+    else
+      :error -> {:reply, :error, state}
+      {:error, unchanged} -> {:reply, :error, unchanged}
+    end
+  end
 
   def handle_call({:reset_connection, intent, seq, pushed_at}, _from, state),
     do: RecoveryHandler.reset(state, intent, seq, pushed_at)

--- a/lib/minga_editor/renderer/state.ex
+++ b/lib/minga_editor/renderer/state.ex
@@ -8,10 +8,13 @@ defmodule MingaEditor.Renderer.State do
   reset, and exact monitor `:DOWN` all discard the same state.
   """
 
+  alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.Frontend.ResourcePolicy
   alias MingaEditor.RenderPipeline
   alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.Renderer.Caches
+  alias MingaEditor.Renderer.RejectionState
   alias MingaEditor.Renderer.ResidentWindowState
   alias MingaEditor.UI.FontRegistry
   alias MingaEditor.UI.Panel.MessageStore
@@ -45,7 +48,8 @@ defmodule MingaEditor.Renderer.State do
           buffer_monitors: %{optional(pid()) => reference()},
           buffer_versions: %{optional(pid()) => non_neg_integer()},
           pipeline: pipeline(),
-          require_ack?: boolean()
+          require_ack?: boolean(),
+          rejection_state: RejectionState.t()
         }
 
   defstruct editor_pid: nil,
@@ -63,7 +67,8 @@ defmodule MingaEditor.Renderer.State do
             buffer_monitors: %{},
             buffer_versions: %{},
             pipeline: &RenderPipeline.run/1,
-            require_ack?: true
+            require_ack?: true,
+            rejection_state: RejectionState.new()
 
   @doc "Constructs renderer state with injected process dependencies."
   @spec new(keyword()) :: t()
@@ -74,6 +79,126 @@ defmodule MingaEditor.Renderer.State do
       require_ack?: Keyword.get(opts, :require_ack?, not Keyword.has_key?(opts, :pipeline)),
       ack_timeout_ms: Keyword.get(opts, :ack_timeout_ms, 2_000)
     }
+  end
+
+  @doc "Accepts changed semantic work and blocks an identical terminally rejected intent."
+  @spec accept_intent(t(), Intent.t()) :: {:accepted, t()} | {:blocked, t()}
+  def accept_intent(%__MODULE__{} = state, %Intent{} = intent) do
+    if RejectionState.blocks?(state.rejection_state, intent) do
+      {:blocked, state}
+    else
+      {:accepted, %{state | rejection_state: RejectionState.clear(state.rejection_state)}}
+    end
+  end
+
+  @doc "Records adapted-retry evidence only for the matching outstanding transaction."
+  @spec record_adaptation(
+          t(),
+          non_neg_integer(),
+          non_neg_integer(),
+          ResourcePolicy.adaptation_descriptor(),
+          Intent.t()
+        ) :: {:ok, t()} | {:error, t()}
+  def record_adaptation(
+        %__MODULE__{awaiting_ack: %{generation: generation, seq: frame_seq, intent: rejected}} =
+          state,
+        generation,
+        frame_seq,
+        %{dimension: dimension} = descriptor,
+        %Intent{} = adapted
+      )
+      when adapted != rejected do
+    if advertised_dimension?(rejected, dimension) do
+      rejection_state =
+        RejectionState.adapt(state.rejection_state, generation, frame_seq, descriptor, adapted)
+
+      {:ok, %{state | rejection_state: rejection_state}}
+    else
+      {:error, state}
+    end
+  end
+
+  def record_adaptation(%__MODULE__{} = state, _generation, _frame_seq, _descriptor, %Intent{}),
+    do: {:error, state}
+
+  @doc "Releases the outstanding acknowledgement lease without committing its output."
+  @spec release_credit(t()) :: t()
+  def release_credit(%__MODULE__{} = state), do: %{state | awaiting_ack: nil}
+
+  @doc "Returns frame credit and queues the next semantic frame through the state owner."
+  @spec queue_frame(t(), frame_work()) :: t()
+  def queue_frame(%__MODULE__{} = state, work) do
+    %{state | awaiting_ack: nil, pending: work}
+  end
+
+  @doc "Enters a visible terminal frontend failure while preserving acknowledged caches."
+  @spec terminal_failure(t(), non_neg_integer(), atom()) :: t()
+  def terminal_failure(
+        %__MODULE__{awaiting_ack: %{generation: generation, seq: seq, intent: intent}} = state,
+        last_good_frame_seq,
+        reason
+      ) do
+    rejection_state =
+      RejectionState.terminal(
+        state.rejection_state,
+        generation,
+        seq,
+        last_good_frame_seq,
+        reason,
+        intent
+      )
+
+    %{
+      state
+      | awaiting_ack: nil,
+        pending: nil,
+        in_flight: nil,
+        rendering?: false,
+        render_token: nil,
+        stale_retry_count: 0,
+        rejection_state: rejection_state
+    }
+  end
+
+  @doc "Returns the currently visible terminal frontend failure, if any."
+  @spec terminal_failure(t()) :: RejectionState.terminal() | nil
+  def terminal_failure(%__MODULE__{} = state), do: state.rejection_state.terminal
+
+  @doc "Consumes matching one-shot evidence and returns its concrete adapted intent."
+  @spec consume_adaptation(t(), non_neg_integer(), non_neg_integer()) ::
+          {:ok, t(), Intent.t()} | :error
+  def consume_adaptation(
+        %__MODULE__{
+          awaiting_ack: %{generation: generation, seq: frame_seq, intent: rejected},
+          rejection_state: %{
+            adaptation: %{
+              generation: generation,
+              frame_seq: frame_seq,
+              dimension: dimension,
+              rejected_value: rejected_value,
+              adapted_value: adapted_value,
+              intent: %Intent{} = adapted
+            }
+          }
+        } = state,
+        generation,
+        frame_seq
+      )
+      when rejected_value != adapted_value and adapted != rejected do
+    if advertised_dimension?(rejected, dimension) do
+      cleared = %{state | rejection_state: RejectionState.clear(state.rejection_state)}
+      {:ok, cleared, adapted}
+    else
+      :error
+    end
+  end
+
+  def consume_adaptation(%__MODULE__{}, _generation, _frame_seq), do: :error
+
+  @doc "Clears rejection visibility after reconnect or another external state change."
+  @spec clear_rejection(t()) :: t()
+  def clear_rejection(%__MODULE__{} = state) do
+    %{state | rejection_state: RejectionState.clear(state.rejection_state)}
   end
 
   @doc "Drops windows absent from the latest intent and monitors each live buffer once."
@@ -163,6 +288,15 @@ defmodule MingaEditor.Renderer.State do
         resident_windows: residents
     }
   end
+
+  @spec advertised_dimension?(Intent.t(), ResourcePolicy.dimension()) :: boolean()
+  defp advertised_dimension?(
+         %Intent{frame: %{capabilities: %Capabilities{resource_policy: policy}}},
+         dimension
+       ),
+       do: ResourcePolicy.advertised?(policy, dimension)
+
+  defp advertised_dimension?(%Intent{}, _dimension), do: false
 
   @spec reconcile_monitors(t(), MapSet.t(pid())) ::
           {%{optional(pid()) => reference()}, %{optional(pid()) => non_neg_integer()}}

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -370,7 +370,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                     generation: generation,
                     frameSeq: frameSeq,
                     lastAppliedFrameSeq: lastApplied,
-                    reason: reason.wireCode
+                    reason: reason.wireCode,
+                    disposition: reason.disposition
                 )
             case .windowRefMiss(let generation, let frameSeq, let lastApplied, let windowId):
                 encoder.sendWindowRefMiss(

--- a/macos/Sources/Protocol/ProtocolConstants.swift
+++ b/macos/Sources/Protocol/ProtocolConstants.swift
@@ -32,7 +32,7 @@ let CURSOR_UNDERLINE: UInt8 = 0x02
 
 // MARK: - Capability constants
 
-let CAPS_VERSION: UInt8 = 1
+let CAPS_VERSION: UInt8 = 2
 
 let FRONTEND_TUI: UInt8 = 0
 let FRONTEND_NATIVE_GUI: UInt8 = 1
@@ -43,6 +43,14 @@ let IMAGE_NATIVE: UInt8 = 3
 let FLOAT_NATIVE: UInt8 = 1
 let TEXT_PROPORTIONAL: UInt8 = 1
 let SEMANTIC_UI_ENABLED: UInt8 = 1
+
+// Capability-format-2 resource-policy tail. Values are hard admission bounds;
+// zero leaves a dimension unadvertised until that limit is enforced. The packet
+// byte ceiling is enforced by ProtocolReader before payload allocation.
+let RESOURCE_POLICY_VERSION: UInt8 = 1
+let RESOURCE_MAX_FRAME_BYTES: UInt32 = 64 * 1024 * 1024
+let RESOURCE_MAX_FRAME_COMMANDS: UInt32 = 0
+let RESOURCE_MAX_WINDOW_ROWS: UInt32 = 0
 
 // MARK: - Text attribute bits
 

--- a/macos/Sources/Protocol/ProtocolEncoder.swift
+++ b/macos/Sources/Protocol/ProtocolEncoder.swift
@@ -102,12 +102,12 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
     /// `semantic_ui = true`. The BEAM uses this capability, not `frontend_type`,
     /// to select the semantic render/chrome path shared with the Go TUI.
     func sendReady(cols: UInt16, rows: UInt16) {
-        var buf = Data(count: 16)
+        var buf = Data(count: 29)
         buf[0] = OP_READY
         writeU16(&buf, 1, cols)
         writeU16(&buf, 3, rows)
         buf[5] = CAPS_VERSION
-        buf[6] = 7 // 7 capability fields
+        buf[6] = 20 // original 7 fields plus capability-format-2 policy tail
         buf[7] = FRONTEND_NATIVE_GUI
         buf[8] = COLOR_RGB
         buf[9] = UNICODE_15
@@ -115,9 +115,13 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
         buf[11] = FLOAT_NATIVE
         buf[12] = TEXT_PROPORTIONAL
         buf[13] = SEMANTIC_UI_ENABLED
+        buf[14] = RESOURCE_POLICY_VERSION
+        writeU32(&buf, 15, RESOURCE_MAX_FRAME_BYTES)
+        writeU32(&buf, 19, RESOURCE_MAX_FRAME_COMMANDS)
+        writeU32(&buf, 23, RESOURCE_MAX_WINDOW_ROWS)
         // protocol_version (u16): the wire contract this frontend was generated
         // against. The BEAM rejects a mismatch with an explicit protocol_error.
-        writeU16(&buf, 14, PROTOCOL_VERSION)
+        writeU16(&buf, 27, PROTOCOL_VERSION)
         writeFrame(buf)
     }
 
@@ -165,13 +169,38 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
         writeFrame(buf)
     }
 
-    func sendFrameRejected(generation: UInt32, frameSeq: UInt32, lastAppliedFrameSeq: UInt32, reason: UInt8) {
-        var buf = Data(count: 14)
+    func sendFrameRejected(
+        generation: UInt32,
+        frameSeq: UInt32,
+        lastAppliedFrameSeq: UInt32,
+        reason: UInt8
+    ) {
+        let generatedReason = GeneratedProtocol.FrameRejectionReason.decode(reason)
+        let disposition: GeneratedProtocol.FrameRejectionDisposition =
+            generatedReason == .resourcePolicy ? .terminalFrontendFailure : .retryableRecovery
+        sendFrameRejected(
+            generation: generation,
+            frameSeq: frameSeq,
+            lastAppliedFrameSeq: lastAppliedFrameSeq,
+            reason: reason,
+            disposition: disposition
+        )
+    }
+
+    func sendFrameRejected(
+        generation: UInt32,
+        frameSeq: UInt32,
+        lastAppliedFrameSeq: UInt32,
+        reason: UInt8,
+        disposition: GeneratedProtocol.FrameRejectionDisposition
+    ) {
+        var buf = Data(count: 15)
         buf[0] = OP_FRAME_REJECTED
         writeU32(&buf, 1, generation)
         writeU32(&buf, 5, frameSeq)
         writeU32(&buf, 9, lastAppliedFrameSeq)
         buf[13] = reason
+        buf[14] = disposition.rawValue
         writeFrame(buf)
     }
 

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -39,6 +39,13 @@ private enum PickerNavigationCodepoints {
     static let upArrow: UInt32 = 57352
 }
 
+private struct TerminalRejectionSignature: Equatable {
+    let generation: UInt32
+    let frameSeq: UInt32
+    let lastGoodFrameSeq: UInt32
+    let reason: UInt8
+}
+
 private enum CompletionNavigationCodepoints {
     static let ctrlN: UInt32 = 110
     static let ctrlP: UInt32 = 112
@@ -176,6 +183,7 @@ final class CommandDispatcher {
     /// by `request_keyframe` on invalidation. 0 until the first clean commit.
     private(set) var lastCommittedFrameSeq: UInt32 = 0
     private(set) var lastCommittedGeneration: UInt32 = 0
+    private var lastTerminalRejection: TerminalRejectionSignature?
 
     /// True once at least one frame has committed, so `lastCommittedFrameSeq == 0`
     /// can still be told apart from "never committed" when validating a base.
@@ -380,6 +388,7 @@ final class CommandDispatcher {
         lastCommittedFrameSeq = frameSeq
         lastCommittedGeneration = openGeneration
         hasCommitted = true
+        lastTerminalRejection = nil
         openFrameSeq = nil
         self.transactionBuilder = nil
 
@@ -484,21 +493,40 @@ final class CommandDispatcher {
             return
         }
 
-        let shouldRequestKeyframe = resyncRecoveryState != .awaitingKeyframe
-        resyncRecoveryState = .awaitingKeyframe
-        PortLogger.warn("Frame transaction rejected (\(logReason)\(opcodeContext)); awaiting BEAM recovery from \(lastCommittedFrameSeq)")
-        guiState.performOutOfBandPublication {
-            guiState.resyncState.markPending(
-                lastGoodFrameSeq: lastCommittedFrameSeq,
-                generation: openGeneration,
-                rejection: rejection.logDescription
-            )
+        let terminal = rejection.disposition == .terminalFrontendFailure
+        if terminal {
+            resyncRecoveryState = .clean
+            if guiState.resyncState.pending {
+                guiState.performOutOfBandPublication {
+                    guiState.resyncState.clear()
+                }
+            }
+            PortLogger.error("Frame transaction terminally rejected (\(logReason)\(opcodeContext)); preserving last-good frame \(lastCommittedFrameSeq)")
+        } else {
+            let shouldRequestKeyframe = resyncRecoveryState != .awaitingKeyframe
+            resyncRecoveryState = .awaitingKeyframe
+            PortLogger.warn("Frame transaction rejected (\(logReason)\(opcodeContext)); awaiting BEAM recovery from \(lastCommittedFrameSeq)")
+            guiState.performOutOfBandPublication {
+                guiState.resyncState.markPending(
+                    lastGoodFrameSeq: lastCommittedFrameSeq,
+                    generation: openGeneration,
+                    rejection: rejection.logDescription
+                )
+            }
+            if shouldRequestKeyframe {
+                // Compatibility/test seam only. Production recovery is driven by the
+                // typed onTransactionResult status wired in MingaApp.
+                onRequestKeyframe?(lastCommittedFrameSeq)
+            }
         }
-        if shouldRequestKeyframe {
-            // Compatibility/test seam only. Production recovery is driven by the
-            // typed onTransactionResult status wired in MingaApp.
-            onRequestKeyframe?(lastCommittedFrameSeq)
-        }
+        let terminalSignature = TerminalRejectionSignature(
+            generation: openGeneration,
+            frameSeq: rejectedFrameSeq,
+            lastGoodFrameSeq: lastCommittedFrameSeq,
+            reason: rejection.wireCode
+        )
+        guard !terminal || lastTerminalRejection != terminalSignature else { return }
+        if terminal { lastTerminalRejection = terminalSignature }
         onTransactionResult?(.rejected(
             generation: openGeneration,
             frameSeq: rejectedFrameSeq,
@@ -519,6 +547,17 @@ final class CommandDispatcher {
             .decodeFailure(frameSeq: openFrameSeq),
             frameSeq: openFrameSeq,
             logReason: "decode failure inside an open transaction"
+        )
+    }
+
+    /// Rejects the open frame under the deterministic hard resource policy.
+    /// The last-good semantic publication remains active and no keyframe is requested.
+    func resourcePolicyRejected() {
+        guard let openFrameSeq else { return }
+        reject(
+            .resourcePolicy,
+            frameSeq: openFrameSeq,
+            logReason: "frontend resource policy exceeded"
         )
     }
 

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -34,24 +34,34 @@ enum PreparedFrameRejection: Error, Sendable, Equatable {
     case transcriptDesynced
     case decodeFailure(frameSeq: UInt32)
     case outOfTransactionCommand(opcode: UInt8?)
+    case resourcePolicy
 
-    /// Stable wire value shared with docs/protocol_schema.toml and Go.
+    /// Stable wire value generated from docs/protocol_schema.toml.
     var wireCode: UInt8 {
         switch self {
-        case .beginWhileOpen: return 1
-        case .commitWithoutBegin, .commitSequenceMismatch: return 2
-        case .frameSequenceNotIncreasing: return 3
-        case .baseSequenceMismatch: return 4
-        case .missingTheme: return 5
-        case .incompleteTheme: return 6
-        case .missingWindowReference: return 7
-        case .windowEpochMismatch: return 8
-        case .invalidRetainedRows: return 9
-        case .missingFontResource: return 10
-        case .transcriptBeforeSeed, .transcriptEpochMismatch, .transcriptDesynced: return 11
-        case .decodeFailure: return 12
-        case .outOfTransactionCommand: return 13
-        case .invalidRowSplice: return 14
+        case .beginWhileOpen: return GeneratedProtocol.FrameRejectionReason.truncation.rawValue
+        case .commitWithoutBegin, .commitSequenceMismatch: return GeneratedProtocol.FrameRejectionReason.commitSequenceMismatch.rawValue
+        case .frameSequenceNotIncreasing: return GeneratedProtocol.FrameRejectionReason.frameSequenceNotIncreasing.rawValue
+        case .baseSequenceMismatch: return GeneratedProtocol.FrameRejectionReason.baseSequenceMismatch.rawValue
+        case .missingTheme: return GeneratedProtocol.FrameRejectionReason.missingTheme.rawValue
+        case .incompleteTheme: return GeneratedProtocol.FrameRejectionReason.incompleteTheme.rawValue
+        case .missingWindowReference: return GeneratedProtocol.FrameRejectionReason.missingWindowReference.rawValue
+        case .windowEpochMismatch: return GeneratedProtocol.FrameRejectionReason.windowEpochMismatch.rawValue
+        case .invalidRetainedRows: return GeneratedProtocol.FrameRejectionReason.invalidRetainedRows.rawValue
+        case .missingFontResource: return GeneratedProtocol.FrameRejectionReason.missingFontResource.rawValue
+        case .transcriptBeforeSeed, .transcriptEpochMismatch, .transcriptDesynced: return GeneratedProtocol.FrameRejectionReason.transcriptDesync.rawValue
+        case .decodeFailure: return GeneratedProtocol.FrameRejectionReason.decodeFailure.rawValue
+        case .outOfTransactionCommand: return GeneratedProtocol.FrameRejectionReason.outOfTransactionCommand.rawValue
+        case .invalidRowSplice: return GeneratedProtocol.FrameRejectionReason.invalidRowSplice.rawValue
+        case .resourcePolicy: return GeneratedProtocol.FrameRejectionReason.resourcePolicy.rawValue
+        }
+    }
+
+    /// Resource-policy rejection is terminal by default; lineage failures recover.
+    var disposition: GeneratedProtocol.FrameRejectionDisposition {
+        switch self {
+        case .resourcePolicy: return .terminalFrontendFailure
+        default: return .retryableRecovery
         }
     }
 
@@ -92,6 +102,8 @@ enum PreparedFrameRejection: Error, Sendable, Equatable {
             return "decode failure in frame \(frameSeq)"
         case .outOfTransactionCommand:
             return "out-of-transaction command"
+        case .resourcePolicy:
+            return "frontend resource policy exceeded"
         }
     }
 }

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -1944,6 +1944,50 @@ struct CommandDispatcherStagingTests {
         #expect(dispatcher.frameState.windowIndentGuides[1]?.guideCols == [4, 8])
     }
 
+    @Test("terminal resource-policy rejection preserves committed state and emits once")
+    @MainActor func terminalResourcePolicyRejectionPreservesLastGood() {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        var requested: [UInt32] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+        dispatcher.onRequestKeyframe = { requested.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("committed.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("rejected.ex")]))
+        dispatcher.resourcePolicyRejected()
+        dispatcher.resourcePolicyRejected()
+
+        #expect(dispatcher.lastCommittedFrameSeq == 1)
+        #expect(gui.tabBarState.tabs.first?.label == "committed.ex")
+        #expect(gui.resyncState.pending == false)
+        #expect(requested.isEmpty)
+        #expect(results.count == 2)
+        guard case .rejected(
+            generation: 1,
+            frameSeq: 2,
+            lastAppliedFrameSeq: 1,
+            reason: .resourcePolicy
+        ) = results.last else {
+            Issue.record("expected one terminal resource-policy rejection")
+            return
+        }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 1, generation: 1))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("adapted.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
+
+        #expect(dispatcher.lastCommittedFrameSeq == 3)
+        #expect(gui.tabBarState.tabs.first?.label == "adapted.ex")
+        #expect(gui.resyncState.pending == false)
+        #expect(results.count == 3)
+        #expect(results.last == .applied(generation: 1, frameSeq: 3))
+    }
+
     @Test("a later invalid domain rejects the whole frame without publication")
     @MainActor func partialFrameRejectionPublishesNothing() {
         let (dispatcher, gui) = makeDispatcher()

--- a/macos/Tests/MingaTests/NonBlockingEncoderTests.swift
+++ b/macos/Tests/MingaTests/NonBlockingEncoderTests.swift
@@ -167,6 +167,44 @@ struct NonBlockingEncoderTests {
 
 @Suite("ProtocolReader")
 struct ProtocolReaderTests {
+    @Test("rejects an oversized packet before reading or decoding its payload")
+    func rejectsOversizedPacketBeforeDecode() throws {
+        let stream = Data([0, 0, 0, 9])
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("minga-protocol-reader-limit-\(UUID().uuidString).bin")
+        try stream.write(to: url)
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        let capture = ProtocolReaderCapture()
+        let disconnected = DispatchSemaphore(value: 0)
+        let handle = try FileHandle(forReadingFrom: url)
+        let reader = ProtocolReader(
+            input: handle,
+            maxPayloadLength: 8,
+            decoder: { data in
+                capture.append(data)
+                return DecodedFrame(
+                    commands: [],
+                    metrics: FrameDecodeMetrics(
+                        packetBytes: data.count,
+                        bytesCopied: 0,
+                        allocations: 0,
+                        decodeDuration: .zero,
+                        actorHopCount: 0
+                    )
+                )
+            },
+            handler: { _ in },
+            onDecodeFailure: { _ in disconnected.signal() },
+            onDisconnect: { disconnected.signal() }
+        )
+
+        reader.start()
+        #expect(disconnected.wait(timeout: .now() + 2) == .success)
+        try handle.close()
+        #expect(capture.snapshot().isEmpty)
+    }
+
     @Test("accepts large render payloads and preserves packet alignment")
     func acceptsLargeRenderPayloads() throws {
         let largePayload = Data(repeating: 0xAB, count: 1_100_000)

--- a/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
+++ b/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
@@ -56,13 +56,13 @@ struct EncoderReadyTests {
     func readyLayout() {
         let payload = captureFrame { $0.sendReady(cols: 120, rows: 40) }
 
-        // 14 caps bytes + a u16 protocol_version tail (the compiled PROTOCOL_VERSION).
-        #expect(payload.count == 16)
+        // Capability format 2 carries 20 fields plus a u16 protocol-version tail.
+        #expect(payload.count == 29)
         #expect(payload[0] == OP_READY)
         #expect(readU16(payload, 1) == 120) // cols
         #expect(readU16(payload, 3) == 40)  // rows
         #expect(payload[5] == CAPS_VERSION)
-        #expect(payload[6] == 7) // 7 capability fields
+        #expect(payload[6] == 20) // original fields plus resource-policy tail
         #expect(payload[7] == FRONTEND_NATIVE_GUI)
         #expect(payload[8] == COLOR_RGB)
         #expect(payload[9] == UNICODE_15)
@@ -70,7 +70,11 @@ struct EncoderReadyTests {
         #expect(payload[11] == FLOAT_NATIVE)
         #expect(payload[12] == TEXT_PROPORTIONAL)
         #expect(payload[13] == SEMANTIC_UI_ENABLED)
-        #expect(readU16(payload, 14) == PROTOCOL_VERSION) // protocol_version tail
+        #expect(payload[14] == RESOURCE_POLICY_VERSION)
+        #expect(readU32(payload, 15) == 64 * 1024 * 1024)
+        #expect(readU32(payload, 19) == 0) // command admission is not enforced yet
+        #expect(readU32(payload, 23) == 0) // per-window row admission is not enforced yet
+        #expect(readU16(payload, 27) == PROTOCOL_VERSION) // protocol_version tail
     }
 }
 
@@ -106,17 +110,37 @@ struct EncoderRequestKeyframeTests {
         #expect(readU32(payload, 5) == 9)
     }
 
-    @Test("frame_rejected encodes stable status fields")
+    @Test("frame_rejected appends the protocol-v12 disposition byte")
     func frameRejectedLayout() {
         let payload = captureFrame {
-            $0.sendFrameRejected(generation: 3, frameSeq: 9, lastAppliedFrameSeq: 7, reason: 4)
+            $0.sendFrameRejected(
+                generation: 3,
+                frameSeq: 9,
+                lastAppliedFrameSeq: 7,
+                reason: GeneratedProtocol.FrameRejectionReason.resourcePolicy.rawValue,
+                disposition: .terminalFrontendFailure
+            )
         }
-        #expect(payload.count == 14)
+        #expect(payload.count == 15)
         #expect(payload[0] == OP_FRAME_REJECTED)
         #expect(readU32(payload, 1) == 3)
         #expect(readU32(payload, 5) == 9)
         #expect(readU32(payload, 9) == 7)
-        #expect(payload[13] == 4)
+        #expect(payload[13] == GeneratedProtocol.FrameRejectionReason.resourcePolicy.rawValue)
+        #expect(payload[14] == GeneratedProtocol.FrameRejectionDisposition.terminalFrontendFailure.rawValue)
+    }
+
+    @Test("resource-policy rejection defaults to terminal disposition")
+    func frameRejectedResourcePolicyDefault() {
+        let payload = captureFrame {
+            $0.sendFrameRejected(
+                generation: 4,
+                frameSeq: 10,
+                lastAppliedFrameSeq: 9,
+                reason: GeneratedProtocol.FrameRejectionReason.resourcePolicy.rawValue
+            )
+        }
+        #expect(payload[14] == GeneratedProtocol.FrameRejectionDisposition.terminalFrontendFailure.rawValue)
     }
 
     @Test("window_ref_miss encodes the targeted window")

--- a/macos/Tests/MingaTests/ProtocolEncoderDisconnectTests.swift
+++ b/macos/Tests/MingaTests/ProtocolEncoderDisconnectTests.swift
@@ -40,8 +40,8 @@ struct EncoderDisconnectTests {
         pipe.fileHandleForWriting.closeFile()
         let raw = pipe.fileHandleForReading.readDataToEndOfFile()
 
-        // Only the ready frame should have been written (16 bytes payload + 4 length).
-        #expect(raw.count == 20)
+        // Only the capability-format-2 ready frame was written (29-byte payload + 4 length).
+        #expect(raw.count == 33)
     }
 
     @Test("disconnect() is idempotent")

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -875,12 +875,12 @@ struct ProtocolEncoderTests {
     // by verifying the ready event structure.
     @Test("Ready event has correct size")
     func readyEventSize() {
-        // The ready payload should be 14 bytes:
-        // opcode:1, cols:2, rows:2, caps_version:1, caps_len:1, fields:7
-        // Total frame: 4 (length prefix) + 14 = 18 bytes
+        // The ready payload is 29 bytes in capability format 2:
+        // opcode:1, cols:2, rows:2, caps_version:1, caps_len:1, fields:20, protocol:2
+        // Total frame: 4 (length prefix) + 29 = 33 bytes.
         // We can't easily capture stdout in tests, but we verify the
         // constants are correct.
-        #expect(CAPS_VERSION == 1)
+        #expect(CAPS_VERSION == 2)
         #expect(FRONTEND_NATIVE_GUI == 1)
         #expect(COLOR_RGB == 2)
         #expect(SEMANTIC_UI_ENABLED == 1)

--- a/test/minga_editor/frontend/capabilities_test.exs
+++ b/test/minga_editor/frontend/capabilities_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.Frontend.CapabilitiesTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.Frontend.ResourcePolicy
 
   describe "query helpers" do
     test "images?/1" do
@@ -55,6 +56,17 @@ defmodule MingaEditor.Frontend.CapabilitiesTest do
     end
   end
 
+  describe "resource policy" do
+    test "only non-zero dimensions on a versioned policy are advertised" do
+      policy = ResourcePolicy.new(1, 64_000, 0, 0)
+
+      assert ResourcePolicy.advertised?(policy, :frame_bytes)
+      refute ResourcePolicy.advertised?(policy, :frame_commands)
+      refute ResourcePolicy.advertised?(policy, :window_rows)
+      refute ResourcePolicy.advertised?(ResourcePolicy.new(0, 64_000, 0, 0), :frame_bytes)
+    end
+  end
+
   describe "from_binary/1" do
     test "decodes 6-byte capability payload" do
       # native_gui, color_256, unicode_15, kitty, native_float, proportional
@@ -76,6 +88,27 @@ defmodule MingaEditor.Frontend.CapabilitiesTest do
       assert caps.color_depth == :rgb
       assert caps.unicode_width == :unicode_15
       assert caps.semantic_ui
+      assert caps.resource_policy == ResourcePolicy.unadvertised()
+    end
+
+    test "decodes capability-format-2 resource policy fields" do
+      binary = <<1, 2, 1, 0, 1, 1, 1, 1, 64_000::32, 4_000::32, 800::32>>
+      caps = Capabilities.from_binary(binary, 2)
+
+      assert caps.frontend_type == :native_gui
+      assert caps.semantic_ui
+
+      assert caps.resource_policy == %ResourcePolicy{
+               version: 1,
+               max_frame_bytes: 64_000,
+               max_frame_commands: 4_000,
+               max_window_rows: 800
+             }
+    end
+
+    test "does not interpret a format-2 tail under a legacy format version" do
+      binary = <<0, 2, 1, 0, 0, 0, 1, 1, 64_000::32, 4_000::32, 800::32>>
+      assert Capabilities.from_binary(binary, 1) == Capabilities.default()
     end
 
     test "returns defaults for invalid binary" do

--- a/test/minga_editor/frontend/protocol_test.exs
+++ b/test/minga_editor/frontend/protocol_test.exs
@@ -163,26 +163,34 @@ defmodule MingaEditor.Frontend.ProtocolTest do
       assert caps.float_support == :emulated
     end
 
-    test "decodes a versioned ready (extended caps + u16 protocol_version tail)" do
-      # 7 caps fields then a u16 protocol_version of 2.
-      payload = <<0x03, 200::16, 60::16, 1, 7, 1, 2, 1, 3, 1, 1, 1, 2::16>>
+    test "decodes a protocol-v12 ready with capability-format-2 resource policy" do
+      capabilities = <<1, 2, 1, 3, 1, 1, 1, 1, 16_777_216::32, 250_000::32, 16_384::32>>
+      payload = <<0x03, 200::16, 60::16, 2, 20, capabilities::binary, 12::16>>
 
-      assert {:ok, {:ready, 200, 60, caps, 2}} = Protocol.decode_event(payload)
+      assert {:ok, {:ready, 200, 60, caps, 12}} = Protocol.decode_event(payload)
       assert caps.frontend_type == :native_gui
       assert caps.image_support == :native
       assert caps.float_support == :native
+      assert caps.resource_policy.version == 1
+      assert caps.resource_policy.max_frame_bytes == 16_777_216
+      assert caps.resource_policy.max_frame_commands == 250_000
+      assert caps.resource_policy.max_window_rows == 16_384
     end
   end
 
   describe "decode_event/1 — capabilities_updated" do
-    test "decodes a capabilities_updated event" do
-      payload = <<0x05, 1, 6, 0, 2, 1, 1, 0, 0>>
+    test "decodes a capability-format-2 capabilities_updated event" do
+      capabilities = <<0, 2, 1, 1, 0, 0, 1, 1, 67_108_864::32, 1_000_000::32, 65_536::32>>
+      payload = <<0x05, 2, 20, capabilities::binary>>
 
       assert {:ok, {:capabilities_updated, caps}} = Protocol.decode_event(payload)
       assert caps.frontend_type == :tui
       assert caps.color_depth == :rgb
       assert caps.unicode_width == :unicode_15
       assert caps.image_support == :kitty
+      assert caps.resource_policy.max_frame_bytes == 67_108_864
+      assert caps.resource_policy.max_frame_commands == 1_000_000
+      assert caps.resource_policy.max_window_rows == 65_536
     end
   end
 
@@ -425,17 +433,30 @@ defmodule MingaEditor.Frontend.ProtocolTest do
   end
 
   describe "decode_event/1 — frame status" do
-    test "decodes generation-aware applied, rejected, and window ref miss statuses" do
+    test "decodes protocol-v12 rejection reasons and dispositions" do
       assert {:ok, {:frame_applied, 3, 9}} = Protocol.decode_event(<<0x0A, 3::32, 9::32>>)
 
-      assert {:ok, {:frame_rejected, 3, 9, 7, :base_sequence_mismatch}} =
-               Protocol.decode_event(<<0x0B, 3::32, 9::32, 7::32, 4>>)
+      assert {:ok, {:frame_rejected, 3, 9, 7, :base_sequence_mismatch, :retryable_recovery}} =
+               Protocol.decode_event(<<0x0B, 3::32, 9::32, 7::32, 4, 1>>)
 
-      assert {:ok, {:frame_rejected, 3, 10, 9, :invalid_row_splice}} =
-               Protocol.decode_event(<<0x0B, 3::32, 10::32, 9::32, 14>>)
+      assert {:ok, {:frame_rejected, 3, 10, 9, :invalid_row_splice, :adapted_retry}} =
+               Protocol.decode_event(<<0x0B, 3::32, 10::32, 9::32, 14, 3>>)
+
+      assert {:ok, {:frame_rejected, 4, 11, 9, :resource_policy, :terminal_frontend_failure}} =
+               Protocol.decode_event(<<0x0B, 4::32, 11::32, 9::32, 15, 4>>)
 
       assert {:ok, {:window_ref_miss, 3, 9, 7, 12}} =
                Protocol.decode_event(<<0x0C, 3::32, 9::32, 7::32, 12::16>>)
+    end
+
+    test "treats a draining protocol-v11 rejection as retryable" do
+      assert {:ok, {:frame_rejected, 3, 9, 7, :base_sequence_mismatch, :retryable_recovery}} =
+               Protocol.decode_event(<<0x0B, 3::32, 9::32, 7::32, 4>>)
+    end
+
+    test "unknown dispositions fail closed as terminal" do
+      assert {:ok, {:frame_rejected, 3, 9, 7, :unknown, :terminal_frontend_failure}} =
+               Protocol.decode_event(<<0x0B, 3::32, 9::32, 7::32, 254, 255>>)
     end
   end
 

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -9,10 +9,12 @@ defmodule MingaEditor.Renderer.ServerTest do
   use ExUnit.Case, async: false
 
   alias Minga.RenderModel.Window.LineIdentity
+  alias MingaEditor.Frontend.ResourcePolicy
   alias MingaEditor.Layout
   alias MingaEditor.RenderPipeline
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.RenderPipeline.Scroll
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Renderer.RenderReceipt
@@ -354,18 +356,170 @@ defmodule MingaEditor.Renderer.ServerTest do
       assert_receive {:ack_pipeline, 31, 1, 30, false}, @async_render_timeout
     end
 
-    test "rejected frame N renders only latest pending N+1 as a fresh-generation keyframe" do
+    test "retryable rejection renders only latest pending intent as a fresh-generation keyframe" do
       renderer = start_ack_renderer(self())
 
       RendererServer.cast_snapshot(renderer, stub_snapshot(), 20)
       assert_receive {:ack_pipeline, 20, 1, 0, true}, @async_render_timeout
       RendererServer.cast_snapshot(renderer, stub_snapshot(), 21)
 
-      RendererServer.frame_status(renderer, {:frame_rejected, 1, 20, 0, :base_sequence_mismatch})
+      RendererServer.frame_status(
+        renderer,
+        {:frame_rejected, 1, 20, 0, :base_sequence_mismatch, :retryable_recovery}
+      )
+
       assert_receive {:ack_pipeline, 21, 2, 0, true}, @async_render_timeout
       assert RendererServer.acknowledgement_state(renderer) == {2, 0}
       refute_receive {:ack_pipeline, _, 3, _, _}, 50
       refute_receive {:render_done, %RenderReceipt{frame_seq: 20}}, 50
+    end
+
+    test "terminal resource rejection cancels credit, preserves last good, and ignores stale duplicates" do
+      renderer = start_ack_renderer(self())
+      snapshot = stub_snapshot()
+
+      RendererServer.cast_snapshot(renderer, snapshot, 10)
+      assert_receive {:ack_pipeline, 10, 1, 0, true}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 1, 10})
+      assert_receive {:render_done, %RenderReceipt{frame_seq: 10}}, @async_render_timeout
+
+      RendererServer.cast_snapshot(renderer, snapshot, 11)
+      assert_receive {:ack_pipeline, 11, 1, 10, false}, @async_render_timeout
+
+      terminal = {:frame_rejected, 1, 11, 10, :resource_policy, :terminal_frontend_failure}
+      RendererServer.frame_status(renderer, terminal)
+
+      refute RendererServer.rendering?(renderer)
+      assert RendererServer.acknowledgement_state(renderer) == {1, 10}
+
+      assert %{generation: 1, frame_seq: 11, last_good_frame_seq: 10, reason: :resource_policy} =
+               RendererServer.terminal_failure(renderer)
+
+      refute_receive {:render_done, %RenderReceipt{frame_seq: 11}}, 50
+
+      RendererServer.frame_status(renderer, terminal)
+
+      RendererServer.frame_status(
+        renderer,
+        {:frame_rejected, 0, 11, 10, :resource_policy, :terminal_frontend_failure}
+      )
+
+      assert RendererServer.acknowledgement_state(renderer) == {1, 10}
+      refute_receive {:ack_pipeline, _, _, _, _}, 50
+    end
+
+    test "identical terminal intent stays blocked until capability state changes" do
+      renderer = start_ack_renderer(self())
+      snapshot = stub_snapshot()
+
+      RendererServer.cast_snapshot(renderer, snapshot, 20)
+      assert_receive {:ack_pipeline, 20, 1, 0, true}, @async_render_timeout
+
+      RendererServer.frame_status(
+        renderer,
+        {:frame_rejected, 1, 20, 0, :resource_policy, :terminal_frontend_failure}
+      )
+
+      refute RendererServer.rendering?(renderer)
+      RendererServer.cast_snapshot(renderer, snapshot, 21)
+      refute_receive {:ack_pipeline, 21, _, _, _}, 50
+
+      changed = %{
+        snapshot
+        | capabilities: %{snapshot.capabilities | semantic_ui: true}
+      }
+
+      RendererServer.cast_snapshot(renderer, changed, 22)
+      assert_receive {:ack_pipeline, 22, 1, 0, true}, @async_render_timeout
+      assert RendererServer.terminal_failure(renderer) == nil
+    end
+
+    test "adapted retry consumes only matching evidence and renders the changed intent" do
+      renderer = start_ack_renderer(self(), pipeline: adaptation_probe_pipeline(self()))
+
+      snapshot = stub_snapshot()
+      policy = ResourcePolicy.new(1, 64 * 1_048_576, 0, 0)
+      snapshot = %{snapshot | capabilities: %{snapshot.capabilities | resource_policy: policy}}
+      rejected_intent = Intent.from_input(snapshot)
+
+      adapted_snapshot = %{snapshot | capabilities: %{snapshot.capabilities | semantic_ui: true}}
+      adapted_intent = Intent.from_input(adapted_snapshot)
+
+      RendererServer.cast_snapshot(renderer, snapshot, 30)
+      assert_receive {:adaptation_pipeline, 30, 1, 0, true, false}, @async_render_timeout
+
+      assert RendererServer.record_adaptation(
+               renderer,
+               1,
+               30,
+               :frame_bytes,
+               1_000,
+               1_000,
+               adapted_intent
+             ) == :error
+
+      assert RendererServer.record_adaptation(
+               renderer,
+               1,
+               30,
+               :frame_commands,
+               1_000,
+               800,
+               adapted_intent
+             ) == :error
+
+      assert RendererServer.record_adaptation(
+               renderer,
+               2,
+               30,
+               :frame_bytes,
+               1_000,
+               800,
+               adapted_intent
+             ) == :error
+
+      assert RendererServer.record_adaptation(
+               renderer,
+               1,
+               30,
+               :frame_bytes,
+               1_000,
+               800,
+               rejected_intent
+             ) == :error
+
+      assert RendererServer.record_adaptation(
+               renderer,
+               1,
+               30,
+               :frame_bytes,
+               1_000,
+               800,
+               adapted_intent
+             ) == :ok
+
+      RendererServer.frame_status(
+        renderer,
+        {:frame_rejected, 1, 30, 0, :resource_policy, :adapted_retry}
+      )
+
+      assert_receive {:adaptation_pipeline, retry_seq, 2, 0, true, true},
+                     @async_render_timeout
+
+      assert retry_seq > 30
+      assert RendererServer.acknowledgement_state(renderer) == {2, 0}
+
+      RendererServer.frame_status(
+        renderer,
+        {:frame_rejected, 2, retry_seq, 0, :resource_policy, :adapted_retry}
+      )
+
+      refute RendererServer.rendering?(renderer)
+
+      assert %{frame_seq: ^retry_seq, reason: :resource_policy} =
+               RendererServer.terminal_failure(renderer)
+
+      refute_receive {:adaptation_pipeline, _, 3, _, _, _}, 50
     end
 
     test "manual retry returns the credit and advances recovery generation every time" do
@@ -803,6 +957,30 @@ defmodule MingaEditor.Renderer.ServerTest do
         input.caches.recovery_generation,
         input.caches.last_acknowledged_frame_seq,
         keyframe?
+      })
+
+      %{
+        input
+        | caches: %{
+            input.caches
+            | last_emitted_frame_seq: input.frame_seq,
+              last_frame_keyframe?: keyframe?
+          }
+      }
+    end
+  end
+
+  defp adaptation_probe_pipeline(parent) do
+    fn input ->
+      keyframe? = input.force_keyframe? or input.caches.last_acknowledged_frame_seq == 0
+
+      send(parent, {
+        :adaptation_pipeline,
+        input.frame_seq,
+        input.caches.recovery_generation,
+        input.caches.last_acknowledged_frame_seq,
+        keyframe?,
+        input.capabilities.semantic_ui
       })
 
       %{


### PR DESCRIPTION
# TL;DR
Frontend frame rejection now carries an explicit shared disposition, so deterministic resource failures stop the rejected frame lineage instead of requesting the same unchanged keyframe. The BEAM, macOS, and Go implementations preserve retryable recovery, targeted window replacement, and last-good state while adding terminal and evidence-backed adapted paths.

Closes #2801

## Context
This is the first delivery unit in #2749. It establishes the rejection and capability contract that #2802 will use when macOS decode, staging, and resident resource limits reject a frame.

## Changes
- Bumped the port protocol to version 12 and generated shared rejection reason, disposition, and resource-dimension vocabularies.
- Added capability format 2 with a versioned resource-policy tail. Frontends advertise only the 64 MiB packet limit they already enforce; unimplemented command and row limits remain zero.
- Made renderer acknowledgement handling disposition-aware. Retryable failures recover, window misses remain targeted, terminal failures release frame credit without committing rejected caches, and identical failed intents remain blocked until relevant state changes.
- Bound adapted retries to the outstanding generation and sequence, an advertised dimension, changed values, and a concrete changed render intent.
- Added terminal rejection encoding, last-good preservation, and duplicate suppression in the macOS and Go frontends.
- Documented the wire compatibility behavior, including the retryable interpretation of a draining protocol-v11 rejection.

## Verification
- `mix protocol.gen --check`
- `mix compile --warnings-as-errors`
- `mix test.debug test/minga_editor/frontend/capabilities_test.exs test/minga_editor/frontend/protocol_test.exs test/minga_editor/renderer/server_test.exs` (187 passed)
- `cd go/tui && go test ./...` (641 passed)
- `mix conformance` (161 passed)
- `mix swift.build`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga test`
- `mix test.llm` (9,179 tests, 0 failures)
- `make lint` passes branch-specific Credo and compilation. Its six Dialyzer warnings reproduce unchanged on clean `main@6cc775456` in parser and LLMDB modules outside this diff.

## Acceptance Criteria Addressed
- Shared generated rejection dispositions cover retryable recovery, targeted replacement, adapted retry, and terminal frontend failure. ✅
- Deterministic terminal rejection stays correlated, preserves the acknowledged base, and does not request an unchanged keyframe. ✅
- Frontend capabilities carry a versioned resource-policy contract and advertise only enforced dimensions. ✅
- Adapted retry requires explicit evidence that the next frame intent materially differs. ✅
- Terminal failure releases credit, preserves rejected caches as unacknowledged, suppresses identical work, and clears after relevant state changes. ✅
- BEAM, Swift, and Go tests cover retryable, targeted, adapted, terminal, stale, duplicate, and reconnect behavior. ✅
