### PR TITLE
refactor(editor): enforce shell stash identity ownership

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -39,7 +39,6 @@ defmodule MingaEditor do
   alias MingaEditor.SemanticTokenSync
   alias MingaEditor.Startup
   alias MingaEditor.State.ResourcePressure
-  alias MingaEditor.Shell.StateStash
   alias MingaEditor.Viewport
 
   alias MingaEditor.Handlers.BufferRegistry
@@ -1291,79 +1290,68 @@ defmodule MingaEditor do
       )
 
     state
-    |> Map.replace!(:shell_state, shell_state)
-    |> Map.replace!(:workspace, workspace)
+    |> EditorState.update_shell_state(fn _shell_state -> shell_state end)
+    |> EditorState.set_workspace(workspace)
     |> EffectHandler.apply_effects(shell_effects)
   end
 
   @spec route_stashed_shell_agent_event(EditorState.t(), pid(), term()) :: EditorState.t()
   defp route_stashed_shell_agent_event(state, session_pid, event) do
-    {stash, state} =
-      Enum.reduce(state.shell_state_stash, {state.shell_state_stash, state}, fn
-        {shell_id, %StateStash{} = stashed}, {stash_acc, state_acc} ->
-          route_stashed_shell_agent_event(
-            stash_acc,
-            state_acc,
-            shell_id,
-            stashed,
-            session_pid,
-            event
-          )
-
-        _entry, acc ->
-          acc
+    {state, _changed?} =
+      EditorState.transform_stashed_shell_states(state, fn module, shell_state, state_acc ->
+        transform_stashed_shell_agent_event(module, shell_state, state_acc, session_pid, event)
       end)
 
-    %{state | shell_state_stash: stash}
+    state
   end
 
-  @spec route_stashed_shell_agent_event(
-          EditorState.shell_state_stash(),
+  @spec transform_stashed_shell_agent_event(
+          module(),
+          MingaEditor.Shell.shell_state(),
           EditorState.t(),
-          EditorState.shell_id(),
-          StateStash.t(),
           pid(),
           term()
-        ) :: {EditorState.shell_state_stash(), EditorState.t()}
-  defp route_stashed_shell_agent_event(
-         stash,
-         state,
-         shell_id,
-         %StateStash{} = stashed,
-         session_pid,
-         event
-       ) do
-    if function_exported?(stashed.module, :on_agent_event, 4) do
-      apply_stashed_shell_agent_event(stash, state, shell_id, stashed, session_pid, event)
+        ) :: {MingaEditor.Shell.StateStash.transformation(), EditorState.t()}
+  defp transform_stashed_shell_agent_event(module, shell_state, state, session_pid, event) do
+    if function_exported?(module, :on_agent_event, 4) do
+      apply_stashed_shell_agent_event(module, shell_state, state, session_pid, event)
     else
-      {stash, state}
+      {:unchanged, state}
     end
   end
 
   @spec apply_stashed_shell_agent_event(
-          EditorState.shell_state_stash(),
+          module(),
+          MingaEditor.Shell.shell_state(),
           EditorState.t(),
-          EditorState.shell_id(),
-          StateStash.t(),
           pid(),
           term()
-        ) :: {EditorState.shell_state_stash(), EditorState.t()}
-  defp apply_stashed_shell_agent_event(
-         stash,
-         state,
-         shell_id,
-         %StateStash{} = stashed,
-         session_pid,
-         event
-       ) do
-    {shell_state, workspace, effects} =
-      stashed.module.on_agent_event(stashed.state, state.workspace, session_pid, event)
+        ) :: {MingaEditor.Shell.StateStash.transformation(), EditorState.t()}
+  defp apply_stashed_shell_agent_event(module, shell_state, state, session_pid, event) do
+    {updated_shell_state, workspace, effects} =
+      module.on_agent_event(shell_state, state.workspace, session_pid, event)
 
-    shell_state = maybe_persist_stashed_shell_state(stashed.module, stashed.state, shell_state)
-    stash = Map.put(stash, shell_id, %StateStash{stashed | state: shell_state})
-    state = EffectHandler.apply_effects(%{state | workspace: workspace}, effects)
-    {stash, state}
+    updated_shell_state =
+      maybe_persist_stashed_shell_state(module, shell_state, updated_shell_state)
+
+    state =
+      state
+      |> EditorState.set_workspace(workspace)
+      |> EffectHandler.apply_effects(effects)
+
+    stashed_shell_agent_transformation(shell_state, updated_shell_state, state)
   end
+
+  @spec stashed_shell_agent_transformation(
+          MingaEditor.Shell.shell_state(),
+          MingaEditor.Shell.shell_state(),
+          EditorState.t()
+        ) :: {MingaEditor.Shell.StateStash.transformation(), EditorState.t()}
+  defp stashed_shell_agent_transformation(shell_state, shell_state, state),
+    do: {:unchanged, state}
+
+  defp stashed_shell_agent_transformation(_old_shell_state, updated_shell_state, state),
+    do: {{:updated, updated_shell_state}, state}
 
   @spec maybe_persist_stashed_shell_state(module(), term(), term()) :: term()
   defp maybe_persist_stashed_shell_state(module, old_state, new_state) do

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -18,6 +18,7 @@ defmodule MingaEditor.Agent.Events do
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Agent.View.Preview
   alias MingaEditor.PickerUI
+  alias MingaEditor.Shell.StateStash
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -29,7 +30,6 @@ defmodule MingaEditor.Agent.Events do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
-  alias MingaEditor.Shell.StateStash
 
   @type effect ::
           :render
@@ -724,7 +724,9 @@ defmodule MingaEditor.Agent.Events do
     shell = EditorState.active_shell_module(state)
 
     if function_exported?(shell, callback, Enum.count(args) + 1) do
-      %{state | shell_state: apply(shell, callback, [state.shell_state | args])}
+      EditorState.update_shell_state(state, fn shell_state ->
+        apply(shell, callback, [shell_state | args])
+      end)
     else
       state
     end
@@ -732,24 +734,40 @@ defmodule MingaEditor.Agent.Events do
 
   @spec update_stashed_shells_for_session(EditorState.t(), atom(), [term()]) :: EditorState.t()
   defp update_stashed_shells_for_session(state, callback, args) do
