### PR TITLE
refactor(agent): canonicalize tool specifications

### DIFF
--- a/lib/minga_agent/ephemeral_session.ex
+++ b/lib/minga_agent/ephemeral_session.ex
@@ -7,8 +7,8 @@ defmodule MingaAgent.EphemeralSession do
 
   alias MingaAgent.Session
   alias MingaAgent.SessionManager
+  alias MingaAgent.Tool.Spec
   alias MingaAgent.Tools
-  alias ReqLLM.Tool
 
   @doc "Starts a read-only ephemeral ask session and sends its prompt."
   @spec ask(String.t(), String.t(), keyword()) :: {:ok, pid()} | {:error, term()}
@@ -49,19 +49,19 @@ defmodule MingaAgent.EphemeralSession do
   end
 
   @doc "Builds the final inline ask tool list. Inline asks use prompt-provided context only."
-  @spec read_only_tools(String.t()) :: [Tool.t()]
+  @spec read_only_tools(String.t()) :: [Spec.t()]
   def read_only_tools(project_root) when is_binary(project_root) do
     _project_root = project_root
     []
   end
 
   @doc "Builds the constrained tool list for inline edit rewrite sessions."
-  @spec rewrite_tools(String.t()) :: [Tool.t()]
+  @spec rewrite_tools(String.t()) :: [Spec.t()]
   def rewrite_tools(project_root) when is_binary(project_root) do
     Enum.concat(Tools.file_read(project_root: project_root), [produce_rewrite_tool()])
   end
 
-  @spec start(String.t(), String.t(), String.t(), [Tool.t()], atom(), keyword()) ::
+  @spec start(String.t(), String.t(), String.t(), [Spec.t()], atom(), keyword()) ::
           {:ok, pid()} | {:error, term()}
   defp start(prompt, project_root, prefix, tools, result_message, opts) do
     manager = Keyword.get(opts, :session_manager, SessionManager)
@@ -127,9 +127,10 @@ defmodule MingaAgent.EphemeralSession do
     :exit, _ -> :ok
   end
 
-  @spec produce_rewrite_tool() :: Tool.t()
+  @spec produce_rewrite_tool() :: Spec.t()
   defp produce_rewrite_tool do
-    Tool.new!(
+    Spec.new!(
+      source: :config,
       name: "produce_rewrite",
       description:
         "Return the single replacement text for the selected inline edit range. This must not edit files.",
@@ -143,7 +144,11 @@ defmodule MingaAgent.EphemeralSession do
         },
         "required" => ["replacement"]
       },
-      callback: fn args -> {:ok, args["replacement"] || ""} end
+      category: :agent,
+      approval_level: :auto,
+      capabilities: [],
+      context_requirements: [],
+      build: fn _context -> fn args -> {:ok, args["replacement"] || ""} end end
     )
   end
 

--- a/lib/minga_agent/providers/native.ex
+++ b/lib/minga_agent/providers/native.ex
@@ -69,6 +69,7 @@ defmodule MingaAgent.Providers.Native do
   alias MingaAgent.ToolCall
   alias MingaAgent.Tools
   alias MingaAgent.Tools.Notebook
+  alias MingaAgent.Tools.ProcessBackend.System, as: SystemProcessBackend
   alias MingaAgent.Tools.Shell
   alias MingaAgent.Tools.Todo
   alias Minga.Config
@@ -96,6 +97,7 @@ defmodule MingaAgent.Providers.Native do
       :config,
       :tools,
       :project_root,
+      :tool_metadata,
       :thinking_level,
       :max_tokens,
       :max_retries,
@@ -112,6 +114,7 @@ defmodule MingaAgent.Providers.Native do
       :project_root,
       :project_view,
       :fork_store,
+      :tool_metadata,
       :changeset,
       :thinking_level,
       :max_tokens,
@@ -133,6 +136,7 @@ defmodule MingaAgent.Providers.Native do
             project_root: String.t(),
             project_view: ProjectView.t() | nil,
             fork_store: pid() | nil,
+            tool_metadata: map(),
             changeset: pid() | nil,
             thinking_level: String.t(),
             max_tokens: pos_integer(),
@@ -185,6 +189,8 @@ defmodule MingaAgent.Providers.Native do
           base_tools: [term()],
           mcp_tools: [term()],
           internal_tools: [term()],
+          tool_metadata: map(),
+          custom_tool_declarations: [Tool.t() | ToolSpec.t()],
           custom_tools?: boolean(),
           configured_mcp_configs: [MCPServerConfig.t()],
           mcp_configs: [MCPServerConfig.t()],
@@ -341,16 +347,33 @@ defmodule MingaAgent.Providers.Native do
     {fork_store, changeset} =
       init_fork_store_and_changeset(project_view, project_root, opts)
 
+    tool_metadata = %{
+      parent_session: subscriber,
+      shell_output_callback: Keyword.get(opts, :shell_output_callback),
+      process_backend: Keyword.get(opts, :process_backend, SystemProcessBackend)
+    }
+
     tool_context =
-      native_tool_context(project_root, project_view, fork_store, changeset, subscriber)
-
-    base_tools =
-      Keyword.get(opts, :tools) ||
-        registry_tools(tool_context, config, hook_runner)
-
-    base_tools = filter_base_tools_for_read_only(base_tools, read_only?)
+      native_tool_context(project_root, project_view, fork_store, changeset, tool_metadata)
 
     custom_tools? = Keyword.has_key?(opts, :tools)
+
+    custom_tool_declarations =
+      if custom_tools?, do: Keyword.get(opts, :tools) || ToolRegistry.all(), else: []
+
+    base_tools =
+      if custom_tools? do
+        provider_tools(
+          custom_tool_declarations,
+          tool_context,
+          config,
+          hook_runner
+        )
+      else
+        registry_tools(tool_context, config, hook_runner)
+      end
+
+    base_tools = filter_base_tools_for_read_only(base_tools, read_only?)
     active_skills = load_active_skills(project_root, Keyword.get(opts, :active_skill_names, []))
     internal_tools = if read_only?, do: [], else: build_internal_tools(provider_pid)
 
@@ -412,6 +435,7 @@ defmodule MingaAgent.Providers.Native do
       mcp_tools: mcp_tools,
       internal_tools: internal_tools,
       custom_tools?: custom_tools?,
+      custom_tool_declarations: custom_tool_declarations,
       configured_mcp_configs: configured_mcp_configs,
       mcp_configs: mcp_configs,
       mcp_client_opts: mcp_client_opts,
@@ -420,7 +444,8 @@ defmodule MingaAgent.Providers.Native do
       mcp_registry: mcp_registry,
       read_only?: read_only?,
       tool_allowlist: tool_allowlist,
-      tool_workers: %{}
+      tool_workers: %{},
+      tool_metadata: tool_metadata
     }
 
     Minga.Events.subscribe(:agent_mcp_servers_changed)
@@ -435,40 +460,47 @@ defmodule MingaAgent.Providers.Native do
           ProjectView.t() | nil,
           pid() | nil,
           pid() | nil,
-          pid() | nil
+          map()
         ) :: ToolContext.t()
-  defp native_tool_context(project_root, project_view, fork_store, changeset, parent_session) do
+  defp native_tool_context(project_root, project_view, fork_store, changeset, metadata) do
     ToolContext.new(
       project_root: project_root,
       project_view: project_view,
       fork_store: fork_store,
       changeset: changeset,
-      metadata: %{parent_session: parent_session}
+      metadata: metadata
     )
   end
 
   @spec registry_tools(ToolContext.t(), AgentConfig.t(), hook_runner()) :: [Tool.t()]
   defp registry_tools(%ToolContext{} = tool_context, %AgentConfig{} = config, hook_runner) do
-    ToolRegistry.all()
-    |> Enum.map(&registry_tool(&1, tool_context, config, hook_runner))
+    provider_tools(ToolRegistry.all(), tool_context, config, hook_runner)
   end
 
-  @spec registry_tool(ToolSpec.t(), ToolContext.t(), AgentConfig.t(), hook_runner()) ::
+  @spec provider_tools([Tool.t() | ToolSpec.t()], ToolContext.t(), AgentConfig.t(), hook_runner()) ::
+          [Tool.t()]
+  defp provider_tools(tools, %ToolContext{} = tool_context, config, hook_runner) do
+    Enum.map(tools, &provider_tool(&1, tool_context, config, hook_runner))
+  end
+
+  @spec provider_tool(Tool.t() | ToolSpec.t(), ToolContext.t(), AgentConfig.t(), hook_runner()) ::
           Tool.t()
-  defp registry_tool(%ToolSpec{} = spec, %ToolContext{} = tool_context, config, hook_runner) do
-    Tool.new!(
-      name: spec.name,
-      description: spec.description,
-      parameter_schema: spec.parameter_schema,
-      provider_options: %{minga_registry_tool: true, source: inspect(spec.source)},
-      callback: fn args ->
-        ToolExecutor.execute_approved(spec, args || %{}, :exec,
-          config: config,
-          hook_runner: hook_runner,
-          tool_context: tool_context
-        )
-      end
-    )
+  defp provider_tool(%Tool{} = tool, _tool_context, _config, _hook_runner), do: tool
+
+  defp provider_tool(%ToolSpec{} = spec, %ToolContext{} = tool_context, config, hook_runner) do
+    callback = fn args ->
+      ToolExecutor.execute_approved(spec, args || %{}, :exec,
+        config: config,
+        hook_runner: hook_runner,
+        tool_context: tool_context
+      )
+    end
+
+    ReqLLMAdapter.tool(spec, callback, %{
+      minga_registry_tool: true,
+      minga_tool_spec: spec,
+      source: inspect(spec.source)
+    })
   end
 
   @spec disable_hooks_for_read_only(AgentConfig.t(), boolean()) :: AgentConfig.t()
@@ -658,6 +690,7 @@ defmodule MingaAgent.Providers.Native do
         project_view: state.project_view,
         fork_store: state.fork_store,
         changeset: state.changeset,
+        tool_metadata: state.tool_metadata,
         thinking_level: state.thinking_level,
         max_tokens: state.max_tokens,
         max_retries: state.max_retries,
@@ -724,6 +757,7 @@ defmodule MingaAgent.Providers.Native do
       project_view: state.project_view,
       fork_store: state.fork_store,
       changeset: state.changeset,
+      tool_metadata: state.tool_metadata,
       thinking_level: state.thinking_level,
       max_tokens: state.max_tokens,
       max_retries: state.max_retries,
@@ -1429,26 +1463,17 @@ defmodule MingaAgent.Providers.Native do
   @spec rebuild_tools(map()) :: map()
   defp rebuild_tools(state) do
     base_tools =
-      state.project_root
-      |> native_tool_context(
-        state.project_view,
-        state.fork_store,
-        state.changeset,
-        state.subscriber
-      )
-      |> registry_tools(state.config, state.hook_runner)
+      state
+      |> refresh_base_tools(state.project_view)
+      |> filter_base_tools_for_read_only(state.read_only?)
 
-    base_tool_names = MapSet.new(Enum.map(base_tools, & &1.name))
     internal_tools = build_internal_tools(self())
-    internal_tool_names = MapSet.new(Enum.map(internal_tools, & &1.name))
 
-    mcp_tools =
-      Enum.reject(state.tools, fn tool ->
-        MapSet.member?(base_tool_names, tool.name) or
-          MapSet.member?(internal_tool_names, tool.name)
-      end)
+    tools =
+      (base_tools ++ state.mcp_tools ++ internal_tools)
+      |> filter_tool_allowlist(state.tool_allowlist)
 
-    %{state | tools: base_tools ++ mcp_tools ++ internal_tools}
+    %{state | base_tools: base_tools, internal_tools: internal_tools, tools: tools}
   end
 
   # ── Terminate cleanup ──────────────────────────────────────────────────────
@@ -1785,7 +1810,7 @@ defmodule MingaAgent.Providers.Native do
 
     {approval_baselines, concurrent_baselines} =
       Enum.split_with(baselines, fn {_index, tool_call, _before_content} ->
-        tool_requires_approval?(tool_call, lctx.config, initial_mode)
+        tool_requires_approval?(tool_call, available_tools, lctx.config, initial_mode)
       end)
 
     concurrent_tasks =
@@ -2009,7 +2034,7 @@ defmodule MingaAgent.Providers.Native do
         lctx.project_view,
         lctx.fork_store,
         lctx.changeset,
-        lctx.session_pid
+        lctx.tool_metadata
       )
 
     {result_text, is_error, _new_mode, post_dispatched?} =
@@ -2128,7 +2153,7 @@ defmodule MingaAgent.Providers.Native do
 
         nil ->
           # No per-tool override; fall through to registry/default policy and global approval mode.
-          case registered_tool_approval(tool_call.name) do
+          case registered_tool_approval(tool_call.name, available_tools) do
             :deny ->
               {"Tool '#{tool_call.name}' is denied by registry policy", true, mode, false}
 
@@ -2215,7 +2240,7 @@ defmodule MingaAgent.Providers.Native do
          hook_runner,
          tool_context
        ) do
