### PR TITLE
feat(macos): bound frame ingestion resources

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -25,6 +25,20 @@ mix swift.test
 (cd go/tui && go test ./...)
 ```
 
+## macOS ingestion limits and calibrated headroom
+
+`FrameResourcePolicy.default` is immutable and is sliced at the macOS composition root into wire, decode, staging, and per-window resident limits. The wire payload ceiling remains 64 MiB. Decode and per-window residence permit 131,072 rows (2x the 65,536-row corpus), so an ordinary structural insertion at the supported corpus size does not turn a valid editor action into a terminal resource failure. Decode permits 2,097,152 spans (32 per row at its ceiling) and 1,048,576 overlays. Per-window residence permits 4,194,304 spans, 2,097,152 overlays, 131,072 locator entries, and 256 MiB of owned UTF-8.
+
+The deterministic no-span fixtures use text `"row <1-based-id>"`. Their exact owned UTF-8 weights are 38,893 bytes for 5,000 rows and 578,718 bytes for 65,536 rows; each owns exactly one locator per row. These values are derived from decimal digit counts, not a wall-clock or allocator measurement. `ResidentRowStoreTests.calibratedCorpusHeadroom` checks both corpus sizes against the shipping multidimensional policy, while replacement/splice tests check cached exact-weight deltas and atomic rejection.
+
+Allocator/RSS calibration is intentionally not claimed by those structural weights. The named Release measurement command is:
+
+```sh
+scripts/check_render_performance
+```
+
+Record environment metadata and raw JSON emitted by that command before changing a default; do not infer allocator headroom from the deterministic weights alone.
+
 ## Deterministic ordinary-edit gate
 
 At both 5,000 and 65,536 resident rows, CI enforces an ordinary one-line edit using production APIs and counters:

--- a/lib/mix/tasks/swift_harness.ex
+++ b/lib/mix/tasks/swift_harness.ex
@@ -25,6 +25,7 @@ defmodule Mix.Tasks.Swift.Harness do
     "macos/Sources/Protocol/ProtocolTypes.swift",
     "macos/Sources/Protocol/StatusBarUpdate.swift",
     "macos/Sources/Protocol/GUIColorSlots.swift",
+    "macos/Sources/Protocol/FrameResourcePolicy.swift",
     "macos/Sources/Renderer/WindowContent.swift",
     "macos/Sources/Renderer/ResidentRowStore.swift",
     "macos/Sources/Protocol/AgentSurfaceTypes.swift",

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -250,6 +250,7 @@
 		C3FAE27B586C49B9172CD41A /* FrameMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */; };
 		C43DAF0776A77C3DE0EE6A90 /* ProtocolErrorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A915C3108F2370C753A1931B /* ProtocolErrorState.swift */; };
 		C44D9CF03C49E7BCA39A76A9 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
+		F41B7A8428024E08A7B6F901 /* FrameResourcePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA4AE7E853248477810B52C /* FrameResourcePolicy.swift */; };
 		C6BCAF6C4605DD682B8BC442 /* FloatPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA0E8F5D7D411B92E9E3FA /* FloatPopupOverlay.swift */; };
 		C6F817BD3BFBFA4C334DC229 /* FeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF185FF7AFC2D9E5430B6B65 /* FeedbackState.swift */; };
 		C715D937E8591D8BA46A29CD /* FontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2DE335B00721CBB29329F9 /* FontTests.swift */; };
@@ -584,6 +585,7 @@
 		CA105569D96F7654005293B2 /* ActivityBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityBar.swift; sourceTree = "<group>"; };
 		CA2269E199608D475AB34F10 /* NativeSidebarRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSidebarRegistryTests.swift; sourceTree = "<group>"; };
 		CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRenderer.swift; sourceTree = "<group>"; };
+		CDA4AE7E853248477810B52C /* FrameResourcePolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrameResourcePolicy.swift; sourceTree = "<group>"; };
 		CE2E468DA824CDB99FCEF94A /* EditorScrollTrackTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorScrollTrackTests.swift; sourceTree = "<group>"; };
 		CE9448826AA38AB5FC0CEB79 /* EditorSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorSettingsView.swift; sourceTree = "<group>"; };
 		D0411DCA866DF30C994521EC /* ProtocolErrorOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolErrorOverlay.swift; sourceTree = "<group>"; };
@@ -891,6 +893,7 @@
 				483AA21EF140F07296D1E16A /* AgentSurfaceTypes.swift */,
 				5E609A9FCD637B39DD56497B /* ByteCursor.swift */,
 				7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */,
+				CDA4AE7E853248477810B52C /* FrameResourcePolicy.swift */,
 				F330603D06228BB2A18F71F5 /* FrontendExtensionRuntimeMessage.swift */,
 				C6154F8ABA71694035D38ED2 /* GUIColorSlots.swift */,
 				92E717A483EC2E50C536785C /* InputEncoder.swift */,
@@ -1470,6 +1473,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				86526CCD268BB390F0C14C53 /* AgentSurfaceTypes.swift in Sources */,
+				F41B7A8428024E08A7B6F901 /* FrameResourcePolicy.swift in Sources */,
 				5DDC0854DEF9C0F6DD82B694 /* FrontendExtensionRuntimeMessage.swift in Sources */,
 				581390BB65F36B77E59F6D9F /* GUIColorSlots.swift in Sources */,
 				D394B6B62354CC4ADD76DB74 /* LatencyRecorder.swift in Sources */,

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -864,11 +864,6 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
     private func handleProtocolDecodeFailure(_ failure: DecodedFrameFailure) {
         // The packet is transactional: no command from it crossed actor isolation.
-        if failure.error.isResourceFailure, let envelope = failure.envelope {
-            dispatcher?.resourcePolicyRejected(envelope: envelope)
-            return
-        }
-        PortLogger.error("Protocol decode error: \(failure.error)")
-        dispatcher?.decodeFailed()
+        dispatcher?.decodedFrameFailed(failure)
     }
 }

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -201,6 +201,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private var editorNSView: EditorNSView?
     private var workspaceNotificationTasks: [Task<Void, Never>] = []
     private var protocolDeliveryTask: Task<Void, Never>?
+    private var protocolEventHandoff: ProtocolEventHandoff?
+    private let frameResourcePolicy = FrameResourcePolicy.default
 
     func applicationDidFinishLaunching(_ notification: Notification) {
         // Ignore SIGPIPE so broken pipe writes return EPIPE instead of
@@ -290,7 +292,10 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         PortLogger.info("Initial grid: \(cols)x\(rows) cells")
 
         // Command dispatcher.
-        let disp = CommandDispatcher(cols: cols, rows: rows, guiState: appState.gui)
+        let disp = CommandDispatcher(
+            cols: cols, rows: rows, guiState: appState.gui,
+            resourcePolicy: frameResourcePolicy
+        )
         disp.fontManager = fm
         disp.onFontChanged = { [weak self] family, size, ligatures, weight in
             self?.handleFontChange(family: family, size: CGFloat(size), ligatures: ligatures, weight: weight)
@@ -437,8 +442,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Start reading protocol commands. One stream consumer preserves the
         // reader's wire order across successful packets and decode failures.
         let protocolHandoff = installProtocolEventHandoff()
+        let resourcePolicy = frameResourcePolicy
         let reader = ProtocolReader(
             input: protocolInput,
+            maxPayloadLength: resourcePolicy.wire.payloadBytes,
+            decoder: { [resourcePolicy] data in
+                try decodeFrame(from: data, policy: resourcePolicy)
+            },
             handler: { frame in
                 protocolHandoff.deliver(frame)
             },
@@ -461,7 +471,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         NSApp.terminate(nil)
                     }
                 }
-            }
+            },
+            acquireAdmission: { protocolHandoff.acquireAdmission() },
+            cancelAdmission: { protocolHandoff.cancel() }
         )
         reader.start()
         self.protocolReader = reader
@@ -680,8 +692,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         // Create new reader for the new pipe. Reconnection replaces the one
         // ordered stream consumer instead of spawning a task per event.
         let protocolHandoff = installProtocolEventHandoff()
+        let resourcePolicy = frameResourcePolicy
         let reader = ProtocolReader(
             input: readHandle,
+            maxPayloadLength: resourcePolicy.wire.payloadBytes,
+            decoder: { [resourcePolicy] data in
+                try decodeFrame(from: data, policy: resourcePolicy)
+            },
             handler: { frame in
                 protocolHandoff.deliver(frame)
             },
@@ -696,7 +713,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                         NSApp.terminate(nil)
                     }
                 }
-            }
+            },
+            acquireAdmission: { protocolHandoff.acquireAdmission() },
+            cancelAdmission: { protocolHandoff.cancel() }
         )
         reader.start()
         self.protocolReader = reader
@@ -810,16 +829,20 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Protocol handling
 
     private func installProtocolEventHandoff() -> ProtocolEventHandoff {
+        // Cancel the old handoff first so its producer cannot deliver stale work.
+        protocolEventHandoff?.cancel()
         protocolDeliveryTask?.cancel()
         let handoff = ProtocolEventHandoff()
+        protocolEventHandoff = handoff
         protocolDeliveryTask = Task { @MainActor [weak self] in
             for await event in handoff.events {
+                handoff.releaseAdmission()
                 guard let self else { return }
                 switch event {
                 case .frame(let frame):
                     self.handleDecodedFrame(frame)
-                case .decodeFailure(let error):
-                    self.handleProtocolDecodeFailure(error)
+                case .failure(let failure):
+                    self.handleProtocolDecodeFailure(failure)
                 }
             }
         }
@@ -839,10 +862,13 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         dispatcher.dispatch(frame)
     }
 
-    private func handleProtocolDecodeFailure(_ error: ProtocolDecodeError) {
-        // The packet is transactional: no command from it crossed actor isolation,
-        // so discarding the staged frame cannot leave a partially applied update.
-        PortLogger.error("Protocol decode error: \(error)")
+    private func handleProtocolDecodeFailure(_ failure: DecodedFrameFailure) {
+        // The packet is transactional: no command from it crossed actor isolation.
+        if failure.error.isResourceFailure, let envelope = failure.envelope {
+            dispatcher?.resourcePolicyRejected(envelope: envelope)
+            return
+        }
+        PortLogger.error("Protocol decode error: \(failure.error)")
         dispatcher?.decodeFailed()
     }
 }

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -339,7 +339,7 @@ enum PreviewRegistry {
             signColWidth: 1,
             entries: previewGutterEntries()
         )
-        guiState.windowContents[1] = GUIWindowContent(
+        guiState.windowContents[1] = try GUIWindowContent(
             windowId: 1,
             fullRefresh: true,
             cursorVisible: true,
@@ -483,7 +483,7 @@ enum PreviewRegistry {
             signColWidth: 1,
             entries: previewDiagnosticsGutterEntries()
         )
-        guiState.windowContents[1] = GUIWindowContent(
+        guiState.windowContents[1] = try GUIWindowContent(
             windowId: 1,
             fullRefresh: true,
             cursorVisible: true,

--- a/macos/Sources/Protocol/ByteCursor.swift
+++ b/macos/Sources/Protocol/ByteCursor.swift
@@ -1,6 +1,7 @@
 /// Checked, zero-copy cursor primitives for protocol packet decoding.
 
 import Foundation
+import MingaProtocol
 
 /// A bounds-checked, `Sendable` cursor over an immutable `Data` range.
 ///
@@ -88,6 +89,8 @@ struct ByteCursor: Sendable {
 
     /// Decodes one final immutable UTF-8 value and accounts for its owned bytes.
     mutating func readString(count: Int) throws -> String {
+        // Reserve before creating the owned String backing storage.
+        try FrameDecodeAccounting.reserve(.ownedUTF8Bytes, count)
         let slice = try readSlice(count: count)
         guard let value = String(data: slice, encoding: .utf8) else {
             throw ProtocolDecodeError.malformed

--- a/macos/Sources/Protocol/DecodedFrame.swift
+++ b/macos/Sources/Protocol/DecodedFrame.swift
@@ -6,6 +6,7 @@ import MingaProtocol
 struct DecodedCommand: Sendable {
     let command: RenderCommand
     let opcode: UInt8
+    let resourceWeight: FrameResourceWeight
 }
 
 struct DecoderOwnedMetrics {

--- a/macos/Sources/Protocol/DecodedFrame.swift
+++ b/macos/Sources/Protocol/DecodedFrame.swift
@@ -1,6 +1,7 @@
 /// Immutable values and deterministic metrics produced by one packet decode.
 
 import Foundation
+import MingaProtocol
 
 struct DecodedCommand: Sendable {
     let command: RenderCommand
@@ -66,11 +67,47 @@ struct FrameDecodeMetrics: Sendable, Equatable {
 /// The main-actor dispatcher consumes the whole value and compiles its commands
 /// directly into a `PreparedFrameTransactionBuilder`; it never stores packet views
 /// or publishes commands individually.
+/// Correlation recovered from a valid leading begin-frame command.
+struct FrameEnvelope: Sendable, Equatable {
+    let generation: UInt32
+    let frameSeq: UInt32
+    let baseFrameSeq: UInt32
+}
+
+/// A fully decoded failure. The optional envelope allows a resource rejection
+/// to use the same correlated terminal status as a staged-frame rejection.
+struct DecodedFrameFailure: Error, Sendable {
+    let error: ProtocolDecodeError
+    let envelope: FrameEnvelope?
+}
+
+enum DecodedFrameEvent: Sendable {
+    case frame(DecodedFrame)
+    case failure(DecodedFrameFailure)
+}
+
 struct DecodedFrame: Sendable {
     let commands: [DecodedCommand]
+    let envelope: FrameEnvelope?
+    let resourceWeight: FrameResourceWeight
     let metrics: FrameDecodeMetrics
 
+    init(
+        commands: [DecodedCommand], envelope: FrameEnvelope? = nil,
+        resourceWeight: FrameResourceWeight = .init(), metrics: FrameDecodeMetrics
+    ) {
+        self.commands = commands
+        self.envelope = envelope
+        self.resourceWeight = resourceWeight
+        self.metrics = metrics
+    }
+
     func recordingActorHop() -> DecodedFrame {
-        DecodedFrame(commands: commands, metrics: metrics.recordingActorHop())
+        DecodedFrame(
+            commands: commands,
+            envelope: envelope,
+            resourceWeight: resourceWeight,
+            metrics: metrics.recordingActorHop()
+        )
     }
 }

--- a/macos/Sources/Protocol/FrameResourcePolicy.swift
+++ b/macos/Sources/Protocol/FrameResourcePolicy.swift
@@ -1,0 +1,252 @@
+import Foundation
+
+/// Immutable limits applied at the four resource-accounting phases of a frame.
+public struct FrameResourcePolicy: Sendable, Equatable {
+    /// Maximum packet bytes admitted before payload allocation.
+    public struct WireLimits: Sendable, Equatable {
+        public let payloadBytes: Int
+        /// Creates a wire-byte ceiling.
+        public init(payloadBytes: Int) { self.payloadBytes = payloadBytes }
+    }
+    /// Limits for one decoder pass.
+    public struct DecodeLimits: Sendable, Equatable {
+        public let weight: FrameResourceWeight
+        /// Creates a decoder weight ceiling.
+        public init(weight: FrameResourceWeight) { self.weight = weight }
+    }
+    /// Limits for phase-local semantic staging.
+    public struct StagingLimits: Sendable, Equatable {
+        public let weight: FrameResourceWeight
+        /// Creates a staging weight ceiling.
+        public init(weight: FrameResourceWeight) { self.weight = weight }
+    }
+    /// Exact limits retained by one published window.
+    public struct ResidentLimits: Sendable, Equatable {
+        public let weightPerWindow: FrameResourceWeight
+        /// Creates a per-window resident weight ceiling.
+        public init(weightPerWindow: FrameResourceWeight) { self.weightPerWindow = weightPerWindow }
+    }
+
+    public let wire: WireLimits
+    public let decode: DecodeLimits
+    public let staging: StagingLimits
+    public let resident: ResidentLimits
+
+    /// Creates immutable phase slices at the composition root.
+    public init(
+        wire: WireLimits, decode: DecodeLimits,
+        staging: StagingLimits, resident: ResidentLimits
+    ) {
+        self.wire = wire
+        self.decode = decode
+        self.staging = staging
+        self.resident = resident
+    }
+
+    /// Production policy. Decode, staging, and per-window residence retain
+    /// headroom above the 65,536-row corpus for ordinary structural edits.
+    public static let `default` = FrameResourcePolicy(
+        wire: WireLimits(payloadBytes: 64 * 1_048_576),
+        decode: DecodeLimits(weight: .init(
+            commands: 131_072, ownedUTF8Bytes: 64 * 1_048_576, arrayEntries: 4_194_304,
+            rows: 131_072, spans: 2_097_152, overlays: 1_048_576,
+            spliceEntries: 131_072, locatorEntries: 131_072
+        )),
+        staging: StagingLimits(weight: .init(
+            commands: 131_072, ownedUTF8Bytes: 64 * 1_048_576, arrayEntries: 8_388_608,
+            rows: 1_048_576, spans: 4_194_304, overlays: 2_097_152,
+            spliceEntries: 131_072, locatorEntries: 1_048_576
+        )),
+        resident: ResidentLimits(weightPerWindow: .init(
+            commands: .max, ownedUTF8Bytes: 256 * 1_048_576, arrayEntries: .max,
+            rows: 131_072, spans: 4_194_304, overlays: 2_097_152,
+            spliceEntries: .max, locatorEntries: 131_072
+        ))
+    )
+}
+
+/// Exact, checked resource dimensions shared by decode, staging, and residency.
+public struct FrameResourceWeight: Sendable, Equatable {
+    public var commands: Int
+    public var ownedUTF8Bytes: Int
+    public var arrayEntries: Int
+    public var rows: Int
+    public var spans: Int
+    public var overlays: Int
+    public var spliceEntries: Int
+    public var locatorEntries: Int
+
+    /// Creates an exact multidimensional weight.
+    public init(
+        commands: Int = 0, ownedUTF8Bytes: Int = 0, arrayEntries: Int = 0,
+        rows: Int = 0, spans: Int = 0, overlays: Int = 0,
+        spliceEntries: Int = 0, locatorEntries: Int = 0
+    ) {
+        self.commands = commands
+        self.ownedUTF8Bytes = ownedUTF8Bytes
+        self.arrayEntries = arrayEntries
+        self.rows = rows
+        self.spans = spans
+        self.overlays = overlays
+        self.spliceEntries = spliceEntries
+        self.locatorEntries = locatorEntries
+    }
+
+    /// Returns the checked component-wise sum.
+    public func adding(_ other: Self) throws -> Self {
+        Self(
+            commands: try Self.add(commands, other.commands, .commands),
+            ownedUTF8Bytes: try Self.add(ownedUTF8Bytes, other.ownedUTF8Bytes, .ownedUTF8Bytes),
+            arrayEntries: try Self.add(arrayEntries, other.arrayEntries, .arrayEntries),
+            rows: try Self.add(rows, other.rows, .rows),
+            spans: try Self.add(spans, other.spans, .spans),
+            overlays: try Self.add(overlays, other.overlays, .overlays),
+            spliceEntries: try Self.add(spliceEntries, other.spliceEntries, .spliceEntries),
+            locatorEntries: try Self.add(locatorEntries, other.locatorEntries, .locatorEntries)
+        )
+    }
+
+    /// Returns the checked component-wise difference.
+    public func subtracting(_ other: Self) throws -> Self {
+        guard commands >= other.commands, ownedUTF8Bytes >= other.ownedUTF8Bytes,
+              arrayEntries >= other.arrayEntries, rows >= other.rows,
+              spans >= other.spans, overlays >= other.overlays,
+              spliceEntries >= other.spliceEntries, locatorEntries >= other.locatorEntries else {
+            throw FrameResourceError.arithmeticOverflow
+        }
+        return Self(commands: commands - other.commands,
+                    ownedUTF8Bytes: ownedUTF8Bytes - other.ownedUTF8Bytes,
+                    arrayEntries: arrayEntries - other.arrayEntries,
+                    rows: rows - other.rows, spans: spans - other.spans,
+                    overlays: overlays - other.overlays,
+                    spliceEntries: spliceEntries - other.spliceEntries,
+                    locatorEntries: locatorEntries - other.locatorEntries)
+    }
+
+    /// Returns the first deterministic dimension above `limit`.
+    public func firstExceeded(limit: Self) -> FrameResourceDimension? {
+        for dimension in FrameResourceDimension.allCases where value(dimension) > limit.value(dimension) {
+            return dimension
+        }
+        return nil
+    }
+
+    /// Returns one dimension's value.
+    public func value(_ dimension: FrameResourceDimension) -> Int {
+        switch dimension {
+        case .commands: commands
+        case .ownedUTF8Bytes: ownedUTF8Bytes
+        case .arrayEntries: arrayEntries
+        case .rows: rows
+        case .spans: spans
+        case .overlays: overlays
+        case .spliceEntries: spliceEntries
+        case .locatorEntries: locatorEntries
+        }
+    }
+
+    private static func add(_ lhs: Int, _ rhs: Int, _ dimension: FrameResourceDimension) throws -> Int {
+        guard rhs >= 0 else { throw FrameResourceError.arithmeticOverflow }
+        let (result, overflow) = lhs.addingReportingOverflow(rhs)
+        guard !overflow else { throw FrameResourceError.arithmeticOverflow }
+        return result
+    }
+}
+
+/// Independently bounded payload-amplification axes.
+public enum FrameResourceDimension: String, Sendable, CaseIterable {
+    case commands, ownedUTF8Bytes, arrayEntries, rows, spans, overlays, spliceEntries, locatorEntries
+}
+
+/// Typed policy and arithmetic failures.
+public enum FrameResourceError: Error, Sendable, Equatable {
+    case wirePayloadLimitExceeded(requested: Int, limit: Int)
+    case limitExceeded(dimension: FrameResourceDimension, used: Int, requested: Int, limit: Int)
+    case arithmeticOverflow
+}
+
+/// Phase-local mutable accounting. It never crosses actor isolation.
+public final class FrameResourceUsageBuilder: @unchecked Sendable {
+    public typealias ReservationProbe = @Sendable (FrameResourceDimension, Int) -> Void
+
+    public private(set) var weight = FrameResourceWeight()
+    public let limit: FrameResourceWeight
+    private let reservationProbe: ReservationProbe?
+
+    /// Creates one phase-local builder and optional metadata-only test probe.
+    public init(limit: FrameResourceWeight, reservationProbe: ReservationProbe? = nil) {
+        self.limit = limit
+        self.reservationProbe = reservationProbe
+    }
+
+    /// Atomically reserves one dimension before the caller allocates.
+    public func reserve(_ dimension: FrameResourceDimension, _ amount: Int) throws {
+        guard amount >= 0 else { throw FrameResourceError.arithmeticOverflow }
+        let used = weight.value(dimension)
+        let (requested, overflow) = used.addingReportingOverflow(amount)
+        guard !overflow else { throw FrameResourceError.arithmeticOverflow }
+        let maximum = limit.value(dimension)
+        guard requested <= maximum else {
+            throw FrameResourceError.limitExceeded(dimension: dimension, used: used, requested: requested, limit: maximum)
+        }
+        // Test instrumentation observes successful admission before the caller's
+        // payload-proportional allocation. It receives metadata only.
+        reservationProbe?(dimension, requested)
+        switch dimension {
+        case .commands: weight.commands = requested
+        case .ownedUTF8Bytes: weight.ownedUTF8Bytes = requested
+        case .arrayEntries: weight.arrayEntries = requested
+        case .rows: weight.rows = requested
+        case .spans: weight.spans = requested
+        case .overlays: weight.overlays = requested
+        case .spliceEntries: weight.spliceEntries = requested
+        case .locatorEntries: weight.locatorEntries = requested
+        }
+    }
+
+    /// Captures usage before speculative legacy decoding.
+    public func checkpoint() -> FrameResourceWeight { weight }
+
+    /// Restores a child-local speculative checkpoint.
+    public func restore(_ checkpoint: FrameResourceWeight) { weight = checkpoint }
+}
+
+/// Task-local bridge used by decoder helpers without a second parser.
+public enum FrameDecodeAccounting {
+    @TaskLocal static var current: FrameResourceUsageBuilder?
+    @TaskLocal static var currentResidentLimit: FrameResourceWeight?
+
+    /// Resident policy active for the complete decode transaction.
+    public static var residentLimit: FrameResourceWeight {
+        currentResidentLimit ?? FrameResourcePolicy.default.resident.weightPerWindow
+    }
+
+    /// Installs one decoder-owned usage builder and resident limit for a complete pass.
+    public static func withUsage<T>(
+        _ usage: FrameResourceUsageBuilder,
+        residentLimit: FrameResourceWeight,
+        operation: () throws -> T
+    ) rethrows -> T {
+        try $current.withValue(usage) {
+            try $currentResidentLimit.withValue(residentLimit, operation: operation)
+        }
+    }
+
+    /// Reserves through the current decoder builder when present.
+    public static func reserve(_ dimension: FrameResourceDimension, _ amount: Int) throws {
+        try current?.reserve(dimension, amount)
+    }
+
+    /// Rolls accounting back when a speculative legacy branch fails. Successful
+    /// branches retain their reservations and are still decoded only once.
+    public static func withCheckpoint<T>(_ body: () throws -> T) throws -> T {
+        guard let current else { return try body() }
+        let checkpoint = current.checkpoint()
+        do {
+            return try body()
+        } catch {
+            current.restore(checkpoint)
+            throw error
+        }
+    }
+}

--- a/macos/Sources/Protocol/FrameResourcePolicy.swift
+++ b/macos/Sources/Protocol/FrameResourcePolicy.swift
@@ -106,6 +106,15 @@ public struct FrameResourceWeight: Sendable, Equatable {
         )
     }
 
+    /// Returns a component-wise sum after an earlier checked aggregate admitted it.
+    func addingPrevalidated(_ other: Self) -> Self {
+        do {
+            return try adding(other)
+        } catch {
+            preconditionFailure("prevalidated frame resource weight overflowed")
+        }
+    }
+
     /// Returns the checked component-wise difference.
     public func subtracting(_ other: Self) throws -> Self {
         guard commands >= other.commands, ownedUTF8Bytes >= other.ownedUTF8Bytes,
@@ -143,6 +152,31 @@ public struct FrameResourceWeight: Sendable, Equatable {
         case .spliceEntries: spliceEntries
         case .locatorEntries: locatorEntries
         }
+    }
+
+    /// Measures owned strings, data, and collection entries in an already-materialized value.
+    public static func measuringOwnedPayload(_ value: Any) throws -> Self {
+        if let string = value as? String {
+            return Self(ownedUTF8Bytes: string.utf8.count)
+        }
+        if let data = value as? Data {
+            return Self(ownedUTF8Bytes: data.count)
+        }
+
+        let mirror = Mirror(reflecting: value)
+        let collectionEntries: Int
+        switch mirror.displayStyle {
+        case .collection, .dictionary, .set:
+            collectionEntries = mirror.children.count
+        default:
+            collectionEntries = 0
+        }
+
+        var weight = Self(arrayEntries: collectionEntries)
+        for child in mirror.children {
+            weight = try weight.adding(try measuringOwnedPayload(child.value))
+        }
+        return weight
     }
 
     private static func add(_ lhs: Int, _ rhs: Int, _ dimension: FrameResourceDimension) throws -> Int {

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -200,6 +200,7 @@ func decodeFrame(
 
             while !cursor.isAtEnd {
                 let commandOffset = cursor.offset
+                let commandStartWeight = usage.checkpoint()
                 let opcode: UInt8
                 do {
                     opcode = try cursor.readUInt8()
@@ -251,7 +252,10 @@ func decodeFrame(
                     if collectOwnedMetrics { ownedMetrics.record(command) }
                     // Child-local scratch is published only after the complete command validated.
                     try FrameDecodeAccounting.reserve(.arrayEntries, 1)
-                    commands.append(DecodedCommand(command: command, opcode: opcode))
+                    let commandWeight = try usage.weight.subtracting(commandStartWeight)
+                    commands.append(DecodedCommand(
+                        command: command, opcode: opcode, resourceWeight: commandWeight
+                    ))
                 }
             }
 

--- a/macos/Sources/Protocol/ProtocolDecoder.swift
+++ b/macos/Sources/Protocol/ProtocolDecoder.swift
@@ -108,11 +108,13 @@ enum RenderCommand: Sendable {
 
 // MARK: - Decoder
 
-indirect enum ProtocolDecodeError: Error, CustomStringConvertible {
+indirect enum ProtocolDecodeError: Error, CustomStringConvertible, Sendable {
     case malformed
     case unknownOpcode(UInt8)
     case insufficientData
     case outOfBounds(offset: Int, required: Int, remaining: Int)
+    case resource(FrameResourceError)
+    case frameFailure(cause: ProtocolDecodeError, envelope: FrameEnvelope?)
     case commandFailed(opcode: UInt8, offset: Int, remaining: Int, cause: ProtocolDecodeError)
 
     var description: String {
@@ -125,16 +127,38 @@ indirect enum ProtocolDecodeError: Error, CustomStringConvertible {
             return "insufficient data"
         case .outOfBounds(let offset, let required, let remaining):
             return "out of bounds at offset \(offset) (required=\(required), remaining=\(remaining))"
+        case .resource(let error):
+            return "frame resource policy: \(error)"
+        case .frameFailure(let cause, _):
+            return cause.description
         case .commandFailed(let opcode, let offset, let remaining, let cause):
             return String(format: "opcode 0x%02X at offset %d failed with %@ (remaining=%d)", opcode, offset, String(describing: cause), remaining)
         }
     }
 
+    var isResourceFailure: Bool {
+        switch self {
+        case .resource: true
+        case .frameFailure(let cause, _), .commandFailed(_, _, _, let cause): cause.isResourceFailure
+        default: false
+        }
+    }
+
+    var frameEnvelope: FrameEnvelope? {
+        if case .frameFailure(_, let envelope) = self { return envelope }
+        return nil
+    }
+
+    var unwrappedFrameFailure: ProtocolDecodeError {
+        if case .frameFailure(let cause, _) = self { return cause }
+        return self
+    }
+
     func contextualized(opcode: UInt8, offset: Int, remaining: Int) -> ProtocolDecodeError {
         switch self {
-        case .commandFailed:
+        case .commandFailed, .frameFailure:
             return self
-        case .malformed, .unknownOpcode, .insufficientData, .outOfBounds:
+        case .malformed, .unknownOpcode, .insufficientData, .outOfBounds, .resource:
             return .commandFailed(opcode: opcode, offset: offset, remaining: remaining, cause: self)
         }
     }
@@ -145,75 +169,117 @@ indirect enum ProtocolDecodeError: Error, CustomStringConvertible {
 /// Command values are accumulated locally and become observable only after the
 /// final byte succeeds. This prevents partial frame application when a later
 /// command is malformed or unknown.
-func decodeFrame(from data: Data, collectOwnedMetrics: Bool = false) throws -> DecodedFrame {
-    let clock = ContinuousClock()
-    let started = clock.now
-    var cursor = ByteCursor(data)
-    var commands: [DecodedCommand] = []
-    var ownedMetrics = DecoderOwnedMetrics()
-
-    while !cursor.isAtEnd {
-        let commandOffset = cursor.offset
-        let opcode: UInt8
-        do {
-            opcode = try cursor.readUInt8()
-        } catch let error as ByteCursor.BoundsError {
-            throw ProtocolDecodeError.outOfBounds(
-                offset: error.offset,
-                required: error.required,
-                remaining: error.remaining
-            )
-        }
-
-        let commandAndSize: (RenderCommand?, Int)
-        do {
-            commandAndSize = try decodeCommand(data: data, offset: commandOffset)
-        } catch let error as ProtocolDecodeError {
-            throw error.contextualized(
-                opcode: opcode,
-                offset: commandOffset,
-                remaining: data.count - commandOffset
-            )
-        }
-
-        let (command, size) = commandAndSize
-        guard size > 0 else { throw ProtocolDecodeError.malformed }
-        do {
-            try cursor.advance(by: size - 1)
-        } catch let error as ByteCursor.BoundsError {
-            throw ProtocolDecodeError.outOfBounds(
-                offset: error.offset,
-                required: error.required,
-                remaining: error.remaining
-            ).contextualized(
-                opcode: opcode,
-                offset: commandOffset,
-                remaining: data.count - commandOffset
-            )
-        }
-        if let command {
-            if collectOwnedMetrics { ownedMetrics.record(command) }
-            commands.append(DecodedCommand(command: command, opcode: opcode))
-        }
+func decodeFrame(
+    from data: Data,
+    collectOwnedMetrics: Bool = false,
+    policy: FrameResourcePolicy = .default,
+    reservationProbe: FrameResourceUsageBuilder.ReservationProbe? = nil
+) throws -> DecodedFrame {
+    guard data.count <= policy.wire.payloadBytes else {
+        throw ProtocolDecodeError.frameFailure(
+            cause: .resource(.wirePayloadLimitExceeded(
+                requested: data.count, limit: policy.wire.payloadBytes
+            )),
+            envelope: nil
+        )
     }
 
-    if collectOwnedMetrics { ownedMetrics.recordFrameCommandStorage(count: commands.count) }
-    return DecodedFrame(
-        commands: commands,
-        metrics: FrameDecodeMetrics(
-            packetBytes: data.count,
-            bytesCopied: collectOwnedMetrics ? ownedMetrics.bytesCopied : -1,
-            allocations: collectOwnedMetrics ? ownedMetrics.allocations : -1,
-            decodeDuration: started.duration(to: clock.now),
-            actorHopCount: 0
-        )
+    let usage = FrameResourceUsageBuilder(
+        limit: policy.decode.weight, reservationProbe: reservationProbe
     )
+    var envelope: FrameEnvelope?
+    do {
+        return try FrameDecodeAccounting.withUsage(
+            usage, residentLimit: policy.resident.weightPerWindow
+        ) {
+            let clock = ContinuousClock()
+            let started = clock.now
+            var cursor = ByteCursor(data)
+            var commands: [DecodedCommand] = []
+            var ownedMetrics = DecoderOwnedMetrics()
+
+            while !cursor.isAtEnd {
+                let commandOffset = cursor.offset
+                let opcode: UInt8
+                do {
+                    opcode = try cursor.readUInt8()
+                    // Admission precedes command decoding and all command-owned materialization.
+                    try usage.reserve(.commands, 1)
+                } catch let error as FrameResourceError {
+                    throw ProtocolDecodeError.resource(error)
+                } catch let error as ByteCursor.BoundsError {
+                    throw ProtocolDecodeError.outOfBounds(
+                        offset: error.offset, required: error.required, remaining: error.remaining
+                    )
+                }
+
+                let commandAndSize: (RenderCommand?, Int)
+                do {
+                    commandAndSize = try decodeCommand(data: data, offset: commandOffset)
+                } catch let error as ProtocolDecodeError {
+                    throw error.contextualized(
+                        opcode: opcode, offset: commandOffset,
+                        remaining: data.count - commandOffset
+                    )
+                } catch let error as FrameResourceError {
+                    throw ProtocolDecodeError.resource(error).contextualized(
+                        opcode: opcode, offset: commandOffset,
+                        remaining: data.count - commandOffset
+                    )
+                }
+
+                let (command, size) = commandAndSize
+                guard size > 0 else { throw ProtocolDecodeError.malformed }
+                do {
+                    try cursor.advance(by: size - 1)
+                } catch let error as ByteCursor.BoundsError {
+                    throw ProtocolDecodeError.outOfBounds(
+                        offset: error.offset, required: error.required, remaining: error.remaining
+                    ).contextualized(
+                        opcode: opcode, offset: commandOffset,
+                        remaining: data.count - commandOffset
+                    )
+                }
+                if let command {
+                    if commandOffset == 0,
+                       case .beginFrame(let frameSeq, let baseFrameSeq, let generation) = command {
+                        envelope = FrameEnvelope(
+                            generation: generation, frameSeq: frameSeq,
+                            baseFrameSeq: baseFrameSeq
+                        )
+                    }
+                    if collectOwnedMetrics { ownedMetrics.record(command) }
+                    // Child-local scratch is published only after the complete command validated.
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
+                    commands.append(DecodedCommand(command: command, opcode: opcode))
+                }
+            }
+
+            if collectOwnedMetrics { ownedMetrics.recordFrameCommandStorage(count: commands.count) }
+            return DecodedFrame(
+                commands: commands,
+                envelope: envelope,
+                resourceWeight: usage.weight,
+                metrics: FrameDecodeMetrics(
+                    packetBytes: data.count,
+                    bytesCopied: collectOwnedMetrics ? ownedMetrics.bytesCopied : -1,
+                    allocations: collectOwnedMetrics ? ownedMetrics.allocations : -1,
+                    decodeDuration: started.duration(to: clock.now),
+                    actorHopCount: 0
+                )
+            )
+        }
+    } catch let error as ProtocolDecodeError {
+        throw ProtocolDecodeError.frameFailure(cause: error, envelope: envelope)
+    } catch let error as FrameResourceError {
+        throw ProtocolDecodeError.frameFailure(cause: .resource(error), envelope: envelope)
+    }
 }
 
 /// Compatibility adapter for tests and harness clients. Delivery is atomic:
 /// handlers run only after the entire packet has decoded successfully.
 func decodeCommands(from data: Data, handler: (RenderCommand) -> Void) throws {
-    let frame = try decodeFrame(from: data)
+    let frame = try decodeCompatibilityFrame(from: data)
     for decoded in frame.commands {
         handler(decoded.command)
     }
@@ -221,9 +287,17 @@ func decodeCommands(from data: Data, handler: (RenderCommand) -> Void) throws {
 
 /// Compatibility adapter that also reports command wire opcodes.
 func decodeCommands(from data: Data, handler: (RenderCommand, UInt8) -> Void) throws {
-    let frame = try decodeFrame(from: data)
+    let frame = try decodeCompatibilityFrame(from: data)
     for decoded in frame.commands {
         handler(decoded.command, decoded.opcode)
+    }
+}
+
+private func decodeCompatibilityFrame(from data: Data) throws -> DecodedFrame {
+    do {
+        return try decodeFrame(from: data)
+    } catch let error as ProtocolDecodeError {
+        throw error.unwrappedFrameFailure
     }
 }
 
@@ -414,6 +488,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= offset + nameLen else { throw ProtocolDecodeError.malformed }
             let nameData = data[offset..<(offset + nameLen)]
             let name = try decodeUTF8(nameData) ?? ""
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             families.append(name)
             offset += nameLen
         }
@@ -472,6 +547,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let esSectionCount = Int(data[pos])
         pos += 1
         var esSections: [Wire.EmptyStateSection] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, esSectionCount)
         esSections.reserveCapacity(esSectionCount)
         for _ in 0..<esSectionCount {
             guard pos + 1 <= payloadEnd else { throw ProtocolDecodeError.malformed }
@@ -482,6 +558,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let itemCount = Int(data[pos])
             pos += 1
             var items: [Wire.EmptyStateItem] = []
+            try FrameDecodeAccounting.reserve(.arrayEntries, itemCount)
             items.reserveCapacity(itemCount)
             for _ in 0..<itemCount {
                 guard pos + 1 <= payloadEnd else { throw ProtocolDecodeError.malformed }
@@ -496,8 +573,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 guard pos + 4 <= payloadEnd else { throw ProtocolDecodeError.malformed }
                 let iconColor = try readU32(data, pos)
                 pos += 4
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 items.append(Wire.EmptyStateItem(kind: kind, id: itemId, label: label, detail: detail, jumpKey: jumpKey, chord: chord, icon: icon, iconColorRGB: iconColor))
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             esSections.append(Wire.EmptyStateSection(sectionId: sectionId, title: title, items: items))
         }
         return (.guiEmptyState(visible: true, crashed: esCrashed, version: esVersion, focusedId: esFocusedId, sections: esSections), 1 + 2 + payloadLen)
@@ -553,6 +632,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         }
 
         var entries: [Wire.FileTreeEntry] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, rowCount)
         entries.reserveCapacity(rowCount)
 
         for _ in 0..<rowCount {
@@ -567,6 +647,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let diagnosticHintCount = try readU16(data, pos); pos += 2
             let guideCount = Int(data[pos]); pos += 1
             guard pos + guideCount <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
+            try FrameDecodeAccounting.reserve(.arrayEntries, guideCount)
             let guides = (0..<guideCount).map { index in data[pos + index] != 0 }
             pos += guideCount
 
@@ -615,6 +696,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard pos + 1 <= payloadStart + payloadLen else { throw ProtocolDecodeError.malformed }
             let heatLevel = data[pos]; pos += 1
 
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             entries.append(Wire.FileTreeEntry(
                 pathHash: pathHash,
                 id: id,
@@ -695,6 +777,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     let memory = try readU32(data, nodePos); nodePos += 4
                     let messageQueueLen = try readU16(data, nodePos); nodePos += 2
                     let reductions = try readU32(data, nodePos); nodePos += 4
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     nodeEntries.append(Wire.ObservatoryNode(pid: pid, parentPid: parentPid, name: name, processClass: processClass, depth: depth, memory: memory, messageQueueLen: messageQueueLen, reductions: reductions, sparkline: []))
                 }
 
@@ -709,9 +792,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     let sampleCount = Int(data[sparkPos]); sparkPos += 1
                     guard sparkPos + sampleCount * 2 <= sectionEnd else { throw ProtocolDecodeError.malformed }
                     var samples: [Float] = []
+                    try FrameDecodeAccounting.reserve(.arrayEntries, sampleCount)
                     samples.reserveCapacity(sampleCount)
                     for _ in 0..<sampleCount {
                         let raw = try readU16(data, sparkPos)
+                        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                         samples.append(Float(raw) / 65535.0)
                         sparkPos += 2
                     }
@@ -725,6 +810,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             pos = sectionEnd
         }
 
+        try FrameDecodeAccounting.reserve(.arrayEntries, nodeEntries.count)
         let nodes = nodeEntries.map { node in
             Wire.ObservatoryNode(pid: node.pid, parentPid: node.parentPid, name: node.name, processClass: node.processClass, depth: node.depth, memory: node.memory, messageQueueLen: node.messageQueueLen, reductions: node.reductions, sparkline: sparklinesByPid[node.pid] ?? [])
         }
@@ -751,6 +837,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let activeIndex = data[rest]
         let tabCount = Int(data[rest + 1])
         var tabs: [Wire.TabEntry] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, tabCount)
         tabs.reserveCapacity(tabCount)
         var pos = rest + 2
         for _ in 0..<tabCount {
@@ -770,6 +857,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             // Bits 4-6 are kind-scoped: agent status for agent tabs,
             // ephemeral (not-on-disk) marker in bit 4 for file tabs.
             let isAgent = flags & 0x04 != 0
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             tabs.append(Wire.TabEntry(
                 id: tabId,
                 groupId: groupId,
@@ -794,9 +882,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let count = Int(data[rest])
         guard data.count >= rest + 1 + count * 4 else { throw ProtocolDecodeError.malformed }
         var slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, count)
         slots.reserveCapacity(count)
         for i in 0..<count {
             let base = rest + 1 + i * 4
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             slots.append((data[base], data[base + 1], data[base + 2], data[base + 3]))
         }
         return (.guiTheme(slots: slots), 1 + 1 + count * 4)
@@ -808,6 +898,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         // raw value matches the UInt8 kind the hand-written decoder produced.
         do {
             let (fields, nextPos) = try GeneratedProtocol.decodeGuiCompletionFields(data, rest, data.count)
+            try FrameDecodeAccounting.reserve(.arrayEntries, fields.items.count)
             let items = fields.items.map {
                 Wire.CompletionItem(kind: $0.kind.rawValue, label: $0.label, detail: $0.detail)
             }
@@ -819,6 +910,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 items: items,
                 documentation: fields.documentation
             ), nextPos - offset)
+        } catch let error as FrameResourceError {
+            throw error
         } catch {
             throw ProtocolDecodeError.malformed
         }
@@ -837,6 +930,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let pageCount = data[rest + 4 + prefixLen]
         let bindingCount = Int(try readU16(data, rest + 5 + prefixLen))
         var bindings: [Wire.WhichKeyBinding] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, bindingCount)
         bindings.reserveCapacity(bindingCount)
         var pos = rest + 7 + prefixLen
         for _ in 0..<bindingCount {
@@ -851,6 +945,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let iconLen = Int(data[pos + 4 + keyLen + descLen])
             guard data.count >= pos + 5 + keyLen + descLen + iconLen else { throw ProtocolDecodeError.malformed }
             let icon = try decodeUTF8(data[(pos + 5 + keyLen + descLen)..<(pos + 5 + keyLen + descLen + iconLen)]) ?? ""
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             bindings.append(Wire.WhichKeyBinding(kind: bKind, key: key, description: desc, icon: icon))
             pos += 5 + keyLen + descLen + iconLen
         }
@@ -862,6 +957,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         do {
             let (fields, nextPos) = try GeneratedProtocol.decodeGuiBreadcrumbFields(data, rest, data.count)
             return (.guiBreadcrumb(segments: fields.segments), nextPos - offset)
+        } catch let error as FrameResourceError {
+            throw error
         } catch {
             throw ProtocolDecodeError.malformed
         }
@@ -1196,6 +1293,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
                 case 0x03: // Items
                     let (items, _) = try GeneratedProtocol.decodeGuiPickerItems(data, psStart, psEnd)
+                    try FrameDecodeAccounting.reserve(.arrayEntries, items.count)
                     pkItems = items.map {
                         Wire.PickerItem(
                             iconColor: $0.iconColor, flags: $0.flags, label: $0.label,
@@ -1224,6 +1322,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
                 default: break
                 }
+            } catch let error as FrameResourceError {
+                throw error
             } catch {
                 throw ProtocolDecodeError.malformed
             }
@@ -1242,6 +1342,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         guard data.count >= rest + 3 else { throw ProtocolDecodeError.malformed }
         let lineCount = Int(try readU16(data, rest + 1))
         var lines: [Wire.PickerPreviewLine] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, lineCount)
         lines.reserveCapacity(lineCount)
         var pos2 = rest + 3
         for _ in 0..<lineCount {
@@ -1249,6 +1350,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let segCount = Int(data[pos2])
             pos2 += 1
             var segments: Wire.PickerPreviewLine = []
+            try FrameDecodeAccounting.reserve(.arrayEntries, segCount)
             segments.reserveCapacity(segCount)
             for _ in 0..<segCount {
                 guard data.count >= pos2 + 6 else { throw ProtocolDecodeError.malformed }
@@ -1257,9 +1359,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 let textLen = Int(try readU16(data, pos2 + 4))
                 guard data.count >= pos2 + 6 + textLen else { throw ProtocolDecodeError.malformed }
                 let text = try decodeUTF8(data[(pos2 + 6)..<(pos2 + 6 + textLen)]) ?? ""
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 segments.append(Wire.PickerPreviewSegment(fgColor: UInt32(fgColor), bold: segFlags & 0x01 != 0, text: text))
                 pos2 += 6 + textLen
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             lines.append(segments)
         }
         return (.guiPickerPreview(visible: true, lines: lines), pos2 - offset)
@@ -1345,6 +1449,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                         let dLen = Int(try readU16(data, cp)); cp += 2
                         guard cp + dLen <= csStart + csLen else { break }
                         let desc = try decodeUTF8(data[cp..<(cp + dLen)]) ?? ""; cp += dLen
+                        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                         candidates.append((name: name, description: desc))
                     }
                     promptCompletion = Wire.PromptCompletion(type: compType, selected: compSelected, anchorLine: compAnchorLine, anchorCol: compAnchorCol, candidates: candidates)
@@ -1388,8 +1493,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                             guard hp + dLen <= csStart + csLen else { break }
                             let desc = try decodeUTF8(data[hp..<(hp + dLen)]) ?? ""
                             hp += dLen
+                            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                             bindings.append((key: key, description: desc))
                         }
+                        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                         helpGroups.append(Wire.HelpGroup(title: title, bindings: bindings))
                     }
                 }
@@ -1408,6 +1515,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                         end: messagesEnd,
                         count: msgCount
                     )
+                    try FrameDecodeAccounting.reserve(.arrayEntries, decodedMessages.count)
                     messages.append(contentsOf: decodedMessages)
                 } else {
                     let msgCount = Int(try readU16(data, csStart))
@@ -1418,6 +1526,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                         end: messagesEnd,
                         remaining: msgCount
                     )
+                    try FrameDecodeAccounting.reserve(.arrayEntries, decodedMessages.count)
                     messages.append(contentsOf: decodedMessages)
                     guard decodedEnd == messagesEnd else { throw ProtocolDecodeError.malformed }
                 }
@@ -1480,6 +1589,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             throw ProtocolDecodeError.malformed
         }
         var transcriptMessages: [Wire.ChatMessage] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, transcriptCount)
         transcriptMessages.reserveCapacity(transcriptCount)
         for _ in 0..<transcriptCount {
             guard transcriptPos + 8 <= transcriptEnd else { throw ProtocolDecodeError.malformed }
@@ -1493,6 +1603,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard let candidate = candidates.first(where: { $0.nextOffset == bodyEnd }) else {
                 throw ProtocolDecodeError.malformed
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             transcriptMessages.append(candidate.message)
             transcriptPos = bodyEnd
         }
@@ -1558,6 +1669,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             case 0x03: // Entries: count(2) + entries...
                 guard gsLen >= 2 else { throw ProtocolDecodeError.malformed }
                 let lineCount = Int(try readU16(data, gsStart))
+                try FrameDecodeAccounting.reserve(.arrayEntries, lineCount)
                 entries.reserveCapacity(lineCount)
                 var ePos = gsStart + 2
                 for _ in 0..<lineCount {
@@ -1576,8 +1688,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                         guard gsEnd >= ePos + textLen else { throw ProtocolDecodeError.malformed }
                         let text = try decodeUTF8(data[ePos..<(ePos + textLen)]) ?? ""
                         ePos += textLen
+                        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                         entries.append(Wire.GutterEntry(bufLine: bufLine, displayType: dt, signType: st, foldEndLine: foldEndLine, signFg: fg, signText: text))
                     } else {
+                        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                         entries.append(Wire.GutterEntry(bufLine: bufLine, displayType: dt, signType: st, foldEndLine: foldEndLine))
                     }
                 }
@@ -1620,6 +1734,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= pos + nameLen else { throw ProtocolDecodeError.malformed }
             let name = try decodeUTF8(data[pos..<(pos + nameLen)]) ?? ""
             pos += nameLen
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             tabs.append(Wire.BottomPanelTab(tabType: tabType, name: name))
         }
         // Messages content payload: stream_instance(4) + entry_count(2) + entries...
@@ -1651,6 +1766,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= pos + textLen else { break }
             let text = try decodeUTF8(data[pos..<(pos + textLen)]) ?? ""
             pos += textLen
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             entries.append(Wire.MessageEntry(streamInstance: streamInstance, id: entryId, level: level, subsystem: subsystem,
                                             timestampSecs: tsSecs, filePath: filePath, text: text))
         }
@@ -1719,7 +1835,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
 
         let scrollPresentation = try validatedScrollPresentation(wcOverlays.scrollPresentation, windowId: wcWindowId, contentEpoch: wcContentEpoch)
 
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: wcWindowId,
             fullRefresh: (wcFlags & 0x01) != 0,
             contentEpoch: wcContentEpoch,
@@ -1736,7 +1852,8 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             lineAnnotations: wcOverlays.lineAnnotations,
             paneGeometry: wcOverlays.paneGeometry,
             cursorline: wcOverlays.cursorline,
-            scrollPresentation: scrollPresentation
+            scrollPresentation: scrollPresentation,
+            residentLimit: FrameDecodeAccounting.residentLimit
         )
         return (.guiWindowContent(data: content), 1 + 4 + wcPayloadLen)
 
@@ -1789,6 +1906,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let toolCount = Int(try readU16(data, rest + 4))
         var pos = rest + 6
         var tools: [Wire.ToolEntry] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, toolCount)
         tools.reserveCapacity(toolCount)
         for _ in 0..<toolCount {
             // name_len(1) + name
@@ -1823,6 +1941,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 guard data.count >= pos + lLen else { break }
                 let lang = try decodeUTF8(data[pos..<(pos + lLen)]) ?? ""
                 pos += lLen
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 langs.append(lang)
             }
             // version_len(1) + version
@@ -1847,6 +1966,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 guard data.count >= pos + cLen else { break }
                 let cmd = try decodeUTF8(data[pos..<(pos + cLen)]) ?? ""
                 pos += cLen
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 provides.append(cmd)
             }
             // error_reason_len(2) + error_reason
@@ -1857,6 +1977,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 ? (try decodeUTF8(data[pos..<(pos + errLen)]) ?? "")
                 : ""
             pos += errLen
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             tools.append(Wire.ToolEntry(
                 name: name, label: toolLabel, description: desc,
                 category: cat, status: stat, method: meth,
@@ -1905,6 +2026,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let mbTotalCandidates = try readU16(data, mbPos); mbPos += 2
         // candidates
         var mbCandidates: [Wire.MinibufferCandidate] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, mbCandCount)
         mbCandidates.reserveCapacity(mbCandCount)
         for _ in 0..<mbCandCount {
             // match_score(1) + label_len(2)
@@ -1930,11 +2052,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= mbPos + 1 else { break }
             let matchPosCount = Int(data[mbPos]); mbPos += 1
             var matchPositions: [UInt16] = []
+            try FrameDecodeAccounting.reserve(.arrayEntries, matchPosCount)
             matchPositions.reserveCapacity(matchPosCount)
             for _ in 0..<matchPosCount {
                 guard data.count >= mbPos + 2 else { break }
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 matchPositions.append(try readU16(data, mbPos)); mbPos += 2
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             mbCandidates.append(Wire.MinibufferCandidate(matchScore: score, label: candLabel, description: candDesc, annotation: candAnnot, matchPositions: matchPositions))
         }
         return (.guiMinibuffer(visible: true, mode: mbMode, cursorPos: mbCursorPos,
@@ -1959,6 +2084,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let hLineCount = Int(try readU16(data, rest + 8))
         var hPos = rest + 10
         var hLines: [Wire.HoverLine] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, hLineCount)
         hLines.reserveCapacity(hLineCount)
         for _ in 0..<hLineCount {
             // line_type(1) + segment_count(2)
@@ -1967,6 +2093,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let segCount = Int(try readU16(data, hPos + 1))
             hPos += 3
             var segments: [Wire.HoverSegment] = []
+            try FrameDecodeAccounting.reserve(.arrayEntries, segCount)
             segments.reserveCapacity(segCount)
             for _ in 0..<segCount {
                 // standard: style(1) + text_len(2) + text
@@ -1993,8 +2120,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 guard data.count >= hPos + textLen else { throw ProtocolDecodeError.malformed }
                 let text = try decodeUTF8(data[hPos..<(hPos + textLen)]) ?? ""
                 hPos += textLen
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 segments.append(Wire.HoverSegment(style: style, fgColor: fgColor, flags: flags, text: text))
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             hLines.append(Wire.HoverLine(lineType: lineType, segments: segments))
         }
         return (.guiHoverPopup(visible: true, anchorRow: hAnchorRow, anchorCol: hAnchorCol,
@@ -2033,6 +2162,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let shSigCount = Int(data[rest + 7])
         var shPos = rest + 8
         var signatures: [Wire.Signature] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, shSigCount)
         signatures.reserveCapacity(shSigCount)
         for _ in 0..<shSigCount {
             // label_len(2) + label
@@ -2051,6 +2181,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= shPos + 1 else { break }
             let paramCount = Int(data[shPos]); shPos += 1
             var params: [Wire.SignatureParameter] = []
+            try FrameDecodeAccounting.reserve(.arrayEntries, paramCount)
             params.reserveCapacity(paramCount)
             for _ in 0..<paramCount {
                 // label_len(2) + label + doc_len(2) + doc
@@ -2064,8 +2195,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 guard data.count >= shPos + pDocLen else { break }
                 let pDoc = try decodeUTF8(data[shPos..<(shPos + pDocLen)]) ?? ""
                 shPos += pDocLen
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 params.append(Wire.SignatureParameter(label: pLabel, documentation: pDoc))
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             signatures.append(Wire.Signature(label: label, documentation: doc, parameters: params))
         }
         return (.guiSignatureHelp(visible: true, anchorRow: shAnchorRow, anchorCol: shAnchorCol,
@@ -2092,6 +2225,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         guard data.count >= fpPos + 2 else { throw ProtocolDecodeError.malformed }
         let fpLineCount = Int(try readU16(data, fpPos)); fpPos += 2
         var fpLines: [String] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, fpLineCount)
         fpLines.reserveCapacity(fpLineCount)
         for _ in 0..<fpLineCount {
             guard data.count >= fpPos + 2 else { throw ProtocolDecodeError.malformed }
@@ -2099,6 +2233,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= fpPos + lineLen else { throw ProtocolDecodeError.malformed }
             let line = try decodeUTF8(data[fpPos..<(fpPos + lineLen)]) ?? ""
             fpPos += lineLen
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             fpLines.append(line)
         }
         return (.guiFloatPopup(visible: true, width: fpWidth, height: fpHeight,
@@ -2114,6 +2249,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let vertCount = Int(data[rest + 3])
         var sepPos = rest + 4
         var verts: [Wire.VerticalSeparator] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, vertCount)
         verts.reserveCapacity(vertCount)
         for _ in 0..<vertCount {
             // col(2) + start_row(2) + end_row(2)
@@ -2122,12 +2258,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let startRow = try readU16(data, sepPos + 2)
             let endRow = try readU16(data, sepPos + 4)
             sepPos += 6
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             verts.append(Wire.VerticalSeparator(col: col, startRow: startRow, endRow: endRow))
         }
         // horizontal_count(1)
         guard data.count >= sepPos + 1 else { throw ProtocolDecodeError.malformed }
         let horizCount = Int(data[sepPos]); sepPos += 1
         var horizs: [Wire.HorizontalSeparator] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, horizCount)
         horizs.reserveCapacity(horizCount)
         for _ in 0..<horizCount {
             // row(2) + col(2) + width(2) + filename_len(2)
@@ -2140,6 +2278,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= sepPos + fnLen else { throw ProtocolDecodeError.malformed }
             let fn = try decodeUTF8(data[sepPos..<(sepPos + fnLen)]) ?? ""
             sepPos += fnLen
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             horizs.append(Wire.HorizontalSeparator(row: hRow, col: hCol, width: hWidth, filename: fn))
         }
         return (.guiSplitSeparators(borderColor: sepColor, verticals: verts, horizontals: horizs),
@@ -2170,6 +2309,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let gsBranchName = try readRequiredUTF8(gsBranchData)
         let gsEntryCount = Int(try readU16(data, rest + 8 + gsBranchLen))
         var gsEntries: [Wire.GitStatusEntry] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, gsEntryCount)
         gsEntries.reserveCapacity(gsEntryCount)
         var gsPos = rest + 10 + gsBranchLen
         for _ in 0..<gsEntryCount {
@@ -2184,6 +2324,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard data.count >= gsPos + 8 + gsPathLen else { throw ProtocolDecodeError.malformed }
             let gsPathData = data[(gsPos + 8)..<(gsPos + 8 + gsPathLen)]
             let gsPath = try readRequiredUTF8(gsPathData)
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             gsEntries.append(Wire.GitStatusEntry(pathHash: gsPathHash, section: gsSection, status: gsStatus, path: gsPath))
             gsPos += 8 + gsPathLen
         }
@@ -2243,6 +2384,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let workspaceFlags = data[payloadStart + 4]
         let workspaceCount = Int(data[payloadStart + 5])
         var workspaces: [Wire.WorkspaceEntry] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, workspaceCount)
         workspaces.reserveCapacity(workspaceCount)
         var pos = payloadStart + 6
 
@@ -2267,6 +2409,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard iconLenPos + 1 + iconLen <= payloadEnd else { throw ProtocolDecodeError.malformed }
             let icon = try readRequiredUTF8(data[(iconLenPos + 1)..<(iconLenPos + 1 + iconLen)])
 
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             workspaces.append(Wire.WorkspaceEntry(
                 id: id,
                 kind: kind,
@@ -2289,6 +2432,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let visibleTabCount = Int(try readU16(data, pos))
         pos += 2
         var visibleTabs: [Wire.WorkspaceTabEntry] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, visibleTabCount)
         visibleTabs.reserveCapacity(visibleTabCount)
 
         for _ in 0..<visibleTabCount {
@@ -2312,6 +2456,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let path = try readRequiredUTF8(data[(pathLenPos + 2)..<(pathLenPos + 2 + pathLen)])
             let tintColorRGB = version >= 2 ? try readU32(data, pathLenPos + 2 + pathLen) : 0
 
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             visibleTabs.append(Wire.WorkspaceTabEntry(
                 id: id,
                 workspaceId: workspaceId,
@@ -2387,6 +2532,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             if contextPos < payloadEnd {
                 let todoCount = Int(data[contextPos])
                 contextPos += 1
+                try FrameDecodeAccounting.reserve(.arrayEntries, todoCount)
                 todos.reserveCapacity(todoCount)
 
                 for _ in 0..<todoCount {
@@ -2396,6 +2542,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     guard contextPos + 3 + descriptionLen <= payloadEnd else { break }
                     let descriptionStart = contextPos + 3
                     let description = try decodeUTF8(data[descriptionStart..<(descriptionStart + descriptionLen)]) ?? ""
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     todos.append(Wire.AgentTodo(status: status, description: description))
                     contextPos = descriptionStart + descriptionLen
                 }
@@ -2414,6 +2561,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let csSelectedIndex = Int(try readU16(data, rest + 1))
         let entryCount = Int(try readU16(data, rest + 3))
         var csEntries: [ChangeSummaryEntry] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, entryCount)
         csEntries.reserveCapacity(entryCount)
         var csPos = rest + 5
         for idx in 0..<entryCount {
@@ -2426,6 +2574,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let actionByte = data[csPos + 2 + pathLen]
             let linesAdded = try readU32(data, csPos + 2 + pathLen + 1)
             let linesRemoved = try readU32(data, csPos + 2 + pathLen + 5)
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             csEntries.append(ChangeSummaryEntry(
                 id: idx,
                 path: path,
@@ -2452,10 +2601,12 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let igActiveCol = try readU16(data, igStart + 3)
         let igGuideCount = Int(data[igStart + 5])
         var igCols: [UInt16] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, igGuideCount)
         igCols.reserveCapacity(igGuideCount)
         var igPos = igStart + 6
         for _ in 0..<igGuideCount {
             guard igPos + 2 <= rest + 2 + igPayloadLen else { break }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             igCols.append(try readU16(data, igPos))
             igPos += 2
         }
@@ -2464,9 +2615,11 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         if igPos + 2 <= igEnd {
             let igLineCount = Int(try readU16(data, igPos))
             igPos += 2
+            try FrameDecodeAccounting.reserve(.arrayEntries, igLineCount)
             igLineLevels.reserveCapacity(igLineCount)
             for _ in 0..<igLineCount {
                 guard igPos < igEnd else { break }
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 igLineLevels.append(data[igPos])
                 igPos += 1
             }
@@ -2518,12 +2671,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             ePos += nameLen
             let tsDelta = try readU32(data, ePos)
             ePos += 4
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             entries.append(Wire.TimelineEntry(index: idx, toolName: toolName, timestampDelta: tsDelta))
         }
         var files: [Wire.TimelineFile] = []
         if ePos < pStart + payloadLen {
             let fileCount = Int(data[ePos])
             ePos += 1
+            try FrameDecodeAccounting.reserve(.arrayEntries, fileCount)
             files.reserveCapacity(fileCount)
 
             for _ in 0..<fileCount {
@@ -2538,6 +2693,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                 let linesRemoved = try readU32(data, ePos + 5)
                 let reviewStatus = data[ePos + 9]
                 ePos += 10
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 files.append(Wire.TimelineFile(path: path, entryCount: entryCount, linesAdded: linesAdded, linesRemoved: linesRemoved, reviewStatus: reviewStatus))
             }
         }
@@ -2578,6 +2734,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             guard eoPos + contentLen <= eoEnd else { break }
             let content = try decodeUTF8(data[eoPos..<(eoPos + contentLen)]) ?? ""
             eoPos += contentLen
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             eoEntries.append(Wire.ExtensionOverlayEntry(
                 extensionName: extName, overlayID: oid, windowID: winId,
                 row: row, col: col, shape: shape,
@@ -2632,6 +2789,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     guard epPos + tLen <= epEnd else { break }
                     let t = try decodeUTF8(data[epPos..<(epPos + tLen)]) ?? ""
                     epPos += tLen
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     blocks.append(.text(t))
                 case 1: // styled_text
                     guard epPos + 1 <= epEnd else { break }
@@ -2646,8 +2804,10 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                         let stR = data[epPos]; let stG = data[epPos + 1]; let stB = data[epPos + 2]
                         let stBold = data[epPos + 3] != 0; let stItalic = data[epPos + 4] != 0
                         epPos += 5
+                        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                         runs.append((text: stText, r: stR, g: stG, b: stB, bold: stBold, italic: stItalic))
                     }
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     blocks.append(.styledText(runs: runs))
                 case 2: // table
                     guard epPos + 5 <= epEnd else { break }
@@ -2660,6 +2820,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                         guard epPos + 2 <= epEnd else { break }
                         let cLen = Int(try readU16(data, epPos)); epPos += 2
                         guard epPos + cLen <= epEnd else { break }
+                        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                         columns.append(try decodeUTF8(data[epPos..<(epPos + cLen)]) ?? "")
                         epPos += cLen
                     }
@@ -2670,11 +2831,14 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                             guard epPos + 2 <= epEnd else { break }
                             let cellLen = Int(try readU16(data, epPos)); epPos += 2
                             guard epPos + cellLen <= epEnd else { break }
+                            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                             row.append(try decodeUTF8(data[epPos..<(epPos + cellLen)]) ?? "")
                             epPos += cellLen
                         }
+                        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                         rows.append(row)
                     }
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     blocks.append(.table(columns: columns, rows: rows, selected: selected))
                 case 3: // key_value
                     guard epPos + 1 <= epEnd else { break }
@@ -2690,10 +2854,13 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                         guard epPos + vLen <= epEnd else { break }
                         let v = try decodeUTF8(data[epPos..<(epPos + vLen)]) ?? ""
                         epPos += vLen
+                        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                         pairs.append((key: k, value: v))
                     }
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     blocks.append(.keyValue(pairs: pairs))
                 case 4: // separator
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     blocks.append(.separator)
                 case 5: // progress
                     guard epPos + 4 <= epEnd else { break }
@@ -2702,18 +2869,22 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
                     let label = try decodeUTF8(data[epPos..<(epPos + labelLen)]) ?? ""
                     epPos += labelLen
                     let pctInt = try readU16(data, epPos); epPos += 2
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     blocks.append(.progress(label: label, percent: Float(pctInt) / 100.0))
                 case 6: // tree (length-prefixed, skip payload)
                     guard epPos + 2 <= epEnd else { break }
                     let treeLen = Int(try readU16(data, epPos)); epPos += 2
                     guard epPos + treeLen <= epEnd else { break }
                     epPos += treeLen
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     blocks.append(.unknown)
                 default:
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     blocks.append(.unknown)
                     break
                 }
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             epPanels.append(Wire.ExtensionPanelEntry(
                 extensionName: extName, panelID: panelId, title: title,
                 position: pos, sizeType: sizeType, sizeValue: sizeVal,
@@ -2760,6 +2931,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
         let count = Int(try readU16(data, pos)); pos += 2
         let activeId = try readString16(data: data, pos: &pos, end: payloadEnd)
         var sidebars: [Wire.SidebarMetadata] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, count)
         sidebars.reserveCapacity(count)
 
         for _ in 0..<count {
@@ -2774,6 +2946,7 @@ private func decodeCommandForRendering(data: Data, offset: Int) throws -> (Rende
             let rawBadgeCount = try readU16(data, pos); pos += 2
             let badgeCount: UInt16? = rawBadgeCount == UInt16.max ? nil : rawBadgeCount
 
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             sidebars.append(Wire.SidebarMetadata(
                 id: id,
                 displayName: displayName,
@@ -2833,6 +3006,7 @@ private func decodeNotifications(data: Data, start: Int, end: Int) throws -> [Wi
     pos += 2
 
     var notifications: [Wire.EditorNotification] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, count)
     notifications.reserveCapacity(count)
 
     for _ in 0..<count {
@@ -2857,27 +3031,28 @@ private func decodeNotifications(data: Data, start: Int, end: Int) throws -> [Wi
         pos += 1
 
         var actions: [Wire.NotificationAction] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, actionCount)
         actions.reserveCapacity(actionCount)
         for _ in 0..<actionCount {
             let actionId = try readString16(data: data, pos: &pos, end: end)
             let label = try readString16(data: data, pos: &pos, end: end)
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             actions.append(Wire.NotificationAction(id: actionId, label: label))
         }
 
-        notifications.append(
-            Wire.EditorNotification(
-                id: id,
-                level: NotificationLevel(rawValue: level),
-                flags: flags,
-                createdAt: createdAt,
-                updatedAt: updatedAt,
-                autoDismissMs: rawAutoDismiss == UInt32.max ? nil : rawAutoDismiss,
-                title: title,
-                body: body,
-                source: source,
-                actions: actions
-            )
-        )
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
+        notifications.append(Wire.EditorNotification(
+            id: id,
+            level: NotificationLevel(rawValue: level),
+            flags: flags,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            autoDismissMs: rawAutoDismiss == UInt32.max ? nil : rawAutoDismiss,
+            title: title,
+            body: body,
+            source: source,
+            actions: actions
+        ))
     }
 
     guard pos == end else { throw ProtocolDecodeError.malformed }
@@ -2904,6 +3079,7 @@ private func decodeConfigState(data: Data, start: Int, end: Int) throws -> Wire.
     pos += 2
 
     var previews: [Wire.ThemePreview] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, previewCount)
     previews.reserveCapacity(previewCount)
     for _ in 0..<previewCount {
         let name = try readString8(data: data, pos: &pos, end: end)
@@ -2913,6 +3089,7 @@ private func decodeConfigState(data: Data, start: Int, end: Int) throws -> Wire.
         let editorFg = try readU24(data, pos + 3)
         let accent = try readU24(data, pos + 6)
         pos += 9
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         previews.append(Wire.ThemePreview(name: name, atom: atom, editorBg: editorBg, editorFg: editorFg, accent: accent))
     }
 
@@ -2921,12 +3098,14 @@ private func decodeConfigState(data: Data, start: Int, end: Int) throws -> Wire.
     pos += 2
 
     var bindings: [Wire.KeybindingEntry] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, bindingCount)
     bindings.reserveCapacity(bindingCount)
     for _ in 0..<bindingCount {
         let mode = try readString8(data: data, pos: &pos, end: end)
         let key = try readString16(data: data, pos: &pos, end: end)
         let command = try readString16(data: data, pos: &pos, end: end)
         let description = try readString16(data: data, pos: &pos, end: end)
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         bindings.append(Wire.KeybindingEntry(mode: mode, key: key, command: command, description: description))
     }
 
@@ -3001,6 +3180,7 @@ private func readRequiredUTF8(_ data: Data.SubSequence) throws -> String {
 
 private func decodeStatusBarSegments(data: Data, pos: inout Int, count: Int, end: Int, version: UInt8) throws -> [Wire.StatusBarSegment] {
     var segments: [Wire.StatusBarSegment] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, count)
     segments.reserveCapacity(count)
 
     for index in 0..<count {
@@ -3026,6 +3206,7 @@ private func decodeStatusBarSegments(data: Data, pos: inout Int, count: Int, end
         guard pos + commandLen <= end else { throw ProtocolDecodeError.malformed }
         guard let command = try decodeUTF8(data[pos..<(pos + commandLen)]) else { throw ProtocolDecodeError.malformed }
         pos += commandLen
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         segments.append(Wire.StatusBarSegment(id: index, kind: kind, text: text, fgColor: fg, bgColor: bg, attrs: attrs, command: command))
     }
 
@@ -3066,10 +3247,13 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
     case 0x04: // Search matches
         guard length >= 2 else { break }
         let count = Int(try readU16(data, start))
+        try FrameDecodeAccounting.reserve(.overlays, count)
+        try FrameDecodeAccounting.reserve(.arrayEntries, count)
         sections.searchMatches.reserveCapacity(count)
         var pos = start + 2
         for _ in 0..<count {
             guard pos + 7 <= end else { break }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             sections.searchMatches.append(GUISearchMatch(
                 row: try readU16(data, pos), startCol: try readU16(data, pos + 2),
                 endCol: try readU16(data, pos + 4), isCurrent: data[pos + 6] != 0
@@ -3081,10 +3265,13 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
     case 0x05: // Diagnostics
         guard length >= 2 else { break }
         let count = Int(try readU16(data, start))
+        try FrameDecodeAccounting.reserve(.overlays, count)
+        try FrameDecodeAccounting.reserve(.arrayEntries, count)
         sections.diagnosticUnderlines.reserveCapacity(count)
         var pos = start + 2
         for _ in 0..<count {
             guard pos + 9 <= end else { break }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             sections.diagnosticUnderlines.append(GUIDiagnosticUnderline(
                 startRow: try readU16(data, pos), startCol: try readU16(data, pos + 2),
                 endRow: try readU16(data, pos + 4), endCol: try readU16(data, pos + 6),
@@ -3097,10 +3284,13 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
     case 0x06: // Document highlights
         guard length >= 2 else { break }
         let count = Int(try readU16(data, start))
+        try FrameDecodeAccounting.reserve(.overlays, count)
+        try FrameDecodeAccounting.reserve(.arrayEntries, count)
         sections.documentHighlights.reserveCapacity(count)
         var pos = start + 2
         for _ in 0..<count {
             guard pos + 9 <= end else { break }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             sections.documentHighlights.append(GUIDocumentHighlight(
                 startRow: try readU16(data, pos), startCol: try readU16(data, pos + 2),
                 endRow: try readU16(data, pos + 4), endCol: try readU16(data, pos + 6),
@@ -3113,6 +3303,8 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
     case 0x07: // Line annotations
         guard length >= 2 else { break }
         let count = Int(try readU16(data, start))
+        try FrameDecodeAccounting.reserve(.overlays, count)
+        try FrameDecodeAccounting.reserve(.arrayEntries, count)
         sections.lineAnnotations.reserveCapacity(count)
         var pos = start + 2
         for _ in 0..<count {
@@ -3126,6 +3318,7 @@ private func decodeOverlaySection(id: UInt8, data: Data, start: Int, length: Int
             guard pos + annTextLen <= end else { break }
             let annText = try decodeUTF8(data[pos..<(pos + annTextLen)]) ?? ""
             pos += annTextLen
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             sections.lineAnnotations.append(GUILineAnnotation(row: annRow, kind: annKind, fg: annFg, bg: annBg, text: annText))
         }
         return true
@@ -3255,7 +3448,9 @@ private func decodeWindowRowSplices(data: Data, start: Int, end: Int) throws ->
     let spliceCount = Int(try readU32(data, start + 8))
     var pos = start + 12
     guard spliceCount <= (end - pos) / 12 else { throw ProtocolDecodeError.malformed }
+    try FrameDecodeAccounting.reserve(.spliceEntries, spliceCount)
     var splices: [GUIWindowRowSplice] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, spliceCount)
     splices.reserveCapacity(spliceCount)
     var previousStart: UInt32?
     var previousEnd: UInt64 = 0
@@ -3276,7 +3471,9 @@ private func decodeWindowRowSplices(data: Data, start: Int, end: Int) throws ->
             throw ProtocolDecodeError.malformed
         }
 
+        try FrameDecodeAccounting.reserve(.locatorEntries, insertCount)
         var entries: [GUIWindowRowDeltaEntry] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, insertCount)
         entries.reserveCapacity(insertCount)
         for _ in 0..<insertCount {
             guard pos < end else { throw ProtocolDecodeError.malformed }
@@ -3285,12 +3482,15 @@ private func decodeWindowRowSplices(data: Data, start: Int, end: Int) throws ->
             switch kind {
             case 0:
                 guard pos + 12 <= end else { throw ProtocolDecodeError.malformed }
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 entries.append(.reference(
                     rowId: try readU64(data, pos),
                     contentHash: try readU32(data, pos + 8)
                 ))
                 pos += 12
             case 1:
+                try FrameDecodeAccounting.reserve(.rows, 1)
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 entries.append(.full(try decodeWindowContentRow(data: data, pos: &pos, end: end)))
             default:
                 throw ProtocolDecodeError.malformed
@@ -3302,6 +3502,7 @@ private func decodeWindowRowSplices(data: Data, start: Int, end: Int) throws ->
         guard computedCount >= 0, computedCount <= Int64(UInt32.max) else {
             throw ProtocolDecodeError.malformed
         }
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         splices.append(GUIWindowRowSplice(
             startIndex: spliceStart, deleteCount: deleteCount, insertEntries: entries
         ))
@@ -3318,7 +3519,9 @@ private func decodeWindowDeltaRows(data: Data, start: Int, end: Int) throws -> [
     let rowCount = Int(try readU32(data, start))
     var pos = start + 4
     guard rowCount <= (end - pos) / 13 else { throw ProtocolDecodeError.malformed }
+    try FrameDecodeAccounting.reserve(.locatorEntries, rowCount)
     var rows: [GUIWindowRowDeltaEntry] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, rowCount)
     rows.reserveCapacity(rowCount)
 
     for _ in 0..<rowCount {
@@ -3329,10 +3532,13 @@ private func decodeWindowDeltaRows(data: Data, start: Int, end: Int) throws -> [
         switch entryKind {
         case 0:
             guard pos + 12 <= end else { throw ProtocolDecodeError.malformed }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             rows.append(.reference(rowId: try readU64(data, pos), contentHash: try readU32(data, pos + 8)))
             pos += 12
         case 1:
+            try FrameDecodeAccounting.reserve(.rows, 1)
             let row = try decodeWindowContentRow(data: data, pos: &pos, end: end)
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             rows.append(.full(row))
         default:
             throw ProtocolDecodeError.malformed
@@ -3348,11 +3554,15 @@ private func decodeWindowContentRows(data: Data, start: Int, end: Int) throws ->
     let rowCount = Int(try readU32(data, start))
     var pos = start + 4
     guard rowCount <= (end - pos) / 23 else { throw ProtocolDecodeError.malformed }
+    try FrameDecodeAccounting.reserve(.rows, rowCount)
+    try FrameDecodeAccounting.reserve(.locatorEntries, rowCount)
     var rows: [GUIVisualRow] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, rowCount)
     rows.reserveCapacity(rowCount)
 
     for _ in 0..<rowCount {
         let row = try decodeWindowContentRow(data: data, pos: &pos, end: end)
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         rows.append(row)
     }
 
@@ -3377,11 +3587,14 @@ private func decodeWindowContentRow(data: Data, pos: inout Int, end: Int) throws
     let spanCount = Int(try readU16(data, pos))
     pos += 2
 
+    try FrameDecodeAccounting.reserve(.spans, spanCount)
     var spans: [GUIHighlightSpan] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, spanCount)
     spans.reserveCapacity(spanCount)
 
     for _ in 0..<spanCount {
         guard pos + 13 <= end else { throw ProtocolDecodeError.malformed }
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         spans.append(GUIHighlightSpan(
             startCol: try readU16(data, pos), endCol: try readU16(data, pos + 2),
             fg: try readU24(data, pos + 4), bg: try readU24(data, pos + 7),
@@ -3410,12 +3623,14 @@ private func decodeToolPreview(data: Data, start: Int, end: Int) throws -> Decod
     let lineCount = Int(try readU16(data, start + 1))
     var pos = start + 3
     var previewLines: [String] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, lineCount)
     previewLines.reserveCapacity(lineCount)
     for _ in 0..<lineCount {
         guard end >= pos + 2 else { throw ProtocolDecodeError.malformed }
         let lineLen = Int(try readU16(data, pos))
         guard end >= pos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
         let line = try decodeUTF8(data[(pos + 2)..<(pos + 2 + lineLen)]) ?? ""
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         previewLines.append(line)
         pos += 2 + lineLen
     }
@@ -3424,6 +3639,7 @@ private func decodeToolPreview(data: Data, start: Int, end: Int) throws -> Decod
 
 private func decodeFramedChatMessages(data: Data, start: Int, end: Int, count: Int) throws -> [Wire.ChatMessage] {
     var messages: [Wire.ChatMessage] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, count)
     messages.reserveCapacity(count)
     var pos = start
 
@@ -3439,6 +3655,7 @@ private func decodeFramedChatMessages(data: Data, start: Int, end: Int, count: I
             throw ProtocolDecodeError.malformed
         }
 
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         messages.append(candidate.message)
         pos = messageEnd
     }
@@ -3456,12 +3673,17 @@ private func decodeLegacyChatMessages(data: Data, start: Int, end: Int, remainin
     let candidates = try decodeChatMessageCandidates(data: data, start: start, end: end)
 
     for candidate in candidates {
-        if let (rest, decodedEnd) = try? decodeLegacyChatMessages(
-            data: data,
-            start: candidate.nextOffset,
-            end: end,
-            remaining: remaining - 1
-        ) {
+        if let (rest, decodedEnd) = try? FrameDecodeAccounting.withCheckpoint({
+            try decodeLegacyChatMessages(
+                data: data,
+                start: candidate.nextOffset,
+                end: end,
+                remaining: remaining - 1
+            )
+        }) {
+            let (combinedCount, overflow) = rest.count.addingReportingOverflow(1)
+            guard !overflow else { throw FrameResourceError.arithmeticOverflow }
+            try FrameDecodeAccounting.reserve(.arrayEntries, combinedCount)
             return ([candidate.message] + rest, decodedEnd)
         }
     }
@@ -3473,12 +3695,14 @@ private func decodeAgentStyledLines(data: Data, start: Int, end: Int) throws -> 
     guard end >= start + 2 else { throw ProtocolDecodeError.malformed }
     let lineCount = Int(try readU16(data, start))
     var lines: [[Wire.StyledTextRun]] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, lineCount)
     lines.reserveCapacity(lineCount)
     var pos = start + 2
     for _ in 0..<lineCount {
         guard end >= pos + 2 else { throw ProtocolDecodeError.malformed }
         let runCount = Int(try readU16(data, pos))
         var runs: [Wire.StyledTextRun] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, runCount)
         runs.reserveCapacity(runCount)
         pos += 2
         for _ in 0..<runCount {
@@ -3498,6 +3722,7 @@ private func decodeAgentStyledLines(data: Data, start: Int, end: Int) throws -> 
                 linkURL = decodedLinkURL
                 nextRunPos += 2 + urlLen
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             runs.append(Wire.StyledTextRun(
                 text: runText,
                 fgR: data[fgOff], fgG: data[fgOff + 1], fgB: data[fgOff + 2],
@@ -3510,6 +3735,7 @@ private func decodeAgentStyledLines(data: Data, start: Int, end: Int) throws -> 
             ))
             pos = nextRunPos
         }
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         lines.append(runs)
     }
     return (lines, pos)
@@ -3519,6 +3745,7 @@ private func decodeAgentMarkdownBlocks(data: Data, start: Int, end: Int) throws 
     guard end >= start + 2 else { throw ProtocolDecodeError.malformed }
     let blockCount = Int(try readU16(data, start))
     var blocks: [Wire.AgentMarkdownBlock] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, blockCount)
     blocks.reserveCapacity(blockCount)
     var pos = start + 2
     for _ in 0..<blockCount {
@@ -3568,6 +3795,7 @@ private func decodeAgentMarkdownBlocks(data: Data, start: Int, end: Int) throws 
             (lines, pos) = try decodeAgentStyledLines(data: data, start: pos, end: end)
         }
 
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         blocks.append(Wire.AgentMarkdownBlock(id: blockID, kind: kind, flags: flags, lines: lines, level: level, indent: indent, ordered: ordered, ordinal: ordinal, height: height, language: language, label: label, targetPath: targetPath, capabilityFlags: capabilityFlags))
     }
     return (blocks, pos)
@@ -3645,14 +3873,20 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
             let autoApprovedScope = data[baseOffset]
             if autoApprovedScope <= 2 {
                 let messageWithAuto = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, previewKind: 0, previewLines: []))
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 candidates.append(DecodedChatMessageCandidate(message: messageWithAuto, nextOffset: baseOffset + 1))
-                if end > baseOffset + 1, let preview = try? decodeToolPreview(data: data, start: baseOffset + 1, end: end) {
+                if end > baseOffset + 1,
+                   let preview = try? FrameDecodeAccounting.withCheckpoint({
+                       try decodeToolPreview(data: data, start: baseOffset + 1, end: end)
+                   }) {
                     let messageWithPreview = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, previewKind: preview.kind, previewLines: preview.lines))
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     candidates.append(DecodedChatMessageCandidate(message: messageWithPreview, nextOffset: preview.nextOffset))
                 }
             }
         }
         let messageWithoutAuto = Wire.ChatMessage(beamId: beamId, content: .toolCall(name: name, summary: summary, status: tcStatus, isError: isError, collapsed: tcCollapsed, autoApprovedScope: 0, durationMs: duration, result: result, previewKind: 0, previewLines: []))
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         candidates.append(DecodedChatMessageCandidate(message: messageWithoutAuto, nextOffset: baseOffset))
         return candidates
 
@@ -3677,12 +3911,14 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
         guard end >= pos + 3 else { throw ProtocolDecodeError.malformed }
         let lineCount = Int(try readU16(data, pos + 1))
         var lines: [[Wire.StyledTextRun]] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, lineCount)
         lines.reserveCapacity(lineCount)
         var rPos = pos + 3
         for _ in 0..<lineCount {
             guard end >= rPos + 2 else { throw ProtocolDecodeError.malformed }
             let runCount = Int(try readU16(data, rPos))
             var runs: [Wire.StyledTextRun] = []
+            try FrameDecodeAccounting.reserve(.arrayEntries, runCount)
             runs.reserveCapacity(runCount)
             rPos += 2
             for _ in 0..<runCount {
@@ -3708,6 +3944,7 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
                     linkURL = decodedLinkURL
                     nextRunPos += 2 + urlLen
                 }
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 runs.append(Wire.StyledTextRun(
                     text: runText,
                     fgR: fgR, fgG: fgG, fgB: fgB,
@@ -3720,6 +3957,7 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
                 ))
                 rPos = nextRunPos
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             lines.append(runs)
         }
         return [DecodedChatMessageCandidate(message: Wire.ChatMessage(beamId: beamId, content: .styledAssistant(lines: lines)), nextOffset: rPos)]
@@ -3738,12 +3976,14 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
         let stcSummary = try decodeUTF8(data[(pos + 12 + stcNameLen)..<(pos + 12 + stcNameLen + stcSummaryLen)]) ?? ""
         let stcLineCount = Int(try readU16(data, pos + 12 + stcNameLen + stcSummaryLen))
         var stcLines: [[Wire.StyledTextRun]] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, stcLineCount)
         stcLines.reserveCapacity(stcLineCount)
         var stcPos = pos + 14 + stcNameLen + stcSummaryLen
         for _ in 0..<stcLineCount {
             guard end >= stcPos + 2 else { throw ProtocolDecodeError.malformed }
             let runCount = Int(try readU16(data, stcPos))
             var runs: [Wire.StyledTextRun] = []
+            try FrameDecodeAccounting.reserve(.arrayEntries, runCount)
             runs.reserveCapacity(runCount)
             stcPos += 2
             for _ in 0..<runCount {
@@ -3763,6 +4003,7 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
                     linkURL = decodedLinkURL
                     nextRunPos += 2 + urlLen
                 }
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 runs.append(Wire.StyledTextRun(
                     text: runText,
                     fgR: data[fgOff], fgG: data[fgOff + 1], fgB: data[fgOff + 2],
@@ -3775,6 +4016,7 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
                 ))
                 stcPos = nextRunPos
             }
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             stcLines.append(runs)
         }
         let stcBaseOffset = stcPos
@@ -3784,14 +4026,20 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
             let stcAutoApprovedScope = data[stcBaseOffset]
             if stcAutoApprovedScope <= 2 {
                 let stcMessageWithAuto = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: stcAutoApprovedScope, durationMs: stcDuration, resultLines: stcLines, previewKind: 0, previewLines: []))
+                try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                 stcCandidates.append(DecodedChatMessageCandidate(message: stcMessageWithAuto, nextOffset: stcBaseOffset + 1))
-                if end > stcBaseOffset + 1, let stcPreview = try? decodeToolPreview(data: data, start: stcBaseOffset + 1, end: end) {
+                if end > stcBaseOffset + 1,
+                   let stcPreview = try? FrameDecodeAccounting.withCheckpoint({
+                       try decodeToolPreview(data: data, start: stcBaseOffset + 1, end: end)
+                   }) {
                     let stcMessageWithPreview = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: stcAutoApprovedScope, durationMs: stcDuration, resultLines: stcLines, previewKind: stcPreview.kind, previewLines: stcPreview.lines))
+                    try FrameDecodeAccounting.reserve(.arrayEntries, 1)
                     stcCandidates.append(DecodedChatMessageCandidate(message: stcMessageWithPreview, nextOffset: stcPreview.nextOffset))
                 }
             }
         }
         let stcMessageWithoutAuto = Wire.ChatMessage(beamId: beamId, content: .styledToolCall(name: stcName, summary: stcSummary, status: stcStatus, isError: stcIsError, collapsed: stcCollapsed, autoApprovedScope: 0, durationMs: stcDuration, resultLines: stcLines, previewKind: 0, previewLines: []))
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         stcCandidates.append(DecodedChatMessageCandidate(message: stcMessageWithoutAuto, nextOffset: stcBaseOffset))
         return stcCandidates
 
@@ -3814,12 +4062,14 @@ private func decodeChatMessageBodyCandidates(data: Data, beamId: UInt32, bodySta
         let lineCount = Int(try readU16(data, pos + 9 + nameLen + summaryLen + idLen))
         var approvalPos = pos + 11 + nameLen + summaryLen + idLen
         var previewLines: [String] = []
+        try FrameDecodeAccounting.reserve(.arrayEntries, lineCount)
         previewLines.reserveCapacity(lineCount)
         for _ in 0..<lineCount {
             guard end >= approvalPos + 2 else { throw ProtocolDecodeError.malformed }
             let lineLen = Int(try readU16(data, approvalPos))
             guard end >= approvalPos + 2 + lineLen else { throw ProtocolDecodeError.malformed }
             let line = try decodeUTF8(data[(approvalPos + 2)..<(approvalPos + 2 + lineLen)]) ?? ""
+            try FrameDecodeAccounting.reserve(.arrayEntries, 1)
             previewLines.append(line)
             approvalPos += 2 + lineLen
         }
@@ -3892,12 +4142,14 @@ private func decodePaneGeometry(data: Data, start: Int, end: Int) throws -> GUIP
     pos += 5
 
     var hitRegions: [GUIHitRegion] = []
+    try FrameDecodeAccounting.reserve(.arrayEntries, hitCount)
     hitRegions.reserveCapacity(hitCount)
     for _ in 0..<hitCount {
         guard pos + 11 <= end else { throw ProtocolDecodeError.malformed }
         let kind = GUIHitRegion.Kind(rawValue: data[pos]) ?? .text
         let rect = try readCellRect(data, pos + 1, end)
         let regionWindowId = try readU16(data, pos + 9)
+        try FrameDecodeAccounting.reserve(.arrayEntries, 1)
         hitRegions.append(GUIHitRegion(kind: kind, rect: rect, windowId: regionWindowId))
         pos += 11
     }
@@ -3949,6 +4201,7 @@ private func readSection32(_ data: Data, at offset: Int, containingEnd: Int) thr
 
 private func decodeUTF8(_ data: Data) throws -> String? {
     var cursor = ByteCursor(data)
+    try FrameDecodeAccounting.reserve(.ownedUTF8Bytes, cursor.remaining)
     let bytes = try cursor.readSlice(count: cursor.remaining)
     return String(bytes: bytes, encoding: .utf8)
 }

--- a/macos/Sources/Protocol/ProtocolEventHandoff.swift
+++ b/macos/Sources/Protocol/ProtocolEventHandoff.swift
@@ -1,32 +1,48 @@
-/// Ordered, single-hop delivery of decoded protocol events to the main actor.
+/// Capacity-one, ordered delivery of decoded protocol events to the main actor.
 
 import Foundation
 
-enum ProtocolDeliveryEvent: Sendable {
-    case frame(DecodedFrame)
-    case decodeFailure(ProtocolDecodeError)
-}
+/// A single-producer/single-consumer admission handoff. The producer must own
+/// the sole slot before reading a payload. The consumer releases it immediately
+/// after dequeue, so payload memory cannot accumulate behind the main actor.
+final class ProtocolEventHandoff: @unchecked Sendable {
+    let events: AsyncStream<DecodedFrameEvent>
 
-/// A thread-safe FIFO handoff from the serial protocol reader to one consumer.
-///
-/// `AsyncStream.Continuation.yield` records each event synchronously in call
-/// order. The app owns exactly one main-actor consumer task for the stream, so
-/// packets and failures cannot overtake one another through independently
-/// scheduled tasks.
-struct ProtocolEventHandoff: Sendable {
-    let events: AsyncStream<ProtocolDeliveryEvent>
-    private let continuation: AsyncStream<ProtocolDeliveryEvent>.Continuation
+    private let continuation: AsyncStream<DecodedFrameEvent>.Continuation
+    private let condition = NSCondition()
+    private var slotOccupied = false
+    private var cancelled = false
 
     init() {
         let pair = AsyncStream.makeStream(
-            of: ProtocolDeliveryEvent.self,
-            bufferingPolicy: .unbounded
+            of: DecodedFrameEvent.self,
+            bufferingPolicy: .bufferingOldest(1)
         )
-        self.events = pair.stream
-        self.continuation = pair.continuation
+        events = pair.stream
+        continuation = pair.continuation
     }
 
-    /// Enqueues a decoded frame at the real reader-to-main-actor boundary.
+    /// Blocks only for the one FIFO permit. Returns false after shutdown.
+    func acquireAdmission() -> Bool {
+        condition.lock()
+        while slotOccupied && !cancelled { condition.wait() }
+        guard !cancelled else {
+            condition.unlock()
+            return false
+        }
+        slotOccupied = true
+        condition.unlock()
+        return true
+    }
+
+    /// Releases admission after the consumer has dequeued the event.
+    func releaseAdmission() {
+        condition.lock()
+        slotOccupied = false
+        condition.signal()
+        condition.unlock()
+    }
+
     @discardableResult
     func deliver(_ frame: DecodedFrame) -> DecodedFrame {
         let deliveredFrame = frame.recordingActorHop()
@@ -34,12 +50,19 @@ struct ProtocolEventHandoff: Sendable {
         return deliveredFrame
     }
 
-    /// Enqueues a decode failure in the same wire-order stream as frames.
-    func deliver(_ error: ProtocolDecodeError) {
-        continuation.yield(.decodeFailure(error))
+    func deliver(_ failure: DecodedFrameFailure) {
+        continuation.yield(.failure(failure))
     }
 
-    func finish() {
+    /// Wakes a blocked producer and ends a blocked consumer. Idempotent.
+    func cancel() {
+        condition.lock()
+        cancelled = true
+        slotOccupied = false
+        condition.broadcast()
+        condition.unlock()
         continuation.finish()
     }
+
+    func finish() { cancel() }
 }

--- a/macos/Sources/Protocol/ProtocolReader.swift
+++ b/macos/Sources/Protocol/ProtocolReader.swift
@@ -5,6 +5,7 @@
 /// (the BEAM batches an entire render frame into one message).
 
 import Foundation
+import MingaProtocol
 import os
 import Synchronization
 
@@ -13,14 +14,16 @@ import Synchronization
 /// Defaults to stdin (BEAM is parent, spawned us). In bundle mode, the
 /// BEAMProcessManager passes the child process's stdout pipe instead.
 final class ProtocolReader: @unchecked Sendable {
-    private static let defaultMaxPayloadLength = 64 * 1_048_576
+    private static let defaultMaxPayloadLength = FrameResourcePolicy.default.wire.payloadBytes
 
     private var thread: Thread?
     private let input: FileHandle
     private let decoder: @Sendable (Data) throws -> DecodedFrame
     private let handler: @Sendable (DecodedFrame) -> Void
-    private let onDecodeFailure: @Sendable (ProtocolDecodeError) -> Void
+    private let onDecodeFailure: @Sendable (DecodedFrameFailure) -> Void
     private let onDisconnect: @Sendable () -> Void
+    private let acquireAdmission: @Sendable () -> Bool
+    private let cancelAdmission: @Sendable () -> Void
     private let maxPayloadLength: Int
     private let running = Mutex(false)
 
@@ -31,8 +34,10 @@ final class ProtocolReader: @unchecked Sendable {
         maxPayloadLength: Int = ProtocolReader.defaultMaxPayloadLength,
         decoder: @escaping @Sendable (Data) throws -> DecodedFrame = { data in try decodeFrame(from: data) },
         handler: @escaping @Sendable (DecodedFrame) -> Void,
-        onDecodeFailure: @escaping @Sendable (ProtocolDecodeError) -> Void,
-        onDisconnect: @escaping @Sendable () -> Void
+        onDecodeFailure: @escaping @Sendable (DecodedFrameFailure) -> Void,
+        onDisconnect: @escaping @Sendable () -> Void,
+        acquireAdmission: @escaping @Sendable () -> Bool = { true },
+        cancelAdmission: @escaping @Sendable () -> Void = {}
     ) {
         self.input = input
         self.maxPayloadLength = maxPayloadLength
@@ -40,6 +45,8 @@ final class ProtocolReader: @unchecked Sendable {
         self.handler = handler
         self.onDecodeFailure = onDecodeFailure
         self.onDisconnect = onDisconnect
+        self.acquireAdmission = acquireAdmission
+        self.cancelAdmission = cancelAdmission
     }
 
     /// Start reading on a background thread.
@@ -64,16 +71,20 @@ final class ProtocolReader: @unchecked Sendable {
     /// only takes effect after the current read completes or stdin closes.
     func stop() {
         running.withLock { $0 = false }
+        cancelAdmission()
     }
 
     // MARK: - Private
 
     private func readLoop() {
         while running.withLock({ $0 }) {
+            // Reserve the sole reader-to-main slot before reading any payload bytes.
+            guard acquireAdmission() else { return }
             // Read 4-byte length header.
             let lenData = input.readData(ofLength: 4)
             guard lenData.count == 4 else {
                 // stdin closed or short read: BEAM has exited.
+                cancelAdmission()
                 onDisconnect()
                 return
             }
@@ -83,6 +94,7 @@ final class ProtocolReader: @unchecked Sendable {
 
             guard length > 0, length <= maxPayloadLength else {
                 os_log(.error, log: protocolLog, "Protocol payload length %{public}d outside valid range 1...%{public}d; disconnecting to avoid stream desync", length, maxPayloadLength)
+                cancelAdmission()
                 onDisconnect()
                 return
             }
@@ -93,6 +105,7 @@ final class ProtocolReader: @unchecked Sendable {
             while remaining > 0 {
                 let chunk = input.readData(ofLength: remaining)
                 guard !chunk.isEmpty else {
+                    cancelAdmission()
                     onDisconnect()
                     return
                 }
@@ -113,10 +126,15 @@ final class ProtocolReader: @unchecked Sendable {
                     frame.metrics.allocations
                 )
                 handler(frame)
+            } catch let failure as DecodedFrameFailure {
+                onDecodeFailure(failure)
             } catch let error as ProtocolDecodeError {
-                onDecodeFailure(error)
+                onDecodeFailure(DecodedFrameFailure(
+                    error: error.unwrappedFrameFailure,
+                    envelope: error.frameEnvelope
+                ))
             } catch {
-                onDecodeFailure(.malformed)
+                onDecodeFailure(DecodedFrameFailure(error: .malformed, envelope: nil))
             }
         }
     }

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -122,6 +122,7 @@ final class CommandDispatcher {
     /// All GUI chrome sub-states. Injected at init from AppDelegate.
     /// Non-optional: forgetting to wire this is a compile-time error.
     let guiState: GUIState
+    private let resourcePolicy: FrameResourcePolicy
 
     /// Records input-to-apply and input-to-presentation as separate milestones.
     /// A committed transaction marks apply only; Metal owns submission/completion.
@@ -213,9 +214,13 @@ final class CommandDispatcher {
         0xA0, 0xA1, 0xA2, 0xA3, 0xA4, 0xA5, 0xA6, 0xA7, 0xA8, 0xA9, 0xAA, 0xAB, 0xAC, 0xAD, 0xAE,
     ]
 
-    init(cols: UInt16, rows: UInt16, guiState: GUIState) {
+    init(
+        cols: UInt16, rows: UInt16, guiState: GUIState,
+        resourcePolicy: FrameResourcePolicy = .default
+    ) {
         self.frameState = FrameState(cols: cols, rows: rows)
         self.guiState = guiState
+        self.resourcePolicy = resourcePolicy
     }
 
     /// Entry point from the protocol reader. Routes a decoded command through the
@@ -317,7 +322,9 @@ final class CommandDispatcher {
             generation: generation,
             committedWindows: guiState.windowContents,
             registeredFontIds: registeredFontIds,
-            committedTranscript: guiState.agentChatState.transcriptSnapshot
+            committedTranscript: guiState.agentChatState.transcriptSnapshot,
+            stagingLimit: resourcePolicy.staging.weight,
+            residentLimit: resourcePolicy.resident.weightPerWindow
         )
         if baseFrameSeq == 0 && resyncRecoveryState == .awaitingKeyframe {
             resyncRecoveryState = .keyframeInFlight
@@ -494,6 +501,15 @@ final class CommandDispatcher {
         }
 
         let terminal = rejection.disposition == .terminalFrontendFailure
+        let terminalSignature = TerminalRejectionSignature(
+            generation: openGeneration,
+            frameSeq: rejectedFrameSeq,
+            lastGoodFrameSeq: lastCommittedFrameSeq,
+            reason: rejection.wireCode
+        )
+        guard !terminal || lastTerminalRejection != terminalSignature else { return }
+        if terminal { lastTerminalRejection = terminalSignature }
+
         if terminal {
             resyncRecoveryState = .clean
             if guiState.resyncState.pending {
@@ -519,14 +535,6 @@ final class CommandDispatcher {
                 onRequestKeyframe?(lastCommittedFrameSeq)
             }
         }
-        let terminalSignature = TerminalRejectionSignature(
-            generation: openGeneration,
-            frameSeq: rejectedFrameSeq,
-            lastGoodFrameSeq: lastCommittedFrameSeq,
-            reason: rejection.wireCode
-        )
-        guard !terminal || lastTerminalRejection != terminalSignature else { return }
-        if terminal { lastTerminalRejection = terminalSignature }
         onTransactionResult?(.rejected(
             generation: openGeneration,
             frameSeq: rejectedFrameSeq,
@@ -558,6 +566,19 @@ final class CommandDispatcher {
             .resourcePolicy,
             frameSeq: openFrameSeq,
             logReason: "frontend resource policy exceeded"
+        )
+    }
+
+    /// Publishes a correlated terminal result when decode failed before the
+    /// transaction crossed actor isolation. Last-good semantic state is untouched.
+    func resourcePolicyRejected(envelope: FrameEnvelope) {
+        openGeneration = envelope.generation
+        openFrameSeq = envelope.frameSeq
+        openBaseFrameSeq = envelope.baseFrameSeq
+        reject(
+            .resourcePolicy,
+            frameSeq: envelope.frameSeq,
+            logReason: "frontend decode resource policy exceeded"
         )
     }
 

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -240,11 +240,25 @@ final class CommandDispatcher {
     /// prepared-transaction builder. Packet decoding itself remains off-main.
     func dispatch(_ frame: DecodedFrame) {
         for decoded in frame.commands {
-            dispatch(decoded.command, opcode: decoded.opcode)
+            dispatch(
+                decoded.command, opcode: decoded.opcode,
+                resourceWeight: decoded.resourceWeight
+            )
         }
     }
 
     func dispatch(_ command: RenderCommand, opcode: UInt8? = nil) {
+        let measured = (try? FrameResourceWeight.measuringOwnedPayload(command))
+            ?? FrameResourceWeight()
+        let resourceWeight = (try? measured.adding(FrameResourceWeight(commands: 1)))
+            ?? FrameResourceWeight(commands: 1)
+        dispatch(command, opcode: opcode, resourceWeight: resourceWeight)
+    }
+
+    private func dispatch(
+        _ command: RenderCommand, opcode: UInt8?,
+        resourceWeight: FrameResourceWeight
+    ) {
         switch command {
         case .beginFrame(let frameSeq, let baseFrameSeq, let generation):
             beginTransaction(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: generation)
@@ -273,7 +287,7 @@ final class CommandDispatcher {
         case .setTitle, .setWindowBg, .setLinkCursor, .protocolError,
              .setFont, .setFontFallback, .registerFont, .clipboardWrite:
             if openFrameSeq != nil {
-                transactionBuilder?.stage(command)
+                transactionBuilder?.stage(command, resourceWeight: resourceWeight)
             } else {
                 guiState.performOutOfBandPublication {
                     apply(command)
@@ -283,7 +297,7 @@ final class CommandDispatcher {
         default:
             if openFrameSeq != nil {
                 // Inside a transaction: compile into typed domain updates.
-                transactionBuilder?.stage(command)
+                transactionBuilder?.stage(command, resourceWeight: resourceWeight)
             } else {
                 // A command arrived with no open transaction and no sanctioned
                 // out-of-band match above. Either a new BEAM out-of-band command
@@ -543,6 +557,20 @@ final class CommandDispatcher {
         ))
     }
 
+    /// Classifies one packet failure against the currently open transaction.
+    func decodedFrameFailed(_ failure: DecodedFrameFailure) {
+        if failure.error.isResourceFailure {
+            if let envelope = failure.envelope {
+                resourcePolicyRejected(envelope: envelope)
+            } else if !resourcePolicyRejected() {
+                PortLogger.error("Protocol resource error outside a frame: \(failure.error)")
+            }
+            return
+        }
+        PortLogger.error("Protocol decode error: \(failure.error)")
+        decodeFailed()
+    }
+
     /// Surfaced by the protocol reader when `decodeCommands` throws mid-stream.
     /// Per the AC-1 consult, a sizing failure or unknown opcode INSIDE an open
     /// transaction tightens the reader's usual warn-and-continue policy: the byte
@@ -560,13 +588,15 @@ final class CommandDispatcher {
 
     /// Rejects the open frame under the deterministic hard resource policy.
     /// The last-good semantic publication remains active and no keyframe is requested.
-    func resourcePolicyRejected() {
-        guard let openFrameSeq else { return }
+    @discardableResult
+    func resourcePolicyRejected() -> Bool {
+        guard let openFrameSeq else { return false }
         reject(
             .resourcePolicy,
             frameSeq: openFrameSeq,
             logReason: "frontend resource policy exceeded"
         )
+        return true
     }
 
     /// Publishes a correlated terminal result when decode failed before the

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -172,23 +172,42 @@ private enum PreparedCoalescingKey: Hashable {
     case appended(Int)
 }
 
+private enum PreparedDomain {
+    case window
+    case chrome
+    case overlay
+    case resource
+    case focus
+    case metadata
+}
+
 private struct PreparedDomainBuffer {
     private var order: [PreparedCoalescingKey] = []
     private var commandsByKey: [PreparedCoalescingKey: RenderCommand] = [:]
+    private var weightsByKey: [PreparedCoalescingKey: FrameResourceWeight] = [:]
     private var nextAppendKey = 0
 
     var isEmpty: Bool { order.isEmpty }
     var commands: [RenderCommand] { order.compactMap { commandsByKey[$0] } }
 
-    mutating func replace(_ command: RenderCommand, key: PreparedCoalescingKey) {
-        if commandsByKey[key] == nil { order.append(key) }
-        commandsByKey[key] = command
+    func weight(for key: PreparedCoalescingKey) -> FrameResourceWeight {
+        weightsByKey[key] ?? FrameResourceWeight()
     }
 
-    mutating func append(_ command: RenderCommand) {
+    mutating func replace(
+        _ command: RenderCommand, key: PreparedCoalescingKey,
+        weight: FrameResourceWeight
+    ) {
+        if commandsByKey[key] == nil { order.append(key) }
+        commandsByKey[key] = command
+        weightsByKey[key] = weight
+    }
+
+    mutating func append(_ command: RenderCommand, weight: FrameResourceWeight) {
         let key = PreparedCoalescingKey.appended(nextAppendKey)
         order.append(key)
         commandsByKey[key] = command
+        weightsByKey[key] = weight
         nextAppendKey += 1
     }
 }
@@ -215,6 +234,9 @@ struct PreparedFrameTransactionBuilder {
     private var requiredFontIds: Set<UInt8> = []
     private var workingTranscript: AgentTranscriptSnapshot
     private var changedTranscript: AgentTranscriptSnapshot?
+    private var themeWeight = FrameResourceWeight()
+    private var transcriptWeight = FrameResourceWeight()
+    private var stagingWeight = FrameResourceWeight()
     private var rejection: PreparedFrameRejection?
     private let stagingLimit: FrameResourceWeight
     private let residentLimit: FrameResourceWeight
@@ -238,11 +260,30 @@ struct PreparedFrameTransactionBuilder {
         self.workingTranscript = committedTranscript
         self.stagingLimit = stagingLimit
         self.residentLimit = residentLimit
+
+        do {
+            transcriptWeight = try committedTranscript.exactResourceWeight()
+            stagingWeight = transcriptWeight
+            for content in workingWindows.values {
+                stagingWeight = try stagingWeight.adding(content.exactResourceWeight())
+            }
+            if stagingWeight.firstExceeded(limit: stagingLimit) != nil {
+                rejection = .resourcePolicy
+            }
+        } catch {
+            rejection = .resourcePolicy
+        }
     }
 
-    mutating func stage(_ command: RenderCommand) {
+    mutating func stage(
+        _ command: RenderCommand,
+        resourceWeight: FrameResourceWeight = FrameResourceWeight(commands: 1)
+    ) {
+        guard rejection == nil else { return }
         switch command {
         case .guiTheme(let slots):
+            guard replaceStagingWeight(removing: themeWeight, adding: resourceWeight) else { return }
+            themeWeight = resourceWeight
             theme = PreparedThemeUpdate(slots: slots)
 
         case .guiWindowContent(let content):
@@ -267,65 +308,70 @@ struct PreparedFrameTransactionBuilder {
         case .guiGutter(let data):
             referencedWindowIds.insert(data.windowId)
             touchedWindowIds.insert(data.windowId)
-            windowCommands.replace(command, key: .window(kind: .gutter, id: data.windowId))
+            stageReplacing(
+                command, key: .window(kind: .gutter, id: data.windowId),
+                weight: resourceWeight, domain: .window
+            )
 
         case .guiIndentGuides(let data):
             referencedWindowIds.insert(data.windowId)
             touchedWindowIds.insert(data.windowId)
-            windowCommands.replace(command, key: .window(kind: .indentGuides, id: data.windowId))
+            stageReplacing(
+                command, key: .window(kind: .indentGuides, id: data.windowId),
+                weight: resourceWeight, domain: .window
+            )
 
         case .setFont, .setFontFallback, .guiConfigState:
-            resourceCommands.replace(command, key: .command(command.preparedUpdateKey))
+            stageReplacing(
+                command, key: .command(command.preparedUpdateKey),
+                weight: resourceWeight, domain: .resource
+            )
 
         case .registerFont(let id, _):
             registeredFontIds.insert(id)
-            resourceCommands.replace(command, key: .font(id))
+            stageReplacing(command, key: .font(id), weight: resourceWeight, domain: .resource)
 
         case .setCursorShape, .setLinkCursor, .guiFileTreeSelection:
-            focusCommands.replace(command, key: .command(command.preparedUpdateKey))
+            stageReplacing(
+                command, key: .command(command.preparedUpdateKey),
+                weight: resourceWeight, domain: .focus
+            )
 
         case .guiCompletion, .guiWhichKey, .guiPicker, .guiPickerPreview,
              .guiAgentChat, .guiMinibuffer, .guiHoverPopup, .guiHoverAction,
              .guiSignatureHelp, .guiFloatPopup, .guiExtensionOverlay,
              .guiSearchState, .guiEmptyState, .protocolError:
-            overlayCommands.replace(command, key: .command(command.preparedUpdateKey))
+            stageReplacing(
+                command, key: .command(command.preparedUpdateKey),
+                weight: resourceWeight, domain: .overlay
+            )
 
         case .setTitle, .setWindowBg, .guiGutterSeparator, .guiCursorline,
              .guiLineSpacing, .guiCursorAnimation, .guiSplitSeparators,
              .guiStatusBar, .clipboardWrite:
-            metadataCommands.replace(command, key: .command(command.preparedUpdateKey))
+            stageReplacing(
+                command, key: .command(command.preparedUpdateKey),
+                weight: resourceWeight, domain: .metadata
+            )
 
         case .guiAgentTranscript(let mode, let epoch, let truncated, let trimFront, let baseCount, let messages):
-            guard rejection == nil else { return }
-            switch AgentChatState.prepareTranscript(
-                from: workingTranscript,
-                mode: mode,
-                epoch: epoch,
-                truncated: truncated,
-                trimFront: Int(trimFront),
-                baseCount: Int(baseCount),
-                messages: messages
-            ) {
-            case .success(let prepared):
-                workingTranscript = prepared
-                changedTranscript = prepared
-            case .failure(.beforeSeed):
-                rejection = .transcriptBeforeSeed
-            case .failure(.epochMismatch):
-                rejection = .transcriptEpochMismatch
-            case .failure(.desynced):
-                rejection = .transcriptDesynced
-            }
+            stageTranscript(
+                mode: mode, epoch: epoch, truncated: truncated,
+                trimFront: Int(trimFront), baseCount: Int(baseCount), messages: messages
+            )
 
         case .guiBottomPanel, .guiExtensionRuntime:
             // These carry append/upsert semantics; every payload is meaningful.
-            chromeCommands.append(command)
+            stageAppending(command, weight: resourceWeight, domain: .chrome)
 
         case .guiTabBar, .guiFileTree, .guiObservatory, .guiBreadcrumb,
              .guiToolManager, .guiGitStatus, .guiWorkspaces, .guiAgentContext,
              .guiChangeSummary, .guiNotifications, .guiEditTimeline,
              .guiExtensionPanel, .guiSidebars:
-            chromeCommands.replace(command, key: .command(command.preparedUpdateKey))
+            stageReplacing(
+                command, key: .command(command.preparedUpdateKey),
+                weight: resourceWeight, domain: .chrome
+            )
 
         case .beginFrame, .commitFrame:
             break
@@ -448,6 +494,126 @@ struct PreparedFrameTransactionBuilder {
         recordFontResources(in: delta)
     }
 
+    private mutating func stageTranscript(
+        mode: UInt8, epoch: UInt32, truncated: Bool,
+        trimFront: Int, baseCount: Int, messages: [Wire.ChatMessage]
+    ) {
+        let nextTranscriptWeight: FrameResourceWeight
+        let nextStagingWeight: FrameResourceWeight
+        do {
+            nextTranscriptWeight = try workingTranscript.resourceWeightAfterPreparing(
+                mode: mode, epoch: epoch, trimFront: trimFront,
+                baseCount: baseCount, messages: messages
+            )
+            nextStagingWeight = try prospectiveStagingWeight(
+                removing: transcriptWeight, adding: nextTranscriptWeight
+            )
+            guard nextStagingWeight.firstExceeded(limit: stagingLimit) == nil else {
+                rejection = .resourcePolicy
+                return
+            }
+        } catch let failure as AgentTranscriptPreparationFailure {
+            switch failure {
+            case .beforeSeed: rejection = .transcriptBeforeSeed
+            case .epochMismatch: rejection = .transcriptEpochMismatch
+            case .desynced: rejection = .transcriptDesynced
+            }
+            return
+        } catch {
+            rejection = .resourcePolicy
+            return
+        }
+
+        switch AgentChatState.prepareTranscript(
+            from: workingTranscript, mode: mode, epoch: epoch,
+            truncated: truncated, trimFront: trimFront,
+            baseCount: baseCount, messages: messages
+        ) {
+        case .success(let prepared):
+            stagingWeight = nextStagingWeight
+            transcriptWeight = nextTranscriptWeight
+            workingTranscript = prepared
+            changedTranscript = prepared
+        case .failure(.beforeSeed): rejection = .transcriptBeforeSeed
+        case .failure(.epochMismatch): rejection = .transcriptEpochMismatch
+        case .failure(.desynced): rejection = .transcriptDesynced
+        }
+    }
+
+    private mutating func stageReplacing(
+        _ command: RenderCommand, key: PreparedCoalescingKey,
+        weight: FrameResourceWeight, domain: PreparedDomain
+    ) {
+        let previousWeight = domainWeight(domain, key: key)
+        guard replaceStagingWeight(removing: previousWeight, adding: weight) else { return }
+        replaceDomainCommand(command, key: key, weight: weight, domain: domain)
+    }
+
+    private mutating func stageAppending(
+        _ command: RenderCommand, weight: FrameResourceWeight, domain: PreparedDomain
+    ) {
+        guard replaceStagingWeight(removing: FrameResourceWeight(), adding: weight) else { return }
+        switch domain {
+        case .chrome: chromeCommands.append(command, weight: weight)
+        case .window, .overlay, .resource, .focus, .metadata:
+            rejection = .resourcePolicy
+        }
+    }
+
+    private func domainWeight(
+        _ domain: PreparedDomain, key: PreparedCoalescingKey
+    ) -> FrameResourceWeight {
+        switch domain {
+        case .window: windowCommands.weight(for: key)
+        case .chrome: chromeCommands.weight(for: key)
+        case .overlay: overlayCommands.weight(for: key)
+        case .resource: resourceCommands.weight(for: key)
+        case .focus: focusCommands.weight(for: key)
+        case .metadata: metadataCommands.weight(for: key)
+        }
+    }
+
+    private mutating func replaceDomainCommand(
+        _ command: RenderCommand, key: PreparedCoalescingKey,
+        weight: FrameResourceWeight, domain: PreparedDomain
+    ) {
+        switch domain {
+        case .window: windowCommands.replace(command, key: key, weight: weight)
+        case .chrome: chromeCommands.replace(command, key: key, weight: weight)
+        case .overlay: overlayCommands.replace(command, key: key, weight: weight)
+        case .resource: resourceCommands.replace(command, key: key, weight: weight)
+        case .focus: focusCommands.replace(command, key: key, weight: weight)
+        case .metadata: metadataCommands.replace(command, key: key, weight: weight)
+        }
+    }
+
+    private func prospectiveStagingWeight(
+        removing previousWeight: FrameResourceWeight,
+        adding nextWeight: FrameResourceWeight
+    ) throws -> FrameResourceWeight {
+        try stagingWeight.subtracting(previousWeight).adding(nextWeight)
+    }
+
+    private mutating func replaceStagingWeight(
+        removing previousWeight: FrameResourceWeight,
+        adding nextWeight: FrameResourceWeight
+    ) -> Bool {
+        do {
+            let prospective = try prospectiveStagingWeight(
+                removing: previousWeight, adding: nextWeight
+            )
+            guard prospective.firstExceeded(limit: stagingLimit) == nil else {
+                rejection = .resourcePolicy
+                return false
+            }
+            stagingWeight = prospective
+            return true
+        } catch {
+            rejection = .resourcePolicy
+            return false
+        }
+    }
+
     private mutating func stageWindow(_ content: GUIWindowContent) -> Bool {
         do {
             let residentWeight = content.exactResourceWeight()
@@ -455,15 +621,11 @@ struct PreparedFrameTransactionBuilder {
                 rejection = .resourcePolicy
                 return false
             }
-            var stagingWeight = FrameResourceWeight()
-            for (windowID, existing) in workingWindows where windowID != content.windowId {
-                stagingWeight = try stagingWeight.adding(existing.exactResourceWeight())
-            }
-            stagingWeight = try stagingWeight.adding(residentWeight)
-            if stagingWeight.firstExceeded(limit: stagingLimit) != nil {
-                rejection = .resourcePolicy
-                return false
-            }
+            let previousWeight = try workingWindows[content.windowId]?.exactResourceWeight()
+                ?? FrameResourceWeight()
+            guard replaceStagingWeight(
+                removing: previousWeight, adding: residentWeight
+            ) else { return false }
             workingWindows[content.windowId] = content
             changedWindows[content.windowId] = content
             return true

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -216,6 +216,8 @@ struct PreparedFrameTransactionBuilder {
     private var workingTranscript: AgentTranscriptSnapshot
     private var changedTranscript: AgentTranscriptSnapshot?
     private var rejection: PreparedFrameRejection?
+    private let stagingLimit: FrameResourceWeight
+    private let residentLimit: FrameResourceWeight
 
     init(
         frameSeq: UInt32,
@@ -223,7 +225,9 @@ struct PreparedFrameTransactionBuilder {
         generation: UInt32,
         committedWindows: [UInt16: GUIWindowContent],
         registeredFontIds: Set<UInt8>,
-        committedTranscript: AgentTranscriptSnapshot
+        committedTranscript: AgentTranscriptSnapshot,
+        stagingLimit: FrameResourceWeight = FrameResourcePolicy.default.staging.weight,
+        residentLimit: FrameResourceWeight = FrameResourcePolicy.default.resident.weightPerWindow
     ) {
         self.frameSeq = frameSeq
         self.baseFrameSeq = baseFrameSeq
@@ -232,6 +236,8 @@ struct PreparedFrameTransactionBuilder {
         self.registeredFontIds = registeredFontIds
         self.registeredFontIds.insert(0)
         self.workingTranscript = committedTranscript
+        self.stagingLimit = stagingLimit
+        self.residentLimit = residentLimit
     }
 
     mutating func stage(_ command: RenderCommand) {
@@ -248,8 +254,7 @@ struct PreparedFrameTransactionBuilder {
                 return
             }
             let aggregated = aggregatingOperationCounters(for: content)
-            workingWindows[content.windowId] = aggregated
-            changedWindows[content.windowId] = aggregated
+            guard stageWindow(aggregated) else { return }
             touchedWindowIds.insert(content.windowId)
             recordFontResources(in: content)
 
@@ -402,8 +407,7 @@ struct PreparedFrameTransactionBuilder {
             return
         }
         let aggregated = aggregatingOperationCounters(for: updated)
-        workingWindows[delta.windowId] = aggregated
-        changedWindows[delta.windowId] = aggregated
+        _ = stageWindow(aggregated)
     }
 
     private mutating func resolveRowsDelta(_ delta: GUIWindowRowsDelta) {
@@ -422,11 +426,16 @@ struct PreparedFrameTransactionBuilder {
             return
         }
         let updated: GUIWindowContent
-        switch current.applyingRowsDeltaChecked(delta) {
+        switch current.applyingRowsDeltaChecked(
+            delta, residentLimit: residentLimit, stagingLimit: stagingLimit
+        ) {
         case .success(let content):
             updated = content
         case .failure(.missingRowID), .failure(.contentHashMismatch):
             rejection = .missingWindowReference(windowId: delta.windowId)
+            return
+        case .failure(.resourcePolicy):
+            rejection = .resourcePolicy
             return
         case .failure:
             rejection = delta.rowSplices == nil
@@ -435,9 +444,33 @@ struct PreparedFrameTransactionBuilder {
             return
         }
         let aggregated = aggregatingOperationCounters(for: updated)
-        workingWindows[delta.windowId] = aggregated
-        changedWindows[delta.windowId] = aggregated
+        guard stageWindow(aggregated) else { return }
         recordFontResources(in: delta)
+    }
+
+    private mutating func stageWindow(_ content: GUIWindowContent) -> Bool {
+        do {
+            let residentWeight = content.exactResourceWeight()
+            if residentWeight.firstExceeded(limit: residentLimit) != nil {
+                rejection = .resourcePolicy
+                return false
+            }
+            var stagingWeight = FrameResourceWeight()
+            for (windowID, existing) in workingWindows where windowID != content.windowId {
+                stagingWeight = try stagingWeight.adding(existing.exactResourceWeight())
+            }
+            stagingWeight = try stagingWeight.adding(residentWeight)
+            if stagingWeight.firstExceeded(limit: stagingLimit) != nil {
+                rejection = .resourcePolicy
+                return false
+            }
+            workingWindows[content.windowId] = content
+            changedWindows[content.windowId] = content
+            return true
+        } catch {
+            rejection = .resourcePolicy
+            return false
+        }
     }
 
     private func aggregatingOperationCounters(for content: GUIWindowContent) -> GUIWindowContent {

--- a/macos/Sources/Renderer/ResidentRowStore.swift
+++ b/macos/Sources/Renderer/ResidentRowStore.swift
@@ -16,6 +16,8 @@ public struct ResidentRowStoreCounters: Sendable, Equatable {
     public var locatorNodesCopied = 0
     /// Complete store resets.
     public var fullResets = 0
+    /// Boundary rows inspected while aggregating cached resource weights.
+    public var resourceWeightRowsVisited = 0
 
     /// Creates zeroed counters.
     public init() {}
@@ -29,7 +31,8 @@ public struct ResidentRowStoreCounters: Sendable, Equatable {
             splices: lhs.splices + rhs.splices,
             changedRowsValidated: lhs.changedRowsValidated + rhs.changedRowsValidated,
             locatorNodesCopied: lhs.locatorNodesCopied + rhs.locatorNodesCopied,
-            fullResets: lhs.fullResets + rhs.fullResets
+            fullResets: lhs.fullResets + rhs.fullResets,
+            resourceWeightRowsVisited: lhs.resourceWeightRowsVisited + rhs.resourceWeightRowsVisited
         )
     }
 
@@ -42,12 +45,16 @@ public struct ResidentRowStoreCounters: Sendable, Equatable {
             splices: max(lhs.splices - rhs.splices, 0),
             changedRowsValidated: max(lhs.changedRowsValidated - rhs.changedRowsValidated, 0),
             locatorNodesCopied: max(lhs.locatorNodesCopied - rhs.locatorNodesCopied, 0),
-            fullResets: max(lhs.fullResets - rhs.fullResets, 0)
+            fullResets: max(lhs.fullResets - rhs.fullResets, 0),
+            resourceWeightRowsVisited: max(
+                lhs.resourceWeightRowsVisited - rhs.resourceWeightRowsVisited, 0
+            )
         )
     }
 
     private init(rowsVisited: Int, chunksTouched: Int, idsResolved: Int, splices: Int,
-                 changedRowsValidated: Int, locatorNodesCopied: Int, fullResets: Int) {
+                 changedRowsValidated: Int, locatorNodesCopied: Int, fullResets: Int,
+                 resourceWeightRowsVisited: Int) {
         self.rowsVisited = rowsVisited
         self.chunksTouched = chunksTouched
         self.idsResolved = idsResolved
@@ -55,6 +62,7 @@ public struct ResidentRowStoreCounters: Sendable, Equatable {
         self.changedRowsValidated = changedRowsValidated
         self.locatorNodesCopied = locatorNodesCopied
         self.fullResets = fullResets
+        self.resourceWeightRowsVisited = resourceWeightRowsVisited
     }
 }
 
@@ -115,12 +123,16 @@ public struct ResidentRowStore: Sendable {
         let rows: [GUIVisualRow]
         let minBufferLine: UInt32
         let maxBufferLine: UInt32
+        let resourceWeight: FrameResourceWeight
 
         init(id: UInt64, rows: [GUIVisualRow]) {
             self.id = id
             self.rows = rows
             minBufferLine = rows.first?.bufLine ?? 0
             maxBufferLine = rows.last?.bufLine ?? 0
+            resourceWeight = rows.reduce(into: FrameResourceWeight()) { weight, row in
+                weight = weight.addingPrevalidated(ResidentRowStore.weight(of: row))
+            }
         }
     }
 
@@ -133,6 +145,7 @@ public struct ResidentRowStore: Sendable {
         let chunkCount: Int
         let minBufferLine: UInt32
         let maxBufferLine: UInt32
+        let resourceWeight: FrameResourceWeight
 
         init(chunk: Chunk, left: Node? = nil, right: Node? = nil) {
             self.chunk = chunk
@@ -143,6 +156,9 @@ public struct ResidentRowStore: Sendable {
             chunkCount = (left?.chunkCount ?? 0) + 1 + (right?.chunkCount ?? 0)
             minBufferLine = left?.minBufferLine ?? chunk.minBufferLine
             maxBufferLine = right?.maxBufferLine ?? chunk.maxBufferLine
+            resourceWeight = (left?.resourceWeight ?? FrameResourceWeight())
+                .addingPrevalidated(chunk.resourceWeight)
+                .addingPrevalidated(right?.resourceWeight ?? FrameResourceWeight())
         }
     }
 
@@ -455,19 +471,24 @@ public struct ResidentRowStore: Sendable {
 
         let removedWeight: FrameResourceWeight
         let insertedWeight: FrameResourceWeight
+        let resourceWeightRowsVisited: Int
         do {
             var removed = FrameResourceWeight()
             var inserted = FrameResourceWeight()
+            var rowsVisited = 0
             for splice in splices {
-                removed = try removed.adding(
-                    try weight(in: splice.startIndex..<(splice.startIndex + splice.deleteCount))
+                let removedRange = try weight(
+                    in: splice.startIndex..<(splice.startIndex + splice.deleteCount)
                 )
+                removed = try removed.adding(removedRange.weight)
+                rowsVisited += removedRange.rowsVisited
                 inserted = try inserted.adding(try Self.weight(of: splice.insertedRows))
             }
             let resulting = try storage.resourceWeight.subtracting(removed).adding(inserted)
             try Self.validate(resulting, limit: limit)
             removedWeight = removed
             insertedWeight = inserted
+            resourceWeightRowsVisited = rowsVisited
         } catch is FrameResourceError {
             throw ResidentRowStoreError.resourcePolicy
         }
@@ -477,11 +498,13 @@ public struct ResidentRowStore: Sendable {
             staged.applyInPlaceReplacements(replacements)
             staged.storage.resourceWeight = try staged.storage.resourceWeight
                 .subtracting(removedWeight).adding(insertedWeight)
+            staged.storage.counters.resourceWeightRowsVisited += resourceWeightRowsVisited
             self = staged
             return
         }
 
         var staged = self
+        staged.storage.counters.resourceWeightRowsVisited += resourceWeightRowsVisited
         var coordinateAdjustment = 0
         for splice in splices {
             try staged.splice(
@@ -510,9 +533,12 @@ public struct ResidentRowStore: Sendable {
 
         let removedResourceWeight: FrameResourceWeight
         let insertedResourceWeight: FrameResourceWeight
+        let resourceWeightRowsVisited: Int
         do {
-            removedResourceWeight = try weight(in: index..<(index + removeCount))
+            let removedRange = try weight(in: index..<(index + removeCount))
+            removedResourceWeight = removedRange.weight
             insertedResourceWeight = try Self.weight(of: insertedRows)
+            resourceWeightRowsVisited = removedRange.rowsVisited
             let resulting = try storage.resourceWeight
                 .subtracting(removedResourceWeight).adding(insertedResourceWeight)
             try Self.validate(resulting, limit: limit)
@@ -544,6 +570,7 @@ public struct ResidentRowStore: Sendable {
             storage.root = Self.buildTree(chunks)
             indexChunks(chunks)
             storage.resourceWeight = insertedResourceWeight
+            storage.counters.resourceWeightRowsVisited += resourceWeightRowsVisited
             recordSplice(oldRows: 0, newRows: insertedRows.count, changedRows: insertedRows.count,
                          oldChunks: 0, newChunks: chunks.count)
             return
@@ -603,6 +630,7 @@ public struct ResidentRowStore: Sendable {
         storage.root = Self.merge(Self.merge(left, Self.buildTree(newChunks)), right)
         storage.resourceWeight = try storage.resourceWeight
             .subtracting(removedResourceWeight).adding(insertedResourceWeight)
+        storage.counters.resourceWeightRowsVisited += resourceWeightRowsVisited
         recordSplice(
             oldRows: removedChunks.reduce(0) { $0 + $1.rows.count },
             newRows: selectedRows.count,
@@ -615,7 +643,13 @@ public struct ResidentRowStore: Sendable {
     /// Debug invariant seam used by deterministic and randomized tests.
     public func validateInvariants() -> Bool {
         let chunks = Self.flattenChunks(storage.root)
-        guard chunks.allSatisfy({ !$0.rows.isEmpty && $0.rows.count <= Self.chunkCapacity }) else { return false }
+        guard chunks.allSatisfy({
+            !$0.rows.isEmpty && $0.rows.count <= Self.chunkCapacity &&
+                (try? Self.weight(of: $0.rows)) == $0.resourceWeight
+        }) else { return false }
+        guard (storage.root?.resourceWeight ?? FrameResourceWeight()) == storage.resourceWeight else {
+            return false
+        }
         if chunks.count > 2 {
             guard chunks.dropFirst().dropLast().allSatisfy({ $0.rows.count >= Self.minimumChunkOccupancy }) else { return false }
         }
@@ -793,15 +827,56 @@ public struct ResidentRowStore: Sendable {
         return Self.flattenChunks(selected).flatMap(\.rows)
     }
 
-    private func weight(in range: Range<Int>) throws -> FrameResourceWeight {
+    private func weight(
+        in range: Range<Int>
+    ) throws -> (weight: FrameResourceWeight, rowsVisited: Int) {
+        guard range.lowerBound >= 0, range.upperBound <= count else {
+            throw ResidentRowStoreError.invalidRange(
+                index: range.lowerBound, removeCount: range.count, rowCount: count
+            )
+        }
+        var rowsVisited = 0
+        let result = try Self.weight(
+            in: storage.root, nodeStart: 0, range: range, rowsVisited: &rowsVisited
+        )
+        return (result, rowsVisited)
+    }
+
+    private static func weight(
+        in node: Node?, nodeStart: Int, range: Range<Int>, rowsVisited: inout Int
+    ) throws -> FrameResourceWeight {
+        guard let node, !range.isEmpty else { return FrameResourceWeight() }
+        let nodeEnd = nodeStart + node.rowCount
+        if range.lowerBound <= nodeStart, range.upperBound >= nodeEnd {
+            return node.resourceWeight
+        }
+
+        let leftCount = node.left?.rowCount ?? 0
+        let chunkStart = nodeStart + leftCount
+        let chunkEnd = chunkStart + node.chunk.rows.count
         var result = FrameResourceWeight()
-        for index in range {
-            guard let row = row(at: index) else {
-                throw ResidentRowStoreError.invalidRange(
-                    index: range.lowerBound, removeCount: range.count, rowCount: count
-                )
+
+        if range.lowerBound < chunkStart {
+            result = try result.adding(try weight(
+                in: node.left, nodeStart: nodeStart,
+                range: range, rowsVisited: &rowsVisited
+            ))
+        }
+
+        let overlapStart = max(range.lowerBound, chunkStart)
+        let overlapEnd = min(range.upperBound, chunkEnd)
+        if overlapStart < overlapEnd {
+            rowsVisited += overlapEnd - overlapStart
+            for row in node.chunk.rows[(overlapStart - chunkStart)..<(overlapEnd - chunkStart)] {
+                result = try result.adding(weight(of: row))
             }
-            result = try result.adding(Self.weight(of: row))
+        }
+
+        if range.upperBound > chunkEnd {
+            result = try result.adding(try weight(
+                in: node.right, nodeStart: chunkEnd,
+                range: range, rowsVisited: &rowsVisited
+            ))
         }
         return result
     }

--- a/macos/Sources/Renderer/ResidentRowStore.swift
+++ b/macos/Sources/Renderer/ResidentRowStore.swift
@@ -70,6 +70,8 @@ public enum ResidentRowStoreError: Error, Sendable, Equatable {
     case missingRowID(UInt64)
     /// A retained identity exists but its content hash differs.
     case contentHashMismatch(rowID: UInt64, expected: UInt32, actual: UInt32)
+    /// The exact resulting resident weight exceeds policy or overflows.
+    case resourcePolicy
 }
 
 /// One resolved immutable-base splice for atomic store application.
@@ -241,17 +243,21 @@ public struct ResidentRowStore: Sendable {
         var locators: LocatorTable
         var nextChunkID: UInt64
         var counters: ResidentRowStoreCounters
+        var resourceWeight: FrameResourceWeight
 
         init(root: Node? = nil, locators: LocatorTable = .init(), nextChunkID: UInt64 = 1,
-             counters: ResidentRowStoreCounters = .init()) {
+             counters: ResidentRowStoreCounters = .init(),
+             resourceWeight: FrameResourceWeight = .init()) {
             self.root = root
             self.locators = locators
             self.nextChunkID = nextChunkID
             self.counters = counters
+            self.resourceWeight = resourceWeight
         }
 
         func copy() -> Storage {
-            Storage(root: root, locators: locators, nextChunkID: nextChunkID, counters: counters)
+            Storage(root: root, locators: locators, nextChunkID: nextChunkID,
+                    counters: counters, resourceWeight: resourceWeight)
         }
     }
 
@@ -265,10 +271,23 @@ public struct ResidentRowStore: Sendable {
         try replaceAll(with: rows)
     }
 
-    /// Builds decoded protocol content without trapping; callers reject the
-    /// transaction when `validateInvariants()` reports duplicate identities.
-    public init(decodedRows rows: [GUIVisualRow]) {
-        self.storage = Storage()
+    /// Builds decoded protocol content from a checked row weight. Identity,
+    /// ordering, and policy validation all complete before chunks or indexes exist.
+    public init(
+        decodedRows rows: [GUIVisualRow],
+        resourceWeight: FrameResourceWeight,
+        limit: FrameResourceWeight? = nil
+    ) throws {
+        do {
+            try Self.validateRows(rows)
+            try Self.validate(resourceWeight, limit: limit)
+        } catch let error as ResidentRowStoreError {
+            throw error
+        } catch is FrameResourceError {
+            throw ResidentRowStoreError.resourcePolicy
+        }
+
+        self.storage = Storage(resourceWeight: resourceWeight)
         let chunks = makeChunks(rows)
         storage.root = Self.buildTree(chunks)
         indexChunks(chunks)
@@ -285,16 +304,23 @@ public struct ResidentRowStore: Sendable {
     public var chunkCount: Int { storage.root?.chunkCount ?? 0 }
     /// Cumulative deterministic store-operation counters.
     public var counters: ResidentRowStoreCounters { storage.counters }
+    /// Exact cached ownership of resident row strings, spans, and locators.
+    public var resourceWeight: FrameResourceWeight { storage.resourceWeight }
 
     /// Replaces the complete sequence and records one explicit full reset.
-    public mutating func replaceAll(with rows: [GUIVisualRow]) throws {
+    public mutating func replaceAll(
+        with rows: [GUIVisualRow], limit: FrameResourceWeight? = nil
+    ) throws {
         try Self.validateRows(rows)
+        let resultingWeight = try Self.weight(of: rows)
+        try Self.validate(resultingWeight, limit: limit)
         ensureUniqueStorage()
         storage.root = nil
         storage.locators.removeAll()
         let chunks = makeChunks(rows)
         storage.root = Self.buildTree(chunks)
         indexChunks(chunks)
+        storage.resourceWeight = resultingWeight
         storage.counters.rowsVisited += rows.count
         storage.counters.chunksTouched += chunks.count
         storage.counters.fullResets += 1
@@ -397,8 +423,10 @@ public struct ResidentRowStore: Sendable {
     /// Applies disjoint immutable-base splices as one value-semantic batch.
     ///
     /// Every range and result count is validated before the receiver is replaced.
-    public mutating func applyBatch(_ splices: [ResidentRowSplice], baseRowCount: Int,
-                                    resultRowCount: Int) throws {
+    public mutating func applyBatch(
+        _ splices: [ResidentRowSplice], baseRowCount: Int,
+        resultRowCount: Int, limit: FrameResourceWeight? = nil
+    ) throws {
         guard baseRowCount == count, resultRowCount >= 0 else {
             throw ResidentRowStoreError.invalidRange(index: 0, removeCount: 0, rowCount: count)
         }
@@ -425,9 +453,30 @@ public struct ResidentRowStore: Sendable {
             throw ResidentRowStoreError.invalidRange(index: computed, removeCount: 0, rowCount: resultRowCount)
         }
 
+        let removedWeight: FrameResourceWeight
+        let insertedWeight: FrameResourceWeight
+        do {
+            var removed = FrameResourceWeight()
+            var inserted = FrameResourceWeight()
+            for splice in splices {
+                removed = try removed.adding(
+                    try weight(in: splice.startIndex..<(splice.startIndex + splice.deleteCount))
+                )
+                inserted = try inserted.adding(try Self.weight(of: splice.insertedRows))
+            }
+            let resulting = try storage.resourceWeight.subtracting(removed).adding(inserted)
+            try Self.validate(resulting, limit: limit)
+            removedWeight = removed
+            insertedWeight = inserted
+        } catch is FrameResourceError {
+            throw ResidentRowStoreError.resourcePolicy
+        }
+
         if !splices.isEmpty, let replacements = try inPlaceReplacements(for: splices) {
             var staged = self
             staged.applyInPlaceReplacements(replacements)
+            staged.storage.resourceWeight = try staged.storage.resourceWeight
+                .subtracting(removedWeight).adding(insertedWeight)
             self = staged
             return
         }
@@ -438,7 +487,8 @@ public struct ResidentRowStore: Sendable {
             try staged.splice(
                 at: splice.startIndex + coordinateAdjustment,
                 removeCount: splice.deleteCount,
-                inserting: splice.insertedRows
+                inserting: splice.insertedRows,
+                limit: nil
             )
             coordinateAdjustment += splice.insertedRows.count - splice.deleteCount
         }
@@ -449,11 +499,26 @@ public struct ResidentRowStore: Sendable {
     }
 
     /// Applies a validated structural edit while preserving unaffected chunk IDs.
-    public mutating func splice(at index: Int, removeCount: Int, inserting insertedRows: [GUIVisualRow]) throws {
+    public mutating func splice(
+        at index: Int, removeCount: Int, inserting insertedRows: [GUIVisualRow],
+        limit: FrameResourceWeight? = nil
+    ) throws {
         guard index >= 0, removeCount >= 0, index <= count, index + removeCount <= count else {
             throw ResidentRowStoreError.invalidRange(index: index, removeCount: removeCount, rowCount: count)
         }
         guard removeCount > 0 || !insertedRows.isEmpty else { return }
+
+        let removedResourceWeight: FrameResourceWeight
+        let insertedResourceWeight: FrameResourceWeight
+        do {
+            removedResourceWeight = try weight(in: index..<(index + removeCount))
+            insertedResourceWeight = try Self.weight(of: insertedRows)
+            let resulting = try storage.resourceWeight
+                .subtracting(removedResourceWeight).adding(insertedResourceWeight)
+            try Self.validate(resulting, limit: limit)
+        } catch is FrameResourceError {
+            throw ResidentRowStoreError.resourcePolicy
+        }
 
         let removedIDs = Set((index..<(index + removeCount)).compactMap { row(at: $0)?.rowId })
         for row in insertedRows where storage.locators[row.rowId] != nil && !removedIDs.contains(row.rowId) {
@@ -478,15 +543,30 @@ public struct ResidentRowStore: Sendable {
             let chunks = makeChunks(insertedRows)
             storage.root = Self.buildTree(chunks)
             indexChunks(chunks)
+            storage.resourceWeight = insertedResourceWeight
             recordSplice(oldRows: 0, newRows: insertedRows.count, changedRows: insertedRows.count,
                          oldChunks: 0, newChunks: chunks.count)
             return
         }
 
-        let startLocation = chunkLocation(forRowIndex: min(index, max(count - 1, 0)))!
-        let endLocation = removeCount == 0
-            ? startLocation
-            : chunkLocation(forRowIndex: index + removeCount - 1)!
+        guard let startLocation = chunkLocation(
+            forRowIndex: min(index, max(count - 1, 0))
+        ) else {
+            throw ResidentRowStoreError.invalidRange(
+                index: index, removeCount: removeCount, rowCount: count
+            )
+        }
+        let endLocation: (rank: Int, offset: Int)
+        if removeCount == 0 {
+            endLocation = startLocation
+        } else {
+            guard let resolvedEnd = chunkLocation(forRowIndex: index + removeCount - 1) else {
+                throw ResidentRowStoreError.invalidRange(
+                    index: index, removeCount: removeCount, rowCount: count
+                )
+            }
+            endLocation = resolvedEnd
+        }
         var firstChunk = max(startLocation.rank - 1, 0)
         var lastChunk = min(endLocation.rank + 1, chunkCount - 1)
         var firstRow = rowPrefix(beforeChunk: firstChunk)
@@ -521,6 +601,8 @@ public struct ResidentRowStore: Sendable {
         let newChunks = makeChunks(selectedRows)
         indexChunks(newChunks)
         storage.root = Self.merge(Self.merge(left, Self.buildTree(newChunks)), right)
+        storage.resourceWeight = try storage.resourceWeight
+            .subtracting(removedResourceWeight).adding(insertedResourceWeight)
         recordSplice(
             oldRows: removedChunks.reduce(0) { $0 + $1.rows.count },
             newRows: selectedRows.count,
@@ -709,6 +791,45 @@ public struct ResidentRowStore: Sendable {
         let (_, remainder) = Self.splitByChunk(storage.root, count: ranks.lowerBound)
         let (selected, _) = Self.splitByChunk(remainder, count: ranks.count)
         return Self.flattenChunks(selected).flatMap(\.rows)
+    }
+
+    private func weight(in range: Range<Int>) throws -> FrameResourceWeight {
+        var result = FrameResourceWeight()
+        for index in range {
+            guard let row = row(at: index) else {
+                throw ResidentRowStoreError.invalidRange(
+                    index: range.lowerBound, removeCount: range.count, rowCount: count
+                )
+            }
+            result = try result.adding(Self.weight(of: row))
+        }
+        return result
+    }
+
+    static func weight(of row: GUIVisualRow) -> FrameResourceWeight {
+        FrameResourceWeight(
+            ownedUTF8Bytes: row.text.utf8.count,
+            arrayEntries: row.spans.count,
+            rows: 1,
+            spans: row.spans.count,
+            locatorEntries: 1
+        )
+    }
+
+    static func weight(of rows: [GUIVisualRow]) throws -> FrameResourceWeight {
+        try rows.reduce(into: FrameResourceWeight()) { result, row in
+            result = try result.adding(weight(of: row))
+        }
+    }
+
+    private static func validate(
+        _ weight: FrameResourceWeight, limit: FrameResourceWeight?
+    ) throws {
+        guard let limit, let dimension = weight.firstExceeded(limit: limit) else { return }
+        throw FrameResourceError.limitExceeded(
+            dimension: dimension, used: 0, requested: weight.value(dimension),
+            limit: limit.value(dimension)
+        )
     }
 
     static func validateRows(_ rows: [GUIVisualRow]) throws {

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -537,6 +537,8 @@ public final class GUIWindowContent: Sendable {
     public let paneGeometry: GUIPaneGeometry?
     public let cursorline: GUICursorline?
     public let scrollPresentation: GUIScrollPresentation?
+    /// Exact immutable ownership retained by this published window.
+    public let resourceWeight: FrameResourceWeight
 
     public init(windowId: UInt16, fullRefresh: Bool, contentEpoch: UInt32 = 0, cursorVisible: Bool = true,
          cursorRow: UInt16, cursorCol: UInt16, cursorShape: CursorShape,
@@ -548,8 +550,19 @@ public final class GUIWindowContent: Sendable {
          lineAnnotations: [GUILineAnnotation] = [],
          paneGeometry: GUIPaneGeometry? = nil,
          cursorline: GUICursorline? = nil,
-         scrollPresentation: GUIScrollPresentation? = nil) {
-        let store = ResidentRowStore(decodedRows: rows)
+         scrollPresentation: GUIScrollPresentation? = nil,
+         residentLimit: FrameResourceWeight = FrameResourcePolicy.default.resident.weightPerWindow) throws {
+        let rowWeight = try ResidentRowStore.weight(of: rows)
+        let completeWeight = try Self.resourceWeight(
+            rowWeight: rowWeight, selection: selection, searchMatches: searchMatches,
+            diagnosticUnderlines: diagnosticUnderlines,
+            documentHighlights: documentHighlights, lineAnnotations: lineAnnotations,
+            paneGeometry: paneGeometry
+        )
+        try Self.validate(completeWeight, limit: residentLimit)
+        let store = try ResidentRowStore(
+            decodedRows: rows, resourceWeight: rowWeight, limit: residentLimit
+        )
         self.windowId = windowId
         self.fullRefresh = fullRefresh
         self.contentEpoch = contentEpoch
@@ -568,6 +581,7 @@ public final class GUIWindowContent: Sendable {
         self.paneGeometry = paneGeometry
         self.cursorline = cursorline
         self.scrollPresentation = scrollPresentation
+        self.resourceWeight = completeWeight
     }
 
     private init(windowId: UInt16, fullRefresh: Bool, contentEpoch: UInt32,
@@ -577,7 +591,8 @@ public final class GUIWindowContent: Sendable {
          selection: GUISelectionOverlay?, searchMatches: [GUISearchMatch],
          diagnosticUnderlines: [GUIDiagnosticUnderline], documentHighlights: [GUIDocumentHighlight],
          lineAnnotations: [GUILineAnnotation], paneGeometry: GUIPaneGeometry?,
-         cursorline: GUICursorline?, scrollPresentation: GUIScrollPresentation?) {
+         cursorline: GUICursorline?, scrollPresentation: GUIScrollPresentation?,
+         resourceWeight: FrameResourceWeight) {
         self.windowId = windowId
         self.fullRefresh = fullRefresh
         self.contentEpoch = contentEpoch
@@ -596,6 +611,7 @@ public final class GUIWindowContent: Sendable {
         self.paneGeometry = paneGeometry
         self.cursorline = cursorline
         self.scrollPresentation = scrollPresentation
+        self.resourceWeight = resourceWeight
     }
 
     /// Returns the same immutable content while replacing per-frame operation counters.
@@ -608,7 +624,7 @@ public final class GUIWindowContent: Sendable {
             searchMatches: searchMatches, diagnosticUnderlines: diagnosticUnderlines,
             documentHighlights: documentHighlights, lineAnnotations: lineAnnotations,
             paneGeometry: paneGeometry, cursorline: cursorline,
-            scrollPresentation: scrollPresentation
+            scrollPresentation: scrollPresentation, resourceWeight: resourceWeight
         )
     }
 
@@ -635,7 +651,8 @@ public final class GUIWindowContent: Sendable {
             lineAnnotations: lineAnnotations,
             paneGeometry: paneGeometry,
             cursorline: delta.cursorline,
-            scrollPresentation: scrollPresentation
+            scrollPresentation: scrollPresentation,
+            resourceWeight: resourceWeight
         )
     }
 
@@ -643,24 +660,37 @@ public final class GUIWindowContent: Sendable {
         try? applyingRowsDeltaChecked(delta).get()
     }
 
+    /// Exact ownership retained by this immutable window value in O(1).
+    public func exactResourceWeight() -> FrameResourceWeight { resourceWeight }
+
     /// Applies A1/A2 entries directly to a COW store copy. References resolve
     /// through durable IDs; no second full resident-row array is materialized.
     public func applyingRowsDeltaChecked(
-        _ delta: GUIWindowRowsDelta
+        _ delta: GUIWindowRowsDelta,
+        residentLimit: FrameResourceWeight? = nil,
+        stagingLimit: FrameResourceWeight? = nil
     ) -> Result<GUIWindowContent, ResidentRowStoreError> {
+        let effectiveResidentLimit = residentLimit ?? FrameResourcePolicy.default.resident.weightPerWindow
+        let effectiveStagingLimit = stagingLimit ?? FrameResourcePolicy.default.staging.weight
         guard delta.windowId == windowId, delta.contentEpoch == contentEpoch else {
             return .failure(.invalidRange(index: 0, removeCount: 0, rowCount: rowStore.count))
         }
         if delta.rowSplices != nil {
-            return applyingRowSplices(delta)
+            return applyingRowSplices(
+                delta, residentLimit: effectiveResidentLimit, stagingLimit: effectiveStagingLimit
+            )
         }
 
+        let stagingUsage = FrameResourceUsageBuilder(limit: effectiveStagingLimit)
         var sourceStore = rowStore
         var nextStore = rowStore
         do {
             // Validate the complete result against the immutable base using
             // identity/hash/order metadata only. Keeping metadata here avoids
             // constructing a second document-sized GUIVisualRow array.
+            try stagingUsage.reserve(.arrayEntries, delta.rows.count)
+            try stagingUsage.reserve(.arrayEntries, delta.rows.count)
+            try stagingUsage.reserve(.rows, delta.rows.count)
             var metadata: [ResidentRowMetadata] = []
             metadata.reserveCapacity(delta.rows.count)
             var seenRowIDs = Set<UInt64>()
@@ -722,6 +752,7 @@ public final class GUIWindowContent: Sendable {
             let removedCount = rowStore.count - prefix - suffix
             let insertedEnd = metadata.count - suffix
             if removedCount > 0 || prefix < insertedEnd {
+                try stagingUsage.reserve(.arrayEntries, insertedEnd - prefix)
                 var insertedRows: [GUIVisualRow] = []
                 insertedRows.reserveCapacity(insertedEnd - prefix)
                 for entry in delta.rows[prefix..<insertedEnd] {
@@ -732,12 +763,17 @@ public final class GUIWindowContent: Sendable {
                         insertedRows.append(row)
                     }
                 }
-                try nextStore.splice(at: prefix, removeCount: removedCount, inserting: insertedRows)
+                try nextStore.splice(
+                    at: prefix, removeCount: removedCount, inserting: insertedRows,
+                    limit: effectiveResidentLimit
+                )
             }
 
             nextStore.recordStagingCounters(sourceStore.counters - rowStore.counters)
         } catch let error as ResidentRowStoreError {
             return .failure(error)
+        } catch is FrameResourceError {
+            return .failure(.resourcePolicy)
         } catch {
             return .failure(.invalidRange(index: 0, removeCount: 0, rowCount: rowStore.count))
         }
@@ -746,12 +782,20 @@ public final class GUIWindowContent: Sendable {
             windowId: windowId, contentEpoch: contentEpoch
         ) == true ? delta.scrollPresentation : nil
 
-        return .success(content(afterApplying: delta, store: nextStore,
-                                scrollPresentation: nextScrollPresentation))
+        do {
+            return .success(try content(
+                afterApplying: delta, store: nextStore,
+                scrollPresentation: nextScrollPresentation, residentLimit: effectiveResidentLimit
+            ))
+        } catch {
+            return .failure(.resourcePolicy)
+        }
     }
 
     private func applyingRowSplices(
-        _ delta: GUIWindowRowsDelta
+        _ delta: GUIWindowRowsDelta,
+        residentLimit: FrameResourceWeight,
+        stagingLimit: FrameResourceWeight
     ) -> Result<GUIWindowContent, ResidentRowStoreError> {
         guard let baseRowCount = delta.baseRowCount,
               let resultRowCount = delta.resultRowCount,
@@ -759,11 +803,17 @@ public final class GUIWindowContent: Sendable {
             return .failure(.invalidRange(index: 0, removeCount: 0, rowCount: rowStore.count))
         }
 
+        let stagingUsage = FrameResourceUsageBuilder(limit: stagingLimit)
         var sourceStore = rowStore
         var resolvedSplices: [ResidentRowSplice] = []
-        resolvedSplices.reserveCapacity(wireSplices.count)
         do {
+            try stagingUsage.reserve(.arrayEntries, wireSplices.count)
+            try stagingUsage.reserve(.spliceEntries, wireSplices.count)
+            resolvedSplices.reserveCapacity(wireSplices.count)
             for splice in wireSplices {
+                try stagingUsage.reserve(.arrayEntries, splice.insertEntries.count)
+                try stagingUsage.reserve(.rows, splice.insertEntries.count)
+                try stagingUsage.reserve(.locatorEntries, splice.insertEntries.count)
                 var rows: [GUIVisualRow] = []
                 rows.reserveCapacity(splice.insertEntries.count)
                 for entry in splice.insertEntries {
@@ -786,24 +836,39 @@ public final class GUIWindowContent: Sendable {
             try nextStore.applyBatch(
                 resolvedSplices,
                 baseRowCount: Int(baseRowCount),
-                resultRowCount: Int(resultRowCount)
+                resultRowCount: Int(resultRowCount),
+                limit: residentLimit
             )
             nextStore.recordStagingCounters(sourceStore.counters - rowStore.counters)
             let nextScroll = delta.scrollPresentation?.belongsTo(
                 windowId: windowId, contentEpoch: contentEpoch
             ) == true ? delta.scrollPresentation : nil
-            return .success(content(afterApplying: delta, store: nextStore,
-                                    scrollPresentation: nextScroll))
+            return .success(try content(
+                afterApplying: delta, store: nextStore,
+                scrollPresentation: nextScroll, residentLimit: residentLimit
+            ))
         } catch let error as ResidentRowStoreError {
             return .failure(error)
+        } catch is FrameResourceError {
+            return .failure(.resourcePolicy)
         } catch {
             return .failure(.invalidRange(index: 0, removeCount: 0, rowCount: rowStore.count))
         }
     }
 
-    private func content(afterApplying delta: GUIWindowRowsDelta, store: ResidentRowStore,
-                         scrollPresentation: GUIScrollPresentation?) -> GUIWindowContent {
-        GUIWindowContent(
+    private func content(
+        afterApplying delta: GUIWindowRowsDelta, store: ResidentRowStore,
+        scrollPresentation: GUIScrollPresentation?, residentLimit: FrameResourceWeight
+    ) throws -> GUIWindowContent {
+        let resultingWeight = try Self.resourceWeight(
+            rowWeight: store.resourceWeight, selection: delta.selection,
+            searchMatches: delta.searchMatches,
+            diagnosticUnderlines: delta.diagnosticUnderlines,
+            documentHighlights: delta.documentHighlights,
+            lineAnnotations: delta.lineAnnotations, paneGeometry: delta.paneGeometry
+        )
+        try Self.validate(resultingWeight, limit: residentLimit)
+        return GUIWindowContent(
             windowId: windowId,
             fullRefresh: false,
             contentEpoch: contentEpoch,
@@ -821,7 +886,48 @@ public final class GUIWindowContent: Sendable {
             lineAnnotations: delta.lineAnnotations,
             paneGeometry: delta.paneGeometry,
             cursorline: delta.cursorline,
-            scrollPresentation: scrollPresentation
+            scrollPresentation: scrollPresentation,
+            resourceWeight: resultingWeight
+        )
+    }
+
+    private static func resourceWeight(
+        rowWeight: FrameResourceWeight, selection: GUISelectionOverlay?,
+        searchMatches: [GUISearchMatch],
+        diagnosticUnderlines: [GUIDiagnosticUnderline],
+        documentHighlights: [GUIDocumentHighlight],
+        lineAnnotations: [GUILineAnnotation], paneGeometry: GUIPaneGeometry?
+    ) throws -> FrameResourceWeight {
+        let overlayCount = try [
+            searchMatches.count, diagnosticUnderlines.count, documentHighlights.count,
+            lineAnnotations.count, selection == nil ? 0 : 1
+        ].reduce(into: 0) { total, count in
+            let (next, overflow) = total.addingReportingOverflow(count)
+            guard !overflow else { throw FrameResourceError.arithmeticOverflow }
+            total = next
+        }
+        let hitRegionCount = paneGeometry?.hitRegions.count ?? 0
+        let (arrayEntries, arrayOverflow) = overlayCount.addingReportingOverflow(hitRegionCount)
+        guard !arrayOverflow else { throw FrameResourceError.arithmeticOverflow }
+        let annotationBytes = try lineAnnotations.reduce(into: 0) { total, annotation in
+            let (next, overflow) = total.addingReportingOverflow(annotation.text.utf8.count)
+            guard !overflow else { throw FrameResourceError.arithmeticOverflow }
+            total = next
+        }
+        return try rowWeight.adding(FrameResourceWeight(
+            ownedUTF8Bytes: annotationBytes,
+            arrayEntries: arrayEntries,
+            overlays: overlayCount
+        ))
+    }
+
+    private static func validate(
+        _ weight: FrameResourceWeight, limit: FrameResourceWeight
+    ) throws {
+        guard let dimension = weight.firstExceeded(limit: limit) else { return }
+        throw FrameResourceError.limitExceeded(
+            dimension: dimension, used: 0, requested: weight.value(dimension),
+            limit: limit.value(dimension)
         )
     }
 }

--- a/macos/Sources/Views/Agent/AgentChatState.swift
+++ b/macos/Sources/Views/Agent/AgentChatState.swift
@@ -53,6 +53,41 @@ public struct AgentTranscriptSnapshot {
     let hasTranscript: Bool
     let truncated: Bool
     let promptVersion: Int
+
+    /// Exact retained payload weight of the resident transcript.
+    public func exactResourceWeight() throws -> FrameResourceWeight {
+        var weight = FrameResourceWeight(arrayEntries: messages.count)
+        for message in messages {
+            weight = try weight.adding(try FrameResourceWeight.measuringOwnedPayload(message))
+        }
+        return weight
+    }
+
+    /// Computes the exact resulting transcript weight without materializing mapped messages.
+    public func resourceWeightAfterPreparing(
+        mode: UInt8, epoch: UInt32, trimFront: Int, baseCount: Int,
+        messages rawMessages: [Wire.ChatMessage]
+    ) throws -> FrameResourceWeight {
+        var weight: FrameResourceWeight
+        if mode == 0 {
+            weight = FrameResourceWeight(arrayEntries: rawMessages.count)
+        } else {
+            guard hasTranscript else { throw AgentTranscriptPreparationFailure.beforeSeed }
+            guard epoch == self.epoch else { throw AgentTranscriptPreparationFailure.epochMismatch }
+            guard trimFront >= 0, baseCount >= 0,
+                  messages.count >= trimFront + baseCount else {
+                throw AgentTranscriptPreparationFailure.desynced
+            }
+            weight = FrameResourceWeight(arrayEntries: baseCount + rawMessages.count)
+            for message in messages[trimFront ..< (trimFront + baseCount)] {
+                weight = try weight.adding(try FrameResourceWeight.measuringOwnedPayload(message))
+            }
+        }
+        for message in rawMessages {
+            weight = try weight.adding(try FrameResourceWeight.measuringOwnedPayload(message))
+        }
+        return weight
+    }
 }
 
 /// Stable reason that a transcript operation cannot join the resident transcript snapshot.

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -1473,6 +1473,14 @@ struct CommandDispatcherStagingTests {
         )
     }
 
+    private func policy(stagingWeight: FrameResourceWeight) -> FrameResourcePolicy {
+        let defaults = FrameResourcePolicy.default
+        return FrameResourcePolicy(
+            wire: defaults.wire, decode: defaults.decode,
+            staging: .init(weight: stagingWeight), resident: defaults.resident
+        )
+    }
+
     // MARK: - Nothing paints between begin and commit
 
     @Test("observable GUIState is unchanged between begin and a partial frame")
@@ -1986,6 +1994,132 @@ struct CommandDispatcherStagingTests {
         #expect(gui.resyncState.pending == false)
         #expect(results.count == 3)
         #expect(results.last == .applied(generation: 1, frameSeq: 3))
+    }
+
+    @Test("semantic staging subtracts coalesced command replacements")
+    @MainActor func stagingSubtractsCoalescedReplacements() throws {
+        let staging = FrameResourceWeight(
+            commands: 2, ownedUTF8Bytes: .max, arrayEntries: .max,
+            rows: .max, spans: .max, overlays: .max,
+            spliceEntries: .max, locatorEntries: .max
+        )
+        let gui = GUIState()
+        let dispatcher = CommandDispatcher(
+            cols: 80, rows: 24, guiState: gui,
+            resourcePolicy: policy(stagingWeight: staging)
+        )
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("first.ex")]))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("replacement.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(gui.tabBarState.tabs.first?.label == "replacement.ex")
+        #expect(results == [.applied(generation: 1, frameSeq: 1)])
+    }
+
+    @Test("semantic staging bounds append-only chrome across packets")
+    @MainActor func stagingBoundsAppendOnlyChrome() throws {
+        let staging = FrameResourceWeight(
+            commands: 2, ownedUTF8Bytes: .max, arrayEntries: .max,
+            rows: .max, spans: .max, overlays: .max,
+            spliceEntries: .max, locatorEntries: .max
+        )
+        let gui = GUIState()
+        let dispatcher = CommandDispatcher(
+            cols: 80, rows: 24, guiState: gui,
+            resourcePolicy: policy(stagingWeight: staging)
+        )
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+        let tabs = [Wire.BottomPanelTab(tabType: 0, name: "Messages")]
+        let entry = Wire.MessageEntry(
+            streamInstance: 1, id: 1, level: 1, subsystem: 0,
+            timestampSecs: 0, filePath: "", text: "entry"
+        )
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiBottomPanel(
+            visible: true, activeTabIndex: 0, heightPercent: 30,
+            filterPreset: 0, tabs: tabs, entries: [entry]
+        ))
+        dispatcher.dispatch(.guiBottomPanel(
+            visible: true, activeTabIndex: 0, heightPercent: 30,
+            filterPreset: 0, tabs: tabs, entries: [entry]
+        ))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(gui.framePublicationCount == 0)
+        #expect(results == [.rejected(
+            generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0,
+            reason: .resourcePolicy
+        )])
+    }
+
+    @Test("semantic staging bounds the resulting transcript before mapping")
+    @MainActor func stagingBoundsResultingTranscript() throws {
+        let staging = FrameResourceWeight(
+            commands: .max, ownedUTF8Bytes: 5, arrayEntries: .max,
+            rows: .max, spans: .max, overlays: .max,
+            spliceEntries: .max, locatorEntries: .max
+        )
+        let gui = GUIState()
+        let dispatcher = CommandDispatcher(
+            cols: 80, rows: 24, guiState: gui,
+            resourcePolicy: policy(stagingWeight: staging)
+        )
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiAgentTranscript(
+            mode: 0, epoch: 1, truncated: false, trimFront: 0, baseCount: 0,
+            messages: [Wire.ChatMessage(beamId: 1, content: .user(text: "seed"))]
+        ))
+        dispatcher.dispatch(.guiAgentTranscript(
+            mode: 1, epoch: 1, truncated: false, trimFront: 0, baseCount: 1,
+            messages: [Wire.ChatMessage(beamId: 2, content: .assistant(text: "more"))]
+        ))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(gui.agentChatState.messages.isEmpty)
+        #expect(results == [.rejected(
+            generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0,
+            reason: .resourcePolicy
+        )])
+    }
+
+    @Test("resource failure in a later packet terminally rejects the open frame")
+    @MainActor func crossPacketResourceFailureIsTerminal() throws {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        var requested: [UInt32] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+        dispatcher.onRequestKeyframe = { requested.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("last-good.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
+        dispatcher.decodedFrameFailed(DecodedFrameFailure(
+            error: .resource(.limitExceeded(
+                dimension: .ownedUTF8Bytes, used: 4, requested: 8, limit: 5
+            )),
+            envelope: nil
+        ))
+
+        #expect(gui.tabBarState.tabs.first?.label == "last-good.ex")
+        #expect(requested.isEmpty)
+        #expect(results.last == .rejected(
+            generation: 1, frameSeq: 2, lastAppliedFrameSeq: 1,
+            reason: .resourcePolicy
+        ))
     }
 
     @Test("semantic staging rejects resident result weight before publication")

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -32,9 +32,9 @@ struct CommandDispatcherRoutingTests {
     // MARK: - Basic commands
 
     @Test("empty keyframe prunes retained windows and stale gutter globals")
-    @MainActor func emptyKeyframePrunesRetainedWindowState() {
+    @MainActor func emptyKeyframePrunesRetainedWindowState() throws {
         let (dispatcher, gui) = makeDispatcher()
-        gui.windowContents[1] = GUIWindowContent(
+        gui.windowContents[1] = try GUIWindowContent(
             windowId: 1, fullRefresh: false,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
@@ -68,9 +68,9 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("keyframe commit prunes stale window content, gutters, and indent guides")
-    @MainActor func keyframeCommitPrunesStaleWindowState() {
+    @MainActor func keyframeCommitPrunesStaleWindowState() throws {
         let (dispatcher, gui) = makeDispatcher()
-        gui.windowContents[2] = GUIWindowContent(
+        gui.windowContents[2] = try GUIWindowContent(
             windowId: 2, fullRefresh: false,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
@@ -89,7 +89,7 @@ struct CommandDispatcherRoutingTests {
 
         dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.dispatch(.guiWindowContent(data: try GUIWindowContent(
             windowId: 1, fullRefresh: false,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
@@ -117,14 +117,14 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("setCursorShape updates frameState cursor shape")
-    @MainActor func setCursorShapeCommand() {
+    @MainActor func setCursorShapeCommand() throws {
         let (dispatcher, _) = makeDispatcher()
         dispatcher.applyForTesting(.setCursorShape(.beam))
         #expect(dispatcher.frameState.cursorShape == .beam)
     }
 
     @Test("protocolError latches a blocking message on protocolErrorState")
-    @MainActor func protocolErrorRouting() {
+    @MainActor func protocolErrorRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         #expect(gui.protocolErrorState.isPresented == false)
 
@@ -135,7 +135,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("setWindowBg updates frameState defaultBg")
-    @MainActor func setWindowBgCommand() {
+    @MainActor func setWindowBgCommand() throws {
         let (dispatcher, _) = makeDispatcher()
         dispatcher.applyForTesting(.setWindowBg(r: 0x28, g: 0x2C, b: 0x34))
         let expected: UInt32 = (0x28 << 16) | (0x2C << 8) | 0x34
@@ -145,7 +145,7 @@ struct CommandDispatcherRoutingTests {
     // MARK: - View-driven FrameState mutations
 
     @Test("applyViewportResize writes grid dimensions and marks dirty")
-    @MainActor func applyViewportResizeUpdatesGrid() {
+    @MainActor func applyViewportResizeUpdatesGrid() throws {
         let (dispatcher, _) = makeDispatcher()
         // Clear the dirty flag set at init so we can assert the resize sets it.
         dispatcher.markRendered()
@@ -160,7 +160,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("applyViewportResize is a no-op when dimensions are unchanged")
-    @MainActor func applyViewportResizeNoOp() {
+    @MainActor func applyViewportResizeNoOp() throws {
         let (dispatcher, _) = makeDispatcher()
         // Dispatcher starts at 80x24 (see makeDispatcher).
         dispatcher.markRendered()
@@ -174,7 +174,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("markRendered clears the dirty flag the view consumed")
-    @MainActor func markRenderedClearsDirty() {
+    @MainActor func markRenderedClearsDirty() throws {
         let (dispatcher, _) = makeDispatcher()
         dispatcher.applyViewportResize(newCols: 100, newRows: 30)
         #expect(dispatcher.frameState.dirty == true)
@@ -187,7 +187,7 @@ struct CommandDispatcherRoutingTests {
     // MARK: - GUI chrome routing
 
     @Test("guiTabBar updates tabBarState")
-    @MainActor func guiTabBarRouting() {
+    @MainActor func guiTabBarRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         let tabs = [
             Wire.TabEntry(id: 1, groupId: 0, isActive: true, isDirty: false, isAgent: false,
@@ -201,7 +201,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiObservatory updates observatoryState")
-    @MainActor func guiObservatoryRouting() {
+    @MainActor func guiObservatoryRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         let nodes = [Wire.ObservatoryNode(pid: "<0.1.0>", parentPid: "", name: "Minga.Supervisor", processClass: 0, depth: 0, memory: 1024, messageQueueLen: 0, reductions: 10, sparkline: [0, 0.5])]
 
@@ -214,7 +214,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiObservatory hidden payload hides observatoryState")
-    @MainActor func guiObservatoryHiddenRouting() {
+    @MainActor func guiObservatoryHiddenRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         let nodes = [Wire.ObservatoryNode(pid: "<0.1.0>", parentPid: "", name: "Minga.Supervisor", processClass: 0, depth: 0, memory: 1024, messageQueueLen: 0, reductions: 10, sparkline: [])]
         dispatcher.applyForTesting(.guiObservatory(visible: true, nodeCount: 1, nodes: nodes))
@@ -226,7 +226,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiFileTree updates fileTreeState when entries present")
-    @MainActor func guiFileTreeRouting() {
+    @MainActor func guiFileTreeRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         let entries = [wireFileTreeEntry(pathHash: 123, isDir: true, isExpanded: true, id: "/project/lib", path: "/project/lib", name: "lib", relPath: "lib")]
         dispatcher.applyForTesting(.guiFileTree(version: 2, treeFlags: 0x03, treeState: 3, selectedId: "/project/lib", treeWidth: 30,
@@ -241,7 +241,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiFileTreeSelection updates selection and focus without replacing entries")
-    @MainActor func guiFileTreeSelectionRouting() {
+    @MainActor func guiFileTreeSelectionRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         let entries = [
             wireFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
@@ -264,7 +264,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiFileTreeSelection ignores unknown selected id without clearing selection")
-    @MainActor func guiFileTreeSelectionIgnoresUnknownId() {
+    @MainActor func guiFileTreeSelectionIgnoresUnknownId() throws {
         let (dispatcher, gui) = makeDispatcher()
         let entries = [
             wireFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a")
@@ -282,7 +282,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("file tree local navigation preview moves selection when eligible")
-    @MainActor func fileTreeLocalNavigationPreviewMovesSelectionWhenEligible() {
+    @MainActor func fileTreeLocalNavigationPreviewMovesSelectionWhenEligible() throws {
         let (dispatcher, gui) = makeDispatcher()
         let entries = [
             wireFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
@@ -301,7 +301,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("file tree local navigation preview is disabled without BEAM eligibility flag")
-    @MainActor func fileTreeLocalNavigationPreviewRequiresEligibilityFlag() {
+    @MainActor func fileTreeLocalNavigationPreviewRequiresEligibilityFlag() throws {
         let (dispatcher, gui) = makeDispatcher()
         let entries = [
             wireFileTreeEntry(pathHash: 1, isSelected: true, isFocused: true, id: "/project/a", path: "/project/a", name: "a", relPath: "a"),
@@ -320,7 +320,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiFileTree hides when explicit tree state is hidden")
-    @MainActor func guiFileTreeHidesOnHiddenState() {
+    @MainActor func guiFileTreeHidesOnHiddenState() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiFileTree(version: 2, treeFlags: 0x01, treeState: 3, selectedId: "/project/a", treeWidth: 30,
                                           rootPath: "/project", errorReason: "",
@@ -334,7 +334,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiFileTree clears project root when hidden payload has no root")
-    @MainActor func guiFileTreeClearsRootOnHiddenPayload() {
+    @MainActor func guiFileTreeClearsRootOnHiddenPayload() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiFileTree(version: 2, treeFlags: 0x01, treeState: 3, selectedId: "/project/a", treeWidth: 30,
                                           rootPath: "/project", errorReason: "",
@@ -348,7 +348,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiFileTree keeps an empty visible tree open")
-    @MainActor func guiFileTreeKeepsEmptyVisibleTreeOpen() {
+    @MainActor func guiFileTreeKeepsEmptyVisibleTreeOpen() throws {
         let (dispatcher, gui) = makeDispatcher()
 
         dispatcher.applyForTesting(.guiFileTree(version: 2, treeFlags: 0x11, treeState: 2, selectedId: "", treeWidth: 30,
@@ -361,7 +361,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiFileTree preserves loading and error states with empty entries")
-    @MainActor func guiFileTreePreservesLoadingAndErrorStates() {
+    @MainActor func guiFileTreePreservesLoadingAndErrorStates() throws {
         let (dispatcher, gui) = makeDispatcher()
 
         dispatcher.applyForTesting(.guiFileTree(version: 2, treeFlags: 0x01, treeState: 1, selectedId: "", treeWidth: 30,
@@ -377,7 +377,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiGitStatus updates state when repo has entries")
-    @MainActor func guiGitStatusRouting() {
+    @MainActor func guiGitStatusRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         let rawEntries = [
             Wire.GitStatusEntry(pathHash: 12345, section: 1, status: 1, path: "lib/editor.ex")
@@ -394,7 +394,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiGitStatus hides when notARepo with empty entries (panel closed signal)")
-    @MainActor func guiGitStatusHidesOnClearSignal() {
+    @MainActor func guiGitStatusHidesOnClearSignal() throws {
         let (dispatcher, gui) = makeDispatcher()
         // First show it with real data
         let rawEntries = [
@@ -414,7 +414,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiGitStatus keeps unknown git status entries")
-    @MainActor func guiGitStatusKeepsUnknownStatus() {
+    @MainActor func guiGitStatusKeepsUnknownStatus() throws {
         let (dispatcher, gui) = makeDispatcher()
         let rawEntries = [
             Wire.GitStatusEntry(pathHash: 12345, section: 1, status: 0, path: "lib/unknown.ex"),
@@ -429,7 +429,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiGitStatus drops entries with invalid sections")
-    @MainActor func guiGitStatusDropsInvalidSections() {
+    @MainActor func guiGitStatusDropsInvalidSections() throws {
         let (dispatcher, gui) = makeDispatcher()
         let rawEntries = [
             Wire.GitStatusEntry(pathHash: 12345, section: 99, status: 1, path: "lib/bad-section.ex")
@@ -441,7 +441,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiGitStatus shows not-a-repo panel when BEAM sends a project root")
-    @MainActor func guiGitStatusShowsNotARepoPanel() {
+    @MainActor func guiGitStatusShowsNotARepoPanel() throws {
         let (dispatcher, gui) = makeDispatcher()
 
         dispatcher.applyForTesting(.guiGitStatus(repoState: 1, syncing: false, ahead: 0, behind: 0,
@@ -453,7 +453,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiGitStatus shows panel for normal repo with clean working tree")
-    @MainActor func guiGitStatusShowsCleanRepo() {
+    @MainActor func guiGitStatusShowsCleanRepo() throws {
         let (dispatcher, gui) = makeDispatcher()
         // Normal repo (0) with zero entries is a clean working tree, NOT
         // a hide signal. Only notARepo + empty triggers hide.
@@ -464,7 +464,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiGitStatus preserves toast message when metadata is unknown")
-    @MainActor func guiGitStatusToastFallback() {
+    @MainActor func guiGitStatusToastFallback() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiGitStatus(repoState: 0, syncing: false, ahead: 0, behind: 0,
                                            branchName: "main", entries: [], toast: (message: "Remote failed", level: 99, action: 99), entryBasePath: "", lastCommitMessage: "", stashCount: 0))
@@ -482,7 +482,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiCompletion visible updates completionState")
-    @MainActor func guiCompletionVisible() {
+    @MainActor func guiCompletionVisible() throws {
         let (dispatcher, gui) = makeDispatcher()
         let items = [Wire.CompletionItem(kind: 1, label: "def", detail: "keyword")]
         dispatcher.applyForTesting(.guiCompletion(visible: true, anchorRow: 5, anchorCol: 10,
@@ -495,7 +495,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiCompletion hidden clears completionState")
-    @MainActor func guiCompletionHidden() {
+    @MainActor func guiCompletionHidden() throws {
         let (dispatcher, gui) = makeDispatcher()
         // Show then hide
         let items = [Wire.CompletionItem(kind: 1, label: "def", detail: "keyword")]
@@ -510,7 +510,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiWhichKey visible updates whichKeyState")
-    @MainActor func guiWhichKeyVisible() {
+    @MainActor func guiWhichKeyVisible() throws {
         let (dispatcher, gui) = makeDispatcher()
         let bindings = [Wire.WhichKeyBinding(kind: 0, key: "f", description: "Find file", icon: "")]
         dispatcher.applyForTesting(.guiWhichKey(visible: true, prefix: "SPC",
@@ -522,7 +522,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiWhichKey hidden clears whichKeyState")
-    @MainActor func guiWhichKeyHidden() {
+    @MainActor func guiWhichKeyHidden() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiWhichKey(visible: false, prefix: "", page: 0,
                                           pageCount: 0, bindings: []))
@@ -530,7 +530,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiStatusBar updates statusBarState and clears safeMode")
-    @MainActor func guiStatusBarRouting() {
+    @MainActor func guiStatusBarRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiStatusBar(StatusBarUpdate(contentKind: 0, mode: 1, cursorLine: 42,
                                            cursorCol: 9, lineCount: 500, flags: 0x0B, safeMode: true,
@@ -586,7 +586,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiStatusBar agent variant populates background buffer fields")
-    @MainActor func guiStatusBarAgentRouting() {
+    @MainActor func guiStatusBarAgentRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiStatusBar(StatusBarUpdate(contentKind: 1, mode: 0, cursorLine: 11,
                                            cursorCol: 6, lineCount: 100, flags: 0x03,
@@ -619,7 +619,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiBreadcrumb updates breadcrumbState")
-    @MainActor func guiBreadcrumbRouting() {
+    @MainActor func guiBreadcrumbRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiBreadcrumb(segments: ["lib", "minga", "editor.ex"]))
 
@@ -627,7 +627,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiPicker visible updates pickerState")
-    @MainActor func guiPickerVisible() {
+    @MainActor func guiPickerVisible() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiPicker(visible: true, selectedIndex: 0, filteredCount: 5,
                                         totalCount: 100, markedCount: 2, title: "Find File", query: "edi",
@@ -641,7 +641,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiPicker hidden clears pickerState")
-    @MainActor func guiPickerHidden() {
+    @MainActor func guiPickerHidden() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiPicker(visible: true, selectedIndex: 0, filteredCount: 5,
                                         totalCount: 100, markedCount: 2, title: "Find File", query: "edi",
@@ -657,7 +657,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiAgentChat updates chrome but ignores its 0x78 messages section")
-    @MainActor func guiAgentChatVisible() {
+    @MainActor func guiAgentChatVisible() throws {
         let (dispatcher, gui) = makeDispatcher()
         // The 0x78 messages section is intentionally ignored (#2654 slice 2): the
         // resident transcript is sourced from the 0x86 stream, not from here.
@@ -676,7 +676,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiAgentTranscript populates agentChatState messages")
-    @MainActor func guiAgentTranscriptPopulatesMessages() {
+    @MainActor func guiAgentTranscriptPopulatesMessages() throws {
         let (dispatcher, gui) = makeDispatcher()
         // Chrome frame first (visible), then the resident transcript stream.
         dispatcher.applyForTesting(.guiAgentChat(visible: true, status: 1, model: "claude",
@@ -695,7 +695,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiAgentChat hidden clears agentChatState")
-    @MainActor func guiAgentChatHidden() {
+    @MainActor func guiAgentChatHidden() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiAgentChat(visible: false, status: 0, model: "",
                                            thinkingLevel: "", prompt: "", promptLineCount: 1,
@@ -709,7 +709,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiBottomPanel visible updates bottomPanelState and appends entries")
-    @MainActor func guiBottomPanelVisible() {
+    @MainActor func guiBottomPanelVisible() throws {
         let (dispatcher, gui) = makeDispatcher()
         let tabs = [Wire.BottomPanelTab(tabType: 0, name: "Messages")]
         let entries = [Wire.MessageEntry(streamInstance: 1, id: 1, level: 1, subsystem: 0,
@@ -724,7 +724,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiBottomPanel hidden hides bottomPanelState")
-    @MainActor func guiBottomPanelHidden() {
+    @MainActor func guiBottomPanelHidden() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiBottomPanel(visible: false, activeTabIndex: 0,
                                              heightPercent: 30, filterPreset: 0,
@@ -733,7 +733,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiToolManager visible updates toolManagerState")
-    @MainActor func guiToolManagerVisible() {
+    @MainActor func guiToolManagerVisible() throws {
         let (dispatcher, gui) = makeDispatcher()
         let tools = [Wire.ToolEntry(name: "elixir_ls", label: "ElixirLS",
                                   description: "LSP", category: 0, status: 1,
@@ -749,7 +749,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiToolManager hidden clears toolManagerState")
-    @MainActor func guiToolManagerHidden() {
+    @MainActor func guiToolManagerHidden() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.applyForTesting(.guiToolManager(visible: false, filter: 0,
                                              selectedIndex: 0, tools: []))
@@ -758,9 +758,9 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiWindowContent stores content in guiState")
-    @MainActor func guiWindowContentRouting() {
+    @MainActor func guiWindowContentRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: true,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -774,7 +774,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("reset-required scroll presentation clears local smooth-scroll state once per promoted frame")
-    @MainActor func resetRequiredScrollPresentationClearsLocalStateOnce() {
+    @MainActor func resetRequiredScrollPresentationClearsLocalStateOnce() throws {
         let (dispatcher, gui) = makeDispatcher()
         var resetCount = 0
         dispatcher.onScrollPresentationReset = { resetCount += 1 }
@@ -793,7 +793,7 @@ struct CommandDispatcherRoutingTests {
             layoutGeneration: 77
         )
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -810,7 +810,7 @@ struct CommandDispatcherRoutingTests {
         )))
         #expect(resetCount == 1)
 
-        gui.windowContents[7] = GUIWindowContent(
+        gui.windowContents[7] = try GUIWindowContent(
             windowId: 7, fullRefresh: false, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -840,7 +840,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("layoutGeneration-only change fires scroll presentation discard")
-    @MainActor func layoutGenerationChangeFiresDiscard() {
+    @MainActor func layoutGenerationChangeFiresDiscard() throws {
         let (dispatcher, _) = makeDispatcher()
         var discardCount = 0
         dispatcher.onScrollPresentationReset = { discardCount += 1 }
@@ -853,7 +853,7 @@ struct CommandDispatcherRoutingTests {
             contentEpoch: 42, layoutGeneration: 1
         )
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -871,7 +871,7 @@ struct CommandDispatcherRoutingTests {
             contentEpoch: 42, layoutGeneration: 2
         )
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -883,7 +883,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("identical anchor key does not fire scroll presentation discard")
-    @MainActor func identicalAnchorKeyDoesNotDiscard() {
+    @MainActor func identicalAnchorKeyDoesNotDiscard() throws {
         let (dispatcher, _) = makeDispatcher()
         var discardCount = 0
         dispatcher.onScrollPresentationReset = { discardCount += 1 }
@@ -896,7 +896,7 @@ struct CommandDispatcherRoutingTests {
             contentEpoch: 42, layoutGeneration: 1
         )
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -906,7 +906,7 @@ struct CommandDispatcherRoutingTests {
         )))
         #expect(discardCount == 0)
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 6, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -918,7 +918,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("identical anchor key with a newer scroll_seq still fires discard (#2661 race case)")
-    @MainActor func newerScrollSeqDiscardsEvenWithSameAnchorKey() {
+    @MainActor func newerScrollSeqDiscardsEvenWithSameAnchorKey() throws {
         let (dispatcher, _) = makeDispatcher()
         var discardCount = 0
         dispatcher.onScrollPresentationReset = { discardCount += 1 }
@@ -931,7 +931,7 @@ struct CommandDispatcherRoutingTests {
             contentEpoch: 42, layoutGeneration: 1, scrollSeq: 3
         )
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -953,7 +953,7 @@ struct CommandDispatcherRoutingTests {
             contentEpoch: 42, layoutGeneration: 1, scrollSeq: 4
         )
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -965,7 +965,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("an unchanged or lower scroll_seq with the same anchor key does not discard")
-    @MainActor func unchangedScrollSeqDoesNotDiscard() {
+    @MainActor func unchangedScrollSeqDoesNotDiscard() throws {
         let (dispatcher, _) = makeDispatcher()
         var discardCount = 0
         dispatcher.onScrollPresentationReset = { discardCount += 1 }
@@ -978,7 +978,7 @@ struct CommandDispatcherRoutingTests {
             contentEpoch: 42, layoutGeneration: 1, scrollSeq: 5
         )
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -991,7 +991,7 @@ struct CommandDispatcherRoutingTests {
         // Same scroll_seq: this is the routine echo-loop case (#2661) — the
         // wheel report kept the cursor inside scrolloff, so the BEAM committed
         // the same anchor and did not advance the authority sequence.
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -1003,7 +1003,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("anchorTop-only change fires scroll presentation discard")
-    @MainActor func anchorTopChangeFiresDiscard() {
+    @MainActor func anchorTopChangeFiresDiscard() throws {
         let (dispatcher, _) = makeDispatcher()
         var discardCount = 0
         dispatcher.onScrollPresentationReset = { discardCount += 1 }
@@ -1016,7 +1016,7 @@ struct CommandDispatcherRoutingTests {
             contentEpoch: 42, layoutGeneration: 1
         )
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -1034,7 +1034,7 @@ struct CommandDispatcherRoutingTests {
             contentEpoch: 42, layoutGeneration: 1
         )
 
-        dispatcher.applyForTesting(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .beam,
             rows: [], selection: nil,
@@ -1046,9 +1046,9 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiWindowOverlayDelta updates matching retained content")
-    @MainActor func guiWindowOverlayDeltaRouting() {
+    @MainActor func guiWindowOverlayDeltaRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
-        gui.windowContents[7] = GUIWindowContent(
+        gui.windowContents[7] = try GUIWindowContent(
             windowId: 7, fullRefresh: false, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .block,
             rows: [], selection: nil,
@@ -1072,9 +1072,9 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiWindowOverlayDelta clears retained cursorline when cursorline is omitted")
-    @MainActor func guiWindowOverlayDeltaClearsRetainedCursorline() {
+    @MainActor func guiWindowOverlayDeltaClearsRetainedCursorline() throws {
         let (dispatcher, gui) = makeDispatcher()
-        gui.windowContents[7] = GUIWindowContent(
+        gui.windowContents[7] = try GUIWindowContent(
             windowId: 7, fullRefresh: false, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .block,
             rows: [], selection: nil,
@@ -1097,9 +1097,9 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("stale guiWindowOverlayDelta is ignored without marking the window live")
-    @MainActor func staleGuiWindowOverlayDeltaIgnored() {
+    @MainActor func staleGuiWindowOverlayDeltaIgnored() throws {
         let (dispatcher, gui) = makeDispatcher()
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: false, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .block,
             rows: [], selection: nil,
@@ -1121,7 +1121,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiWindowOverlayDelta without retained content is ignored")
-    @MainActor func missingGuiWindowOverlayDeltaIgnored() {
+    @MainActor func missingGuiWindowOverlayDeltaIgnored() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.frameState.cursorVisible = true
 
@@ -1137,11 +1137,11 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiWindowRowsDelta updates retained rows and marks window live")
-    @MainActor func guiWindowRowsDeltaRouting() {
+    @MainActor func guiWindowRowsDeltaRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         let retained = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 11, text: "old", spans: [])
         let replacement = GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 1, contentHash: 22, text: "new", spans: [])
-        gui.windowContents[7] = GUIWindowContent(
+        gui.windowContents[7] = try GUIWindowContent(
             windowId: 7, fullRefresh: false, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .block,
             rows: [retained], selection: nil,
@@ -1174,10 +1174,10 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiWindowViewportDelta updates retained rows and marks window live")
-    @MainActor func guiWindowViewportDeltaRouting() {
+    @MainActor func guiWindowViewportDeltaRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         let retained = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 11, text: "old", spans: [])
-        gui.windowContents[7] = GUIWindowContent(
+        gui.windowContents[7] = try GUIWindowContent(
             windowId: 7, fullRefresh: false, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .block,
             rows: [retained], selection: nil,
@@ -1210,10 +1210,10 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("stale guiWindowRowsDelta is ignored without clearing current content")
-    @MainActor func staleGuiWindowRowsDeltaIgnored() {
+    @MainActor func staleGuiWindowRowsDeltaIgnored() throws {
         let (dispatcher, gui) = makeDispatcher()
         let retained = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 11, text: "old", spans: [])
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: false, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .block,
             rows: [retained], selection: nil,
@@ -1245,10 +1245,10 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiWindowRowsDelta missing retained ref clears content for full-refresh recovery")
-    @MainActor func guiWindowRowsDeltaMissingRefClearsContent() {
+    @MainActor func guiWindowRowsDeltaMissingRefClearsContent() throws {
         let (dispatcher, gui) = makeDispatcher()
         let retained = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 11, text: "old", spans: [])
-        gui.windowContents[7] = GUIWindowContent(
+        gui.windowContents[7] = try GUIWindowContent(
             windowId: 7, fullRefresh: false, contentEpoch: 42,
             cursorRow: 5, cursorCol: 10, cursorShape: .block,
             rows: [retained], selection: nil,
@@ -1279,7 +1279,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiGutterSeparator updates frameState gutter state")
-    @MainActor func guiGutterSepRouting() {
+    @MainActor func guiGutterSepRouting() throws {
         let (dispatcher, _) = makeDispatcher()
         dispatcher.applyForTesting(.guiGutterSeparator(col: 4, r: 0x3F, g: 0x44, b: 0x4A))
 
@@ -1289,7 +1289,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiCursorline updates frameState cursorline state")
-    @MainActor func guiCursorlineRouting() {
+    @MainActor func guiCursorlineRouting() throws {
         let (dispatcher, _) = makeDispatcher()
         dispatcher.applyForTesting(.guiCursorline(row: 12, r: 0x2C, g: 0x32, b: 0x3C))
 
@@ -1299,7 +1299,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiGutter stores gutter data in frameState")
-    @MainActor func guiGutterRouting() {
+    @MainActor func guiGutterRouting() throws {
         let (dispatcher, _) = makeDispatcher()
         let gutter = Wire.WindowGutter(
             windowId: 1, contentRow: 0, contentCol: 5, contentHeight: 24,
@@ -1315,7 +1315,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("guiHoverPopup exposes lines after scroll offset")
-    @MainActor func guiHoverPopupScrollOffset() {
+    @MainActor func guiHoverPopupScrollOffset() throws {
         let (dispatcher, gui) = makeDispatcher()
         let lines = [
             Wire.HoverLine(lineType: .text, segments: [Wire.HoverSegment(style: .plain, fgColor: nil, flags: 0, text: "one")]),
@@ -1333,7 +1333,7 @@ struct CommandDispatcherRoutingTests {
     // MARK: - Batch lifecycle
 
     @Test("commitFrame fires onFirstRender once then clears it")
-    @MainActor func commitFrameFiresFirstRenderOnce() {
+    @MainActor func commitFrameFiresFirstRenderOnce() throws {
         let (dispatcher, _) = makeDispatcher()
         var callCount = 0
         dispatcher.onFirstRender = { callCount += 1 }
@@ -1354,7 +1354,7 @@ struct CommandDispatcherRoutingTests {
     // MARK: - Theme
 
     @Test("guiTheme updates themeColors and syncs to frameState")
-    @MainActor func guiThemeRouting() {
+    @MainActor func guiThemeRouting() throws {
         let (dispatcher, gui) = makeDispatcher()
         let slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)] = [
             (GUI_COLOR_GUTTER_FG, 0xAA, 0xBB, 0xCC)
@@ -1369,7 +1369,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("keyframe with content but no guiTheme returns a typed rejection")
-    @MainActor func keyframeWithoutThemeErrors() {
+    @MainActor func keyframeWithoutThemeErrors() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
@@ -1384,7 +1384,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("keyframe with empty guiTheme rejects promotion")
-    @MainActor func keyframeWithEmptyThemeErrors() {
+    @MainActor func keyframeWithEmptyThemeErrors() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
@@ -1405,7 +1405,7 @@ struct CommandDispatcherRoutingTests {
     }
 
     @Test("keyframe with partial guiTheme rejects promotion")
-    @MainActor func keyframeWithPartialThemeErrors() {
+    @MainActor func keyframeWithPartialThemeErrors() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
@@ -1449,7 +1449,7 @@ struct CommandDispatcherStagingTests {
                       icon: "", label: label)
     }
 
-    private func windowContent(windowId: UInt16 = 7, epoch: UInt32 = 42, fontId: UInt8 = 0) -> GUIWindowContent {
+    private func windowContent(windowId: UInt16 = 7, epoch: UInt32 = 42, fontId: UInt8 = 0) throws -> GUIWindowContent {
         let span = GUIHighlightSpan(
             startCol: 0, endCol: 3, fg: 0xFFFFFF, bg: 0,
             attrs: 0, fontWeight: 0, fontId: fontId
@@ -1458,7 +1458,7 @@ struct CommandDispatcherStagingTests {
             rowType: .normal, rowId: 1, bufLine: 0,
             contentHash: 11, text: "old", spans: [span]
         )
-        return GUIWindowContent(
+        return try GUIWindowContent(
             windowId: windowId, fullRefresh: true, contentEpoch: epoch,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [row], selection: nil, searchMatches: [],
@@ -1476,7 +1476,7 @@ struct CommandDispatcherStagingTests {
     // MARK: - Nothing paints between begin and commit
 
     @Test("observable GUIState is unchanged between begin and a partial frame")
-    @MainActor func guiStateUnchangedMidTransaction() {
+    @MainActor func guiStateUnchangedMidTransaction() throws {
         let (dispatcher, gui) = makeDispatcher()
 
         // Establish a committed baseline so we have a "presented" tab bar.
@@ -1495,7 +1495,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("observable FrameState is unchanged between begin and a partial frame")
-    @MainActor func frameStateUnchangedMidTransaction() {
+    @MainActor func frameStateUnchangedMidTransaction() throws {
         let (dispatcher, _) = makeDispatcher()
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
@@ -1513,7 +1513,7 @@ struct CommandDispatcherStagingTests {
     // MARK: - Commit promotes atomically
 
     @Test("commit promotes all staged commands in one batch")
-    @MainActor func commitPromotesStagedCommands() {
+    @MainActor func commitPromotesStagedCommands() throws {
         let (dispatcher, gui) = makeDispatcher()
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
@@ -1533,7 +1533,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("onFrameReady fires only at commit, not on staged commands")
-    @MainActor func frameReadyFiresAtCommit() {
+    @MainActor func frameReadyFiresAtCommit() throws {
         let (dispatcher, _) = makeDispatcher()
         var readyCount = 0
         dispatcher.onFrameReady = { readyCount += 1 }
@@ -1550,7 +1550,7 @@ struct CommandDispatcherStagingTests {
     // MARK: - Delta-base validation
 
     @Test("delta frame committing against the last committed seq promotes cleanly")
-    @MainActor func deltaBaseMatchesCommits() {
+    @MainActor func deltaBaseMatchesCommits() throws {
         let (dispatcher, gui) = makeDispatcher()
 
         dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0, generation: 1))
@@ -1568,7 +1568,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("delta frame with empty guiTheme rejects promotion")
-    @MainActor func deltaFrameWithEmptyThemeErrors() {
+    @MainActor func deltaFrameWithEmptyThemeErrors() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
@@ -1597,7 +1597,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("delta frame with partial guiTheme rejects promotion")
-    @MainActor func deltaFrameWithPartialThemeErrors() {
+    @MainActor func deltaFrameWithPartialThemeErrors() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
@@ -1628,7 +1628,7 @@ struct CommandDispatcherStagingTests {
     // MARK: - Invalidation requests a keyframe with no partial promotion
 
     @Test("commit seq mismatch invalidates with no promotion and requests keyframe")
-    @MainActor func seqMismatchInvalidates() {
+    @MainActor func seqMismatchInvalidates() throws {
         let (dispatcher, gui) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -1655,7 +1655,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("pending resync debounces further keyframe requests until a valid commit")
-    @MainActor func resyncDebouncesRequests() {
+    @MainActor func resyncDebouncesRequests() throws {
         let (dispatcher, gui) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -1683,7 +1683,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("a stale delta commit does not clear a pending resync")
-    @MainActor func staleDeltaDoesNotClearPendingResync() {
+    @MainActor func staleDeltaDoesNotClearPendingResync() throws {
         let (dispatcher, gui) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -1708,7 +1708,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("invalidating a requested keyframe sends one replacement request")
-    @MainActor func failedKeyframeRequestsReplacement() {
+    @MainActor func failedKeyframeRequestsReplacement() throws {
         let (dispatcher, gui) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -1732,7 +1732,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("double begin (truncation) invalidates the open frame and requests keyframe")
-    @MainActor func doubleBeginTruncates() {
+    @MainActor func doubleBeginTruncates() throws {
         let (dispatcher, gui) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -1751,7 +1751,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("base mismatch invalidates without promotion")
-    @MainActor func baseMismatchInvalidates() {
+    @MainActor func baseMismatchInvalidates() throws {
         let (dispatcher, gui) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -1773,7 +1773,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("commit with no open begin invalidates and requests keyframe")
-    @MainActor func commitWithoutBeginInvalidates() {
+    @MainActor func commitWithoutBeginInvalidates() throws {
         let (dispatcher, _) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -1783,7 +1783,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("decodeFailed inside an open transaction invalidates and requests keyframe")
-    @MainActor func decodeFailureInsideTransactionInvalidates() {
+    @MainActor func decodeFailureInsideTransactionInvalidates() throws {
         let (dispatcher, gui) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -1803,7 +1803,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("a clean commit after a resync clears the pending hint")
-    @MainActor func cleanCommitClearsResyncHint() {
+    @MainActor func cleanCommitClearsResyncHint() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.onRequestKeyframe = { _ in }
 
@@ -1825,10 +1825,10 @@ struct CommandDispatcherStagingTests {
     // MARK: - Prepared transaction publication contract (#2747)
 
     @Test("prepared publication is equivalent to the direct command fixture")
-    @MainActor func preparedPublicationEquivalence() {
+    @MainActor func preparedPublicationEquivalence() throws {
         let (direct, directGUI) = makeDispatcher()
         let (prepared, preparedGUI) = makeDispatcher()
-        let content = windowContent()
+        let content = try windowContent()
         let commands: [RenderCommand] = [
             .guiTheme(slots: completeThemeSlots()),
             .guiWindowContent(data: content),
@@ -1848,14 +1848,14 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("one valid frame enters the publication boundary exactly once")
-    @MainActor func onePublicationPerFrame() {
+    @MainActor func onePublicationPerFrame() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: windowContent()))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("prepared.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
@@ -1867,7 +1867,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("applied follows semantic publication and does not wait for Metal presentation")
-    @MainActor func appliedAtSemanticBoundary() {
+    @MainActor func appliedAtSemanticBoundary() throws {
         let (dispatcher, gui) = makeDispatcher()
         var readyCount = 0
         var publicationSeenByApplied = false
@@ -1888,7 +1888,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("one aggregate observation callback sees all sibling domains committed")
-    @MainActor func aggregateObservationIsAtomic() {
+    @MainActor func aggregateObservationIsAtomic() throws {
         let (dispatcher, gui) = makeDispatcher()
         let notificationCount = Mutex(0)
 
@@ -1920,7 +1920,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("gutter and indent guide keys cannot collide across window ids")
-    @MainActor func typedWindowCoalescingKeysDoNotCollide() {
+    @MainActor func typedWindowCoalescingKeysDoNotCollide() throws {
         let (dispatcher, _) = makeDispatcher()
         let gutter = Wire.WindowGutter(
             windowId: 1001, contentRow: 0, contentCol: 4, contentHeight: 1,
@@ -1934,8 +1934,8 @@ struct CommandDispatcherStagingTests {
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: windowContent(windowId: 1001)))
-        dispatcher.dispatch(.guiWindowContent(data: windowContent(windowId: 1)))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent(windowId: 1001)))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent(windowId: 1)))
         dispatcher.dispatch(.guiGutter(data: gutter))
         dispatcher.dispatch(.guiIndentGuides(data: guides))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
@@ -1945,7 +1945,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("terminal resource-policy rejection preserves committed state and emits once")
-    @MainActor func terminalResourcePolicyRejectionPreservesLastGood() {
+    @MainActor func terminalResourcePolicyRejectionPreservesLastGood() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         var requested: [UInt32] = []
@@ -1988,8 +1988,83 @@ struct CommandDispatcherStagingTests {
         #expect(results.last == .applied(generation: 1, frameSeq: 3))
     }
 
+    @Test("semantic staging rejects resident result weight before publication")
+    @MainActor func residentWeightRejectsBeforePublication() throws {
+        let defaults = FrameResourcePolicy.default
+        let residentLimit = FrameResourceWeight(
+            commands: .max, ownedUTF8Bytes: .max, arrayEntries: .max,
+            rows: 1, spans: .max, overlays: .max,
+            spliceEntries: .max, locatorEntries: 1
+        )
+        let policy = FrameResourcePolicy(
+            wire: defaults.wire,
+            decode: defaults.decode,
+            staging: defaults.staging,
+            resident: .init(weightPerWindow: residentLimit)
+        )
+        let gui = GUIState()
+        let dispatcher = CommandDispatcher(
+            cols: 80, rows: 24, guiState: gui, resourcePolicy: policy
+        )
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+        let content = try GUIWindowContent(
+            windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0,
+            cursorShape: .block,
+            rows: [
+                GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0,
+                             contentHash: 1, text: "one", spans: []),
+                GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 1,
+                             contentHash: 2, text: "two", spans: [])
+            ],
+            selection: nil, searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: content))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(gui.windowContents.isEmpty)
+        #expect(results == [.rejected(
+            generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0,
+            reason: .resourcePolicy
+        )])
+    }
+
+    @Test("correlated decode rejection is terminal, deduplicated, and preserves last-good")
+    @MainActor func correlatedDecodeResourceRejection() throws {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        var requested: [UInt32] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+        dispatcher.onRequestKeyframe = { requested.append($0) }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 4))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("last-good.ex")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        let envelope = FrameEnvelope(generation: 4, frameSeq: 2, baseFrameSeq: 1)
+        dispatcher.resourcePolicyRejected(envelope: envelope)
+        dispatcher.resourcePolicyRejected(envelope: envelope)
+
+        #expect(dispatcher.lastCommittedFrameSeq == 1)
+        #expect(gui.tabBarState.tabs.first?.label == "last-good.ex")
+        #expect(gui.resyncState.pending == false)
+        #expect(requested.isEmpty)
+        #expect(results == [
+            .applied(generation: 4, frameSeq: 1),
+            .rejected(
+                generation: 4, frameSeq: 2, lastAppliedFrameSeq: 1,
+                reason: .resourcePolicy
+            )
+        ])
+    }
+
     @Test("a later invalid domain rejects the whole frame without publication")
-    @MainActor func partialFrameRejectionPublishesNothing() {
+    @MainActor func partialFrameRejectionPublishesNothing() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
@@ -2007,7 +2082,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("invalid transcript operations reject without publishing sibling state")
-    @MainActor func invalidTranscriptRejectsWholeTransaction() {
+    @MainActor func invalidTranscriptRejectsWholeTransaction() throws {
         let invalidCommands: [(RenderCommand, PreparedFrameRejection)] = [
             (
                 .guiAgentTranscript(mode: 1, epoch: 1, truncated: false, trimFront: 0, baseCount: 0, messages: []),
@@ -2056,7 +2131,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("duplicate and out-of-order frame sequences return typed rejections")
-    @MainActor func duplicateAndOutOfOrderFramesReject() {
+    @MainActor func duplicateAndOutOfOrderFramesReject() throws {
         for incoming: UInt32 in [5, 4] {
             let (dispatcher, _) = makeDispatcher()
             var results: [FrameTransactionResult] = []
@@ -2075,14 +2150,14 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("missing window references and stale epochs reject before publication")
-    @MainActor func windowReferenceAndEpochValidation() {
+    @MainActor func windowReferenceAndEpochValidation() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: windowContent()))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
         dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
@@ -2094,40 +2169,33 @@ struct CommandDispatcherStagingTests {
         #expect(gui.windowContents[7]?.cursorShape == .block)
     }
 
-    @Test("unsorted full content rejects without partial transaction publication")
-    @MainActor func unsortedContentIsTransactional() {
-        let (dispatcher, gui) = makeDispatcher()
-        var results: [FrameTransactionResult] = []
-        dispatcher.onTransactionResult = { results.append($0) }
+    @Test("unsorted full content fails before resident construction or publication")
+    @MainActor func unsortedContentIsTransactional() throws {
+        let (_, gui) = makeDispatcher()
         let high = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 2,
             contentHash: 11, text: "high", spans: [])
         let low = GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 1,
             contentHash: 22, text: "low", spans: [])
-        let unsorted = GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42,
-            cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [high, low], selection: nil,
-            searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
 
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
-        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: unsorted))
-        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
-
+        #expect(throws: ResidentRowStoreError.unsortedBufferLine(previous: 2, next: 1)) {
+            _ = try GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42,
+                cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [high, low],
+                selection: nil, searchMatches: [], diagnosticUnderlines: [],
+                documentHighlights: [])
+        }
         #expect(gui.framePublicationCount == 0)
         #expect(gui.windowContents.isEmpty)
-        #expect(results.last == .rejected(generation: 1, frameSeq: 1,
-            lastAppliedFrameSeq: 0,
-            reason: .invalidRetainedRows(windowId: 7, contentEpoch: 42)))
     }
 
     @Test("missing retained row reports targeted miss without partial publication")
-    @MainActor func missingRetainedRowIsTransactional() {
+    @MainActor func missingRetainedRowIsTransactional() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: windowContent()))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent()))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("baseline.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
@@ -2154,14 +2222,14 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("unregistered font resources reject a prepared frame")
-    @MainActor func missingFontResourceRejects() {
+    @MainActor func missingFontResourceRejects() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: windowContent(fontId: 3)))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent(fontId: 3)))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
         #expect(gui.framePublicationCount == 0)
@@ -2169,14 +2237,14 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("unregistered font resources in row splices reject a prepared frame")
-    @MainActor func missingSpliceFontResourceRejects() {
+    @MainActor func missingSpliceFontResourceRejects() throws {
         let (dispatcher, gui) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: windowContent()))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
         let replacement = GUIVisualRow(
@@ -2210,7 +2278,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("publication operation count depends on changed domains, not command count")
-    @MainActor func changedDomainOperationCount() {
+    @MainActor func changedDomainOperationCount() throws {
         let (dispatcher, gui) = makeDispatcher()
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
@@ -2238,7 +2306,7 @@ struct CommandDispatcherStagingTests {
     // This is the negative-guard pattern from Go's model.go applyCommands.
 
     @Test("set_title applies immediately with no open transaction")
-    @MainActor func titleAppliesOutOfBand() {
+    @MainActor func titleAppliesOutOfBand() throws {
         let (dispatcher, _) = makeDispatcher()
         var requested: [UInt32] = []
         var title: String?
@@ -2252,7 +2320,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("set_window_bg applies immediately with no open transaction")
-    @MainActor func windowBgAppliesOutOfBand() {
+    @MainActor func windowBgAppliesOutOfBand() throws {
         let (dispatcher, _) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -2265,7 +2333,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("protocol_error applies immediately with no open transaction")
-    @MainActor func protocolErrorAppliesOutOfBand() {
+    @MainActor func protocolErrorAppliesOutOfBand() throws {
         let (dispatcher, gui) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -2277,7 +2345,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("set_font applies immediately with no open transaction")
-    @MainActor func setFontAppliesOutOfBand() {
+    @MainActor func setFontAppliesOutOfBand() throws {
         let (dispatcher, _) = makeDispatcher()
         var requested: [UInt32] = []
         var fontArgs: (family: String, size: UInt16, ligatures: Bool, weight: UInt8)?
@@ -2296,7 +2364,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("set_font_fallback applies immediately with no open transaction")
-    @MainActor func setFontFallbackAppliesOutOfBand() {
+    @MainActor func setFontFallbackAppliesOutOfBand() throws {
         let (dispatcher, _) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -2309,7 +2377,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("register_font applies immediately with no open transaction")
-    @MainActor func registerFontAppliesOutOfBand() {
+    @MainActor func registerFontAppliesOutOfBand() throws {
         let (dispatcher, _) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -2322,7 +2390,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("gui_config_state applies immediately with no open transaction")
-    @MainActor func guiConfigStateAppliesOutOfBand() {
+    @MainActor func guiConfigStateAppliesOutOfBand() throws {
         let (dispatcher, _) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -2334,7 +2402,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("clipboard_write applies immediately with no open transaction")
-    @MainActor func clipboardWriteAppliesOutOfBand() {
+    @MainActor func clipboardWriteAppliesOutOfBand() throws {
         let (dispatcher, _) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -2347,7 +2415,7 @@ struct CommandDispatcherStagingTests {
     }
 
     @Test("non-sanctioned command outside a transaction triggers keyframe request, not silent drop")
-    @MainActor func chromeOutOfBandInvalidates() {
+    @MainActor func chromeOutOfBandInvalidates() throws {
         let (dispatcher, gui) = makeDispatcher()
         var requested: [UInt32] = []
         dispatcher.onRequestKeyframe = { requested.append($0) }
@@ -2429,7 +2497,7 @@ struct CommandDispatcherPresentationSampleTests {
     }
 
     @Test("a newer semantic frame discards the unsubmitted sample as superseded")
-    @MainActor func supersededSampleIsDiscarded() {
+    @MainActor func supersededSampleIsDiscarded() throws {
         let dispatcher = makeDispatcher()
         let first = dispatcher.latency.stamp()
         commit(dispatcher, frameSeq: 1, baseFrameSeq: 0, inputSeq: first)
@@ -2441,7 +2509,7 @@ struct CommandDispatcherPresentationSampleTests {
     }
 
     @Test("an unavailable surface discards rather than selects the pending sample")
-    @MainActor func unavailableSurfaceDiscardsPendingSample() {
+    @MainActor func unavailableSurfaceDiscardsPendingSample() throws {
         let dispatcher = makeDispatcher()
         let seq = dispatcher.latency.stamp()
         commit(dispatcher, frameSeq: 1, baseFrameSeq: 0, inputSeq: seq)

--- a/macos/Tests/MingaTests/ConformanceTranscriptTests.swift
+++ b/macos/Tests/MingaTests/ConformanceTranscriptTests.swift
@@ -277,7 +277,7 @@ struct ConformanceTranscriptTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
         let theme = CommandDispatcher.requiredThemeSlots.map { ($0, $0, $0, $0) }
-        let epochContent = GUIWindowContent(
+        let epochContent = try GUIWindowContent(
             windowId: 1, fullRefresh: true, contentEpoch: epoch,
             cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: originalRows,
             selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
@@ -355,7 +355,7 @@ struct ConformanceTranscriptTests {
             gui.framePublicationCount == committedPublication ? .staleDiscarded : .accepted
 
         dispatcher.dispatch(.beginFrame(frameSeq: 7, baseFrameSeq: 4, generation: staleGeneration))
-        dispatcher.dispatch(.guiWindowContent(data: GUIWindowContent(
+        dispatcher.dispatch(.guiWindowContent(data: try GUIWindowContent(
             windowId: 1, fullRefresh: true, contentEpoch: epoch,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [GUIVisualRow(rowType: .normal, rowId: 999, bufLine: 0,

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -9,7 +9,7 @@ import MingaProtocol
 @Suite("CoreTextMetalRenderer cursor geometry")
 struct CoreTextMetalRendererCursorTests {
     @Test("semantic window cursor overrides legacy frameState cursor")
-    func semanticCursorOverridesLegacyCursor() {
+    func semanticCursorOverridesLegacyCursor() throws {
         let cellW: Float = 7.5
         let displayCellH: Float = 16.0
         let scale: Float = 2.0
@@ -26,7 +26,7 @@ struct CoreTextMetalRendererCursorTests {
             lineNumberWidth: 4, signColWidth: 1, entries: []
         )
 
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 2, fullRefresh: true,
             cursorRow: 2, cursorCol: 10, cursorShape: .beam,
             scrollLeft: 3,
@@ -73,7 +73,7 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("boundary availability uses BEAM document position")
-    func boundaryAvailabilityUsesBeamDocumentPosition() {
+    func boundaryAvailabilityUsesBeamDocumentPosition() throws {
         let geometry = GUIPaneGeometry(
             windowId: 7,
             totalRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
@@ -85,7 +85,7 @@ struct CoreTextMetalRendererCursorTests {
             gutterMetrics: GUIGutterMetrics(lineNumberWidth: 1, signColWidth: 1),
             hitRegions: []
         )
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
             scrollLeft: 0, rows: [], selection: nil, searchMatches: [], diagnosticUnderlines: [],
             documentHighlights: [], lineAnnotations: [], paneGeometry: geometry, cursorline: nil,
@@ -125,7 +125,7 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("renderer row origin includes document visual row offset")
-    func rendererRowOriginIncludesDocumentVisualRowOffset() {
+    func rendererRowOriginIncludesDocumentVisualRowOffset() throws {
         let geometry = GUIPaneGeometry(
             windowId: 7,
             totalRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
@@ -137,7 +137,7 @@ struct CoreTextMetalRendererCursorTests {
             gutterMetrics: GUIGutterMetrics(lineNumberWidth: 1, signColWidth: 1),
             hitRegions: []
         )
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
             scrollLeft: 0,
             rows: [
@@ -161,8 +161,8 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("payload overscan preserves line-delta rows before viewport")
-    func payloadOverscanPreservesLineDeltaRowsBeforeViewport() {
-        let content = GUIWindowContent(
+    func payloadOverscanPreservesLineDeltaRowsBeforeViewport() throws {
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
             scrollLeft: 0,
             rows: [
@@ -185,8 +185,8 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("payload overscan counts wrapped visual rows before viewport")
-    func payloadOverscanCountsWrappedVisualRowsBeforeViewport() {
-        let content = GUIWindowContent(
+    func payloadOverscanCountsWrappedVisualRowsBeforeViewport() throws {
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
             scrollLeft: 0,
             rows: [
@@ -312,7 +312,7 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("pane vertical bounds use the pane text rect")
-    func paneVerticalBoundsUsePaneTextRect() {
+    func paneVerticalBoundsUsePaneTextRect() throws {
         let geometry = GUIPaneGeometry(
             windowId: 1,
             totalRect: GUICellRect(row: 2, col: 4, width: 10, height: 14),
@@ -324,7 +324,7 @@ struct CoreTextMetalRendererCursorTests {
             gutterMetrics: GUIGutterMetrics(lineNumberWidth: 4, signColWidth: 1),
             hitRegions: []
         )
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1,
             fullRefresh: true,
             cursorRow: 0,
@@ -547,8 +547,8 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("semantic block cursor at end of line renders over final character")
-    func semanticBlockCursorAtEndOfLineUsesFinalCharacterCell() {
-        let content = GUIWindowContent(
+    func semanticBlockCursorAtEndOfLineUsesFinalCharacterCell() throws {
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 4, cursorShape: .block,
             rows: [GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1, text: "this", spans: [])],
@@ -561,8 +561,8 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("semantic beam cursor at end of line keeps insertion point column")
-    func semanticBeamCursorAtEndOfLineKeepsInsertionPointColumn() {
-        let content = GUIWindowContent(
+    func semanticBeamCursorAtEndOfLineKeepsInsertionPointColumn() throws {
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 4, cursorShape: .beam,
             rows: [GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1, text: "this", spans: [])],
@@ -575,8 +575,8 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("semantic block cursor uses display width for wide characters")
-    func semanticBlockCursorUsesDisplayWidthForWideCharacters() {
-        let content = GUIWindowContent(
+    func semanticBlockCursorUsesDisplayWidthForWideCharacters() throws {
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 2, cursorShape: .block,
             rows: [GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1, text: "界", spans: [])],
@@ -589,8 +589,8 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("semantic block cursor accounts for overscan rows before the viewport")
-    func semanticBlockCursorAccountsForOverscanRowsBeforeTheViewport() {
-        let content = GUIWindowContent(
+    func semanticBlockCursorAccountsForOverscanRowsBeforeTheViewport() throws {
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 4, cursorShape: .block,
             rows: [
@@ -607,8 +607,8 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("wrapped block cursor uses anchored visual-row width at end of line")
-    func wrappedBlockCursorUsesAnchoredVisualRowWidth() {
-        let content = GUIWindowContent(
+    func wrappedBlockCursorUsesAnchoredVisualRowWidth() throws {
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, contentEpoch: 1,
             cursorRow: 0, cursorCol: 4, cursorShape: .block,
             rows: [
@@ -734,7 +734,7 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("semantic window rows land on spaced positions at line spacing 1.2")
-    func semanticWindowRowsLandOnSpacedPositionsAtSpacing1_2() {
+    func semanticWindowRowsLandOnSpacedPositionsAtSpacing1_2() throws {
         // The semantic content path positions each row at rowIndex * displayCellH.
         // resolveCursor shares that formula through the window's contentRow +
         // cursorRow, so a spaced computation must place the cursor's row on the
@@ -757,7 +757,7 @@ struct CoreTextMetalRendererCursorTests {
         )
 
         // Cursor is on the 6th visible row of the window content.
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 5, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
@@ -881,7 +881,7 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("hidden active semantic cursor is skipped so visible prompt cursor wins")
-    func hiddenActiveSemanticCursorIsSkippedSoPromptWins() {
+    func hiddenActiveSemanticCursorIsSkippedSoPromptWins() throws {
         var frameState = FrameState(cols: 80, rows: 24)
         frameState.windowGutters[1] = Wire.WindowGutter(
             windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
@@ -894,14 +894,14 @@ struct CoreTextMetalRendererCursorTests {
             lineNumberWidth: 0, signColWidth: 0, entries: []
         )
 
-        let hiddenChat = GUIWindowContent(
+        let hiddenChat = try GUIWindowContent(
             windowId: 1, fullRefresh: true, cursorVisible: false,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
             searchMatches: [], diagnosticUnderlines: [],
             documentHighlights: []
         )
-        let visiblePrompt = GUIWindowContent(
+        let visiblePrompt = try GUIWindowContent(
             windowId: 65_534, fullRefresh: true, cursorVisible: true,
             cursorRow: 0, cursorCol: 3, cursorShape: .beam,
             rows: [], selection: nil,
@@ -926,7 +926,7 @@ struct CoreTextMetalRendererCursorTests {
     }
 
     @Test("hidden semantic cursor suppresses legacy fallback after dispatcher sync")
-    @MainActor func hiddenSemanticCursorSuppressesFallback() {
+    @MainActor func hiddenSemanticCursorSuppressesFallback() throws {
         let gui = GUIState()
         let dispatcher = CommandDispatcher(cols: 80, rows: 24, guiState: gui)
         dispatcher.frameState.cursorRow = 3
@@ -938,7 +938,7 @@ struct CoreTextMetalRendererCursorTests {
             lineNumberWidth: 4, signColWidth: 1, entries: []
         )
 
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, cursorVisible: false,
             cursorRow: 0, cursorCol: 0, cursorShape: .beam,
             rows: [], selection: nil,

--- a/macos/Tests/MingaTests/DecodedFrameTests.swift
+++ b/macos/Tests/MingaTests/DecodedFrameTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MingaProtocol
 import Testing
 
 @Suite("Transactional frame decoding")
@@ -51,6 +52,133 @@ struct DecodedFrameTests {
         #expect(frame.metrics.decodeDuration >= .zero)
     }
 
+    @Test("resource usage freezes into the decoded frame")
+    func frozenResourceUsage() throws {
+        let packet = Data([OP_SET_TITLE, 0, 3, 0x61, 0x62, 0x63])
+        let frame = try decodeFrame(from: packet)
+
+        #expect(frame.resourceWeight.commands == 1)
+        #expect(frame.resourceWeight.ownedUTF8Bytes == 3)
+        #expect(frame.resourceWeight.arrayEntries == 1)
+    }
+
+    @Test("array reservation rejects before payload-proportional allocation")
+    func arrayPreallocationLimit() {
+        let packet = Data([
+            OP_GUI_THEME, 3,
+            1, 1, 2, 3,
+            2, 4, 5, 6,
+            3, 7, 8, 9
+        ])
+        let defaults = FrameResourcePolicy.default
+        let policy = FrameResourcePolicy(
+            wire: defaults.wire,
+            decode: .init(weight: .init(
+                commands: 1, ownedUTF8Bytes: 64, arrayEntries: 2,
+                rows: 0, spans: 0, overlays: 0, spliceEntries: 0, locatorEntries: 0
+            )),
+            staging: defaults.staging,
+            resident: defaults.resident
+        )
+
+        do {
+            _ = try decodeFrame(from: packet, policy: policy)
+            Issue.record("expected array-entry resource rejection")
+        } catch let error as ProtocolDecodeError {
+            #expect(error.isResourceFailure)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
+    @Test("generated picker strings and both item arrays reserve before materialization")
+    func generatedPickerReservations() throws {
+        let items = Data([
+            0, 1,
+            0, 0, 0, 0,
+            0, 1, 0x61,
+            0, 1, 0x62,
+            0, 1, 0x63,
+            1, 0, 2
+        ])
+        var packet = Data([OP_GUI_PICKER, 1, 0x03, 0, UInt8(items.count)])
+        packet.append(items)
+        let defaults = FrameResourcePolicy.default
+        let constrained = FrameResourcePolicy(
+            wire: defaults.wire,
+            decode: .init(weight: .init(
+                commands: 1, ownedUTF8Bytes: 3, arrayEntries: 2,
+                rows: 0, spans: 0, overlays: 0, spliceEntries: 0, locatorEntries: 0
+            )),
+            staging: defaults.staging,
+            resident: defaults.resident
+        )
+
+        do {
+            _ = try decodeFrame(from: packet, policy: constrained)
+            Issue.record("expected mapped picker array reservation to exceed the limit")
+        } catch let error as ProtocolDecodeError {
+            #expect(error.isResourceFailure)
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+
+        let frame = try decodeFrame(from: packet)
+        #expect(frame.resourceWeight.ownedUTF8Bytes == 3)
+        #expect(frame.resourceWeight.arrayEntries == 4)
+    }
+
+    @Test("reservation probe runs before array materialization")
+    func reservationProbeOrder() throws {
+        let packet = Data([
+            OP_GUI_THEME, 2,
+            1, 1, 2, 3,
+            2, 4, 5, 6
+        ])
+        let capture = ReservationCapture()
+        _ = try decodeFrame(from: packet, reservationProbe: { dimension, resulting in
+            capture.record(dimension, resulting: resulting)
+        })
+
+        #expect(capture.snapshot().contains(.arrayEntries, resulting: 2))
+    }
+
+    @Test("resource arithmetic rejects overflow without trapping")
+    func checkedWeightOverflow() {
+        let nearMaximum = FrameResourceWeight(ownedUTF8Bytes: .max)
+        #expect(throws: FrameResourceError.arithmeticOverflow) {
+            _ = try nearMaximum.adding(FrameResourceWeight(ownedUTF8Bytes: 1))
+        }
+    }
+
+    @Test("correlated resource failure retains the leading frame envelope")
+    func correlatedFailureEnvelope() {
+        var packet = Data([OP_BEGIN_FRAME, 0, 0, 0, 7, 0, 0, 0, 3, 0, 0, 0, 9])
+        packet.append(contentsOf: [OP_SET_TITLE, 0, 2, 0x61, 0x62])
+        let defaults = FrameResourcePolicy.default
+        let policy = FrameResourcePolicy(
+            wire: defaults.wire,
+            decode: .init(weight: .init(
+                commands: 2, ownedUTF8Bytes: 1, arrayEntries: 0,
+                rows: 0, spans: 0, overlays: 0, spliceEntries: 0, locatorEntries: 0
+            )),
+            staging: defaults.staging,
+            resident: defaults.resident
+        )
+
+        do {
+            _ = try decodeFrame(from: packet, policy: policy)
+            Issue.record("expected correlated resource rejection")
+        } catch let error as ProtocolDecodeError {
+            #expect(error.isResourceFailure)
+            #expect(error.frameEnvelope == FrameEnvelope(
+                generation: 9, frameSeq: 7, baseFrameSeq: 3
+            ))
+        } catch {
+            Issue.record("unexpected error: \(error)")
+        }
+    }
+
     @Test("production decode skips deep owned-value accounting")
     func productionMetricsStayLightweight() throws {
         let packet = makeRenderingPacket(size: 64 * 1024)
@@ -99,22 +227,56 @@ struct DecodedFrameTests {
     }
 }
 
+private final class ReservationCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [(FrameResourceDimension, Int)] = []
+
+    func record(_ dimension: FrameResourceDimension, resulting: Int) {
+        lock.lock()
+        values.append((dimension, resulting))
+        lock.unlock()
+    }
+
+    func snapshot() -> ReservationSnapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return ReservationSnapshot(values: values)
+    }
+}
+
+private struct ReservationSnapshot {
+    let values: [(FrameResourceDimension, Int)]
+
+    func contains(_ dimension: FrameResourceDimension, resulting: Int) -> Bool {
+        values.contains { $0.0 == dimension && $0.1 == resulting }
+    }
+}
+
 private final class DecodeThreadCapture: @unchecked Sendable {
     private let lock = NSLock()
     private var decodedOnMain = true
     private var hops = 0
+    private var admitted = false
+    private var decoderSawAdmission = false
+
+    func recordAdmission() {
+        lock.lock()
+        admitted = true
+        lock.unlock()
+    }
 
     func record(decodedOnMain: Bool, hops: Int) {
         lock.lock()
         self.decodedOnMain = decodedOnMain
         self.hops = hops
+        decoderSawAdmission = admitted
         lock.unlock()
     }
 
-    func snapshot() -> (decodedOnMain: Bool, hops: Int) {
+    func snapshot() -> (decodedOnMain: Bool, hops: Int, decoderSawAdmission: Bool) {
         lock.lock()
         defer { lock.unlock() }
-        return (decodedOnMain, hops)
+        return (decodedOnMain, hops, decoderSawAdmission)
     }
 }
 
@@ -147,7 +309,11 @@ struct ProtocolReaderDecodeIsolationTests {
                 delivered.signal()
             },
             onDecodeFailure: { _ in delivered.signal() },
-            onDisconnect: { disconnected.signal() }
+            onDisconnect: { disconnected.signal() },
+            acquireAdmission: {
+                capture.recordAdmission()
+                return true
+            }
         )
 
         reader.start()
@@ -158,6 +324,7 @@ struct ProtocolReaderDecodeIsolationTests {
         let result = capture.snapshot()
         #expect(!result.decodedOnMain)
         #expect(result.hops == 0)
+        #expect(result.decoderSawAdmission)
     }
 }
 
@@ -177,6 +344,7 @@ struct ProtocolEventHandoffTests {
             var opcodes: [UInt8] = []
             var hops: [Int] = []
             for await event in handoff.events {
+                handoff.releaseAdmission()
                 guard case .frame(let frame) = event else { continue }
                 opcodes.append(contentsOf: frame.commands.map(\.opcode))
                 hops.append(frame.metrics.actorHopCount)
@@ -186,11 +354,38 @@ struct ProtocolEventHandoffTests {
         }
 
         for frame in frames {
+            #expect(handoff.acquireAdmission())
             handoff.deliver(frame)
         }
 
         let result = await consumer.value
+        handoff.cancel()
         #expect(result.0 == [OP_SET_WINDOW_BG, OP_SET_TITLE, OP_COMMIT_FRAME])
         #expect(result.1 == [1, 1, 1])
+    }
+
+    @Test("cancelled handoff cannot deliver stale events")
+    func cancelledHandoffDropsStaleDelivery() async throws {
+        let handoff = ProtocolEventHandoff()
+        let frame = try decodeFrame(from: Data([OP_SET_WINDOW_BG, 1, 2, 3]))
+        #expect(handoff.acquireAdmission())
+        handoff.cancel()
+        handoff.deliver(frame)
+
+        var received = 0
+        for await _ in handoff.events { received += 1 }
+        #expect(received == 0)
+    }
+
+    @Test("cancellation wakes a producer blocked behind the capacity-one slot")
+    func cancellationWakesAdmission() async {
+        let handoff = ProtocolEventHandoff()
+        #expect(handoff.acquireAdmission())
+
+        let blocked = Task.detached { handoff.acquireAdmission() }
+        handoff.cancel()
+
+        #expect(await blocked.value == false)
+        #expect(handoff.acquireAdmission() == false)
     }
 }

--- a/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
+++ b/macos/Tests/MingaTests/GUIChromeDecoderTests.swift
@@ -9,6 +9,7 @@
 
 import Testing
 import Foundation
+import MingaProtocol
 
 // MARK: - Binary builder helpers
 
@@ -1224,6 +1225,21 @@ struct GUIObservatoryDecoderTests {
         appendU32(&data, UInt32(payload.count))
         data.append(payload)
 
+        let defaults = FrameResourcePolicy.default
+        let mapConstrained = FrameResourcePolicy(
+            wire: defaults.wire,
+            decode: .init(weight: .init(
+                commands: 1, ownedUTF8Bytes: .max, arrayEntries: 8,
+                rows: .max, spans: .max, overlays: .max,
+                spliceEntries: .max, locatorEntries: .max
+            )),
+            staging: defaults.staging,
+            resident: defaults.resident
+        )
+        #expect(throws: ProtocolDecodeError.self) {
+            _ = try decodeFrame(from: data, policy: mapConstrained)
+        }
+
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)
 
@@ -1309,6 +1325,21 @@ struct GUIFileTreeDecoderTests {
         data.append(OP_GUI_FILE_TREE)
         appendU32(&data, UInt32(payload.count))
         data.append(payload)
+
+        let defaults = FrameResourcePolicy.default
+        let guideConstrained = FrameResourcePolicy(
+            wire: defaults.wire,
+            decode: .init(weight: .init(
+                commands: 1, ownedUTF8Bytes: .max, arrayEntries: 5,
+                rows: .max, spans: .max, overlays: .max,
+                spliceEntries: .max, locatorEntries: .max
+            )),
+            staging: defaults.staging,
+            resident: defaults.resident
+        )
+        #expect(throws: ProtocolDecodeError.self) {
+            _ = try decodeFrame(from: data, policy: guideConstrained)
+        }
 
         let (cmd, size) = try decodeCommand(data: data, offset: 0)
         #expect(size == data.count)

--- a/macos/Tests/MingaTests/MouseInputTests.swift
+++ b/macos/Tests/MingaTests/MouseInputTests.swift
@@ -60,7 +60,7 @@ struct MouseInputTests {
     }
 
     @MainActor
-    private func installPaneGeometryDivider(view: EditorNSView, dividerCol: UInt16) {
+    private func installPaneGeometryDivider(view: EditorNSView, dividerCol: UInt16) throws {
         let geometry = GUIPaneGeometry(
             windowId: 1,
             totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
@@ -75,7 +75,7 @@ struct MouseInputTests {
             ]
         )
 
-        view.guiState?.windowContents[1] = GUIWindowContent(
+        view.guiState?.windowContents[1] = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
@@ -194,7 +194,7 @@ struct MouseInputTests {
         guard let view = makeView(spy: spy) else { return }
         let cw = view.cellWidth
         let ch = view.cellHeight
-        installPaneGeometryDivider(view: view, dividerCol: 40)
+        try installPaneGeometryDivider(view: view, dividerCol: 40)
 
         guard let leftEvent = mouseEvent(type: .leftMouseDown, location: NSPoint(x: cw * 40 - 1, y: ch * 5.5)) else { return }
         view.mouseDown(with: leftEvent)
@@ -354,7 +354,7 @@ struct MouseInputTests {
         )
         view.dispatcher.applyForTesting(.guiGutter(data: activeGutter))
         view.dispatcher.applyForTesting(.guiGutter(data: inactiveGutter))
-        view.guiState?.windowContents[7] = GUIWindowContent(
+        view.guiState?.windowContents[7] = try GUIWindowContent(
             windowId: 7, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
@@ -404,7 +404,7 @@ struct MouseInputTests {
         )
 
         view.dispatcher.applyForTesting(.guiGutter(data: gutter))
-        view.guiState?.windowContents[7] = GUIWindowContent(
+        view.guiState?.windowContents[7] = try GUIWindowContent(
             windowId: 7, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [
@@ -654,7 +654,7 @@ struct MouseInputTests {
     }
 
     @Test("mid-document wrapped scroll with no payload rows before does not bounce at top")
-    func midDocumentWrappedScrollWithoutPayloadBeforeDoesNotBounceAtTop() {
+    func midDocumentWrappedScrollWithoutPayloadBeforeDoesNotBounceAtTop() throws {
         let geometry = GUIPaneGeometry(
             windowId: 1,
             totalRect: GUICellRect(row: 0, col: 0, width: 10, height: 5),
@@ -679,7 +679,7 @@ struct MouseInputTests {
             contentEpoch: 1,
             layoutGeneration: 1
         )
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, contentEpoch: 1, cursorVisible: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
             scrollLeft: 0,
             rows: [

--- a/macos/Tests/MingaTests/RendererResidentSliceTests.swift
+++ b/macos/Tests/MingaTests/RendererResidentSliceTests.swift
@@ -4,9 +4,9 @@ import Testing
 @Suite("Renderer resident row slicing")
 struct RendererResidentSliceTests {
     @Test("fixed viewport visits the same rows for 5,000 and 65,536 row documents")
-    func boundedVisitedRows() {
-        let small = content(rowCount: 5_000, visibleStart: 2_000, visibleRows: 40)
-        let large = content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40)
+    func boundedVisitedRows() throws {
+        let small = try content(rowCount: 5_000, visibleStart: 2_000, visibleRows: 40)
+        let large = try content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40)
 
         let smallSlice = RendererSignposts.visibleSlice(for: small, fallbackVisibleRows: 40)
         let largeSlice = RendererSignposts.visibleSlice(for: large, fallbackVisibleRows: 40)
@@ -21,9 +21,9 @@ struct RendererResidentSliceTests {
     }
 
     @Test("content, gutters, and atlas demand stay bounded to one identical range")
-    func boundedCompletePreparation() {
-        let small = content(rowCount: 5_000, visibleStart: 2_000, visibleRows: 40, visualOffset: 3)
-        let large = content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40, visualOffset: 3)
+    func boundedCompletePreparation() throws {
+        let small = try content(rowCount: 5_000, visibleStart: 2_000, visibleRows: 40, visualOffset: 3)
+        let large = try content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40, visualOffset: 3)
         let entries = (0..<65_536).map {
             Wire.GutterEntry(bufLine: UInt32($0), displayType: .normal, signType: $0.isMultiple(of: 7) ? .diagError : .none)
         }
@@ -52,7 +52,7 @@ struct RendererResidentSliceTests {
 
     @Test("idle and overlay-only frames report zero reset and reference work")
     func perFrameOperationCounters() throws {
-        let resident = content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40)
+        let resident = try content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40)
         var identities: [UInt16: ObjectIdentifier] = [:]
         let first = RendererSignposts.operationCounters(for: resident, lastContentIdentities: &identities)
         let idle = RendererSignposts.operationCounters(for: resident, lastContentIdentities: &identities)
@@ -86,7 +86,7 @@ struct RendererResidentSliceTests {
     func deterministicComplexityGate() throws {
         let visibleRows = 40
         for rowCount in [5_000, 65_536] {
-            let content = content(rowCount: rowCount, visibleStart: 2_000, visibleRows: visibleRows)
+            let content = try content(rowCount: rowCount, visibleStart: 2_000, visibleRows: visibleRows)
             let replacement = GUIVisualRow(
                 rowType: .normal, rowId: 2_001, bufLine: 2_000,
                 contentHash: 999_001, text: "edited", spans: []
@@ -126,8 +126,8 @@ struct RendererResidentSliceTests {
     }
 
     @Test("shared CoreText preparation clips text and spans with bounded gutter commands")
-    func sharedCommandPreparationParity() {
-        let resident = content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40)
+    func sharedCommandPreparationParity() throws {
+        let resident = try content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40)
         let prepared = ResidentRenderPreparation.prepare(
             content: resident, fallbackVisibleRows: 40, overscanRows: 2,
             scrollLeft: 2, viewportCols: 4
@@ -155,8 +155,8 @@ struct RendererResidentSliceTests {
     }
 
     @Test("shared preparation feeds atlas demand and row counters once")
-    func sharedPreparationCounterParity() {
-        let resident = content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40)
+    func sharedPreparationCounterParity() throws {
+        let resident = try content(rowCount: 65_536, visibleStart: 2_000, visibleRows: 40)
         let prepared = ResidentRenderPreparation.prepare(
             content: resident, fallbackVisibleRows: 40, overscanRows: RendererSignposts.configuredOverscanRows,
             scrollLeft: 0, viewportCols: 80
@@ -177,7 +177,7 @@ struct RendererResidentSliceTests {
     }
 
     @Test("failure seams reject an extra reset, chunk, or full-row scan")
-    func deterministicComplexityFailureSeams() {
+    func deterministicComplexityFailureSeams() throws {
         let boundary = RendererComplexityMeasurement(
             fullResets: 0, chunksTouched: 4, editorRowsVisited: 44,
             visibleRows: 40, overscanRows: 4, decorationsVisited: 10_000
@@ -196,7 +196,7 @@ struct RendererResidentSliceTests {
 
     @Test("far-down resident viewport keeps cursor, selection, and annotation rows viewport-local")
     func viewportLocalOverlayCoordinates() throws {
-        let resident = content(rowCount: 65_536, visibleStart: 50_000, visibleRows: 40, visualOffset: 3)
+        let resident = try content(rowCount: 65_536, visibleStart: 50_000, visibleRows: 40, visualOffset: 3)
         let slice = RendererSignposts.visibleSlice(for: resident, fallbackVisibleRows: 40)
         #expect(slice.visibleStartIndex == 50_003)
 
@@ -225,7 +225,7 @@ struct RendererResidentSliceTests {
     }
 
     @Test("slice origin preserves wraps and decorations sharing a buffer line")
-    func wrappedRows() {
+    func wrappedRows() throws {
         let rows = [
             row(id: 1, line: 9),
             row(id: 2, line: 10),
@@ -234,7 +234,7 @@ struct RendererResidentSliceTests {
             row(id: 5, line: 11),
             row(id: 6, line: 12)
         ]
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, contentEpoch: 8,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [],
@@ -248,8 +248,8 @@ struct RendererResidentSliceTests {
         #expect(slice.overscanBeforeRows == 0)
     }
 
-    private func content(rowCount: Int, visibleStart: Int, visibleRows: Int, visualOffset: Int = 0) -> GUIWindowContent {
-        GUIWindowContent(
+    private func content(rowCount: Int, visibleStart: Int, visibleRows: Int, visualOffset: Int = 0) throws -> GUIWindowContent {
+        try GUIWindowContent(
             windowId: 1, fullRefresh: true, contentEpoch: 8,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: (0..<rowCount).map { row(id: UInt64($0 + 1), line: UInt32($0)) },

--- a/macos/Tests/MingaTests/ResidentRowStoreTests.swift
+++ b/macos/Tests/MingaTests/ResidentRowStoreTests.swift
@@ -201,6 +201,19 @@ struct ResidentRowStoreTests {
         }
     }
 
+    @Test("full-corpus removal uses cached aggregate resource weight")
+    func fullCorpusRemovalUsesCachedWeight() throws {
+        let count = 65_536
+        var store = try ResidentRowStore(rows: rows(0..<count))
+        let before = store.counters.resourceWeightRowsVisited
+
+        try store.splice(at: 0, removeCount: count, inserting: [])
+
+        #expect(store.isEmpty)
+        #expect(store.counters.resourceWeightRowsVisited - before == 0)
+        #expect(store.validateInvariants())
+    }
+
     @Test("structural updates do not touch chunks after the splice")
     func boundedChunkUpdates() throws {
         var store = try ResidentRowStore(rows: rows(0..<65_536))

--- a/macos/Tests/MingaTests/ResidentRowStoreTests.swift
+++ b/macos/Tests/MingaTests/ResidentRowStoreTests.swift
@@ -115,6 +115,92 @@ struct ResidentRowStoreTests {
         #expect(staged.counters == committed.counters)
     }
 
+    @Test("cached resident weight exactly owns UTF-8, spans, rows, and locators")
+    func exactResidentWeight() throws {
+        let styled = GUIVisualRow(
+            rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1,
+            text: "a😀", spans: [
+                GUIHighlightSpan(
+                    startCol: 0, endCol: 1, fg: 1, bg: 0,
+                    attrs: 0, fontWeight: 0, fontId: 0
+                )
+            ]
+        )
+        var store = try ResidentRowStore(rows: [styled, row(2, text: "xy")])
+
+        #expect(store.resourceWeight == FrameResourceWeight(
+            ownedUTF8Bytes: 7, arrayEntries: 1, rows: 2, spans: 1,
+            locatorEntries: 2
+        ))
+
+        let replacement = row(2, bufferLine: 1, text: "four", hash: 9)
+        try store.replace(at: 1, with: replacement)
+        #expect(store.resourceWeight.ownedUTF8Bytes == 9)
+        #expect(store.resourceWeight.rows == 2)
+        #expect(store.resourceWeight.locatorEntries == 2)
+    }
+
+    @Test("decoded construction rejects checked weight and identities before indexing")
+    func decodedConstructionRejectsBeforeIndexing() throws {
+        let validRows = [row(1, bufferLine: 0, text: "ok")]
+        let overLimit = FrameResourceWeight(
+            commands: .max, ownedUTF8Bytes: 3, arrayEntries: .max,
+            rows: 1, spans: .max, overlays: .max,
+            spliceEntries: .max, locatorEntries: 1
+        )
+
+        #expect(throws: ResidentRowStoreError.resourcePolicy) {
+            _ = try ResidentRowStore(
+                decodedRows: validRows,
+                resourceWeight: FrameResourceWeight(ownedUTF8Bytes: .max),
+                limit: overLimit
+            )
+        }
+        #expect(throws: ResidentRowStoreError.duplicateRowID(1)) {
+            _ = try ResidentRowStore(
+                decodedRows: validRows + validRows,
+                resourceWeight: FrameResourceWeight(rows: 2, locatorEntries: 2)
+            )
+        }
+    }
+
+    @Test("replacement validates exact resulting weight before publication")
+    func replacementWeightRejectsAtomically() throws {
+        let original = try ResidentRowStore(rows: [row(1, bufferLine: 0, text: "ok")])
+        var staged = original
+        let limit = FrameResourceWeight(
+            commands: .max, ownedUTF8Bytes: 3, arrayEntries: .max,
+            rows: 1, spans: .max, overlays: .max,
+            spliceEntries: .max, locatorEntries: 1
+        )
+
+        #expect(throws: ResidentRowStoreError.resourcePolicy) {
+            try staged.splice(
+                at: 0, removeCount: 1,
+                inserting: [row(1, bufferLine: 0, text: "four")], limit: limit
+            )
+        }
+        #expect(staged.resourceWeight == original.resourceWeight)
+        #expect(staged.row(at: 0) == original.row(at: 0))
+    }
+
+    @Test("5k and 65,536-row corpora retain calibrated default headroom")
+    func calibratedCorpusHeadroom() throws {
+        for count in [5_000, 65_536] {
+            let fixture = rows(0..<count)
+            let store = try ResidentRowStore(rows: fixture)
+            let limit = FrameResourcePolicy.default.resident.weightPerWindow
+
+            #expect(store.resourceWeight.rows == count)
+            #expect(store.resourceWeight.locatorEntries == count)
+            #expect(store.resourceWeight.spans == 0)
+            #expect(store.resourceWeight.ownedUTF8Bytes == fixture.reduce(0) {
+                $0 + $1.text.utf8.count
+            })
+            #expect(store.resourceWeight.firstExceeded(limit: limit) == nil)
+        }
+    }
+
     @Test("structural updates do not touch chunks after the splice")
     func boundedChunkUpdates() throws {
         var store = try ResidentRowStore(rows: rows(0..<65_536))

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -276,7 +276,7 @@ struct WindowContentFrameMetricsTests {
         #expect(first != nil)
         #expect(metrics.bufferRowsRasterized == 1)
 
-        let content = GUIWindowContent(windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [row], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
+        let content = try GUIWindowContent(windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [row], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
         atlas.beginFrame()
         CoreTextMetalRenderer.invalidateFullRefreshWindows(in: atlas, windowContents: [1: content])
         metrics.reset()
@@ -314,10 +314,10 @@ struct WindowContentFrameMetricsTests {
     }
 
     @Test("Atlas slot demand accounts for split-window texture entries")
-    func atlasDemandCountsSplitWindows() {
+    func atlasDemandCountsSplitWindows() throws {
         let rows = [GUIVisualRow(rowType: .normal, rowId: 700, bufLine: 0, contentHash: 1, text: "row", spans: [])]
-        let left = GUIWindowContent(windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [], lineAnnotations: [GUILineAnnotation(row: 0, kind: .inlineText, fg: 0xFFFFFF, bg: 0, text: "hint")])
-        let right = GUIWindowContent(windowId: 2, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
+        let left = try GUIWindowContent(windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [], lineAnnotations: [GUILineAnnotation(row: 0, kind: .inlineText, fg: 0xFFFFFF, bg: 0, text: "hint")])
+        let right = try GUIWindowContent(windowId: 2, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
 
         var frameState = FrameState(cols: 80, rows: 2)
         frameState.windowGutters = [
@@ -332,7 +332,7 @@ struct WindowContentFrameMetricsTests {
     }
 
     @Test("Atlas slot demand ignores retained rows outside the visible pane")
-    func atlasDemandIgnoresOffscreenRecoveryRows() {
+    func atlasDemandIgnoresOffscreenRecoveryRows() throws {
         let rows = (0..<5_000).map { index in
             GUIVisualRow(rowType: .normal, rowId: UInt64(index + 1), bufLine: UInt32(index), contentHash: UInt32(index), text: "row", spans: [])
         }
@@ -349,7 +349,7 @@ struct WindowContentFrameMetricsTests {
             hitRegions: []
         )
 
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [],
             documentHighlights: [], paneGeometry: geometry
@@ -384,9 +384,9 @@ struct WindowContentFrameMetricsTests {
 @Suite("GUIState Frame Lifecycle")
 struct GUIStateFrameTests {
     @Test("beginFrame preserves windowContents as fallback")
-    @MainActor func beginFramePreservesContents() {
+    @MainActor func beginFramePreservesContents() throws {
         let state = GUIState()
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,

--- a/macos/Tests/MingaTests/WindowContentTests.swift
+++ b/macos/Tests/MingaTests/WindowContentTests.swift
@@ -254,6 +254,29 @@ struct WindowContentBuilder {
 
 // MARK: - Tests
 
+private func resourceTestGeometry(hitRegionCount: Int) -> GUIPaneGeometry {
+    GUIPaneGeometry(
+        windowId: 7,
+        totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+        contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+        textRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+        gutterRect: GUICellRect(row: 0, col: 0, width: 0, height: 24),
+        clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+        viewport: GUIViewportSummary(
+            top: 0, left: 0, rows: 24, cols: 80, totalLines: 24,
+            visualRowOffset: 0, totalVisualRows: 24
+        ),
+        gutterMetrics: GUIGutterMetrics(lineNumberWidth: 0, signColWidth: 0),
+        hitRegions: (0..<hitRegionCount).map { index in
+            GUIHitRegion(
+                kind: .text,
+                rect: GUICellRect(row: UInt16(index), col: 0, width: 1, height: 1),
+                windowId: 7
+            )
+        }
+    )
+}
+
 @Suite("GUI Window Content Decoder")
 struct WindowContentDecoderTests {
 
@@ -515,6 +538,98 @@ struct WindowContentDecoderTests {
         #expect(geometry.gutterMetrics.lineNumberWidth == 2)
         #expect(geometry.gutterMetrics.signColWidth == 3)
         #expect(geometry.hitRegions.map(\.kind) == [.text, .foldControl])
+        #expect(content.exactResourceWeight().arrayEntries == 2)
+    }
+
+    @Test("Cached window weight includes annotation bytes and pane hit regions")
+    func cachedExactWindowWeight() throws {
+        let row = GUIVisualRow(
+            rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1,
+            text: "row", spans: []
+        )
+        let geometry = resourceTestGeometry(hitRegionCount: 2)
+        let content = try GUIWindowContent(
+            windowId: 7, fullRefresh: true,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [row], selection: nil, searchMatches: [],
+            diagnosticUnderlines: [], documentHighlights: [],
+            lineAnnotations: [GUILineAnnotation(
+                row: 0, kind: .inlineText, fg: 0, bg: 0, text: "😀"
+            )],
+            paneGeometry: geometry
+        )
+
+        let expected = FrameResourceWeight(
+            ownedUTF8Bytes: 7, arrayEntries: 3, rows: 1,
+            overlays: 1, locatorEntries: 1
+        )
+        #expect(content.resourceWeight == expected)
+        #expect(content.exactResourceWeight() == expected)
+        #expect(content.exactResourceWeight() == content.resourceWeight)
+        #expect(content.reportingOperationCounters(.init()).exactResourceWeight() == expected)
+    }
+
+    @Test("Full content rejects complete weight before row-store construction")
+    func fullContentRejectsBeforeStoreConstruction() {
+        let duplicate = GUIVisualRow(
+            rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1,
+            text: "x", spans: []
+        )
+        let limit = FrameResourceWeight(
+            commands: .max, ownedUTF8Bytes: .max, arrayEntries: 0,
+            rows: 2, spans: .max, overlays: .max,
+            spliceEntries: .max, locatorEntries: 2
+        )
+
+        #expect(throws: FrameResourceError.self) {
+            _ = try GUIWindowContent(
+                windowId: 7, fullRefresh: true,
+                cursorRow: 0, cursorCol: 0, cursorShape: .block,
+                rows: [duplicate, duplicate], selection: nil, searchMatches: [],
+                diagnosticUnderlines: [], documentHighlights: [],
+                paneGeometry: resourceTestGeometry(hitRegionCount: 1),
+                residentLimit: limit
+            )
+        }
+    }
+
+    @Test("Rows delta rejects complete resulting weight without changing prior content")
+    func rowsDeltaCompleteWeightRollback() throws {
+        let row = GUIVisualRow(
+            rowType: .normal, rowId: 1, bufLine: 0, contentHash: 1,
+            text: "ok", spans: []
+        )
+        let content = try GUIWindowContent(
+            windowId: 7, fullRefresh: true, contentEpoch: 42,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: [row], selection: nil, searchMatches: [],
+            diagnosticUnderlines: [], documentHighlights: []
+        )
+        let priorWeight = content.exactResourceWeight()
+        let limit = FrameResourceWeight(
+            commands: .max, ownedUTF8Bytes: 2, arrayEntries: .max,
+            rows: 1, spans: .max, overlays: .max,
+            spliceEntries: .max, locatorEntries: 1
+        )
+        let delta = GUIWindowRowsDelta(
+            windowId: 7, contentEpoch: 42, cursorVisible: true,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block, scrollLeft: 0,
+            rows: [.reference(rowId: 1, contentHash: 1)],
+            selection: nil, searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [],
+            lineAnnotations: [GUILineAnnotation(
+                row: 0, kind: .inlineText, fg: 0, bg: 0, text: "overflow"
+            )],
+            paneGeometry: nil, cursorline: nil
+        )
+
+        if case .failure(.resourcePolicy) = content.applyingRowsDeltaChecked(
+            delta, residentLimit: limit
+        ) {} else {
+            Issue.record("Expected complete resulting window weight rejection")
+        }
+        #expect(content.rows == [row])
+        #expect(content.exactResourceWeight() == priorWeight)
     }
 
     @Test("Decode scroll presentation metadata")
@@ -928,7 +1043,7 @@ struct WindowContentDecoderTests {
         let replacement = GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 1, contentHash: 22, text: "new", spans: [])
         let baseline = GUIScrollPresentation(windowId: 7, resetRequired: true, anchorTop: 10, anchorLeft: 2, anchorVisualRowOffset: 0, visibleStartLine: 10, visibleEndLine: 20, overscanStartLine: 9, overscanEndLine: 21, contentEpoch: 42, layoutGeneration: 11)
 
-        let content = GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [retained], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [], scrollPresentation: baseline)
+        let content = try GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [retained], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [], scrollPresentation: baseline)
         let delta = GUIWindowRowsDelta(windowId: 7, contentEpoch: 42, cursorVisible: true, cursorRow: 1, cursorCol: 2, cursorShape: .beam, scrollLeft: 3, rows: [.reference(rowId: 1, contentHash: 11), .full(replacement)], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [], lineAnnotations: [], paneGeometry: nil, cursorline: nil)
 
         guard let updated = content.applyingRowsDelta(delta) else {
@@ -946,7 +1061,7 @@ struct WindowContentDecoderTests {
         let baseline = GUIScrollPresentation(windowId: 7, resetRequired: true, anchorTop: 10, anchorLeft: 2, anchorVisualRowOffset: 0, visibleStartLine: 10, visibleEndLine: 20, overscanStartLine: 9, overscanEndLine: 21, contentEpoch: 42, layoutGeneration: 11)
         let next = GUIScrollPresentation(windowId: 7, resetRequired: false, anchorTop: 12, anchorLeft: 3, anchorVisualRowOffset: 1, visibleStartLine: 12, visibleEndLine: 22, overscanStartLine: 11, overscanEndLine: 23, contentEpoch: 42, layoutGeneration: 12)
 
-        let content = GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [retained], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [], scrollPresentation: baseline)
+        let content = try GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [retained], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [], scrollPresentation: baseline)
         let delta = GUIWindowRowsDelta(windowId: 7, contentEpoch: 42, cursorVisible: true, cursorRow: 1, cursorCol: 2, cursorShape: .beam, scrollLeft: 3, rows: [.reference(rowId: 1, contentHash: 11), .full(replacement)], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [], lineAnnotations: [], paneGeometry: nil, cursorline: nil, scrollPresentation: next)
 
         guard let updated = content.applyingRowsDelta(delta) else {
@@ -962,7 +1077,7 @@ struct WindowContentDecoderTests {
         let retained = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 11, text: "old", spans: [])
         let replacement = GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 1, contentHash: 22, text: "new", spans: [])
 
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7,
             fullRefresh: true,
             contentEpoch: 42,
@@ -1008,7 +1123,7 @@ struct WindowContentDecoderTests {
     func rowsDeltaMissingRefReturnsNil() throws {
         let retained = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 11, text: "old", spans: [])
 
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7,
             fullRefresh: true,
             contentEpoch: 42,
@@ -1048,7 +1163,7 @@ struct WindowContentDecoderTests {
         let a = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 11, text: "A", spans: [])
         let b = GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 1, contentHash: 22, text: "B", spans: [])
         let c = GUIVisualRow(rowType: .normal, rowId: 3, bufLine: 2, contentHash: 33, text: "C", spans: [])
-        let content = GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42,
+        let content = try GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [a, b, c], selection: nil,
             searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
 
@@ -1068,7 +1183,7 @@ struct WindowContentDecoderTests {
         #expect(try content.applyingRowsDeltaChecked(middle).get().rows.map(\.rowId) == [1, 3])
 
         let wrap = GUIVisualRow(rowType: .wrapContinuation, rowId: 4, bufLine: 1, contentHash: 44, text: "wrap", spans: [])
-        let movable = GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42,
+        let movable = try GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [b, wrap], selection: nil,
             searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
         let move = GUIWindowRowsDelta(windowId: 7, contentEpoch: 42, cursorVisible: true,
@@ -1090,7 +1205,7 @@ struct WindowContentDecoderTests {
                 contentHash: UInt32(index + 1), text: "row", spans: []
             ))
         }
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: rows, selection: nil, searchMatches: [],
@@ -1127,7 +1242,7 @@ struct WindowContentDecoderTests {
                 contentHash: UInt32(index + 1), text: "row", spans: []
             ))
         }
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: rows, selection: nil, searchMatches: [],
@@ -1157,7 +1272,7 @@ struct WindowContentDecoderTests {
     func rowsDeltaValidationRollback() throws {
         let a = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0, contentHash: 11, text: "A", spans: [])
         let b = GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 1, contentHash: 22, text: "B", spans: [])
-        let content = GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42,
+        let content = try GUIWindowContent(windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [a, b], selection: nil,
             searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
         let beforeRows = content.rows
@@ -1194,7 +1309,7 @@ struct WindowContentDecoderTests {
                 contentHash: contentHash, text: "row", spans: []
             ))
         }
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: true, contentEpoch: 42,
             cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: rows,
             selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: []

--- a/macos/Tests/Performance/main.swift
+++ b/macos/Tests/Performance/main.swift
@@ -12,7 +12,7 @@ private struct Fixture {
     let base: GUIWindowContent
     let deltaPayload: Data
 
-    static func make() -> Fixture {
+    static func make() throws -> Fixture {
         let rows = (0..<fixtureRows).map { index in
             let indexText = String(index)
             return GUIVisualRow(
@@ -34,7 +34,7 @@ private struct Fixture {
             overscanEndLine: UInt32(editIndex + visibleRows / 2 + overscanRows),
             contentEpoch: 7, layoutGeneration: 1
         )
-        let content = GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, contentEpoch: 7,
             cursorRow: UInt16(visibleRows / 2), cursorCol: 0, cursorShape: .block,
             rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [],
@@ -150,7 +150,7 @@ guard CommandLine.arguments.count == 2 else {
     exit(2)
 }
 
-private let fixture = Fixture.make()
+private let fixture = try Fixture.make()
 for _ in 0..<warmupIterations {
     let content = try decodeAndApply(fixture)
     _ = consumePreparedCommands(prepareVisibleCommands(content))

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -31,6 +31,8 @@ targets:
         type: file
       - path: Sources/Protocol/GUIColorSlots.swift
         type: file
+      - path: Sources/Protocol/FrameResourcePolicy.swift
+        type: file
       - path: Sources/Renderer/WindowContent.swift
         type: file
       - path: Sources/Renderer/ResidentRowStore.swift
@@ -113,6 +115,7 @@ targets:
           - "Protocol/ProtocolTypes.swift"
           - "Protocol/StatusBarUpdate.swift"
           - "Protocol/GUIColorSlots.swift"
+          - "Protocol/FrameResourcePolicy.swift"
           # MingaProtocol-owned (Slice 3)
           - "Renderer/WindowContent.swift"
           - "Renderer/ResidentRowStore.swift"
@@ -233,6 +236,7 @@ targets:
           - "Protocol/ProtocolTypes.swift"
           - "Protocol/StatusBarUpdate.swift"
           - "Protocol/GUIColorSlots.swift"
+          - "Protocol/FrameResourcePolicy.swift"
           # MingaProtocol-owned (Slice 3)
           - "Renderer/WindowContent.swift"
           - "Renderer/ResidentRowStore.swift"
@@ -308,6 +312,7 @@ targets:
           - "Protocol/ProtocolTypes.swift"
           - "Protocol/StatusBarUpdate.swift"
           - "Protocol/GUIColorSlots.swift"
+          - "Protocol/FrameResourcePolicy.swift"
           # MingaProtocol-owned (Slice 3)
           - "Renderer/WindowContent.swift"
           - "Renderer/ResidentRowStore.swift"

--- a/mix/protocol_generator.ex
+++ b/mix/protocol_generator.ex
@@ -2824,7 +2824,8 @@ defmodule Minga.Mix.ProtocolGenerator do
       "//\n",
       "// Structural twin of the Go semantic decoders. The production ProtocolDecoder\n",
       "// calls these and maps the result into its `RenderCommand` cases.\n\n",
-      "import Foundation\n\n",
+      "import Foundation\n",
+      "import MingaProtocol\n\n",
       "/// Namespace for schema-generated payload decoders, enum types, and struct types.\n",
       "enum GeneratedProtocol {\n\n",
       swift_decode_error(),
@@ -2899,6 +2900,7 @@ defmodule Minga.Mix.ProtocolGenerator do
             let l = Int(data[offset])
             let body = offset + 1
             try requireWindow(windowEnd, body + l, "string8 body")
+            try FrameDecodeAccounting.reserve(.ownedUTF8Bytes, l)
             let s = String(data: data[body..<(body + l)], encoding: .utf8) ?? ""
             return (s, body + l)
         }
@@ -2908,6 +2910,7 @@ defmodule Minga.Mix.ProtocolGenerator do
             let l = Int(decodeU16(data, offset))
             let body = offset + 2
             try requireWindow(windowEnd, body + l, "string16 body")
+            try FrameDecodeAccounting.reserve(.ownedUTF8Bytes, l)
             let s = String(data: data[body..<(body + l)], encoding: .utf8) ?? ""
             return (s, body + l)
         }
@@ -2917,6 +2920,7 @@ defmodule Minga.Mix.ProtocolGenerator do
             let l = Int(decodeU32(data, offset))
             let body = offset + 4
             try requireWindow(windowEnd, body + l, "string32 body")
+            try FrameDecodeAccounting.reserve(.ownedUTF8Bytes, l)
             let s = String(data: data[body..<(body + l)], encoding: .utf8) ?? ""
             return (s, body + l)
         }
@@ -3260,6 +3264,7 @@ defmodule Minga.Mix.ProtocolGenerator do
       "#{ind}let #{local}Count = Int(#{count_read})\n",
       "#{ind}pos += #{count_size}\n",
       stride_check,
+      "#{ind}try FrameDecodeAccounting.reserve(.arrayEntries, #{local}Count)\n",
       "#{ind}#{bind}#{local} = #{swift_array_type(element, smap)}()\n",
       "#{ind}#{local}.reserveCapacity(#{swift_prealloc("#{local}Count", element, smap)})\n",
       "#{ind}for _ in 0..<#{local}Count {\n",
@@ -3367,6 +3372,7 @@ defmodule Minga.Mix.ProtocolGenerator do
       "        let count = Int(#{count_read})\n",
       "        pos += #{count_size}\n",
       stride_check,
+      "        try FrameDecodeAccounting.reserve(.arrayEntries, count)\n",
       "        var items = #{array_type}()\n",
       "        items.reserveCapacity(#{swift_prealloc("count", element, smap)})\n",
       "        for _ in 0..<count {\n",

--- a/scripts/check_render_performance
+++ b/scripts/check_render_performance
@@ -28,6 +28,7 @@ swiftc -O -emit-library -emit-module -module-name MingaProtocol \
   macos/Sources/Protocol/ProtocolTypes.swift \
   macos/Sources/Protocol/StatusBarUpdate.swift \
   macos/Sources/Protocol/GUIColorSlots.swift \
+  macos/Sources/Protocol/FrameResourcePolicy.swift \
   macos/Sources/Renderer/WindowContent.swift \
   macos/Sources/Renderer/ResidentRowStore.swift \
   macos/Sources/Renderer/ResidentRenderPreparation.swift \


### PR DESCRIPTION
# TL;DR
The macOS frontend now bounds frame amplification across decode, handoff, semantic staging, and resident storage before payload-proportional allocations. Resource failures remain correlated and terminal, preserve the last-good semantic frame, and support ordinary edits at the 65,536-row production boundary.

Closes #2802

## Context
This is the bounded-ingestion delivery unit in #2749. It consumes the rejection disposition contract from #2801 and leaves CoreText/Metal allocation atomicity to #2803.

## Changes
- Added one immutable `FrameResourcePolicy` composition root with wire, decode, staging, and per-window resident slices.
- Added checked multidimensional resource weights for commands, owned UTF-8, arrays, rows, spans, overlays, splices, and locator entries.
- Reserved generated and hand-written decoder allocations before materialization, including generated strings and counted arrays, mapped picker/completion/observatory arrays, file-tree guides, and resident metadata.
- Added envelope-aware decoded failure events and immutable frozen usage on successful frames.
- Replaced the unbounded protocol event stream with a capacity-one FIFO handoff whose permit is acquired before the next packet read and released on dequeue.
- Added cancellation, reconnect, EOF, and shutdown handling that wakes waiters and prevents stale old-handoff delivery.
- Cached exact resident, chunk, tree-node, and window weights, then validated full replacements and splice results without scanning removed rows for accounting.
- Carried per-command decode weights into semantic staging, with exact subtraction for coalesced replacements and accumulation for append-only chrome and transcript updates.
- Kept cross-packet resource failures terminal even when only an earlier packet carried the frame envelope.
- Wired deterministic policy failures through #2801’s terminal status without repeated recovery requests or partial publication.
- Documented calibrated limits and integrated the new policy source into the optimized Release harness.

## Verification
- `make lint`
- `mix protocol.gen --check`
- `mix conformance` (161 passed)
- `mix test.llm` (9,218 tests, 0 failures)
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga test` (full Swift suite passed)
- `scripts/check_render_performance`
  - decode/apply p95: 0.012 ms
  - command preparation p95: 0.185 ms
  - combined p95: 0.205 ms
  - fixture: 65,536 resident rows, 160 visible rows, 4 overscan rows

## Acceptance Criteria Addressed
- Every declared decode dimension reserves before payload-proportional allocation in one pass. ✅
- Malformed and resource failures publish no partial state and preserve a valid leading frame envelope. ✅
- Successful decode freezes immutable usage while mutable builders remain phase-local. ✅
- The reader-to-main handoff has one FIFO slot and safe cancellation, reconnect, EOF, and shutdown behavior. ✅
- Resident rows and indexes cache exact checked weights and validate replacement/splice results before publication. ✅
- Resource rejection is correlated, terminal, last-good preserving, and does not repeat keyframe recovery. ✅
- The 5,000-row and 65,536-row corpus, adversarial boundaries, and optimized Release gate pass with documented headroom. ✅

---
**Updated after review:** Added complete semantic staging accounting, cached subtree resource aggregates, cross-packet terminal rejection coverage, and the missing Swift integration harness source.
