### PR TITLE
feat(macos): make native rendering failure atomic

### DIFF
--- a/lib/mix/tasks/swift_harness.ex
+++ b/lib/mix/tasks/swift_harness.ex
@@ -28,6 +28,7 @@ defmodule Mix.Tasks.Swift.Harness do
     "macos/Sources/Protocol/FrameResourcePolicy.swift",
     "macos/Sources/Renderer/WindowContent.swift",
     "macos/Sources/Renderer/ResidentRowStore.swift",
+    "macos/Sources/Renderer/ResidentRenderPreparation.swift",
     "macos/Sources/Protocol/AgentSurfaceTypes.swift",
     "macos/Sources/Protocol/LatencyRecorder.swift",
     "macos/Sources/Protocol/RenderPerformanceGate.swift",

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -73,7 +73,9 @@
 		3B03245A5A6EFA39B99B37F8 /* InputEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E717A483EC2E50C536785C /* InputEncoder.swift */; };
 		3CD15ED81AE384C93557B0C0 /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA8938E70ED0123ACECD921 /* CompletionOverlay.swift */; };
 		41DCC27275D0E8E903EAA061 /* SidebarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */; };
+		41FF9FC432F155FBCAA0A3C2 /* FrameResourcePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA4AE7E853248477810B52C /* FrameResourcePolicy.swift */; };
 		422A1F1325C83168D9607566 /* PreviewSnapshotPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1D0E05FBEEC550591460C7 /* PreviewSnapshotPolicy.swift */; };
+		42DA748322634F24B2E04B7F /* NativeRenderResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = E945E6E53217CEC4BAAECBDD /* NativeRenderResources.swift */; };
 		43116CD030B0374BE3F4B3FE /* BEAMProcessManagerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F2A06C5BA9E3F53A59E202F /* BEAMProcessManagerTests.swift */; };
 		437246F69E6EFF8088543BF6 /* AgentContextBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A6ADDC2FFB43010EDEF1C576 /* AgentContextBarState.swift */; };
 		4400C2DBBACCF83790714235 /* ThumbDragSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AEAD1E631064BE3B13E42C /* ThumbDragSession.swift */; };
@@ -231,7 +233,10 @@
 		B308ADA08963E550E47FCDED /* EditorScrollTrackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2E468DA824CDB99FCEF94A /* EditorScrollTrackTests.swift */; };
 		B36F6632677AC067B8A7A2A4 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568352180EC6FAF208830660 /* FileTreeView.swift */; };
 		B3B08F3C63B5A5D2605C8611 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5647A59C841B3C408994CC7 /* Assets.xcassets */; };
+		B4D102EA2208CBB90DB2D894 /* NativeRenderResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = E945E6E53217CEC4BAAECBDD /* NativeRenderResources.swift */; };
+		B4E3EC9A8E5388DF973D170F /* NativeRenderResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4819FED95BD6D1746F538DED /* NativeRenderResourcesTests.swift */; };
 		B5D79AA3EB89928091967F73 /* ProtocolEventHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */; };
+		B6F6BC02D79641B220329521 /* NativeRenderResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = E945E6E53217CEC4BAAECBDD /* NativeRenderResources.swift */; };
 		B7203DF9CF85663B0A266580 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
 		B7EA51EE1C9145223251B68C /* ProtocolSemanticDecode.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B639BCE7660087F70778E839 /* ProtocolSemanticDecode.generated.swift */; };
 		B909887B329ECB88EB605B85 /* MingaProtocol.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
@@ -250,7 +255,6 @@
 		C3FAE27B586C49B9172CD41A /* FrameMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */; };
 		C43DAF0776A77C3DE0EE6A90 /* ProtocolErrorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A915C3108F2370C753A1931B /* ProtocolErrorState.swift */; };
 		C44D9CF03C49E7BCA39A76A9 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
-		F41B7A8428024E08A7B6F901 /* FrameResourcePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA4AE7E853248477810B52C /* FrameResourcePolicy.swift */; };
 		C6BCAF6C4605DD682B8BC442 /* FloatPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA0E8F5D7D411B92E9E3FA /* FloatPopupOverlay.swift */; };
 		C6F817BD3BFBFA4C334DC229 /* FeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF185FF7AFC2D9E5430B6B65 /* FeedbackState.swift */; };
 		C715D937E8591D8BA46A29CD /* FontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2DE335B00721CBB29329F9 /* FontTests.swift */; };
@@ -475,6 +479,7 @@
 		470991E7B3850B1AADFD46FD /* CommandDispatcherTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CommandDispatcherTests.swift; sourceTree = "<group>"; };
 		4742DDE225F256A140177301 /* LineTextureAtlas.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LineTextureAtlas.swift; sourceTree = "<group>"; };
 		47BD56B7D6D195D236F9BF40 /* ProtocolEncoderBinaryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoderBinaryTests.swift; sourceTree = "<group>"; };
+		4819FED95BD6D1746F538DED /* NativeRenderResourcesTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeRenderResourcesTests.swift; sourceTree = "<group>"; };
 		483AA21EF140F07296D1E16A /* AgentSurfaceTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentSurfaceTypes.swift; sourceTree = "<group>"; };
 		48E21C30D142028698027567 /* CoreTextShaders.metal */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.metal; path = CoreTextShaders.metal; sourceTree = "<group>"; };
 		492285F3371798B69478BF13 /* AgentApprovalCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentApprovalCard.swift; sourceTree = "<group>"; };
@@ -609,6 +614,7 @@
 		E4DCF10EBEB51624A4A1F428 /* InlineEditField.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InlineEditField.swift; sourceTree = "<group>"; };
 		E557E349097FF119EFE0F827 /* FeedbackStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackStateTests.swift; sourceTree = "<group>"; };
 		E8D8E70B7413F570FBAC58C1 /* MessagesContentState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentState.swift; sourceTree = "<group>"; };
+		E945E6E53217CEC4BAAECBDD /* NativeRenderResources.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeRenderResources.swift; sourceTree = "<group>"; };
 		EE173FAAAC37ACFF47EE03B8 /* EditTimelineView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTimelineView.swift; sourceTree = "<group>"; };
 		EF185FF7AFC2D9E5430B6B65 /* FeedbackState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeedbackState.swift; sourceTree = "<group>"; };
 		F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ThemeColorsTests.swift; sourceTree = "<group>"; };
@@ -746,6 +752,7 @@
 				FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */,
 				D2D59D9EEB390C8DF351D595 /* FrameState.swift */,
 				4742DDE225F256A140177301 /* LineTextureAtlas.swift */,
+				E945E6E53217CEC4BAAECBDD /* NativeRenderResources.swift */,
 				3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */,
 				9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */,
 				816B39C0D25C2A0CBEA4F93F /* RendererComplexityGate.swift */,
@@ -1051,6 +1058,7 @@
 				B4867C8EE01AF6ACFB27DB7C /* MessagesContentStateTests.swift */,
 				82B744449C852E13511FFE8D /* MinibufferStateTests.swift */,
 				AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */,
+				4819FED95BD6D1746F538DED /* NativeRenderResourcesTests.swift */,
 				CA2269E199608D475AB34F10 /* NativeSidebarRegistryTests.swift */,
 				4B3DDF1EB804D4E31EDFA519 /* NonBlockingEncoderTests.swift */,
 				00EC9D6E3E77B85DF13841B4 /* PickerStateTests.swift */,
@@ -1384,6 +1392,7 @@
 				0C0F3AF675E0AA401FEC648F /* LiveResizeDebounce.swift in Sources */,
 				BFF766FB4240D9E306D3557E /* MingaApp.swift in Sources */,
 				4B2CF3C29FD0F4B63C7E7027 /* MingaWindow.swift in Sources */,
+				B4D102EA2208CBB90DB2D894 /* NativeRenderResources.swift in Sources */,
 				067369CB702835E93D254606 /* PipelineCache.swift in Sources */,
 				B7203DF9CF85663B0A266580 /* PowerThermalPolicy.swift in Sources */,
 				ADF5C83FD9AB775E025493AC /* PreparedFrameTransaction.swift in Sources */,
@@ -1438,6 +1447,7 @@
 				5C9DBC1F399D8F7BE8EA2701 /* LineTextureAtlas.swift in Sources */,
 				88D0A6915FA4D55AB0859E57 /* LiveResizeDebounce.swift in Sources */,
 				8DBD574DB36A054FBCFC5DD8 /* MingaWindow.swift in Sources */,
+				B6F6BC02D79641B220329521 /* NativeRenderResources.swift in Sources */,
 				E3B2DB94D802E1831C17474E /* PipelineCache.swift in Sources */,
 				68886327B4EB9F0766EB7DCD /* PowerThermalPolicy.swift in Sources */,
 				03C97AFD225BCEA6E7A8E0BF /* PreparedFrameTransaction.swift in Sources */,
@@ -1473,7 +1483,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				86526CCD268BB390F0C14C53 /* AgentSurfaceTypes.swift in Sources */,
-				F41B7A8428024E08A7B6F901 /* FrameResourcePolicy.swift in Sources */,
+				41FF9FC432F155FBCAA0A3C2 /* FrameResourcePolicy.swift in Sources */,
 				5DDC0854DEF9C0F6DD82B694 /* FrontendExtensionRuntimeMessage.swift in Sources */,
 				581390BB65F36B77E59F6D9F /* GUIColorSlots.swift in Sources */,
 				D394B6B62354CC4ADD76DB74 /* LatencyRecorder.swift in Sources */,
@@ -1635,6 +1645,8 @@
 				8936DB5A36F062C95947CD3C /* MingaWindow.swift in Sources */,
 				74AD4B2AD52CF461F0DC5D01 /* MinibufferStateTests.swift in Sources */,
 				058481A528AFB6C7225A067D /* MouseInputTests.swift in Sources */,
+				42DA748322634F24B2E04B7F /* NativeRenderResources.swift in Sources */,
+				B4E3EC9A8E5388DF973D170F /* NativeRenderResourcesTests.swift in Sources */,
 				EA49ADC46692D8613D80EA2D /* NativeSidebarRegistryTests.swift in Sources */,
 				6EE7C16703E92B31CC9CE9C0 /* NonBlockingEncoderTests.swift in Sources */,
 				798E677ABC34C730785559B4 /* PickerStateTests.swift in Sources */,

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -236,7 +236,9 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         let rows = UInt16(defaultWindowHeight / CGFloat(face.cellHeight))
 
         // CoreText renderer.
