### PR TITLE
fix(buffer): make formatting replacement atomic

### DIFF
--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -108,6 +108,10 @@ defmodule Minga.Buffer do
   @spec content(t()) :: String.t()
   defdelegate content(server), to: BufferProcess
 
+  @doc "Content and mutation version captured atomically in one call."
+  @spec content_with_version(t()) :: {String.t(), non_neg_integer()}
+  defdelegate content_with_version(server), to: BufferProcess
+
   @doc "Content and cursor position in a single call (avoids two round-trips)."
   @spec content_and_cursor(t()) :: {String.t(), position()}
   defdelegate content_and_cursor(server), to: BufferProcess
@@ -229,6 +233,16 @@ defmodule Minga.Buffer do
   @spec replace_content(t(), String.t(), Minga.Buffer.State.edit_source()) ::
           :ok | {:error, term()}
   defdelegate replace_content(server, new_content, source \\ :user), to: BufferProcess
+
+  @doc "Atomically replaces content at `expected_version`, preserving the nearest valid cursor position."
+  @spec replace_content_if_version(
+          t(),
+          non_neg_integer(),
+          String.t(),
+          Minga.Buffer.State.edit_source()
+        ) :: :ok | {:error, :read_only | :stale}
+  defdelegate replace_content_if_version(server, expected_version, new_content, source \\ :user),
+    to: BufferProcess
 
   @doc "Replace generated/internal content, bypassing user read-only restrictions."
   @spec replace_generated_content(t(), String.t()) :: :ok

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -286,6 +286,19 @@ defmodule Minga.Buffer.Process do
     GenServer.call(server, {:replace_content, new_content, source})
   end
 
+  @doc "Atomically replaces content at `expected_version`, preserving the nearest valid cursor position."
+  @spec replace_content_if_version(
+          GenServer.server(),
+          non_neg_integer(),
+          String.t(),
+          BufState.edit_source()
+        ) :: :ok | {:error, :read_only | :stale}
+  def replace_content_if_version(server, expected_version, new_content, source \\ :user)
+      when is_integer(expected_version) and expected_version >= 0 and is_binary(new_content) and
+             source in [:user, :agent, :lsp, :recovery] do
+    GenServer.call(server, {:replace_content_if_version, expected_version, new_content, source})
+  end
+
   @doc "Replaces buffer content bypassing read-only. For programmatic panel updates."
   @spec replace_generated_content(GenServer.server(), String.t()) :: :ok
   def replace_generated_content(server, new_content) do
@@ -308,6 +321,12 @@ defmodule Minga.Buffer.Process do
   @spec content(GenServer.server()) :: String.t()
   def content(server) do
     GenServer.call(server, :content)
+  end
+
+  @doc "Returns content and mutation version atomically in one call."
+  @spec content_with_version(GenServer.server()) :: {String.t(), non_neg_integer()}
+  def content_with_version(server) do
+    GenServer.call(server, :content_with_version)
   end
 
   @doc "Returns the byte offset for the start of a given line."
@@ -1262,13 +1281,29 @@ defmodule Minga.Buffer.Process do
   end
 
   def handle_call({:replace_content, new_content, source}, _from, state) do
-    new_buf = Document.new(new_content)
-    event_source = EditSource.from_undo_source(source)
+    {:reply, :ok, replace_content_state(state, new_content, source)}
+  end
 
-    new_state =
-      apply_operation(state, {:full, new_buf}, event_source, {:force_full, source, :clear})
+  def handle_call(
+        {:replace_content_if_version, _expected_version, _new_content, _source},
+        _from,
+        %{read_only: true} = state
+      ) do
+    {:reply, {:error, :read_only}, state}
+  end
 
-    {:reply, :ok, new_state}
+  def handle_call(
+        {:replace_content_if_version, expected_version, new_content, source},
+        _from,
+        state
+      ) do
+    case BufState.version(state) do
+      ^expected_version ->
+        {:reply, :ok, replace_content_preserving_cursor_state(state, new_content, source)}
+
+      _other_version ->
+        {:reply, {:error, :stale}, state}
+    end
   end
 
   # Force replace bypasses read_only. Used by panel buffers (file tree, agent)