-    if global_mode_requires_approval?(tool_call, :ask) do
+    if global_mode_requires_approval?(tool_call, available_tools, :ask, config) do
       request_approval(
         provider_pid,
         session_pid,
@@ -2242,32 +2267,50 @@ defmodule MingaAgent.Providers.Native do
     end
   end
 
-  @spec tool_requires_approval?(map(), AgentConfig.t(), approval_mode()) :: boolean()
-  defp tool_requires_approval?(tool_call, config, mode) do
+  @spec tool_requires_approval?(map(), [Tool.t()], AgentConfig.t(), approval_mode()) :: boolean()
+  defp tool_requires_approval?(tool_call, available_tools, config, mode) do
     case tool_permission(tool_call.name, config) do
       :ask -> true
       :allow -> false
       :deny -> false
-      nil -> global_mode_requires_approval?(tool_call, mode)
+      nil -> global_mode_requires_approval?(tool_call, available_tools, mode, config)
     end
   end
 
-  @spec global_mode_requires_approval?(map(), approval_mode()) :: boolean()
-  defp global_mode_requires_approval?(_tool_call, :none), do: false
-  defp global_mode_requires_approval?(_tool_call, :ask_all), do: true
+  @spec global_mode_requires_approval?(map(), [Tool.t()], approval_mode(), AgentConfig.t()) ::
+          boolean()
+  defp global_mode_requires_approval?(_tool_call, _available_tools, :none, _config), do: false
+  defp global_mode_requires_approval?(_tool_call, _available_tools, :ask_all, _config), do: true
 
-  defp global_mode_requires_approval?(tool_call, :ask) do
-    registered_tool_approval(tool_call.name) == :ask or
-      Tools.destructive?(tool_call.name, tool_call.arguments || %{})
+  defp global_mode_requires_approval?(tool_call, available_tools, :ask, config) do
+    registered_tool_approval(tool_call.name, available_tools) == :ask or
+      Tools.destructive?(
+        tool_call.name,
+        tool_call.arguments || %{},
+        config.destructive_tools
+      )
   end
 
-  @spec registered_tool_approval(String.t()) :: ToolSpec.approval_level() | nil
-  defp registered_tool_approval(tool_name) do
+  @spec registered_tool_approval(String.t(), [Tool.t()]) :: ToolSpec.approval_level() | nil
+  defp registered_tool_approval(tool_name, available_tools) do
+    case Enum.find(available_tools, &(&1.name == tool_name)) do
+      %Tool{provider_options: %{minga_tool_spec: %ToolSpec{} = spec}} -> spec_approval(spec)
+      _tool -> registry_tool_approval(tool_name)
+    end
+  end
+
+  @spec registry_tool_approval(String.t()) :: ToolSpec.approval_level() | nil
+  defp registry_tool_approval(tool_name) do
     case ToolRegistry.lookup(tool_name) do
-      {:ok, %ToolSpec{approval_level: approval}} -> approval
+      {:ok, %ToolSpec{} = spec} -> spec_approval(spec)
       :error -> nil
     end
   end
+
+  @spec spec_approval(ToolSpec.t()) :: ToolSpec.approval_level() | nil
+  defp spec_approval(%ToolSpec{source: :builtin}), do: nil
+  defp spec_approval(%ToolSpec{source: {:bundle, _name}}), do: nil
+  defp spec_approval(%ToolSpec{approval_level: approval}), do: approval
 
   # Looks up per-tool permission from config. Returns :allow, :deny, :ask, or nil
   # (no override for this tool).
@@ -2561,7 +2604,7 @@ defmodule MingaAgent.Providers.Native do
 
       tool ->
         if registry_tool?(tool) do
-          execute_registry_tool(tool_call, provider_pid, config, hook_runner, tool_context)
+          execute_registry_tool(tool, tool_call, provider_pid, config, hook_runner, tool_context)
         else
           case dispatch_pre_tool_use(tool_call, config, hook_runner, provider_pid) do
             :ok -> tuple_with_post_flag(execute_found_tool(tool, tool_call, provider_pid), false)
@@ -2575,25 +2618,32 @@ defmodule MingaAgent.Providers.Native do
   defp registry_tool?(%Tool{provider_options: %{minga_registry_tool: true}}), do: true
   defp registry_tool?(_tool), do: false
 
-  @spec execute_registry_tool(map(), pid(), AgentConfig.t(), hook_runner(), ToolContext.t()) ::
-          {String.t(), boolean(), boolean()}
-  defp execute_registry_tool(tool_call, provider_pid, config, hook_runner, tool_context) do
+  @spec execute_registry_tool(
+          Tool.t(),
+          map(),
+          pid(),
+          AgentConfig.t(),
+          hook_runner(),
+          ToolContext.t()
+        ) :: {String.t(), boolean(), boolean()}
+  defp execute_registry_tool(
+         %Tool{provider_options: %{minga_tool_spec: %ToolSpec{} = spec}},
+         tool_call,
+         provider_pid,
+         config,
+         hook_runner,
+         tool_context
+       ) do
     args = tool_call.arguments || %{}
     tool_context = tool_context_with_call_metadata(tool_context, tool_call, provider_pid)
 
-    case ToolRegistry.lookup(tool_call.name) do
-      {:ok, spec} ->
-        spec
-        |> ToolExecutor.execute_approved(args, :exec,
-          config: config,
-          hook_runner: hook_runner,
-          tool_context: tool_context
-        )
-        |> format_executor_result()
-
-      :error ->
-        {"Tool '#{tool_call.name}' not found", true, true}
-    end
+    spec
+    |> ToolExecutor.execute_approved(args, :exec,
+      config: config,
+      hook_runner: hook_runner,
+      tool_context: tool_context
+    )
+    |> format_executor_result()
   end
 
   @spec tool_context_with_call_metadata(ToolContext.t(), map(), pid()) :: ToolContext.t()
@@ -2833,8 +2883,23 @@ defmodule MingaAgent.Providers.Native do
   end
 
   @spec refresh_base_tools(state(), ProjectView.t() | nil) :: [Tool.t()]
-  defp refresh_base_tools(%{custom_tools?: true, base_tools: base_tools}, _project_view) do
-    base_tools
+  defp refresh_base_tools(
+         %{
+           custom_tools?: true,
+           custom_tool_declarations: declarations,
+           project_root: project_root,
+           fork_store: fork_store,
+           changeset: changeset,
+           tool_metadata: tool_metadata,
+           config: config,
+           hook_runner: hook_runner
+         },
+         project_view
+       ) do
+    tool_context =
+      native_tool_context(project_root, project_view, fork_store, changeset, tool_metadata)
+
+    provider_tools(declarations, tool_context, config, hook_runner)
   end
 
   defp refresh_base_tools(
@@ -2842,14 +2907,14 @@ defmodule MingaAgent.Providers.Native do
            project_root: project_root,
            fork_store: fork_store,
            changeset: changeset,
-           subscriber: subscriber,
+           tool_metadata: tool_metadata,
            config: config,
            hook_runner: hook_runner
          },
          project_view
        ) do
     project_root
-    |> native_tool_context(project_view, fork_store, changeset, subscriber)
+    |> native_tool_context(project_view, fork_store, changeset, tool_metadata)
     |> registry_tools(config, hook_runner)
   end
 

--- a/lib/minga_agent/providers/native/req_llm_adapter.ex
+++ b/lib/minga_agent/providers/native/req_llm_adapter.ex
@@ -9,6 +9,7 @@ defmodule MingaAgent.Providers.Native.ReqLLMAdapter do
   alias MingaAgent.Credentials
   alias MingaAgent.Providers.Native.ReqLLMAdapter.ToolCall
   alias MingaAgent.Providers.Native.ReqLLMAdapter.TurnResult
+  alias MingaAgent.Tool.Spec, as: ToolSpec
   alias ReqLLM.Response
   alias ReqLLM.StreamResponse
   alias ReqLLM.Tool
@@ -77,6 +78,19 @@ defmodule MingaAgent.Providers.Native.ReqLLMAdapter do
 
         {:error, message, :invalid_format}
     end
+  end
+
+  @doc "Builds the provider-specific tool value for a canonical tool declaration."
+  @spec tool(ToolSpec.t(), ToolSpec.callback(), map()) :: Tool.t()
+  def tool(%ToolSpec{} = spec, callback, provider_options \\ %{})
+      when is_function(callback, 1) and is_map(provider_options) do
+    Tool.new!(
+      name: spec.name,
+      description: spec.description,
+      parameter_schema: spec.parameter_schema,
+      provider_options: provider_options,
+      callback: callback
+    )
   end
 
   @doc "Builds ReqLLM stream options for one native provider request."

--- a/lib/minga_agent/tool/registry.ex
+++ b/lib/minga_agent/tool/registry.ex
@@ -135,17 +135,30 @@ defmodule MingaAgent.Tool.Registry do
   @doc "Converts a `ReqLLM.Tool` struct to a config-owned `MingaAgent.Tool.Spec`."
   @spec from_req_tool(ReqLLM.Tool.t()) :: Spec.t()
   def from_req_tool(%ReqLLM.Tool{} = tool) do
+    metadata = canonical_metadata(tool.name)
+
     Spec.new!(
       source: :config,
       name: tool.name,
       description: tool.description || "",
       parameter_schema: tool.parameter_schema || %{},
       callback: tool.callback,
-      category: categorize(tool.name),
-      approval_level: approval_for(tool.name),
-      capabilities: capabilities_for(tool.name),
-      context_requirements: context_requirements_for(tool.name)
+      category: metadata.category,
+      approval_level: metadata.approval_level,
+      capabilities: metadata.capabilities,
+      context_requirements: metadata.context_requirements
     )
+  end
+
+  @spec canonical_metadata(String.t()) :: map()
+  defp canonical_metadata(name) do
+    case Enum.find(MingaAgent.Tools.specs(), &(&1.name == name)) do
+      %Spec{} = spec ->
+        Map.take(spec, [:category, :approval_level, :capabilities, :context_requirements])
+
+      nil ->
+        %{category: :custom, approval_level: :auto, capabilities: [], context_requirements: []}
+    end
   end
 
   @spec register_validated(atom(), Spec.t() | keyword() | map()) ::
@@ -275,101 +288,4 @@ defmodule MingaAgent.Tool.Registry do
       BundledSources.reserved_source_for(name)
     end
   end
-
-  @spec categorize(String.t()) :: Spec.category()
-  defp categorize("read_file"), do: :filesystem
-  defp categorize("write_file"), do: :filesystem
-  defp categorize("edit_file"), do: :filesystem
-  defp categorize("multi_edit_file"), do: :filesystem
-  defp categorize("apply_diff"), do: :filesystem
-  defp categorize("list_directory"), do: :filesystem
-  defp categorize("find"), do: :filesystem
-  defp categorize("grep"), do: :filesystem
-  defp categorize("shell"), do: :shell
-  defp categorize("fetch_url"), do: :network
-  defp categorize("subagent"), do: :agent
-  defp categorize("describe_runtime"), do: :agent
-  defp categorize("describe_tools"), do: :agent
-  defp categorize("git_status"), do: :git
-  defp categorize("git_diff"), do: :git
-  defp categorize("git_log"), do: :git
-  defp categorize("git_stage"), do: :git
-  defp categorize("git_commit"), do: :git
-  defp categorize("memory_write"), do: :memory
-  defp categorize("diagnostics"), do: :lsp
-  defp categorize("definition"), do: :lsp
-  defp categorize("references"), do: :lsp
-  defp categorize("hover"), do: :lsp
-  defp categorize("document_symbols"), do: :lsp
-  defp categorize("workspace_symbols"), do: :lsp
-  defp categorize("rename"), do: :lsp
-  defp categorize("code_actions"), do: :lsp
-  defp categorize(_), do: :custom
-
-  @spec approval_for(String.t()) :: Spec.approval_level()
-  defp approval_for(name) do
-    if MingaAgent.Tools.destructive?(name), do: :ask, else: :auto
-  end
-
-  @spec capabilities_for(String.t()) :: [Spec.capability()]
-  defp capabilities_for(name)
-       when name in ["write_file", "edit_file", "multi_edit_file", "apply_diff", "delete_file"],
-       do: [:mutate_project]
-
-  defp capabilities_for(name) when name in ["read_file", "list_directory", "find", "grep"],
-    do: [:read_project]
-
-  defp capabilities_for("shell"), do: [:run_shell]
-  defp capabilities_for(name) when name in ["git_stage", "git_commit"], do: [:git_mutate]
-  defp capabilities_for(name) when name in ["git_status", "git_diff", "git_log"], do: [:git_read]
-  defp capabilities_for("fetch_url"), do: [:network]
-  defp capabilities_for("memory_write"), do: [:memory_write]
-  defp capabilities_for("subagent"), do: [:spawn_agent]
-  defp capabilities_for(name) when name in ["rename", "code_actions"], do: [:lsp_mutate]
-
-  defp capabilities_for(name)
-       when name in [
-              "diagnostics",
-              "definition",
-              "references",
-              "hover",
-              "document_symbols",
-              "workspace_symbols"
-            ],
-       do: [:lsp_read]
-
-  defp capabilities_for(_name), do: []
-
-  @spec context_requirements_for(String.t()) :: [Spec.context_requirement()]
-  defp context_requirements_for(name)
-       when name in [
-              "read_file",
-              "write_file",
-              "edit_file",
-              "multi_edit_file",
-              "apply_diff",
-              "delete_file",
-              "list_directory",
-              "find",
-              "grep",
-              "shell",
-              "subagent",
-              "git_status",
-              "git_diff",
-              "git_log",
-              "git_stage",
-              "git_commit",
-              "memory_write",
-              "diagnostics",
-              "definition",
-              "references",
-              "hover",
-              "document_symbols",
-              "workspace_symbols",
-              "rename",
-              "code_actions"
-            ],
-       do: [:tool_context]
-
-  defp context_requirements_for(_name), do: []
 end