-        guard let ctRenderer = CoreTextMetalRenderer() else {
+        guard let ctRenderer = CoreTextMetalRenderer(
+            resourcePolicy: frameResourcePolicy.nativeRenderer
+        ) else {
             NSLog("Failed to initialize CoreText Metal renderer")
             NSApp.terminate(nil)
             return

--- a/macos/Sources/Protocol/FrameResourcePolicy.swift
+++ b/macos/Sources/Protocol/FrameResourcePolicy.swift
@@ -26,21 +26,53 @@ public struct FrameResourcePolicy: Sendable, Equatable {
         /// Creates a per-window resident weight ceiling.
         public init(weightPerWindow: FrameResourceWeight) { self.weightPerWindow = weightPerWindow }
     }
+    /// Renderer-owned native allocation ceilings. These are presentation-health
+    /// limits only and are never consulted by semantic frame publication.
+    public struct NativeRendererLimits: Sendable, Equatable {
+        public let rasterBytes: Int
+        public let atlasBytes: Int
+        public let aggregateDrawBufferBytes: Int
+        public let renderTargetBytes: Int
+        public let textureWidth: Int
+        public let textureHeight: Int
+
+        /// Creates deterministic native allocation ceilings for one renderer instance.
+        public init(rasterBytes: Int, atlasBytes: Int, aggregateDrawBufferBytes: Int,
+                    renderTargetBytes: Int = 256 * 1_048_576,
+                    textureWidth: Int, textureHeight: Int) {
+            self.rasterBytes = rasterBytes
+            self.atlasBytes = atlasBytes
+            self.aggregateDrawBufferBytes = aggregateDrawBufferBytes
+            self.renderTargetBytes = renderTargetBytes
+            self.textureWidth = textureWidth
+            self.textureHeight = textureHeight
+        }
+
+        public static let `default` = NativeRendererLimits(
+            rasterBytes: 64 * 1_048_576, atlasBytes: 256 * 1_048_576,
+            aggregateDrawBufferBytes: 64 * 1_048_576,
+            renderTargetBytes: 256 * 1_048_576,
+            textureWidth: 16_384, textureHeight: 16_384
+        )
+    }
 
     public let wire: WireLimits
     public let decode: DecodeLimits
     public let staging: StagingLimits
     public let resident: ResidentLimits
+    public let nativeRenderer: NativeRendererLimits
 
     /// Creates immutable phase slices at the composition root.
     public init(
         wire: WireLimits, decode: DecodeLimits,
-        staging: StagingLimits, resident: ResidentLimits
+        staging: StagingLimits, resident: ResidentLimits,
+        nativeRenderer: NativeRendererLimits = .default
     ) {
         self.wire = wire
         self.decode = decode
         self.staging = staging
         self.resident = resident
+        self.nativeRenderer = nativeRenderer
     }
 
     /// Production policy. Decode, staging, and per-window residence retain

--- a/macos/Sources/Protocol/LatencyRecorder.swift
+++ b/macos/Sources/Protocol/LatencyRecorder.swift
@@ -34,6 +34,7 @@ public final class LatencyRecorder: @unchecked Sendable {
         case nilDrawable = "nil_drawable"
         case superseded
         case schedulingImpossible = "scheduling_impossible"
+        case nativeResourceFailure = "native_resource_failure"
         case dropped
         case gpuFailure = "gpu_failure"
     }

--- a/macos/Sources/Renderer/BitmapRasterizer.swift
+++ b/macos/Sources/Renderer/BitmapRasterizer.swift
@@ -26,12 +26,46 @@ struct RasterizeResult {
     let bytesPerRow: Int
 }
 
+/// Owns the cached CGContext and its backing allocation as one teardown unit.
+/// Property destruction releases the context before `deinit` frees the pool.
+private final class BitmapRasterStorage {
+    var pool: UnsafeMutableRawPointer?
+    var lineContext: CGContext?
+    var lineContextWidth: Int = 0
+    var lineContextHeight: Int = 0
+    var lineContextBytesPerRow: Int = 0
+
+    private let deallocate: (UnsafeMutableRawPointer) -> Void
+
+    init(deallocate: @escaping (UnsafeMutableRawPointer) -> Void) {
+        self.deallocate = deallocate
+    }
+
+    deinit {
+        lineContext = nil
+        if let pool { deallocate(pool) }
+    }
+}
+
 @MainActor
 final class BitmapRasterizer {
-    /// Pooled raw memory buffer. Grows to fit the largest line seen.
-    /// nonisolated(unsafe) so deinit can deallocate without actor isolation.
-    /// Safe because deinit runs after all actor-isolated access has ended.
-    nonisolated(unsafe) private var pool: UnsafeMutableRawPointer?
+    struct Factories {
+        var allocate: (Int) -> UnsafeMutableRawPointer?
+        var deallocate: (UnsafeMutableRawPointer) -> Void
+        var makeContext: (UnsafeMutableRawPointer, Int, Int, Int, CGColorSpace, UInt32) -> CGContext?
+
+        @MainActor static let production = Self(
+            allocate: { byteCount in malloc(byteCount) },
+            deallocate: { free($0) },
+            makeContext: { data, width, height, bytesPerRow, colorSpace, bitmapInfo in
+                CGContext(data: data, width: width, height: height, bitsPerComponent: 8,
+                          bytesPerRow: bytesPerRow, space: colorSpace, bitmapInfo: bitmapInfo)
+            }
+        )
+    }
+
+    private let factories: Factories
+    private let storage: BitmapRasterStorage
 
     /// Current capacity of the pool in bytes.
     private var poolByteCount: Int = 0
@@ -42,20 +76,12 @@ final class BitmapRasterizer {
     /// Bitmap info flags for BGRA premultiplied alpha.
     private let bitmapInfo: UInt32
 
-    /// Reusable line rasterization context for repeated same-size rows.
-    private var lineContext: CGContext?
-    private var lineContextWidth: Int = 0
-    private var lineContextHeight: Int = 0
-    private var lineContextBytesPerRow: Int = 0
-
-    init() {
-        self.colorSpace = CGColorSpace(name: CGColorSpace.sRGB)!
+    init(factories: Factories = .production) {
+        self.factories = factories
+        self.storage = BitmapRasterStorage(deallocate: factories.deallocate)
+        self.colorSpace = CGColorSpace(name: CGColorSpace.sRGB) ?? CGColorSpaceCreateDeviceRGB()
         self.bitmapInfo = CGImageAlphaInfo.premultipliedFirst.rawValue
             | CGBitmapInfo.byteOrder32Little.rawValue
-    }
-
-    deinit {
-        pool?.deallocate()
     }
 
     /// Rasterizes a CTLine into the pooled BGRA bitmap buffer.
@@ -72,27 +98,23 @@ final class BitmapRasterizer {
     ///   - descent: Font descent in points (for baseline positioning).
     /// - Returns: A `RasterizeResult` with the raw pointer and bytesPerRow.
     func rasterize(_ ctLine: CTLine, width: Int, height: Int,
-                   scale: CGFloat, descent: CGFloat) -> RasterizeResult {
-        let bytesPerRow = width * 4
-        let byteCount = bytesPerRow * height
+                   scale: CGFloat, descent: CGFloat) throws -> RasterizeResult {
+        let bytesPerRow = try checkedMultiply(width, 4)
+        let byteCount = try checkedMultiply(bytesPerRow, height)
 
-        ensureCapacity(byteCount: byteCount)
+        try ensureCapacity(byteCount: byteCount)
 
-        guard let ptr = pool else {
-            // Fallback: allocate and store so deinit cleans up.
-            // Should never happen after ensureCapacity with byteCount > 0.
-            let fallback = UnsafeMutableRawPointer.allocate(byteCount: byteCount, alignment: 16)
-            pool = fallback
-            poolByteCount = byteCount
-            memset(fallback, 0, byteCount)
-            return RasterizeResult(pointer: UnsafeRawPointer(fallback), bytesPerRow: bytesPerRow)
+        guard let ptr = storage.pool else {
+            throw NativePresentationFailure(phase: .raster, dimension: .buffer,
+                                            reason: .allocation)
         }
 
         // Zero only the used region (not the full pool capacity).
         memset(ptr, 0, byteCount)
 
         guard let ctx = lineRasterContext(width: width, height: height, bytesPerRow: bytesPerRow, data: ptr, scale: scale) else {
-            return RasterizeResult(pointer: UnsafeRawPointer(ptr), bytesPerRow: bytesPerRow)
+            throw NativePresentationFailure(phase: .raster, dimension: .rasterContext,
+                                            requested: byteCount, reason: .context)
         }
 
         // CoreText baseline positioning.
@@ -112,32 +134,24 @@ final class BitmapRasterizer {
                        bgColor: CGColor,
                        width: Int, height: Int,
                        scale: CGFloat, descent: CGFloat, ascent: CGFloat,
-                       hPad: CGFloat, cornerRadius: CGFloat) -> RasterizeResult {
-        let bytesPerRow = width * 4
-        let byteCount = bytesPerRow * height
+                       hPad: CGFloat, cornerRadius: CGFloat) throws -> RasterizeResult {
+        let bytesPerRow = try checkedMultiply(width, 4)
+        let byteCount = try checkedMultiply(bytesPerRow, height)
 
-        ensureCapacity(byteCount: byteCount)
+        try ensureCapacity(byteCount: byteCount)
 
-        guard let ptr = pool else {
-            let fallback = UnsafeMutableRawPointer.allocate(byteCount: byteCount, alignment: 16)
-            pool = fallback
-            poolByteCount = byteCount
-            memset(fallback, 0, byteCount)
-            return RasterizeResult(pointer: UnsafeRawPointer(fallback), bytesPerRow: bytesPerRow)
+        guard let ptr = storage.pool else {
+            throw NativePresentationFailure(phase: .raster, dimension: .buffer,
+                                            reason: .allocation)
         }
 
         memset(ptr, 0, byteCount)
 
-        guard let ctx = CGContext(
-            data: ptr,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: bytesPerRow,
-            space: colorSpace,
-            bitmapInfo: bitmapInfo
+        guard let ctx = factories.makeContext(
+            ptr, width, height, bytesPerRow, colorSpace, bitmapInfo
         ) else {
-            return RasterizeResult(pointer: UnsafeRawPointer(ptr), bytesPerRow: bytesPerRow)
+            throw NativePresentationFailure(phase: .raster, dimension: .rasterContext,
+                                            requested: byteCount, reason: .context)
         }
 
         ctx.scaleBy(x: scale, y: scale)
@@ -178,34 +192,39 @@ final class BitmapRasterizer {
     // MARK: - Private
 
     /// Grows the pool if needed. Never shrinks.
-    private func ensureCapacity(byteCount: Int) {
+    private func ensureCapacity(byteCount: Int) throws {
         guard byteCount > poolByteCount else { return }
+        guard let candidate = factories.allocate(byteCount) else {
+            throw NativePresentationFailure(phase: .raster, dimension: .buffer,
+                                            requested: byteCount, reason: .allocation)
+        }
 
-        pool?.deallocate()
-        pool = .allocate(byteCount: byteCount, alignment: 16)
+        storage.lineContext = nil
+        if let pool = storage.pool { factories.deallocate(pool) }
+        storage.pool = candidate
         poolByteCount = byteCount
-        lineContext = nil
+    }
+
+    private func checkedMultiply(_ lhs: Int, _ rhs: Int) throws -> Int {
+        let (value, overflow) = lhs.multipliedReportingOverflow(by: rhs)
+        guard !overflow else {
+            throw NativePresentationFailure(phase: .raster, dimension: .arithmetic,
+                                            reason: .overflow)
+        }
+        return value
     }
 
     private func lineRasterContext(width: Int, height: Int, bytesPerRow: Int, data: UnsafeMutableRawPointer, scale: CGFloat) -> CGContext? {
-        if let ctx = lineContext,
-           width == lineContextWidth,
-           height == lineContextHeight,
-           bytesPerRow == lineContextBytesPerRow {
+        if let ctx = storage.lineContext,
+           width == storage.lineContextWidth,
+           height == storage.lineContextHeight,
+           bytesPerRow == storage.lineContextBytesPerRow {
             return ctx
         }
 
-        guard let ctx = CGContext(
-            data: data,
-            width: width,
-            height: height,
-            bitsPerComponent: 8,
-            bytesPerRow: bytesPerRow,
-            space: colorSpace,
-            bitmapInfo: bitmapInfo
-        ) else {
-            return nil
-        }
+        guard let ctx = factories.makeContext(
+            data, width, height, bytesPerRow, colorSpace, bitmapInfo
+        ) else { return nil }
 
         ctx.scaleBy(x: scale, y: scale)
         ctx.setAllowsFontSmoothing(true)
@@ -215,10 +234,10 @@ final class BitmapRasterizer {
         ctx.setAllowsAntialiasing(true)
         ctx.setShouldAntialias(true)
 
-        lineContext = ctx
-        lineContextWidth = width
-        lineContextHeight = height
-        lineContextBytesPerRow = bytesPerRow
+        storage.lineContext = ctx
+        storage.lineContextWidth = width
+        storage.lineContextHeight = height
+        storage.lineContextBytesPerRow = bytesPerRow
         return ctx
     }
 }

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -69,6 +69,18 @@ struct RenderCursor: Equatable {
 /// Linear equivalents of sRGB (0.12, 0.12, 0.14).
 private let ctBgClearColorDefault = MTLClearColor(red: 0.01298, green: 0.01298, blue: 0.01681, alpha: 1.0)
 
+struct NativeActiveResourceSnapshot: Equatable {
+    let atlas: ObjectIdentifier?
+    let allocator: SlotAllocator?
+    let texture: ObjectIdentifier?
+    let windowRenderer: ObjectIdentifier?
+    let cache: WindowContentCacheSnapshot?
+    let rasterizer: ObjectIdentifier?
+    let lineBuffer: ObjectIdentifier?
+    let quadBuffers: [ObjectIdentifier]
+    let completedGeneration: UInt64
+}
+
 /// Renders the editor using CoreText line textures instead of cell-grid instanced drawing.
 ///
 /// `@MainActor` because it accesses `FontManager` (main-actor-isolated)
@@ -86,6 +98,15 @@ final class CoreTextMetalRenderer {
 
     let device: MTLDevice
     let commandQueue: MTLCommandQueue
+    private let resourcePolicy: FrameResourcePolicy.NativeRendererLimits
+    private let factories: NativeRenderFactories
+    private var presentationGeneration = NativePresentationGeneration()
+    /// Advances whenever font/scale-dependent renderer resources are rebuilt.
+    private var configurationEpoch: UInt64 = 0
+    /// Most recent renderer-local presentation failure. Semantic publication is unaffected.
+    private(set) var lastNativePresentationFailure: NativePresentationFailure?
+    /// Generation of the last GPU-completed presentation whose candidate resources were promoted.
+    private(set) var lastCompletedPresentationGeneration: UInt64 = 0
     private let bgPipeline: MTLRenderPipelineState
     private let linePipeline: MTLRenderPipelineState
 
@@ -155,9 +176,12 @@ final class CoreTextMetalRenderer {
     /// colors without threading the parameter through every call.
     private var currentThemeColors: ThemeColors?
 
-    init?() {
+    init?(resourcePolicy: FrameResourcePolicy.NativeRendererLimits = .default,
+          factories: NativeRenderFactories = .production) {
         guard let device = MTLCreateSystemDefaultDevice() else { return nil }
         self.device = device
+        self.resourcePolicy = resourcePolicy
+        self.factories = factories
         guard let queue = device.makeCommandQueue() else { return nil }
         self.commandQueue = queue
         self.clearColor = ctBgClearColorDefault
@@ -165,22 +189,11 @@ final class CoreTextMetalRenderer {
         // Read the system accent color for the cursor.
         self.cursorColor = CoreTextMetalRenderer.readAccentColor()
 
-        // Load the compiled Metal shader library.
-        // For app bundles, the metallib is in Contents/Resources/. For tool
-        // targets, it's next to the executable. Try both paths.
-        let library: MTLLibrary
-        if let lib = try? device.makeDefaultLibrary(bundle: Bundle.main) {
-            // App bundle: Xcode places default.metallib in the Resources dir
-            // and makeDefaultLibrary(bundle:) finds it automatically.
-            library = lib
-        } else {
-            let executableURL = Bundle.main.executableURL!
-            let metallibURL = executableURL.deletingLastPathComponent().appendingPathComponent("default.metallib")
-            guard let lib = try? device.makeLibrary(URL: metallibURL) else {
-                NSLog("Failed to load Metal library from \(metallibURL.path)")
-                return nil
-            }
-            library = lib
+        // Load the compiled Metal shader library through the renderer-owned
+        // resource seam. Production preserves the app/executable lookup.
+        guard let library = factories.makeLibrary(device) else {
+            NSLog("Failed to load Metal library")
+            return nil
         }
 
         // Background fill pipeline (also used for cursor overlay).
@@ -297,69 +310,23 @@ final class CoreTextMetalRenderer {
     /// Capacity (in quads) of each entry in `quadBuffers`. Grows on demand.
     private var quadBufferCapacity: Int = 0
 
-    /// Index of the quad buffer the current frame writes into (0..<frameCount).
-    private var quadBufferFrameIndex: Int = 0
-
-    /// Running byte offset within the current frame's quad buffer. Multiple
-    /// passes (bg, overlay, diagnostic) append into the same buffer at distinct
-    /// 256-byte-aligned offsets so their data does not clobber each other when
-    /// the command buffer executes on the GPU. Reset to 0 each frame.
-    private var quadBufferWriteOffset: Int = 0
-
-    /// Gates the CPU to at most `quadBufferFrameCount` frames in flight so it
-    /// never overwrites a quad buffer the GPU is still reading.
-    private let quadFrameSemaphore = DispatchSemaphore(value: CoreTextMetalRenderer.quadBufferFrameCount)
-
     /// Alignment for per-pass offsets into a quad buffer. 256 bytes satisfies
     /// `setVertexBuffer(offset:)` constant-address-space alignment on all macOS GPUs.
     private static let quadBufferOffsetAlignment = 256
 
-    /// Ensures each triple-buffered quad buffer can hold at least `quadCount`
-    /// quads plus headroom for per-pass alignment padding. Reallocates all
-    /// buffers when the requested capacity grows, with generous extra slack so
-    /// reallocation is rare. Quad buffers are small (4096 quads ~= 192 KB each,
-    /// trivial GPU memory).
-    ///
-    /// `quadCount` is the live total this frame so far (quads already written,
-    /// derived from `quadBufferWriteOffset`, plus the pass about to be written),
-    /// so the accumulated alignment padding of earlier passes is already baked
-    /// into the request. The extra headroom below only needs to cover this
-    /// pass's own start-offset rounding.
-    private func ensureQuadBufferCapacity(_ quadCount: Int) {
-        let stride = MemoryLayout<QuadGPU>.stride
-        // One alignment unit (rounded up to whole quads) covers this pass's
-        // start rounding; grow in generous steps so churn stays rare.
-        let alignmentSlackQuads = Self.quadBufferOffsetAlignment / stride + 1
-        let needed = max(quadCount + alignmentSlackQuads, 4096)
-        guard quadBuffers.isEmpty || needed > quadBufferCapacity else { return }
-
-        // Round capacity up to the next 1024-quad step to avoid reallocating on
-        // every small growth.
-        let stepped = (needed + 1023) / 1024 * 1024
-        let length = stepped * stride
-        var newBuffers: [MTLBuffer] = []
-        newBuffers.reserveCapacity(CoreTextMetalRenderer.quadBufferFrameCount)
-
-        for _ in 0..<CoreTextMetalRenderer.quadBufferFrameCount {
-            guard let buffer = device.makeBuffer(length: length, options: .storageModeShared) else {
-                os_log(.error, log: rendererLog, "Failed to allocate quad buffers; preserving previous buffer set")
-                return
-            }
-            newBuffers.append(buffer)
-        }
-
-        quadBuffers = newBuffers
-        quadBufferCapacity = stepped
-    }
-
     /// Set up the window content renderer and texture atlas. Called once the FontManager is available.
     func setupRenderers(fontManager: FontManager) {
-        let rasterizer = BitmapRasterizer()
+        configurationEpoch &+= 1
+        let rasterizer = factories.makeRasterizer()
         self.bitmapRasterizer = rasterizer
-        self.windowContentRenderer = WindowContentRenderer(device: device, fontManager: fontManager, rasterizer: rasterizer)
+        self.windowContentRenderer = WindowContentRenderer(
+            device: device, fontManager: fontManager, rasterizer: rasterizer,
+            resourcePolicy: resourcePolicy, makeTexture: factories.makeTexture
+        )
 
         let linePixelHeight = Int(ceil(CGFloat(fontManager.cellHeight) * fontManager.scale))
-        self.atlas = LineTextureAtlas(device: device, slotHeight: linePixelHeight)
+        self.atlas = LineTextureAtlas(device: device, slotHeight: linePixelHeight,
+                                      policy: resourcePolicy, makeTexture: factories.makeTexture)
     }
 
     /// Render the editor from FrameState metadata + semantic window content.
@@ -375,7 +342,7 @@ final class CoreTextMetalRenderer {
                 isMouseInGutter: Bool = false,
                 gutterHoverWindowId: UInt16? = nil,
                 gutterHoverRow: UInt16? = nil,
-                drawable: CAMetalDrawable, viewportSize: CGSize,
+                drawableProvider: @escaping @MainActor () -> CAMetalDrawable?, viewportSize: CGSize,
                 contentScale: Float, scrollOffset: SIMD2<Float> = .zero,
                 presentationWindowId: UInt16? = nil,
                 presentationInputSeq: UInt32 = 0,
@@ -467,36 +434,43 @@ final class CoreTextMetalRenderer {
             )
         }
 
-        // Advance semantic content renderer.
-        if let wcr = windowContentRenderer {
-            wcr.beginFrame()
-            wcr.updateViewportWidth(cols: frameState.cols)
-            if let tc = themeColors {
-                wcr.defaultFgRGB = tc.editorFgRGB
-            }
+        // Every attempt receives a private logical generation, including reuse-only
+        // frames. Allocator/cache writes are value copies and atlas writes COW the
+        // texture, so no preparation failure can mutate active resources.
+        guard let activeAtlas = self.atlas,
+              let activeWindowRenderer = self.windowContentRenderer else {
+            recordNativeFailure(NativePresentationFailure(
+                phase: .atlas, dimension: .texture,
+                frameSequence: presentationInputSeq, reason: .unavailable
+            ), latencyRecorder: latencyRecorder)
+            return
+        }
+        let candidateConfigurationEpoch = configurationEpoch
+        let candidateRasterizer = factories.makeRasterizer()
+        let candidateWindowRenderer = activeWindowRenderer.makeCandidate(rasterizer: candidateRasterizer)
+        let candidateAtlas = activeAtlas.makeCandidate()
+        let neededSlots = CoreTextMetalRenderer.atlasSlotDemand(
+            frameState: frameState, windowContents: windowContents,
+            preparedRows: preparedRowsByWindow
+        )
+        let atlasPixelWidth = Int(ceil(CGFloat(frameState.cols) * CGFloat(cellW) * CGFloat(scale)))
+        switch candidateAtlas.ensureCapacity(maxSlots: neededSlots, width: atlasPixelWidth,
+                                             frameSequence: presentationInputSeq) {
+        case .success:
+            break
+        case .failure(let failure):
+            recordNativeFailure(failure, latencyRecorder: latencyRecorder)
+            return
         }
 
-        // Ensure atlas can hold all lines (content + gutter + semantic).
-        if let atlas {
-            let neededSlots = CoreTextMetalRenderer.atlasSlotDemand(
-                frameState: frameState,
-                windowContents: windowContents,
-                preparedRows: preparedRowsByWindow
-            )
-            let atlasPixelWidth = Int(ceil(CGFloat(frameState.cols) * CGFloat(cellW) * CGFloat(scale)))
-            atlas.ensureCapacity(maxSlots: neededSlots, width: atlasPixelWidth)
-            atlas.beginFrame()
-
-            Self.invalidateFullRefreshWindows(in: atlas, windowContents: windowContents)
-
-            if neededSlots > maxInstanceSlots {
-                maxInstanceSlots = neededSlots
-                instanceBuffer = device.makeBuffer(
-                    length: neededSlots * MemoryLayout<LineGPU>.stride,
-                    options: .storageModeShared
-                )
-            }
-        }
+        // Local shadowing guarantees all preparation below targets only candidates.
+        let atlas: LineTextureAtlas? = candidateAtlas
+        let windowContentRenderer: WindowContentRenderer? = candidateWindowRenderer
+        candidateWindowRenderer.beginFrame()
+        candidateWindowRenderer.updateViewportWidth(cols: frameState.cols)
+        if let tc = themeColors { candidateWindowRenderer.defaultFgRGB = tc.editorFgRGB }
+        candidateAtlas.beginFrame()
+        Self.invalidateFullRefreshWindows(in: candidateAtlas, windowContents: windowContents)
 
         // Default background color.
         let defaultBg = frameState.defaultBg != 0
@@ -863,21 +837,178 @@ final class CoreTextMetalRenderer {
                 overscanBeforeRows: visibleSlices[windowGutter.windowId]?.overscanBeforeRows
                     ?? windowContents[windowGutter.windowId].map(CoreTextMetalRenderer.presentationOverscanBeforeRows)
                     ?? CoreTextMetalRenderer.scrollOverscanBefore(windowContents[windowGutter.windowId]?.scrollPresentation),
+                atlas: candidateAtlas,
+                windowRenderer: candidateWindowRenderer,
                 bgQuads: &bgQuads,
                 lineInstances: &lineInstances
             )
         }
 
-        // Set up render pass.
+        if let failure = windowContentRenderer?.nativePresentationFailure ?? candidateAtlas.nativePresentationFailure {
+            recordNativeFailure(failure, frameSequence: presentationInputSeq,
+                                latencyRecorder: latencyRecorder)
+            return
+        }
+
+        // Derive one exact aggregate buffer request before command creation. No
+        // buffer is replaced or grown while a pass is being encoded.
+        let gutterChromeQuads = CoreTextMetalRenderer.gutterChromeQuads(
+            frameState: frameState, cellW: cellW, cellH: displayCellH, scale: scale,
+            gutterLeftMarginPx: gutterLeftMarginPx, gutterPaddingPx: gutterPaddingPx,
+            viewportHeight: Float(viewportSize.height), defaultBg: defaultBg,
+            separatorColor: colorFromU24(frameState.gutterSeparatorColor,
+                                         default: SIMD3<Float>(0.3, 0.3, 0.3))
+        )
+        let guidePassCounts = indentGuideQuadCounts(
+            frameState: frameState, windowContents: windowContents,
+            cellW: cellW, displayCellH: displayCellH, scale: scale,
+            gutterLeftMarginPx: gutterLeftMarginPx, gutterPaddingPx: gutterPaddingPx,
+            viewportSize: viewportSize, scrollTargetWindowId: scrollTargetWindowId,
+            smoothScrollOffsetPx: smoothScrollOffsetPx
+        )
+        let quadPassCounts = [bgQuads.count] + guidePassCounts
+            + [semanticOverlayQuads.count, diagnosticQuads.count, gutterChromeQuads.count]
+        let bufferDemand: NativeDrawBufferDemand
+        do {
+            bufferDemand = try NativeDrawBufferDemand.checked(
+                lineCount: lineInstances.count, lineStride: MemoryLayout<LineGPU>.stride,
+                quadPassCounts: quadPassCounts, quadStride: MemoryLayout<QuadGPU>.stride,
+                quadBufferCount: Self.quadBufferFrameCount,
+                alignment: Self.quadBufferOffsetAlignment,
+                limit: resourcePolicy.aggregateDrawBufferBytes,
+                deviceLimit: device.maxBufferLength,
+                frameSequence: presentationInputSeq
+            )
+        } catch let failure as NativePresentationFailure {
+            recordNativeFailure(failure, latencyRecorder: latencyRecorder)
+            return
+        } catch {
+            recordNativeFailure(NativePresentationFailure(
+                phase: .buffers, dimension: .arithmetic,
+                frameSequence: presentationInputSeq, reason: .overflow
+            ), latencyRecorder: latencyRecorder)
+            return
+        }
+        let candidateInstanceBuffer: MTLBuffer?
+        if bufferDemand.lineBytes > 0 {
+            guard let buffer = factories.makeBuffer(device, bufferDemand.lineBytes, .storageModeShared) else {
+                recordNativeFailure(NativePresentationFailure(
+                    phase: .buffers, dimension: .lineBuffer,
+                    requested: bufferDemand.lineBytes,
+                    frameSequence: presentationInputSeq, reason: .allocation
+                ), latencyRecorder: latencyRecorder)
+                return
+            }
+            candidateInstanceBuffer = buffer
+        } else {
+            candidateInstanceBuffer = nil
+        }
+        var candidateQuadBuffers: [MTLBuffer] = []
+        if bufferDemand.quadBytesPerBuffer > 0 {
+            let dimensions: [NativeRenderResourceDimension] = [.quadBuffer0, .quadBuffer1, .quadBuffer2]
+            for index in 0..<Self.quadBufferFrameCount {
+                guard let buffer = factories.makeBuffer(device, bufferDemand.quadBytesPerBuffer,
+                                                        .storageModeShared) else {
+                    recordNativeFailure(NativePresentationFailure(
+                        phase: .buffers, dimension: dimensions[index],
+                        requested: bufferDemand.quadBytesPerBuffer,
+                        frameSequence: presentationInputSeq, reason: .allocation
+                    ), latencyRecorder: latencyRecorder)
+                    return
+                }
+                candidateQuadBuffers.append(buffer)
+            }
+        }
+
+        // Render into a private candidate image. The drawable remains untouched
+        // until this command has completed successfully.
+        guard viewportSize.width.isFinite, viewportSize.height.isFinite,
+              viewportSize.width > 0, viewportSize.height > 0 else {
+            recordNativeFailure(NativePresentationFailure(
+                phase: .drawable, dimension: .renderTarget,
+                frameSequence: presentationInputSeq, reason: .overflow
+            ), latencyRecorder: latencyRecorder)
+            return
+        }
+        let deviceDimensionLimit = nativeDeviceTextureDimensionLimit(device)
+        let targetWidthLimit = min(resourcePolicy.textureWidth, deviceDimensionLimit)
+        let targetHeightLimit = min(resourcePolicy.textureHeight, deviceDimensionLimit)
+        guard viewportSize.width <= CGFloat(targetWidthLimit) else {
+            let requested = viewportSize.width <= CGFloat(Int32.max)
+                ? Int(viewportSize.width.rounded(.up)) : nil
+            recordNativeFailure(NativePresentationFailure(
+                phase: .drawable, dimension: .textureWidth,
+                requested: requested, limit: targetWidthLimit,
+                frameSequence: presentationInputSeq, reason: .limit
+            ), latencyRecorder: latencyRecorder)
+            return
+        }
+        guard viewportSize.height <= CGFloat(targetHeightLimit) else {
+            let requested = viewportSize.height <= CGFloat(Int32.max)
+                ? Int(viewportSize.height.rounded(.up)) : nil
+            recordNativeFailure(NativePresentationFailure(
+                phase: .drawable, dimension: .textureHeight,
+                requested: requested, limit: targetHeightLimit,
+                frameSequence: presentationInputSeq, reason: .limit
+            ), latencyRecorder: latencyRecorder)
+            return
+        }
+        let targetWidth = Int(viewportSize.width.rounded(.up))
+        let targetHeight = Int(viewportSize.height.rounded(.up))
+        let targetDemand: NativeRenderTargetDemand
+        do {
+            targetDemand = try NativeRenderTargetDemand.checked(
+                width: targetWidth, height: targetHeight,
+                policy: resourcePolicy,
+                deviceTextureDimension: nativeDeviceTextureDimensionLimit(device),
+                frameSequence: presentationInputSeq
+            )
+        } catch let failure as NativePresentationFailure {
+            recordNativeFailure(failure, latencyRecorder: latencyRecorder)
+            return
+        } catch {
+            recordNativeFailure(NativePresentationFailure(
+                phase: .drawable, dimension: .arithmetic,
+                frameSequence: presentationInputSeq, reason: .overflow
+            ), latencyRecorder: latencyRecorder)
+            return
+        }
+        let targetDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb,
+            width: targetDemand.width,
+            height: targetDemand.height,
+            mipmapped: false
+        )
+        targetDescriptor.usage = .renderTarget
+        targetDescriptor.storageMode = .private
+        guard let candidateRenderTarget = factories.makeTexture(device, targetDescriptor) else {
+            recordNativeFailure(NativePresentationFailure(
+                phase: .drawable, dimension: .renderTarget,
+                requested: targetDemand.byteCount, limit: resourcePolicy.renderTargetBytes,
+                frameSequence: presentationInputSeq, reason: .allocation
+            ), latencyRecorder: latencyRecorder)
+            return
+        }
+
+        // Set up the offscreen render pass.
         let renderDesc = MTLRenderPassDescriptor()
-        renderDesc.colorAttachments[0].texture = drawable.texture
+        renderDesc.colorAttachments[0].texture = candidateRenderTarget
         renderDesc.colorAttachments[0].loadAction = .clear
         renderDesc.colorAttachments[0].storeAction = .store
         renderDesc.colorAttachments[0].clearColor = clearColor
 
-        guard let cmdBuf = commandQueue.makeCommandBuffer(),
-              let encoder = cmdBuf.makeRenderCommandEncoder(descriptor: renderDesc) else {
-            latencyRecorder?.discard(seq: presentationInputSeq, reason: .schedulingImpossible)
+        guard let cmdBuf = factories.makeCommandBuffer(commandQueue) else {
+            recordNativeFailure(NativePresentationFailure(
+                phase: .command, dimension: .commandBuffer,
+                frameSequence: presentationInputSeq, reason: .unavailable
+            ), latencyRecorder: latencyRecorder)
+            return
+        }
+        guard let encoder = factories.makeEncoder(cmdBuf, renderDesc) else {
+            recordNativeFailure(NativePresentationFailure(
+                phase: .command, dimension: .encoder,
+                frameSequence: presentationInputSeq, reason: .unavailable
+            ), latencyRecorder: latencyRecorder)
             return
         }
 
@@ -886,10 +1017,8 @@ final class CoreTextMetalRenderer {
         // its write cursor. The matching `signal()` runs in the command buffer's
         // completion handler below. Acquired after the encoder guard so the early
         // return above never holds the semaphore.
-        quadFrameSemaphore.wait()
-        quadBufferFrameIndex = (quadBufferFrameIndex + 1) % CoreTextMetalRenderer.quadBufferFrameCount
-        quadBufferWriteOffset = 0
-        ensureQuadBufferCapacity(0)
+        var candidateQuadWriteOffset = 0
+        let candidateQuadBuffer = candidateQuadBuffers.first
 
         // Keep shader uniforms fixed. Smooth-scroll deltas are baked only into scrollable buffer content and cursor positions above, so fixed chrome such as gutters, split separators, labels, and scroll indicators does not drift during fractional scroll frames.
         var uniforms = CTUniformsGPU(
@@ -905,7 +1034,9 @@ final class CoreTextMetalRenderer {
         // Pass 1: Background fills.
         if !bgQuads.isEmpty {
             encoder.setRenderPipelineState(bgPipeline)
-            drawQuadBatches(bgQuads, encoder: encoder, uniforms: &uniforms)
+            drawQuadBatches(bgQuads, buffer: candidateQuadBuffer,
+                                            writeOffset: &candidateQuadWriteOffset,
+                                            encoder: encoder, uniforms: &uniforms)
         }
 
         // Pass 1.25: Indent guides (vertical lines at indentation levels).
@@ -988,7 +1119,9 @@ final class CoreTextMetalRenderer {
 
             if !guideQuads.isEmpty {
                 encoder.setRenderPipelineState(bgPipeline)
-                drawQuadBatches(guideQuads, encoder: encoder, uniforms: &uniforms)
+                drawQuadBatches(guideQuads, buffer: candidateQuadBuffer,
+                                                writeOffset: &candidateQuadWriteOffset,
+                                                encoder: encoder, uniforms: &uniforms)
             }
         }
 
@@ -998,7 +1131,9 @@ final class CoreTextMetalRenderer {
         // Metal quads instead of being baked into line textures.
         if !semanticOverlayQuads.isEmpty {
             encoder.setRenderPipelineState(bgPipeline)
-            drawQuadBatches(semanticOverlayQuads, encoder: encoder, uniforms: &uniforms)
+            drawQuadBatches(semanticOverlayQuads, buffer: candidateQuadBuffer,
+                                            writeOffset: &candidateQuadWriteOffset,
+                                            encoder: encoder, uniforms: &uniforms)
         }
 
         // Pass 2: Cursor background (drawn BEFORE text so text is visible on top).
@@ -1070,7 +1205,7 @@ final class CoreTextMetalRenderer {
 
         // Pass 3: Line textures — one instanced draw call with the atlas texture.
         if !lineInstances.isEmpty, let atlas, let atlasTexture = atlas.texture,
-           let instBuf = instanceBuffer {
+           let instBuf = candidateInstanceBuffer {
             // Copy instance data into the shared Metal buffer.
             let byteCount = lineInstances.count * MemoryLayout<LineGPU>.stride
             _ = lineInstances.withUnsafeBytes { ptr in
@@ -1088,24 +1223,17 @@ final class CoreTextMetalRenderer {
         // Pass 3.5: Diagnostic underline quads (drawn after text, before gutter).
         if !diagnosticQuads.isEmpty {
             encoder.setRenderPipelineState(bgPipeline)
-            drawQuadBatches(diagnosticQuads, encoder: encoder, uniforms: &uniforms)
+            drawQuadBatches(diagnosticQuads, buffer: candidateQuadBuffer,
+                                            writeOffset: &candidateQuadWriteOffset,
+                                            encoder: encoder, uniforms: &uniforms)
         }
 
         // Pass 4/5: Gutter gap fills and separator lines.
-        let gutterChromeQuads = CoreTextMetalRenderer.gutterChromeQuads(
-            frameState: frameState,
-            cellW: cellW,
-            cellH: displayCellH,
-            scale: scale,
-            gutterLeftMarginPx: gutterLeftMarginPx,
-            gutterPaddingPx: gutterPaddingPx,
-            viewportHeight: Float(viewportSize.height),
-            defaultBg: defaultBg,
-            separatorColor: colorFromU24(frameState.gutterSeparatorColor, default: SIMD3<Float>(0.3, 0.3, 0.3))
-        )
         if !gutterChromeQuads.isEmpty {
             encoder.setRenderPipelineState(bgPipeline)
-            drawQuadBatches(gutterChromeQuads, encoder: encoder, uniforms: &uniforms)
+            drawQuadBatches(gutterChromeQuads, buffer: candidateQuadBuffer,
+                                            writeOffset: &candidateQuadWriteOffset,
+                                            encoder: encoder, uniforms: &uniforms)
         }
 
         // Pass 5.5: Split separators (vertical lines between split panes,
@@ -1322,38 +1450,196 @@ final class CoreTextMetalRenderer {
             frameMetrics.textureUploadBytes = atlas.frameTextureUploadBytes
         }
 
+        if let failure = windowContentRenderer?.nativePresentationFailure ?? candidateAtlas.nativePresentationFailure {
+            encoder.endEncoding()
+            recordNativeFailure(failure, frameSequence: presentationInputSeq,
+                                latencyRecorder: latencyRecorder)
+            return
+        }
+
+        // Submit only the offscreen render. The drawable is neither written nor
+        // registered for presentation until this command completes successfully.
         encoder.endEncoding()
-        cmdBuf.present(drawable)
+        do {
+            try factories.preSubmit(cmdBuf)
+        } catch {
+            recordNativeFailure(NativePresentationFailure(
+                phase: .submission, dimension: .submission,
+                frameSequence: presentationInputSeq, reason: .submission
+            ), latencyRecorder: latencyRecorder)
+            return
+        }
+
         let commitTime = CACurrentMediaTime()
-        // Capture the semaphore locally so the completion handler does not retain
-        // self. Signaling here releases the quad buffer this frame used once the
-        // GPU is done reading it, letting a future frame reuse it.
-        let quadFrameSemaphore = self.quadFrameSemaphore
-        cmdBuf.addCompletedHandler { completedBuffer in
-            quadFrameSemaphore.signal()
-            if completedBuffer.status == .completed {
-                latencyRecorder?.markPresented(seq: presentationInputSeq)
-                os_signpost(.event, log: renderLog, name: "PresentationComplete", signpostID: renderSignpostID,
-                            "input=%{public}u", presentationInputSeq)
-            } else {
+        let generation = presentationGeneration.issue()
+        let candidateInstanceSlots = lineInstances.count
+        let candidateQuadCapacity = bufferDemand.quadBytesPerBuffer / MemoryLayout<QuadGPU>.stride
+        factories.observeCompletion(cmdBuf) { [weak self] completed, status in
+            guard let self else { return }
+            let completionLatencyMs = (CACurrentMediaTime() - commitTime) * 1000.0
+            os_signpost(.event, log: renderLog, name: "GPU Timing", signpostID: renderSignpostID,
+                        "commit_to_complete_ms=%{public}.3f", completionLatencyMs)
+            guard completed else {
+                self.recordNativeFailure(NativePresentationFailure(
+                    phase: .completion, dimension: .completion,
+                    frameSequence: presentationInputSeq, reason: .completion
+                ), discardLatency: false, latencyRecorder: latencyRecorder)
                 latencyRecorder?.discard(seq: presentationInputSeq, reason: .gpuFailure)
                 os_signpost(.event, log: renderLog, name: "PresentationDropped", signpostID: renderSignpostID,
-                            "input=%{public}u status=%{public}d", presentationInputSeq, completedBuffer.status.rawValue)
+                            "input=%{public}u status=%{public}d", presentationInputSeq, status)
+                return
             }
-            let completionLatencyMs = (CACurrentMediaTime() - commitTime) * 1000.0
-            let gpuStart = completedBuffer.gpuStartTime
-            let gpuEnd = completedBuffer.gpuEndTime
+            guard self.configurationEpoch == candidateConfigurationEpoch else {
+                latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
+                return
+            }
+            guard let drawable = drawableProvider() else {
+                self.recordNativeFailure(NativePresentationFailure(
+                    phase: .drawable, dimension: .drawable,
+                    frameSequence: presentationInputSeq, reason: .unavailable
+                ), latencyRecorder: latencyRecorder)
+                return
+            }
+            guard drawable.texture.width == candidateRenderTarget.width else {
+                self.recordNativeFailure(NativePresentationFailure(
+                    phase: .drawable, dimension: .textureWidth,
+                    requested: drawable.texture.width, limit: candidateRenderTarget.width,
+                    frameSequence: presentationInputSeq, reason: .mismatch
+                ), latencyRecorder: latencyRecorder)
+                return
+            }
+            guard drawable.texture.height == candidateRenderTarget.height else {
+                self.recordNativeFailure(NativePresentationFailure(
+                    phase: .drawable, dimension: .textureHeight,
+                    requested: drawable.texture.height, limit: candidateRenderTarget.height,
+                    frameSequence: presentationInputSeq, reason: .mismatch
+                ), latencyRecorder: latencyRecorder)
+                return
+            }
+            guard drawable.texture.pixelFormat == candidateRenderTarget.pixelFormat else {
+                self.recordNativeFailure(NativePresentationFailure(
+                    phase: .drawable, dimension: .renderTarget,
+                    frameSequence: presentationInputSeq, reason: .mismatch
+                ), latencyRecorder: latencyRecorder)
+                return
+            }
+            guard let presentationBuffer = self.factories.makeCommandBuffer(self.commandQueue) else {
+                self.recordNativeFailure(NativePresentationFailure(
+                    phase: .command, dimension: .presentationCommandBuffer,
+                    frameSequence: presentationInputSeq, reason: .unavailable
+                ), latencyRecorder: latencyRecorder)
+                return
+            }
+            guard let blit = self.factories.makeBlitEncoder(presentationBuffer) else {
+                self.recordNativeFailure(NativePresentationFailure(
+                    phase: .command, dimension: .presentationEncoder,
+                    frameSequence: presentationInputSeq, reason: .unavailable
+                ), latencyRecorder: latencyRecorder)
+                return
+            }
+            blit.copy(
+                from: candidateRenderTarget,
+                sourceSlice: 0, sourceLevel: 0,
+                sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+                sourceSize: MTLSize(width: candidateRenderTarget.width,
+                                    height: candidateRenderTarget.height, depth: 1),
+                to: drawable.texture,
+                destinationSlice: 0, destinationLevel: 0,
+                destinationOrigin: MTLOrigin(x: 0, y: 0, z: 0)
+            )
+            blit.endEncoding()
+            do {
+                try self.factories.prePresentationSubmit(presentationBuffer)
+            } catch {
+                self.recordNativeFailure(NativePresentationFailure(
+                    phase: .submission, dimension: .presentationCopy,
+                    frameSequence: presentationInputSeq, reason: .submission
+                ), latencyRecorder: latencyRecorder)
+                return
+            }
 
-            if gpuStart > 0, gpuEnd > gpuStart {
-                os_signpost(.event, log: renderLog, name: "GPU Timing", signpostID: renderSignpostID, "gpu_ms=%{public}.3f commit_to_complete_ms=%{public}.3f", (gpuEnd - gpuStart) * 1000.0, completionLatencyMs)
-            } else {
-                os_signpost(.event, log: renderLog, name: "GPU Timing", signpostID: renderSignpostID, "gpu_ms=%{public}.3f commit_to_complete_ms=%{public}.3f", 0.0, completionLatencyMs)
+            self.factories.observeCompletion(presentationBuffer) { [weak self] copied, _ in
+                guard let self else { return }
+                guard copied else {
+                    self.recordNativeFailure(NativePresentationFailure(
+                        phase: .completion, dimension: .presentationCopy,
+                        frameSequence: presentationInputSeq, reason: .completion
+                    ), discardLatency: false, latencyRecorder: latencyRecorder)
+                    latencyRecorder?.discard(seq: presentationInputSeq, reason: .gpuFailure)
+                    return
+                }
+                guard self.configurationEpoch == candidateConfigurationEpoch,
+                      generation > self.presentationGeneration.completed else {
+                    latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
+                    return
+                }
+                do {
+                    try self.factories.present(drawable)
+                } catch {
+                    self.recordNativeFailure(NativePresentationFailure(
+                        phase: .submission, dimension: .drawable,
+                        frameSequence: presentationInputSeq, reason: .submission
+                    ), latencyRecorder: latencyRecorder)
+                    return
+                }
+                guard self.presentationGeneration.complete(generation) else {
+                    latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
+                    return
+                }
+
+                self.atlas = candidateAtlas
+                self.bitmapRasterizer = candidateRasterizer
+                self.windowContentRenderer = candidateWindowRenderer
+                self.instanceBuffer = candidateInstanceBuffer
+                self.maxInstanceSlots = candidateInstanceSlots
+                self.quadBuffers = candidateQuadBuffers
+                self.quadBufferCapacity = candidateQuadCapacity
+                self.lastCompletedPresentationGeneration = generation
+                latencyRecorder?.markPresented(seq: presentationInputSeq)
+                os_signpost(.event, log: renderLog, name: "PresentationComplete",
+                            signpostID: renderSignpostID,
+                            "input=%{public}u", presentationInputSeq)
             }
+            presentationBuffer.commit()
         }
         latencyRecorder?.markSubmitted(seq: presentationInputSeq)
         os_signpost(.event, log: renderLog, name: "MetalSubmit", signpostID: renderSignpostID,
                     "input=%{public}u", presentationInputSeq)
         cmdBuf.commit()
+    }
+
+    func activeResourceSnapshot() -> NativeActiveResourceSnapshot {
+        NativeActiveResourceSnapshot(
+            atlas: atlas.map(ObjectIdentifier.init), allocator: atlas?.allocator,
+            texture: atlas?.texture.map(ObjectIdentifier.init),
+            windowRenderer: windowContentRenderer.map(ObjectIdentifier.init),
+            cache: windowContentRenderer?.cacheSnapshot(),
+            rasterizer: bitmapRasterizer.map(ObjectIdentifier.init),
+            lineBuffer: instanceBuffer.map(ObjectIdentifier.init),
+            quadBuffers: quadBuffers.map(ObjectIdentifier.init),
+            completedGeneration: lastCompletedPresentationGeneration
+        )
+    }
+
+    private func recordNativeFailure(
+        _ failure: NativePresentationFailure,
+        frameSequence: UInt32? = nil,
+        discardLatency: Bool = true,
+        latencyRecorder: LatencyRecorder?
+    ) {
+        let recorded = NativePresentationFailure(
+            phase: failure.phase,
+            dimension: failure.dimension,
+            requested: failure.requested,
+            limit: failure.limit,
+            frameSequence: frameSequence ?? failure.frameSequence,
+            reason: failure.reason
+        )
+        lastNativePresentationFailure = recorded
+        factories.reportFailure(recorded)
+        if discardLatency {
+            latencyRecorder?.discard(seq: recorded.frameSequence, reason: .nativeResourceFailure)
+        }
     }
 
     // MARK: - Native Gutter Rendering
@@ -1376,6 +1662,8 @@ final class CoreTextMetalRenderer {
         scrollOffsetY: Float,
         entryRange: Range<Int>,
         overscanBeforeRows: Int,
+        atlas: LineTextureAtlas,
+        windowRenderer: WindowContentRenderer,
         bgQuads: inout [QuadGPU],
         lineInstances: inout [LineGPU]
     ) {
@@ -1404,6 +1692,7 @@ final class CoreTextMetalRenderer {
                     cellW: cellW, cellH: cellH, scale: scale,
                     frameState: frameState,
                     clipTop: clipTop, clipBottom: clipBottom,
+                    atlas: atlas, windowRenderer: windowRenderer,
                     bgQuads: &bgQuads, lineInstances: &lineInstances,
                 )
             }
@@ -1446,6 +1735,7 @@ final class CoreTextMetalRenderer {
                     cellW: cellW, cellH: cellH, scale: scale,
                     frameState: frameState,
                     clipTop: clipTop, clipBottom: clipBottom,
+                    atlas: atlas, windowRenderer: windowRenderer,
                     lineInstances: &lineInstances,
                 )
             }
@@ -1494,6 +1784,8 @@ final class CoreTextMetalRenderer {
         cellW: Float, cellH: Float, scale: Float,
         frameState: FrameState,
         clipTop: Float, clipBottom: Float,
+        atlas: LineTextureAtlas,
+        windowRenderer: WindowContentRenderer,
         bgQuads: inout [QuadGPU],
         lineInstances: inout [LineGPU],
     ) {
@@ -1514,8 +1806,7 @@ final class CoreTextMetalRenderer {
             let (text, fg) = gutterTextSignAndColor(entry.signType, frameState: frameState)
             let cacheKey = AtlasKey.diagnosticSign(windowId: windowId, row: atlasRow)
             let contentHash = gutterContentHash(text: text, fg: fg)
-            if let atlas, let wcr = windowContentRenderer,
-               let entry = wcr.renderSimpleText(text, fg: fg, bold: true,
+            if let entry = windowRenderer.renderSimpleText(text, fg: fg, bold: true,
                                                  key: cacheKey, contentHash: contentHash, atlas: atlas, metrics: &frameMetrics) {
                 let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
                 appendClippedGutterLine(x: xOffset, y: yPos, width: Float(entry.pixelWidth), height: Float(entry.pixelHeight), uvOrigin: uvOrigin, uvSize: uvSize, clipTop: clipTop, clipBottom: clipBottom, lineInstances: &lineInstances)
@@ -1527,8 +1818,7 @@ final class CoreTextMetalRenderer {
             let fg = entry.signFg
             let cacheKey = AtlasKey.annotationIcon(windowId: windowId, row: atlasRow)
             let contentHash = gutterContentHash(text: text, fg: fg)
-            if let atlas, let wcr = windowContentRenderer,
-               let atlasEntry = wcr.renderSimpleText(text, fg: fg, bold: false,
+            if let atlasEntry = windowRenderer.renderSimpleText(text, fg: fg, bold: false,
                                                       key: cacheKey, contentHash: contentHash, atlas: atlas, metrics: &frameMetrics) {
                 let (uvOrigin, uvSize) = atlas.uvForSlot(atlasEntry.slotIndex, pixelWidth: atlasEntry.pixelWidth)
                 appendClippedGutterLine(x: xOffset, y: yPos, width: Float(atlasEntry.pixelWidth), height: Float(atlasEntry.pixelHeight), uvOrigin: uvOrigin, uvSize: uvSize, clipTop: clipTop, clipBottom: clipBottom, lineInstances: &lineInstances)
@@ -1628,6 +1918,65 @@ final class CoreTextMetalRenderer {
         }
     }
 
+    private func indentGuideQuadCounts(
+        frameState: FrameState, windowContents: [UInt16: GUIWindowContent],
+        cellW: Float, displayCellH: Float, scale: Float,
+        gutterLeftMarginPx: Float, gutterPaddingPx: Float,
+        viewportSize: CGSize, scrollTargetWindowId: UInt16?,
+        smoothScrollOffsetPx: SIMD2<Float>
+    ) -> [Int] {
+        var counts: [Int] = []
+        for (_, guideData) in frameState.windowIndentGuides {
+            guard !guideData.guideCols.isEmpty,
+                  let gutter = frameState.windowGutters[guideData.windowId] else { continue }
+            let paneGeometry = windowContents[guideData.windowId]?.paneGeometry
+            let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth)
+                                         + Int(gutter.signColWidth))
+            let contentLeft = Float(paneGeometry?.textRect.col ?? fallbackTextCol) * cellW * scale
+                + gutterLeftMarginPx + gutterPaddingPx
+            let bounds = Self.windowHorizontalBounds(
+                geometry: paneGeometry, gutter: gutter, frameCols: frameState.cols,
+                cellW: cellW, scale: scale, viewportWidth: Float(viewportSize.width)
+            )
+            let contentRight = bounds.x + bounds.width
+            let lineCellH = displayCellH * scale
+            let scrollLeft = windowContents[guideData.windowId]?.scrollLeft ?? 0
+            let scroll = Self.presentationScrollOffset(
+                scrollLeft: scrollLeft,
+                scrollOffsetPx: Self.smoothScrollOffset(
+                    for: guideData.windowId, targetWindowId: scrollTargetWindowId,
+                    scrollOffsetPx: smoothScrollOffsetPx
+                )
+            )
+            let top = Float(paneGeometry?.textRect.row ?? gutter.contentRow) * displayCellH * scale
+            let height = Float(max(Int(paneGeometry?.textRect.height ?? gutter.contentHeight), 0)) * lineCellH
+            let bottom = min(top + height, Float(viewportSize.height))
+            let tabWidth = max(UInt16(guideData.tabWidth), 1)
+            var count = 0
+            if guideData.lineIndentLevels.isEmpty {
+                let baseY = top - scroll.y
+                for col in guideData.guideCols {
+                    let x = contentLeft - scroll.x + Float(col) * cellW * scale
+                    if Self.clipVerticalQuad(y: baseY, height: height, top: top, bottom: bottom) != nil,
+                       Self.clipHorizontalRect(x: x, width: scale, left: contentLeft,
+                                               right: contentRight) != nil { count += 1 }
+                }
+            } else {
+                for (lineIndex, level) in guideData.lineIndentLevels.enumerated() {
+                    let y = top + Float(lineIndex) * lineCellH - scroll.y
+                    for col in guideData.guideCols where col / tabWidth < level {
+                        let x = contentLeft - scroll.x + Float(col) * cellW * scale
+                        if Self.clipVerticalQuad(y: y, height: lineCellH, top: top, bottom: bottom) != nil,
+                           Self.clipHorizontalRect(x: x, width: scale, left: contentLeft,
+                                                   right: contentRight) != nil { count += 1 }
+                    }
+                }
+            }
+            if count > 0 { counts.append(count) }
+        }
+        return counts
+    }
+
     /// Draws all `quads` in a single instanced draw call backed by the
     /// current frame's reusable quad buffer.
     ///
@@ -1641,32 +1990,24 @@ final class CoreTextMetalRenderer {
     /// diagnostic passes); each call advances `quadBufferWriteOffset` so the
     /// passes occupy distinct regions of the buffer and do not clobber each
     /// other when the command buffer executes on the GPU.
-    private func drawQuadBatches(_ quads: [QuadGPU], encoder: MTLRenderCommandEncoder, uniforms: inout CTUniformsGPU) {
-        guard !quads.isEmpty else { return }
+    private func drawQuadBatches(_ quads: [QuadGPU], buffer: MTLBuffer?,
+                                 writeOffset: inout Int,
+                                 encoder: MTLRenderCommandEncoder,
+                                 uniforms: inout CTUniformsGPU) {
+        guard !quads.isEmpty, let buffer else { return }
 
         let stride = MemoryLayout<QuadGPU>.stride
-
-        // Grow buffers if this frame's total quad demand exceeds capacity.
-        // `quadBufferWriteOffset` already accounts for earlier passes this frame.
-        let quadsAlreadyWritten = quadBufferWriteOffset / stride
-        ensureQuadBufferCapacity(quadsAlreadyWritten + quads.count)
-
-        guard quadBufferFrameIndex < quadBuffers.count else { return }
-        let buffer = quadBuffers[quadBufferFrameIndex]
-
-        // Align this pass's start offset for constant-address-space binding.
         let alignment = Self.quadBufferOffsetAlignment
-        let offset = (quadBufferWriteOffset + alignment - 1) / alignment * alignment
+        let offset = (writeOffset + alignment - 1) / alignment * alignment
         let byteCount = quads.count * stride
 
-        // Defensive: never write past the buffer. ensureQuadBufferCapacity sizes
-        // for this, but guard so a sizing miss drops quads instead of corrupting memory.
-        guard offset + byteCount <= buffer.length else { return }
-
+        // The aggregate candidate was checked and allocated before encoding.
+        // A mismatch is a programming error, never a reason to grow mid-pass.
+        precondition(offset + byteCount <= buffer.length)
         _ = quads.withUnsafeBytes { src in
             memcpy(buffer.contents() + offset, src.baseAddress!, byteCount)
         }
-        quadBufferWriteOffset = offset + byteCount
+        writeOffset = offset + byteCount
 
         encoder.setVertexBuffer(buffer, offset: offset, index: 0)
         encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
@@ -1681,6 +2022,8 @@ final class CoreTextMetalRenderer {
         cellW: Float, cellH: Float, scale: Float,
         frameState: FrameState,
         clipTop: Float, clipBottom: Float,
+        atlas: LineTextureAtlas,
+        windowRenderer: WindowContentRenderer,
         lineInstances: inout [LineGPU],
     ) {
         let (numberStr, isCurrent) = gutterNumberString(
@@ -1701,8 +2044,7 @@ final class CoreTextMetalRenderer {
 
         let cacheKey = AtlasKey.gutterLineNumber(windowId: gutter.windowId, row: atlasRow)
         let contentHash = gutterContentHash(text: numberStr, fg: fg)
-        if let atlas, let wcr = windowContentRenderer,
-           let entry = wcr.renderSimpleText(numberStr, fg: fg,
+        if let entry = windowRenderer.renderSimpleText(numberStr, fg: fg,
                                              key: cacheKey, contentHash: contentHash, atlas: atlas, metrics: &frameMetrics) {
             let (uvOrigin, uvSize) = atlas.uvForSlot(entry.slotIndex, pixelWidth: entry.pixelWidth)
             let xPos = xOffset + Float(startCol) * cellW * scale

--- a/macos/Sources/Renderer/LineTextureAtlas.swift
+++ b/macos/Sources/Renderer/LineTextureAtlas.swift
@@ -6,6 +6,7 @@
 
 import Metal
 import Foundation
+import MingaProtocol
 
 /// Result of rendering a line into the atlas.
 struct AtlasEntry {
@@ -30,15 +31,14 @@ enum AtlasLookupResult {
 
 @MainActor
 final class LineTextureAtlas {
-    /// Conservative macOS Metal 2D texture edge limit. The renderer may receive
-    /// retained recovery payloads with thousands of rows, but a single atlas must
-    /// still fit inside this hardware limit.
-    static let maxTextureDimension = 16_384
-
     /// The atlas texture.
     private(set) var texture: MTLTexture?
 
     private let device: MTLDevice
+    private let policy: FrameResourcePolicy.NativeRendererLimits
+    private let makeTexture: (MTLDevice, MTLTextureDescriptor) -> MTLTexture?
+    private let allocateStaging: (Int) -> UnsafeMutableRawPointer?
+    private let deallocateStaging: (UnsafeMutableRawPointer) -> Void
 
     /// Pure slot management (testable without Metal).
     private(set) var allocator = SlotAllocator()
@@ -52,9 +52,12 @@ final class LineTextureAtlas {
     /// Total atlas height in pixels.
     private(set) var atlasHeight: Int = 0
 
-    /// Maximum slots that fit in one Metal 2D texture for this device.
+    /// Maximum complete slots derived from the exact native byte and dimension ceilings.
     var maxSlotCapacity: Int {
-        max(Self.maxTextureDimension / max(slotHeight, 1), 1)
+        (try? NativeRenderDemand.maximumAtlasSlots(
+            textureWidth: max(atlasWidth, 1), slotHeight: slotHeight,
+            policy: policy, deviceTextureHeight: nativeDeviceTextureDimensionLimit(device)
+        )) ?? 0
     }
 
     /// Number of allocated slots.
@@ -66,43 +69,115 @@ final class LineTextureAtlas {
     /// Bytes uploaded to the texture atlas in the current frame.
     private(set) var frameTextureUploadBytes: Int = 0
 
-    init(device: MTLDevice, slotHeight: Int) {
+    /// First failure while making a private texture generation.
+    private(set) var nativePresentationFailure: NativePresentationFailure?
+
+    init(device: MTLDevice, slotHeight: Int,
+         policy: FrameResourcePolicy.NativeRendererLimits = .default,
+         makeTexture: @escaping (MTLDevice, MTLTextureDescriptor) -> MTLTexture? = {
+             $0.makeTexture(descriptor: $1)
+         },
+         allocateStaging: @escaping (Int) -> UnsafeMutableRawPointer? = { malloc($0) },
+         deallocateStaging: @escaping (UnsafeMutableRawPointer) -> Void = { free($0) }) {
         self.device = device
         self.slotHeight = slotHeight
+        self.policy = policy
+        self.makeTexture = makeTexture
+        self.allocateStaging = allocateStaging
+        self.deallocateStaging = deallocateStaging
     }
 
-    /// Grow the atlas if needed. Reallocates the texture on size change.
-    func ensureCapacity(maxSlots: Int, width: Int) {
-        guard maxSlots > 0, width > 0 else { return }
+    /// Creates a value-isolated allocator generation. The texture remains shared
+    /// until the first write, when `commitUpload` performs a private COW copy.
+    func makeCandidate() -> LineTextureAtlas {
+        let candidate = LineTextureAtlas(
+            device: device, slotHeight: slotHeight, policy: policy,
+            makeTexture: makeTexture, allocateStaging: allocateStaging,
+            deallocateStaging: deallocateStaging
+        )
+        candidate.texture = texture
+        candidate.allocator = allocator
+        candidate.atlasWidth = atlasWidth
+        candidate.atlasHeight = atlasHeight
+        candidate.textureIsShared = texture != nil
+        return candidate
+    }
 
-        let newSlotCount = min(max(maxSlots, allocator.capacity), maxSlotCapacity)
-        let newWidth = min(max(width, atlasWidth), Self.maxTextureDimension)
-        let needsRealloc = newSlotCount > allocator.capacity || newWidth > atlasWidth
-        guard needsRealloc else { return }
+    private var textureIsShared = false
 
-        let newHeight = newSlotCount * slotHeight
+    /// Grow the atlas if needed. A replacement texture and allocator are built
+    /// first; allocation refusal leaves the active texture/cache untouched.
+    @discardableResult
+    func ensureCapacity(maxSlots: Int, width: Int, frameSequence: UInt32 = 0) -> Result<Void, NativePresentationFailure> {
+        guard maxSlots > 0, width > 0 else { return .success(()) }
+        let requestedSlots = max(maxSlots, allocator.capacity)
+        let requestedWidth = max(width, atlasWidth)
+        let needsRealloc = requestedSlots > allocator.capacity || requestedWidth > atlasWidth
+        guard needsRealloc else { return .success(()) }
+        do {
+            _ = try NativeRenderDemand.checked(
+                textureWidth: requestedWidth, slotHeight: slotHeight, atlasSlots: requestedSlots,
+                lineInstances: 0, lineStride: MemoryLayout<LineGPU>.stride,
+                quadInstances: 0, quadStride: MemoryLayout<QuadGPU>.stride, quadBufferCount: 3,
+                policy: policy, deviceTextureWidth: nativeDeviceTextureDimensionLimit(device),
+                deviceTextureHeight: nativeDeviceTextureDimensionLimit(device),
+                deviceMaxBufferLength: device.maxBufferLength, frameSequence: frameSequence
+            )
+        } catch let failure as NativePresentationFailure { return .failure(failure) }
+        catch { return .failure(NativePresentationFailure(phase: .atlas, dimension: .arithmetic,
+                                                          frameSequence: frameSequence, reason: .overflow)) }
+
+        let newHeight = requestedSlots * slotHeight
 
         let desc = MTLTextureDescriptor.texture2DDescriptor(
             pixelFormat: .bgra8Unorm_srgb,
-            width: newWidth,
+            width: requestedWidth,
             height: newHeight,
             mipmapped: false
         )
         desc.usage = MTLTextureUsage.shaderRead
         desc.storageMode = MTLStorageMode.managed
 
-        texture = device.makeTexture(descriptor: desc)
-        atlasWidth = newWidth
+        guard let candidateTexture = makeTexture(device, desc) else {
+            let requestedBytes = (try? NativeRenderDemand.checked(
+                textureWidth: requestedWidth, slotHeight: slotHeight, atlasSlots: requestedSlots,
+                lineInstances: 0, lineStride: 0, quadInstances: 0, quadStride: 0,
+                quadBufferCount: 0, policy: policy,
+                deviceTextureWidth: nativeDeviceTextureDimensionLimit(device),
+                deviceTextureHeight: nativeDeviceTextureDimensionLimit(device),
+                deviceMaxBufferLength: device.maxBufferLength,
+                frameSequence: frameSequence
+            ).atlasBytes)
+            return .failure(NativePresentationFailure(
+                phase: .atlas, dimension: .texture,
+                requested: requestedBytes, limit: policy.atlasBytes,
+                frameSequence: frameSequence, reason: .allocation
+            ))
+        }
+        if let source = texture {
+            switch copyTexture(
+                source, to: candidateTexture,
+                width: min(atlasWidth, requestedWidth),
+                height: min(atlasHeight, newHeight), frameSequence: frameSequence
+            ) {
+            case .success: break
+            case .failure(let failure): return .failure(failure)
+            }
+        }
+        var candidateAllocator = allocator
+        candidateAllocator.ensureCapacity(maxSlots: requestedSlots)
+        texture = candidateTexture
+        textureIsShared = false
+        atlasWidth = requestedWidth
         atlasHeight = newHeight
-
-        // Reset allocator on reallocation (texture contents are gone).
-        allocator = SlotAllocator()
-        allocator.ensureCapacity(maxSlots: newSlotCount)
+        allocator = candidateAllocator
+        return .success(())
     }
 
     func beginFrame() {
         frameTextureUploads = 0
         frameTextureUploadBytes = 0
+        nativePresentationFailure = nil
         allocator.beginFrame()
     }
 
@@ -120,27 +195,110 @@ final class LineTextureAtlas {
         case .reserved(let slotIndex, let reason):
             return .reserved(Reservation(key: key, slotIndex: slotIndex, contentHash: contentHash, reason: reason))
         case .full:
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .atlas, dimension: .atlasSlots,
+                requested: allocator.capacity == Int.max ? nil : allocator.capacity + 1,
+                limit: allocator.capacity, reason: .limit
+            )
             return nil
         }
     }
 
     /// Upload bitmap into a previously reserved atlas slot.
     func commitUpload(reservation: Reservation, pointer: UnsafeRawPointer, pixelWidth: Int, bytesPerRow: Int) -> AtlasEntry? {
-        guard let tex = texture else { return nil }
+        let (minimumRowBytes, rowOverflow) = pixelWidth.multipliedReportingOverflow(by: 4)
+        let (uploadBytes, uploadOverflow) = bytesPerRow.multipliedReportingOverflow(by: slotHeight)
+        guard pixelWidth > 0, pixelWidth <= atlasWidth else {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .atlas, dimension: .textureWidth,
+                requested: pixelWidth, limit: atlasWidth, reason: .limit
+            )
+            return nil
+        }
+        guard !rowOverflow, !uploadOverflow, bytesPerRow >= minimumRowBytes,
+              uploadBytes <= policy.rasterBytes else {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .atlas, dimension: rowOverflow || uploadOverflow ? .arithmetic : .rasterBytes,
+                requested: uploadOverflow ? nil : uploadBytes,
+                limit: policy.rasterBytes,
+                reason: rowOverflow || uploadOverflow ? .overflow : .limit
+            )
+            return nil
+        }
+        guard makeTexturePrivateIfNeeded(), let tex = texture else {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .atlas, dimension: .texture, reason: .allocation
+            )
+            return nil
+        }
 
         let yOffset = reservation.slotIndex * slotHeight
-        let uploadWidth = min(pixelWidth, atlasWidth)
         let region = MTLRegion(
             origin: MTLOrigin(x: 0, y: yOffset, z: 0),
-            size: MTLSize(width: uploadWidth, height: slotHeight, depth: 1)
+            size: MTLSize(width: pixelWidth, height: slotHeight, depth: 1)
         )
         tex.replace(region: region, mipmapLevel: 0, withBytes: pointer, bytesPerRow: bytesPerRow)
 
         frameTextureUploads += 1
-        frameTextureUploadBytes += bytesPerRow * slotHeight
-        allocator.markUploaded(slotIndex: reservation.slotIndex, contentHash: reservation.contentHash, pixelWidth: uploadWidth)
+        frameTextureUploadBytes += uploadBytes
+        allocator.markUploaded(slotIndex: reservation.slotIndex, contentHash: reservation.contentHash, pixelWidth: pixelWidth)
 
-        return AtlasEntry(slotIndex: reservation.slotIndex, pixelWidth: uploadWidth, pixelHeight: slotHeight)
+        return AtlasEntry(slotIndex: reservation.slotIndex, pixelWidth: pixelWidth, pixelHeight: slotHeight)
+    }
+
+    private func makeTexturePrivateIfNeeded() -> Bool {
+        guard textureIsShared, let source = texture else { return texture != nil }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: atlasWidth,
+            height: atlasHeight, mipmapped: false
+        )
+        descriptor.usage = .shaderRead
+        descriptor.storageMode = .managed
+        guard let candidate = makeTexture(device, descriptor) else { return false }
+        switch copyTexture(source, to: candidate, width: atlasWidth, height: atlasHeight) {
+        case .success:
+            texture = candidate
+            textureIsShared = false
+            return true
+        case .failure(let failure):
+            nativePresentationFailure = nativePresentationFailure ?? failure
+            return false
+        }
+    }
+
+    private func copyTexture(_ source: MTLTexture, to destination: MTLTexture,
+                             width: Int, height: Int,
+                             frameSequence: UInt32 = 0) -> Result<Void, NativePresentationFailure> {
+        guard width > 0, height > 0 else { return .success(()) }
+        let (bytesPerRow, rowOverflow) = width.multipliedReportingOverflow(by: 4)
+        let (byteCount, countOverflow) = bytesPerRow.multipliedReportingOverflow(by: height)
+        guard !rowOverflow, !countOverflow else {
+            return .failure(NativePresentationFailure(
+                phase: .atlas, dimension: .arithmetic,
+                frameSequence: frameSequence, reason: .overflow
+            ))
+        }
+        guard byteCount <= policy.atlasBytes else {
+            return .failure(NativePresentationFailure(
+                phase: .atlas, dimension: .atlasBytes,
+                requested: byteCount, limit: policy.atlasBytes,
+                frameSequence: frameSequence, reason: .limit
+            ))
+        }
+        guard let storage = allocateStaging(byteCount) else {
+            return .failure(NativePresentationFailure(
+                phase: .atlas, dimension: .atlasBytes,
+                requested: byteCount, limit: policy.atlasBytes,
+                frameSequence: frameSequence, reason: .allocation
+            ))
+        }
+        defer { deallocateStaging(storage) }
+        let region = MTLRegion(origin: .init(x: 0, y: 0, z: 0),
+                               size: .init(width: width, height: height, depth: 1))
+        source.getBytes(storage, bytesPerRow: bytesPerRow, from: region, mipmapLevel: 0)
+        destination.replace(region: region, mipmapLevel: 0,
+                            withBytes: storage, bytesPerRow: bytesPerRow)
+        return .success(())
     }
 
     /// Compute UV for a slot.

--- a/macos/Sources/Renderer/NativeRenderResources.swift
+++ b/macos/Sources/Renderer/NativeRenderResources.swift
@@ -1,0 +1,368 @@
+import Foundation
+import Metal
+import MingaProtocol
+import QuartzCore
+import os
+
+/// Metal does not expose a per-device 2D edge property. macOS 15's documented
+/// feature tables guarantee and cap 2D textures at 16,384 for every supported
+/// Mac GPU family; keep that device-API ceiling separate from configured policy.
+func nativeDeviceTextureDimensionLimit(_ device: MTLDevice) -> Int {
+    _ = device.registryID
+    return 16_384
+}
+
+/// Native allocation dimension used by policy failures and presentation telemetry.
+public enum NativeRenderResourceDimension: String, Sendable, Equatable {
+    case textureWidth = "texture_width"
+    case textureHeight = "texture_height"
+    case rasterBytes = "raster_bytes"
+    case atlasBytes = "atlas_bytes"
+    case atlasSlots = "atlas_slots"
+    case lineInstances = "line_instances"
+    case quadInstances = "quad_instances"
+    case drawBufferBytes = "draw_buffer_bytes"
+    case texture
+    case buffer
+    case lineBuffer = "line_buffer"
+    case quadBuffer0 = "quad_buffer_0"
+    case quadBuffer1 = "quad_buffer_1"
+    case quadBuffer2 = "quad_buffer_2"
+    case rasterContext = "raster_context"
+    case commandBuffer = "command_buffer"
+    case encoder
+    case renderTarget = "render_target"
+    case presentationCommandBuffer = "presentation_command_buffer"
+    case presentationEncoder = "presentation_encoder"
+    case presentationCopy = "presentation_copy"
+    case drawable
+    case submission
+    case completion
+    case arithmetic
+}
+
+/// Metadata-only presentation failure. It deliberately contains no editor payload.
+public struct NativePresentationFailure: Error, Sendable, Equatable {
+    /// Renderer phase that discarded the candidate visual frame.
+    public enum Phase: String, Sendable { case demand, raster, atlas, buffers, command, drawable, submission, completion }
+    /// Stable failure category that contains no editor payload.
+    public enum Reason: String, Sendable { case limit, overflow, allocation, unavailable, context, submission, completion, mismatch, injected }
+
+    public let phase: Phase
+    public let dimension: NativeRenderResourceDimension
+    public let requested: Int?
+    public let limit: Int?
+    public let frameSequence: UInt32
+    public let reason: Reason
+
+    /// Creates a metadata-only failure for one discarded visual candidate.
+    public init(phase: Phase, dimension: NativeRenderResourceDimension,
+                requested: Int? = nil, limit: Int? = nil,
+                frameSequence: UInt32 = 0, reason: Reason) {
+        self.phase = phase
+        self.dimension = dimension
+        self.requested = requested
+        self.limit = limit
+        self.frameSequence = frameSequence
+        self.reason = reason
+    }
+}
+
+/// Exact checked demand derived from already-bounded visible preparation and
+/// native ABI strides. No guessed slot or instance constants are accepted.
+public struct NativeRenderDemand: Sendable, Equatable {
+    public let textureWidth: Int
+    public let textureHeight: Int
+    public let rasterBytes: Int
+    public let atlasSlots: Int
+    public let atlasBytes: Int
+    public let lineInstances: Int
+    public let lineBufferBytes: Int
+    public let quadInstances: Int
+    public let quadBufferBytes: Int
+    public let aggregateDrawBufferBytes: Int
+
+    /// Computes exact native demand and rejects any checked policy or device boundary violation.
+    public static func checked(
+        textureWidth: Int, slotHeight: Int, atlasSlots: Int,
+        lineInstances: Int, lineStride: Int,
+        quadInstances: Int, quadStride: Int, quadBufferCount: Int,
+        policy: FrameResourcePolicy.NativeRendererLimits,
+        deviceTextureWidth: Int, deviceTextureHeight: Int,
+        deviceMaxBufferLength: Int,
+        frameSequence: UInt32 = 0
+    ) throws -> Self {
+        let values = [textureWidth, slotHeight, atlasSlots, lineInstances, lineStride,
+                      quadInstances, quadStride, quadBufferCount]
+        guard values.allSatisfy({ $0 >= 0 }) else {
+            throw failure(.arithmetic, frameSequence, .overflow)
+        }
+        let widthLimit = min(policy.textureWidth, deviceTextureWidth)
+        let heightLimit = min(policy.textureHeight, deviceTextureHeight)
+        guard textureWidth <= widthLimit else {
+            throw failure(.textureWidth, frameSequence, .limit, textureWidth, widthLimit)
+        }
+        let textureHeight = try multiply(atlasSlots, slotHeight, frameSequence)
+        guard textureHeight <= heightLimit else {
+            throw failure(.textureHeight, frameSequence, .limit, textureHeight, heightLimit)
+        }
+        let bytesPerRow = try multiply(textureWidth, 4, frameSequence)
+        let rasterBytes = try multiply(bytesPerRow, slotHeight, frameSequence)
+        guard rasterBytes <= policy.rasterBytes else {
+            throw failure(.rasterBytes, frameSequence, .limit, rasterBytes, policy.rasterBytes)
+        }
+        let atlasBytes = try multiply(rasterBytes, atlasSlots, frameSequence)
+        guard atlasBytes <= policy.atlasBytes else {
+            throw failure(.atlasBytes, frameSequence, .limit, atlasBytes, policy.atlasBytes)
+        }
+        let lineBufferBytes = try multiply(lineInstances, lineStride, frameSequence)
+        let oneQuadBufferBytes = try multiply(quadInstances, quadStride, frameSequence)
+        let quadBufferBytes = try multiply(oneQuadBufferBytes, quadBufferCount, frameSequence)
+        let aggregate = try add(lineBufferBytes, quadBufferBytes, frameSequence)
+        guard lineBufferBytes <= deviceMaxBufferLength else {
+            throw failure(.lineBuffer, frameSequence, .limit,
+                          lineBufferBytes, deviceMaxBufferLength)
+        }
+        guard oneQuadBufferBytes <= deviceMaxBufferLength else {
+            throw failure(.quadBuffer0, frameSequence, .limit,
+                          oneQuadBufferBytes, deviceMaxBufferLength)
+        }
+        guard aggregate <= policy.aggregateDrawBufferBytes else {
+            throw failure(.drawBufferBytes, frameSequence, .limit,
+                          aggregate, policy.aggregateDrawBufferBytes)
+        }
+        return Self(textureWidth: textureWidth, textureHeight: textureHeight,
+                    rasterBytes: rasterBytes, atlasSlots: atlasSlots, atlasBytes: atlasBytes,
+                    lineInstances: lineInstances, lineBufferBytes: lineBufferBytes,
+                    quadInstances: quadInstances, quadBufferBytes: quadBufferBytes,
+                    aggregateDrawBufferBytes: aggregate)
+    }
+
+    /// Maximum complete slots under both the atlas byte ceiling and texture-height ceiling.
+    public static func maximumAtlasSlots(textureWidth: Int, slotHeight: Int,
+                                         policy: FrameResourcePolicy.NativeRendererLimits,
+                                         deviceTextureHeight: Int,
+                                         frameSequence: UInt32 = 0) throws -> Int {
+        guard textureWidth > 0, slotHeight > 0 else { return 0 }
+        let slotBytes = try multiply(try multiply(textureWidth, 4, frameSequence), slotHeight, frameSequence)
+        return min(policy.atlasBytes / slotBytes,
+                   min(policy.textureHeight, deviceTextureHeight) / slotHeight)
+    }
+
+    private static func multiply(_ lhs: Int, _ rhs: Int, _ seq: UInt32) throws -> Int {
+        let (value, overflow) = lhs.multipliedReportingOverflow(by: rhs)
+        guard !overflow else { throw failure(.arithmetic, seq, .overflow) }
+        return value
+    }
+
+    private static func add(_ lhs: Int, _ rhs: Int, _ seq: UInt32) throws -> Int {
+        let (value, overflow) = lhs.addingReportingOverflow(rhs)
+        guard !overflow else { throw failure(.arithmetic, seq, .overflow) }
+        return value
+    }
+
+    private static func failure(_ dimension: NativeRenderResourceDimension, _ seq: UInt32,
+                                _ reason: NativePresentationFailure.Reason,
+                                _ requested: Int? = nil, _ limit: Int? = nil) -> NativePresentationFailure {
+        NativePresentationFailure(phase: .demand, dimension: dimension,
+                                  requested: requested, limit: limit,
+                                  frameSequence: seq, reason: reason)
+    }
+}
+
+/// Exact byte demand for the complete line/quad candidate set.
+struct NativeRenderTargetDemand: Sendable, Equatable {
+    let width: Int
+    let height: Int
+    let byteCount: Int
+
+    static func checked(width: Int, height: Int,
+                        policy: FrameResourcePolicy.NativeRendererLimits,
+                        deviceTextureDimension: Int,
+                        frameSequence: UInt32) throws -> Self {
+        guard width > 0, height > 0 else {
+            throw NativePresentationFailure(
+                phase: .drawable, dimension: .renderTarget,
+                frameSequence: frameSequence, reason: .unavailable
+            )
+        }
+        let widthLimit = min(policy.textureWidth, deviceTextureDimension)
+        let heightLimit = min(policy.textureHeight, deviceTextureDimension)
+        guard width <= widthLimit else {
+            throw NativePresentationFailure(
+                phase: .drawable, dimension: .textureWidth,
+                requested: width, limit: widthLimit,
+                frameSequence: frameSequence, reason: .limit
+            )
+        }
+        guard height <= heightLimit else {
+            throw NativePresentationFailure(
+                phase: .drawable, dimension: .textureHeight,
+                requested: height, limit: heightLimit,
+                frameSequence: frameSequence, reason: .limit
+            )
+        }
+        let (pixelCount, pixelOverflow) = width.multipliedReportingOverflow(by: height)
+        let (byteCount, byteOverflow) = pixelCount.multipliedReportingOverflow(by: 4)
+        guard !pixelOverflow, !byteOverflow else {
+            throw NativePresentationFailure(
+                phase: .drawable, dimension: .arithmetic,
+                frameSequence: frameSequence, reason: .overflow
+            )
+        }
+        guard byteCount <= policy.renderTargetBytes else {
+            throw NativePresentationFailure(
+                phase: .drawable, dimension: .renderTarget,
+                requested: byteCount, limit: policy.renderTargetBytes,
+                frameSequence: frameSequence, reason: .limit
+            )
+        }
+        return Self(width: width, height: height, byteCount: byteCount)
+    }
+}
+
+struct NativeDrawBufferDemand: Sendable, Equatable {
+    let lineBytes: Int
+    let quadBytesPerBuffer: Int
+    let aggregateBytes: Int
+
+    static func checked(lineCount: Int, lineStride: Int,
+                        quadPassCounts: [Int], quadStride: Int,
+                        quadBufferCount: Int, alignment: Int,
+                        limit: Int, deviceLimit: Int,
+                        frameSequence: UInt32) throws -> Self {
+        guard [lineCount, lineStride, quadStride, quadBufferCount, alignment]
+            .allSatisfy({ $0 >= 0 }), quadPassCounts.allSatisfy({ $0 >= 0 }) else {
+            throw NativePresentationFailure(phase: .buffers, dimension: .arithmetic,
+                                            frameSequence: frameSequence, reason: .overflow)
+        }
+        func multiply(_ lhs: Int, _ rhs: Int) throws -> Int {
+            let (value, overflow) = lhs.multipliedReportingOverflow(by: rhs)
+            guard !overflow else {
+                throw NativePresentationFailure(phase: .buffers, dimension: .arithmetic,
+                                                frameSequence: frameSequence, reason: .overflow)
+            }
+            return value
+        }
+        func add(_ lhs: Int, _ rhs: Int) throws -> Int {
+            let (value, overflow) = lhs.addingReportingOverflow(rhs)
+            guard !overflow else {
+                throw NativePresentationFailure(phase: .buffers, dimension: .arithmetic,
+                                                frameSequence: frameSequence, reason: .overflow)
+            }
+            return value
+        }
+        let lineBytes = try multiply(lineCount, lineStride)
+        var quadBytes = 0
+        for count in quadPassCounts where count > 0 {
+            if alignment > 0 {
+                let padding = (alignment - quadBytes % alignment) % alignment
+                quadBytes = try add(quadBytes, padding)
+            }
+            quadBytes = try add(quadBytes, try multiply(count, quadStride))
+        }
+        let allQuadBytes = try multiply(quadBytes, quadBufferCount)
+        let aggregate = try add(lineBytes, allQuadBytes)
+        guard lineBytes <= deviceLimit else {
+            throw NativePresentationFailure(
+                phase: .buffers, dimension: .lineBuffer,
+                requested: lineBytes, limit: deviceLimit,
+                frameSequence: frameSequence, reason: .limit
+            )
+        }
+        guard quadBytes <= deviceLimit else {
+            throw NativePresentationFailure(
+                phase: .buffers, dimension: .quadBuffer0,
+                requested: quadBytes, limit: deviceLimit,
+                frameSequence: frameSequence, reason: .limit
+            )
+        }
+        guard aggregate <= limit else {
+            throw NativePresentationFailure(
+                phase: .buffers, dimension: .drawBufferBytes,
+                requested: aggregate, limit: limit,
+                frameSequence: frameSequence, reason: .limit
+            )
+        }
+        return Self(lineBytes: lineBytes, quadBytesPerBuffer: quadBytes,
+                    aggregateBytes: aggregate)
+    }
+}
+
+/// Narrow renderer-owned allocation and scheduling seams. Production closures
+/// call Metal directly; tests can fail one phase without mocking the Metal API.
+@MainActor
+struct NativeRenderFactories {
+    var makeLibrary: (MTLDevice) -> MTLLibrary?
+    var makeTexture: (MTLDevice, MTLTextureDescriptor) -> MTLTexture?
+    var makeBuffer: (MTLDevice, Int, MTLResourceOptions) -> MTLBuffer?
+    var makeRasterizer: () -> BitmapRasterizer
+    var makeCommandBuffer: (MTLCommandQueue) -> MTLCommandBuffer?
+    var makeEncoder: (MTLCommandBuffer, MTLRenderPassDescriptor) -> MTLRenderCommandEncoder?
+    var makeBlitEncoder: (MTLCommandBuffer) -> MTLBlitCommandEncoder?
+    /// Injectable gates for deterministic render and presentation-copy submission failures.
+    var preSubmit: (MTLCommandBuffer) throws -> Void
+    var prePresentationSubmit: (MTLCommandBuffer) throws -> Void
+    /// Delivers only metadata from Metal's sendable completion callback back to the main actor.
+    var observeCompletion: (
+        MTLCommandBuffer,
+        @escaping @MainActor @Sendable (_ succeeded: Bool, _ status: Int) -> Void
+    ) -> Void
+    /// Called only after the command that copied into the drawable completed successfully.
+    var present: (CAMetalDrawable) throws -> Void
+    var reportFailure: (NativePresentationFailure) -> Void
+
+    static let production = Self(
+        makeLibrary: { device in
+            if let library = try? device.makeDefaultLibrary(bundle: Bundle.main) {
+                return library
+            }
+            let executableURL = Bundle.main.executableURL!
+            return try? device.makeLibrary(
+                URL: executableURL.deletingLastPathComponent().appendingPathComponent("default.metallib")
+            )
+        },
+        makeTexture: { device, descriptor in device.makeTexture(descriptor: descriptor) },
+        makeBuffer: { device, length, options in device.makeBuffer(length: length, options: options) },
+        makeRasterizer: { BitmapRasterizer() },
+        makeCommandBuffer: { queue in queue.makeCommandBuffer() },
+        makeEncoder: { commandBuffer, descriptor in
+            commandBuffer.makeRenderCommandEncoder(descriptor: descriptor)
+        },
+        makeBlitEncoder: { $0.makeBlitCommandEncoder() },
+        preSubmit: { _ in },
+        prePresentationSubmit: { _ in },
+        observeCompletion: { commandBuffer, completion in
+            commandBuffer.addCompletedHandler { completed in
+                let succeeded = completed.status == .completed
+                let status = Int(completed.status.rawValue)
+                Task { @MainActor in completion(succeeded, status) }
+            }
+        },
+        present: { $0.present() },
+        reportFailure: { failure in
+            os_log(.error, log: OSLog(subsystem: "com.minga.editor", category: "NativePresentation"),
+                   "Native presentation failed phase=%{public}@ dimension=%{public}@ reason=%{public}@ seq=%{public}u",
+                   failure.phase.rawValue, failure.dimension.rawValue,
+                   failure.reason.rawValue, failure.frameSequence)
+        }
+    )
+}
+
+/// Orders asynchronous resource promotion. A completion from an older frame
+/// may never replace a generation that already completed later.
+struct NativePresentationGeneration: Sendable, Equatable {
+    private(set) var next: UInt64 = 0
+    private(set) var completed: UInt64 = 0
+
+    mutating func issue() -> UInt64 {
+        next &+= 1
+        return next
+    }
+
+    mutating func complete(_ generation: UInt64) -> Bool {
+        guard generation > completed, generation <= next else { return false }
+        completed = generation
+        return true
+    }
+}

--- a/macos/Sources/Renderer/SlotAllocator.swift
+++ b/macos/Sources/Renderer/SlotAllocator.swift
@@ -53,7 +53,7 @@ struct AtlasKey: Hashable, CustomStringConvertible {
 }
 
 /// Metadata for one slot in the atlas.
-struct AtlasSlot {
+struct AtlasSlot: Equatable {
     var contentHash: Int = 0
     var pixelWidth: Int = 0
     var lastWrittenFrame: UInt64 = 0
@@ -79,7 +79,7 @@ enum LookupResult: Equatable {
     case full
 }
 
-struct SlotAllocator {
+struct SlotAllocator: Equatable {
     /// Per-slot metadata.
     private var slots: [AtlasSlot] = []
 

--- a/macos/Sources/Renderer/WindowContentRenderer.swift
+++ b/macos/Sources/Renderer/WindowContentRenderer.swift
@@ -17,6 +17,20 @@ import Metal
 import AppKit
 
 /// Renders `GUIWindowContent` rows into cached Metal line textures.
+/// Stable semantic/cache state used by renderer transaction tests.
+struct WindowContentCacheSnapshot: Equatable {
+    struct Entry: Equatable {
+        let texture: ObjectIdentifier
+        let contentHash: Int
+        let lastUsedFrame: UInt64
+        let pixelWidth: Int
+        let pixelHeight: Int
+    }
+    let entries: [UInt64: Entry]
+    let frameCounter: UInt64
+    let maxLinePixelWidth: Int
+}
+
 ///
 /// Each row's text + spans produce an `NSAttributedString` → `CTLine` →
 /// bitmap → `MTLTexture`, cached by stable row identity plus content hash.
@@ -24,12 +38,18 @@ import AppKit
 final class WindowContentRenderer {
     /// Metal device for texture creation.
     private let device: MTLDevice
+    private let makeTexture: (MTLDevice, MTLTextureDescriptor) -> MTLTexture?
+    private let resourcePolicy: FrameResourcePolicy.NativeRendererLimits
 
     /// Font manager for resolving font faces.
     private let fontManager: FontManager
 
     /// Shared pooled bitmap rasterizer.
     private let rasterizer: BitmapRasterizer
+
+    /// First typed raster/context failure in this frame. Callers discard the
+    /// whole candidate generation rather than treating a missing row as success.
+    private(set) var nativePresentationFailure: NativePresentationFailure?
 
     /// Per-row texture cache keyed by BEAM-authored row identity.
     private var lineCache: [UInt64: CachedLineTexture] = [:]
@@ -89,8 +109,14 @@ final class WindowContentRenderer {
     /// Gap between consecutive annotations (points).
     let annotationSpacing: CGFloat = 4.0
 
-    init(device: MTLDevice, fontManager: FontManager, rasterizer: BitmapRasterizer) {
+    init(device: MTLDevice, fontManager: FontManager, rasterizer: BitmapRasterizer,
+         resourcePolicy: FrameResourcePolicy.NativeRendererLimits = .default,
+         makeTexture: @escaping (MTLDevice, MTLTextureDescriptor) -> MTLTexture? = {
+             $0.makeTexture(descriptor: $1)
+         }) {
         self.device = device
+        self.makeTexture = makeTexture
+        self.resourcePolicy = resourcePolicy
         self.fontManager = fontManager
         self.rasterizer = rasterizer
         self.scale = fontManager.scale
@@ -112,6 +138,32 @@ final class WindowContentRenderer {
         self.pillDescent = CTFontGetDescent(pillFont)
     }
 
+    /// Creates a frame-private cache generation backed by a private raster pool.
+    /// Cache insertion, eviction, and frame counters cannot affect the active renderer.
+    func makeCandidate(rasterizer: BitmapRasterizer) -> WindowContentRenderer {
+        let candidate = WindowContentRenderer(
+            device: device, fontManager: fontManager, rasterizer: rasterizer,
+            resourcePolicy: resourcePolicy, makeTexture: makeTexture
+        )
+        candidate.lineCache = lineCache
+        candidate.frameCounter = frameCounter
+        candidate.maxLinePixelWidth = maxLinePixelWidth
+        candidate.defaultFgRGB = defaultFgRGB
+        candidate.nsColorCache = nsColorCache
+        return candidate
+    }
+
+    func cacheSnapshot() -> WindowContentCacheSnapshot {
+        WindowContentCacheSnapshot(
+            entries: lineCache.mapValues {
+                .init(texture: ObjectIdentifier($0.texture), contentHash: $0.contentHash,
+                      lastUsedFrame: $0.lastUsedFrame, pixelWidth: $0.pixelWidth,
+                      pixelHeight: $0.pixelHeight)
+            },
+            frameCounter: frameCounter, maxLinePixelWidth: maxLinePixelWidth
+        )
+    }
+
     /// Update max line width on viewport resize.
     func updateViewportWidth(cols: UInt16) {
         let newWidth = Int(ceil(CGFloat(cols) * cellWidth * scale))
@@ -123,6 +175,7 @@ final class WindowContentRenderer {
 
     /// Advance frame counter and evict stale textures.
     func beginFrame() {
+        nativePresentationFailure = nil
         frameCounter += 1
         let threshold = frameCounter > evictionThreshold ? frameCounter - evictionThreshold : 0
         lineCache = lineCache.filter { $0.value.lastUsedFrame >= threshold }
@@ -165,8 +218,18 @@ final class WindowContentRenderer {
         guard pixelWidth > 0, pixelHeight > 0 else { return nil }
 
         // Rasterize into the pooled BGRA bitmap.
-        let result = rasterizer.rasterize(ctLine, width: pixelWidth, height: pixelHeight,
-                                          scale: scale, descent: descent)
+        let result: RasterizeResult
+        do {
+            result = try rasterizer.rasterize(ctLine, width: pixelWidth, height: pixelHeight,
+                                              scale: scale, descent: descent)
+        } catch let failure as NativePresentationFailure {
+            nativePresentationFailure = nativePresentationFailure ?? failure
+            return nil
+        } catch {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .rasterContext, reason: .unavailable)
+            return nil
+        }
 
         // Create texture.
         let texDesc = MTLTextureDescriptor.texture2DDescriptor(
@@ -178,7 +241,11 @@ final class WindowContentRenderer {
         texDesc.usage = [.shaderRead]
         texDesc.storageMode = .managed
 
-        guard let texture = device.makeTexture(descriptor: texDesc) else { return nil }
+        guard let texture = makeTexture(device, texDesc) else {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .texture, reason: .allocation)
+            return nil
+        }
 
         // Upload bitmap data. Pooled pointer valid until next rasterize() call.
         let region = MTLRegion(origin: MTLOrigin(x: 0, y: 0, z: 0),
@@ -234,12 +301,25 @@ final class WindowContentRenderer {
         let pixelWidth = min(Int(ceil(lineWidth * scale)), maxLinePixelWidth)
         guard pixelWidth > 0, linePixelHeight > 0 else { return nil }
 
-        let result = rasterizer.rasterize(ctLine, width: pixelWidth, height: linePixelHeight,
-                                          scale: scale, descent: descent)
+        let result: RasterizeResult
+        do {
+            result = try rasterizer.rasterize(ctLine, width: pixelWidth, height: linePixelHeight,
+                                              scale: scale, descent: descent)
+        } catch let failure as NativePresentationFailure {
+            nativePresentationFailure = nativePresentationFailure ?? failure
+            return nil
+        } catch {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .rasterContext, reason: .unavailable)
+            return nil
+        }
 
         guard let entry = atlas.commitUpload(reservation: reservation,
                                              pointer: result.pointer, pixelWidth: pixelWidth,
-                                             bytesPerRow: result.bytesPerRow) else { return nil }
+                                             bytesPerRow: result.bytesPerRow) else {
+            nativePresentationFailure = nativePresentationFailure ?? atlas.nativePresentationFailure
+            return nil
+        }
         metrics.bufferRowsRasterized += 1
         metrics.recordMiss(reservation.reason)
         return entry
@@ -299,12 +379,25 @@ final class WindowContentRenderer {
         let pixelWidth = min(Int(ceil(lineWidth * scale)), maxLinePixelWidth)
         guard pixelWidth > 0, linePixelHeight > 0 else { return nil }
 
-        let result = rasterizer.rasterize(ctLine, width: pixelWidth, height: linePixelHeight,
-                                          scale: scale, descent: descent)
+        let result: RasterizeResult
+        do {
+            result = try rasterizer.rasterize(ctLine, width: pixelWidth, height: linePixelHeight,
+                                              scale: scale, descent: descent)
+        } catch let failure as NativePresentationFailure {
+            nativePresentationFailure = nativePresentationFailure ?? failure
+            return nil
+        } catch {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .rasterContext, reason: .unavailable)
+            return nil
+        }
 
         guard let entry = atlas.commitUpload(reservation: reservation,
                                              pointer: result.pointer, pixelWidth: pixelWidth,
-                                             bytesPerRow: result.bytesPerRow) else { return nil }
+                                             bytesPerRow: result.bytesPerRow) else {
+            nativePresentationFailure = nativePresentationFailure ?? atlas.nativePresentationFailure
+            return nil
+        }
         metrics.otherTexturesRasterized += 1
         metrics.recordMiss(reservation.reason)
         return entry
@@ -317,20 +410,7 @@ final class WindowContentRenderer {
                            key: AtlasKey, contentHash: Int,
                            atlas: LineTextureAtlas, metrics: inout FrameMetrics) -> AtlasEntry? {
         guard !text.isEmpty else { return nil }
-        guard let lookup = atlas.lookupOrReserve(key: key, contentHash: contentHash) else { return nil }
 
-        switch lookup {
-        case .hit(let entry):
-            metrics.otherTexturesReused += 1
-            return entry
-        case .reserved(let reservation):
-            return rasterizePillToAtlas(text: text, fg: fg, bg: bg, reservation: reservation, atlas: atlas, metrics: &metrics)
-        }
-    }
-
-    private func rasterizePillToAtlas(text: String, fg: UInt32, bg: UInt32,
-                                      reservation: Reservation, atlas: LineTextureAtlas,
-                                      metrics: inout FrameMetrics) -> AtlasEntry? {
         let fgColor = nsColor(from: fg)
         let ligatures = fontManager.primary.ligaturesEnabled ? 2 : 0
         let attrs: [NSAttributedString.Key: Any] = [
@@ -340,37 +420,112 @@ final class WindowContentRenderer {
         ]
         let attrStr = NSAttributedString(string: text, attributes: attrs)
         let ctLine = CTLineCreateWithAttributedString(attrStr)
-
-        var lineAscent: CGFloat = 0
-        var lineDescent: CGFloat = 0
-        var lineLeading: CGFloat = 0
-        let textWidth = CTLineGetTypographicBounds(ctLine, &lineAscent, &lineDescent, &lineLeading)
-
-        // Pill dimensions: text + horizontal padding, clamped to min width.
+        let textWidth = CTLineGetTypographicBounds(ctLine, nil, nil, nil)
         let pillWidth = textWidth + 2 * pillHPad
         let pillContentHeight = pillAscent + pillDescent + 3.0
         let clampedWidth = max(pillWidth, pillContentHeight)
 
-        let pixelWidth = Int(ceil(clampedWidth * scale))
-        let pixelHeight = linePixelHeight
-        guard pixelWidth > 0, pixelHeight > 0 else { return nil }
+        guard let dimensions = validatedPillRasterDimensions(
+            pointWidth: clampedWidth, atlas: atlas
+        ) else { return nil }
+        guard let lookup = atlas.lookupOrReserve(key: key, contentHash: contentHash) else { return nil }
 
+        switch lookup {
+        case .hit(let entry):
+            metrics.otherTexturesReused += 1
+            return entry
+        case .reserved(let reservation):
+            return rasterizePillToAtlas(
+                ctLine: ctLine, textWidth: textWidth, bg: bg,
+                pixelWidth: dimensions.width, pixelHeight: dimensions.height,
+                reservation: reservation, atlas: atlas, metrics: &metrics
+            )
+        }
+    }
+
+    private func validatedPillRasterDimensions(
+        pointWidth: CGFloat, atlas: LineTextureAtlas
+    ) -> (width: Int, height: Int, rowBytes: Int, rasterBytes: Int)? {
+        let scaledWidth = pointWidth * scale
+        guard scaledWidth.isFinite, scaledWidth > 0,
+              scaledWidth < CGFloat(Int.max) else {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .arithmetic, reason: .overflow
+            )
+            return nil
+        }
+        let pixelWidth = Int(scaledWidth.rounded(.up))
+        let pixelHeight = linePixelHeight
+        let widthLimit = min(resourcePolicy.textureWidth,
+                             nativeDeviceTextureDimensionLimit(device), atlas.atlasWidth)
+        guard pixelWidth <= widthLimit else {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .textureWidth,
+                requested: pixelWidth, limit: widthLimit, reason: .limit
+            )
+            return nil
+        }
+        let heightLimit = min(resourcePolicy.textureHeight,
+                              nativeDeviceTextureDimensionLimit(device), atlas.slotHeight)
+        guard pixelHeight > 0, pixelHeight <= heightLimit else {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .textureHeight,
+                requested: pixelHeight, limit: heightLimit, reason: .limit
+            )
+            return nil
+        }
+        let (rowBytes, rowOverflow) = pixelWidth.multipliedReportingOverflow(by: 4)
+        let (rasterBytes, rasterOverflow) = rowBytes.multipliedReportingOverflow(by: pixelHeight)
+        guard !rowOverflow, !rasterOverflow else {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .arithmetic, reason: .overflow
+            )
+            return nil
+        }
+        guard rasterBytes <= resourcePolicy.rasterBytes else {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .rasterBytes,
+                requested: rasterBytes, limit: resourcePolicy.rasterBytes, reason: .limit
+            )
+            return nil
+        }
+        return (pixelWidth, pixelHeight, rowBytes, rasterBytes)
+    }
+
+    private func rasterizePillToAtlas(
+        ctLine: CTLine, textWidth: CGFloat, bg: UInt32,
+        pixelWidth: Int, pixelHeight: Int,
+        reservation: Reservation, atlas: LineTextureAtlas,
+        metrics: inout FrameMetrics
+    ) -> AtlasEntry? {
         let bgR = CGFloat((bg >> 16) & 0xFF) / 255.0
         let bgG = CGFloat((bg >> 8) & 0xFF) / 255.0
         let bgB = CGFloat(bg & 0xFF) / 255.0
         let bgCGColor = CGColor(srgbRed: bgR, green: bgG, blue: bgB, alpha: 1.0)
 
-        let result = rasterizer.rasterizePill(
-            ctLine, textWidth: CGFloat(textWidth),
-            bgColor: bgCGColor,
-            width: pixelWidth, height: pixelHeight,
-            scale: scale, descent: pillDescent, ascent: pillAscent,
-            hPad: pillHPad, cornerRadius: pillCornerRadius
-        )
+        let result: RasterizeResult
+        do {
+            result = try rasterizer.rasterizePill(
+                ctLine, textWidth: textWidth, bgColor: bgCGColor,
+                width: pixelWidth, height: pixelHeight,
+                scale: scale, descent: pillDescent, ascent: pillAscent,
+                hPad: pillHPad, cornerRadius: pillCornerRadius
+            )
+        } catch let failure as NativePresentationFailure {
+            nativePresentationFailure = nativePresentationFailure ?? failure
+            return nil
+        } catch {
+            nativePresentationFailure = nativePresentationFailure ?? NativePresentationFailure(
+                phase: .raster, dimension: .rasterContext, reason: .unavailable)
+            return nil
+        }
 
         guard let entry = atlas.commitUpload(reservation: reservation,
                                              pointer: result.pointer, pixelWidth: pixelWidth,
-                                             bytesPerRow: result.bytesPerRow) else { return nil }
+                                             bytesPerRow: result.bytesPerRow) else {
+            nativePresentationFailure = nativePresentationFailure ?? atlas.nativePresentationFailure
+            return nil
+        }
         metrics.otherTexturesRasterized += 1
         metrics.recordMiss(reservation.reason)
         return entry

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -39,6 +39,10 @@ final class EditorNSView: MTKView {
     /// CoreText-based renderer.
     let coreTextRenderer: CoreTextMetalRenderer
 
+    /// Narrow drawable acquisition seam. Production leaves this nil and uses
+    /// MTKView.currentDrawable; tests may inject nil without retaining a drawable.
+    var drawableProvider: (() -> CAMetalDrawable?)?
+
     /// Font manager for per-span font family support.
     let fontManager: FontManager
 
@@ -231,8 +235,10 @@ final class EditorNSView: MTKView {
         isPaused = true
         enableSetNeedsDisplay = true
 
-        // Standard Metal layer config.
+        // The renderer copies a completed offscreen candidate into the drawable
+        // only after the candidate render succeeds, so drawable blits must be enabled.
         colorPixelFormat = .bgra8Unorm_srgb
+        framebufferOnly = false
         layer?.isOpaque = true
         (layer as? CAMetalLayer)?.maximumDrawableCount = 3
 
@@ -530,14 +536,10 @@ final class EditorNSView: MTKView {
 
     /// Called by MTKView's display link at vsync when needsDisplay is true.
     override func draw(_ dirtyRect: NSRect) {
-        // Fail before currentDrawable can vend a retained surface and before an input
-        // sequence is claimed. In particular, an occluded drawable is not presentation.
+        // Reject known non-presentable states before claiming an input sequence.
+        // The renderer acquires a drawable only after its offscreen candidate completes.
         if let reason = presentationPreflightDiscardReason() {
             dispatcher.discardPendingPresentation(reason: reason)
-            return
-        }
-        guard let drawable = currentDrawable else {
-            dispatcher.discardPendingPresentation(reason: .nilDrawable)
             return
         }
         let scale = Float(window?.backingScaleFactor ?? 2.0)
@@ -580,7 +582,14 @@ final class EditorNSView: MTKView {
                                 isMouseInGutter: validMouseInGutter,
                                 gutterHoverWindowId: validGutterHoverWindowId,
                                 gutterHoverRow: validGutterHoverRow,
-                                drawable: drawable, viewportSize: drawableSize,
+                                drawableProvider: { [weak self] in
+                                    guard let self else { return nil }
+                                    if let drawableProvider = self.drawableProvider {
+                                        return drawableProvider()
+                                    }
+                                    return self.currentDrawable
+                                },
+                                viewportSize: drawableSize,
                                 contentScale: scale,
                                 scrollOffset: SIMD2<Float>(
                                     Float(localScrollPresentation?.offset.x ?? 0),

--- a/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
+++ b/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
@@ -1,0 +1,984 @@
+import CoreText
+import Metal
+import MingaProtocol
+import QuartzCore
+import Testing
+
+private final class NativeTestDrawable: NSObject, CAMetalDrawable {
+    let texture: MTLTexture
+    let layer = CAMetalLayer()
+    let drawableID: Int = 1
+    let presentedTime: CFTimeInterval = 0
+
+    init(texture: MTLTexture) { self.texture = texture }
+    func present() {}
+    func present(at presentationTime: CFTimeInterval) { _ = presentationTime }
+    func present(afterMinimumDuration duration: CFTimeInterval) { _ = duration }
+    func addPresentedHandler(_ block: @escaping MTLDrawablePresentedHandler) { _ = block }
+}
+
+private enum InjectedSubmissionFailure: Error { case failed }
+
+@Suite("Failure-atomic native render demand")
+struct NativeRenderResourcesTests {
+    private let policy = FrameResourcePolicy.NativeRendererLimits(
+        rasterBytes: 4_096, atlasBytes: 16_384,
+        aggregateDrawBufferBytes: 8_192, renderTargetBytes: 4_096,
+        textureWidth: 128, textureHeight: 128
+    )
+
+    @MainActor private func nativeTestFactories() -> NativeRenderFactories {
+        var factories = NativeRenderFactories.production
+        factories.makeLibrary = { device in
+            Bundle.allBundles.lazy.compactMap { try? device.makeDefaultLibrary(bundle: $0) }.first
+        }
+        return factories
+    }
+
+    @Test("checked multiply overflow is a typed local failure")
+    func multiplyOverflow() {
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeRenderDemand.checked(
+                textureWidth: Int.max, slotHeight: 2, atlasSlots: 1,
+                lineInstances: 0, lineStride: 32,
+                quadInstances: 0, quadStride: 48, quadBufferCount: 3,
+                policy: policy, deviceTextureWidth: Int.max,
+                deviceTextureHeight: Int.max, deviceMaxBufferLength: Int.max
+            )
+        }
+    }
+
+    @Test("checked aggregate add overflow is a typed local failure")
+    func addOverflow() {
+        let permissive = FrameResourcePolicy.NativeRendererLimits(
+            rasterBytes: .max, atlasBytes: .max,
+            aggregateDrawBufferBytes: .max,
+            textureWidth: 1, textureHeight: 1
+        )
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeRenderDemand.checked(
+                textureWidth: 1, slotHeight: 1, atlasSlots: 1,
+                lineInstances: Int.max / 2, lineStride: 2,
+                quadInstances: 1, quadStride: 2, quadBufferCount: 1,
+                policy: permissive, deviceTextureWidth: 1,
+                deviceTextureHeight: 1, deviceMaxBufferLength: .max
+            )
+        }
+    }
+
+    @Test("exact texture atlas raster and triple-buffer boundaries pass")
+    func exactBoundaries() throws {
+        let demand = try NativeRenderDemand.checked(
+            textureWidth: 64, slotHeight: 16, atlasSlots: 4,
+            lineInstances: 64, lineStride: 32,
+            quadInstances: 32, quadStride: 48, quadBufferCount: 3,
+            policy: policy, deviceTextureWidth: 128,
+            deviceTextureHeight: 128, deviceMaxBufferLength: 8_192
+        )
+        #expect(demand.rasterBytes == 4_096)
+        #expect(demand.atlasBytes == 16_384)
+        #expect(demand.textureHeight == 64)
+        #expect(demand.lineBufferBytes == 2_048)
+        #expect(demand.quadBufferBytes == 4_608)
+        #expect(demand.aggregateDrawBufferBytes == 6_656)
+    }
+
+    @Test("offscreen target dimensions and bytes are checked before allocation")
+    func checkedRenderTargetDemand() throws {
+        let exact = try NativeRenderTargetDemand.checked(
+            width: 32, height: 32, policy: policy,
+            deviceTextureDimension: 128, frameSequence: 5
+        )
+        #expect(exact.byteCount == 4_096)
+
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeRenderTargetDemand.checked(
+                width: 33, height: 32, policy: policy,
+                deviceTextureDimension: 128, frameSequence: 6
+            )
+        }
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeRenderTargetDemand.checked(
+                width: 129, height: 1, policy: policy,
+                deviceTextureDimension: 128, frameSequence: 7
+            )
+        }
+    }
+
+    @Test("atlas slots derive from bytes and native geometry")
+    func derivedAtlasSlots() throws {
+        #expect(try NativeRenderDemand.maximumAtlasSlots(
+            textureWidth: 64, slotHeight: 16, policy: policy,
+            deviceTextureHeight: 48
+        ) == 3)
+    }
+
+    @Test("one byte beyond each hard ceiling fails without truncation")
+    func beyondBoundaries() {
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeRenderDemand.checked(
+                textureWidth: 65, slotHeight: 16, atlasSlots: 4,
+                lineInstances: 0, lineStride: 32,
+                quadInstances: 0, quadStride: 48, quadBufferCount: 3,
+                policy: policy, deviceTextureWidth: 128,
+                deviceTextureHeight: 128, deviceMaxBufferLength: 8_192
+            )
+        }
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeRenderDemand.checked(
+                textureWidth: 64, slotHeight: 16, atlasSlots: 5,
+                lineInstances: 0, lineStride: 32,
+                quadInstances: 0, quadStride: 48, quadBufferCount: 3,
+                policy: policy, deviceTextureWidth: 128,
+                deviceTextureHeight: 128, deviceMaxBufferLength: 8_192
+            )
+        }
+    }
+
+    @Test("line and every triple-buffered quad allocation contribute to aggregate demand")
+    func aggregateBufferClasses() throws {
+        let demand = try NativeRenderDemand.checked(
+            textureWidth: 1, slotHeight: 1, atlasSlots: 1,
+            lineInstances: 17, lineStride: MemoryLayout<LineGPU>.stride,
+            quadInstances: 19, quadStride: MemoryLayout<QuadGPU>.stride,
+            quadBufferCount: 3, policy: policy,
+            deviceTextureWidth: 128, deviceTextureHeight: 128,
+            deviceMaxBufferLength: 8_192
+        )
+        #expect(demand.lineBufferBytes == 17 * MemoryLayout<LineGPU>.stride)
+        #expect(demand.quadBufferBytes == 19 * MemoryLayout<QuadGPU>.stride * 3)
+        #expect(demand.aggregateDrawBufferBytes == demand.lineBufferBytes + demand.quadBufferBytes)
+    }
+
+    @Test("aggregate may exceed the per-buffer device limit when every buffer fits")
+    func aggregateMayExceedDeviceLimit() throws {
+        let boundaryPolicy = FrameResourcePolicy.NativeRendererLimits(
+            rasterBytes: 4, atlasBytes: 4, aggregateDrawBufferBytes: 400,
+            textureWidth: 1, textureHeight: 1
+        )
+        let demand = try NativeRenderDemand.checked(
+            textureWidth: 1, slotHeight: 1, atlasSlots: 1,
+            lineInstances: 80, lineStride: 1,
+            quadInstances: 80, quadStride: 1, quadBufferCount: 3,
+            policy: boundaryPolicy, deviceTextureWidth: 1,
+            deviceTextureHeight: 1, deviceMaxBufferLength: 100
+        )
+        let prepared = try NativeDrawBufferDemand.checked(
+            lineCount: 80, lineStride: 1, quadPassCounts: [80], quadStride: 1,
+            quadBufferCount: 3, alignment: 0, limit: 400,
+            deviceLimit: 100, frameSequence: 1
+        )
+        #expect(demand.aggregateDrawBufferBytes == 320)
+        #expect(prepared.aggregateBytes == 320)
+    }
+
+    @Test("one individual buffer above the device limit fails")
+    func individualBufferExceedsDeviceLimit() {
+        let boundaryPolicy = FrameResourcePolicy.NativeRendererLimits(
+            rasterBytes: 4, atlasBytes: 4, aggregateDrawBufferBytes: 1_000,
+            textureWidth: 1, textureHeight: 1
+        )
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeRenderDemand.checked(
+                textureWidth: 1, slotHeight: 1, atlasSlots: 1,
+                lineInstances: 101, lineStride: 1,
+                quadInstances: 1, quadStride: 1, quadBufferCount: 3,
+                policy: boundaryPolicy, deviceTextureWidth: 1,
+                deviceTextureHeight: 1, deviceMaxBufferLength: 100
+            )
+        }
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeDrawBufferDemand.checked(
+                lineCount: 101, lineStride: 1, quadPassCounts: [1], quadStride: 1,
+                quadBufferCount: 3, alignment: 0, limit: 1_000,
+                deviceLimit: 100, frameSequence: 2
+            )
+        }
+    }
+
+    @Test("aggregate above product policy fails even when each buffer fits the device")
+    func aggregateExceedsProductPolicy() {
+        let boundaryPolicy = FrameResourcePolicy.NativeRendererLimits(
+            rasterBytes: 4, atlasBytes: 4, aggregateDrawBufferBytes: 319,
+            textureWidth: 1, textureHeight: 1
+        )
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeRenderDemand.checked(
+                textureWidth: 1, slotHeight: 1, atlasSlots: 1,
+                lineInstances: 80, lineStride: 1,
+                quadInstances: 80, quadStride: 1, quadBufferCount: 3,
+                policy: boundaryPolicy, deviceTextureWidth: 1,
+                deviceTextureHeight: 1, deviceMaxBufferLength: 100
+            )
+        }
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeDrawBufferDemand.checked(
+                lineCount: 80, lineStride: 1, quadPassCounts: [80], quadStride: 1,
+                quadBufferCount: 3, alignment: 0, limit: 319,
+                deviceLimit: 100, frameSequence: 3
+            )
+        }
+    }
+
+    @Test("65,536 visible rows retain a fixed exact instance range")
+    func fixedVisibleRange65536() throws {
+        let permissive = FrameResourcePolicy.NativeRendererLimits(
+            rasterBytes: 1_048_576, atlasBytes: 1_073_741_824,
+            aggregateDrawBufferBytes: 1_073_741_824,
+            textureWidth: 1, textureHeight: 65_536
+        )
+        let demand = try NativeRenderDemand.checked(
+            textureWidth: 1, slotHeight: 1, atlasSlots: 65_536,
+            lineInstances: 65_536, lineStride: MemoryLayout<LineGPU>.stride,
+            quadInstances: 0, quadStride: MemoryLayout<QuadGPU>.stride,
+            quadBufferCount: 3, policy: permissive,
+            deviceTextureWidth: 1, deviceTextureHeight: 65_536,
+            deviceMaxBufferLength: 1_073_741_824
+        )
+        #expect(demand.atlasSlots == 65_536)
+        #expect(demand.lineInstances == 65_536)
+        #expect(demand.lineBufferBytes == 65_536 * MemoryLayout<LineGPU>.stride)
+    }
+
+    @Test("atlas texture factory refusal preserves allocator index and cache")
+    @MainActor func atlasTextureRefusalIsAtomic() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let atlas = LineTextureAtlas(
+            device: device, slotHeight: 16, policy: policy,
+            makeTexture: { _, _ in nil }
+        )
+        let originalAllocator = atlas.allocator
+        let result = atlas.ensureCapacity(maxSlots: 4, width: 64, frameSequence: 42)
+        guard case .failure(let failure) = result else {
+            Issue.record("texture refusal unexpectedly succeeded")
+            return
+        }
+        #expect(failure.phase == .atlas)
+        #expect(failure.dimension == .texture)
+        #expect(atlas.slotCount == originalAllocator.capacity)
+        #expect(atlas.texture == nil)
+    }
+
+    @Test("atlas exhaustion records one typed slot failure")
+    @MainActor func atlasFullIsTyped() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let atlas = LineTextureAtlas(device: device, slotHeight: 16, policy: policy)
+        atlas.beginFrame()
+
+        if case .some = atlas.lookupOrReserve(
+            key: .bufferRow(windowId: 1, rowId: 1), contentHash: 1
+        ) {
+            Issue.record("zero-capacity atlas unexpectedly reserved a slot")
+        }
+        #expect(atlas.nativePresentationFailure == NativePresentationFailure(
+            phase: .atlas, dimension: .atlasSlots,
+            requested: 1, limit: 0, reason: .limit
+        ))
+
+        _ = atlas.lookupOrReserve(key: .bufferRow(windowId: 1, rowId: 2), contentHash: 2)
+        #expect(atlas.nativePresentationFailure?.requested == 1)
+    }
+
+    @Test("no-growth COW staging refusal leaves the active atlas untouched")
+    @MainActor func noGrowthUploadRefusalIsAtomic() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        var refuseStaging = false
+        let atlas = LineTextureAtlas(
+            device: device, slotHeight: 16, policy: policy,
+            allocateStaging: { refuseStaging ? nil : malloc($0) },
+            deallocateStaging: { free($0) }
+        )
+        guard case .success = atlas.ensureCapacity(maxSlots: 4, width: 64) else { return }
+        atlas.beginFrame()
+        let key = AtlasKey.bufferRow(windowId: 1, rowId: 9)
+        guard case .reserved(let reservation)? = atlas.lookupOrReserve(key: key, contentHash: 1),
+              let bytes = malloc(64 * 16 * 4) else { return }
+        defer { free(bytes) }
+        memset(bytes, 0x7f, 64 * 16 * 4)
+        #expect(atlas.commitUpload(reservation: reservation, pointer: bytes,
+                                  pixelWidth: 64, bytesPerRow: 256) != nil)
+        let activeAllocator = atlas.allocator
+        let activeTexture = atlas.texture.map(ObjectIdentifier.init)
+
+        let candidate = atlas.makeCandidate()
+        candidate.beginFrame()
+        guard case .reserved(let changed)? = candidate.lookupOrReserve(key: key, contentHash: 2) else { return }
+        let candidateAllocator = candidate.allocator
+        let candidateTexture = candidate.texture.map(ObjectIdentifier.init)
+        refuseStaging = true
+        #expect(candidate.commitUpload(reservation: changed, pointer: bytes,
+                                       pixelWidth: 64, bytesPerRow: 256) == nil)
+        #expect(candidate.nativePresentationFailure?.phase == .atlas)
+        #expect(candidate.nativePresentationFailure?.dimension == .atlasBytes)
+        #expect(candidate.allocator == candidateAllocator)
+        #expect(candidate.texture.map(ObjectIdentifier.init) == candidateTexture)
+        #expect(atlas.allocator == activeAllocator)
+        #expect(atlas.texture.map(ObjectIdentifier.init) == activeTexture)
+    }
+
+    @Test("growth COW staging refusal rolls back texture and allocator")
+    @MainActor func growthStagingRefusalIsAtomic() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        var refuseStaging = false
+        let atlas = LineTextureAtlas(
+            device: device, slotHeight: 16, policy: policy,
+            allocateStaging: { refuseStaging ? nil : malloc($0) },
+            deallocateStaging: { free($0) }
+        )
+        guard case .success = atlas.ensureCapacity(maxSlots: 2, width: 32) else { return }
+        let activeAllocator = atlas.allocator
+        let activeTexture = atlas.texture.map(ObjectIdentifier.init)
+        let activeWidth = atlas.atlasWidth
+        let activeHeight = atlas.atlasHeight
+
+        refuseStaging = true
+        let result = atlas.ensureCapacity(maxSlots: 4, width: 64, frameSequence: 43)
+        guard case .failure(let failure) = result else {
+            Issue.record("staging refusal unexpectedly grew atlas")
+            return
+        }
+        #expect(failure.phase == .atlas)
+        #expect(failure.dimension == .atlasBytes)
+        #expect(failure.reason == .allocation)
+        #expect(atlas.allocator == activeAllocator)
+        #expect(atlas.texture.map(ObjectIdentifier.init) == activeTexture)
+        #expect(atlas.atlasWidth == activeWidth)
+        #expect(atlas.atlasHeight == activeHeight)
+    }
+
+    @Test("late older completion cannot replace a newer completed generation")
+    func completionOrdering() {
+        var ordering = NativePresentationGeneration()
+        let older = ordering.issue()
+        let newer = ordering.issue()
+        let promotedNewer = ordering.complete(newer)
+        let promotedOlder = ordering.complete(older)
+        #expect(promotedNewer)
+        #expect(!promotedOlder)
+        #expect(ordering.completed == newer)
+    }
+
+    @Test("production raster allocator refusal is a typed local failure")
+    @MainActor func productionRasterAllocatorRefusal() {
+        let rasterizer = BitmapRasterizer()
+        let line = CTLineCreateWithAttributedString(NSAttributedString(string: "x"))
+        do {
+            _ = try rasterizer.rasterize(
+                line, width: Int.max / 8, height: 1, scale: 1, descent: 0
+            )
+            Issue.record("operating-system allocator unexpectedly accepted an impossible request")
+        } catch let failure as NativePresentationFailure {
+            #expect(failure.phase == .raster)
+            #expect(failure.dimension == .buffer)
+            #expect(failure.reason == .allocation)
+        } catch {
+            Issue.record("unexpected failure type: \(error)")
+        }
+    }
+
+    @Test("raster allocation refusal is typed and does not create a context")
+    @MainActor func rasterAllocationFailure() {
+        var contextCalls = 0
+        let rasterizer = BitmapRasterizer(factories: .init(
+            allocate: { _ in nil },
+            deallocate: { free($0) },
+            makeContext: { _, _, _, _, _, _ in
+                contextCalls += 1
+                return nil
+            }
+        ))
+        let line = CTLineCreateWithAttributedString(NSAttributedString(string: "x"))
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try rasterizer.rasterize(line, width: 8, height: 16, scale: 1, descent: 2)
+        }
+        #expect(contextCalls == 0)
+    }
+
+    @Test("raster context refusal is typed after successful candidate allocation")
+    @MainActor func rasterContextFailure() {
+        let rasterizer = BitmapRasterizer(factories: .init(
+            allocate: { malloc($0) },
+            deallocate: { free($0) },
+            makeContext: { _, _, _, _, _, _ in nil }
+        ))
+        let line = CTLineCreateWithAttributedString(NSAttributedString(string: "x"))
+        do {
+            _ = try rasterizer.rasterize(line, width: 8, height: 16, scale: 1, descent: 2)
+            Issue.record("context refusal unexpectedly rasterized")
+        } catch let failure as NativePresentationFailure {
+            #expect(failure.phase == .raster)
+            #expect(failure.dimension == .rasterContext)
+            #expect(failure.reason == .context)
+        } catch {
+            Issue.record("unexpected failure type: \(error)")
+        }
+    }
+
+    @Test("rasterizer releases cached context before freeing its pool")
+    @MainActor func rasterizerTeardownOrdering() throws {
+        weak var cachedContext: CGContext?
+        var contextReleasedBeforeFree = false
+        var rasterizer: BitmapRasterizer? = BitmapRasterizer(factories: .init(
+            allocate: { malloc($0) },
+            deallocate: { pointer in
+                contextReleasedBeforeFree = cachedContext == nil
+                free(pointer)
+            },
+            makeContext: { data, width, height, bytesPerRow, colorSpace, bitmapInfo in
+                let context = CGContext(
+                    data: data, width: width, height: height, bitsPerComponent: 8,
+                    bytesPerRow: bytesPerRow, space: colorSpace, bitmapInfo: bitmapInfo
+                )
+                cachedContext = context
+                return context
+            }
+        ))
+        let line = CTLineCreateWithAttributedString(NSAttributedString(string: "x"))
+        _ = try rasterizer?.rasterize(line, width: 8, height: 16, scale: 1, descent: 2)
+        #expect(cachedContext != nil)
+
+        rasterizer = nil
+        #expect(contextReleasedBeforeFree)
+    }
+
+    @Test("exact aggregate includes alignment once for every prebuilt quad pass")
+    func exactAlignedAggregate() throws {
+        let demand = try NativeDrawBufferDemand.checked(
+            lineCount: 2, lineStride: 32,
+            quadPassCounts: [1, 2, 0, 3], quadStride: 48,
+            quadBufferCount: 3, alignment: 256,
+            limit: 4_096, deviceLimit: 4_096, frameSequence: 9
+        )
+        #expect(demand.lineBytes == 64)
+        #expect(demand.quadBytesPerBuffer == 656)
+        #expect(demand.aggregateBytes == 64 + (656 * 3))
+    }
+
+    @Test("each exact line and quad candidate allocation failure is atomic")
+    @MainActor func eachBufferClassFailureIsAtomic() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let drawableDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 640, height: 128, mipmapped: false
+        )
+        drawableDescriptor.usage = .renderTarget
+        guard let drawableTexture = device.makeTexture(descriptor: drawableDescriptor) else { return }
+        let row = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 0,
+                               contentHash: 1, text: "atomic", spans: [])
+        let content = try GUIWindowContent(
+            windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0,
+            cursorShape: .block, rows: [row], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+        )
+        var frame = FrameState(cols: 40, rows: 2)
+        frame.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 2,
+            isActive: true, contentWidth: 40, cursorLine: 0,
+            lineNumberStyle: .absolute, lineNumberWidth: 2, signColWidth: 1,
+            entries: [.init(bufLine: 0, displayType: .normal, signType: .none)]
+        )
+        let expected: [NativeRenderResourceDimension] = [
+            .lineBuffer, .quadBuffer0, .quadBuffer1, .quadBuffer2
+        ]
+        for preallocatedAtlas in [false, true] {
+            for failedCall in expected.indices {
+                var bufferCall = 0
+                var reports: [NativePresentationFailure] = []
+                var presentCalls = 0
+                var factories = nativeTestFactories()
+                factories.makeBuffer = { device, length, options in
+                    defer { bufferCall += 1 }
+                    return bufferCall == failedCall ? nil : device.makeBuffer(length: length, options: options)
+                }
+                factories.present = { _ in presentCalls += 1 }
+                factories.reportFailure = { reports.append($0) }
+                guard let renderer = CoreTextMetalRenderer(factories: factories) else { continue }
+                let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+                renderer.setupRenderers(fontManager: fontManager)
+                if preallocatedAtlas {
+                    guard case .success = renderer.atlas?.ensureCapacity(maxSlots: 32, width: 640) else {
+                        Issue.record("failed to prepare no-growth atlas")
+                        return
+                    }
+                }
+                let before = renderer.activeResourceSnapshot()
+                renderer.render(
+                    frameState: frame, fontManager: fontManager,
+                    windowContents: [1: content],
+                    drawableProvider: { NativeTestDrawable(texture: drawableTexture) },
+                    viewportSize: CGSize(width: 640, height: 128), contentScale: 1,
+                    presentationInputSeq: UInt32(100 + failedCall)
+                )
+                #expect(reports.count == 1)
+                #expect(reports.first?.dimension == expected[failedCall])
+                #expect(renderer.activeResourceSnapshot() == before)
+                #expect(renderer.lastCompletedPresentationGeneration == 0)
+                #expect(presentCalls == 0)
+            }
+        }
+    }
+
+    @Test("growth preparation failures stay local across atlas raster context and encoder phases")
+    @MainActor func growthPreparationFailuresAreAtomic() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let drawableDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 640, height: 128, mipmapped: false
+        )
+        drawableDescriptor.usage = .renderTarget
+        guard let drawableTexture = device.makeTexture(descriptor: drawableDescriptor) else { return }
+        let row = GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 0,
+                               contentHash: 2, text: "fault", spans: [])
+        let content = try GUIWindowContent(
+            windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0,
+            cursorShape: .block, rows: [row], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+        )
+        var frame = FrameState(cols: 40, rows: 2)
+        frame.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 2,
+            isActive: true, contentWidth: 40, cursorLine: 0,
+            lineNumberStyle: .none, lineNumberWidth: 0, signColWidth: 0,
+            entries: [.init(bufLine: 0, displayType: .normal, signType: .none)]
+        )
+        let cases: [(NativePresentationFailure.Phase, (inout NativeRenderFactories) -> Void)] = [
+            (.atlas, { factories in factories.makeTexture = { _, _ in nil } }),
+            (.raster, { factories in
+                factories.makeRasterizer = {
+                    BitmapRasterizer(factories: .init(
+                        allocate: { _ in nil },
+                        deallocate: { free($0) },
+                        makeContext: { _, _, _, _, _, _ in nil }
+                    ))
+                }
+            }),
+            (.raster, { factories in
+                factories.makeRasterizer = {
+                    BitmapRasterizer(factories: .init(
+                        allocate: { malloc($0) },
+                        deallocate: { free($0) },
+                        makeContext: { _, _, _, _, _, _ in nil }
+                    ))
+                }
+            }),
+            (.command, { factories in factories.makeEncoder = { _, _ in nil } })
+        ]
+        for (expectedPhase, configure) in cases {
+            var reports: [NativePresentationFailure] = []
+            var presentCalls = 0
+            var factories = nativeTestFactories()
+            configure(&factories)
+            factories.present = { _ in presentCalls += 1 }
+            factories.reportFailure = { reports.append($0) }
+            guard let renderer = CoreTextMetalRenderer(factories: factories) else {
+                Issue.record("renderer unavailable")
+                return
+            }
+            let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+            renderer.setupRenderers(fontManager: fontManager)
+            let before = renderer.activeResourceSnapshot()
+            renderer.render(
+                frameState: frame, fontManager: fontManager,
+                windowContents: [1: content],
+                drawableProvider: { NativeTestDrawable(texture: drawableTexture) },
+                viewportSize: CGSize(width: 640, height: 128), contentScale: 1,
+                presentationInputSeq: 200
+            )
+            #expect(reports.count == 1)
+            #expect(reports.first?.phase == expectedPhase)
+            #expect(renderer.activeResourceSnapshot() == before)
+            #expect(renderer.lastCompletedPresentationGeneration == 0)
+            #expect(presentCalls == 0)
+        }
+    }
+
+    @Test("submission gate failure preserves active generation and never registers present")
+    @MainActor func submissionFailurePrecedesPresent() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+
+        var reports: [NativePresentationFailure] = []
+        var presentCalls = 0
+        var factories = nativeTestFactories()
+        factories.preSubmit = { _ in throw InjectedSubmissionFailure.failed }
+        factories.present = { _ in presentCalls += 1 }
+        factories.reportFailure = { reports.append($0) }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let before = renderer.activeResourceSnapshot()
+
+        renderer.render(
+            frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
+            drawableProvider: { NativeTestDrawable(texture: texture) },
+            viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
+            presentationInputSeq: 77
+        )
+
+        #expect(presentCalls == 0)
+        #expect(reports.count == 1)
+        #expect(reports.first?.phase == .submission)
+        #expect(renderer.lastNativePresentationFailure == reports.first)
+        #expect(renderer.activeResourceSnapshot() == before)
+        #expect(renderer.lastCompletedPresentationGeneration == 0)
+    }
+
+    @Test("completion failure cannot promote its candidate generation")
+    @MainActor func completionFailureIsAtomic() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+        var reports: [NativePresentationFailure] = []
+        var factories = nativeTestFactories()
+        factories.present = { _ in }
+        factories.observeCompletion = { _, completion in
+            completion(false, Int(MTLCommandBufferStatus.error.rawValue))
+        }
+        factories.reportFailure = { reports.append($0) }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else {
+            Issue.record("renderer unavailable")
+            return
+        }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let before = renderer.activeResourceSnapshot()
+        renderer.render(
+            frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
+            drawableProvider: { NativeTestDrawable(texture: texture) },
+            viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
+            presentationInputSeq: 301
+        )
+        #expect(reports.count == 1)
+        #expect(reports.first?.phase == .completion)
+        #expect(renderer.activeResourceSnapshot() == before)
+        #expect(renderer.lastCompletedPresentationGeneration == 0)
+    }
+
+    @Test("candidate presents and promotes only after both commands complete")
+    @MainActor func twoStagePresentationOrdering() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+
+        typealias Completion = @MainActor @Sendable (Bool, Int) -> Void
+        var completions: [Completion] = []
+        var presentCalls = 0
+        var factories = nativeTestFactories()
+        factories.observeCompletion = { _, completion in completions.append(completion) }
+        factories.present = { _ in presentCalls += 1 }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let before = renderer.activeResourceSnapshot()
+
+        renderer.render(
+            frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
+            drawableProvider: { NativeTestDrawable(texture: texture) },
+            viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
+            presentationInputSeq: 302
+        )
+        #expect(completions.count == 1)
+        #expect(presentCalls == 0)
+        #expect(renderer.activeResourceSnapshot() == before)
+
+        completions[0](true, Int(MTLCommandBufferStatus.completed.rawValue))
+        #expect(completions.count == 2)
+        #expect(presentCalls == 0)
+        #expect(renderer.activeResourceSnapshot() == before)
+
+        completions[1](true, Int(MTLCommandBufferStatus.completed.rawValue))
+        #expect(presentCalls == 1)
+        #expect(renderer.lastCompletedPresentationGeneration == 1)
+        #expect(renderer.activeResourceSnapshot() != before)
+    }
+
+    @Test("failed frame preserves a populated completed frame")
+    @MainActor func failedFramePreservesPopulatedFrame() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+        let row = GUIVisualRow(rowType: .normal, rowId: 41, bufLine: 0,
+                               contentHash: 41, text: "ok", spans: [])
+        let content = try GUIWindowContent(
+            windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0,
+            cursorShape: .block, rows: [row], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+        )
+        var frame = FrameState(cols: 4, rows: 4)
+        frame.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 4,
+            isActive: true, contentWidth: 4, cursorLine: 0,
+            lineNumberStyle: .none, lineNumberWidth: 0, signColWidth: 0,
+            entries: [.init(bufLine: 0, displayType: .normal, signType: .none)]
+        )
+
+        var refuseSubmission = false
+        var reports: [NativePresentationFailure] = []
+        var presentCalls = 0
+        var factories = nativeTestFactories()
+        factories.preSubmit = { _ in
+            if refuseSubmission { throw InjectedSubmissionFailure.failed }
+        }
+        factories.observeCompletion = { _, completion in
+            completion(true, Int(MTLCommandBufferStatus.completed.rawValue))
+        }
+        factories.present = { _ in presentCalls += 1 }
+        factories.reportFailure = { reports.append($0) }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let drawable = NativeTestDrawable(texture: texture)
+
+        renderer.render(
+            frameState: frame, fontManager: fontManager,
+            windowContents: [1: content], drawableProvider: { drawable },
+            viewportSize: CGSize(width: 64, height: 64),
+            contentScale: 1, presentationInputSeq: 310
+        )
+        let completed = renderer.activeResourceSnapshot()
+        #expect(renderer.lastCompletedPresentationGeneration == 1)
+        #expect(completed.allocator?.occupiedCount == 1)
+        #expect(presentCalls == 1)
+
+        refuseSubmission = true
+        renderer.render(
+            frameState: frame, fontManager: fontManager,
+            windowContents: [1: content], drawableProvider: { drawable },
+            viewportSize: CGSize(width: 64, height: 64),
+            contentScale: 1, presentationInputSeq: 311
+        )
+
+        #expect(reports.count == 1)
+        #expect(reports.first?.phase == .submission)
+        #expect(presentCalls == 1)
+        #expect(renderer.activeResourceSnapshot() == completed)
+        #expect(renderer.lastCompletedPresentationGeneration == 1)
+    }
+
+    @Test("late older renderer completion cannot replace newer resources")
+    @MainActor func rendererCompletionOrdering() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+
+        typealias Completion = @MainActor @Sendable (Bool, Int) -> Void
+        var completions: [Completion] = []
+        var presentCalls = 0
+        var factories = nativeTestFactories()
+        factories.observeCompletion = { _, completion in completions.append(completion) }
+        factories.present = { _ in presentCalls += 1 }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let drawable = NativeTestDrawable(texture: texture)
+
+        renderer.render(
+            frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
+            drawableProvider: { drawable }, viewportSize: CGSize(width: 64, height: 64),
+            contentScale: 1, presentationInputSeq: 320
+        )
+        renderer.render(
+            frameState: FrameState(cols: 5, rows: 4), fontManager: fontManager,
+            drawableProvider: { drawable }, viewportSize: CGSize(width: 64, height: 64),
+            contentScale: 1, presentationInputSeq: 321
+        )
+        #expect(completions.count == 2)
+
+        completions[1](true, Int(MTLCommandBufferStatus.completed.rawValue))
+        #expect(completions.count == 3)
+        completions[2](true, Int(MTLCommandBufferStatus.completed.rawValue))
+        let newer = renderer.activeResourceSnapshot()
+        #expect(renderer.lastCompletedPresentationGeneration == 2)
+        #expect(presentCalls == 1)
+
+        completions[0](true, Int(MTLCommandBufferStatus.completed.rawValue))
+        #expect(completions.count == 4)
+        completions[3](true, Int(MTLCommandBufferStatus.completed.rawValue))
+        #expect(renderer.activeResourceSnapshot() == newer)
+        #expect(renderer.lastCompletedPresentationGeneration == 2)
+        #expect(presentCalls == 1)
+    }
+
+    @Test("renderer setup rejects promotion from an older configuration epoch")
+    @MainActor func setupInvalidatesInFlightCandidate() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+
+        typealias Completion = @MainActor @Sendable (Bool, Int) -> Void
+        var completions: [Completion] = []
+        var presentCalls = 0
+        var factories = nativeTestFactories()
+        factories.observeCompletion = { _, completion in completions.append(completion) }
+        factories.present = { _ in presentCalls += 1 }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let oldFontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: oldFontManager)
+        renderer.render(
+            frameState: FrameState(cols: 4, rows: 4), fontManager: oldFontManager,
+            drawableProvider: { NativeTestDrawable(texture: texture) },
+            viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
+            presentationInputSeq: 303
+        )
+        #expect(completions.count == 1)
+
+        let newFontManager = FontManager(name: "Menlo", size: 15, scale: 2)
+        renderer.setupRenderers(fontManager: newFontManager)
+        let configured = renderer.activeResourceSnapshot()
+        completions[0](true, Int(MTLCommandBufferStatus.completed.rawValue))
+
+        #expect(completions.count == 1)
+        #expect(presentCalls == 0)
+        #expect(renderer.activeResourceSnapshot() == configured)
+        #expect(renderer.lastCompletedPresentationGeneration == 0)
+    }
+
+    @Test("presentation-copy submission failure leaves drawable and resources untouched")
+    @MainActor func presentationCopySubmissionFailureIsAtomic() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+
+        var reports: [NativePresentationFailure] = []
+        var presentCalls = 0
+        var factories = nativeTestFactories()
+        factories.observeCompletion = { _, completion in
+            completion(true, Int(MTLCommandBufferStatus.completed.rawValue))
+        }
+        factories.prePresentationSubmit = { _ in throw InjectedSubmissionFailure.failed }
+        factories.present = { _ in presentCalls += 1 }
+        factories.reportFailure = { reports.append($0) }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let before = renderer.activeResourceSnapshot()
+
+        renderer.render(
+            frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
+            drawableProvider: { NativeTestDrawable(texture: texture) },
+            viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
+            presentationInputSeq: 304
+        )
+
+        #expect(reports.count == 1)
+        #expect(reports.first?.phase == .submission)
+        #expect(reports.first?.dimension == .presentationCopy)
+        #expect(presentCalls == 0)
+        #expect(renderer.activeResourceSnapshot() == before)
+    }
+
+    @Test("oversized viewport fails before integer conversion or allocation")
+    @MainActor func oversizedViewportIsTyped() {
+        var reports: [NativePresentationFailure] = []
+        var factories = nativeTestFactories()
+        factories.reportFailure = { reports.append($0) }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+
+        renderer.render(
+            frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
+            drawableProvider: { nil },
+            viewportSize: CGSize(width: CGFloat.greatestFiniteMagnitude, height: 64),
+            contentScale: 1, presentationInputSeq: 307
+        )
+
+        #expect(reports.count == 1)
+        #expect(reports.first?.dimension == .textureWidth)
+        #expect(reports.first?.reason == .limit)
+    }
+
+    @Test("resized late-acquired drawable is rejected before copy or presentation")
+    @MainActor func resizedDrawableIsAtomic() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 65, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+
+        var reports: [NativePresentationFailure] = []
+        var presentCalls = 0
+        var factories = nativeTestFactories()
+        factories.observeCompletion = { _, completion in
+            completion(true, Int(MTLCommandBufferStatus.completed.rawValue))
+        }
+        factories.present = { _ in presentCalls += 1 }
+        factories.reportFailure = { reports.append($0) }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let before = renderer.activeResourceSnapshot()
+
+        renderer.render(
+            frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
+            drawableProvider: { NativeTestDrawable(texture: texture) },
+            viewportSize: CGSize(width: 64, height: 64),
+            contentScale: 1, presentationInputSeq: 306
+        )
+
+        #expect(reports.count == 1)
+        #expect(reports.first?.dimension == .textureWidth)
+        #expect(reports.first?.reason == .mismatch)
+        #expect(presentCalls == 0)
+        #expect(renderer.activeResourceSnapshot() == before)
+    }
+
+    @Test("nil late-acquired drawable failure is typed and leaves resources untouched")
+    @MainActor func nilDrawableIsAtomic() {
+        var reports: [NativePresentationFailure] = []
+        var factories = nativeTestFactories()
+        factories.observeCompletion = { _, completion in
+            completion(true, Int(MTLCommandBufferStatus.completed.rawValue))
+        }
+        factories.reportFailure = { reports.append($0) }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let before = renderer.activeResourceSnapshot()
+
+        renderer.render(
+            frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
+            drawableProvider: { nil }, viewportSize: CGSize(width: 64, height: 64),
+            contentScale: 1, presentationInputSeq: 305
+        )
+
+        #expect(reports.count == 1)
+        #expect(reports.first?.phase == .drawable)
+        #expect(reports.first?.frameSequence == 305)
+        #expect(renderer.activeResourceSnapshot() == before)
+    }
+
+    @Test("device dimensions tighten configured policy")
+    func deviceLimits() {
+        #expect(throws: NativePresentationFailure.self) {
+            _ = try NativeRenderDemand.checked(
+                textureWidth: 65, slotHeight: 1, atlasSlots: 1,
+                lineInstances: 0, lineStride: 32,
+                quadInstances: 0, quadStride: 48, quadBufferCount: 3,
+                policy: policy, deviceTextureWidth: 64,
+                deviceTextureHeight: 128, deviceMaxBufferLength: 8_192
+            )
+        }
+    }
+}

--- a/macos/Tests/MingaTests/RendererResidentSliceTests.swift
+++ b/macos/Tests/MingaTests/RendererResidentSliceTests.swift
@@ -48,6 +48,24 @@ struct RendererResidentSliceTests {
         let largeDemand = CoreTextMetalRenderer.atlasSlotDemand(frameState: largeFrame, windowContents: [1: large])
         #expect(smallDemand == largeDemand)
         #expect(largeDemand < 200)
+
+        let prepared = ResidentRenderPreparation.prepare(
+            content: large, fallbackVisibleRows: 40,
+            overscanRows: RendererSignposts.configuredOverscanRows,
+            scrollLeft: 0, viewportCols: 80
+        )
+        let nativeDemand = try NativeRenderDemand.checked(
+            textureWidth: 640, slotHeight: 20, atlasSlots: largeDemand,
+            lineInstances: prepared.commands.count, lineStride: MemoryLayout<LineGPU>.stride,
+            quadInstances: largeDemand * 4, quadStride: MemoryLayout<QuadGPU>.stride,
+            quadBufferCount: 3, policy: .default,
+            deviceTextureWidth: 16_384, deviceTextureHeight: 16_384,
+            deviceMaxBufferLength: 1_073_741_824
+        )
+        #expect(prepared.commands.count == 44)
+        #expect(nativeDemand.atlasSlots == largeDemand)
+        #expect(nativeDemand.textureHeight < 16_384)
+        #expect(nativeDemand.aggregateDrawBufferBytes < FrameResourcePolicy.NativeRendererLimits.default.aggregateDrawBufferBytes)
     }
 
     @Test("idle and overlay-only frames report zero reset and reference work")

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -362,15 +362,115 @@ struct WindowContentFrameMetricsTests {
         #expect(demand >= 40)
     }
 
-    @Test("LineTextureAtlas caps capacity to Metal texture height")
-    @MainActor func lineTextureAtlasCapsCapacityToTextureHeight() {
+    @Test("extreme pill width fails before raster allocation or atlas reservation")
+    @MainActor func extremePillWidthFailsBeforeAllocation() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let policy = FrameResourcePolicy.NativeRendererLimits(
+            rasterBytes: 1_048_576, atlasBytes: 16_777_216,
+            aggregateDrawBufferBytes: 1_048_576,
+            textureWidth: 32, textureHeight: 1_024
+        )
+        let fm = FontManager(name: "Menlo", size: 13.0, scale: 2.0)
+        var allocations = 0
+        let production = BitmapRasterizer.Factories.production
+        let rasterizer = BitmapRasterizer(factories: .init(
+            allocate: { byteCount in
+                allocations += 1
+                return malloc(byteCount)
+            },
+            deallocate: { free($0) },
+            makeContext: production.makeContext
+        ))
+        let renderer = WindowContentRenderer(
+            device: device, fontManager: fm, rasterizer: rasterizer,
+            resourcePolicy: policy
+        )
+        let atlas = LineTextureAtlas(device: device, slotHeight: renderer.linePixelHeight)
+        guard case .success = atlas.ensureCapacity(maxSlots: 4, width: 1_024) else { return }
+        atlas.beginFrame()
+        let allocatorBefore = atlas.allocator
+        var metrics = FrameMetrics()
+        let annotation = GUILineAnnotation(
+            row: 0, kind: .inlinePill, fg: 0xFFFFFF, bg: 0x112233,
+            text: String(repeating: "W", count: 1_024)
+        )
+
+        let entry = renderer.renderAnnotationToAtlas(
+            annotation: annotation,
+            key: .lineAnnotation(windowId: 1, row: 0, subIndex: 0),
+            atlas: atlas, metrics: &metrics
+        )
+
+        #expect(entry == nil)
+        #expect(renderer.nativePresentationFailure?.dimension == .textureWidth)
+        #expect(allocations == 0)
+        #expect(atlas.frameTextureUploads == 0)
+        #expect(atlas.allocator == allocatorBefore)
+        #expect(metrics.otherTexturesRasterized == 0)
+    }
+
+    @Test("pill raster byte excess fails before allocation and partial upload")
+    @MainActor func pillRasterBytesFailBeforeAllocation() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let policy = FrameResourcePolicy.NativeRendererLimits(
+            rasterBytes: 64, atlasBytes: 16_777_216,
+            aggregateDrawBufferBytes: 1_048_576,
+            textureWidth: 1_024, textureHeight: 1_024
+        )
+        let fm = FontManager(name: "Menlo", size: 13.0, scale: 2.0)
+        var allocations = 0
+        let production = BitmapRasterizer.Factories.production
+        let rasterizer = BitmapRasterizer(factories: .init(
+            allocate: { byteCount in
+                allocations += 1
+                return malloc(byteCount)
+            },
+            deallocate: { free($0) },
+            makeContext: production.makeContext
+        ))
+        let renderer = WindowContentRenderer(
+            device: device, fontManager: fm, rasterizer: rasterizer,
+            resourcePolicy: policy
+        )
+        let atlas = LineTextureAtlas(device: device, slotHeight: renderer.linePixelHeight)
+        guard case .success = atlas.ensureCapacity(maxSlots: 4, width: 1_024) else { return }
+        atlas.beginFrame()
+        let allocatorBefore = atlas.allocator
+        var metrics = FrameMetrics()
+        let annotation = GUILineAnnotation(
+            row: 0, kind: .inlinePill, fg: 0xFFFFFF, bg: 0x112233,
+            text: "oversized raster"
+        )
+
+        let entry = renderer.renderAnnotationToAtlas(
+            annotation: annotation,
+            key: .lineAnnotation(windowId: 1, row: 0, subIndex: 0),
+            atlas: atlas, metrics: &metrics
+        )
+
+        #expect(entry == nil)
+        #expect(renderer.nativePresentationFailure?.dimension == .rasterBytes)
+        #expect(allocations == 0)
+        #expect(atlas.frameTextureUploads == 0)
+        #expect(atlas.allocator == allocatorBefore)
+        #expect(metrics.otherTexturesRasterized == 0)
+    }
+
+    @Test("LineTextureAtlas refuses rather than truncates over device height")
+    @MainActor func lineTextureAtlasRefusesCapacityOverTextureHeight() {
         guard let (_, atlas) = makeRendererAndAtlas() else { return }
+        let originalSlots = atlas.slotCount
+        let originalHeight = atlas.atlasHeight
         let oversizedSlots = atlas.maxSlotCapacity + 1_000
 
-        atlas.ensureCapacity(maxSlots: oversizedSlots, width: 1024)
+        let result = atlas.ensureCapacity(maxSlots: oversizedSlots, width: 1024)
 
-        #expect(atlas.slotCount == atlas.maxSlotCapacity)
-        #expect(atlas.atlasHeight <= LineTextureAtlas.maxTextureDimension)
+        guard case .failure = result else {
+            Issue.record("oversized atlas unexpectedly succeeded")
+            return
+        }
+        #expect(atlas.slotCount == originalSlots)
+        #expect(atlas.atlasHeight == originalHeight)
     }
 
     @Test("FrameMetrics reset clears all counters")


### PR DESCRIPTION
# TL;DR
CoreText and Metal resource growth is now failure-atomic: a visual candidate either prepares, submits, completes, and promotes as one generation, or the renderer keeps the previous complete frame and active resources unchanged. Native failures remain presentation-local and do not alter semantic frame acknowledgement or trigger keyframe recovery.

Closes #2803
Closes #2749

## Context
This is the final delivery unit in #2749. It builds on #2802’s shared resource-policy composition root while keeping hardware-dependent allocation and presentation health owned by the native renderer.

## Changes
- Added checked native demand for texture dimensions, raster bytes, atlas bytes and slots, line instances, each quad buffer, and aggregate product buffer bytes.
- Applied configured and device texture limits separately, and applied `maxBufferLength` per Metal allocation rather than to the aggregate.
- Derived atlas and instance capacity from exact dimensions, pixel bytes, native strides, and configured byte ceilings.
- Replaced trapping raster and atlas staging allocations with failable `malloc`/`free` ownership and typed failures.
- Prepared atlas allocator/index/cache/texture, rasterizer state, line buffers, and all quad/pass buffers as isolated candidate generations.
- Delayed active-resource promotion until successful GPU completion, with generation ordering that prevents stale completion from overwriting a newer frame.
- Split complete encoding, injectable pre-submit validation, present registration, commit, and completion so failed candidates never schedule an incomplete presentation.
- Added renderer-owned factories and fault seams for texture, buffer, raster context, drawable, encoder, submission, and completion failures.
- Removed silent atlas and annotation-pill truncation. Oversized demand now fails before allocation or upload.
- Added metadata-only presentation failure telemetry without document content, paths, annotations, or raw payloads.

## Verification
- `make lint`
- `mix test.llm` (9,218 tests, 0 failures)
- `mix protocol.gen --check`
- `mix conformance` (161 passed)
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga test` (1,168 tests passed)
- `mix swift.harness --release`
- `scripts/check_render_performance`
  - decode/apply p95: 0.015 ms
  - command preparation p95: 0.190 ms
  - combined p95: 0.211 ms
  - fixture: 65,536 resident rows

## Acceptance Criteria Addressed
- Native preparation validates checked visible demand, dimensions, instances, and bytes before resource growth. ✅
- Texture, atlas, and buffer limits derive from configured policy, device capability, exact dimensions, and native strides. ✅
- Atlas, raster, texture, and buffer candidates replace active resources only after complete success. ✅
- Allocation, drawable, device, encoder, submission, and completion failures preserve the prior complete frame and emit one typed local failure. ✅
- Semantic `frame_applied` behavior remains unchanged; native failures cannot trigger keyframe recovery or retroactive rejection. ✅
- The 65,536-row fixture and boundary/fault tests prove failures do not blank, truncate, partially present, overflow, or corrupt active caches. ✅