@@ -1320,6 +1355,10 @@ defmodule Minga.Buffer.Process do
 
   def handle_call(:content, _from, state) do
     {:reply, Document.content(state.document), state}
+  end
+
+  def handle_call(:content_with_version, _from, state) do
+    {:reply, {Document.content(state.document), BufState.version(state)}, state}
   end
 
   def handle_call({:byte_offset_for_line, line}, _from, state) do
@@ -2064,6 +2103,28 @@ defmodule Minga.Buffer.Process do
 
     seed_options(state.options_server, filetype)
     |> Map.merge(explicit_values)
+  end
+
+  @spec replace_content_state(state(), String.t(), BufState.edit_source()) :: state()
+  defp replace_content_state(state, new_content, source) do
+    replace_content_document_state(state, Document.new(new_content), source)
+  end
+
+  @spec replace_content_preserving_cursor_state(state(), String.t(), BufState.edit_source()) ::
+          state()
+  defp replace_content_preserving_cursor_state(state, new_content, source) do
+    new_document =
+      new_content
+      |> Document.new()
+      |> Document.move_to(Document.cursor(state.document))
+
+    replace_content_document_state(state, new_document, source)
+  end
+
+  @spec replace_content_document_state(state(), Document.t(), BufState.edit_source()) :: state()
+  defp replace_content_document_state(state, new_document, source) do
+    event_source = EditSource.from_undo_source(source)
+    apply_operation(state, {:full, new_document}, event_source, {:force_full, source, :clear})
   end
 
   @spec apply_operation(state(), operation_result(), EditSource.t(), operation_opts()) :: state()

--- a/lib/minga_editor/commands/formatting.ex
+++ b/lib/minga_editor/commands/formatting.ex
@@ -18,6 +18,7 @@ defmodule MingaEditor.Commands.Formatting do
 
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
+  @type format_commit_error :: :not_alive | :read_only | :stale
 
   @spec format_buffer(state()) :: state()
   def format_buffer(%{workspace: %{buffers: %{active: buf}}} = state) when is_pid(buf) do
@@ -98,11 +99,15 @@ defmodule MingaEditor.Commands.Formatting do
     end)
   end
 
-  @doc "Applies LSP text edits to a buffer and restores the cursor to the nearest valid line."
-  @spec apply_lsp_edits(pid(), [map()]) :: :ok
-  def apply_lsp_edits(buf, edits) when is_pid(buf) and is_list(edits) do
-    if edits != [] do
-      {cursor_line, cursor_col} = Buffer.cursor(buf)
+  @doc "Applies LSP text edits only when the buffer still has `expected_version`."
+  @spec apply_lsp_edits(pid(), [map()], non_neg_integer()) ::
+          :ok | {:error, format_commit_error()}
+  def apply_lsp_edits(_buf, [], _expected_version), do: :ok
+
+  def apply_lsp_edits(buf, edits, expected_version)
+      when is_pid(buf) and is_list(edits) and is_integer(expected_version) and
+             expected_version >= 0 do
+    safely_commit(fn ->
       content = Buffer.content(buf)
 
       new_content =
@@ -117,14 +122,8 @@ defmodule MingaEditor.Commands.Formatting do
           apply_single_edit(acc, start_line, start_col, end_line, end_col, new_text)
         end)
 