--- a/lib/minga_agent/tool/spec.ex
+++ b/lib/minga_agent/tool/spec.ex
@@ -48,7 +48,6 @@ defmodule MingaAgent.Tool.Spec do
           name: String.t(),
           description: String.t(),
           parameter_schema: map(),
-          callback: callback() | nil,
           build: build_fun(),
           category: category(),
           approval_level: approval_level(),
@@ -71,7 +70,6 @@ defmodule MingaAgent.Tool.Spec do
             name: nil,
             description: nil,
             parameter_schema: %{},
-            callback: nil,
             build: nil,
             category: :custom,
             approval_level: :auto,
@@ -89,7 +87,7 @@ defmodule MingaAgent.Tool.Spec do
     description = Map.get(attrs, :description)
     parameter_schema = Map.get(attrs, :parameter_schema, %{})
     callback = Map.get(attrs, :callback)
-    build = Map.get(attrs, :build) || build_from_callback(callback)
+    build = resolve_build(Map.get(attrs, :build), callback)
     category = Map.get(attrs, :category, :custom)
     approval_level = Map.get(attrs, :approval_level, :auto)
     capabilities = Map.get(attrs, :capabilities, [])
@@ -100,7 +98,7 @@ defmodule MingaAgent.Tool.Spec do
          :ok <- validate_name(name),
          :ok <- validate_description(description),
          :ok <- validate_schema(parameter_schema),
-         :ok <- validate_callback(callback),
+         :ok <- validate_callback_declaration(Map.get(attrs, :build), callback),
          :ok <- validate_build(build),
          :ok <- validate_category(category),
          :ok <- validate_approval_level(approval_level),
@@ -114,7 +112,6 @@ defmodule MingaAgent.Tool.Spec do
          name: name,
          description: description,
          parameter_schema: parameter_schema,
-         callback: callback,
          build: build,
          category: category,
          approval_level: approval_level,
@@ -136,13 +133,28 @@ defmodule MingaAgent.Tool.Spec do
 
   @doc "Builds an executable callback for the given runtime context."
   @spec build_callback(t(), term()) :: callback()
-  def build_callback(%__MODULE__{build: build}, context), do: build.(context)
+  def build_callback(%__MODULE__{build: build, name: name, source: source}, context) do
+    callback = build.(context)
 
-  @spec build_from_callback(term()) :: build_fun() | nil
-  defp build_from_callback(callback) when is_function(callback, 1),
-    do: fn _context -> callback end
+    Minga.Telemetry.execute(
+      [:minga, :agent, :tool, :callback_built],
+      %{count: 1},
+      %{name: name, source: source}
+    )
 
-  defp build_from_callback(_callback), do: nil
+    callback
+  end
+
+  @spec resolve_build(term(), term()) :: build_fun() | nil
+  defp resolve_build(nil, callback) when is_function(callback, 1), do: fn _context -> callback end
+  defp resolve_build(build, _callback), do: build
+
+  @spec validate_callback_declaration(term(), term()) :: :ok | {:error, term()}
+  defp validate_callback_declaration(build, callback)
+       when is_function(build, 1) and is_function(callback, 1),
+       do: {:error, {:conflicting_execution_declarations, [:build, :callback]}}
+
+  defp validate_callback_declaration(_build, callback), do: validate_callback(callback)
 
   @spec validate_source(term()) :: :ok | {:error, term()}
   defp validate_source(:builtin), do: :ok

--- a/lib/minga_agent/tool_packs/lsp.ex
+++ b/lib/minga_agent/tool_packs/lsp.ex
@@ -8,13 +8,8 @@ defmodule MingaAgent.ToolPacks.LSP do
   use GenServer
 
   alias MingaAgent.Tool.BundledSources
-  alias MingaAgent.Tool.Context, as: ToolContext
   alias MingaAgent.Tool.Registry
   alias MingaAgent.Tool.Spec
-  alias ReqLLM.Tool
-
-  @read_only_names ~w(diagnostics definition references hover document_symbols workspace_symbols)
-  @mutating_names ~w(rename code_actions)
 
   @typedoc "Bundled LSP tool pack source."
   @type source :: {:bundle, :lsp_tools}
@@ -58,8 +53,8 @@ defmodule MingaAgent.ToolPacks.LSP do
   @doc "Returns source-owned specs for every bundled LSP tool."
   @spec specs() :: [Spec.t()]
   def specs do
-    tool_names()
-    |> Enum.map(&spec_for!/1)
+    MingaAgent.Tools.specs()
+    |> Enum.filter(&(&1.source == source()))
   end
 
   @doc "Registers all bundled LSP specs into a registry table or service."
@@ -120,55 +115,4 @@ defmodule MingaAgent.ToolPacks.LSP do
   rescue
     ArgumentError -> :ok
   end
-
-  @spec spec_for!(String.t()) :: Spec.t()
-  defp spec_for!(name) do
-    tool = tool_for!(name, MingaAgent.Tools.all(project_root: "."))
-
-    Spec.new!(
-      source: source(),
-      name: tool.name,
-      description: tool.description,
-      parameter_schema: tool.parameter_schema,
-      category: :lsp,
-      approval_level: approval_for(tool.name),
-      capabilities: capabilities_for(tool.name),
-      context_requirements: [:tool_context],
-      build: fn context -> callback_for(tool.name, context) end,
-      metadata: metadata_for(tool.name)
-    )
-  end
-
-  @spec callback_for(String.t(), ToolContext.t() | nil) :: Spec.callback()
-  defp callback_for(name, nil) do
-    name
-    |> tool_for!(MingaAgent.Tools.all(project_root: "."))
-    |> Map.fetch!(:callback)
-  end
-
-  defp callback_for(name, %ToolContext{} = context) do
-    name
-    |> tool_for!(MingaAgent.Tools.all(ToolContext.tools_opts(context)))
-    |> Map.fetch!(:callback)
-  end
-
-  @spec tool_for!(String.t(), [Tool.t()]) :: Tool.t()
-  defp tool_for!(name, tools) do
-    Enum.find(tools, &(&1.name == name)) ||
-      raise ArgumentError, "unknown LSP pack tool: #{name}"
-  end
-
-  @spec approval_for(String.t()) :: Spec.approval_level()
-  defp approval_for(name) when name in @mutating_names, do: :ask
-  defp approval_for(name) when name in @read_only_names, do: :auto
-
-  @spec capabilities_for(String.t()) :: [Spec.capability()]
-  defp capabilities_for("code_actions"), do: [:lsp_read, :lsp_mutate]
-  defp capabilities_for(name) when name in @mutating_names, do: [:lsp_mutate]
-  defp capabilities_for(name) when name in @read_only_names, do: [:lsp_read]
-
-  @spec metadata_for(String.t()) :: map()
-  defp metadata_for("code_actions"), do: %{pack: :lsp_tools, destructive: :conditional}
-  defp metadata_for(name) when name in @mutating_names, do: %{pack: :lsp_tools, destructive: true}
-  defp metadata_for(_name), do: %{pack: :lsp_tools, destructive: false}
 end

--- a/lib/minga_agent/tool_packs/read_only.ex
+++ b/lib/minga_agent/tool_packs/read_only.ex
@@ -8,10 +8,8 @@ defmodule MingaAgent.ToolPacks.ReadOnly do
   use GenServer
 
   alias MingaAgent.Tool.BundledSources
-  alias MingaAgent.Tool.Context, as: ToolContext
   alias MingaAgent.Tool.Registry
   alias MingaAgent.Tool.Spec
-  alias ReqLLM.Tool
 
   @typedoc "Bundled read-only tool pack source."
   @type source :: {:bundle, :read_only_tools}
@@ -55,8 +53,8 @@ defmodule MingaAgent.ToolPacks.ReadOnly do
   @doc "Returns source-owned specs for every tool in the bundled pack."
   @spec specs() :: [Spec.t()]
   def specs do
-    tool_names()
-    |> Enum.map(&spec_for!/1)
+    MingaAgent.Tools.specs()
+    |> Enum.filter(&(&1.source == source()))
   end
 
   @doc "Registers all read-only pack specs into a registry table or service."
@@ -101,53 +99,4 @@ defmodule MingaAgent.ToolPacks.ReadOnly do
     Enum.each(previous_specs, fn spec -> :ok = Registry.register(table, spec) end)
     :ok
   end
-
-  @spec spec_for!(String.t()) :: Spec.t()
-  defp spec_for!(name) do
-    tool = tool_for!(name, MingaAgent.Tools.all(project_root: "."))
-
-    Spec.new!(
-      source: source(),
-      name: tool.name,
-      description: tool.description,
-      parameter_schema: tool.parameter_schema,
-      category: category_for(tool.name),
-      approval_level: :auto,
-      capabilities: capabilities_for(tool.name),
-      context_requirements: context_requirements_for(tool.name),
-      build: fn context -> callback_for(tool.name, context) end,
-      metadata: %{pack: :read_only_tools}
-    )
-  end
-
-  @spec callback_for(String.t(), ToolContext.t() | nil) :: Spec.callback()
-  defp callback_for(name, nil) do
-    name
-    |> tool_for!(MingaAgent.Tools.all(project_root: "."))
-    |> Map.fetch!(:callback)
-  end
-
-  defp callback_for(name, %ToolContext{} = context) do
-    name
-    |> tool_for!(MingaAgent.Tools.all(ToolContext.tools_opts(context)))
-    |> Map.fetch!(:callback)
-  end
-
-  @spec tool_for!(String.t(), [Tool.t()]) :: Tool.t()
-  defp tool_for!(name, tools) do
-    Enum.find(tools, &(&1.name == name)) ||
-      raise ArgumentError, "unknown read-only pack tool: #{name}"
-  end
-
-  @spec category_for(String.t()) :: Spec.category()
-  defp category_for("fetch_url"), do: :network
-  defp category_for(_name), do: :filesystem
-
-  @spec capabilities_for(String.t()) :: [Spec.capability()]
-  defp capabilities_for("fetch_url"), do: [:network]
-  defp capabilities_for(_name), do: [:read_project]
-
-  @spec context_requirements_for(String.t()) :: [Spec.context_requirement()]
-  defp context_requirements_for("fetch_url"), do: []
-  defp context_requirements_for(_name), do: [:tool_context]
 end