-    stash =
-      Map.new(state.shell_state_stash, fn
-        {shell_id, %StateStash{} = stashed} ->
-          {shell_id, update_stashed_shell_for_session(stashed, callback, args)}
-
-        entry ->
-          entry
+    {state, _changed?} =
+      EditorState.transform_stashed_shell_states(state, fn module, shell_state, state_acc ->
+        transform_stashed_shell_for_session(module, shell_state, state_acc, callback, args)
       end)
 
-    %{state | shell_state_stash: stash}
+    state
   end
 
-  @spec update_stashed_shell_for_session(StateStash.t(), atom(), [term()]) :: StateStash.t()
-  defp update_stashed_shell_for_session(%StateStash{} = stashed, callback, args) do
-    if function_exported?(stashed.module, callback, Enum.count(args) + 1) do
-      %StateStash{stashed | state: apply(stashed.module, callback, [stashed.state | args])}
+  @spec transform_stashed_shell_for_session(
+          module(),
+          MingaEditor.Shell.shell_state(),
+          EditorState.t(),
+          atom(),
+          [term()]
+        ) :: {StateStash.transformation(), EditorState.t()}
+  defp transform_stashed_shell_for_session(module, shell_state, state, callback, args) do
+    if function_exported?(module, callback, Enum.count(args) + 1) do
+      transformed_shell_for_session(module, shell_state, state, callback, args)
     else
-      stashed
+      {:unchanged, state}
+    end
+  end
+
+  @spec transformed_shell_for_session(
+          module(),
+          MingaEditor.Shell.shell_state(),
+          EditorState.t(),
+          atom(),
+          [term()]
+        ) :: {StateStash.transformation(), EditorState.t()}
+  defp transformed_shell_for_session(module, shell_state, state, callback, args) do
+    case apply(module, callback, [shell_state | args]) do
+      ^shell_state -> {:unchanged, state}
+      updated -> {{:updated, updated}, state}
     end
   end
 

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1088,13 +1088,20 @@ defmodule MingaEditor.Commands.BufferManagement do
     end
   end
 
-  @spec agent_session_restart_owned?(state(), pid()) :: boolean()
-  def agent_session_restart_owned?(state, old_pid) when is_pid(old_pid) do
+  @type session_restart_ownership :: {:owned, state()} | {:stale, state()}
+
+  @doc "Normalizes shell identity and returns whether the old session is still owned."
+  @spec prepare_agent_session_restart(state(), pid()) :: session_restart_ownership()
+  def prepare_agent_session_restart(state, old_pid) when is_pid(old_pid) do
     state = EditorState.ensure_shell_available(state)
     shell_owned? = shell_state_restart_owned?(state.shell_state, old_pid)
     stash_owned? = stashed_shell_restart_owned?(state.shell_state_stash, old_pid)
-    shell_owned? or stash_owned?
+    session_restart_ownership(state, shell_owned? or stash_owned?)
   end
+
+  @spec session_restart_ownership(state(), boolean()) :: session_restart_ownership()
+  defp session_restart_ownership(state, true), do: {:owned, state}
+  defp session_restart_ownership(state, false), do: {:stale, state}
 
   @doc "Refreshes editor state after SessionManager restarts a managed session."
   @spec handle_agent_session_restarted(state(), String.t(), pid(), pid(), term()) :: state()

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1060,18 +1060,25 @@ defmodule MingaEditor.Commands.BufferManagement do
   """
   @spec handle_agent_session_down(state(), pid(), term()) :: state()
   def handle_agent_session_down(state, session_pid, :noconnection) do
-    handle_remote_session_disconnected(state, session_pid)
+    state
+    |> EditorState.ensure_shell_available()
+    |> handle_remote_session_disconnected(session_pid)
   end
 
   def handle_agent_session_down(state, session_pid, {:nodedown, _node}) do
-    handle_remote_session_disconnected(state, session_pid)
+    state
+    |> EditorState.ensure_shell_available()
+    |> handle_remote_session_disconnected(session_pid)
   end
 
   def handle_agent_session_down(state, session_pid, {:noconnection, _node}) do
-    handle_remote_session_disconnected(state, session_pid)
+    state
+    |> EditorState.ensure_shell_available()
+    |> handle_remote_session_disconnected(session_pid)
   end
 
   def handle_agent_session_down(state, session_pid, reason) do
+    state = EditorState.ensure_shell_available(state)
     {state, owned?} = update_active_shell_session_down(state, session_pid, reason)
 
     if owned? do
@@ -1083,6 +1090,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec agent_session_restart_owned?(state(), pid()) :: boolean()
   def agent_session_restart_owned?(state, old_pid) when is_pid(old_pid) do
+    state = EditorState.ensure_shell_available(state)
     shell_owned? = shell_state_restart_owned?(state.shell_state, old_pid)
     stash_owned? = stashed_shell_restart_owned?(state.shell_state_stash, old_pid)
     shell_owned? or stash_owned?
@@ -1091,6 +1099,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   @doc "Refreshes editor state after SessionManager restarts a managed session."
   @spec handle_agent_session_restarted(state(), String.t(), pid(), pid(), term()) :: state()
   def handle_agent_session_restarted(state, session_id, old_pid, new_pid, reason) do
+    state = EditorState.ensure_shell_available(state)
     state = update_active_shell_session_restarted(state, session_id, old_pid, new_pid, reason)
     state = update_stashed_shell_session_restarted(state, session_id, old_pid, new_pid, reason)
     maybe_rebuild_active_agent_after_restart(state, new_pid)
@@ -1122,8 +1131,17 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec stashed_shell_restart_owned?(EditorState.shell_state_stash(), pid()) :: boolean()
   defp stashed_shell_restart_owned?(stash, old_pid) do
-    Enum.any?(stash, fn {_shell_id, %StateStash{state: shell_state}} ->
-      shell_state_restart_owned?(shell_state, old_pid)
+    Enum.any?(stash, fn {shell_id, %StateStash{} = stashed} ->
+      case MingaEditor.Shell.Registry.get(shell_id) do
+        %MingaEditor.Shell.Entry{} = entry ->
+          case StateStash.restore(stashed, entry) do
+            {:ok, shell_state} -> shell_state_restart_owned?(shell_state, old_pid)
+            :mismatch -> false
+          end
+
+        nil ->
+          false
+      end
     end)
   end
 
@@ -1555,56 +1573,27 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec update_stashed_shell_for_session(state(), atom(), [term()]) :: {state(), boolean()}
   defp update_stashed_shell_for_session(state, callback, args) do
-    {stash, handled?} =
-      Enum.reduce(state.shell_state_stash, {state.shell_state_stash, false}, fn
-        {shell_id, %StateStash{} = stashed}, {stash_acc, false} ->
-          update_matching_stashed_shell(stash_acc, shell_id, stashed, callback, args)
+    EditorState.transform_first_stashed_shell_state(state, fn module, shell_state, state_acc ->
+      if function_exported?(module, callback, length(args) + 1) do
+        case apply(module, callback, [shell_state | args]) do
+          {updated_shell_state, true} ->
+            Minga.Log.info(
+              :agent,
+              "Agent session update applied to stashed #{inspect(module)} shell"
+            )
 
-        _entry, acc ->
-          acc
-      end)
+            updated_shell_state =
+              maybe_persist_owned_shell_state(module, updated_shell_state, true)
 
-    {%{state | shell_state_stash: stash}, handled?}
-  end
+            {{:updated, updated_shell_state}, state_acc}
 
-  @spec update_matching_stashed_shell(
-          EditorState.shell_state_stash(),
-          EditorState.shell_id(),
-          StateStash.t(),
-          atom(),
-          [term()]
-        ) :: {EditorState.shell_state_stash(), boolean()}
-  defp update_matching_stashed_shell(stash, shell_id, %StateStash{} = stashed, callback, args) do
-    arity = length(args) + 1
-
-    if function_exported?(stashed.module, callback, arity) do
-      apply_stashed_shell_callback(stash, shell_id, stashed, callback, args)
-    else
-      {stash, false}
-    end
-  end
-
-  @spec apply_stashed_shell_callback(
-          EditorState.shell_state_stash(),
-          EditorState.shell_id(),
-          StateStash.t(),
-          atom(),
-          [term()]
-        ) :: {EditorState.shell_state_stash(), boolean()}
-  defp apply_stashed_shell_callback(stash, shell_id, %StateStash{} = stashed, callback, args) do
-    case apply(stashed.module, callback, [stashed.state | args]) do
-      {shell_state, true} ->
-        Minga.Log.info(
-          :agent,
-          "Agent session update applied to stashed #{inspect(shell_id)} shell"
-        )
-
-        shell_state = maybe_persist_owned_shell_state(stashed.module, shell_state, true)
-        {Map.put(stash, shell_id, %StateStash{stashed | state: shell_state}), true}
-
-      {_shell_state, false} ->
-        {stash, false}
-    end
+          {_updated_shell_state, false} ->
+            {:unchanged, state_acc}
+        end
+      else
+        {:unchanged, state_acc}
+      end
+    end)
   end
 
   # Shared state cleanup for agent sessions: stops spinner, clears agent state session,

--- a/lib/minga_editor/handlers/event_dispatcher.ex
+++ b/lib/minga_editor/handlers/event_dispatcher.ex
@@ -306,28 +306,37 @@ defmodule MingaEditor.Handlers.EventDispatcher do
     new_pid = event.new_pid
 
     with {:ok, ^new_pid} <- safe_session_lookup(event.session_id),
-         true <- Commands.BufferManagement.agent_session_restart_owned?(state, event.old_pid),
-         :ok <- subscribe_to_restarted_session(state, event) do
-      {:ok,
-       Commands.BufferManagement.handle_agent_session_restarted(
-         state,
-         event.session_id,
-         event.old_pid,
-         new_pid,
-         event.reason
-       )}
+         {:owned, state} <-
+           Commands.BufferManagement.prepare_agent_session_restart(state, event.old_pid) do
+      finish_agent_session_restart(state, event)
     else
       {:ok, current_pid} ->
         log_stale_agent_session_restart(event, {:current_pid, current_pid})
         {:stale, state}
 
-      false ->
+      {:stale, normalized_state} ->
         log_stale_agent_session_restart(event, :unowned_old_pid)
-        {:stale, state}
+        {:stale, normalized_state}
 
       {:error, reason} ->
         log_stale_agent_session_restart(event, reason)
         {:stale, state}
+    end
+  end
+
+  @spec finish_agent_session_restart(EditorState.t(), SessionManager.SessionRestartedEvent.t()) ::
+          {:ok, EditorState.t()} | {:stale, EditorState.t()}
+  defp finish_agent_session_restart(state, %SessionManager.SessionRestartedEvent{} = event) do
+    case subscribe_to_restarted_session(state, event) do
+      :ok ->
+        {:ok,
+         Commands.BufferManagement.handle_agent_session_restarted(
+           state,
+           event.session_id,
+           event.old_pid,
+           event.new_pid,
+           event.reason
+         )}
 
       :stale ->
         {:stale, state}

--- a/lib/minga_editor/shell/state_stash.ex
+++ b/lib/minga_editor/shell/state_stash.ex
@@ -2,25 +2,32 @@ defmodule MingaEditor.Shell.StateStash do
   @moduledoc """
   Stashed shell state tied to the exact shell registry identity that produced it.
 
-  Shell state is only safe to restore into the same registered shell module and source. Extension shell ids can be unregistered and later reused, so the registry generation is part of the identity as well.
+  Shell state is only safe to restore into the same registered shell id, module, and source. Extension shell ids can be unregistered and later reused, so the registry generation is part of the identity as well.
   """
 
   alias MingaEditor.Shell.Entry
 
-  @enforce_keys [:module, :source, :generation, :state]
-  defstruct [:module, :source, :generation, :state]
+  @enforce_keys [:id, :module, :source, :generation, :state]
+  defstruct [:id, :module, :source, :generation, :state]
 
   @type t :: %__MODULE__{
+          id: atom(),
           module: module(),
           source: Entry.source(),
           generation: non_neg_integer(),
           state: MingaEditor.Shell.shell_state()
         }
 
+  @type transformation :: {:updated, MingaEditor.Shell.shell_state()} | :unchanged
+  @type transform_result :: {:updated, t()} | {:unchanged, t()} | :mismatch
+  @type transform_result(context) ::
+          {:updated, t(), context} | {:unchanged, t(), context} | {:mismatch, context}
+
   @doc "Stores shell state with the registry identity that produced it."
   @spec new(Entry.t(), MingaEditor.Shell.shell_state()) :: t()
   def new(%Entry{} = entry, state) do
     %__MODULE__{
+      id: entry.id,
       module: entry.module,
       source: entry.source,
       generation: entry.generation,
@@ -31,7 +38,52 @@ defmodule MingaEditor.Shell.StateStash do
   @doc "Returns true when the stash belongs to the current registry entry."
   @spec matches?(t(), Entry.t()) :: boolean()
   def matches?(%__MODULE__{} = stash, %Entry{} = entry) do
-    stash.module == entry.module and stash.source == entry.source and
+    stash.id == entry.id and stash.module == entry.module and stash.source == entry.source and
       stash.generation == entry.generation
+  end
+
+  @doc "Restores stored state only when the current registry entry has the same identity."
+  @spec restore(t(), Entry.t()) :: {:ok, MingaEditor.Shell.shell_state()} | :mismatch
+  def restore(%__MODULE__{} = stash, %Entry{} = entry) do
+    if matches?(stash, entry), do: {:ok, stash.state}, else: :mismatch
+  end
+
+  @doc "Transforms stored state only when the current registry entry has the same identity."
+  @spec transform(t(), Entry.t(), (MingaEditor.Shell.shell_state() -> transformation())) ::
+          transform_result()
+  def transform(%__MODULE__{} = stash, %Entry{} = entry, fun) when is_function(fun, 1) do
+    case transform(stash, entry, nil, fn state, nil -> {fun.(state), nil} end) do
+      {:updated, updated, nil} -> {:updated, updated}
+      {:unchanged, unchanged, nil} -> {:unchanged, unchanged}
+      {:mismatch, nil} -> :mismatch
+    end
+  end
+
+  @doc "Transforms stored state with caller context after validating registry identity."
+  @spec transform(
+          t(),
+          Entry.t(),
+          context,
+          (MingaEditor.Shell.shell_state(), context -> {transformation(), context})
+        ) :: transform_result(context)
+        when context: term()
+  def transform(%__MODULE__{} = stash, %Entry{} = entry, context, fun)
+      when is_function(fun, 2) do
+    if matches?(stash, entry) do
+      apply_transformation(stash, context, fun.(stash.state, context))
+    else
+      {:mismatch, context}
+    end
+  end
+
+  @spec apply_transformation(t(), context, {transformation(), context}) ::
+          transform_result(context)
+        when context: term()
+  defp apply_transformation(%__MODULE__{} = stash, _old_context, {:unchanged, context}) do
+    {:unchanged, stash, context}
+  end
+
+  defp apply_transformation(%__MODULE__{} = stash, _context, {{:updated, state}, context}) do
+    {:updated, %__MODULE__{stash | state: state}, context}
   end
 end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -920,6 +920,108 @@ defmodule MingaEditor.State do
     %{state | shell_state: fun.(ss)}
   end
 
+  @type stashed_shell_transform ::
+          (module(), shell_state(), t() -> {StateStash.transformation(), t()})
+
+  @doc "Transforms current stashed shell states and reports whether any matching value changed."
+  @spec transform_stashed_shell_states(t(), stashed_shell_transform()) :: {t(), boolean()}
+  def transform_stashed_shell_states(%__MODULE__{} = state, fun) when is_function(fun, 3) do
+    {stash, state, changed?} =
+      Enum.reduce(state.shell_state_stash, {state.shell_state_stash, state, false}, fn
+        {shell_id, %StateStash{} = stashed}, {stash_acc, state_acc, changed?} ->
+          transform_stashed_shell_state(
+            stash_acc,
+            state_acc,
+            changed?,
+            shell_id,
+            stashed,
+            fun
+          )
+
+        _entry, acc ->
+          acc
+      end)
+
+    {%{state | shell_state_stash: stash}, changed?}
+  end
+
+  @doc "Transforms the first matching stashed shell that accepts the change."
+  @spec transform_first_stashed_shell_state(t(), stashed_shell_transform()) :: {t(), boolean()}
+  def transform_first_stashed_shell_state(%__MODULE__{} = state, fun) when is_function(fun, 3) do
+    {stash, state, changed?} =
+      Enum.reduce_while(state.shell_state_stash, {state.shell_state_stash, state, false}, fn
+        {shell_id, %StateStash{} = stashed}, {stash_acc, state_acc, false} ->
+          result =
+            transform_stashed_shell_state(stash_acc, state_acc, false, shell_id, stashed, fun)
+
+          continue_stashed_shell_transform(result)
+
+        _entry, acc ->
+          {:cont, acc}
+      end)
+
+    {%{state | shell_state_stash: stash}, changed?}
+  end
+
+  @spec continue_stashed_shell_transform({shell_state_stash(), t(), boolean()}) ::
+          {:cont, {shell_state_stash(), t(), boolean()}}
+          | {:halt, {shell_state_stash(), t(), boolean()}}
+  defp continue_stashed_shell_transform({_stash, _state, true} = result), do: {:halt, result}
+  defp continue_stashed_shell_transform(result), do: {:cont, result}
+
+  @spec transform_stashed_shell_state(
+          shell_state_stash(),
+          t(),
+          boolean(),
+          shell_id(),
+          StateStash.t(),
+          stashed_shell_transform()
+        ) :: {shell_state_stash(), t(), boolean()}
+  defp transform_stashed_shell_state(stash, state, changed?, shell_id, stashed, fun) do
+    entry = MingaEditor.Shell.Registry.get(shell_id)
+    transform_stashed_shell_state(stash, state, changed?, shell_id, stashed, entry, fun)
+  end
+
+  @spec transform_stashed_shell_state(
+          shell_state_stash(),
+          t(),
+          boolean(),
+          shell_id(),
+          StateStash.t(),
+          MingaEditor.Shell.Entry.t() | nil,
+          stashed_shell_transform()
+        ) :: {shell_state_stash(), t(), boolean()}
+  defp transform_stashed_shell_state(stash, state, changed?, _shell_id, _stashed, nil, _fun),
+    do: {stash, state, changed?}
+
+  defp transform_stashed_shell_state(stash, state, changed?, shell_id, stashed, entry, fun) do
+    stashed
+    |> StateStash.transform(entry, state, fn shell_state, state_acc ->
+      fun.(entry.module, shell_state, state_acc)
+    end)
+    |> merge_stashed_shell_transformation(stash, shell_id, changed?)
+  end
+
+  @spec merge_stashed_shell_transformation(
+          StateStash.transform_result(t()),
+          shell_state_stash(),
+          shell_id(),
+          boolean()
+        ) :: {shell_state_stash(), t(), boolean()}
+  defp merge_stashed_shell_transformation({:updated, updated, state}, stash, shell_id, _changed?),
+    do: {Map.put(stash, shell_id, updated), state, true}
+
+  defp merge_stashed_shell_transformation(
+         {:unchanged, _unchanged, state},
+         stash,
+         _shell_id,
+         changed?
+       ),
+       do: {stash, state, changed?}
+
+  defp merge_stashed_shell_transformation({:mismatch, state}, stash, _shell_id, changed?),
+    do: {stash, state, changed?}
+
   @doc "Returns the active shell id, preserving compatibility with tests that still set only `:shell`."
   @spec active_shell_id(t() | map()) :: shell_id()
   def active_shell_id(%{shell_id: id, shell: shell}) do
@@ -1180,7 +1282,10 @@ defmodule MingaEditor.State do
        ) do
     case Map.get(stash, target_entry.id) do
       %StateStash{} = stashed ->
-        restore_matching_shell_state(stashed, target_entry, module, previous_shell_state)
+        case StateStash.restore(stashed, target_entry) do
+          {:ok, shell_state} -> shell_state
+          :mismatch -> init_shell_state(module, previous_shell_state)
+        end
 
       _other ->
         init_shell_state(module, previous_shell_state)
@@ -1189,21 +1294,6 @@ defmodule MingaEditor.State do
 
   defp restore_shell_state(_stash, _target_entry, module, previous_shell_state) do
     init_shell_state(module, previous_shell_state)
-  end
-
-  @spec restore_matching_shell_state(
-          StateStash.t(),
-          MingaEditor.Shell.Entry.t(),
-          module(),
-          shell_state()
-        ) ::
-          shell_state()
-  defp restore_matching_shell_state(stashed, target_entry, module, previous_shell_state) do
-    if StateStash.matches?(stashed, target_entry) do
-      stashed.state
-    else
-      init_shell_state(module, previous_shell_state)
-    end
   end
 
   @spec init_shell_state(module(), shell_state()) :: shell_state()
@@ -1419,41 +1509,23 @@ defmodule MingaEditor.State do
     module = active_shell_module(state)
 
     case apply_optional_shell_callback(module, state.shell_state, callback, args) do
-      {:ok, shell_state} -> %{state | shell_state: shell_state}
+      {:ok, shell_state} -> update_shell_state(state, fn _shell_state -> shell_state end)
       :missing -> state
     end
   end
 
   @spec update_stashed_shell_feature_state(t(), atom(), [term()]) :: t()
-  defp update_stashed_shell_feature_state(
-         %__MODULE__{shell_state_stash: stash} = state,
-         callback,
-         args
-       ) do
-    stash =
-      Map.new(stash, fn {shell_id, shell_state} ->
-        {shell_id, clean_stashed_shell_state(shell_id, shell_state, callback, args)}
+  defp update_stashed_shell_feature_state(%__MODULE__{} = state, callback, args) do
+    {state, _changed?} =
+      transform_stashed_shell_states(state, fn module, shell_state, state_acc ->
+        case apply_optional_shell_callback(module, shell_state, callback, args) do
+          {:ok, ^shell_state} -> {:unchanged, state_acc}
+          {:ok, cleaned_shell_state} -> {{:updated, cleaned_shell_state}, state_acc}
+          :missing -> {:unchanged, state_acc}
+        end
       end)
 
-    %{state | shell_state_stash: stash}
-  end
-
-  @spec clean_stashed_shell_state(shell_id(), StateStash.t() | term(), atom(), [term()]) ::
-          StateStash.t() | term()
-  defp clean_stashed_shell_state(_shell_id, %StateStash{} = stashed, callback, args) do
-    case apply_optional_shell_callback(stashed.module, stashed.state, callback, args) do
-      {:ok, cleaned_shell_state} -> %StateStash{stashed | state: cleaned_shell_state}
-      :missing -> stashed
-    end
-  end
-
-  defp clean_stashed_shell_state(shell_id, shell_state, callback, args) do
-    module = MingaEditor.Shell.Registry.module_for(shell_id)
-
-    case apply_optional_shell_callback(module, shell_state, callback, args) do
-      {:ok, cleaned_shell_state} -> cleaned_shell_state
-      :missing -> shell_state
-    end
+    state
   end
 
   @spec apply_optional_shell_callback(module() | nil, term(), atom(), [term()]) ::

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -926,101 +926,79 @@ defmodule MingaEditor.State do
   @doc "Transforms current stashed shell states and reports whether any matching value changed."
   @spec transform_stashed_shell_states(t(), stashed_shell_transform()) :: {t(), boolean()}
   def transform_stashed_shell_states(%__MODULE__{} = state, fun) when is_function(fun, 3) do
-    {stash, state, changed?} =
-      Enum.reduce(state.shell_state_stash, {state.shell_state_stash, state, false}, fn
-        {shell_id, %StateStash{} = stashed}, {stash_acc, state_acc, changed?} ->
-          transform_stashed_shell_state(
-            stash_acc,
-            state_acc,
-            changed?,
-            shell_id,
-            stashed,
-            fun
-          )
-
-        _entry, acc ->
-          acc
-      end)
-
-    {%{state | shell_state_stash: stash}, changed?}
+    state.shell_state_stash
+    |> Map.keys()
+    |> Enum.reduce({state, false}, fn shell_id, {state_acc, changed?} ->
+      transform_stashed_shell_state(state_acc, changed?, shell_id, fun)
+    end)
   end
 
   @doc "Transforms the first matching stashed shell that accepts the change."
   @spec transform_first_stashed_shell_state(t(), stashed_shell_transform()) :: {t(), boolean()}
   def transform_first_stashed_shell_state(%__MODULE__{} = state, fun) when is_function(fun, 3) do
-    {stash, state, changed?} =
-      Enum.reduce_while(state.shell_state_stash, {state.shell_state_stash, state, false}, fn
-        {shell_id, %StateStash{} = stashed}, {stash_acc, state_acc, false} ->
-          result =
-            transform_stashed_shell_state(stash_acc, state_acc, false, shell_id, stashed, fun)
-
-          continue_stashed_shell_transform(result)
-
-        _entry, acc ->
-          {:cont, acc}
-      end)
-
-    {%{state | shell_state_stash: stash}, changed?}
+    state.shell_state_stash
+    |> Map.keys()
+    |> Enum.reduce_while({state, false}, fn shell_id, {state_acc, false} ->
+      state_acc
+      |> transform_stashed_shell_state(false, shell_id, fun)
+      |> continue_stashed_shell_transform()
+    end)
   end
 
-  @spec continue_stashed_shell_transform({shell_state_stash(), t(), boolean()}) ::
-          {:cont, {shell_state_stash(), t(), boolean()}}
-          | {:halt, {shell_state_stash(), t(), boolean()}}
-  defp continue_stashed_shell_transform({_stash, _state, true} = result), do: {:halt, result}
+  @spec continue_stashed_shell_transform({t(), boolean()}) ::
+          {:cont, {t(), boolean()}} | {:halt, {t(), boolean()}}
+  defp continue_stashed_shell_transform({_state, true} = result), do: {:halt, result}
   defp continue_stashed_shell_transform(result), do: {:cont, result}
 
-  @spec transform_stashed_shell_state(
-          shell_state_stash(),
-          t(),
-          boolean(),
-          shell_id(),
-          StateStash.t(),
-          stashed_shell_transform()
-        ) :: {shell_state_stash(), t(), boolean()}
-  defp transform_stashed_shell_state(stash, state, changed?, shell_id, stashed, fun) do
+  @spec transform_stashed_shell_state(t(), boolean(), shell_id(), stashed_shell_transform()) ::
+          {t(), boolean()}
+  defp transform_stashed_shell_state(state, changed?, shell_id, fun) do
+    stashed = Map.get(state.shell_state_stash, shell_id)
     entry = MingaEditor.Shell.Registry.get(shell_id)
-    transform_stashed_shell_state(stash, state, changed?, shell_id, stashed, entry, fun)
+    transform_stashed_shell_state(state, changed?, shell_id, stashed, entry, fun)
   end
 
   @spec transform_stashed_shell_state(
-          shell_state_stash(),
           t(),
           boolean(),
           shell_id(),
-          StateStash.t(),
+          StateStash.t() | nil,
           MingaEditor.Shell.Entry.t() | nil,
           stashed_shell_transform()
-        ) :: {shell_state_stash(), t(), boolean()}
-  defp transform_stashed_shell_state(stash, state, changed?, _shell_id, _stashed, nil, _fun),
-    do: {stash, state, changed?}
+        ) :: {t(), boolean()}
+  defp transform_stashed_shell_state(state, changed?, _shell_id, _stashed, nil, _fun),
+    do: {state, changed?}
 
-  defp transform_stashed_shell_state(stash, state, changed?, shell_id, stashed, entry, fun) do
+  defp transform_stashed_shell_state(state, changed?, _shell_id, nil, _entry, _fun),
+    do: {state, changed?}
+
+  defp transform_stashed_shell_state(state, changed?, shell_id, stashed, entry, fun) do
     stashed
     |> StateStash.transform(entry, state, fn shell_state, state_acc ->
       fun.(entry.module, shell_state, state_acc)
     end)
-    |> merge_stashed_shell_transformation(stash, shell_id, changed?)
+    |> merge_stashed_shell_transformation(shell_id, changed?)
   end
 
   @spec merge_stashed_shell_transformation(
           StateStash.transform_result(t()),
-          shell_state_stash(),
           shell_id(),
           boolean()
-        ) :: {shell_state_stash(), t(), boolean()}
-  defp merge_stashed_shell_transformation({:updated, updated, state}, stash, shell_id, _changed?),
-    do: {Map.put(stash, shell_id, updated), state, true}
+        ) :: {t(), boolean()}
+  defp merge_stashed_shell_transformation({:updated, updated, state}, shell_id, _changed?) do
+    stash = Map.put(state.shell_state_stash, shell_id, updated)
+    {%{state | shell_state_stash: stash}, true}
+  end
 
   defp merge_stashed_shell_transformation(
          {:unchanged, _unchanged, state},
-         stash,
          _shell_id,
          changed?
        ),
-       do: {stash, state, changed?}
+       do: {state, changed?}
 
-  defp merge_stashed_shell_transformation({:mismatch, state}, stash, _shell_id, changed?),
-    do: {stash, state, changed?}
+  defp merge_stashed_shell_transformation({:mismatch, state}, _shell_id, changed?),
+    do: {state, changed?}
 
   @doc "Returns the active shell id, preserving compatibility with tests that still set only `:shell`."
   @spec active_shell_id(t() | map()) :: shell_id()

--- a/test/minga_agent/session_transcript_test.exs
+++ b/test/minga_agent/session_transcript_test.exs
@@ -136,6 +136,8 @@ defmodule MingaAgent.SessionTranscriptTest do
          }}
       )
 
+      :sys.get_state(session)
+
       assert_receive {:agent_event, _,
                       {:file_changed, "lib/foo.ex", "old content", "new content", "tc1",
                        _tool_name}},

--- a/test/minga_editor/feature_state_shell_cleanup_test.exs
+++ b/test/minga_editor/feature_state_shell_cleanup_test.exs
@@ -69,6 +69,37 @@ defmodule MingaEditor.FeatureStateShellCleanupTest do
              :stashed_other
   end
 
+  test "editor cleanup does not transform a stash from an obsolete registration" do
+    stashed_context = context_with_feature_state(:stashed_owned, :stashed_other)
+    stale_entry = Registry.get(:fake_shell)
+
+    state = %EditorState{
+      port_manager: self(),
+      workspace: workspace(),
+      shell_state_stash: %{
+        fake_shell: StateStash.new(stale_entry, %{contexts: [stashed_context]})
+      }
+    }
+
+    assert :ok = Registry.unregister_source({:extension, :fake_shell})
+
+    assert :ok =
+             Registry.register({:extension, :fake_shell}, %{
+               id: :fake_shell,
+               module: MingaEditor.Test.FakeShell,
+               display_name: "Fake Shell",
+               description: "Replacement shell",
+               default?: false,
+               capabilities: []
+             })
+
+    cleaned = EditorState.drop_feature_state_source(state, @source)
+    %StateStash{state: %{contexts: [unchanged_context]}} = cleaned.shell_state_stash.fake_shell
+    restored = SessionState.restore_tab_context(workspace(), unchanged_context)
+
+    assert SessionState.get_feature_state(restored, @source, @feature) == :stashed_owned
+  end
+
   @spec context_with_feature_state(atom(), atom()) :: MingaEditor.State.Tab.Context.t()
   defp context_with_feature_state(owned, other) do
     workspace()

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -3,11 +3,14 @@ defmodule MingaEditor.Shell.RegistryTest do
   use ExUnit.Case, async: false
 
   alias Minga.Extension.ContributionCleanup
+  alias MingaEditor.Commands.BufferManagement
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Identity
   alias MingaEditor.Input.Router
   alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.StateStash
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Test.FakeShell
   alias MingaEditor.Test.FakeShellAlt
@@ -119,6 +122,293 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     assert switched.shell == FakeShellAlt
     assert switched.shell_state == %{name: :fake_alt, events: []}
+  end
+
+  test "switching back restores state for the matching registration" do
+    Registry.seed_builtin()
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    state =
+      TestHelpers.base_state()
+      |> EditorState.switch_shell(:fake)
+      |> EditorState.update_shell_state(&Map.put(&1, :marker, :preserved))
+      |> EditorState.switch_shell(:traditional)
+      |> EditorState.switch_shell(:fake)
+
+    assert state.shell_state.marker == :preserved
+  end
+
+  test "switch invalidates layout and focus while active-shell selection remains a no-op" do
+    Registry.seed_builtin()
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    switched =
+      %{TestHelpers.base_state() | layout: :layout, focus_tree: :focus}
+      |> EditorState.switch_shell(:fake)
+
+    assert switched.layout == nil
+    assert switched.focus_tree == nil
+
+    unchanged =
+      %{TestHelpers.base_state() | layout: :layout, focus_tree: :focus}
+      |> EditorState.switch_shell(:traditional)
+
+    assert unchanged.layout == :layout
+    assert unchanged.focus_tree == :focus
+    assert EditorState.status_msg(unchanged) == "Already using Traditional"
+  end
+
+  test "unavailable active shell falls back with the default identity and fresh state" do
+    Registry.seed_builtin()
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    state =
+      TestHelpers.base_state()
+      |> EditorState.switch_shell(:fake)
+      |> EditorState.update_shell_state(&Map.put(&1, :obsolete, true))
+
+    assert :ok = Registry.unregister_source({:extension, :fake})
+
+    result = EditorState.ensure_shell_available(state)
+    default = Registry.default()
+
+    assert result.shell_id == default.id
+    assert result.shell == default.module
+    assert Identity.matches?(result.shell_identity, default)
+    refute Map.has_key?(result.shell_state, :obsolete)
+    refute Map.has_key?(result.shell_state_stash, :fake)
+    assert result.layout == nil
+    assert result.focus_tree == nil
+  end
+
+  test "background agent events update a matching stash but not a replaced registration" do
+    Registry.seed_builtin()
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    assert :ok =
+             Registry.register({:extension, :fake_alt}, %{
+               id: :fake_alt,
+               module: FakeShellAlt,
+               display_name: "Fake Alt",
+               description: "Fake shell alt",
+               capabilities: [:tui]
+             })
+
+    state =
+      TestHelpers.base_state()
+      |> EditorState.switch_shell(:fake)
+      |> EditorState.update_shell_state(&Map.put(&1, :record_agent_events?, true))
+      |> EditorState.switch_shell(:fake_alt)
+      |> Map.put(:backend, :gui)
+
+    event = {:status_changed, :error}
+    {:noreply, matching} = MingaEditor.handle_info({:agent_event, self(), event}, state)
+    assert matching.shell_state_stash.fake.state.events == [event]
+
+    assert :ok = Registry.unregister_source({:extension, :fake})
+
+    assert :ok =
+             Registry.register({:extension, :fake_replacement}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake replacement",
+               description: "Replacement registration",
+               capabilities: [:tui]
+             })
+
+    {:noreply, stale} =
+      MingaEditor.handle_info({:agent_event, self(), {:status_changed, :idle}}, matching)
+
+    assert stale.shell_state_stash.fake.state.events == [event]
+    Process.cancel_timer(stale.render_timer)
+  end
+
+  test "buffer session restart updates a matching stash but not a replaced registration" do
+    Registry.seed_builtin()
+    old_pid = self()
+    new_pid = spawn(fn -> receive do: (:stop -> :ok) end)
+    on_exit(fn -> send(new_pid, :stop) end)
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    entry = Registry.get(:fake)
+
+    state = %{
+      TestHelpers.base_state()
+      | shell_state_stash: %{fake: StateStash.new(entry, %{session: old_pid})}
+    }
+
+    matching =
+      BufferManagement.handle_agent_session_restarted(
+        state,
+        "session-id",
+        old_pid,
+        new_pid,
+        :restarted
+      )
+
+    assert matching.shell_state_stash.fake.state.session == new_pid
+
+    stale_state = %{
+      state
+      | shell_state_stash: %{fake: StateStash.new(entry, %{session: old_pid})}
+    }
+
+    assert :ok = Registry.unregister_source({:extension, :fake})
+
+    assert :ok =
+             Registry.register({:extension, :fake_replacement}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake replacement",
+               description: "Replacement registration",
+               capabilities: [:tui]
+             })
+
+    stale =
+      BufferManagement.handle_agent_session_restarted(
+        stale_state,
+        "session-id",
+        old_pid,
+        new_pid,
+        :restarted
+      )
+
+    assert stale.shell_state_stash.fake.state.session == old_pid
+    refute BufferManagement.agent_session_restart_owned?(stale, old_pid)
+  end
+
+  test "active shell session restart resets obsolete registration state before callbacks" do
+    Registry.seed_builtin()
+    old_pid = self()
+    new_pid = spawn(fn -> receive do: (:stop -> :ok) end)
+    on_exit(fn -> send(new_pid, :stop) end)
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    state =
+      TestHelpers.base_state()
+      |> EditorState.switch_shell(:fake)
+      |> EditorState.update_shell_state(&Map.put(&1, :session, old_pid))
+
+    assert :ok = Registry.unregister_source({:extension, :fake})
+
+    assert :ok =
+             Registry.register({:extension, :fake_replacement}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake replacement",
+               description: "Replacement registration",
+               capabilities: [:tui]
+             })
+
+    current_entry = Registry.get(:fake)
+
+    restarted =
+      BufferManagement.handle_agent_session_restarted(
+        state,
+        "session-id",
+        old_pid,
+        new_pid,
+        :restarted
+      )
+
+    assert Map.take(restarted.shell_state, [:name, :events]) == %{name: :fake, events: []}
+    refute Map.has_key?(restarted.shell_state, :session)
+    assert Identity.matches?(restarted.shell_identity, current_entry)
+    refute BufferManagement.agent_session_restart_owned?(state, old_pid)
+  end
+
+  test "buffer lifecycle stops after the first stashed shell handles a restart" do
+    Registry.seed_builtin()
+    old_pid = self()
+    new_pid = spawn(fn -> receive do: (:stop -> :ok) end)
+    on_exit(fn -> send(new_pid, :stop) end)
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    assert :ok =
+             Registry.register({:extension, :fake_alt}, %{
+               id: :fake_alt,
+               module: FakeShellAlt,
+               display_name: "Fake Alt",
+               description: "Fake shell alt",
+               capabilities: [:tui]
+             })
+
+    state = %{
+      TestHelpers.base_state()
+      | shell_state_stash: %{
+          fake: StateStash.new(Registry.get(:fake), %{session: old_pid}),
+          fake_alt: StateStash.new(Registry.get(:fake_alt), %{session: old_pid})
+        }
+    }
+
+    restarted =
+      BufferManagement.handle_agent_session_restarted(
+        state,
+        "session-id",
+        old_pid,
+        new_pid,
+        :restarted
+      )
+
+    sessions = Enum.map(restarted.shell_state_stash, fn {_id, stash} -> stash.state.session end)
+    assert Enum.count(sessions, &(&1 == new_pid)) == 1
+    assert Enum.count(sessions, &(&1 == old_pid)) == 1
   end
 
   test "renderer writeback drops stale output after a shell id is re-registered" do

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -3,7 +3,11 @@ defmodule MingaEditor.Shell.RegistryTest do
   use ExUnit.Case, async: false
 
   alias Minga.Extension.ContributionCleanup
+  alias MingaAgent.SessionManager
+  alias MingaAgent.SessionManager.SessionRestartedEvent
+  alias MingaEditor.Agent.Events
   alias MingaEditor.Commands.BufferManagement
+  alias MingaEditor.Handlers.EventDispatcher
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Shell.Entry
@@ -12,6 +16,7 @@ defmodule MingaEditor.Shell.RegistryTest do
   alias MingaEditor.Shell.Registry
   alias MingaEditor.Shell.StateStash
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.Test.FakeShell
   alias MingaEditor.Test.FakeShellAlt
 
@@ -255,6 +260,58 @@ defmodule MingaEditor.Shell.RegistryTest do
     Process.cancel_timer(stale.render_timer)
   end
 
+  test "Agent.Events updates matching stashes but skips a replaced registration" do
+    Registry.seed_builtin()
+    session = self()
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    assert :ok =
+             Registry.register({:extension, :fake_alt}, %{
+               id: :fake_alt,
+               module: FakeShellAlt,
+               display_name: "Fake Alt",
+               description: "Fake shell alt",
+               capabilities: [:tui]
+             })
+
+    fake_entry = Registry.get(:fake)
+
+    state =
+      TestHelpers.base_state()
+      |> EditorState.switch_shell(:fake_alt)
+      |> EditorState.update_shell_state(fn shell_state ->
+        Map.merge(shell_state, %{agent: %AgentState{}, session: session, tab_bar: nil})
+      end)
+      |> Map.put(:shell_state_stash, %{
+        fake: StateStash.new(fake_entry, %{session: session})
+      })
+
+    {matching, _effects} = Events.handle(state, {:status_changed, :thinking})
+    assert matching.shell_state_stash.fake.state.synced_agent_status == :thinking
+
+    assert :ok = Registry.unregister_source({:extension, :fake})
+
+    assert :ok =
+             Registry.register({:extension, :fake_replacement}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake replacement",
+               description: "Replacement registration",
+               capabilities: [:tui]
+             })
+
+    {stale, _effects} = Events.handle(matching, {:status_changed, :idle})
+    assert stale.shell_state_stash.fake.state.synced_agent_status == :thinking
+  end
+
   test "buffer session restart updates a matching stash but not a replaced registration" do
     Registry.seed_builtin()
     old_pid = self()
@@ -314,7 +371,7 @@ defmodule MingaEditor.Shell.RegistryTest do
       )
 
     assert stale.shell_state_stash.fake.state.session == old_pid
-    refute BufferManagement.agent_session_restart_owned?(stale, old_pid)
+    assert {:stale, _normalized} = BufferManagement.prepare_agent_session_restart(stale, old_pid)
   end
 
   test "active shell session restart resets obsolete registration state before callbacks" do
@@ -362,7 +419,121 @@ defmodule MingaEditor.Shell.RegistryTest do
     assert Map.take(restarted.shell_state, [:name, :events]) == %{name: :fake, events: []}
     refute Map.has_key?(restarted.shell_state, :session)
     assert Identity.matches?(restarted.shell_identity, current_entry)
-    refute BufferManagement.agent_session_restart_owned?(state, old_pid)
+
+    assert {:stale, normalized} = BufferManagement.prepare_agent_session_restart(state, old_pid)
+    assert Identity.matches?(normalized.shell_identity, current_entry)
+    refute Map.has_key?(normalized.shell_state, :session)
+  end
+
+  test "restart dispatch retains normalized state when subscription is stale" do
+    Registry.seed_builtin()
+    old_pid = self()
+    session_id = "registry-restart-#{System.unique_integer([:positive])}"
+    assert {:ok, ^session_id, new_pid} = SessionManager.start_session(session_id: session_id)
+    on_exit(fn -> SessionManager.stop_session(session_id) end)
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    assert :ok =
+             Registry.register({:extension, :valid}, %{
+               id: :valid,
+               module: FakeShellAlt,
+               display_name: "Valid",
+               description: "Valid shell",
+               capabilities: [:tui]
+             })
+
+    valid_entry = Registry.get(:valid)
+    dead_ingest = spawn(fn -> :ok end)
+    monitor = Process.monitor(dead_ingest)
+    assert_receive {:DOWN, ^monitor, :process, ^dead_ingest, :normal}
+
+    state =
+      TestHelpers.base_state()
+      |> EditorState.switch_shell(:fake)
+      |> EditorState.update_shell_state(&Map.put(&1, :session, old_pid))
+      |> Map.put(:agent_ingest, dead_ingest)
+      |> Map.put(:shell_state_stash, %{
+        valid: StateStash.new(valid_entry, %{session: old_pid})
+      })
+
+    assert :ok = Registry.unregister_source({:extension, :fake})
+
+    assert :ok =
+             Registry.register({:extension, :fake_replacement}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake replacement",
+               description: "Replacement registration",
+               capabilities: [:tui]
+             })
+
+    current_entry = Registry.get(:fake)
+
+    normalized =
+      EventDispatcher.dispatch(
+        state,
+        :agent_session_restarted,
+        %SessionRestartedEvent{
+          session_id: session_id,
+          old_pid: old_pid,
+          new_pid: new_pid,
+          reason: :restarted
+        },
+        nil
+      )
+
+    assert Identity.matches?(normalized.shell_identity, current_entry)
+    refute Map.has_key?(normalized.shell_state, :session)
+    assert normalized.shell_state_stash.valid.state.session == old_pid
+  end
+
+  test "session down and disconnect reset obsolete active shell state before callbacks" do
+    Registry.seed_builtin()
+    session = self()
+
+    assert :ok =
+             Registry.register({:extension, :fake}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake",
+               description: "Fake shell",
+               capabilities: [:tui]
+             })
+
+    state =
+      TestHelpers.base_state()
+      |> EditorState.switch_shell(:fake)
+      |> EditorState.update_shell_state(&Map.put(&1, :session, session))
+
+    assert :ok = Registry.unregister_source({:extension, :fake})
+
+    assert :ok =
+             Registry.register({:extension, :fake_replacement}, %{
+               id: :fake,
+               module: FakeShell,
+               display_name: "Fake replacement",
+               description: "Replacement registration",
+               capabilities: [:tui]
+             })
+
+    current_entry = Registry.get(:fake)
+    normal = BufferManagement.handle_agent_session_down(state, session, :boom)
+    disconnected = BufferManagement.handle_agent_session_down(state, session, :noconnection)
+
+    for normalized <- [normal, disconnected] do
+      assert Identity.matches?(normalized.shell_identity, current_entry)
+      refute Map.has_key?(normalized.shell_state, :session)
+      refute Map.has_key?(normalized.shell_state, :session_down?)
+      refute Map.has_key?(normalized.shell_state, :remote_disconnected?)
+    end
   end
 
   test "buffer lifecycle stops after the first stashed shell handles a restart" do
@@ -409,6 +580,110 @@ defmodule MingaEditor.Shell.RegistryTest do
     sessions = Enum.map(restarted.shell_state_stash, fn {_id, stash} -> stash.state.session end)
     assert Enum.count(sessions, &(&1 == new_pid)) == 1
     assert Enum.count(sessions, &(&1 == old_pid)) == 1
+  end
+
+  test "buffer lifecycle skips a stale stash before the matching owner" do
+    Registry.seed_builtin()
+    old_pid = self()
+    new_pid = spawn(fn -> receive do: (:stop -> :ok) end)
+    on_exit(fn -> send(new_pid, :stop) end)
+
+    assert :ok =
+             Registry.register({:extension, :stale}, %{
+               id: :a_stale,
+               module: FakeShell,
+               display_name: "Stale",
+               description: "Stale shell",
+               capabilities: [:tui]
+             })
+
+    assert :ok =
+             Registry.register({:extension, :valid}, %{
+               id: :z_valid,
+               module: FakeShellAlt,
+               display_name: "Valid",
+               description: "Valid shell",
+               capabilities: [:tui]
+             })
+
+    stale_entry = Registry.get(:a_stale)
+    valid_entry = Registry.get(:z_valid)
+    assert :ok = Registry.unregister_source({:extension, :stale})
+
+    assert :ok =
+             Registry.register({:extension, :stale_replacement}, %{
+               id: :a_stale,
+               module: FakeShell,
+               display_name: "Stale replacement",
+               description: "Replacement registration",
+               capabilities: [:tui]
+             })
+
+    state = %{
+      TestHelpers.base_state()
+      | shell_state_stash: %{
+          a_stale: StateStash.new(stale_entry, %{session: old_pid}),
+          z_valid: StateStash.new(valid_entry, %{session: old_pid})
+        }
+    }
+
+    restarted =
+      BufferManagement.handle_agent_session_restarted(
+        state,
+        "session-id",
+        old_pid,
+        new_pid,
+        :restarted
+      )
+
+    assert restarted.shell_state_stash.a_stale.state.session == old_pid
+    assert restarted.shell_state_stash.z_valid.state.session == new_pid
+  end
+
+  test "stash transformations thread the current aggregate into later callbacks" do
+    Registry.seed_builtin()
+
+    assert :ok =
+             Registry.register({:extension, :first}, %{
+               id: :first,
+               module: FakeShell,
+               display_name: "First",
+               description: "First shell",
+               capabilities: [:tui]
+             })
+
+    assert :ok =
+             Registry.register({:extension, :second}, %{
+               id: :second,
+               module: FakeShellAlt,
+               display_name: "Second",
+               description: "Second shell",
+               capabilities: [:tui]
+             })
+
+    state = %{
+      TestHelpers.base_state()
+      | shell_state_stash: %{
+          first: StateStash.new(Registry.get(:first), %{}),
+          second: StateStash.new(Registry.get(:second), %{})
+        }
+    }
+
+    {transformed, true} =
+      EditorState.transform_stashed_shell_states(state, fn _module, shell_state, state_acc ->
+        transformed_count =
+          Enum.count(state_acc.shell_state_stash, fn {_id, stash} ->
+            Map.get(stash.state, :transformed?, false)
+          end)
+
+        send(self(), {:transformed_count, transformed_count})
+        {{:updated, Map.put(shell_state, :transformed?, true)}, state_acc}
+      end)
+
+    assert_receive {:transformed_count, 0}
+    assert_receive {:transformed_count, 1}
+    assert transformed.shell_state_stash.first.state.transformed?
+    assert transformed.shell_state_stash.second.state.transformed?
   end
 
   test "renderer writeback drops stale output after a shell id is re-registered" do

--- a/test/minga_editor/shell/state_stash_test.exs
+++ b/test/minga_editor/shell/state_stash_test.exs
@@ -1,0 +1,74 @@
+defmodule MingaEditor.Shell.StateStashTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.StateStash
+
+  test "restore returns stored state for the matching registry identity" do
+    entry = entry()
+    stash = StateStash.new(entry, %{count: 2})
+
+    assert StateStash.restore(stash, entry) == {:ok, %{count: 2}}
+  end
+
+  test "transform updates state while preserving registry identity metadata" do
+    entry = entry()
+    stash = StateStash.new(entry, %{count: 2})
+
+    assert {:updated, updated} =
+             StateStash.transform(stash, entry, fn state ->
+               {:updated, Map.update!(state, :count, &(&1 + 1))}
+             end)
+
+    assert updated.state == %{count: 3}
+    assert updated.id == stash.id
+    assert updated.module == stash.module
+    assert updated.source == stash.source
+    assert updated.generation == stash.generation
+  end
+
+  test "transform reports unchanged without rebuilding the stash" do
+    entry = entry()
+    stash = StateStash.new(entry, %{count: 2})
+
+    assert StateStash.transform(stash, entry, fn _state -> :unchanged end) ==
+             {:unchanged, stash}
+  end
+
+  test "module, source, generation, and id mismatches never invoke the transformation" do
+    entry = entry()
+    stash = StateStash.new(entry, %{count: 2})
+    test_pid = self()
+
+    mismatches = [
+      %{entry | module: String},
+      %{entry | source: {:extension, :replacement}},
+      %{entry | generation: entry.generation + 1},
+      %{entry | id: :replacement}
+    ]
+
+    Enum.each(mismatches, fn mismatch ->
+      assert StateStash.restore(stash, mismatch) == :mismatch
+
+      assert StateStash.transform(stash, mismatch, fn state ->
+               send(test_pid, {:invoked, mismatch})
+               {:updated, state}
+             end) == :mismatch
+    end)
+
+    refute_receive {:invoked, _mismatch}
+  end
+
+  @spec entry() :: Entry.t()
+  defp entry do
+    %Entry{
+      id: :fake,
+      source: {:extension, :fake},
+      module: MingaEditor.Test.FakeShell,
+      display_name: "Fake",
+      description: "Fake shell",
+      capabilities: [:tui],
+      generation: 7
+    }
+  end
+end

--- a/test/support/fake_shell.ex
+++ b/test/support/fake_shell.ex
@@ -88,10 +88,18 @@ defmodule MingaEditor.Test.FakeShell do
   @impl true
   @spec on_agent_event(map(), MingaEditor.Session.State.t(), pid(), term()) ::
           {map(), MingaEditor.Session.State.t(), [MingaEditor.effect()]}
+  def on_agent_event(%{record_agent_events?: true} = shell_state, workspace, _session, event) do
+    {%{shell_state | events: [event | Map.get(shell_state, :events, [])]}, workspace, []}
+  end
+
   def on_agent_event(shell_state, workspace, _session, _event), do: {shell_state, workspace, []}
 
   @impl true
   @spec handle_agent_session_restarted(map(), pid(), pid(), term()) :: {map(), boolean()}
+  def handle_agent_session_restarted(%{session: old_pid} = shell_state, old_pid, new_pid, _reason) do
+    {Map.put(shell_state, :session, new_pid), true}
+  end
+
   def handle_agent_session_restarted(shell_state, _old_pid, _new_pid, _reason),
     do: {shell_state, false}
 

--- a/test/support/fake_shell.ex
+++ b/test/support/fake_shell.ex
@@ -103,6 +103,24 @@ defmodule MingaEditor.Test.FakeShell do
   def handle_agent_session_restarted(shell_state, _old_pid, _new_pid, _reason),
     do: {shell_state, false}
 
+  @spec handle_agent_session_down(map(), pid(), term()) :: {map(), boolean()}
+  def handle_agent_session_down(%{session: session} = shell_state, session, _reason),
+    do: {Map.put(shell_state, :session_down?, true), true}
+
+  def handle_agent_session_down(shell_state, _session, _reason), do: {shell_state, false}
+
+  @spec handle_remote_session_disconnected(map(), pid()) :: {map(), boolean()}
+  def handle_remote_session_disconnected(%{session: session} = shell_state, session),
+    do: {Map.put(shell_state, :remote_disconnected?, true), true}
+
+  def handle_remote_session_disconnected(shell_state, _session), do: {shell_state, false}
+
+  @spec sync_agent_status(map(), pid(), atom()) :: map()
+  def sync_agent_status(%{session: session} = shell_state, session, status),
+    do: Map.put(shell_state, :synced_agent_status, status)
+
+  def sync_agent_status(shell_state, _session, _status), do: shell_state
+
   @impl true
   @spec active_tab(map()) :: nil
   def active_tab(_shell_state), do: nil
@@ -120,7 +138,8 @@ defmodule MingaEditor.Test.FakeShell do
   def set_tab_session(shell_state, _tab_id, _session_pid), do: shell_state
 
   @impl true
-  @spec active_session(map()) :: nil
+  @spec active_session(map()) :: pid() | nil
+  def active_session(%{session: session}) when is_pid(session), do: session
   def active_session(_shell_state), do: nil
 
   @spec drop_feature_state_source(map(), MingaEditor.FeatureState.source()) :: map()

--- a/test/support/fake_shell_alt.ex
+++ b/test/support/fake_shell_alt.ex
@@ -90,6 +90,12 @@ defmodule MingaEditor.Test.FakeShellAlt do
   def handle_agent_session_restarted(shell_state, _old_pid, _new_pid, _reason),
     do: {shell_state, false}
 
+  @spec sync_agent_status(map(), pid(), atom()) :: map()
+  def sync_agent_status(%{session: session} = shell_state, session, status),
+    do: Map.put(shell_state, :synced_agent_status, status)
+
+  def sync_agent_status(shell_state, _session, _status), do: shell_state
+
   @impl true
   @spec active_tab(map()) :: nil
   def active_tab(_shell_state), do: nil
@@ -107,6 +113,7 @@ defmodule MingaEditor.Test.FakeShellAlt do
   def set_tab_session(shell_state, _tab_id, _session_pid), do: shell_state
 
   @impl true
-  @spec active_session(map()) :: nil
+  @spec active_session(map()) :: pid() | nil
+  def active_session(%{session: session}) when is_pid(session), do: session
   def active_session(_shell_state), do: nil
 end

--- a/test/support/fake_shell_alt.ex
+++ b/test/support/fake_shell_alt.ex
@@ -83,6 +83,10 @@ defmodule MingaEditor.Test.FakeShellAlt do
 
   @impl true
   @spec handle_agent_session_restarted(map(), pid(), pid(), term()) :: {map(), boolean()}
+  def handle_agent_session_restarted(%{session: old_pid} = shell_state, old_pid, new_pid, _reason) do
+    {Map.put(shell_state, :session, new_pid), true}
+  end
+
   def handle_agent_session_restarted(shell_state, _old_pid, _new_pid, _reason),
     do: {shell_state, false}
 


### PR DESCRIPTION
# TL;DR
Shell state is now restored or transformed only while its full registry identity still matches. Stale extension registrations cannot receive background agent or buffer lifecycle updates, while `MingaEditor.State` remains the sole aggregate owner.

Closes #2823

## Context
Shell state compatibility previously depended on checks and mutations spread across Editor state, background agent routing, feature cleanup, and buffer lifecycle handling. Reusing a shell id after an extension reload could leave obsolete state reachable, and callers updated `StateStash` directly.

## Changes
- Make `StateStash` own its complete id, module, source, and generation identity plus guarded restore and transformation operations.
- Keep stash-map replacement, active-shell fallback, initialization, status, and layout/focus invalidation in `MingaEditor.State`.
- Route feature cleanup, background agent events, and buffer session lifecycle updates through identity validation before callbacks run.
- Preserve the prior first-handler short circuit for buffer lifecycle callbacks.
- Refresh or reset stale active-shell identity before session ownership checks and lifecycle callbacks.
- Add deterministic coverage for matching restoration, every identity mismatch, replacement registrations, active fallback, background events, buffer restarts, callback ordering, and invalidation behavior.
- Replace one timing-dependent Session transcript assertion with the project-standard mailbox barrier discovered during full-suite validation.

## Verification
- `make lint`
  - Format, changed Credo, warnings-as-errors compilation, and incremental Dialyzer passed.
- `mix test.llm`
  - 9,202 tests, 58 doctests, and 97 properties passed with zero failures.
- Focused shell, feature cleanup, agent routing, and buffer management scope
  - 86 tests passed.
- LSP diagnostics
  - No diagnostics in the five changed production files.
- Final reviewer
  - PASS on candidate tree `97606a84be84a9a97b07f9b1b2e179431cb88ea2`.

## Acceptance Criteria Addressed
- Matching shell registrations restore prior state ✅
- Replaced registrations reject obsolete stashed state ✅
- Background agent, buffer lifecycle, and feature cleanup updates validate identity ✅
- Unavailable or replaced active shells fall back or reset safely ✅
- Layout/focus invalidation and active-shell no-op behavior remain intact ✅
- Deterministic matching, mismatch, fallback, and callback coverage is present ✅