-      Buffer.replace_content(buf, new_content)
-      line_count = Buffer.line_count(buf)
-      safe_line = min(cursor_line, max(line_count - 1, 0))
-      Buffer.move_to(buf, {safe_line, cursor_col})
-      Minga.Log.info(:editor, "Formatted (LSP)")
-    end
-
-    :ok
+      commit_formatted_content(buf, expected_version, new_content, :lsp)
+    end)
   end
 
   @spec apply_single_edit(
@@ -190,8 +189,7 @@ defmodule MingaEditor.Commands.Formatting do
 
   @spec format_and_replace(state(), pid(), Minga.Editing.Formatter.formatter_spec()) :: state()
   defp format_and_replace(state, buf, spec) do
-    content = Buffer.content(buf)
-    version = Buffer.version(buf)
+    {content, version} = Buffer.content_with_version(buf)
 
     state
     |> EditorState.set_status("Formatting…")
@@ -206,23 +204,59 @@ defmodule MingaEditor.Commands.Formatting do
   @doc "Applies the result of an asynchronous external formatter run."
   @spec apply_format_external_result(state(), term()) :: state()
   def apply_format_external_result(state, {:ok, formatted, buf, version}) do
-    if Process.alive?(buf) and Buffer.version(buf) == version do
-      {cursor_line, cursor_col} = Buffer.cursor(buf)
-      Buffer.replace_content(buf, formatted)
-      line_count = Buffer.line_count(buf)
-      safe_line = min(cursor_line, max(line_count - 1, 0))
-      Buffer.move_to(buf, {safe_line, cursor_col})
-      buf_name = (Buffer.file_path(buf) || "scratch") |> Path.basename()
-      Minga.Log.info(:editor, "Formatted: #{buf_name}")
-      EditorState.set_status(state, "Formatted")
-    else
-      EditorState.set_status(state, "Buffer changed, format skipped")
-    end
+    result =
+      safely_commit(fn ->
+        case commit_formatted_content(buf, version, formatted, :user) do
+          :ok -> {:ok, Buffer.file_path(buf)}
+          {:error, reason} -> {:error, reason}
+        end
+      end)
+
+    apply_external_commit_status(state, result)
   end
 
   def apply_format_external_result(state, {:error, msg}) do
     Minga.Log.warning(:editor, "Formatter failed: #{msg}")
     EditorState.set_status(state, "Format error: #{msg}")
+  end
+
+  @spec commit_formatted_content(
+          pid(),
+          non_neg_integer(),
+          String.t(),
+          Minga.Buffer.State.edit_source()
+        ) :: :ok | {:error, :read_only | :stale}
+  defp commit_formatted_content(buf, expected_version, content, source) do
+    Buffer.replace_content_if_version(buf, expected_version, content, source)
+  end
+
+  @spec safely_commit((-> term())) :: term()
+  defp safely_commit(fun) do
+    fun.()
+  catch
+    :exit, _reason -> {:error, :not_alive}
+  end
+
+  @spec apply_external_commit_status(
+          state(),
+          {:ok, String.t() | nil} | {:error, format_commit_error()}
+        ) :: state()
+  defp apply_external_commit_status(state, {:ok, file_path}) do
+    buf_name = (file_path || "scratch") |> Path.basename()
+    Minga.Log.info(:editor, "Formatted: #{buf_name}")
+    EditorState.set_status(state, "Formatted")
+  end
+
+  defp apply_external_commit_status(state, {:error, :stale}) do
+    EditorState.set_status(state, "Buffer changed, format skipped")
+  end
+
+  defp apply_external_commit_status(state, {:error, :read_only}) do
+    EditorState.set_status(state, "Buffer is read-only, format skipped")
+  end
+
+  defp apply_external_commit_status(state, {:error, :not_alive}) do
+    EditorState.set_status(state, "Buffer closed, format skipped")
   end
 
   # When the formatter binary is missing and a tool recipe exists for it,

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -1027,11 +1027,11 @@ defmodule MingaEditor.LspActions do
   end
 
   def handle_formatting_response(state, {:ok, edits}, buf, version) when is_list(edits) do
-    if Process.alive?(buf) and Buffer.version(buf) == version do
-      MingaEditor.Commands.Formatting.apply_lsp_edits(buf, edits)
-      EditorState.set_status(state, "Formatted (LSP)")
-    else
-      EditorState.set_status(state, "Buffer changed, format skipped")
+    case Commands.Formatting.apply_lsp_edits(buf, edits, version) do
+      :ok -> EditorState.set_status(state, "Formatted (LSP)")
+      {:error, :stale} -> EditorState.set_status(state, "Buffer changed, format skipped")
+      {:error, :read_only} -> EditorState.set_status(state, "Buffer is read-only, format skipped")
+      {:error, :not_alive} -> EditorState.set_status(state, "Buffer closed, format skipped")
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -47,7 +47,7 @@ defmodule Minga.MixProject do
       dialyzer: [
         plt_add_deps: :apps_direct,
         # Keep the PLT lean for dev/agent loops: include only direct runtime deps by default, then add transitive apps that Minga source references directly.
-        plt_add_apps: [:mix, :plug, :plug_crypto, :thousand_island, :websock],
+        plt_add_apps: [:llm_db, :mix, :plug, :plug_crypto, :thousand_island, :websock],
         ignore_warnings: ".dialyzer_ignore.exs"
       ],
       consolidate_protocols: Mix.env() != :prod,

--- a/test/minga/buffer/process_test.exs
+++ b/test/minga/buffer/process_test.exs
@@ -822,6 +822,88 @@ defmodule Minga.Buffer.ProcessTest do
       assert BufferProcess.last_undo_source(pid) == :user
     end
 
+    test "content_with_version captures a matching content and version pair" do
+      pid = start_supervised!({BufferProcess, content: "hello"})
+
+      assert {"hello", version} = Buffer.content_with_version(pid)
+      assert version == Buffer.version(pid)
+
+      Buffer.insert_text(pid, "!")
+      assert {"!hello", next_version} = Buffer.content_with_version(pid)
+      assert next_version == version + 1
+    end
+
+    test "replace_content_if_version atomically replaces the expected version" do
+      pid = start_supervised!({BufferProcess, content: "hello\nworld"})
+      Buffer.move_to(pid, {1, 4})
+      version = Buffer.version(pid)
+
+      assert :ok = Buffer.replace_content_if_version(pid, version, "goodbye", :lsp)
+      assert Buffer.content(pid) == "goodbye"
+      assert Buffer.cursor(pid) == {0, 4}
+      assert Buffer.version(pid) == version + 1
+      assert BufferProcess.last_undo_source(pid) == :lsp
+    end
+
+    test "replace_content_if_version leaves all buffer state unchanged when stale" do
+      pid = start_supervised!({BufferProcess, content: "hello"})
+      stale_version = Buffer.version(pid)
+      Buffer.move_to(pid, {0, 3})
+      Buffer.insert_text(pid, "!")
+
+      content = Buffer.content(pid)
+      cursor = Buffer.cursor(pid)
+      version = Buffer.version(pid)
+      dirty? = Buffer.dirty?(pid)
+      undo_source = BufferProcess.last_undo_source(pid)
+
+      assert {:error, :stale} =
+               Buffer.replace_content_if_version(pid, stale_version, "stale", :lsp)
+
+      assert Buffer.content(pid) == content
+      assert Buffer.cursor(pid) == cursor
+      assert Buffer.version(pid) == version
+      assert Buffer.dirty?(pid) == dirty?
+      assert BufferProcess.last_undo_source(pid) == undo_source
+
+      assert :ok = Buffer.undo(pid)
+      assert Buffer.content(pid) == "hello"
+    end
+
+    test "replace_content_if_version rejects read-only buffers without mutation" do
+      pid = start_supervised!({BufferProcess, content: "hello", read_only: true})
+      version = Buffer.version(pid)
+
+      assert {:error, :read_only} =
+               Buffer.replace_content_if_version(pid, version, "goodbye", :lsp)
+
+      assert Buffer.content(pid) == "hello"
+      assert Buffer.version(pid) == version
+      refute Buffer.dirty?(pid)
+    end
+
+    test "a queued prior mutation makes version-checked replacement stale" do
+      pid = start_supervised!({BufferProcess, content: "hello"})
+      expected_version = Buffer.version(pid)
+      insert_tag = make_ref()
+      replace_tag = make_ref()
+
+      send(
+        pid,
+        {:"$gen_call", {self(), insert_tag}, {:insert_text, "!", Minga.Buffer.EditSource.user()}}
+      )
+
+      send(
+        pid,
+        {:"$gen_call", {self(), replace_tag},
+         {:replace_content_if_version, expected_version, "stale", :lsp}}
+      )
+
+      assert_receive {^insert_tag, :ok}
+      assert_receive {^replace_tag, {:error, :stale}}
+      assert Buffer.content(pid) == "!hello"
+    end
+
     test "generated replacement APIs clear stale undo history" do
       cases = [
         {"generated", fn pid -> BufferProcess.replace_generated_content(pid, "generated") end},

--- a/test/minga_editor/commands/formatting_async_test.exs
+++ b/test/minga_editor/commands/formatting_async_test.exs
@@ -40,6 +40,72 @@ defmodule MingaEditor.Commands.FormattingAsyncTest do
       assert new_state.shell_state.status_msg =~ "Buffer changed"
     end
 
+    test "a mutation queued after the atomic external commit is not overwritten" do
+      state = base_state("hello world\n")
+      buf = state.workspace.buffers.active
+      version = Buffer.version(buf)
+      :ok = :sys.suspend(buf)
+
+      task =
+        Task.async(fn ->
+          receive do
+            :apply_result ->
+              Formatting.apply_format_external_result(
+                state,
+                {:ok, "FORMATTED\n", buf, version}
+              )
+          end
+        end)
+
+      task_pid = task.pid
+      1 = :erlang.trace(task_pid, true, [:send])
+      send(task_pid, :apply_result)
+
+      assert_receive {:trace, ^task_pid, :send,
+                      {:"$gen_call", {_from, _tag},
+                       {:replace_content_if_version, ^version, "FORMATTED\n", :user}}, ^buf}
+
+      insert_tag = make_ref()
+
+      send(
+        buf,
+        {:"$gen_call", {self(), insert_tag}, {:insert_text, "!", Minga.Buffer.EditSource.user()}}
+      )
+
+      :ok = :sys.resume(buf)
+      assert_receive {^insert_tag, :ok}
+      new_state = Task.await(task)
+
+      assert Buffer.content(buf) == "!FORMATTED\n"
+      assert new_state.shell_state.status_msg == "Formatted"
+      assert :ok = Buffer.undo(buf)
+      assert Buffer.content(buf) == "hello world\n"
+    end
+
+    test "rejects a matching-version result when the buffer is read-only" do
+      state = base_state("hello\n", read_only: true)
+      buf = state.workspace.buffers.active
+      version = Buffer.version(buf)
+
+      new_state = Formatting.apply_format_external_result(state, {:ok, "HELLO\n", buf, version})
+
+      assert Buffer.content(buf) == "hello\n"
+      assert new_state.shell_state.status_msg =~ "read-only"
+    end
+
+    test "drops a result when the target buffer exited" do
+      state = base_state("hello\n")
+      buf = state.workspace.buffers.active
+      version = Buffer.version(buf)
+      monitor = Process.monitor(buf)
+      Process.exit(buf, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^buf, :killed}
+
+      new_state = Formatting.apply_format_external_result(state, {:ok, "HELLO\n", buf, version})
+
+      assert new_state.shell_state.status_msg =~ "closed"
+    end
+
     test "handles formatter error" do
       state = base_state("hello\n")
 
@@ -69,8 +135,9 @@ defmodule MingaEditor.Commands.FormattingAsyncTest do
     end
   end
 
-  defp base_state(content) do
-    buffer = start_supervised!({BufferProcess, content: content}, id: {:buffer, make_ref()})
+  defp base_state(content, opts \\ []) do
+    buffer_opts = Keyword.merge([content: content], opts)
+    buffer = start_supervised!({BufferProcess, buffer_opts}, id: {:buffer, make_ref()})
 
     workspace = %MingaEditor.Session.State{
       viewport: Viewport.new(24, 80),

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -268,6 +268,108 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       assert new_state.shell_state.status_msg =~ "Buffer changed"
     end
 
+    test "a mutation queued after the LSP content read makes the commit stale" do
+      state = base_state()
+      buf = state.workspace.buffers.active
+      version = Minga.Buffer.version(buf)
+      ref = make_ref()
+      state = put_lsp_pending(state, ref, {:format, buf, version})
+
+      edits = [
+        %{
+          "range" => %{
+            "start" => %{"line" => 0, "character" => 0},
+            "end" => %{"line" => 0, "character" => 8}
+          },
+          "newText" => "STALE"
+        }
+      ]
+
+      :ok = :sys.suspend(buf)
+
+      task =
+        Task.async(fn ->
+          receive do
+            :apply_result ->
+              LspEventHandler.handle(state, {:lsp_response, ref, {:ok, edits}})
+          end
+        end)
+
+      task_pid = task.pid
+      1 = :erlang.trace(task_pid, true, [:send])
+      send(task_pid, :apply_result)
+
+      assert_receive {:trace, ^task_pid, :send, {:"$gen_call", {_from, _tag}, :content}, ^buf}
+
+      insert_tag = make_ref()
+
+      send(
+        buf,
+        {:"$gen_call", {self(), insert_tag}, {:insert_text, "!", Minga.Buffer.EditSource.user()}}
+      )
+
+      :ok = :sys.resume(buf)
+      assert_receive {^insert_tag, :ok}
+      {new_state, effects} = Task.await(task)
+
+      assert effects == [:render_now]
+      assert Minga.Buffer.content(buf) =~ "!line one"
+      assert new_state.shell_state.status_msg =~ "Buffer changed"
+    end
+
+    test "does not apply edits to a read-only buffer" do
+      state = base_state()
+      buf = state.workspace.buffers.active
+      version = Minga.Buffer.version(buf)
+      :ok = Minga.Buffer.set_read_only(buf, true)
+      ref = make_ref()
+      state = put_lsp_pending(state, ref, {:format, buf, version})
+
+      edits = [
+        %{
+          "range" => %{
+            "start" => %{"line" => 0, "character" => 0},
+            "end" => %{"line" => 0, "character" => 8}
+          },
+          "newText" => "READ ONLY"
+        }
+      ]
+
+      {new_state, effects} =
+        LspEventHandler.handle(state, {:lsp_response, ref, {:ok, edits}})
+
+      assert effects == [:render_now]
+      assert Minga.Buffer.content(buf) =~ "line one"
+      assert new_state.shell_state.status_msg =~ "read-only"
+    end
+
+    test "drops edits when the target buffer exited" do
+      state = base_state()
+      buf = state.workspace.buffers.active
+      version = Minga.Buffer.version(buf)
+      ref = make_ref()
+      state = put_lsp_pending(state, ref, {:format, buf, version})
+      monitor = Process.monitor(buf)
+      Process.exit(buf, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^buf, :killed}
+
+      edits = [
+        %{
+          "range" => %{
+            "start" => %{"line" => 0, "character" => 0},
+            "end" => %{"line" => 0, "character" => 8}
+          },
+          "newText" => "CLOSED"
+        }
+      ]
+
+      {new_state, effects} =
+        LspEventHandler.handle(state, {:lsp_response, ref, {:ok, edits}})
+
+      assert effects == [:render_now]
+      assert new_state.shell_state.status_msg =~ "closed"
+    end
+
     test "handles nil response (no formatting changes)" do
       state = base_state()
       buf = state.workspace.buffers.active


### PR DESCRIPTION
# TL;DR

Formatting results now commit through a Buffer-owned atomic compare-and-replace, so neither external nor LSP formatting can overwrite edits made after formatting started.

Closes #2804

## Context

Formatting previously checked a buffer version and replaced content in separate calls. A mutation could land between those calls and then be overwritten by the stale formatted snapshot.

## Changes

- Add atomic content/version capture and version-checked replacement APIs to `Minga.Buffer`.
- Compare the expected version, preserve and clamp the cursor, and apply the full replacement within one `Minga.Buffer.Process` call.
- Route both external and LSP formatting through the atomic operation and report stale, read-only, and closed-buffer outcomes without mutating newer state.
- Add deterministic mailbox-order tests for owner, external formatter, and LSP formatter races without sleeps.
- Include `:llm_db` in the Dialyzer PLT apps because Minga directly calls `LLMDB.models/0`, making clean incremental lint caches deterministic.

## Verification

- `make lint` (full Credo: 0 issues; compile: pass; incremental Dialyzer: 0 errors)
- `mix test.debug test/minga/buffer/process_test.exs` (110 tests, 0 failures)
- `mix test.llm test/minga_editor/commands/formatting_async_test.exs test/minga_editor/handlers/lsp_event_handler_test.exs` (28 tests, 0 failures)
- `mix test.llm --max-cases 4 --seed 551223` (9,182 tests, 58 doctests, 97 properties, 0 failures)
- LSP diagnostics on all changed Elixir files: 0
- `git diff --check`: pass

## Acceptance Criteria Addressed

- Formatting replaces content only at the exact version captured at dispatch. ✅
- Version validation and content replacement are atomic against every Buffer mutation. ✅
- Stale results preserve content, cursor, undo history, and dirty state while reporting a skipped format. ✅
- External and LSP formatting both use the atomic operation. ✅
- Deterministic tests cover success, stale rejection, read-only buffers, exited targets, cursor preservation, and queued mutation ordering. ✅