--- a/lib/minga_agent/tools.ex
+++ b/lib/minga_agent/tools.ex
@@ -2,8 +2,8 @@ defmodule MingaAgent.Tools do
   @moduledoc """
   Tool definitions for the native agent provider.
 
-  Each tool is a `ReqLLM.Tool` struct with a name, description, JSON Schema
-  parameters, and a callback that executes the operation. Tools are scoped
+  Each tool is declared once as a `MingaAgent.Tool.Spec` with a name, description,
+  JSON Schema parameters, and a context-bound callback factory. Tools are scoped
   to the project root directory for safety: file operations refuse to escape
   the project boundary.
 
@@ -43,7 +43,6 @@ defmodule MingaAgent.Tools do
   alias Minga.Buffer.Document
   alias Minga.Buffer.Replace
   alias MingaAgent.ProjectView
-  alias MingaAgent.Tool.Context, as: ToolContext
   alias MingaAgent.Tool.Spec
   alias MingaAgent.ToolRouter
   alias MingaAgent.Tools.DeleteFile
@@ -67,10 +66,8 @@ defmodule MingaAgent.Tools do
   alias MingaAgent.Tools.ReadFile
   alias MingaAgent.Tools.ProcessBackend.System, as: SystemProcessBackend
   alias MingaAgent.Tools.Subagent
-  alias MingaAgent.Tool.BundledSources
   alias MingaAgent.Tools.WriteFile
   alias Minga.Config
-  alias ReqLLM.Tool
 
   @typedoc "Options passed to `all/1`."
   @type tools_opts :: [
@@ -128,217 +125,76 @@ defmodule MingaAgent.Tools do
     _ -> @default_destructive_tools
   end
 
-  @doc """
-  Returns all available tools scoped to the given project root.
-
-  The `project_root` is baked into each tool's callback closure so that every
-  file operation is sandboxed to that directory tree.
-  """
-  @spec all(tools_opts()) :: [Tool.t()]
-  def all(opts \\ []) do
-    root = Keyword.get(opts, :project_root, File.cwd!())
-    project_view = Keyword.get(opts, :project_view)
-    cs = Keyword.get(opts, :changeset)
-    fs = Keyword.get(opts, :fork_store)
-    parent_session = Keyword.get(opts, :parent_session)
-    shell_output_callback = Keyword.get(opts, :shell_output_callback)
-    process_backend = Keyword.get(opts, :process_backend, SystemProcessBackend)
-    router_ctx = ToolRouter.context(project_view, fs, cs)
-
+  @doc "Returns every canonical built-in and bundled tool declaration."
+  @spec specs() :: [Spec.t()]
+  def specs do
     [
-      read_file(root, router_ctx),
-      write_file(root, router_ctx),
-      edit_file(root, router_ctx),
-      multi_edit_file(root, router_ctx),
-      apply_diff(root, router_ctx),
-      delete_file(root, router_ctx),
-      list_directory(root, router_ctx),
-      find(root, router_ctx, process_backend),
-      grep(root, router_ctx, process_backend),
+      read_file(),
+      write_file(),
+      edit_file(),
+      multi_edit_file(),
+      apply_diff(),
+      delete_file(),
+      list_directory(),
+      find(),
+      grep(),
       fetch_url(),
-      shell(root, router_ctx, shell_output_callback, process_backend),
-      subagent(root, parent_session),
-      git_status(root),
-      git_diff(root, router_ctx),
-      git_log(root),
-      git_stage(root),
-      git_commit(root),
+      shell(),
+      subagent(),
+      git_status(),
+      git_diff(),
+      git_log(),
+      git_stage(),
+      git_commit(),
       memory_write(),
-      lsp_diagnostics(root),
-      lsp_definition(root),
-      lsp_references(root),
-      lsp_hover(root),
-      lsp_document_symbols(root),
+      lsp_diagnostics(),
+      lsp_definition(),
+      lsp_references(),
+      lsp_hover(),
+      lsp_document_symbols(),
       lsp_workspace_symbols(),
-      lsp_rename(root),
-      lsp_code_actions(root),
+      lsp_rename(),
+      lsp_code_actions(),
       describe_runtime(),
       describe_tools()
     ]
   end
 
+  @doc "Returns every canonical tool declaration. Options are accepted for source compatibility."
+  @spec all(tools_opts()) :: [Spec.t()]
+  def all(_opts \\ []), do: specs()
+
   @doc "Returns source-owned built-in tool declarations."
   @spec builtin_specs() :: [Spec.t()]
-  def builtin_specs do
-    all(project_root: ".")
-    |> Enum.reject(&(&1.name in BundledSources.reserved_names()))
-    |> Enum.map(&builtin_spec_from_tool/1)
-  end
+  def builtin_specs, do: Enum.filter(specs(), &(&1.source == :builtin))
 
   @doc "Returns all core built-in tool names."
   @spec builtin_names() :: [String.t()]
-  def builtin_names do
-    builtin_specs()
-    |> Enum.map(& &1.name)
-  end
+  def builtin_names, do: Enum.map(builtin_specs(), & &1.name)
 
-  @spec builtin_spec_from_tool(Tool.t()) :: Spec.t()
-  defp builtin_spec_from_tool(%Tool{} = tool) do
-    name = tool.name
+  @doc "Returns the read-only tool declaration subset for ephemeral inline ask sessions."
+  @spec read_only(tools_opts()) :: [Spec.t()]
+  def read_only(_opts \\ []), do: Enum.filter(specs(), &read_only_name?/1)
 
-    Spec.new!(
-      source: :builtin,
-      name: name,
-      description: tool.description || "",
-      parameter_schema: tool.parameter_schema || %{},
-      category: category_for(name),
-      approval_level: approval_for(name),
-      capabilities: capabilities_for(name),
-      context_requirements: context_requirements_for(name),
-      build: fn context -> built_in_callback(name, context) end
-    )
-  end
-
-  @spec built_in_callback(String.t(), ToolContext.t() | nil) :: Spec.callback()
-  defp built_in_callback(name, nil) do
-    callback_from_tools(name, all(project_root: "."))
-  end
-
-  defp built_in_callback(name, %ToolContext{} = context) do
-    callback_from_tools(name, all(ToolContext.tools_opts(context)))
-  end
-
-  @spec callback_from_tools(String.t(), [Tool.t()]) :: Spec.callback()
-  defp callback_from_tools(name, tools) do
-    tools
-    |> Enum.find(&(&1.name == name))
-    |> case do
-      %Tool{callback: callback} -> callback
-      nil -> fn _args -> {:error, {:tool_not_found, name}} end
-    end
-  end
-
-  @doc "Returns the read-only tool subset for ephemeral inline ask sessions."
-  @spec read_only(tools_opts()) :: [Tool.t()]
-  def read_only(opts \\ []) do
-    opts
-    |> all()
-    |> Enum.filter(&read_only_name?/1)
-  end
-
-  @doc "Returns the file/project read tool subset for constrained rewrite sessions."
-  @spec file_read(tools_opts()) :: [Tool.t()]
-  def file_read(opts \\ []) do
-    opts
-    |> all()
-    |> Enum.filter(&file_read_name?/1)
-  end
+  @doc "Returns the file/project read declaration subset for constrained rewrite sessions."
+  @spec file_read(tools_opts()) :: [Spec.t()]
+  def file_read(_opts \\ []), do: Enum.filter(specs(), &file_read_name?/1)
 
   @doc "Returns true when the tool name is allowed in constrained file-read sessions."
-  @spec file_read_name?(Tool.t() | String.t()) :: boolean()
-  def file_read_name?(%Tool{name: name}), do: file_read_name?(name)
+  @spec file_read_name?(Spec.t() | %{required(:name) => String.t()} | String.t()) :: boolean()
+  def file_read_name?(%{name: name}), do: file_read_name?(name)
   def file_read_name?(name) when is_binary(name), do: name in @file_read_tools
 
   @doc "Returns true when the tool name is allowed in read-only sessions."
-  @spec read_only_name?(Tool.t() | String.t()) :: boolean()
-  def read_only_name?(%Tool{name: name}), do: read_only_name?(name)
+  @spec read_only_name?(Spec.t() | %{required(:name) => String.t()} | String.t()) :: boolean()
+  def read_only_name?(%{name: name}), do: read_only_name?(name)
   def read_only_name?(name) when is_binary(name), do: name in @read_only_tools
-
-  @spec category_for(String.t()) :: Spec.category()
-  defp category_for("read_file"), do: :filesystem
-  defp category_for("write_file"), do: :filesystem
-  defp category_for("edit_file"), do: :filesystem
-  defp category_for("multi_edit_file"), do: :filesystem
-  defp category_for("apply_diff"), do: :filesystem
-  defp category_for("delete_file"), do: :filesystem
-  defp category_for("list_directory"), do: :filesystem
-  defp category_for("find"), do: :filesystem
-  defp category_for("grep"), do: :filesystem
-  defp category_for("shell"), do: :shell
-  defp category_for("fetch_url"), do: :network
-  defp category_for("subagent"), do: :agent
-  defp category_for("describe_runtime"), do: :agent
-  defp category_for("describe_tools"), do: :agent
-  defp category_for("git_status"), do: :git
-  defp category_for("git_diff"), do: :git
-  defp category_for("git_log"), do: :git
-  defp category_for("git_stage"), do: :git
-  defp category_for("git_commit"), do: :git
-  defp category_for("memory_write"), do: :memory
-  defp category_for("diagnostics"), do: :lsp
-  defp category_for("definition"), do: :lsp
-  defp category_for("references"), do: :lsp
-  defp category_for("hover"), do: :lsp
-  defp category_for("document_symbols"), do: :lsp
-  defp category_for("workspace_symbols"), do: :lsp
-  defp category_for("rename"), do: :lsp
-  defp category_for("code_actions"), do: :lsp
-  defp category_for(_name), do: :custom
-
-  @spec approval_for(String.t()) :: Spec.approval_level()
-  defp approval_for(name) do
-    if destructive?(name), do: :ask, else: :auto
-  end
-
-  @spec capabilities_for(String.t()) :: [Spec.capability()]
-  defp capabilities_for(name)
-       when name in ["write_file", "edit_file", "multi_edit_file", "apply_diff", "delete_file"],
-       do: [:mutate_project]
-
-  defp capabilities_for(name) when name in ["read_file", "list_directory", "find", "grep"],
-    do: [:read_project]
-
-  defp capabilities_for("shell"), do: [:run_shell]
-  defp capabilities_for(name) when name in ["git_stage", "git_commit"], do: [:git_mutate]
-  defp capabilities_for(name) when name in ["git_status", "git_diff", "git_log"], do: [:git_read]
-  defp capabilities_for("fetch_url"), do: [:network]
-  defp capabilities_for("memory_write"), do: [:memory_write]
-  defp capabilities_for("subagent"), do: [:spawn_agent]
-  defp capabilities_for(name) when name in ["rename", "code_actions"], do: [:lsp_mutate]
-
-  defp capabilities_for(name)
-       when name in [
-              "diagnostics",
-              "definition",
-              "references",
-              "hover",
-              "document_symbols",
-              "workspace_symbols"
-            ],
-       do: [:lsp_read]
-
-  defp capabilities_for(_name), do: []
-
-  @spec context_requirements_for(String.t()) :: [Spec.context_requirement()]
-  defp context_requirements_for(name) when name in @read_only_tools,
-    do: context_requirements_for_read_only(name)
-
-  defp context_requirements_for("fetch_url"), do: []
-  defp context_requirements_for("describe_runtime"), do: []
-  defp context_requirements_for("describe_tools"), do: []
-  defp context_requirements_for(_name), do: [:tool_context]
-
-  @spec context_requirements_for_read_only(String.t()) :: [Spec.context_requirement()]
-  defp context_requirements_for_read_only("fetch_url"), do: []
-  defp context_requirements_for_read_only("describe_runtime"), do: []
-  defp context_requirements_for_read_only("describe_tools"), do: []
-  defp context_requirements_for_read_only(_name), do: [:tool_context]
 
   # ── Tool definitions ────────────────────────────────────────────────────────
 
-  @spec read_file(String.t(), MingaAgent.ToolRouter.context()) :: Tool.t()
-  defp read_file(root, router_ctx) do
-    Tool.new!(
+  @spec read_file() :: Spec.t()
+  defp read_file do
+    Spec.new!(
       name: "read_file",
       description: """
       Read the contents of a file. Returns the file content as a string.
@@ -364,16 +220,26 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
+      source: :builtin,
+      category: :filesystem,
+      approval_level: :auto,
+      capabilities: [:read_project],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
 
-        case ToolRouter.read_file(router_ctx, path) do
-          {:ok, content} ->
-            opts = build_read_opts(args)
-            routed_result(router_ctx, apply_read_slice(content, path, opts))
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
 
-          {:error, reason} ->
-            read_file_fallback(router_ctx, path, reason, args)
+          case ToolRouter.read_file(router_ctx, path) do
+            {:ok, content} ->
+              opts = build_read_opts(args)
+              routed_result(router_ctx, apply_read_slice(content, path, opts))
+
+            {:error, reason} ->
+              read_file_fallback(router_ctx, path, reason, args)
+          end
         end
       end
     )
@@ -387,9 +253,9 @@ defmodule MingaAgent.Tools do
     opts
   end
 
-  @spec fetch_url() :: Tool.t()
+  @spec fetch_url() :: Spec.t()
   defp fetch_url do
-    Tool.new!(
+    Spec.new!(
       name: "fetch_url",
       description: """
       Fetch a URL and return readable text content. HTML pages are converted to structured text with headings, lists, paragraphs, and code blocks preserved. Non-HTML text responses such as JSON, plain text, and XML are returned as-is. This is read-only and does not require approval.
@@ -413,13 +279,21 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["url"]
       },
-      callback: &FetchUrl.execute/1
+      source: {:bundle, :read_only_tools},
+      category: :network,
+      approval_level: :auto,
+      capabilities: [:network],
+      context_requirements: [],
+      metadata: %{pack: :read_only_tools},
+      build: fn _context ->
+        &FetchUrl.execute/1
+      end
     )
   end
 
-  @spec write_file(String.t(), MingaAgent.ToolRouter.context()) :: Tool.t()
-  defp write_file(root, router_ctx) do
-    Tool.new!(
+  @spec write_file() :: Spec.t()
+  defp write_file do
+    Spec.new!(
       name: "write_file",
       description: """
       Write content to a file. Creates the file if it doesn't exist, overwrites
@@ -439,36 +313,46 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path", "content"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
+      source: :builtin,
+      category: :filesystem,
+      approval_level: :ask,
+      capabilities: [:mutate_project],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
 
-        case ToolRouter.write_file(router_ctx, path, args["content"]) do
-          :passthrough ->
-            case WriteFile.execute(path, args["content"]) do
-              {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
-              error -> error
-            end
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
 
-          :ok ->
-            {:ok,
-             maybe_append_diagnostics(
-               path,
-               append_workspace_context(
-                 router_ctx,
-                 "wrote #{byte_size(args["content"])} bytes to #{path} (via #{route_name(router_ctx)})"
-               )
-             )}
+          case ToolRouter.write_file(router_ctx, path, args["content"]) do
+            :passthrough ->
+              case WriteFile.execute(path, args["content"]) do
+                {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
+                error -> error
+              end
 
-          {:error, reason} ->
-            {:error, inspect(reason)}
+            :ok ->
+              {:ok,
+               maybe_append_diagnostics(
+                 path,
+                 append_workspace_context(
+                   router_ctx,
+                   "wrote #{byte_size(args["content"])} bytes to #{path} (via #{route_name(router_ctx)})"
+                 )
+               )}
+
+            {:error, reason} ->
+              {:error, inspect(reason)}
+          end
         end
       end
     )
   end
 
-  @spec edit_file(String.t(), MingaAgent.ToolRouter.context()) :: Tool.t()
-  defp edit_file(root, router_ctx) do
-    Tool.new!(
+  @spec edit_file() :: Spec.t()
+  defp edit_file do
+    Spec.new!(
       name: "edit_file",
       description: """
       Replace exact text in a file. The old_text must match exactly (including
@@ -493,41 +377,51 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path", "old_text", "new_text"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
+      source: :builtin,
+      category: :filesystem,
+      approval_level: :ask,
+      capabilities: [:mutate_project],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
 
-        case ToolRouter.edit_file(
-               router_ctx,
-               path,
-               args["old_text"],
-               args["new_text"]
-             ) do
-          :passthrough ->
-            case EditFile.execute(path, args["old_text"], args["new_text"]) do
-              {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
-              error -> error
-            end
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
 
-          :ok ->
-            {:ok,
-             maybe_append_diagnostics(
-               path,
-               append_workspace_context(
+          case ToolRouter.edit_file(
                  router_ctx,
-                 "edited #{path} (via #{route_name(router_ctx)})"
-               )
-             )}
+                 path,
+                 args["old_text"],
+                 args["new_text"]
+               ) do
+            :passthrough ->
+              case EditFile.execute(path, args["old_text"], args["new_text"]) do
+                {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
+                error -> error
+              end
 
-          {:error, reason} ->
-            {:error, inspect(reason)}
+            :ok ->
+              {:ok,
+               maybe_append_diagnostics(
+                 path,
+                 append_workspace_context(
+                   router_ctx,
+                   "edited #{path} (via #{route_name(router_ctx)})"
+                 )
+               )}
+
+            {:error, reason} ->
+              {:error, inspect(reason)}
+          end
         end
       end
     )
   end
 
-  @spec multi_edit_file(String.t(), MingaAgent.ToolRouter.context()) :: Tool.t()
-  defp multi_edit_file(root, router_ctx) do
-    Tool.new!(
+  @spec multi_edit_file() :: Spec.t()
+  defp multi_edit_file do
+    Spec.new!(
       name: "multi_edit_file",
       description: """
       Apply multiple edits to a single file in one call. Each edit is a
@@ -563,25 +457,35 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path", "edits"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
-        edits = args["edits"] || []
+      source: :builtin,
+      category: :filesystem,
+      approval_level: :ask,
+      capabilities: [:mutate_project],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
 
-        if ToolRouter.routing_configured?(router_ctx) do
-          apply_multi_edit_via_router(router_ctx, path, edits)
-        else
-          case MultiEditFile.execute(path, edits) do
-            {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
-            error -> error
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
+          edits = args["edits"] || []
+
+          if ToolRouter.routing_configured?(router_ctx) do
+            apply_multi_edit_via_router(router_ctx, path, edits)
+          else
+            case MultiEditFile.execute(path, edits) do
+              {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
+              error -> error
+            end
           end
         end
       end
     )
   end
 
-  @spec apply_diff(String.t(), MingaAgent.ToolRouter.context()) :: Tool.t()
-  defp apply_diff(root, router_ctx) do
-    Tool.new!(
+  @spec apply_diff() :: Spec.t()
+  defp apply_diff do
+    Spec.new!(
       name: "apply_diff",
       description: """
       Apply a unified diff to a single file. The diff must use standard
@@ -603,25 +507,35 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path", "diff"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
-        diff = args["diff"] || ""
+      source: :builtin,
+      category: :filesystem,
+      approval_level: :ask,
+      capabilities: [:mutate_project],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
 
-        if ToolRouter.routing_configured?(router_ctx) do
-          apply_diff_via_router(router_ctx, path, diff)
-        else
-          case ApplyDiff.execute(path, diff) do
-            {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
-            error -> error
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
+          diff = args["diff"] || ""
+
+          if ToolRouter.routing_configured?(router_ctx) do
+            apply_diff_via_router(router_ctx, path, diff)
+          else
+            case ApplyDiff.execute(path, diff) do
+              {:ok, msg} -> {:ok, maybe_append_diagnostics(path, msg)}
+              error -> error
+            end
           end
         end
       end
     )
   end
 
-  @spec delete_file(String.t(), ToolRouter.context()) :: Tool.t()
-  defp delete_file(root, router_ctx) do
-    Tool.new!(
+  @spec delete_file() :: Spec.t()
+  defp delete_file do
+    Spec.new!(
       name: "delete_file",
       description: """
       Delete a file from the project. Destructive: requires approval.
@@ -636,30 +550,40 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
+      source: :builtin,
+      category: :filesystem,
+      approval_level: :ask,
+      capabilities: [:mutate_project],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
 
-        case ToolRouter.delete_file(router_ctx, path) do
-          :passthrough ->
-            DeleteFile.execute(path)
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
 
-          :ok ->
-            {:ok,
-             append_workspace_context(
-               router_ctx,
-               "deleted #{path} (via #{route_name(router_ctx)})"
-             )}
+          case ToolRouter.delete_file(router_ctx, path) do
+            :passthrough ->
+              DeleteFile.execute(path)
 
-          {:error, reason} ->
-            {:error, inspect(reason)}
+            :ok ->
+              {:ok,
+               append_workspace_context(
+                 router_ctx,
+                 "deleted #{path} (via #{route_name(router_ctx)})"
+               )}
+
+            {:error, reason} ->
+              {:error, inspect(reason)}
+          end
         end
       end
     )
   end
 
-  @spec list_directory(String.t(), ToolRouter.context()) :: Tool.t()
-  defp list_directory(root, router_ctx) do
-    Tool.new!(
+  @spec list_directory() :: Spec.t()
+  defp list_directory do
+    Spec.new!(
       name: "list_directory",
       description: """
       List files and directories at a known-small path. Returns at most 200 entries, one per line. Directories have a trailing slash. Generated, dependency, build, cache, and secret env files are omitted. Use find for broad file discovery instead of walking directories.
@@ -675,27 +599,38 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
+      source: {:bundle, :read_only_tools},
+      category: :filesystem,
+      approval_level: :auto,
+      capabilities: [:read_project],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :read_only_tools},
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
 
-        case ToolRouter.list_directory(router_ctx, path) do
-          :passthrough ->
-            ListDirectory.execute(path)
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
 
-          {:ok, entries} ->
-            {:ok,
-             append_workspace_context(router_ctx, format_project_view_entries(path, entries))}
+          case ToolRouter.list_directory(router_ctx, path) do
+            :passthrough ->
+              ListDirectory.execute(path)
 
-          {:error, reason} ->
-            {:error, inspect(reason)}
+            {:ok, entries} ->
+              {:ok,
+               append_workspace_context(router_ctx, format_project_view_entries(path, entries))}
+
+            {:error, reason} ->
+              {:error, inspect(reason)}
+          end
         end
       end
     )
   end
 
-  @spec find(String.t(), ToolRouter.context(), module()) :: Tool.t()
-  defp find(root, router_ctx, process_backend) do
-    Tool.new!(
+  @spec find() :: Spec.t()
+  defp find do
+    Spec.new!(
       name: "find",
       description: """
       Find files and directories by name pattern (glob). Returns at most 200
@@ -727,30 +662,42 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["pattern"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"] || ".")
+      source: {:bundle, :read_only_tools},
+      category: :filesystem,
+      approval_level: :auto,
+      capabilities: [:read_project],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :read_only_tools},
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
+        process_backend = Map.get(context.metadata, :process_backend, SystemProcessBackend)
 
-        case ToolRouter.search_context(router_ctx, path) do
-          {:ok, search} ->
-            public_args = Map.take(args, ["type", "max_depth"])
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"] || ".")
 
-            routed_result(
-              router_ctx,
-              process_backend.find(args["pattern"], search.exec_path, public_args,
-                filter_root: search.filter_root
+          case ToolRouter.search_context(router_ctx, path) do
+            {:ok, search} ->
+              public_args = Map.take(args, ["type", "max_depth"])
+
+              routed_result(
+                router_ctx,
+                process_backend.find(args["pattern"], search.exec_path, public_args,
+                  filter_root: search.filter_root
+                )
               )
-            )
 
-          {:error, reason} ->
-            {:error, inspect(reason)}
+            {:error, reason} ->
+              {:error, inspect(reason)}
+          end
         end
       end
     )
   end
 
-  @spec grep(String.t(), ToolRouter.context(), module()) :: Tool.t()
-  defp grep(root, router_ctx, process_backend) do
-    Tool.new!(
+  @spec grep() :: Spec.t()
+  defp grep do
+    Spec.new!(
       name: "grep",
       description: """
       Search file contents for a pattern. Returns at most 100 matching lines with
@@ -785,31 +732,42 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["pattern"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"] || ".")
+      source: {:bundle, :read_only_tools},
+      category: :filesystem,
+      approval_level: :auto,
+      capabilities: [:read_project],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :read_only_tools},
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
+        process_backend = Map.get(context.metadata, :process_backend, SystemProcessBackend)
 
-        case ToolRouter.search_context(router_ctx, path) do
-          {:ok, search} ->
-            public_args = Map.take(args, ["glob", "case_sensitive", "context_lines"])
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"] || ".")
 
-            routed_result(
-              router_ctx,
-              process_backend.grep(args["pattern"], search.exec_path, public_args,
-                filter_root: search.filter_root
+          case ToolRouter.search_context(router_ctx, path) do
+            {:ok, search} ->
+              public_args = Map.take(args, ["glob", "case_sensitive", "context_lines"])
+
+              routed_result(
+                router_ctx,
+                process_backend.grep(args["pattern"], search.exec_path, public_args,
+                  filter_root: search.filter_root
+                )
               )
-            )
 
-          {:error, reason} ->
-            {:error, inspect(reason)}
+            {:error, reason} ->
+              {:error, inspect(reason)}
+          end
         end
       end
     )
   end
 
-  @spec shell(String.t(), MingaAgent.ToolRouter.context(), (String.t() -> :ok) | nil, module()) ::
-          Tool.t()
-  defp shell(root, router_ctx, shell_output_callback, process_backend) do
-    Tool.new!(
+  @spec shell() :: Spec.t()
+  defp shell do
+    Spec.new!(
       name: "shell",
       description: """
       Run a shell command in the project root directory. Returns the combined
@@ -832,34 +790,46 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["command"]
       },
-      callback: fn args ->
-        timeout_secs = min(args["timeout"] || 30, 300)
+      source: :builtin,
+      category: :shell,
+      approval_level: :ask,
+      capabilities: [:run_shell],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
+        shell_output_callback = Map.get(context.metadata, :shell_output_callback)
+        process_backend = Map.get(context.metadata, :process_backend, SystemProcessBackend)
 
-        with {:ok, cwd} <- ToolRouter.working_dir_result(router_ctx),
-             {:ok, env} <- ToolRouter.command_env_result(router_ctx) do
-          shell_root = cwd || root
+        fn args ->
+          timeout_secs = min(args["timeout"] || 30, 300)
 
-          if is_nil(cwd) do
-            flush_before_shell()
-          end
+          with {:ok, cwd} <- ToolRouter.working_dir_result(router_ctx),
+               {:ok, env} <- ToolRouter.command_env_result(router_ctx) do
+            shell_root = cwd || root
 
-          routed_result(
-            router_ctx,
-            process_backend.shell(args["command"], shell_root, timeout_secs,
-              env: env,
-              on_output: shell_output_callback
+            if is_nil(cwd) do
+              flush_before_shell()
+            end
+
+            routed_result(
+              router_ctx,
+              process_backend.shell(args["command"], shell_root, timeout_secs,
+                env: env,
+                on_output: shell_output_callback
+              )
             )
-          )
-        else
-          {:error, reason} -> {:error, inspect(reason)}
+          else
+            {:error, reason} -> {:error, inspect(reason)}
+          end
         end
       end
     )
   end
 
-  @spec subagent(String.t(), GenServer.server() | nil) :: Tool.t()
-  defp subagent(root, parent_session) do
-    Tool.new!(
+  @spec subagent() :: Spec.t()
+  defp subagent do
+    Spec.new!(
       name: "subagent",
       description: """
       Spawn a child agent to work on a subtask. By default this is foreground:
@@ -900,24 +870,34 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["task"]
       },
-      callback: fn args ->
-        Subagent.execute(args["task"],
-          project_root: root,
-          model: args["model"],
-          provider: args["provider"],
-          background: args["background"] == true,
-          isolation: args["isolation"],
-          parent_session: parent_session
-        )
+      source: :builtin,
+      category: :agent,
+      approval_level: :auto,
+      capabilities: [:spawn_agent],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        parent_session = Map.get(context.metadata, :parent_session)
+
+        fn args ->
+          Subagent.execute(args["task"],
+            project_root: root,
+            model: args["model"],
+            provider: args["provider"],
+            background: args["background"] == true,
+            isolation: args["isolation"],
+            parent_session: parent_session
+          )
+        end
       end
     )
   end
 
   # ── Git tools ────────────────────────────────────────────────────────────────
 
-  @spec git_status(String.t()) :: Tool.t()
-  defp git_status(root) do
-    Tool.new!(
+  @spec git_status() :: Spec.t()
+  defp git_status do
+    Spec.new!(
       name: "git_status",
       description: """
       Show git status: staged, unstaged, and untracked files with their change type.
@@ -927,13 +907,21 @@ defmodule MingaAgent.Tools do
         "type" => "object",
         "properties" => %{}
       },
-      callback: fn _args -> GitTools.status(root) end
+      source: :builtin,
+      category: :git,
+      approval_level: :auto,
+      capabilities: [:git_read],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        fn _args -> GitTools.status(root) end
+      end
     )
   end
 
-  @spec git_diff(String.t(), ToolRouter.context()) :: Tool.t()
-  defp git_diff(root, router_ctx) do
-    Tool.new!(
+  @spec git_diff() :: Spec.t()
+  defp git_diff do
+    Spec.new!(
       name: "git_diff",
       description: """
       Show git diff. Returns unified diff output. Read-only.
@@ -951,18 +939,28 @@ defmodule MingaAgent.Tools do
           }
         }
       },
-      callback: fn args ->
-        opts = []
-        opts = if args["path"], do: [{:path, args["path"]} | opts], else: opts
-        opts = if args["staged"], do: [{:staged, args["staged"]} | opts], else: opts
-        GitTools.diff(root, opts, router_ctx)
+      source: :builtin,
+      category: :git,
+      approval_level: :auto,
+      capabilities: [:git_read],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+        router_ctx = context.router_context
+
+        fn args ->
+          opts = []
+          opts = if args["path"], do: [{:path, args["path"]} | opts], else: opts
+          opts = if args["staged"], do: [{:staged, args["staged"]} | opts], else: opts
+          GitTools.diff(root, opts, router_ctx)
+        end
       end
     )
   end
 
-  @spec git_log(String.t()) :: Tool.t()
-  defp git_log(root) do
-    Tool.new!(
+  @spec git_log() :: Spec.t()
+  defp git_log do
+    Spec.new!(
       name: "git_log",
       description: """
       Show recent git commits with hash, author, date, and message. Read-only.
@@ -980,18 +978,27 @@ defmodule MingaAgent.Tools do
           }
         }
       },
-      callback: fn args ->
-        opts = []
-        opts = if args["count"], do: [{:count, args["count"]} | opts], else: opts
-        opts = if args["path"], do: [{:path, args["path"]} | opts], else: opts
-        GitTools.log(root, opts)
+      source: :builtin,
+      category: :git,
+      approval_level: :auto,
+      capabilities: [:git_read],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          opts = []
+          opts = if args["count"], do: [{:count, args["count"]} | opts], else: opts
+          opts = if args["path"], do: [{:path, args["path"]} | opts], else: opts
+          GitTools.log(root, opts)
+        end
       end
     )
   end
 
-  @spec git_stage(String.t()) :: Tool.t()
-  defp git_stage(root) do
-    Tool.new!(
+  @spec git_stage() :: Spec.t()
+  defp git_stage do
+    Spec.new!(
       name: "git_stage",
       description: """
       Stage files for commit (equivalent to git add). Destructive: requires approval.
@@ -1007,16 +1014,25 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["paths"]
       },
-      callback: fn args ->
-        paths = args["paths"] || []
-        GitTools.stage(root, paths)
+      source: :builtin,
+      category: :git,
+      approval_level: :ask,
+      capabilities: [:git_mutate],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          paths = args["paths"] || []
+          GitTools.stage(root, paths)
+        end
       end
     )
   end
 
-  @spec git_commit(String.t()) :: Tool.t()
-  defp git_commit(root) do
-    Tool.new!(
+  @spec git_commit() :: Spec.t()
+  defp git_commit do
+    Spec.new!(
       name: "git_commit",
       description: """
       Create a git commit with a message. Stage files first with git_stage.
@@ -1032,17 +1048,26 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["message"]
       },
-      callback: fn args ->
-        GitTools.commit(root, args["message"])
+      source: :builtin,
+      category: :git,
+      approval_level: :ask,
+      capabilities: [:git_mutate],
+      context_requirements: [:tool_context],
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          GitTools.commit(root, args["message"])
+        end
       end
     )
   end
 
   # ── Memory tools ──────────────────────────────────────────────────────────────
 
-  @spec memory_write() :: Tool.t()
+  @spec memory_write() :: Spec.t()
   defp memory_write do
-    Tool.new!(
+    Spec.new!(
       name: "memory_write",
       description: """
       Save a learning, preference, or project convention to persistent memory.
@@ -1061,17 +1086,24 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["text"]
       },
-      callback: fn args ->
-        MemoryWrite.execute(args["text"] || "")
+      source: :builtin,
+      category: :memory,
+      approval_level: :auto,
+      capabilities: [:memory_write],
+      context_requirements: [:tool_context],
+      build: fn _context ->
+        fn args ->
+          MemoryWrite.execute(args["text"] || "")
+        end
       end
     )
   end
 
   # ── LSP tools ──────────────────────────────────────────────────────────────
 
-  @spec lsp_diagnostics(String.t()) :: Tool.t()
-  defp lsp_diagnostics(root) do
-    Tool.new!(
+  @spec lsp_diagnostics() :: Spec.t()
+  defp lsp_diagnostics do
+    Spec.new!(
       name: "diagnostics",
       description: """
       Get current LSP diagnostics (errors, warnings, hints) for a file.
@@ -1089,16 +1121,26 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
-        LspDiagnostics.execute(path)
+      source: {:bundle, :lsp_tools},
+      category: :lsp,
+      approval_level: :auto,
+      capabilities: [:lsp_read],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :lsp_tools, destructive: false},
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
+          LspDiagnostics.execute(path)
+        end
       end
     )
   end
 
-  @spec lsp_definition(String.t()) :: Tool.t()
-  defp lsp_definition(root) do
-    Tool.new!(
+  @spec lsp_definition() :: Spec.t()
+  defp lsp_definition do
+    Spec.new!(
       name: "definition",
       description: """
       Find where a symbol is defined. Returns the file path, line, and
@@ -1123,16 +1165,26 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path", "line", "column"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
-        LspDefinition.execute(path, args["line"], args["column"])
+      source: {:bundle, :lsp_tools},
+      category: :lsp,
+      approval_level: :auto,
+      capabilities: [:lsp_read],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :lsp_tools, destructive: false},
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
+          LspDefinition.execute(path, args["line"], args["column"])
+        end
       end
     )
   end
 
-  @spec lsp_references(String.t()) :: Tool.t()
-  defp lsp_references(root) do
-    Tool.new!(
+  @spec lsp_references() :: Spec.t()
+  defp lsp_references do
+    Spec.new!(
       name: "references",
       description: """
       Find all usages of a symbol across the project. Returns file paths,
@@ -1158,16 +1210,26 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path", "line", "column"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
-        LspReferences.execute(path, args["line"], args["column"])
+      source: {:bundle, :lsp_tools},
+      category: :lsp,
+      approval_level: :auto,
+      capabilities: [:lsp_read],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :lsp_tools, destructive: false},
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
+          LspReferences.execute(path, args["line"], args["column"])
+        end
       end
     )
   end
 
-  @spec lsp_hover(String.t()) :: Tool.t()
-  defp lsp_hover(root) do
-    Tool.new!(
+  @spec lsp_hover() :: Spec.t()
+  defp lsp_hover do
+    Spec.new!(
       name: "hover",
       description: """
       Get type signature and documentation for a symbol. Returns the same
@@ -1192,16 +1254,26 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path", "line", "column"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
-        LspHover.execute(path, args["line"], args["column"])
+      source: {:bundle, :lsp_tools},
+      category: :lsp,
+      approval_level: :auto,
+      capabilities: [:lsp_read],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :lsp_tools, destructive: false},
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
+          LspHover.execute(path, args["line"], args["column"])
+        end
       end
     )
   end
 
-  @spec lsp_document_symbols(String.t()) :: Tool.t()
-  defp lsp_document_symbols(root) do
-    Tool.new!(
+  @spec lsp_document_symbols() :: Spec.t()
+  defp lsp_document_symbols do
+    Spec.new!(
       name: "document_symbols",
       description: """
       List all symbols (functions, types, modules) defined in a file.
@@ -1218,16 +1290,26 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
-        LspDocumentSymbols.execute(path)
+      source: {:bundle, :lsp_tools},
+      category: :lsp,
+      approval_level: :auto,
+      capabilities: [:lsp_read],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :lsp_tools, destructive: false},
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
+          LspDocumentSymbols.execute(path)
+        end
       end
     )
   end
 
-  @spec lsp_workspace_symbols() :: Tool.t()
+  @spec lsp_workspace_symbols() :: Spec.t()
   defp lsp_workspace_symbols do
-    Tool.new!(
+    Spec.new!(
       name: "workspace_symbols",
       description: """
       Search for symbols (modules, functions, types) across the entire project.
@@ -1244,15 +1326,23 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["query"]
       },
-      callback: fn args ->
-        LspWorkspaceSymbols.execute(args["query"])
+      source: {:bundle, :lsp_tools},
+      category: :lsp,
+      approval_level: :auto,
+      capabilities: [:lsp_read],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :lsp_tools, destructive: false},
+      build: fn _context ->
+        fn args ->
+          LspWorkspaceSymbols.execute(args["query"])
+        end
       end
     )
   end
 
-  @spec lsp_rename(String.t()) :: Tool.t()
-  defp lsp_rename(root) do
-    Tool.new!(
+  @spec lsp_rename() :: Spec.t()
+  defp lsp_rename do
+    Spec.new!(
       name: "rename",
       description: """
       Rename a symbol across the entire project using LSP semantic rename.
@@ -1282,16 +1372,26 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path", "line", "column", "new_name"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
-        LspRename.execute(path, args["line"], args["column"], args["new_name"])
+      source: {:bundle, :lsp_tools},
+      category: :lsp,
+      approval_level: :ask,
+      capabilities: [:lsp_mutate],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :lsp_tools, destructive: true},
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
+          LspRename.execute(path, args["line"], args["column"], args["new_name"])
+        end
       end
     )
   end
 
-  @spec lsp_code_actions(String.t()) :: Tool.t()
-  defp lsp_code_actions(root) do
-    Tool.new!(
+  @spec lsp_code_actions() :: Spec.t()
+  defp lsp_code_actions do
+    Spec.new!(
       name: "code_actions",
       description: """
       List or apply LSP code actions (quickfixes, refactorings, source actions)
@@ -1322,21 +1422,31 @@ defmodule MingaAgent.Tools do
         },
         "required" => ["path", "line"]
       },
-      callback: fn args ->
-        path = resolve_and_validate_path!(root, args["path"])
-        opts = []
-        opts = if args["column"], do: [{:col, args["column"]} | opts], else: opts
-        opts = if args["apply"], do: [{:apply, args["apply"]} | opts], else: opts
-        LspCodeActions.execute(path, args["line"], opts)
+      source: {:bundle, :lsp_tools},
+      category: :lsp,
+      approval_level: :ask,
+      capabilities: [:lsp_read, :lsp_mutate],
+      context_requirements: [:tool_context],
+      metadata: %{pack: :lsp_tools, destructive: :conditional},
+      build: fn context ->
+        root = context.project_root
+
+        fn args ->
+          path = resolve_and_validate_path!(root, args["path"])
+          opts = []
+          opts = if args["column"], do: [{:col, args["column"]} | opts], else: opts
+          opts = if args["apply"], do: [{:apply, args["apply"]} | opts], else: opts
+          LspCodeActions.execute(path, args["line"], opts)
+        end
       end
     )
   end
 
   # ── Introspection tools ─────────────────────────────────────────────────────
 
-  @spec describe_runtime() :: Tool.t()
+  @spec describe_runtime() :: Spec.t()
   defp describe_runtime do
-    Tool.new!(
+    Spec.new!(
       name: "describe_runtime",
       description: """
       Describe the Minga runtime's capabilities: version, available tool
@@ -1347,13 +1457,20 @@ defmodule MingaAgent.Tools do
         "type" => "object",
         "properties" => %{}
       },
-      callback: &MingaAgent.Tools.Introspection.describe_runtime/1
+      source: :builtin,
+      category: :agent,
+      approval_level: :auto,
+      capabilities: [],
+      context_requirements: [],
+      build: fn _context ->
+        &MingaAgent.Tools.Introspection.describe_runtime/1
+      end
     )
   end
 
-  @spec describe_tools() :: Tool.t()
+  @spec describe_tools() :: Spec.t()
   defp describe_tools do
-    Tool.new!(
+    Spec.new!(
       name: "describe_tools",
       description: """
       List all available tools with their names, categories, and
@@ -1363,7 +1480,14 @@ defmodule MingaAgent.Tools do
         "type" => "object",
         "properties" => %{}
       },
-      callback: &MingaAgent.Tools.Introspection.describe_tools/1
+      source: :builtin,
+      category: :agent,
+      approval_level: :auto,
+      capabilities: [],
+      context_requirements: [],
+      build: fn _context ->
+        &MingaAgent.Tools.Introspection.describe_tools/1
+      end
     )
   end
 

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -10,6 +10,7 @@ defmodule MingaAgent.Providers.NativeTest do
   alias MingaAgent.TurnUsage
   alias MingaAgent.ProjectView.RecordingBackend
   alias MingaAgent.Providers.Native
+  alias MingaAgent.Tool.Spec
   alias MingaAgent.ToolCall
   alias MingaAgent.Tools
   alias ReqLLM.Context
@@ -365,6 +366,51 @@ defmodule MingaAgent.Providers.NativeTest do
       assert Minga.Buffer.content(buffer) == "direct\n"
     end
 
+    test "rebuilds only custom tool declarations after fork store down", %{tmp_dir: dir} do
+      test_pid = self()
+
+      spec =
+        Spec.new!(
+          source: :config,
+          name: "custom_restart",
+          description: "Reports the bound fork store",
+          parameter_schema: %{},
+          build: fn context ->
+            fn _args ->
+              send(test_pid, {:bound_fork_store, context.router_context.fork_store})
+              {:ok, "reported"}
+            end
+          end
+        )
+
+      {:ok, pid} = start_provider(tmp_dir: dir, tools: [spec])
+      fork_store = Native.fork_store(pid)
+      assert is_pid(fork_store)
+
+      custom_tool = pid |> Native.tools() |> Enum.find(&(&1.name == "custom_restart"))
+      assert {:ok, "reported"} = custom_tool.callback.(%{})
+      assert_receive {:bound_fork_store, ^fork_store}
+
+      ref = Process.monitor(fork_store)
+      Process.exit(fork_store, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^fork_store, _reason}
+      assert Native.fork_store(pid) == nil
+
+      rebuilt_tools = Native.tools(pid)
+
+      assert Enum.map(rebuilt_tools, & &1.name) == [
+               "custom_restart",
+               "todo_write",
+               "todo_read",
+               "notebook_write",
+               "notebook_read"
+             ]
+
+      rebuilt_custom_tool = Enum.find(rebuilt_tools, &(&1.name == "custom_restart"))
+      assert {:ok, "reported"} = rebuilt_custom_tool.callback.(%{})
+      assert_receive {:bound_fork_store, nil}
+    end
+
     test "project_view-backed tools reuse the workspace-owned draft machinery and survive provider exit",
          %{tmp_dir: dir} do
       path = Path.join(dir, "lib/view_draft.ex")
@@ -581,6 +627,82 @@ defmodule MingaAgent.Providers.NativeTest do
       # Should eventually get a text response and AgentEnd
       assert Enum.any?(events, &match?(%Event.TextDelta{}, &1))
       assert Enum.any?(events, &match?(%Event.AgentEnd{}, &1))
+    end
+
+    test "executes the supplied custom spec with refreshed project context", %{tmp_dir: dir} do
+      root = Path.join(dir, "root")
+      first_working_dir = Path.join(dir, "first")
+      second_working_dir = Path.join(dir, "second")
+      File.mkdir_p!(root)
+
+      {:ok, first_view} =
+        RecordingBackend.create(root,
+          parent: self(),
+          working_dir: first_working_dir,
+          workspace_id: 1
+        )
+
+      {:ok, second_view} =
+        RecordingBackend.create(root,
+          parent: self(),
+          working_dir: second_working_dir,
+          workspace_id: 2
+        )
+
+      spec =
+        Spec.new!(
+          source: :config,
+          name: "custom_context",
+          description: "Reports the bound project context",
+          parameter_schema: %{},
+          build: fn context ->
+            fn _args -> {:ok, ProjectView.working_dir(context.router_context.project_view)} end
+          end
+        )
+
+      call_count = :counters.new(1, [:atomics])
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          if count == 0 do
+            [
+              ReqLLM.StreamChunk.tool_call("custom_context", %{}, %{
+                id: "tc_custom_context",
+                index: 0
+              }),
+              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+            ]
+          else
+            [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: root,
+          project_view: first_view,
+          llm_client: client,
+          tools: [spec],
+          config: agent_config(tool_approval: :none)
+        )
+
+      assert :ok = Native.refresh_project_view(pid, second_view)
+      assert :ok = Native.send_prompt(pid, "Report context")
+
+      events = collect_run_events()
+
+      assert Enum.any?(events, fn
+               %Event.ToolEnd{name: "custom_context", result: result, is_error: false} ->
+                 result == second_working_dir
+
+               _event ->
+                 false
+             end)
     end
 
     test "executes independent tool calls concurrently and appends results in call order", %{
@@ -944,6 +1066,176 @@ defmodule MingaAgent.Providers.NativeTest do
       after
         Process.flag(:trap_exit, previous_trap)
       end
+    end
+
+    test "empty destructive tool configuration allows formerly destructive builtins", %{
+      tmp_dir: dir
+    } do
+      call_count = :counters.new(1, [:atomics])
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call(
+                  "write_file",
+                  %{"path" => "allowed.txt", "content" => "allowed\n"},
+                  %{id: "tc_write", index: 0}
+                ),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: client,
+          tools: nil,
+          config: agent_config(tool_approval: :destructive, destructive_tools: [])
+        )
+
+      assert :ok = Native.send_prompt(pid, "Write the file")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+      events = collect_run_events()
+
+      refute Enum.any?(events, &match?(%Event.ToolApproval{}, &1))
+
+      assert Enum.any?(
+               events,
+               &match?(%Event.ToolEnd{name: "write_file", is_error: false}, &1)
+             )
+    end
+
+    test "destructive mode asks for names in the configured list", %{tmp_dir: dir} do
+      File.write!(Path.join(dir, "configured.txt"), "configured\n")
+      call_count = :counters.new(1, [:atomics])
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          case count do
+            0 ->
+              [
+                ReqLLM.StreamChunk.tool_call(
+                  "read_file",
+                  %{"path" => "configured.txt"},
+                  %{id: "tc_read_configured", index: 0}
+                ),
+                ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+              ]
+
+            _ ->
+              [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: client,
+          tools: nil,
+          config: agent_config(tool_approval: :destructive, destructive_tools: ["read_file"])
+        )
+
+      assert :ok = Native.send_prompt(pid, "Read the file")
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolApproval{
+                        tool_call_id: "tc_read_configured",
+                        reply_to: reply_to
+                      }},
+                     1_000
+
+      send(reply_to, {:tool_approval_response, "tc_read_configured", :approve})
+      events = collect_run_events()
+
+      assert Enum.any?(
+               events,
+               &match?(%Event.ToolEnd{name: "read_file", is_error: false}, &1)
+             )
+    end
+
+    test "custom spec approval metadata is honored", %{tmp_dir: dir} do
+      test_pid = self()
+      call_count = :counters.new(1, [:atomics])
+
+      spec =
+        Spec.new!(
+          source: :config,
+          name: "custom_approval",
+          description: "Requires approval",
+          parameter_schema: %{},
+          approval_level: :ask,
+          build: fn _context ->
+            fn _args ->
+              send(test_pid, :custom_approval_ran)
+              {:ok, "approved"}
+            end
+          end
+        )
+
+      client = fn _model, _messages, _opts ->
+        count = :counters.get(call_count, 1)
+        :counters.add(call_count, 1, 1)
+
+        chunks =
+          if count == 0 do
+            [
+              ReqLLM.StreamChunk.tool_call("custom_approval", %{}, %{
+                id: "tc_custom_approval",
+                index: 0
+              }),
+              ReqLLM.StreamChunk.meta(%{finish_reason: :tool_use})
+            ]
+          else
+            [ReqLLM.StreamChunk.text("done"), ReqLLM.StreamChunk.meta(%{finish_reason: :stop})]
+          end
+
+        build_stream_response(chunks)
+      end
+
+      {:ok, pid} =
+        start_provider(
+          tmp_dir: dir,
+          llm_client: client,
+          tools: [spec],
+          config: agent_config(tool_approval: :destructive, destructive_tools: [])
+        )
+
+      assert :ok = Native.send_prompt(pid, "Run custom tool")
+
+      assert_receive {:agent_provider_event,
+                      %Event.ToolApproval{
+                        tool_call_id: "tc_custom_approval",
+                        reply_to: reply_to
+                      }},
+                     1_000
+
+      refute_receive :custom_approval_ran, 50
+      send(reply_to, {:tool_approval_response, "tc_custom_approval", :approve})
+      events = collect_run_events()
+
+      assert_received :custom_approval_ran
+
+      assert Enum.any?(
+               events,
+               &match?(%Event.ToolEnd{name: "custom_approval", is_error: false}, &1)
+             )
     end
 
     test "approval-required tools wait while allowed tools continue", %{tmp_dir: dir} do

--- a/test/minga_agent/tool/registry_test.exs
+++ b/test/minga_agent/tool/registry_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaAgent.Tool.RegistryTest do
   use ExUnit.Case, async: true
 
+  alias MingaAgent.Tool.Executor
   alias MingaAgent.Tool.Registry
   alias MingaAgent.Tool.Spec
 
@@ -35,6 +36,15 @@ defmodule MingaAgent.Tool.RegistryTest do
       spec = sample_spec()
       assert :ok = Registry.register(table, spec)
       assert {:ok, ^spec} = Registry.lookup(table, "test_tool")
+    end
+
+    test "revalidates directly constructed spec structs", %{table: table} do
+      malformed = %{sample_spec() | approval_level: :invalid}
+
+      assert {:error, {:invalid_spec, {:invalid_approval_level, :invalid}}} =
+               Registry.register(table, malformed)
+
+      assert :error = Registry.lookup(table, malformed.name)
     end
 
     test "same-source registration replaces an existing custom tool", %{table: table} do
@@ -260,6 +270,37 @@ defmodule MingaAgent.Tool.RegistryTest do
       assert write_spec.context_requirements == [:tool_context]
       assert is_function(write_spec.build, 1)
     end
+
+    test "startup builds no callbacks and execution builds only the requested factory" do
+      handler_id = "tool-factory-test-#{System.unique_integer([:positive])}"
+      test_pid = self()
+
+      :ok =
+        :telemetry.attach(
+          handler_id,
+          [:minga, :agent, :tool, :callback_built],
+          fn event, measurements, metadata, _config ->
+            send(test_pid, {:factory_built, self(), event, measurements, metadata})
+          end,
+          nil
+        )
+
+      on_exit(fn -> :telemetry.detach(handler_id) end)
+
+      table = :"registry_allocation_#{System.unique_integer([:positive])}"
+      registry_pid = start_supervised!({Registry, name: table})
+      :sys.get_state(registry_pid)
+      refute_received {:factory_built, ^registry_pid, _, _, _}
+
+      caller = self()
+      assert {:ok, result} = Executor.execute("describe_runtime", %{}, table)
+      assert result =~ "Minga Runtime"
+
+      assert_receive {:factory_built, ^caller, [:minga, :agent, :tool, :callback_built],
+                      %{count: 1}, %{name: "describe_runtime", source: :builtin}}
+
+      refute_received {:factory_built, ^caller, _, _, _}
+    end
   end
 
   describe "from_req_tool/1" do
@@ -281,7 +322,7 @@ defmodule MingaAgent.Tool.RegistryTest do
       assert spec.approval_level == :auto
     end
 
-    test "marks destructive tools with :ask approval" do
+    test "derives canonical destructive approval" do
       req_tool =
         ReqLLM.Tool.new!(
           name: "write_file",

--- a/test/minga_agent/tool/spec_test.exs
+++ b/test/minga_agent/tool/spec_test.exs
@@ -33,6 +33,18 @@ defmodule MingaAgent.Tool.SpecTest do
     assert {:ok, {"/tmp/demo", %{"path" => "file.txt"}}} = callback.(%{"path" => "file.txt"})
   end
 
+  test "rejects conflicting callback and build declarations" do
+    assert {:error, {:conflicting_execution_declarations, [:build, :callback]}} =
+             Spec.new(
+               source: :config,
+               name: "conflicting",
+               description: "Conflicting",
+               parameter_schema: %{},
+               callback: fn _args -> :callback end,
+               build: fn _context -> fn _args -> :build end end
+             )
+  end
+
   test "rejects invalid context-bound build functions" do
     assert {:error, {:invalid_build, :not_a_function}} =
              Spec.new(

--- a/test/minga_agent/tool_packs/lsp_test.exs
+++ b/test/minga_agent/tool_packs/lsp_test.exs
@@ -32,9 +32,9 @@ defmodule MingaAgent.ToolPacks.LSPTest do
   test "registers LSP tools as source-owned specs with stable metadata", %{table: table} do
     assert :ok = LSP.register(table)
 
-    before_metadata =
-      MingaAgent.Tools.all(project_root: ".")
-      |> Map.new(fn tool -> {tool.name, {tool.description, tool.parameter_schema}} end)
+    canonical_metadata =
+      MingaAgent.Tools.specs()
+      |> Map.new(fn spec -> {spec.name, {spec.description, spec.parameter_schema}} end)
 
     for name <- LSP.tool_names() do
       assert {:ok, %Spec{} = spec} = Registry.lookup(table, name)
@@ -42,7 +42,7 @@ defmodule MingaAgent.ToolPacks.LSPTest do
       assert spec.category == :lsp
       assert spec.context_requirements == [:tool_context]
       assert spec.metadata.pack == :lsp_tools
-      assert {spec.description, spec.parameter_schema} == Map.fetch!(before_metadata, name)
+      assert {spec.description, spec.parameter_schema} == Map.fetch!(canonical_metadata, name)
     end
 
     for name <- ~w(diagnostics definition references hover document_symbols workspace_symbols) do

--- a/test/minga_agent/tool_packs/read_only_test.exs
+++ b/test/minga_agent/tool_packs/read_only_test.exs
@@ -32,16 +32,16 @@ defmodule MingaAgent.ToolPacks.ReadOnlyTest do
   test "registers read-only tools as source-owned specs with stable metadata", %{table: table} do
     assert :ok = ReadOnly.register(table)
 
-    before_metadata =
-      MingaAgent.Tools.all(project_root: ".")
-      |> Map.new(fn tool -> {tool.name, {tool.description, tool.parameter_schema}} end)
+    canonical_metadata =
+      MingaAgent.Tools.specs()
+      |> Map.new(fn spec -> {spec.name, {spec.description, spec.parameter_schema}} end)
 
     for name <- ReadOnly.tool_names() do
       assert {:ok, %Spec{} = spec} = Registry.lookup(table, name)
       assert spec.source == ReadOnly.source()
       assert spec.approval_level == :auto
       assert spec.metadata == %{pack: :read_only_tools}
-      assert {spec.description, spec.parameter_schema} == Map.fetch!(before_metadata, name)
+      assert {spec.description, spec.parameter_schema} == Map.fetch!(canonical_metadata, name)
     end
 
     assert {:ok, find_spec} = Registry.lookup(table, "find")

--- a/test/minga_agent/tools/apply_diff_test.exs
+++ b/test/minga_agent/tools/apply_diff_test.exs
@@ -202,8 +202,8 @@ defmodule MingaAgent.Tools.ApplyDiffTest do
     test "registers an apply_diff tool callback", %{tmp_dir: dir} do
       path = Path.join(dir, "tool.txt")
       File.write!(path, "old\n")
-      tools = Tools.all(project_root: dir)
-      tool = Enum.find(tools, &(&1.name == "apply_diff"))
+      context = MingaAgent.Tool.Context.new(project_root: dir)
+      spec = Enum.find(Tools.all(), &(&1.name == "apply_diff"))
 
       diff = """
       @@ -1,1 +1,1 @@
@@ -211,8 +211,9 @@ defmodule MingaAgent.Tools.ApplyDiffTest do
       +new
       """
 
-      assert tool != nil
-      assert {:ok, message} = tool.callback.(%{"path" => "tool.txt", "diff" => diff})
+      assert spec != nil
+      callback = MingaAgent.Tool.Spec.build_callback(spec, context)
+      assert {:ok, message} = callback.(%{"path" => "tool.txt", "diff" => diff})
       assert message =~ "applied 1 diff hunk"
       assert File.read!(path) == "new\n"
     end

--- a/test/minga_agent/tools/multi_edit_file_test.exs
+++ b/test/minga_agent/tools/multi_edit_file_test.exs
@@ -172,10 +172,10 @@ defmodule MingaAgent.Tools.MultiEditFileTest do
       {:ok, fork_store} = start_supervised(MingaAgent.BufferForkStore)
       Process.exit(fork_store, :kill)
 
-      tools = Tools.all(project_root: root, fork_store: fork_store)
+      context = MingaAgent.Tool.Context.new(project_root: root, fork_store: fork_store)
 
       assert {:error, message} =
-               call_tool(tools, "multi_edit_file", %{
+               call_tool(context, "multi_edit_file", %{
                  "path" => "lib/unopened.txt",
                  "edits" => [%{"old_text" => "old", "new_text" => "new"}]
                })
@@ -185,9 +185,10 @@ defmodule MingaAgent.Tools.MultiEditFileTest do
     end
   end
 
-  defp call_tool(tools, name, args) do
-    tool = Enum.find(tools, &(&1.name == name))
-    tool.callback.(args)
+  defp call_tool(context, name, args) do
+    spec = Enum.find(Tools.all(), &(&1.name == name))
+    callback = MingaAgent.Tool.Spec.build_callback(spec, context)
+    callback.(args)
   end
 
   defp buffer_content(path) do

--- a/test/minga_agent/tools/project_view_process_routing_test.exs
+++ b/test/minga_agent/tools/project_view_process_routing_test.exs
@@ -21,28 +21,30 @@ defmodule MingaAgent.Tools.ProjectViewProcessRoutingTest do
         env: [{"PROJECT_VIEW_SENTINEL", "present"}]
       )
 
-    tools =
-      Tools.all(
+    context =
+      MingaAgent.Tool.Context.new(
         project_root: root,
         project_view: view,
-        process_backend: RecordingProcessBackend
+        metadata: %{process_backend: RecordingProcessBackend}
       )
 
-    %{root: root, tools: tools, working_dir: working_dir}
+    %{root: root, context: context, working_dir: working_dir}
   end
 
   test "find, grep, and shell receive ProjectView execution context", %{
     root: root,
-    tools: tools,
+    context: context,
     working_dir: working_dir
   } do
-    assert {:ok, find_result} = call_tool(tools, "find", %{"pattern" => "*.txt", "path" => "lib"})
+    assert {:ok, find_result} =
+             call_tool(context, "find", %{"pattern" => "*.txt", "path" => "lib"})
+
     assert find_result =~ "path=#{Path.join(working_dir, "lib")}"
     assert find_result =~ "filter_root: #{inspect(Path.join(root, "lib"))}"
     assert find_result =~ "ProjectView workspace 42"
 
     assert {:ok, grep_result} =
-             call_tool(tools, "grep", %{
+             call_tool(context, "grep", %{
                "pattern" => "needle",
                "path" => "lib",
                "case_sensitive" => false
@@ -52,18 +54,17 @@ defmodule MingaAgent.Tools.ProjectViewProcessRoutingTest do
     assert grep_result =~ "case_sensitive"
     assert grep_result =~ "ProjectView workspace 42"
 
-    assert {:ok, shell_result} = call_tool(tools, "shell", %{"command" => "echo hello"})
+    assert {:ok, shell_result} = call_tool(context, "shell", %{"command" => "echo hello"})
     assert shell_result =~ "cwd=#{working_dir}"
     assert shell_result =~ "PROJECT_VIEW_SENTINEL"
     assert shell_result =~ "ProjectView workspace 42"
   end
 
-  @spec call_tool([ReqLLM.Tool.t()], String.t(), map()) ::
+  @spec call_tool(MingaAgent.Tool.Context.t(), String.t(), map()) ::
           MingaAgent.Tools.ProcessBackend.result()
-  defp call_tool(tools, name, args) do
-    tools
-    |> Enum.find(&(&1.name == name))
-    |> Map.fetch!(:callback)
-    |> then(& &1.(args))
+  defp call_tool(context, name, args) do
+    spec = Enum.find(Tools.all(), &(&1.name == name))
+    callback = MingaAgent.Tool.Spec.build_callback(spec, context)
+    callback.(args)
   end
 end

--- a/test/minga_agent/tools/project_view_routing_test.exs
+++ b/test/minga_agent/tools/project_view_routing_test.exs
@@ -48,7 +48,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
         env: [{"PROJECT_VIEW_SENTINEL", "present"}]
       )
 
-    tools = Tools.all(project_root: root, project_view: view)
+    tools = build_tools(project_root: root, project_view: view)
     %{root: root, working_dir: working_dir, tools: tools}
   end
 
@@ -265,7 +265,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
         workspace_id: 99
       )
 
-    tools = Tools.all(project_root: root, project_view: view)
+    tools = build_tools(project_root: root, project_view: view)
 
     for {name, args, expected} <- [
           {"read_file", %{"path" => "lib/view_only.txt"}, ":read_failed"},
@@ -313,7 +313,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     File.write!(target_path, "one two one\n")
 
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
 
     assert {:ok, result} =
              call_tool(tools, "multi_edit_file", %{
@@ -334,7 +334,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     File.write!(target_path, "one\ntwo\n")
 
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
 
     diff = """
     @@ -1,2 +1,2 @@
@@ -361,7 +361,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     File.write!(Path.join(root, "lib/deleted.txt"), "delete me\n")
 
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
 
     assert {:ok, write_result} =
              call_tool(tools, "write_file", %{
@@ -417,7 +417,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     File.write!(Path.join(root, "lib/delete.txt"), "root delete\n")
 
     {:ok, view} = MingaAgent.ProjectView.overlay(root)
-    tools = Tools.all(project_root: root, project_view: view)
+    tools = build_tools(project_root: root, project_view: view)
 
     assert {:ok, _} =
              call_tool(tools, "write_file", %{
@@ -472,7 +472,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     File.write!(Path.join(root, "node_modules/leaked.txt"), "shared_secret_token\n")
 
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
 
     assert {:ok, write_result} =
              call_tool(tools, "write_file", %{
@@ -555,7 +555,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
       )
 
     {:ok, store} = start_supervised(BufferForkStore)
-    tools = Tools.all(project_root: root, fork_store: store)
+    tools = build_tools(project_root: root, fork_store: store)
 
     assert {:ok, write_result} =
              call_tool(tools, "write_file", %{
@@ -602,7 +602,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     on_exit(fn -> GitStub.clear(root) end)
 
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
 
     assert {:error, message} = call_tool(tools, "git_diff", %{"staged" => true})
     assert message =~ "staged=true is unavailable"
@@ -620,7 +620,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     File.write!(Path.join(root, "old/file with space.txt"), "old spaced path\n")
 
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
 
     assert {:ok, _result} =
              call_tool(tools, "write_file", %{
@@ -677,7 +677,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
       )
 
     assert {:ok, [%{path: "lib/link.txt"}]} = MingaAgent.ProjectView.diff(view)
-    tools = Tools.all(project_root: root, project_view: view)
+    tools = build_tools(project_root: root, project_view: view)
     assert {:error, message} = call_tool(tools, "git_diff", %{})
     assert message =~ "refusing to diff symlink path lib/link.txt"
     refute message =~ "outside secret token"
@@ -688,7 +688,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     {_out, 0} = System.cmd("git", ["init"], cd: root, stderr_to_stdout: true)
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
     big_content = String.duplicate("large diff line\n", 500)
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
 
     assert {:ok, _result} =
              call_tool(tools, "write_file", %{"path" => "big.txt", "content" => big_content})
@@ -708,7 +708,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
 
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
     oversized = String.duplicate("oversized secret token\n", 20)
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
 
     assert {:ok, _result} =
              call_tool(tools, "write_file", %{"path" => "big.txt", "content" => oversized})
@@ -735,7 +735,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
 
     {:ok, store} = start_supervised(BufferForkStore)
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, fork_store: store, changeset: changeset)
+    tools = build_tools(project_root: root, fork_store: store, changeset: changeset)
     oversized = String.duplicate("combined fork secret\n", 20)
 
     assert {:ok, write_result} =
@@ -766,7 +766,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
       )
 
     {:ok, view} = MingaAgent.ProjectView.overlay(root)
-    tools = Tools.all(project_root: root, project_view: view)
+    tools = build_tools(project_root: root, project_view: view)
     oversized = String.duplicate("project view fork secret\n", 20)
 
     assert {:ok, write_result} =
@@ -802,7 +802,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
 
     {:ok, store} = start_supervised(BufferForkStore)
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, fork_store: store, changeset: changeset)
+    tools = build_tools(project_root: root, fork_store: store, changeset: changeset)
 
     assert {:ok, write_result} =
              call_tool(tools, "write_file", %{
@@ -840,7 +840,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     on_exit(fn -> GitStub.clear(root) end)
 
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
     ref = Process.monitor(changeset)
     Process.exit(changeset, :kill)
     assert_receive {:DOWN, ^ref, :process, ^changeset, _reason}
@@ -857,7 +857,7 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
     File.write!(target_path, "one two one\n")
 
     {:ok, changeset} = start_supervised({Changeset.Server, project_root: root})
-    tools = Tools.all(project_root: root, changeset: changeset)
+    tools = build_tools(project_root: root, changeset: changeset)
     ref = Process.monitor(changeset)
     Process.exit(changeset, :kill)
     assert_receive {:DOWN, ^ref, :process, ^changeset, _reason}
@@ -894,12 +894,23 @@ defmodule MingaAgent.Tools.ProjectViewRoutingTest do
         workspace_id: 100
       )
 
-    tools = Tools.all(project_root: root, project_view: view)
+    tools = build_tools(project_root: root, project_view: view)
 
     assert {:error, message} = call_tool(tools, "shell", %{"command" => "cat lib/dirty.txt"})
     assert message =~ "project_view_unavailable"
     assert File.read!(file) == "original\n"
     assert Minga.Buffer.content(buffer) == "dirty\n"
+  end
+
+  defp build_tools(opts) do
+    context =
+      opts
+      |> Keyword.take([:project_root, :project_view, :fork_store, :changeset])
+      |> MingaAgent.Tool.Context.new()
+
+    Enum.map(Tools.all(), fn spec ->
+      %{name: spec.name, callback: MingaAgent.Tool.Spec.build_callback(spec, context)}
+    end)
   end
 
   defp call_tool(tools, name, args) do

--- a/test/minga_agent/tools_test.exs
+++ b/test/minga_agent/tools_test.exs
@@ -135,11 +135,12 @@ defmodule MingaAgent.ToolsTest do
       assert "code_actions" in names
     end
 
-    test "all tools have descriptions and callbacks", %{tmp_dir: dir} do
-      for tool <- Tools.all(project_root: dir) do
-        assert is_binary(tool.description)
-        assert String.length(tool.description) > 0
-        assert is_function(tool.callback, 1)
+    test "all tools remain provider-neutral source declarations", %{tmp_dir: dir} do
+      for spec <- Tools.all(project_root: dir) do
+        assert %MingaAgent.Tool.Spec{} = spec
+        assert is_binary(spec.description)
+        assert String.length(spec.description) > 0
+        assert is_function(spec.build, 1)
       end
     end
 


### PR DESCRIPTION
# TL;DR
Agent tools now have one canonical `Tool.Spec` declaration. Registries and bundled packs consume those specs directly, while native provider adapters create `ReqLLM.Tool` values only at the external boundary.

Closes #2849

## Context
The previous flow built complete `ReqLLM.Tool` catalogs, converted them into registry specs, then rebuilt provider tools and callbacks later. That duplicated metadata and allowed callback declarations to disagree with callback factories.

## Changes
- Declare builtin and bundled tools once as `Tool.Spec` values with context-bound callback factories.
- Make registry startup and tool packs consume canonical specs without constructing callbacks.
- Move `ReqLLM.Tool` construction into the native ReqLLM adapter and preserve MCP/provider boundary compatibility.
- Remove duplicated category, capability, approval, context requirement, and callback lookup declarations.
- Remove the stored callback field from `Tool.Spec`; legacy callback input is converted into a factory, and conflicting callback/build input is rejected.
- Preserve configurable destructive-tool approval behavior and canonical approval metadata.
- Add deterministic telemetry-based allocation evidence showing startup builds no callbacks and one execution builds only the requested callback.

## Verification
- `make lint`
- `mix test.llm` (9,209 tests, 0 failures, 1 skipped)
- Focused registry, executor, tool-pack, builtin-tool, ephemeral-session, and native-provider contract tests

## Acceptance Criteria Addressed
- Every builtin and bundled tool is declared once as `Tool.Spec` with one context-bound callback factory. ✅
- The registry stores `Tool.Spec` directly and provider adapters construct `ReqLLM.Tool` only at the external provider boundary. ✅
- Parallel metadata and execution declarations are removed or derived from the canonical spec. ✅
- Existing tool names, schemas, approvals, capabilities, and execution behavior remain unchanged. ✅
- Allocation evidence covers startup and one representative tool execution. ✅
