### PR TITLE
fix(agent): make event log durability explicit

### DIFF
--- a/lib/minga_agent/event_log.ex
+++ b/lib/minga_agent/event_log.ex
@@ -17,6 +17,9 @@ defmodule MingaAgent.EventLog do
   @default_db_dir Path.expand("~/.local/share/minga")
   @db_filename "agent_events.db"
   @default_max_queue_size 1_000
+  @default_max_queue_bytes 8 * 1024 * 1024
+  @max_event_bytes 256 * 1024
+  @max_payload_depth 64
   @default_writer_restart_delay_ms 1_000
   @retention_sweep_interval_ms :timer.hours(1)
   @initial_retention_sweep_delay_ms :timer.seconds(5)
@@ -26,7 +29,8 @@ defmodule MingaAgent.EventLog do
   @type receipt :: reference()
   @type persistence_result ::
           {:persisted, pos_integer()} | {:error, {:persistence_failed, term()}}
-  @type admission_error :: {:error, :overloaded | :unavailable}
+  @type admission_error ::
+          {:error, :overloaded | :unavailable | :payload_too_large | :invalid_payload}
   @type admission_result :: {:queued, receipt()} | admission_error()
   @type best_effort_admission_result :: :queued | admission_error()
 
@@ -65,8 +69,13 @@ defmodule MingaAgent.EventLog do
           admission_result()
   def record(session_id, event_type, payload \\ %{}, server \\ __MODULE__)
       when is_binary(session_id) and is_atom(event_type) and is_map(payload) do
-    record = EventRecord.new(session_id, event_type, sanitize_payload(payload))
-    GenServer.call(server, {:admit, :critical, record})
+    with {:ok, raw_bytes} <- bounded_raw_payload_size(payload) do
+      GenServer.call(
+        server,
+        {:admit_payload, :critical, session_id, event_type, payload, raw_bytes},
+        :infinity
+      )
+    end
   catch
     :exit, _reason -> {:error, :unavailable}
   end
@@ -80,8 +89,13 @@ defmodule MingaAgent.EventLog do
           best_effort_admission_result()
   def record_best_effort(session_id, event_type, payload \\ %{}, server \\ __MODULE__)
       when is_binary(session_id) and is_atom(event_type) and is_map(payload) do
-    record = EventRecord.new(session_id, event_type, sanitize_payload(payload))
-    GenServer.call(server, {:admit, :best_effort, record})
+    with {:ok, raw_bytes} <- bounded_raw_payload_size(payload) do
+      GenServer.call(
+        server,
+        {:admit_payload, :best_effort, session_id, event_type, payload, raw_bytes},
+        :infinity
+      )
+    end
   catch
     :exit, _reason -> {:error, :unavailable}
   end
@@ -132,20 +146,61 @@ defmodule MingaAgent.EventLog do
     Process.flag(:trap_exit, true)
     path = db_path(opts)
     max_queue_size = Keyword.get(opts, :max_queue_size, @default_max_queue_size)
+    max_queue_bytes = Keyword.get(opts, :max_queue_bytes, @default_max_queue_bytes)
 
     retention_days =
       Keyword.get_lazy(opts, :retention_days, fn -> Minga.Config.get(:event_retention_days) end)
 
-    initialize(opts, path, retention_days, max_queue_size)
+    initialize(opts, path, retention_days, max_queue_size, max_queue_bytes)
   end
 
   @impl GenServer
-  def handle_call({:admit, _kind, _record}, _from, %State{status: :unavailable} = state) do
+  @spec handle_call(term(), GenServer.from(), State.t()) ::
+          {:reply, term(), State.t()} | {:noreply, State.t()}
+  def handle_call(
+        {:admit_payload, _kind, _session_id, _event_type, _payload, _raw_bytes},
+        _from,
+        %State{
+          status: :unavailable
+        } = state
+      ) do
     {:reply, {:error, :unavailable}, state}
   end
 
-  def handle_call({:admit, kind, record}, from, state) do
-    admit(kind, record, from, state, outstanding_count(state) < state.max_queue_size)
+  def handle_call(
+        {:admit_payload, kind, session_id, event_type, payload, raw_bytes},
+        from,
+        state
+      ) do
+    admit_payload(
+      kind,
+      session_id,
+      event_type,
+      payload,
+      raw_bytes,
+      from,
+      state,
+      State.admission_available?(state, raw_bytes)
+    )
+  end
+
+  def handle_call(
+        {:admit, _kind, _record, _payload_bytes},
+        _from,
+        %State{status: :unavailable} = state
+      ) do
+    {:reply, {:error, :unavailable}, state}
+  end
+
+  def handle_call({:admit, kind, record, payload_bytes}, from, state) do
+    admit(
+      kind,
+      record,
+      payload_bytes,
+      from,
+      state,
+      State.admission_available?(state, payload_bytes)
+    )
   end
 
   def handle_call(:await_idle, from, state) do
@@ -162,6 +217,7 @@ defmodule MingaAgent.EventLog do
   def handle_call(:writer_pid, _from, state), do: {:reply, state.writer, state}
 
   @impl GenServer
+  @spec handle_info(term(), State.t()) :: {:noreply, State.t()}
   def handle_info({:event_log_writer_ready, writer}, %{writer: writer} = state) do
     Minga.Log.info(:agent, "[AgentEventLog] started, logging to #{state.path}")
     {:noreply, state |> State.writer_ready() |> dispatch_next()}
@@ -231,21 +287,24 @@ defmodule MingaAgent.EventLog do
   end
 
   @impl GenServer
+  @spec terminate(term(), State.t()) :: :ok
   def terminate(_reason, state) do
     cancel_timer(state.sweep_ref)
     stop_writer(state.writer)
     :ok
   end
 
-  @spec initialize(keyword(), String.t(), pos_integer(), term()) ::
+  @spec initialize(keyword(), String.t(), pos_integer(), term(), term()) ::
           {:ok, State.t()} | {:stop, term()}
-  defp initialize(opts, path, retention_days, max_queue_size)
-       when is_integer(max_queue_size) and max_queue_size > 0 do
+  defp initialize(opts, path, retention_days, max_queue_size, max_queue_bytes)
+       when is_integer(max_queue_size) and max_queue_size > 0 and
+              is_integer(max_queue_bytes) and max_queue_bytes > 0 do
     state =
       State.new(
         path,
         retention_days,
         max_queue_size,
+        max_queue_bytes,
         Keyword.get(opts, :store_backend, Store),
         Keyword.get(opts, :store_backend_opts, []),
         Keyword.get(opts, :writer_restart_delay_ms, @default_writer_restart_delay_ms)
@@ -257,35 +316,66 @@ defmodule MingaAgent.EventLog do
     {:ok, State.schedule_sweep(state, sweep_ref)}
   end
 
-  defp initialize(_opts, _path, _retention_days, max_queue_size) do
-    {:stop, {:invalid_max_queue_size, max_queue_size}}
+  defp initialize(_opts, _path, _retention_days, max_queue_size, max_queue_bytes) do
+    {:stop, {:invalid_queue_limits, max_queue_size, max_queue_bytes}}
   end
 
-  @spec admit(:critical | :best_effort, EventRecord.t(), GenServer.from(), State.t(), boolean()) ::
-          {:reply, admission_result() | best_effort_admission_result(), State.t()}
-  defp admit(_kind, _record, _from, state, false), do: {:reply, {:error, :overloaded}, state}
+  @spec admit_payload(
+          :critical | :best_effort,
+          String.t(),
+          EventRecord.event_type(),
+          map(),
+          non_neg_integer(),
+          GenServer.from(),
+          State.t(),
+          boolean()
+        ) :: {:reply, admission_result() | best_effort_admission_result(), State.t()}
+  defp admit_payload(
+         _kind,
+         _session_id,
+         _event_type,
+         _payload,
+         _raw_bytes,
+         _from,
+         state,
+         false
+       ),
+       do: {:reply, {:error, :overloaded}, state}
 
-  defp admit(:critical, record, {caller, _tag}, state, true) do
+  defp admit_payload(kind, session_id, event_type, payload, _raw_bytes, from, state, true) do
+    with {:ok, sanitized, payload_bytes} <- prepare_payload(payload),
+         true <- State.admission_available?(state, payload_bytes) do
+      record = EventRecord.new(session_id, event_type, sanitized)
+      admit(kind, record, payload_bytes, from, state, true)
+    else
+      false -> {:reply, {:error, :overloaded}, state}
+      {:error, reason} -> {:reply, {:error, reason}, state}
+    end
+  end
+
+  @spec admit(
+          :critical | :best_effort,
+          EventRecord.t(),
+          non_neg_integer(),
+          GenServer.from(),
+          State.t(),
+          boolean()
+        ) :: {:reply, admission_result() | best_effort_admission_result(), State.t()}
+  defp admit(_kind, _record, _payload_bytes, _from, state, false),
+    do: {:reply, {:error, :overloaded}, state}
+
+  defp admit(:critical, record, payload_bytes, {caller, _tag}, state, true) do
     receipt = make_ref()
-    entry = {:critical, receipt, caller, record.event_type, record}
+    entry = {:critical, receipt, caller, record.event_type, payload_bytes, record}
     state = state |> State.enqueue(entry) |> dispatch_next()
     {:reply, {:queued, receipt}, state}
   end
 
-  defp admit(:best_effort, record, _from, state, true) do
-    entry = {:best_effort, record.event_type, record}
+  defp admit(:best_effort, record, payload_bytes, _from, state, true) do
+    entry = {:best_effort, record.event_type, payload_bytes, record}
     state = state |> State.enqueue(entry) |> dispatch_next()
     {:reply, :queued, state}
   end
-
-  @spec outstanding_count(State.t()) :: non_neg_integer()
-  defp outstanding_count(state) do
-    :queue.len(state.queue) + in_flight_event_count(state.in_flight)
-  end
-
-  @spec in_flight_event_count(State.in_flight() | nil) :: 0 | 1
-  defp in_flight_event_count({:event, _token, _entry}), do: 1
-  defp in_flight_event_count(_in_flight), do: 0
 
   @spec dispatch_next(State.t()) :: State.t()
   defp dispatch_next(%State{status: :ready, in_flight: nil} = state) do
@@ -317,31 +407,36 @@ defmodule MingaAgent.EventLog do
   end
 
   @spec entry_record(State.entry()) :: EventRecord.t()
-  defp entry_record({:critical, _receipt, _caller, _event_type, record}), do: record
-  defp entry_record({:best_effort, _event_type, record}), do: record
+  defp entry_record({:critical, _receipt, _caller, _event_type, _bytes, record}), do: record
+  defp entry_record({:best_effort, _event_type, _bytes, record}), do: record
 
   @spec acknowledge_entry(State.entry(), EventRecord.event_type(), term()) :: :ok
-  defp acknowledge_entry({:critical, receipt, caller, _type, _record}, event_type, {:ok, id}) do
+  defp acknowledge_entry(
+         {:critical, receipt, caller, _type, _bytes, _record},
+         event_type,
+         {:ok, id}
+       ) do
     send(caller, {:event_log_commit, receipt, event_type, {:persisted, id}})
     :ok
   end
 
   defp acknowledge_entry(
-         {:critical, receipt, caller, _type, _record},
+         {:critical, receipt, caller, _type, _bytes, _record},
          event_type,
          {:error, reason}
        ) do
     send_persistence_failure(caller, receipt, event_type, reason)
   end
 
-  defp acknowledge_entry({:best_effort, _type, _record}, event_type, {:error, reason}) do
+  defp acknowledge_entry({:best_effort, _type, _bytes, _record}, event_type, {:error, reason}) do
     Minga.Log.warning(
       :agent,
       "[AgentEventLog] best-effort #{event_type} persistence failed: #{inspect(reason)}"
     )
   end
 
-  defp acknowledge_entry({:best_effort, _type, _record}, _event_type, {:ok, _id}), do: :ok
+  defp acknowledge_entry({:best_effort, _type, _bytes, _record}, _event_type, {:ok, _id}),
+    do: :ok
 
   @spec send_persistence_failure(pid(), receipt(), EventRecord.event_type(), term()) :: :ok
   defp send_persistence_failure(caller, receipt, event_type, reason) do
@@ -378,7 +473,7 @@ defmodule MingaAgent.EventLog do
   @spec fail_all_events(State.t(), term()) :: State.t()
   defp fail_all_events(state, reason) do
     Enum.each(outstanding_entries(state), &fail_entry(&1, reason))
-    State.clear_work(state)
+    State.clear_event_work(state)
   end
 
   @spec outstanding_entries(State.t()) :: [State.entry()]
@@ -389,11 +484,11 @@ defmodule MingaAgent.EventLog do
   defp outstanding_entries(state), do: :queue.to_list(state.queue)
 
   @spec fail_entry(State.entry(), term()) :: :ok
-  defp fail_entry({:critical, receipt, caller, event_type, _record}, reason) do
+  defp fail_entry({:critical, receipt, caller, event_type, _bytes, _record}, reason) do
     send_persistence_failure(caller, receipt, event_type, reason)
   end
 
-  defp fail_entry({:best_effort, _event_type, _record}, _reason), do: :ok
+  defp fail_entry({:best_effort, _event_type, _bytes, _record}, _reason), do: :ok
 
   @spec start_writer(State.t()) :: State.t()
   defp start_writer(state) do
@@ -519,26 +614,111 @@ defmodule MingaAgent.EventLog do
                  ~w(api_key apikey token access_token refresh_token secret password credential credentials authorization remote_token)
                )
 
-  @spec sanitize_payload(term()) :: term()
-  defp sanitize_payload(%_{} = struct), do: sanitize_payload(Map.from_struct(struct))
+  @spec bounded_raw_payload_size(map()) ::
+          {:ok, non_neg_integer()} | {:error, :payload_too_large | :invalid_payload}
+  defp bounded_raw_payload_size(payload) do
+    with {:ok, raw_bytes} <- external_payload_size(payload),
+         :ok <- enforce_event_size(raw_bytes) do
+      {:ok, raw_bytes}
+    else
+      {:error, :payload_too_large} = error -> error
+      {:error, _reason} -> {:error, :invalid_payload}
+    end
+  end
 
-  defp sanitize_payload(map) when is_map(map) do
-    Map.new(map, fn {key, value} ->
-      string_key = to_string(key)
-      sanitized = if secret_key?(string_key), do: "[REDACTED]", else: sanitize_payload(value)
-      {string_key, sanitized}
+  @spec prepare_payload(map()) ::
+          {:ok, map(), non_neg_integer()} | {:error, :payload_too_large | :invalid_payload}
+  defp prepare_payload(payload) do
+    with {:ok, sanitized} <- sanitize_payload(payload, 0),
+         {:ok, encoded_bytes} <- encoded_payload_size(sanitized),
+         :ok <- enforce_event_size(encoded_bytes) do
+      {:ok, sanitized, encoded_bytes}
+    else
+      {:error, :payload_too_large} = error -> error
+      {:error, _reason} -> {:error, :invalid_payload}
+    end
+  end
+
+  @spec external_payload_size(term()) :: {:ok, non_neg_integer()} | {:error, term()}
+  defp external_payload_size(payload) do
+    {:ok, :erlang.external_size(payload)}
+  rescue
+    _exception -> {:error, :invalid_external_term}
+  end
+
+  @spec encoded_payload_size(map()) :: {:ok, non_neg_integer()} | {:error, term()}
+  defp encoded_payload_size(payload) do
+    {:ok, payload |> JSON.encode!() |> byte_size()}
+  rescue
+    _exception -> {:error, :not_json_encodable}
+  end
+
+  @spec enforce_event_size(non_neg_integer()) :: :ok | {:error, :payload_too_large}
+  defp enforce_event_size(bytes) when bytes <= @max_event_bytes, do: :ok
+  defp enforce_event_size(_bytes), do: {:error, :payload_too_large}
+
+  @spec sanitize_payload(term(), non_neg_integer()) :: {:ok, term()} | {:error, term()}
+  defp sanitize_payload(_payload, depth) when depth > @max_payload_depth,
+    do: {:error, :payload_too_deep}
+
+  defp sanitize_payload(%_{} = struct, depth),
+    do: sanitize_payload(Map.from_struct(struct), depth + 1)
+
+  defp sanitize_payload(map, depth) when is_map(map) do
+    Enum.reduce_while(map, {:ok, %{}}, fn {key, value}, {:ok, sanitized_map} ->
+      with {:ok, string_key} <- sanitize_key(key),
+           {:ok, sanitized} <- sanitize_value(string_key, value, depth) do
+        {:cont, {:ok, Map.put(sanitized_map, string_key, sanitized)}}
+      else
+        {:error, _reason} = error -> {:halt, error}
+      end
     end)
   end
 
-  defp sanitize_payload(list) when is_list(list), do: Enum.map(list, &sanitize_payload/1)
-  defp sanitize_payload(pid) when is_pid(pid), do: "[PID]"
-  defp sanitize_payload(ref) when is_reference(ref), do: "[REFERENCE]"
-  defp sanitize_payload(boolean) when is_boolean(boolean), do: boolean
-  defp sanitize_payload(nil), do: nil
-  defp sanitize_payload(atom) when is_atom(atom), do: Atom.to_string(atom)
-  defp sanitize_payload(binary) when is_binary(binary), do: binary
-  defp sanitize_payload(number) when is_number(number), do: number
-  defp sanitize_payload(other), do: inspect(other)
+  defp sanitize_payload(list, depth) when is_list(list), do: sanitize_list(list, depth, [])
+  defp sanitize_payload(pid, _depth) when is_pid(pid), do: {:ok, "[PID]"}
+  defp sanitize_payload(ref, _depth) when is_reference(ref), do: {:ok, "[REFERENCE]"}
+  defp sanitize_payload(boolean, _depth) when is_boolean(boolean), do: {:ok, boolean}
+  defp sanitize_payload(nil, _depth), do: {:ok, nil}
+  defp sanitize_payload(atom, _depth) when is_atom(atom), do: {:ok, Atom.to_string(atom)}
+
+  defp sanitize_payload(binary, _depth) when is_binary(binary) do
+    if String.valid?(binary), do: {:ok, binary}, else: {:error, :invalid_utf8}
+  end
+
+  defp sanitize_payload(number, _depth) when is_number(number), do: {:ok, number}
+  defp sanitize_payload(_other, _depth), do: {:error, :unsupported_payload_type}
+
+  @spec sanitize_list(term(), non_neg_integer(), [term()]) ::
+          {:ok, [term()]} | {:error, term()}
+  defp sanitize_list([], _depth, acc), do: {:ok, Enum.reverse(acc)}
+
+  defp sanitize_list([value | rest], depth, acc) do
+    case sanitize_payload(value, depth + 1) do
+      {:ok, sanitized} -> sanitize_list(rest, depth, [sanitized | acc])
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp sanitize_list(_improper_tail, _depth, _acc), do: {:error, :improper_list}
+
+  @spec sanitize_key(term()) :: {:ok, String.t()} | {:error, term()}
+  defp sanitize_key(key) when is_binary(key) do
+    if String.valid?(key), do: {:ok, key}, else: {:error, :invalid_utf8_key}
+  end
+
+  defp sanitize_key(key) when is_atom(key) or is_number(key), do: {:ok, to_string(key)}
+  defp sanitize_key(_key), do: {:error, :unsupported_map_key}
+
+  @spec sanitize_value(String.t(), term(), non_neg_integer()) ::
+          {:ok, term()} | {:error, term()}
+  defp sanitize_value(key, value, depth) do
+    if secret_key?(key) do
+      {:ok, "[REDACTED]"}
+    else
+      sanitize_payload(value, depth + 1)
+    end
+  end
 
   @spec secret_key?(String.t()) :: boolean()
   defp secret_key?(key) do

--- a/lib/minga_agent/event_log.ex
+++ b/lib/minga_agent/event_log.ex
@@ -1,37 +1,36 @@
 defmodule MingaAgent.EventLog do
   @moduledoc """
-  Durable append-only event log for agent sessions.
+  Bounded admission owner for the durable agent-session event log.
 
-  Agent sessions call `record/3`, which is a cast to this writer process, so session execution never waits on SQLite I/O. Readers open their own connections through `open_read_connection/1` and query by cursor with `events_after/4`; WAL mode lets those reads proceed without blocking the writer.
+  `record/4` synchronously performs only queue admission. Accepted critical events receive a receipt and later deliver `{:event_log_commit, receipt, event_type, result}` to the admitting process. The result is `{:persisted, event_id}` only after SQLite reports the insert committed, or `{:error, {:persistence_failed, reason}}` when durability cannot be established.
+
+  A separately monitored `MingaAgent.EventLog.Writer` owns the SQLite connection and executes inserts and retention serially. SQLite stalls therefore do not prevent EventLog from admitting work up to its configured bound or rejecting excess work explicitly.
   """
 
   use GenServer
 
   alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.State
   alias MingaAgent.EventLog.Store
+  alias MingaAgent.EventLog.Writer
 
   @default_db_dir Path.expand("~/.local/share/minga")
   @db_filename "agent_events.db"
+  @default_max_queue_size 1_000
+  @default_writer_restart_delay_ms 1_000
   @retention_sweep_interval_ms :timer.hours(1)
   @initial_retention_sweep_delay_ms :timer.seconds(5)
   @health_check_delay_ms :timer.seconds(10)
   @default_health_check :quick
 
-  defmodule State do
-    @moduledoc false
-    @enforce_keys [:path, :retention_days]
-    defstruct [:db, :path, :retention_days, :sweep_ref, pending_events: []]
+  @type receipt :: reference()
+  @type persistence_result ::
+          {:persisted, pos_integer()} | {:error, {:persistence_failed, term()}}
+  @type admission_error :: {:error, :overloaded | :unavailable}
+  @type admission_result :: {:queued, receipt()} | admission_error()
+  @type best_effort_admission_result :: :queued | admission_error()
 
-    @type t :: %__MODULE__{
-            db: Store.db() | nil,
-            path: String.t(),
-            retention_days: pos_integer(),
-            sweep_ref: reference() | nil,
-            pending_events: [{String.t(), EventRecord.event_type(), map()}]
-          }
-  end
-
-  @doc "Starts the event log writer."
+  @doc "Starts the bounded event-log admission owner and its monitored writer."
   @spec start_link(keyword()) :: GenServer.on_start()
   def start_link(opts \\ []) do
     {name, opts} = Keyword.pop(opts, :name, __MODULE__)
@@ -45,7 +44,7 @@ defmodule MingaAgent.EventLog do
     Path.join(dir, @db_filename)
   end
 
-  @doc "Opens a read connection to the agent event database."
+  @doc "Opens an independent read connection to the agent event database."
   @spec open_read_connection(keyword()) :: {:ok, Store.db()} | {:error, term()}
   def open_read_connection(opts \\ []) do
     path = db_path(opts)
@@ -57,14 +56,66 @@ defmodule MingaAgent.EventLog do
     end
   end
 
-  @doc "Records an agent event asynchronously."
-  @spec record(String.t(), EventRecord.event_type(), map(), GenServer.server()) :: :ok
+  @doc """
+  Admits a durability-critical event to the bounded ordered queue.
+
+  This call performs no SQLite work. `{:queued, receipt}` means admission only; the caller later receives the documented `{:event_log_commit, receipt, event_type, result}` message after the writer reports success or failure.
+  """
+  @spec record(String.t(), EventRecord.event_type(), map(), GenServer.server()) ::
+          admission_result()
   def record(session_id, event_type, payload \\ %{}, server \\ __MODULE__)
       when is_binary(session_id) and is_atom(event_type) and is_map(payload) do
-    GenServer.cast(server, {:record, session_id, event_type, sanitize_payload(payload)})
+    record = EventRecord.new(session_id, event_type, sanitize_payload(payload))
+    GenServer.call(server, {:admit, :critical, record})
   catch
-    :exit, _ -> :ok
+    :exit, _reason -> {:error, :unavailable}
   end
+
+  @doc """
+  Admits a high-rate event without requesting a durability acknowledgment.
+
+  The return value reports queue admission only. Accepted events share the same ordered queue as critical events, may be rejected under pressure, and never send a durability acknowledgment.
+  """
+  @spec record_best_effort(String.t(), EventRecord.event_type(), map(), GenServer.server()) ::
+          best_effort_admission_result()
+  def record_best_effort(session_id, event_type, payload \\ %{}, server \\ __MODULE__)
+      when is_binary(session_id) and is_atom(event_type) and is_map(payload) do
+    record = EventRecord.new(session_id, event_type, sanitize_payload(payload))
+    GenServer.call(server, {:admit, :best_effort, record})
+  catch
+    :exit, _reason -> {:error, :unavailable}
+  end
+
+  @doc "Waits for the durability result associated with a critical-event receipt."
+  @spec await(receipt(), timeout()) :: persistence_result() | {:error, :timeout}
+  def await(receipt, timeout \\ 5_000) when is_reference(receipt) do
+    receive do
+      {:event_log_commit, ^receipt, _event_type, result} -> result
+    after
+      timeout -> {:error, :timeout}
+    end
+  end
+
+  @doc "Waits until all currently outstanding event-log work has completed."
+  @spec await_idle(GenServer.server(), timeout()) :: :ok | {:error, :timeout | :unavailable}
+  def await_idle(server \\ __MODULE__, timeout \\ 5_000) do
+    GenServer.call(server, :await_idle, timeout)
+  catch
+    :exit, {:timeout, _details} -> {:error, :timeout}
+    :exit, _reason -> {:error, :unavailable}
+  end
+
+  @doc "Requests an immediate writer restart when admission is unavailable."
+  @spec restart_writer(GenServer.server()) :: :ok | {:error, :unavailable}
+  def restart_writer(server \\ __MODULE__) do
+    GenServer.call(server, :restart_writer)
+  catch
+    :exit, _reason -> {:error, :unavailable}
+  end
+
+  @doc "Returns the current monitored writer pid, primarily for operational inspection."
+  @spec writer_pid(GenServer.server()) :: pid() | nil
+  def writer_pid(server \\ __MODULE__), do: GenServer.call(server, :writer_pid)
 
   @doc "Queries events for a session after the given cursor."
   @spec events_after(Store.db(), String.t(), non_neg_integer(), pos_integer()) ::
@@ -75,74 +126,99 @@ defmodule MingaAgent.EventLog do
   @spec latest_id(Store.db(), String.t()) :: {:ok, non_neg_integer()} | {:error, term()}
   defdelegate latest_id(db, session_id), to: Store
 
-  @impl true
-  @spec init(keyword()) :: {:ok, State.t(), {:continue, {:open_db, keyword()}}}
+  @impl GenServer
+  @spec init(keyword()) :: {:ok, State.t()} | {:stop, term()}
   def init(opts) do
+    Process.flag(:trap_exit, true)
     path = db_path(opts)
+    max_queue_size = Keyword.get(opts, :max_queue_size, @default_max_queue_size)
 
     retention_days =
       Keyword.get_lazy(opts, :retention_days, fn -> Minga.Config.get(:event_retention_days) end)
 
-    {:ok, %State{path: path, retention_days: retention_days}, {:continue, {:open_db, opts}}}
+    initialize(opts, path, retention_days, max_queue_size)
   end
 
-  @impl true
-  def handle_continue({:open_db, opts}, state) do
-    case open_or_recreate(state.path) do
-      {:ok, db} ->
-        sweep_ref = schedule_initial_retention_sweep(opts)
-        schedule_health_check(Keyword.get(opts, :health_check, @default_health_check), opts)
-        Minga.Log.info(:agent, "[AgentEventLog] started, logging to #{state.path}")
-
-        Enum.each(Enum.reverse(state.pending_events), fn {sid, etype, payload} ->
-          record = EventRecord.new(sid, etype, payload)
-          Store.insert(db, record)
-        end)
-
-        {:noreply, %{state | db: db, sweep_ref: sweep_ref, pending_events: []}}
-
-      {:error, reason} ->
-        Minga.Log.warning(:agent, "[AgentEventLog] failed to open database: #{inspect(reason)}")
-        {:stop, reason, state}
-    end
+  @impl GenServer
+  def handle_call({:admit, _kind, _record}, _from, %State{status: :unavailable} = state) do
+    {:reply, {:error, :unavailable}, state}
   end
 
-  @impl true
-  def handle_cast({:record, session_id, event_type, payload}, %State{db: nil} = state) do
-    {:noreply,
-     %{state | pending_events: [{session_id, event_type, payload} | state.pending_events]}}
+  def handle_call({:admit, kind, record}, from, state) do
+    admit(kind, record, from, state, outstanding_count(state) < state.max_queue_size)
   end
 
-  def handle_cast({:record, session_id, event_type, payload}, state) do
-    record = EventRecord.new(session_id, event_type, payload)
+  def handle_call(:await_idle, from, state) do
+    await_idle_reply(state, from, idle?(state))
+  end
 
-    case Store.insert(state.db, record) do
-      {:ok, _id} ->
-        :ok
+  def handle_call(:restart_writer, _from, %State{status: :unavailable} = state) do
+    new_state = state |> State.clear_writer(:starting) |> start_writer()
+    reply = if new_state.status == :unavailable, do: {:error, :unavailable}, else: :ok
+    {:reply, reply, new_state}
+  end
 
-      {:error, reason} ->
-        Minga.Log.warning(:agent, "[AgentEventLog] failed to write event: #{inspect(reason)}")
-    end
+  def handle_call(:restart_writer, _from, state), do: {:reply, :ok, state}
+  def handle_call(:writer_pid, _from, state), do: {:reply, state.writer, state}
+
+  @impl GenServer
+  def handle_info({:event_log_writer_ready, writer}, %{writer: writer} = state) do
+    Minga.Log.info(:agent, "[AgentEventLog] started, logging to #{state.path}")
+    {:noreply, state |> State.writer_ready() |> dispatch_next()}
+  end
+
+  def handle_info({:event_log_writer_unavailable, writer, reason}, %{writer: writer} = state) do
+    Minga.Log.warning(:agent, "[AgentEventLog] failed to open database: #{inspect(reason)}")
+    Process.demonitor(state.writer_ref, [:flush])
+
+    state =
+      state
+      |> fail_all_events({:writer_start_failed, reason})
+      |> State.clear_writer(:unavailable)
+      |> schedule_writer_restart()
+      |> notify_idle_waiters()
 
     {:noreply, state}
   end
 
-  @impl true
+  def handle_info(
+        {:event_log_writer_result, writer, token, event_type, result},
+        %{writer: writer, in_flight: {:event, token, entry}} = state
+      ) do
+    acknowledge_entry(entry, event_type, result)
+    {:noreply, state |> State.finish_in_flight() |> dispatch_next()}
+  end
+
+  def handle_info(
+        {:event_log_retention_result, writer, token, result},
+        %{writer: writer, in_flight: {:retention, token, _cutoff}} = state
+      ) do
+    log_retention_result(result)
+
+    {:noreply,
+     state
+     |> State.finish_in_flight()
+     |> State.schedule_sweep(schedule_retention_sweep())
+     |> dispatch_next()}
+  end
+
+  def handle_info(
+        {:DOWN, ref, :process, writer, reason},
+        %{writer_ref: ref, writer: writer} = state
+      ) do
+    {:noreply, handle_writer_down(state, reason)}
+  end
+
+  def handle_info({:EXIT, _writer, _reason}, state), do: {:noreply, state}
+
+  def handle_info(:restart_writer, %State{status: :unavailable} = state) do
+    {:noreply, state |> State.clear_writer(:starting) |> start_writer()}
+  end
+
+  def handle_info(:restart_writer, state), do: {:noreply, state}
+
   def handle_info(:retention_sweep, state) do
-    cutoff = DateTime.add(DateTime.utc_now(), -state.retention_days, :day)
-
-    case Store.delete_before(state.db, cutoff) do
-      {:ok, 0} ->
-        :ok
-
-      {:ok, count} ->
-        Minga.Log.info(:agent, "[AgentEventLog] retention sweep deleted #{count} events")
-
-      {:error, reason} ->
-        Minga.Log.warning(:agent, "[AgentEventLog] retention sweep failed: #{inspect(reason)}")
-    end
-
-    {:noreply, %{state | sweep_ref: schedule_retention_sweep()}}
+    {:noreply, state |> State.mark_retention_pending() |> dispatch_next()}
   end
 
   def handle_info({:health_check_result, result}, state) do
@@ -154,53 +230,225 @@ defmodule MingaAgent.EventLog do
     {:noreply, state}
   end
 
-  @impl true
-  def terminate(_reason, %State{db: nil}), do: :ok
-
+  @impl GenServer
   def terminate(_reason, state) do
-    Store.close(state.db)
+    cancel_timer(state.sweep_ref)
+    stop_writer(state.writer)
     :ok
   end
 
-  @spec open_or_recreate(String.t()) :: {:ok, Store.db()} | {:error, term()}
-  defp open_or_recreate(path) do
-    case Store.open(path) do
-      {:ok, db} ->
-        {:ok, db}
+  @spec initialize(keyword(), String.t(), pos_integer(), term()) ::
+          {:ok, State.t()} | {:stop, term()}
+  defp initialize(opts, path, retention_days, max_queue_size)
+       when is_integer(max_queue_size) and max_queue_size > 0 do
+    state =
+      State.new(
+        path,
+        retention_days,
+        max_queue_size,
+        Keyword.get(opts, :store_backend, Store),
+        Keyword.get(opts, :store_backend_opts, []),
+        Keyword.get(opts, :writer_restart_delay_ms, @default_writer_restart_delay_ms)
+      )
+      |> start_writer()
+
+    sweep_ref = schedule_initial_retention_sweep(opts)
+    schedule_health_check(Keyword.get(opts, :health_check, @default_health_check), opts)
+    {:ok, State.schedule_sweep(state, sweep_ref)}
+  end
+
+  defp initialize(_opts, _path, _retention_days, max_queue_size) do
+    {:stop, {:invalid_max_queue_size, max_queue_size}}
+  end
+
+  @spec admit(:critical | :best_effort, EventRecord.t(), GenServer.from(), State.t(), boolean()) ::
+          {:reply, admission_result() | best_effort_admission_result(), State.t()}
+  defp admit(_kind, _record, _from, state, false), do: {:reply, {:error, :overloaded}, state}
+
+  defp admit(:critical, record, {caller, _tag}, state, true) do
+    receipt = make_ref()
+    entry = {:critical, receipt, caller, record.event_type, record}
+    state = state |> State.enqueue(entry) |> dispatch_next()
+    {:reply, {:queued, receipt}, state}
+  end
+
+  defp admit(:best_effort, record, _from, state, true) do
+    entry = {:best_effort, record.event_type, record}
+    state = state |> State.enqueue(entry) |> dispatch_next()
+    {:reply, :queued, state}
+  end
+
+  @spec outstanding_count(State.t()) :: non_neg_integer()
+  defp outstanding_count(state) do
+    :queue.len(state.queue) + in_flight_event_count(state.in_flight)
+  end
+
+  @spec in_flight_event_count(State.in_flight() | nil) :: 0 | 1
+  defp in_flight_event_count({:event, _token, _entry}), do: 1
+  defp in_flight_event_count(_in_flight), do: 0
+
+  @spec dispatch_next(State.t()) :: State.t()
+  defp dispatch_next(%State{status: :ready, in_flight: nil} = state) do
+    dispatch_queued_entry(State.dequeue(state))
+  end
+
+  defp dispatch_next(state), do: state
+
+  @spec dispatch_queued_entry({:empty, State.t()} | {:ok, State.entry(), State.t()}) :: State.t()
+  defp dispatch_queued_entry({:empty, state}) do
+    dispatch_retention(state, state.pending_retention)
+  end
+
+  defp dispatch_queued_entry({:ok, entry, state}) do
+    token = make_ref()
+    record = entry_record(entry)
+    send(state.writer, {:write_event, token, record})
+    State.start_event(state, token, entry)
+  end
+
+  @spec dispatch_retention(State.t(), boolean()) :: State.t()
+  defp dispatch_retention(state, false), do: notify_idle_waiters(state)
+
+  defp dispatch_retention(state, true) do
+    cutoff = DateTime.add(DateTime.utc_now(), -state.retention_days, :day)
+    token = make_ref()
+    send(state.writer, {:delete_before, token, cutoff})
+    State.start_retention(state, token, cutoff)
+  end
+
+  @spec entry_record(State.entry()) :: EventRecord.t()
+  defp entry_record({:critical, _receipt, _caller, _event_type, record}), do: record
+  defp entry_record({:best_effort, _event_type, record}), do: record
+
+  @spec acknowledge_entry(State.entry(), EventRecord.event_type(), term()) :: :ok
+  defp acknowledge_entry({:critical, receipt, caller, _type, _record}, event_type, {:ok, id}) do
+    send(caller, {:event_log_commit, receipt, event_type, {:persisted, id}})
+    :ok
+  end
+
+  defp acknowledge_entry(
+         {:critical, receipt, caller, _type, _record},
+         event_type,
+         {:error, reason}
+       ) do
+    send_persistence_failure(caller, receipt, event_type, reason)
+  end
+
+  defp acknowledge_entry({:best_effort, _type, _record}, event_type, {:error, reason}) do
+    Minga.Log.warning(
+      :agent,
+      "[AgentEventLog] best-effort #{event_type} persistence failed: #{inspect(reason)}"
+    )
+  end
+
+  defp acknowledge_entry({:best_effort, _type, _record}, _event_type, {:ok, _id}), do: :ok
+
+  @spec send_persistence_failure(pid(), receipt(), EventRecord.event_type(), term()) :: :ok
+  defp send_persistence_failure(caller, receipt, event_type, reason) do
+    send(
+      caller,
+      {:event_log_commit, receipt, event_type, {:error, {:persistence_failed, reason}}}
+    )
+
+    :ok
+  end
+
+  @spec handle_writer_down(State.t(), term()) :: State.t()
+  defp handle_writer_down(%State{status: :ready} = state, reason) do
+    Minga.Log.warning(:agent, "[AgentEventLog] writer terminated: #{inspect(reason)}")
+
+    state
+    |> State.requeue_in_flight()
+    |> State.clear_writer(:starting)
+    |> start_writer()
+  end
+
+  defp handle_writer_down(%State{status: :starting} = state, reason) do
+    Minga.Log.warning(:agent, "[AgentEventLog] writer failed to start: #{inspect(reason)}")
+
+    state
+    |> fail_all_events({:writer_start_failed, reason})
+    |> State.clear_writer(:unavailable)
+    |> schedule_writer_restart()
+    |> notify_idle_waiters()
+  end
+
+  defp handle_writer_down(state, _reason), do: State.clear_writer(state, :unavailable)
+
+  @spec fail_all_events(State.t(), term()) :: State.t()
+  defp fail_all_events(state, reason) do
+    Enum.each(outstanding_entries(state), &fail_entry(&1, reason))
+    State.clear_work(state)
+  end
+
+  @spec outstanding_entries(State.t()) :: [State.entry()]
+  defp outstanding_entries(%State{in_flight: {:event, _token, entry}} = state) do
+    [entry | :queue.to_list(state.queue)]
+  end
+
+  defp outstanding_entries(state), do: :queue.to_list(state.queue)
+
+  @spec fail_entry(State.entry(), term()) :: :ok
+  defp fail_entry({:critical, receipt, caller, event_type, _record}, reason) do
+    send_persistence_failure(caller, receipt, event_type, reason)
+  end
+
+  defp fail_entry({:best_effort, _event_type, _record}, _reason), do: :ok
+
+  @spec start_writer(State.t()) :: State.t()
+  defp start_writer(state) do
+    opts = [path: state.path, backend: state.store_backend, backend_opts: state.writer_opts]
+
+    case Writer.start(self(), opts) do
+      {:ok, writer} ->
+        State.writer_started(state, writer, Process.monitor(writer))
 
       {:error, reason} ->
-        if File.exists?(path) and corrupt?(path) do
-          Minga.Log.warning(
-            :agent,
-            "[AgentEventLog] corrupt database, recreating: #{inspect(reason)}"
-          )
+        Minga.Log.warning(:agent, "[AgentEventLog] could not start writer: #{inspect(reason)}")
 
-          recreate_database(path)
-        else
-          {:error, reason}
-        end
+        state
+        |> fail_all_events({:writer_start_failed, reason})
+        |> State.clear_writer(:unavailable)
+        |> schedule_writer_restart()
     end
   end
 
-  @spec corrupt?(String.t()) :: boolean()
-  defp corrupt?(path) do
-    case Exqlite.Sqlite3.open(path) do
-      {:ok, db} ->
-        result = Store.integrity_check(db, :quick)
-        Store.close(db)
-        match?({:error, _}, result)
-
-      {:error, _} ->
-        false
-    end
+  @spec schedule_writer_restart(State.t()) :: State.t()
+  defp schedule_writer_restart(state) do
+    Process.send_after(self(), :restart_writer, state.restart_delay_ms)
+    state
   end
 
-  @spec recreate_database(String.t()) :: {:ok, Store.db()} | {:error, term()}
-  defp recreate_database(path) do
-    _ = File.rm(path)
-    _ = File.rm(path <> "-wal")
-    _ = File.rm(path <> "-shm")
-    Store.open(path)
+  @spec notify_idle_waiters(State.t()) :: State.t()
+  defp notify_idle_waiters(%State{idle_waiters: []} = state), do: state
+
+  defp notify_idle_waiters(state) do
+    Enum.each(state.idle_waiters, &GenServer.reply(&1, :ok))
+    State.clear_idle_waiters(state)
+  end
+
+  @spec idle?(State.t()) :: boolean()
+  defp idle?(state) do
+    state.in_flight == nil and :queue.is_empty(state.queue) and not state.pending_retention
+  end
+
+  @spec await_idle_reply(State.t(), GenServer.from(), boolean()) ::
+          {:reply, :ok, State.t()} | {:noreply, State.t()}
+  defp await_idle_reply(state, _from, true), do: {:reply, :ok, state}
+
+  defp await_idle_reply(state, from, false) do
+    {:noreply, State.add_idle_waiter(state, from)}
+  end
+
+  @spec log_retention_result({:ok, non_neg_integer()} | {:error, term()}) :: :ok
+  defp log_retention_result({:ok, 0}), do: :ok
+
+  defp log_retention_result({:ok, count}) do
+    Minga.Log.info(:agent, "[AgentEventLog] retention sweep deleted #{count} events")
+  end
+
+  defp log_retention_result({:error, reason}) do
+    Minga.Log.warning(:agent, "[AgentEventLog] retention sweep failed: #{inspect(reason)}")
   end
 
   @spec schedule_initial_retention_sweep(keyword()) :: reference() | nil
@@ -249,6 +497,22 @@ defmodule MingaAgent.EventLog do
   defp handle_health_check_result({:error, reason}, state) do
     Minga.Log.warning(:agent, "[AgentEventLog] health check failed: #{inspect(reason)}")
     {:noreply, state}
+  end
+
+  @spec cancel_timer(reference() | nil) :: :ok
+  defp cancel_timer(nil), do: :ok
+
+  defp cancel_timer(ref) do
+    _ = Process.cancel_timer(ref)
+    :ok
+  end
+
+  @spec stop_writer(pid() | nil) :: :ok
+  defp stop_writer(nil), do: :ok
+
+  defp stop_writer(writer) do
+    Process.exit(writer, :shutdown)
+    :ok
   end
 
   @secret_keys MapSet.new(

--- a/lib/minga_agent/event_log/event_record.ex
+++ b/lib/minga_agent/event_log/event_record.ex
@@ -1,8 +1,8 @@
 defmodule MingaAgent.EventLog.EventRecord do
   @moduledoc "A durable, replay-safe agent session event."
 
-  @enforce_keys [:session_id, :event_type, :payload, :wall_clock, :monotonic_ts]
-  defstruct [:id, :session_id, :event_type, :payload, :wall_clock, :monotonic_ts]
+  @enforce_keys [:event_key, :session_id, :event_type, :payload, :wall_clock, :monotonic_ts]
+  defstruct [:id, :event_key, :session_id, :event_type, :payload, :wall_clock, :monotonic_ts]
 
   @type event_type ::
           :session_started
@@ -32,6 +32,7 @@ defmodule MingaAgent.EventLog.EventRecord do
 
   @type t :: %__MODULE__{
           id: non_neg_integer() | nil,
+          event_key: String.t(),
           session_id: String.t(),
           event_type: event_type(),
           payload: map(),
@@ -44,11 +45,19 @@ defmodule MingaAgent.EventLog.EventRecord do
   def new(session_id, event_type, payload, opts \\ [])
       when is_binary(session_id) and is_atom(event_type) and is_map(payload) do
     %__MODULE__{
+      event_key: Keyword.get_lazy(opts, :event_key, &new_event_key/0),
       session_id: session_id,
       event_type: event_type,
       payload: payload,
       wall_clock: Keyword.get_lazy(opts, :wall_clock, &DateTime.utc_now/0),
       monotonic_ts: Keyword.get_lazy(opts, :monotonic_ts, &System.monotonic_time/0)
     }
+  end
+
+  @spec new_event_key() :: String.t()
+  defp new_event_key do
+    16
+    |> :crypto.strong_rand_bytes()
+    |> Base.url_encode64(padding: false)
   end
 end

--- a/lib/minga_agent/event_log/failure.ex
+++ b/lib/minga_agent/event_log/failure.ex
@@ -1,0 +1,37 @@
+defmodule MingaAgent.EventLog.Failure do
+  @moduledoc "Typed, observable failure of EventLog admission or durable commitment."
+
+  alias MingaAgent.EventLog.EventRecord
+
+  @enforce_keys [:stage, :event_type, :reason]
+  defstruct [:stage, :event_type, :reason, :receipt]
+
+  @type stage :: :admission | :persistence
+  @type t :: %__MODULE__{
+          stage: stage(),
+          event_type: EventRecord.event_type(),
+          reason: term(),
+          receipt: reference() | nil
+        }
+
+  @doc "Builds an admission failure, which has no durability receipt."
+  @spec admission(EventRecord.event_type(), term()) :: t()
+  def admission(event_type, reason) do
+    %__MODULE__{stage: :admission, event_type: event_type, reason: reason}
+  end
+
+  @doc "Builds a post-admission persistence failure."
+  @spec persistence(reference(), EventRecord.event_type(), term()) :: t()
+  def persistence(receipt, event_type, reason) when is_reference(receipt) do
+    %__MODULE__{
+      stage: :persistence,
+      event_type: event_type,
+      reason: reason,
+      receipt: receipt
+    }
+  end
+
+  @doc "Removes the original receipt before replaying a retained failure to a later subscriber."
+  @spec retained(t()) :: t()
+  def retained(failure), do: %{failure | receipt: nil}
+end

--- a/lib/minga_agent/event_log/limits.ex
+++ b/lib/minga_agent/event_log/limits.ex
@@ -1,0 +1,51 @@
+defmodule MingaAgent.EventLog.Limits do
+  @moduledoc "Count and serialized-byte accounting for outstanding event-log work."
+
+  @enforce_keys [:max_count, :max_bytes]
+  defstruct max_count: nil, max_bytes: nil, outstanding_count: 0, outstanding_bytes: 0
+
+  @type t :: %__MODULE__{
+          max_count: pos_integer(),
+          max_bytes: pos_integer(),
+          outstanding_count: non_neg_integer(),
+          outstanding_bytes: non_neg_integer()
+        }
+
+  @doc "Builds empty outstanding-work limits."
+  @spec new(pos_integer(), pos_integer()) :: t()
+  def new(max_count, max_bytes)
+      when is_integer(max_count) and max_count > 0 and is_integer(max_bytes) and max_bytes > 0 do
+    %__MODULE__{max_count: max_count, max_bytes: max_bytes}
+  end
+
+  @doc "Returns whether one event of the given serialized size can be admitted."
+  @spec available?(t(), non_neg_integer()) :: boolean()
+  def available?(limits, bytes) when is_integer(bytes) and bytes >= 0 do
+    limits.outstanding_count < limits.max_count and
+      limits.outstanding_bytes + bytes <= limits.max_bytes
+  end
+
+  @doc "Accounts for one newly admitted event."
+  @spec admit(t(), non_neg_integer()) :: t()
+  def admit(limits, bytes) when is_integer(bytes) and bytes >= 0 do
+    %{
+      limits
+      | outstanding_count: limits.outstanding_count + 1,
+        outstanding_bytes: limits.outstanding_bytes + bytes
+    }
+  end
+
+  @doc "Releases one terminally completed or failed event."
+  @spec release(t(), non_neg_integer()) :: t()
+  def release(limits, bytes) when is_integer(bytes) and bytes >= 0 do
+    %{
+      limits
+      | outstanding_count: limits.outstanding_count - 1,
+        outstanding_bytes: limits.outstanding_bytes - bytes
+    }
+  end
+
+  @doc "Clears accounting after all outstanding events have terminally failed."
+  @spec reset(t()) :: t()
+  def reset(limits), do: %{limits | outstanding_count: 0, outstanding_bytes: 0}
+end

--- a/lib/minga_agent/event_log/state.ex
+++ b/lib/minga_agent/event_log/state.ex
@@ -1,0 +1,150 @@
+defmodule MingaAgent.EventLog.State do
+  @moduledoc "Owned runtime state and transitions for `MingaAgent.EventLog`."
+
+  alias MingaAgent.EventLog.EventRecord
+
+  @type receipt :: reference()
+  @type critical_entry ::
+          {:critical, receipt(), pid(), EventRecord.event_type(), EventRecord.t()}
+  @type best_effort_entry :: {:best_effort, EventRecord.event_type(), EventRecord.t()}
+  @type entry :: critical_entry() | best_effort_entry()
+  @type in_flight ::
+          {:event, reference(), entry()}
+          | {:retention, reference(), DateTime.t()}
+
+  @enforce_keys [
+    :path,
+    :retention_days,
+    :max_queue_size,
+    :store_backend,
+    :writer_opts,
+    :restart_delay_ms
+  ]
+  defstruct path: nil,
+            retention_days: nil,
+            max_queue_size: nil,
+            store_backend: nil,
+            writer_opts: [],
+            restart_delay_ms: nil,
+            queue: :queue.new(),
+            writer: nil,
+            writer_ref: nil,
+            status: :starting,
+            in_flight: nil,
+            pending_retention: false,
+            sweep_ref: nil,
+            idle_waiters: []
+
+  @type t :: %__MODULE__{
+          path: String.t(),
+          retention_days: pos_integer(),
+          max_queue_size: pos_integer(),
+          store_backend: module(),
+          writer_opts: keyword(),
+          restart_delay_ms: non_neg_integer(),
+          queue: term(),
+          writer: pid() | nil,
+          writer_ref: reference() | nil,
+          status: :starting | :ready | :unavailable,
+          in_flight: in_flight() | nil,
+          pending_retention: boolean(),
+          sweep_ref: reference() | nil,
+          idle_waiters: [GenServer.from()]
+        }
+
+  @doc "Builds initial EventLog state from validated values."
+  @spec new(String.t(), pos_integer(), pos_integer(), module(), keyword(), non_neg_integer()) ::
+          t()
+  def new(path, retention_days, max_queue_size, store_backend, writer_opts, restart_delay_ms)
+      when is_binary(path) and is_integer(retention_days) and retention_days > 0 and
+             is_integer(max_queue_size) and max_queue_size > 0 and is_atom(store_backend) and
+             is_list(writer_opts) and is_integer(restart_delay_ms) and restart_delay_ms >= 0 do
+    %__MODULE__{
+      path: path,
+      retention_days: retention_days,
+      max_queue_size: max_queue_size,
+      store_backend: store_backend,
+      writer_opts: writer_opts,
+      restart_delay_ms: restart_delay_ms
+    }
+  end
+
+  @doc "Marks a writer process as starting."
+  @spec writer_started(t(), pid(), reference()) :: t()
+  def writer_started(state, writer, writer_ref) do
+    %{state | writer: writer, writer_ref: writer_ref, status: :starting}
+  end
+
+  @doc "Marks the current writer as ready."
+  @spec writer_ready(t()) :: t()
+  def writer_ready(state), do: %{state | status: :ready}
+
+  @doc "Clears writer identity and sets its availability state."
+  @spec clear_writer(t(), :starting | :unavailable) :: t()
+  def clear_writer(state, status) do
+    %{state | writer: nil, writer_ref: nil, status: status}
+  end
+
+  @doc "Enqueues an admitted event at the back of the ordered queue."
+  @spec enqueue(t(), entry()) :: t()
+  def enqueue(state, entry), do: %{state | queue: :queue.in(entry, state.queue)}
+
+  @doc "Removes the next admitted event from the ordered queue."
+  @spec dequeue(t()) :: {:empty, t()} | {:ok, entry(), t()}
+  def dequeue(state) do
+    case :queue.out(state.queue) do
+      {:empty, _queue} -> {:empty, state}
+      {{:value, entry}, queue} -> {:ok, entry, %{state | queue: queue}}
+    end
+  end
+
+  @doc "Marks an event as the writer's single in-flight operation."
+  @spec start_event(t(), reference(), entry()) :: t()
+  def start_event(state, token, entry) do
+    %{state | in_flight: {:event, token, entry}}
+  end
+
+  @doc "Marks a retention sweep as the writer's single in-flight operation."
+  @spec start_retention(t(), reference(), DateTime.t()) :: t()
+  def start_retention(state, token, cutoff) do
+    %{state | pending_retention: false, in_flight: {:retention, token, cutoff}}
+  end
+
+  @doc "Clears the completed in-flight operation."
+  @spec finish_in_flight(t()) :: t()
+  def finish_in_flight(state), do: %{state | in_flight: nil}
+
+  @doc "Requeues an uncertain in-flight event at the front without changing its idempotency key."
+  @spec requeue_in_flight(t()) :: t()
+  def requeue_in_flight(%__MODULE__{in_flight: {:event, _token, entry}} = state) do
+    %{state | queue: :queue.in_r(entry, state.queue), in_flight: nil}
+  end
+
+  def requeue_in_flight(%__MODULE__{in_flight: {:retention, _token, _cutoff}} = state) do
+    %{state | in_flight: nil, pending_retention: true}
+  end
+
+  def requeue_in_flight(state), do: state
+
+  @doc "Clears all event and retention work after callers have been notified of a definite failure."
+  @spec clear_work(t()) :: t()
+  def clear_work(state) do
+    %{state | queue: :queue.new(), in_flight: nil, pending_retention: false}
+  end
+
+  @doc "Marks a retention sweep pending behind admitted events."
+  @spec mark_retention_pending(t()) :: t()
+  def mark_retention_pending(state), do: %{state | pending_retention: true}
+
+  @doc "Stores the timer for the next retention sweep."
+  @spec schedule_sweep(t(), reference() | nil) :: t()
+  def schedule_sweep(state, sweep_ref), do: %{state | sweep_ref: sweep_ref}
+
+  @doc "Adds a caller waiting for all currently outstanding work."
+  @spec add_idle_waiter(t(), GenServer.from()) :: t()
+  def add_idle_waiter(state, from), do: %{state | idle_waiters: [from | state.idle_waiters]}
+
+  @doc "Clears callers after the owner has replied that work is idle."
+  @spec clear_idle_waiters(t()) :: t()
+  def clear_idle_waiters(state), do: %{state | idle_waiters: []}
+end

--- a/lib/minga_agent/event_log/state.ex
+++ b/lib/minga_agent/event_log/state.ex
@@ -2,11 +2,14 @@ defmodule MingaAgent.EventLog.State do
   @moduledoc "Owned runtime state and transitions for `MingaAgent.EventLog`."
 
   alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.Limits
 
   @type receipt :: reference()
   @type critical_entry ::
-          {:critical, receipt(), pid(), EventRecord.event_type(), EventRecord.t()}
-  @type best_effort_entry :: {:best_effort, EventRecord.event_type(), EventRecord.t()}
+          {:critical, receipt(), pid(), EventRecord.event_type(), non_neg_integer(),
+           EventRecord.t()}
+  @type best_effort_entry ::
+          {:best_effort, EventRecord.event_type(), non_neg_integer(), EventRecord.t()}
   @type entry :: critical_entry() | best_effort_entry()
   @type in_flight ::
           {:event, reference(), entry()}
@@ -15,14 +18,14 @@ defmodule MingaAgent.EventLog.State do
   @enforce_keys [
     :path,
     :retention_days,
-    :max_queue_size,
+    :limits,
     :store_backend,
     :writer_opts,
     :restart_delay_ms
   ]
   defstruct path: nil,
             retention_days: nil,
-            max_queue_size: nil,
+            limits: nil,
             store_backend: nil,
             writer_opts: [],
             restart_delay_ms: nil,
@@ -38,7 +41,7 @@ defmodule MingaAgent.EventLog.State do
   @type t :: %__MODULE__{
           path: String.t(),
           retention_days: pos_integer(),
-          max_queue_size: pos_integer(),
+          limits: Limits.t(),
           store_backend: module(),
           writer_opts: keyword(),
           restart_delay_ms: non_neg_integer(),
@@ -53,16 +56,32 @@ defmodule MingaAgent.EventLog.State do
         }
 
   @doc "Builds initial EventLog state from validated values."
-  @spec new(String.t(), pos_integer(), pos_integer(), module(), keyword(), non_neg_integer()) ::
-          t()
-  def new(path, retention_days, max_queue_size, store_backend, writer_opts, restart_delay_ms)
+  @spec new(
+          String.t(),
+          pos_integer(),
+          pos_integer(),
+          pos_integer(),
+          module(),
+          keyword(),
+          non_neg_integer()
+        ) :: t()
+  def new(
+        path,
+        retention_days,
+        max_queue_size,
+        max_queue_bytes,
+        store_backend,
+        writer_opts,
+        restart_delay_ms
+      )
       when is_binary(path) and is_integer(retention_days) and retention_days > 0 and
-             is_integer(max_queue_size) and max_queue_size > 0 and is_atom(store_backend) and
-             is_list(writer_opts) and is_integer(restart_delay_ms) and restart_delay_ms >= 0 do
+             is_integer(max_queue_size) and max_queue_size > 0 and is_integer(max_queue_bytes) and
+             max_queue_bytes > 0 and is_atom(store_backend) and is_list(writer_opts) and
+             is_integer(restart_delay_ms) and restart_delay_ms >= 0 do
     %__MODULE__{
       path: path,
       retention_days: retention_days,
-      max_queue_size: max_queue_size,
+      limits: Limits.new(max_queue_size, max_queue_bytes),
       store_backend: store_backend,
       writer_opts: writer_opts,
       restart_delay_ms: restart_delay_ms
@@ -85,9 +104,19 @@ defmodule MingaAgent.EventLog.State do
     %{state | writer: nil, writer_ref: nil, status: status}
   end
 
+  @doc "Returns whether one event of the given serialized size fits the outstanding-work bounds."
+  @spec admission_available?(t(), non_neg_integer()) :: boolean()
+  def admission_available?(state, bytes), do: Limits.available?(state.limits, bytes)
+
   @doc "Enqueues an admitted event at the back of the ordered queue."
   @spec enqueue(t(), entry()) :: t()
-  def enqueue(state, entry), do: %{state | queue: :queue.in(entry, state.queue)}
+  def enqueue(state, entry) do
+    %{
+      state
+      | queue: :queue.in(entry, state.queue),
+        limits: Limits.admit(state.limits, entry_bytes(entry))
+    }
+  end
 
   @doc "Removes the next admitted event from the ordered queue."
   @spec dequeue(t()) :: {:empty, t()} | {:ok, entry(), t()}
@@ -110,8 +139,12 @@ defmodule MingaAgent.EventLog.State do
     %{state | pending_retention: false, in_flight: {:retention, token, cutoff}}
   end
 
-  @doc "Clears the completed in-flight operation."
+  @doc "Clears the completed in-flight operation and releases completed event bytes."
   @spec finish_in_flight(t()) :: t()
+  def finish_in_flight(%__MODULE__{in_flight: {:event, _token, entry}} = state) do
+    %{state | in_flight: nil, limits: Limits.release(state.limits, entry_bytes(entry))}
+  end
+
   def finish_in_flight(state), do: %{state | in_flight: nil}
 
   @doc "Requeues an uncertain in-flight event at the front without changing its idempotency key."
@@ -126,10 +159,19 @@ defmodule MingaAgent.EventLog.State do
 
   def requeue_in_flight(state), do: state
 
-  @doc "Clears all event and retention work after callers have been notified of a definite failure."
-  @spec clear_work(t()) :: t()
-  def clear_work(state) do
-    %{state | queue: :queue.new(), in_flight: nil, pending_retention: false}
+  @doc "Clears failed event work while preserving any pending or interrupted retention sweep."
+  @spec clear_event_work(t()) :: t()
+  def clear_event_work(state) do
+    pending_retention =
+      state.pending_retention or match?({:retention, _token, _cutoff}, state.in_flight)
+
+    %{
+      state
+      | queue: :queue.new(),
+        in_flight: nil,
+        pending_retention: pending_retention,
+        limits: Limits.reset(state.limits)
+    }
   end
 
   @doc "Marks a retention sweep pending behind admitted events."
@@ -147,4 +189,8 @@ defmodule MingaAgent.EventLog.State do
   @doc "Clears callers after the owner has replied that work is idle."
   @spec clear_idle_waiters(t()) :: t()
   def clear_idle_waiters(state), do: %{state | idle_waiters: []}
+
+  @spec entry_bytes(entry()) :: non_neg_integer()
+  defp entry_bytes({:critical, _receipt, _caller, _event_type, bytes, _record}), do: bytes
+  defp entry_bytes({:best_effort, _event_type, bytes, _record}), do: bytes
 end

--- a/lib/minga_agent/event_log/store.ex
+++ b/lib/minga_agent/event_log/store.ex
@@ -14,7 +14,8 @@ defmodule MingaAgent.EventLog.Store do
   @doc "Opens or creates the agent event database."
   @spec open(String.t()) :: {:ok, db()} | {:error, term()}
   def open(db_path) do
-    with :ok <- ensure_database_directory(db_path) do
+    with :ok <- ensure_database_directory(db_path),
+         :ok <- ensure_private_database_files(db_path) do
       case Sqlite3.open(db_path) do
         {:ok, db} -> setup_opened(db, db_path)
         {:error, reason} -> {:error, reason}
@@ -53,34 +54,8 @@ defmodule MingaAgent.EventLog.Store do
   @impl MingaAgent.EventLog.StoreBackend
   @spec insert(db(), EventRecord.t()) :: {:ok, pos_integer()} | {:error, term()}
   def insert(db, %EventRecord{} = record) do
-    sql = """
-    INSERT INTO events (event_key, session_id, event_type, payload, wall_clock, monotonic_ts)
-    VALUES (?1, ?2, ?3, ?4, ?5, ?6)
-    ON CONFLICT(event_key) DO NOTHING
-    RETURNING id
-    """
-
-    params = [
-      record.event_key,
-      record.session_id,
-      Atom.to_string(record.event_type),
-      JSON.encode!(record.payload),
-      DateTime.to_iso8601(record.wall_clock),
-      record.monotonic_ts
-    ]
-
-    case Sqlite3.prepare(db, sql) do
-      {:ok, stmt} ->
-        result =
-          with :ok <- Sqlite3.bind(stmt, params) do
-            insert_result(db, stmt, record.event_key)
-          end
-
-        Sqlite3.release(db, stmt)
-        result
-
-      {:error, reason} ->
-        {:error, reason}
+    with {:ok, payload_json} <- encode_payload(record.payload) do
+      insert_encoded(db, record, payload_json)
     end
   end
 
@@ -196,6 +171,49 @@ defmodule MingaAgent.EventLog.Store do
     end
   end
 
+  @spec insert_encoded(db(), EventRecord.t(), String.t()) ::
+          {:ok, pos_integer()} | {:error, term()}
+  defp insert_encoded(db, record, payload_json) do
+    sql = """
+    INSERT INTO events (event_key, session_id, event_type, payload, wall_clock, monotonic_ts)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+    ON CONFLICT(event_key) DO NOTHING
+    RETURNING id
+    """
+
+    params = [
+      record.event_key,
+      record.session_id,
+      Atom.to_string(record.event_type),
+      payload_json,
+      DateTime.to_iso8601(record.wall_clock),
+      record.monotonic_ts
+    ]
+
+    case Sqlite3.prepare(db, sql) do
+      {:ok, stmt} ->
+        result =
+          with :ok <- Sqlite3.bind(stmt, params) do
+            insert_result(db, stmt, record.event_key)
+          end
+
+        Sqlite3.release(db, stmt)
+        result
+
+      {:error, reason} ->
+        {:error, reason}
+    end
+  end
+
+  @spec encode_payload(map()) :: {:ok, String.t()} | {:error, term()}
+  defp encode_payload(payload) do
+    {:ok, JSON.encode!(payload)}
+  rescue
+    exception -> {:error, {:serialization_failed, exception.__struct__}}
+  catch
+    kind, _reason -> {:error, {:serialization_failed, kind}}
+  end
+
   @spec insert_result(db(), Sqlite3.statement(), String.t()) ::
           {:ok, pos_integer()} | {:error, term()}
   defp insert_result(db, stmt, event_key) do
@@ -241,15 +259,16 @@ defmodule MingaAgent.EventLog.Store do
   @spec recreate_corrupt_database(String.t(), term(), boolean()) ::
           {:ok, db()} | {:error, term()}
   defp recreate_corrupt_database(path, reason, true) do
+    suffix = ".corrupt-#{System.system_time(:millisecond)}-#{System.unique_integer([:positive])}"
+
     Minga.Log.warning(
       :agent,
-      "[AgentEventLog] corrupt database, recreating: #{inspect(reason)}"
+      "[AgentEventLog] corrupt database, quarantining before recreation: #{inspect(reason)}"
     )
 
-    _ = File.rm(path)
-    _ = File.rm(path <> "-wal")
-    _ = File.rm(path <> "-shm")
-    open(path)
+    with :ok <- quarantine_database_files(path, suffix) do
+      open(path)
+    end
   end
 
   defp recreate_corrupt_database(_path, reason, false), do: {:error, reason}
@@ -397,28 +416,26 @@ defmodule MingaAgent.EventLog.Store do
   @spec ensure_private_created_directory(String.t()) :: :ok | {:error, term()}
   defp ensure_private_created_directory(dir) do
     expanded_dir = Path.expand(dir)
-    ensure_private_created_directory(expanded_dir, File.cwd!(), File.stat(expanded_dir))
+    ensure_private_created_directory(expanded_dir, File.lstat(expanded_dir))
   end
 
   @spec ensure_private_created_directory(
           String.t(),
-          String.t(),
           {:ok, File.Stat.t()} | {:error, term()}
-        ) ::
-          :ok | {:error, term()}
-  defp ensure_private_created_directory(dir, dir, _stat), do: :ok
+        ) :: :ok | {:error, term()}
+  defp ensure_private_created_directory(dir, {:ok, %File.Stat{type: :directory}}),
+    do: File.chmod(dir, 0o700)
 
-  defp ensure_private_created_directory(_dir, _cwd, {:ok, %File.Stat{type: :directory}}), do: :ok
+  defp ensure_private_created_directory(_dir, {:ok, %File.Stat{type: type}}),
+    do: {:error, {:unsafe_database_directory, type}}
 
-  defp ensure_private_created_directory(_dir, _cwd, {:ok, %File.Stat{}}), do: {:error, :enotdir}
-
-  defp ensure_private_created_directory(dir, _cwd, {:error, :enoent}) do
+  defp ensure_private_created_directory(dir, {:error, :enoent}) do
     with :ok <- File.mkdir_p(dir) do
       File.chmod(dir, 0o700)
     end
   end
 
-  defp ensure_private_created_directory(_dir, _cwd, {:error, reason}), do: {:error, reason}
+  defp ensure_private_created_directory(_dir, {:error, reason}), do: {:error, reason}
 
   @spec ensure_private_database_files(String.t() | nil) :: :ok | {:error, term()}
   defp ensure_private_database_files(nil), do: :ok
@@ -435,13 +452,49 @@ defmodule MingaAgent.EventLog.Store do
   @spec chmod_existing_file(String.t(), non_neg_integer()) ::
           {:cont, :ok} | {:halt, {:error, term()}}
   defp chmod_existing_file(path, mode) do
-    if File.exists?(path) do
-      case File.chmod(path, mode) do
-        :ok -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    else
-      {:cont, :ok}
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :regular}} ->
+        case File.chmod(path, mode) do
+          :ok -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, reason}}
+        end
+
+      {:ok, %File.Stat{type: type}} ->
+        {:halt, {:error, {:unsafe_database_path, path, type}}}
+
+      {:error, :enoent} ->
+        {:cont, :ok}
+
+      {:error, reason} ->
+        {:halt, {:error, reason}}
+    end
+  end
+
+  @spec quarantine_database_files(String.t(), String.t()) :: :ok | {:error, term()}
+  defp quarantine_database_files(path, suffix) do
+    path
+    |> database_file_paths()
+    |> Enum.reduce_while(:ok, fn file_path, :ok -> quarantine_existing_file(file_path, suffix) end)
+  end
+
+  @spec quarantine_existing_file(String.t(), String.t()) ::
+          {:cont, :ok} | {:halt, {:error, term()}}
+  defp quarantine_existing_file(path, suffix) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: :regular}} ->
+        case File.rename(path, path <> suffix) do
+          :ok -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, {:quarantine_failed, path, reason}}}
+        end
+
+      {:ok, %File.Stat{type: type}} ->
+        {:halt, {:error, {:unsafe_database_path, path, type}}}
+
+      {:error, :enoent} ->
+        {:cont, :ok}
+
+      {:error, reason} ->
+        {:halt, {:error, reason}}
     end
   end
 

--- a/lib/minga_agent/event_log/store.ex
+++ b/lib/minga_agent/event_log/store.ex
@@ -1,13 +1,15 @@
 defmodule MingaAgent.EventLog.Store do
   @moduledoc "SQLite storage backend for durable agent session events."
 
+  @behaviour MingaAgent.EventLog.StoreBackend
+
   alias MingaAgent.EventLog.EventRecord
   alias MingaAgent.EventLog.Taxonomy
   alias Exqlite.Sqlite3
 
   @type db :: Sqlite3.db()
 
-  @schema_version 1
+  @schema_version 2
 
   @doc "Opens or creates the agent event database."
   @spec open(String.t()) :: {:ok, db()} | {:error, term()}
@@ -17,6 +19,19 @@ defmodule MingaAgent.EventLog.Store do
         {:ok, db} -> setup_opened(db, db_path)
         {:error, reason} -> {:error, reason}
       end
+    end
+  end
+
+  @doc "Opens the writer connection, recreating a database that fails an integrity check."
+  @impl MingaAgent.EventLog.StoreBackend
+  @spec open_writer(String.t(), keyword()) :: {:ok, db()} | {:error, term()}
+  def open_writer(db_path, _opts) do
+    case open(db_path) do
+      {:ok, db} ->
+        {:ok, db}
+
+      {:error, reason} ->
+        maybe_recreate_corrupt_database(db_path, reason)
     end
   end
 
@@ -30,18 +45,23 @@ defmodule MingaAgent.EventLog.Store do
   end
 
   @doc "Closes the database connection."
+  @impl MingaAgent.EventLog.StoreBackend
   @spec close(db()) :: :ok | {:error, term()}
   def close(db), do: Sqlite3.close(db)
 
   @doc "Inserts an append-only event record."
+  @impl MingaAgent.EventLog.StoreBackend
   @spec insert(db(), EventRecord.t()) :: {:ok, pos_integer()} | {:error, term()}
   def insert(db, %EventRecord{} = record) do
     sql = """
-    INSERT INTO events (session_id, event_type, payload, wall_clock, monotonic_ts)
-    VALUES (?1, ?2, ?3, ?4, ?5)
+    INSERT INTO events (event_key, session_id, event_type, payload, wall_clock, monotonic_ts)
+    VALUES (?1, ?2, ?3, ?4, ?5, ?6)
+    ON CONFLICT(event_key) DO NOTHING
+    RETURNING id
     """
 
     params = [
+      record.event_key,
       record.session_id,
       Atom.to_string(record.event_type),
       JSON.encode!(record.payload),
@@ -52,17 +72,12 @@ defmodule MingaAgent.EventLog.Store do
     case Sqlite3.prepare(db, sql) do
       {:ok, stmt} ->
         result =
-          with :ok <- Sqlite3.bind(stmt, params),
-               :done <- Sqlite3.step(db, stmt) do
-            :ok
+          with :ok <- Sqlite3.bind(stmt, params) do
+            insert_result(db, stmt, record.event_key)
           end
 
         Sqlite3.release(db, stmt)
-
-        case result do
-          :ok -> private_last_insert_rowid(db)
-          {:error, reason} -> {:error, reason}
-        end
+        result
 
       {:error, reason} ->
         {:error, reason}
@@ -76,7 +91,7 @@ defmodule MingaAgent.EventLog.Store do
       when is_binary(session_id) and is_integer(last_id) and last_id >= 0 and is_integer(limit) and
              limit > 0 do
     sql = """
-    SELECT id, session_id, event_type, payload, wall_clock, monotonic_ts
+    SELECT id, event_key, session_id, event_type, payload, wall_clock, monotonic_ts
     FROM events
     WHERE session_id = ?1 AND id > ?2
     ORDER BY id ASC
@@ -110,7 +125,7 @@ defmodule MingaAgent.EventLog.Store do
   def file_edits_for_path(db, path, limit \\ 200)
       when is_binary(path) and is_integer(limit) and limit > 0 do
     sql = """
-    SELECT id, session_id, event_type, payload, wall_clock, monotonic_ts
+    SELECT id, event_key, session_id, event_type, payload, wall_clock, monotonic_ts
     FROM events
     WHERE event_type = 'file_edit_proposed' AND json_extract(payload, '$.path') = ?1
     ORDER BY id DESC
@@ -140,6 +155,7 @@ defmodule MingaAgent.EventLog.Store do
   end
 
   @doc "Deletes events older than the given wall-clock time."
+  @impl MingaAgent.EventLog.StoreBackend
   @spec delete_before(db(), DateTime.t()) :: {:ok, non_neg_integer()} | {:error, term()}
   def delete_before(db, cutoff) do
     sql = "DELETE FROM events WHERE wall_clock < ?1"
@@ -180,6 +196,77 @@ defmodule MingaAgent.EventLog.Store do
     end
   end
 
+  @spec insert_result(db(), Sqlite3.statement(), String.t()) ::
+          {:ok, pos_integer()} | {:error, term()}
+  defp insert_result(db, stmt, event_key) do
+    case Sqlite3.step(db, stmt) do
+      {:row, [id]} -> finish_returning_insert(db, stmt, id)
+      :done -> event_id_by_key(db, event_key)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec finish_returning_insert(db(), Sqlite3.statement(), pos_integer()) ::
+          {:ok, pos_integer()} | {:error, term()}
+  defp finish_returning_insert(db, stmt, id) do
+    case Sqlite3.step(db, stmt) do
+      :done -> {:ok, id}
+      {:error, reason} -> {:error, reason}
+      other -> {:error, {:unexpected_result, other}}
+    end
+  end
+
+  @spec event_id_by_key(db(), String.t()) :: {:ok, pos_integer()} | {:error, term()}
+  defp event_id_by_key(db, event_key) do
+    with {:ok, stmt} <- Sqlite3.prepare(db, "SELECT id FROM events WHERE event_key = ?1"),
+         :ok <- Sqlite3.bind(stmt, [event_key]) do
+      result = Sqlite3.step(db, stmt)
+      Sqlite3.release(db, stmt)
+      normalize_event_id(result)
+    end
+  end
+
+  @spec normalize_event_id({:row, [pos_integer()]} | :done | {:error, term()}) ::
+          {:ok, pos_integer()} | {:error, term()}
+  defp normalize_event_id({:row, [id]}), do: {:ok, id}
+  defp normalize_event_id(:done), do: {:error, :event_not_found_after_conflict}
+  defp normalize_event_id({:error, reason}), do: {:error, reason}
+
+  @spec maybe_recreate_corrupt_database(String.t(), term()) ::
+          {:ok, db()} | {:error, term()}
+  defp maybe_recreate_corrupt_database(path, reason) do
+    recreate_corrupt_database(path, reason, File.exists?(path) and corrupt?(path))
+  end
+
+  @spec recreate_corrupt_database(String.t(), term(), boolean()) ::
+          {:ok, db()} | {:error, term()}
+  defp recreate_corrupt_database(path, reason, true) do
+    Minga.Log.warning(
+      :agent,
+      "[AgentEventLog] corrupt database, recreating: #{inspect(reason)}"
+    )
+
+    _ = File.rm(path)
+    _ = File.rm(path <> "-wal")
+    _ = File.rm(path <> "-shm")
+    open(path)
+  end
+
+  defp recreate_corrupt_database(_path, reason, false), do: {:error, reason}
+
+  @spec corrupt?(String.t()) :: boolean()
+  defp corrupt?(path) do
+    case Sqlite3.open(path) do
+      {:ok, db} ->
+        result = integrity_check(db, :quick)
+        _ = close(db)
+        match?({:error, _}, result)
+
+      {:error, _reason} ->
+        false
+    end
+  end
+
   @spec setup_opened(db(), String.t() | nil) :: {:ok, db()} | {:error, term()}
   defp setup_opened(db, db_path \\ nil) do
     result =
@@ -208,6 +295,7 @@ defmodule MingaAgent.EventLog.Store do
       """
       CREATE TABLE IF NOT EXISTS events (
         id INTEGER PRIMARY KEY AUTOINCREMENT,
+        event_key TEXT NOT NULL,
         session_id TEXT NOT NULL,
         event_type TEXT NOT NULL,
         payload TEXT NOT NULL DEFAULT '{}',
@@ -220,7 +308,13 @@ defmodule MingaAgent.EventLog.Store do
       "CREATE TABLE IF NOT EXISTS schema_version (version INTEGER NOT NULL)"
     ]
 
-    with :ok <- execute_all(db, statements), do: ensure_schema_version(db)
+    with :ok <- execute_all(db, statements),
+         :ok <- ensure_schema_version(db) do
+      execute(
+        db,
+        "CREATE UNIQUE INDEX IF NOT EXISTS idx_agent_events_event_key ON events(event_key)"
+      )
+    end
   end
 
   @spec ensure_schema_version(db()) :: :ok | {:error, term()}
@@ -228,13 +322,42 @@ defmodule MingaAgent.EventLog.Store do
     with {:ok, stmt} <- Sqlite3.prepare(db, "SELECT version FROM schema_version LIMIT 1") do
       result = Sqlite3.step(db, stmt)
       Sqlite3.release(db, stmt)
-
-      case result do
-        :done -> execute(db, "INSERT INTO schema_version (version) VALUES (#{@schema_version})")
-        {:row, [@schema_version]} -> :ok
-        {:row, [_old_version]} -> :ok
-      end
+      apply_schema_version(db, result)
     end
+  end
+
+  @spec apply_schema_version(db(), :done | {:row, [integer()]} | {:error, term()}) ::
+          :ok | {:error, term()}
+  defp apply_schema_version(db, :done) do
+    execute(db, "INSERT INTO schema_version (version) VALUES (#{@schema_version})")
+  end
+
+  defp apply_schema_version(_db, {:row, [@schema_version]}), do: :ok
+  defp apply_schema_version(db, {:row, [1]}), do: migrate_schema_v1(db)
+  defp apply_schema_version(_db, {:row, [version]}), do: {:error, {:unsupported_schema, version}}
+  defp apply_schema_version(_db, {:error, reason}), do: {:error, reason}
+
+  @spec migrate_schema_v1(db()) :: :ok | {:error, term()}
+  defp migrate_schema_v1(db) do
+    with :ok <- execute(db, "BEGIN IMMEDIATE") do
+      result =
+        execute_all(db, [
+          "ALTER TABLE events ADD COLUMN event_key TEXT",
+          "UPDATE events SET event_key = 'legacy-' || id WHERE event_key IS NULL",
+          "CREATE UNIQUE INDEX idx_agent_events_event_key ON events(event_key)",
+          "UPDATE schema_version SET version = #{@schema_version}"
+        ])
+
+      finish_migration(db, result)
+    end
+  end
+
+  @spec finish_migration(db(), :ok | {:error, term()}) :: :ok | {:error, term()}
+  defp finish_migration(db, :ok), do: execute(db, "COMMIT")
+
+  defp finish_migration(db, {:error, _reason} = error) do
+    _ = execute(db, "ROLLBACK")
+    error
   end
 
   @spec execute_all(db(), [String.t()]) :: :ok | {:error, term()}
@@ -297,41 +420,6 @@ defmodule MingaAgent.EventLog.Store do
 
   defp ensure_private_created_directory(_dir, _cwd, {:error, reason}), do: {:error, reason}
 
-  @spec private_last_insert_rowid(db()) :: {:ok, pos_integer()} | {:error, term()}
-  defp private_last_insert_rowid(db) do
-    with {:ok, id} <- last_insert_rowid(db),
-         :ok <- ensure_private_open_database_files(db) do
-      {:ok, id}
-    end
-  end
-
-  @spec ensure_private_open_database_files(db()) :: :ok | {:error, term()}
-  defp ensure_private_open_database_files(db) do
-    case database_path(db) do
-      {:ok, path} -> ensure_private_database_files(path)
-      {:error, _reason} = error -> error
-    end
-  end
-
-  @spec database_path(db()) :: {:ok, String.t() | nil} | {:error, term()}
-  defp database_path(db) do
-    case Sqlite3.prepare(db, "PRAGMA database_list") do
-      {:ok, stmt} ->
-        result = Sqlite3.step(db, stmt)
-        Sqlite3.release(db, stmt)
-
-        case result do
-          {:row, [_seq, "main", ""]} -> {:ok, nil}
-          {:row, [_seq, "main", path]} when is_binary(path) -> {:ok, path}
-          {:error, reason} -> {:error, reason}
-          other -> {:error, {:unexpected_result, other}}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
   @spec ensure_private_database_files(String.t() | nil) :: :ok | {:error, term()}
   defp ensure_private_database_files(nil), do: :ok
 
@@ -389,13 +477,22 @@ defmodule MingaAgent.EventLog.Store do
   end
 
   @spec row_to_record([term()]) :: EventRecord.t() | nil
-  defp row_to_record([id, session_id, event_type, payload_json, wall_clock_iso, monotonic_ts]) do
+  defp row_to_record([
+         id,
+         event_key,
+         session_id,
+         event_type,
+         payload_json,
+         wall_clock_iso,
+         monotonic_ts
+       ]) do
     case Taxonomy.from_string(event_type) do
       {:ok, atom_type} ->
         {:ok, wall_clock, _offset} = DateTime.from_iso8601(wall_clock_iso)
 
         %EventRecord{
           id: id,
+          event_key: event_key,
           session_id: session_id,
           event_type: atom_type,
           payload: JSON.decode!(payload_json),
@@ -405,24 +502,6 @@ defmodule MingaAgent.EventLog.Store do
 
       :error ->
         nil
-    end
-  end
-
-  @spec last_insert_rowid(db()) :: {:ok, pos_integer()} | {:error, term()}
-  defp last_insert_rowid(db) do
-    case Sqlite3.prepare(db, "SELECT last_insert_rowid()") do
-      {:ok, stmt} ->
-        result = Sqlite3.step(db, stmt)
-        Sqlite3.release(db, stmt)
-
-        case result do
-          {:row, [id]} -> {:ok, id}
-          {:error, reason} -> {:error, reason}
-          other -> {:error, {:unexpected_result, other}}
-        end
-
-      {:error, reason} ->
-        {:error, reason}
     end
   end
 

--- a/lib/minga_agent/event_log/store_backend.ex
+++ b/lib/minga_agent/event_log/store_backend.ex
@@ -1,0 +1,23 @@
+defmodule MingaAgent.EventLog.StoreBackend do
+  @moduledoc """
+  Minimal contract used by the event-log writer.
+
+  The production implementation is `MingaAgent.EventLog.Store`. The contract exists so the writer's admission, failure, and recovery behavior can be tested without controlling SQLite itself.
+  """
+
+  alias MingaAgent.EventLog.EventRecord
+
+  @type db :: term()
+
+  @doc "Opens the writer-owned database connection."
+  @callback open_writer(String.t(), keyword()) :: {:ok, db()} | {:error, term()}
+
+  @doc "Closes the writer-owned database connection."
+  @callback close(db()) :: :ok | {:error, term()}
+
+  @doc "Inserts one event and returns its committed id."
+  @callback insert(db(), EventRecord.t()) :: {:ok, pos_integer()} | {:error, term()}
+
+  @doc "Deletes events older than a retention cutoff."
+  @callback delete_before(db(), DateTime.t()) :: {:ok, non_neg_integer()} | {:error, term()}
+end

--- a/lib/minga_agent/event_log/writer.ex
+++ b/lib/minga_agent/event_log/writer.ex
@@ -33,6 +33,8 @@ defmodule MingaAgent.EventLog.Writer do
   end
 
   @impl GenServer
+  @spec handle_continue(:open, WriterState.t()) ::
+          {:noreply, WriterState.t()} | {:stop, term(), WriterState.t()}
   def handle_continue(:open, state) do
     case state.backend.open_writer(state.path, state.backend_opts) do
       {:ok, db} ->
@@ -46,6 +48,8 @@ defmodule MingaAgent.EventLog.Writer do
   end
 
   @impl GenServer
+  @spec handle_info(term(), WriterState.t()) ::
+          {:noreply, WriterState.t()} | {:stop, term(), WriterState.t()}
   def handle_info({:write_event, token, %EventRecord{} = record}, state) do
     result = state.backend.insert(state.db, record)
     send(state.owner, {:event_log_writer_result, self(), token, record.event_type, result})
@@ -63,6 +67,7 @@ defmodule MingaAgent.EventLog.Writer do
   end
 
   @impl GenServer
+  @spec terminate(term(), WriterState.t()) :: :ok
   def terminate(_reason, %{db: nil}), do: :ok
 
   def terminate(_reason, state) do

--- a/lib/minga_agent/event_log/writer.ex
+++ b/lib/minga_agent/event_log/writer.ex
@@ -1,0 +1,72 @@
+defmodule MingaAgent.EventLog.Writer do
+  @moduledoc """
+  Single ordered SQLite writer for `MingaAgent.EventLog`.
+
+  This process exclusively owns the write connection and executes at most one insert or retention operation at a time. It monitors its EventLog owner so the connection is closed when that owner terminates, including an untrappable kill.
+  """
+
+  use GenServer
+
+  alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.WriterState
+
+  @doc "Starts an unlinked writer monitored by its EventLog owner."
+  @spec start(pid(), keyword()) :: GenServer.on_start()
+  def start(owner, opts) when is_pid(owner) do
+    GenServer.start(__MODULE__, {owner, opts})
+  end
+
+  @impl GenServer
+  @spec init({pid(), keyword()}) :: {:ok, WriterState.t(), {:continue, :open}}
+  def init({owner, opts}) do
+    Process.link(owner)
+
+    state =
+      WriterState.new(
+        owner,
+        Keyword.fetch!(opts, :path),
+        Keyword.fetch!(opts, :backend),
+        Keyword.get(opts, :backend_opts, [])
+      )
+
+    {:ok, state, {:continue, :open}}
+  end
+
+  @impl GenServer
+  def handle_continue(:open, state) do
+    case state.backend.open_writer(state.path, state.backend_opts) do
+      {:ok, db} ->
+        send(state.owner, {:event_log_writer_ready, self()})
+        {:noreply, WriterState.opened(state, db)}
+
+      {:error, reason} ->
+        send(state.owner, {:event_log_writer_unavailable, self(), reason})
+        {:stop, {:shutdown, {:open_failed, reason}}, state}
+    end
+  end
+
+  @impl GenServer
+  def handle_info({:write_event, token, %EventRecord{} = record}, state) do
+    result = state.backend.insert(state.db, record)
+    send(state.owner, {:event_log_writer_result, self(), token, record.event_type, result})
+    {:noreply, state}
+  end
+
+  def handle_info({:delete_before, token, %DateTime{} = cutoff}, state) do
+    result = state.backend.delete_before(state.db, cutoff)
+    send(state.owner, {:event_log_retention_result, self(), token, result})
+    {:noreply, state}
+  end
+
+  def handle_info({:DOWN, ref, :process, owner, reason}, %{owner_ref: ref, owner: owner} = state) do
+    {:stop, {:owner_terminated, reason}, state}
+  end
+
+  @impl GenServer
+  def terminate(_reason, %{db: nil}), do: :ok
+
+  def terminate(_reason, state) do
+    _ = state.backend.close(state.db)
+    :ok
+  end
+end

--- a/lib/minga_agent/event_log/writer_state.ex
+++ b/lib/minga_agent/event_log/writer_state.ex
@@ -1,0 +1,32 @@
+defmodule MingaAgent.EventLog.WriterState do
+  @moduledoc "Owned runtime state and transitions for `MingaAgent.EventLog.Writer`."
+
+  @enforce_keys [:owner, :owner_ref, :path, :backend, :backend_opts]
+  defstruct [:owner, :owner_ref, :path, :backend, :backend_opts, :db]
+
+  @type t :: %__MODULE__{
+          owner: pid(),
+          owner_ref: reference(),
+          path: String.t(),
+          backend: module(),
+          backend_opts: keyword(),
+          db: term() | nil
+        }
+
+  @doc "Builds writer state before the database connection opens."
+  @spec new(pid(), String.t(), module(), keyword()) :: t()
+  def new(owner, path, backend, backend_opts)
+      when is_pid(owner) and is_binary(path) and is_atom(backend) and is_list(backend_opts) do
+    %__MODULE__{
+      owner: owner,
+      owner_ref: Process.monitor(owner),
+      path: path,
+      backend: backend,
+      backend_opts: backend_opts
+    }
+  end
+
+  @doc "Stores the connection exclusively owned by the writer."
+  @spec opened(t(), term()) :: t()
+  def opened(state, db), do: %{state | db: db}
+end

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -810,6 +810,7 @@ defmodule MingaAgent.Session do
   end
 
   @impl GenServer
+  @spec handle_call(term(), GenServer.from(), state()) :: {:reply, term(), state()}
   def handle_call({:seed_messages, messages}, _from, state) do
     state =
       state
@@ -1396,6 +1397,7 @@ defmodule MingaAgent.Session do
   end
 
   @impl GenServer
+  @spec handle_cast(term(), state()) :: {:noreply, state()}
   def handle_cast({:add_system_message, text, level}, state) do
     state = append_system_message(state, text, level)
     state = notify_messages_changed(state)
@@ -1407,6 +1409,7 @@ defmodule MingaAgent.Session do
   end
 
   @impl GenServer
+  @spec handle_info(term(), state()) :: {:noreply, state()} | {:stop, term(), state()}
   def handle_info(:start_provider, state) do
     {:noreply, refresh_credentials_state(state)}
   end
@@ -3859,6 +3862,7 @@ defmodule MingaAgent.Session do
   end
 
   @impl GenServer
+  @spec terminate(term(), state()) :: :ok
   def terminate(reason, state) do
     record_critical_event(state, :session_stopped, %{
       reason: inspect(reason),

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -28,6 +28,7 @@ defmodule MingaAgent.Session do
   alias MingaAgent.Credentials
   alias MingaAgent.Event
   alias MingaAgent.EventLog
+  alias MingaAgent.EventLog.Failure
   alias MingaAgent.Hooks.Dispatcher, as: HookDispatcher
   alias MingaAgent.Hooks.SessionEndPayload
   alias MingaAgent.Hooks.SessionStartPayload
@@ -76,6 +77,9 @@ defmodule MingaAgent.Session do
   @typedoc "Remote attachment role."
   @type attachment_role :: :driver | :viewer
 
+  @typedoc "Latest EventLog admission or persistence failure retained for reconnecting subscribers."
+  @type event_log_failure :: Failure.t()
+
   @typedoc "How a session handles tool approvals when no interactive driver should answer them."
   @type tool_approval_policy ::
           :interactive | {:auto_approve, trust_scope()} | {:reject, String.t()}
@@ -103,6 +107,7 @@ defmodule MingaAgent.Session do
           remote_token: String.t() | nil,
           workdir: String.t() | nil,
           event_log_server: GenServer.server(),
+          event_log_failure: event_log_failure() | nil,
           provider: pid() | nil,
           provider_module: module(),
           provider_id: String.t(),
@@ -733,6 +738,7 @@ defmodule MingaAgent.Session do
       remote_token: Keyword.get(opts, :remote_token),
       workdir: Keyword.get(opts, :workdir),
       event_log_server: Keyword.get(opts, :event_log_server, EventLog),
+      event_log_failure: nil,
       provider: nil,
       provider_module: provider_module,
       provider_id: provider_resolution.id,
@@ -788,16 +794,11 @@ defmodule MingaAgent.Session do
 
     maybe_mark_interrupted_work(state, Keyword.get(opts, :recover_interrupted_work?, true))
 
-    EventLog.record(
-      state.session_id,
-      :session_started,
-      %{
-        model: state.model_name,
-        provider: state.provider_name,
-        background_subagent: state.background_subagent
-      },
-      state.event_log_server
-    )
+    record_critical_event(state, :session_started, %{
+      model: state.model_name,
+      provider: state.provider_name,
+      background_subagent: state.background_subagent
+    })
 
     # Start provider asynchronously so init doesn't block. An unconfigured local
     # session is still useful for draft preservation, but must not boot a provider.
@@ -963,12 +964,7 @@ defmodule MingaAgent.Session do
       state.provider_module.new_session(state.provider)
     end
 
-    EventLog.record(
-      state.session_id,
-      :session_stopped,
-      %{reason: "new_session", status: state.status},
-      state.event_log_server
-    )
+    record_critical_event(state, :session_stopped, %{reason: "new_session", status: state.status})
 
     now = DateTime.utc_now()
     timestamp = Calendar.strftime(now, "%H:%M:%S UTC")
@@ -997,16 +993,11 @@ defmodule MingaAgent.Session do
 
     state = reset_messages(state, [Message.system("Session cleared · #{timestamp}")])
 
-    EventLog.record(
-      state.session_id,
-      :session_started,
-      %{
-        model: state.model_name,
-        provider: state.provider_name,
-        background_subagent: state.background_subagent
-      },
-      state.event_log_server
-    )
+    record_critical_event(state, :session_started, %{
+      model: state.model_name,
+      provider: state.provider_name,
+      background_subagent: state.background_subagent
+    })
 
     broadcast(state, {:status_changed, :idle})
     state = notify_messages_changed(state)
@@ -1190,6 +1181,7 @@ defmodule MingaAgent.Session do
       Process.monitor(pid)
       state = state |> cancel_idle_gc_timer() |> put_subscriber(pid, role)
       send(pid, {:agent_event, self(), {:credentials_status, state.credentials_configured}})
+      notify_retained_event_log_failure(pid, state.event_log_failure)
       {:reply, :ok, state}
     else
       {:reply, {:error, :invalid_role}, state}
@@ -1433,6 +1425,37 @@ defmodule MingaAgent.Session do
     {:noreply, state}
   end
 
+  def handle_info(
+        {:event_log_commit, _receipt, _event_type, {:persisted, _event_id}},
+        state
+      ) do
+    {:noreply, state}
+  end
+
+  def handle_info(
+        {:event_log_commit, receipt, event_type, {:error, {:persistence_failed, reason}}},
+        state
+      ) do
+    Minga.Log.error(
+      :agent,
+      "[Agent.Session] event-log persistence failed for #{event_type}: #{inspect(reason)}"
+    )
+
+    failure = Failure.persistence(receipt, event_type, reason)
+    notify_event_log_failure(state, failure)
+    {:noreply, %{state | event_log_failure: failure}}
+  end
+
+  def handle_info({:event_log_failure, %Failure{} = failure}, state) do
+    Minga.Log.error(
+      :agent,
+      "[Agent.Session] event-log admission failed for #{failure.event_type}: #{inspect(failure.reason)}"
+    )
+
+    notify_event_log_failure(state, failure)
+    {:noreply, %{state | event_log_failure: failure}}
+  end
+
   def handle_info({:DOWN, _ref, :process, pid, reason}, %{provider: pid} = state) do
     {:noreply, handle_provider_death(state, reason)}
   end
@@ -1522,17 +1545,12 @@ defmodule MingaAgent.Session do
     # Send the execution decision directly to the blocked Task process.
     send(reply_to, {:tool_approval_response, tool_call_id, execution_decision(decision)})
 
-    EventLog.record(
-      state.session_id,
-      :approval_resolved,
-      %{
-        approval_id: tool_call_id,
-        tool_call_id: tool_call_id,
-        name: approval.name,
-        decision: decision
-      },
-      state.event_log_server
-    )
+    record_critical_event(state, :approval_resolved, %{
+      approval_id: tool_call_id,
+      tool_call_id: tool_call_id,
+      name: approval.name,
+      decision: decision
+    })
 
     state = maybe_record_rejection(state, approval, decision)
     state = %{state | pending_approval: nil}
@@ -1699,12 +1717,11 @@ defmodule MingaAgent.Session do
     state = track_active_tool_start(state, event.tool_call_id, event.name)
     state = set_working_status(state, :tool_executing)
 
-    EventLog.record(
-      state.session_id,
-      :tool_call_started,
-      %{tool_call_id: event.tool_call_id, name: event.name, args: event.args},
-      state.event_log_server
-    )
+    record_critical_event(state, :tool_call_started, %{
+      tool_call_id: event.tool_call_id,
+      name: event.name,
+      args: event.args
+    })
 
     broadcast(state, {:tool_started, event.name, event.args})
     notify_messages_changed(state)
@@ -1774,12 +1791,12 @@ defmodule MingaAgent.Session do
     state = track_active_tool_end(state, event.tool_call_id)
     status = if event.is_error, do: :error, else: :done
 
-    EventLog.record(
-      state.session_id,
-      :tool_call_finished,
-      %{tool_call_id: event.tool_call_id, name: event.name, result: event.result, status: status},
-      state.event_log_server
-    )
+    record_critical_event(state, :tool_call_finished, %{
+      tool_call_id: event.tool_call_id,
+      name: event.name,
+      result: event.result,
+      status: status
+    })
 
     broadcast(state, {:tool_ended, event.name, event.result, status})
     notify_messages_changed(state)
@@ -1944,12 +1961,7 @@ defmodule MingaAgent.Session do
 
   @spec append_system_message(state(), String.t(), Message.system_level()) :: state()
   defp append_system_message(state, text, level) do
-    EventLog.record(
-      state.session_id,
-      :system_message,
-      %{message: text, level: level},
-      state.event_log_server
-    )
+    record_critical_event(state, :system_message, %{message: text, level: level})
 
     msg = Message.system(text, level)
     append_msg(state, msg)
@@ -2289,14 +2301,14 @@ defmodule MingaAgent.Session do
     maybe_schedule_idle_gc(state)
   end
 
-  @spec record_user_disconnected(state(), pid(), attachment_role() | nil, term()) :: :ok
+  @spec record_user_disconnected(state(), pid(), attachment_role() | nil, term()) ::
+          EventLog.admission_result()
   defp record_user_disconnected(state, pid, role, reason) do
-    EventLog.record(
-      state.session_id,
-      :user_disconnected,
-      %{pid: inspect(pid), role: role, reason: inspect(reason)},
-      state.event_log_server
-    )
+    record_critical_event(state, :user_disconnected, %{
+      pid: inspect(pid),
+      role: role,
+      reason: inspect(reason)
+    })
   end
 
   @spec maybe_schedule_idle_gc(map()) :: map()
@@ -2359,6 +2371,23 @@ defmodule MingaAgent.Session do
     Enum.each(state.subscribers, fn pid ->
       send(pid, {:agent_event, session_pid, event})
     end)
+  end
+
+  @spec notify_event_log_failure(state(), Failure.t()) :: :ok
+  defp notify_event_log_failure(state, failure) do
+    session_pid = self()
+
+    Enum.each(state.subscribers, fn pid ->
+      send(pid, {:agent_event, session_pid, failure})
+    end)
+  end
+
+  @spec notify_retained_event_log_failure(pid(), event_log_failure() | nil) :: :ok
+  defp notify_retained_event_log_failure(_pid, nil), do: :ok
+
+  defp notify_retained_event_log_failure(pid, failure) do
+    send(pid, {:agent_event, self(), Failure.retained(failure)})
+    :ok
   end
 
   @spec maybe_mark_interrupted_work(state(), boolean()) :: :ok
@@ -2433,21 +2462,14 @@ defmodule MingaAgent.Session do
     approval_ids = open_approval_ids(events)
 
     Enum.each(tool_ids, fn tool_call_id ->
-      EventLog.record(
-        state.session_id,
-        :tool_call_interrupted,
-        %{tool_call_id: tool_call_id},
-        state.event_log_server
-      )
+      record_critical_event(state, :tool_call_interrupted, %{tool_call_id: tool_call_id})
     end)
 
     Enum.each(approval_ids, fn approval_id ->
-      EventLog.record(
-        state.session_id,
-        :approval_interrupted,
-        %{approval_id: approval_id, tool_call_id: approval_id},
-        state.event_log_server
-      )
+      record_critical_event(state, :approval_interrupted, %{
+        approval_id: approval_id,
+        tool_call_id: approval_id
+      })
     end)
   end
 
@@ -2483,15 +2505,60 @@ defmodule MingaAgent.Session do
     |> Enum.filter(&is_binary/1)
   end
 
-  @spec record_broadcast_event(state(), term()) :: :ok
+  @spec record_broadcast_event(state(), term()) ::
+          EventLog.admission_result() | EventLog.best_effort_admission_result() | :ok
   defp record_broadcast_event(state, event) do
     case event_log_entry(event) do
       {event_type, payload} ->
-        EventLog.record(state.session_id, event_type, payload, state.event_log_server)
+        record_event_log_entry(state, event_type, payload)
 
       nil ->
         :ok
     end
+  end
+
+  @spec record_event_log_entry(state(), EventLog.EventRecord.event_type(), map()) ::
+          EventLog.admission_result() | EventLog.best_effort_admission_result()
+  defp record_event_log_entry(state, :assistant_delta, payload) do
+    EventLog.record_best_effort(
+      state.session_id,
+      :assistant_delta,
+      payload,
+      state.event_log_server
+    )
+  end
+
+  defp record_event_log_entry(state, :thinking_delta, payload) do
+    EventLog.record_best_effort(
+      state.session_id,
+      :thinking_delta,
+      payload,
+      state.event_log_server
+    )
+  end
+
+  defp record_event_log_entry(state, event_type, payload) do
+    record_critical_event(state, event_type, payload)
+  end
+
+  @spec record_critical_event(state(), EventLog.EventRecord.event_type(), map()) ::
+          EventLog.admission_result()
+  defp record_critical_event(state, event_type, payload) do
+    result = EventLog.record(state.session_id, event_type, payload, state.event_log_server)
+    report_admission_failure(state, event_type, result)
+    result
+  end
+
+  @spec report_admission_failure(
+          state(),
+          EventLog.EventRecord.event_type(),
+          EventLog.admission_result()
+        ) :: :ok
+  defp report_admission_failure(_state, _event_type, {:queued, _receipt}), do: :ok
+
+  defp report_admission_failure(_state, event_type, {:error, reason}) do
+    send(self(), {:event_log_failure, Failure.admission(event_type, reason)})
+    :ok
   end
 
   @spec event_log_entry(term()) :: {EventLog.EventRecord.event_type(), map()} | nil
@@ -2613,23 +2680,13 @@ defmodule MingaAgent.Session do
     {Message.user(text, attachments), parts}
   end
 
-  @spec record_user_message(state(), Message.t()) :: :ok
+  @spec record_user_message(state(), Message.t()) :: EventLog.admission_result()
   defp record_user_message(state, {:user, text}) do
-    EventLog.record(
-      state.session_id,
-      :user_message,
-      %{text: text, attachments: []},
-      state.event_log_server
-    )
+    record_critical_event(state, :user_message, %{text: text, attachments: []})
   end
 
   defp record_user_message(state, {:user, text, attachments}) do
-    EventLog.record(
-      state.session_id,
-      :user_message,
-      %{text: text, attachments: attachments},
-      state.event_log_server
-    )
+    record_critical_event(state, :user_message, %{text: text, attachments: attachments})
   end
 
   @spec parse_size_kb(String.t()) :: non_neg_integer()
@@ -3803,12 +3860,10 @@ defmodule MingaAgent.Session do
 
   @impl GenServer
   def terminate(reason, state) do
-    EventLog.record(
-      state.session_id,
-      :session_stopped,
-      %{reason: inspect(reason), status: state.status},
-      state.event_log_server
-    )
+    record_critical_event(state, :session_stopped, %{
+      reason: inspect(reason),
+      status: state.status
+    })
 
     dispatch_session_end(state, reason)
     release_provider_lease(state.provider_lease)

--- a/test/minga_agent/event_log/session_integration_test.exs
+++ b/test/minga_agent/event_log/session_integration_test.exs
@@ -3,11 +3,14 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
 
   alias MingaAgent.Event
   alias MingaAgent.EventLog
+  alias MingaAgent.EventLog.ControllableStore
+  alias MingaAgent.EventLog.Failure
   alias MingaAgent.EventLog.Store
   alias MingaAgent.Session
   alias MingaAgent.TodoItem
 
   @moduletag :tmp_dir
+  @event_timeout 2_000
 
   defmodule SteeringProvider do
     @behaviour MingaAgent.Provider
@@ -254,23 +257,25 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
         {EventLog, name: log_name, db_dir: tmp_dir, retention_sweep?: false, health_check: :none}
       )
 
-    EventLog.record(
-      "redaction-session",
-      :system_message,
-      %{
-        remote_token: "remote-secret",
-        nested: %{
-          access_token: "access-secret",
-          refresh_token: "refresh-secret",
-          authorization: "Bearer secret",
-          owner_pid: self(),
-          owner_ref: make_ref()
-        }
-      },
-      log_name
-    )
+    assert {:queued, receipt} =
+             EventLog.record(
+               "redaction-session",
+               :system_message,
+               %{
+                 remote_token: "remote-secret",
+                 nested: %{
+                   access_token: "access-secret",
+                   refresh_token: "refresh-secret",
+                   authorization: "Bearer secret",
+                   owner_pid: self(),
+                   owner_ref: make_ref()
+                 }
+               },
+               log_name
+             )
 
-    :sys.get_state(log_pid)
+    assert {:persisted, _event_id} = EventLog.await(receipt)
+    assert :ok = EventLog.await_idle(log_pid)
 
     {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
     {:ok, [event]} = EventLog.events_after(db, "redaction-session", 0, 10)
@@ -282,6 +287,84 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
     assert event.payload["nested"]["authorization"] == "[REDACTED]"
     assert event.payload["nested"]["owner_pid"] == "[PID]"
     assert event.payload["nested"]["owner_ref"] == "[REFERENCE]"
+  end
+
+  test "session stays responsive to a stalled critical write and exposes commitment failure" do
+    log_name = unique_name("session-failure-log")
+
+    start_supervised!(
+      {EventLog,
+       name: log_name,
+       store_backend: ControllableStore,
+       store_backend_opts: [controller: self()],
+       writer_restart_delay_ms: 60_000,
+       retention_sweep?: false,
+       health_check: :none}
+    )
+
+    assert_receive {:event_log_store_open, writer, _path}, @event_timeout
+    send(writer, {:event_log_store_open_result, :ok})
+
+    session =
+      start_supervised!(
+        {Session,
+         session_id: "failure-session",
+         provider: ReplayProvider,
+         event_log_server: log_name,
+         persist?: false,
+         hooks_enabled?: false}
+      )
+
+    assert :ok = Session.subscribe(session, self(), role: :viewer)
+    assert_receive {:agent_event, ^session, {:credentials_status, _configured?}}
+    assert_receive {:event_log_store_insert, ^writer, %{event_type: :session_started}}
+    assert Session.status(session) == :idle
+
+    send(writer, {:event_log_store_insert_result, {:error, :disk_full}})
+
+    assert_receive {:agent_event, ^session,
+                    %Failure{
+                      stage: :persistence,
+                      receipt: receipt,
+                      event_type: :session_started,
+                      reason: :disk_full
+                    }}
+
+    assert is_reference(receipt)
+
+    Session.add_system_message(session, "persistence recovered", :info)
+    :sys.get_state(session)
+    assert_receive {:event_log_store_insert, ^writer, %{event_type: :system_message}}
+    send(writer, {:event_log_store_insert_result, {:ok, 41}})
+    assert :ok = EventLog.await_idle(log_name)
+    :sys.get_state(session)
+
+    parent = self()
+
+    late_subscriber =
+      spawn(fn ->
+        Enum.each(1..2, fn _index ->
+          receive do
+            event -> send(parent, {:late_subscriber, event})
+          end
+        end)
+      end)
+
+    assert :ok = Session.subscribe(session, late_subscriber, role: :viewer)
+
+    assert_receive {:late_subscriber,
+                    {:agent_event, ^session, {:credentials_status, _configured?}}}
+
+    assert_receive {:late_subscriber,
+                    {:agent_event, ^session,
+                     %Failure{
+                       stage: :persistence,
+                       receipt: nil,
+                       event_type: :session_started,
+                       reason: :disk_full
+                     }}}
+
+    refute_receive {:event_log_store_insert, ^writer, %{event_type: :error}}
   end
 
   test "subscriber disconnects are durably recorded", %{tmp_dir: tmp_dir} do
@@ -380,7 +463,7 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
     :sys.get_state(session)
     Session.add_system_message(session, "before crash", :info)
     :sys.get_state(session)
-    :sys.get_state(log_pid)
+    assert :ok = EventLog.await_idle(log_pid)
 
     ref = Process.monitor(session)
     Process.exit(session, :kill)
@@ -414,7 +497,7 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
 
   defp wait_for_user_texts(db, session_id, session_pid, log_pid, attempts) when attempts > 0 do
     :sys.get_state(session_pid)
-    :sys.get_state(log_pid)
+    assert :ok = EventLog.await_idle(log_pid)
     {:ok, events} = EventLog.events_after(db, session_id, 0, 50)
 
     user_texts =
@@ -445,7 +528,7 @@ defmodule MingaAgent.EventLog.SessionIntegrationTest do
   defp wait_for_event(db, session_id, event_type, session_pid, log_pid, attempts)
        when attempts > 0 do
     :sys.get_state(session_pid)
-    :sys.get_state(log_pid)
+    assert :ok = EventLog.await_idle(log_pid)
     {:ok, events} = EventLog.events_after(db, session_id, 0, 50)
 
     if Enum.any?(events, &(&1.event_type == event_type)) do

--- a/test/minga_agent/event_log/store_test.exs
+++ b/test/minga_agent/event_log/store_test.exs
@@ -91,20 +91,49 @@ defmodule MingaAgent.EventLog.StoreTest do
     assert file_mode(path) == 0o600
   end
 
-  test "open does not chmod an existing database parent directory", %{tmp_dir: tmp_dir} do
-    dir = Path.join(tmp_dir, "shared-parent")
+  test "open protects an existing application-owned directory and database before SQLite setup",
+       %{
+         tmp_dir: tmp_dir
+       } do
+    dir = Path.join(tmp_dir, "agent-log")
     path = Path.join(dir, "agent_events.db")
 
     File.mkdir_p!(dir)
-    File.write!(path, "")
+    File.write!(path, "not a sqlite database")
     File.chmod!(dir, 0o755)
     File.chmod!(path, 0o666)
 
-    {:ok, db} = Store.open(path)
-    :ok = Store.close(db)
-
-    assert file_mode(dir) == 0o755
+    assert {:error, _reason} = Store.open(path)
+    assert file_mode(dir) == 0o700
     assert file_mode(path) == 0o600
+  end
+
+  test "open rejects symlink and non-regular database paths", %{tmp_dir: tmp_dir} do
+    dir = Path.join(tmp_dir, "agent-log")
+    File.mkdir_p!(dir)
+
+    target = Path.join(tmp_dir, "outside.db")
+    File.write!(target, "outside")
+    symlink_path = Path.join(dir, "agent_events.db")
+    File.ln_s!(target, symlink_path)
+
+    assert {:error, {:unsafe_database_path, ^symlink_path, :symlink}} = Store.open(symlink_path)
+    assert File.read!(target) == "outside"
+
+    File.rm!(symlink_path)
+    File.mkdir!(symlink_path)
+
+    assert {:error, {:unsafe_database_path, ^symlink_path, :directory}} = Store.open(symlink_path)
+  end
+
+  test "open rejects a symlink database directory", %{tmp_dir: tmp_dir} do
+    real_dir = Path.join(tmp_dir, "real")
+    linked_dir = Path.join(tmp_dir, "linked")
+    File.mkdir_p!(real_dir)
+    File.ln_s!(real_dir, linked_dir)
+
+    assert {:error, {:unsafe_database_directory, :symlink}} =
+             Store.open(Path.join(linked_dir, "agent_events.db"))
   end
 
   test "writes keep SQLite WAL and SHM files private", %{tmp_dir: tmp_dir} do
@@ -123,6 +152,25 @@ defmodule MingaAgent.EventLog.StoreTest do
     end
 
     :ok = Store.close(db)
+  end
+
+  test "writer open quarantines a corrupt database instead of deleting the evidence", %{
+    tmp_dir: tmp_dir
+  } do
+    path = Path.join(tmp_dir, "agent_events.db")
+    {:ok, db} = Store.open(path)
+    :ok = Store.close(db)
+
+    {:ok, file} = :file.open(path, [:read, :write, :binary, :raw])
+    :ok = :file.pwrite(file, 100, :binary.copy(<<255>>, 512))
+    :ok = :file.close(file)
+
+    {:ok, replacement} = Store.open_writer(path, [])
+    :ok = Store.close(replacement)
+
+    assert [quarantined] = Path.wildcard(path <> ".corrupt-*")
+    assert File.stat!(quarantined).size > 0
+    assert File.exists?(path)
   end
 
   test "records survive reopening the database", %{tmp_dir: tmp_dir} do

--- a/test/minga_agent/event_log/store_test.exs
+++ b/test/minga_agent/event_log/store_test.exs
@@ -34,6 +34,52 @@ defmodule MingaAgent.EventLog.StoreTest do
     assert {:ok, []} = Store.events_after(db, "session-a", second_id, 10)
   end
 
+  test "repeated insertion of one event key returns the committed id without duplication", %{
+    db: db
+  } do
+    record = EventRecord.new("session-a", :tool_call_started, %{"tool_call_id" => "tool-1"})
+    %EventRecord{event_key: expected_event_key} = record
+
+    assert {:ok, first_id} = Store.insert(db, record)
+    assert {:ok, ^first_id} = Store.insert(db, record)
+    assert {:ok, 1} = Store.count(db)
+
+    assert {:ok, [%{id: ^first_id, event_key: event_key}]} =
+             Store.events_after(db, "session-a", 0, 10)
+
+    assert event_key == expected_event_key
+  end
+
+  test "open migrates version one events to stable idempotency keys", %{tmp_dir: tmp_dir} do
+    path = Path.join(tmp_dir, "legacy-agent-events.db")
+    {:ok, legacy} = Exqlite.Sqlite3.open(path)
+
+    :ok =
+      Exqlite.Sqlite3.execute(
+        legacy,
+        "CREATE TABLE events (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, event_type TEXT NOT NULL, payload TEXT NOT NULL DEFAULT '{}', wall_clock TEXT NOT NULL, monotonic_ts INTEGER NOT NULL)"
+      )
+
+    :ok =
+      Exqlite.Sqlite3.execute(legacy, "CREATE TABLE schema_version (version INTEGER NOT NULL)")
+
+    :ok = Exqlite.Sqlite3.execute(legacy, "INSERT INTO schema_version (version) VALUES (1)")
+
+    :ok =
+      Exqlite.Sqlite3.execute(
+        legacy,
+        "INSERT INTO events (session_id, event_type, payload, wall_clock, monotonic_ts) VALUES ('legacy-session', 'session_started', '{}', '2026-01-01T00:00:00Z', 1)"
+      )
+
+    :ok = Exqlite.Sqlite3.close(legacy)
+    {:ok, migrated} = Store.open(path)
+
+    assert {:ok, [%{id: 1, event_key: "legacy-1"}]} =
+             Store.events_after(migrated, "legacy-session", 0, 10)
+
+    :ok = Store.close(migrated)
+  end
+
   test "open creates a missing database directory as private", %{tmp_dir: tmp_dir} do
     dir = Path.join(tmp_dir, "agent-log")
     path = Path.join(dir, "agent_events.db")

--- a/test/minga_agent/event_log_test.exs
+++ b/test/minga_agent/event_log_test.exs
@@ -2,42 +2,304 @@ defmodule MingaAgent.EventLogTest do
   use ExUnit.Case, async: true
 
   alias MingaAgent.EventLog
+  alias MingaAgent.EventLog.ControllableStore
   alias MingaAgent.EventLog.Store
 
   @moduletag :tmp_dir
+  @event_timeout 2_000
 
-  test "record writes asynchronously and redacts secrets", %{tmp_dir: tmp_dir} do
+  test "record acknowledges queue admission before committed persistence and redacts secrets", %{
+    tmp_dir: tmp_dir
+  } do
     name = unique_name("event-log")
+    start_event_log(name, db_dir: tmp_dir)
 
-    pid =
-      start_supervised!(
-        {EventLog, name: name, db_dir: tmp_dir, retention_sweep?: false, health_check: :none}
-      )
+    assert {:queued, receipt} =
+             EventLog.record(
+               "session-1",
+               :tool_call_started,
+               %{
+                 :api_key => "secret",
+                 :accessToken => "camel",
+                 "client-secret" => "hyphen",
+                 :nested => %{refreshToken: "abc"},
+                 :pid => self()
+               },
+               name
+             )
 
-    :ok =
-      EventLog.record(
-        "session-1",
-        :tool_call_started,
-        %{
-          :api_key => "secret",
-          :accessToken => "camel",
-          "client-secret" => "hyphen",
-          :nested => %{refreshToken: "abc"},
-          :pid => self()
-        },
-        name
-      )
-
-    :sys.get_state(pid)
+    assert_receive {:event_log_commit, ^receipt, :tool_call_started, {:persisted, event_id}}
+    assert is_integer(event_id)
 
     {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
     assert {:ok, [record]} = EventLog.events_after(db, "session-1", 0, 10)
+    assert record.id == event_id
     assert record.payload["api_key"] == "[REDACTED]"
     assert record.payload["accessToken"] == "[REDACTED]"
     assert record.payload["client-secret"] == "[REDACTED]"
     assert record.payload["nested"]["refreshToken"] == "[REDACTED]"
     assert record.payload["pid"] == "[PID]"
     :ok = Store.close(db)
+  end
+
+  test "stalled writer preserves bounded ordered admission and best-effort semantics" do
+    name = unique_name("bounded-log")
+    start_controlled_event_log(name, max_queue_size: 2)
+    writer = open_controlled_writer()
+
+    assert {:queued, first_receipt} =
+             EventLog.record("session", :tool_call_started, %{sequence: 1}, name)
+
+    assert_receive {:event_log_store_insert, ^writer, first_record}
+    assert first_record.payload["sequence"] == 1
+
+    assert :queued =
+             EventLog.record_best_effort("session", :assistant_delta, %{sequence: 2}, name)
+
+    assert {:error, :overloaded} =
+             EventLog.record("session", :tool_call_finished, %{sequence: 3}, name)
+
+    assert EventLog.writer_pid(name) == writer
+
+    send(writer, {:event_log_store_insert_result, {:ok, 11}})
+
+    assert_receive {:event_log_commit, ^first_receipt, :tool_call_started, {:persisted, 11}}
+    assert_receive {:event_log_store_insert, ^writer, second_record}
+    assert second_record.event_type == :assistant_delta
+    assert second_record.payload["sequence"] == 2
+
+    send(writer, {:event_log_store_insert_result, {:ok, 12}})
+    assert :ok = EventLog.await_idle(name)
+    refute_receive {:event_log_commit, _receipt, :assistant_delta, _result}
+
+    assert {:queued, final_receipt} =
+             EventLog.record("session", :tool_call_finished, %{sequence: 4}, name)
+
+    assert_receive {:event_log_store_insert, ^writer, final_record}
+    assert final_record.payload["sequence"] == 4
+    send(writer, {:event_log_store_insert_result, {:ok, 13}})
+    assert {:persisted, 13} = EventLog.await(final_receipt)
+  end
+
+  test "insert failure produces an explicit post-store persistence failure" do
+    name = unique_name("failure-log")
+    start_controlled_event_log(name)
+    writer = open_controlled_writer()
+
+    assert {:queued, receipt} =
+             EventLog.record("session", :approval_requested, %{approval_id: "a-1"}, name)
+
+    assert_receive {:event_log_store_insert, ^writer, _record}
+    send(writer, {:event_log_store_insert_result, {:error, :disk_full}})
+
+    assert_receive {:event_log_commit, ^receipt, :approval_requested,
+                    {:error, {:persistence_failed, :disk_full}}}
+  end
+
+  test "writer death retries the uncertain event idempotently before later queued work" do
+    name = unique_name("writer-death-log")
+    start_controlled_event_log(name)
+    first_writer = open_controlled_writer()
+
+    assert {:queued, first_receipt} =
+             EventLog.record("session", :tool_call_started, %{sequence: 1}, name)
+
+    assert_receive {:event_log_store_insert, ^first_writer, first_record}
+
+    assert {:queued, second_receipt} =
+             EventLog.record("session", :tool_call_finished, %{sequence: 2}, name)
+
+    send(first_writer, {:event_log_store_insert_result, {:committed, 21}})
+    assert_receive {:event_log_store_committed, ^first_writer, committed_record, 21}
+    assert committed_record.event_key == first_record.event_key
+    Process.exit(first_writer, :kill)
+
+    second_writer = open_controlled_writer()
+    assert second_writer != first_writer
+    assert_receive {:event_log_store_insert, ^second_writer, retried_record}
+    assert first_record.event_key == retried_record.event_key
+    assert retried_record.payload["sequence"] == 1
+
+    send(second_writer, {:event_log_store_insert_result, {:ok, 21}})
+    assert {:persisted, 21} = EventLog.await(first_receipt)
+
+    assert_receive {:event_log_store_insert, ^second_writer, second_record}
+    assert second_record.payload["sequence"] == 2
+    send(second_writer, {:event_log_store_insert_result, {:ok, 22}})
+    assert {:persisted, 22} = EventLog.await(second_receipt)
+  end
+
+  test "writer death before commit retries the same key without reordering later work" do
+    name = unique_name("pre-commit-death-log")
+    start_controlled_event_log(name)
+    first_writer = open_controlled_writer()
+
+    assert {:queued, first_receipt} =
+             EventLog.record("session", :tool_call_started, %{sequence: 1}, name)
+
+    assert_receive {:event_log_store_insert, ^first_writer, first_record}
+
+    assert {:queued, second_receipt} =
+             EventLog.record("session", :tool_call_finished, %{sequence: 2}, name)
+
+    Process.exit(first_writer, :kill)
+    second_writer = open_controlled_writer()
+
+    assert_receive {:event_log_store_insert, ^second_writer, retried_record}
+    assert retried_record.event_key == first_record.event_key
+    assert retried_record.payload["sequence"] == 1
+    send(second_writer, {:event_log_store_insert_result, {:ok, 31}})
+    assert {:persisted, 31} = EventLog.await(first_receipt)
+
+    assert_receive {:event_log_store_insert, ^second_writer, second_record}
+    assert second_record.payload["sequence"] == 2
+    send(second_writer, {:event_log_store_insert_result, {:ok, 32}})
+    assert {:persisted, 32} = EventLog.await(second_receipt)
+  end
+
+  test "writer open failure fails queued receipts and stays unavailable until restart" do
+    name = unique_name("open-failure-log")
+    start_controlled_event_log(name, writer_restart_delay_ms: 60_000)
+
+    assert_receive {:event_log_store_open, first_writer, _path}, @event_timeout
+
+    assert {:queued, receipt} =
+             EventLog.record("session", :session_started, %{sequence: 1}, name)
+
+    send(first_writer, {:event_log_store_open_result, {:error, :permission_denied}})
+
+    assert_receive {:event_log_commit, ^receipt, :session_started,
+                    {:error, {:persistence_failed, {:writer_start_failed, :permission_denied}}}}
+
+    assert {:error, :unavailable} =
+             EventLog.record("session", :session_started, %{sequence: 2}, name)
+
+    assert :ok = EventLog.restart_writer(name)
+    second_writer = open_controlled_writer()
+
+    assert {:queued, recovered_receipt} =
+             EventLog.record("session", :session_started, %{sequence: 3}, name)
+
+    assert_receive {:event_log_store_insert, ^second_writer, recovered_record}
+    assert recovered_record.payload["sequence"] == 3
+    send(second_writer, {:event_log_store_insert_result, {:ok, 31}})
+    assert {:persisted, 31} = EventLog.await(recovered_receipt)
+  end
+
+  test "acknowledged critical boundaries remain ordered and unique after a full log restart", %{
+    tmp_dir: tmp_dir
+  } do
+    first_name = unique_name("durable-log")
+    first_id = unique_name("durable-child")
+    start_event_log(first_name, [db_dir: tmp_dir], first_id)
+
+    first_boundaries = [
+      {:tool_call_started, %{tool_call_id: "tool-1", sequence: 1}},
+      {:tool_call_finished, %{tool_call_id: "tool-1", sequence: 2}},
+      {:approval_requested, %{approval_id: "approval-1", sequence: 3}}
+    ]
+
+    first_event_ids =
+      Enum.map(first_boundaries, fn {event_type, payload} ->
+        record_and_await(first_name, event_type, payload)
+      end)
+
+    stop_supervised(first_id)
+
+    second_name = unique_name("durable-log")
+    start_event_log(second_name, db_dir: tmp_dir)
+
+    second_boundaries = [
+      {:approval_resolved, %{approval_id: "approval-1", sequence: 4}},
+      {:file_edit_proposed, %{path: "lib/example.ex", sequence: 5}},
+      {:waiting_for_input, %{status: :idle, sequence: 6}}
+    ]
+
+    second_event_ids =
+      Enum.map(second_boundaries, fn {event_type, payload} ->
+        record_and_await(second_name, event_type, payload)
+      end)
+
+    event_ids = first_event_ids ++ second_event_ids
+    assert event_ids == Enum.sort(event_ids)
+
+    {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
+    assert {:ok, events} = EventLog.events_after(db, "durable-session", 0, 10)
+    assert Enum.map(events, & &1.id) == event_ids
+
+    assert Enum.map(events, & &1.event_type) ==
+             Enum.map(first_boundaries ++ second_boundaries, &elem(&1, 0))
+
+    assert Enum.map(events, & &1.payload["sequence"]) == Enum.to_list(1..6)
+    assert events |> Enum.map(& &1.id) |> Enum.uniq() == event_ids
+    :ok = Store.close(db)
+  end
+
+  test "blocked writer dies when its EventLog owner is killed" do
+    name = unique_name("killed-owner-log")
+    log = start_controlled_event_log(name)
+    writer = open_controlled_writer()
+
+    assert {:queued, _receipt} =
+             EventLog.record("session", :session_started, %{sequence: 1}, name)
+
+    assert_receive {:event_log_store_insert, ^writer, _record}
+    writer_ref = Process.monitor(writer)
+    Process.exit(log, :kill)
+
+    assert_receive {:DOWN, ^writer_ref, :process, ^writer, :killed}
+  end
+
+  test "writer terminates when its EventLog owner is stopped" do
+    name = unique_name("owner-log")
+    child_id = unique_name("owner-child")
+    log = start_controlled_event_log(name, [], child_id)
+    writer = open_controlled_writer()
+    writer_ref = Process.monitor(writer)
+    log_ref = Process.monitor(log)
+
+    stop_supervised(child_id)
+
+    assert_receive {:DOWN, ^writer_ref, :process, ^writer, _reason}
+    assert_receive {:DOWN, ^log_ref, :process, ^log, :shutdown}
+  end
+
+  @spec record_and_await(atom(), MingaAgent.EventLog.EventRecord.event_type(), map()) ::
+          pos_integer()
+  defp record_and_await(server, event_type, payload) do
+    assert {:queued, receipt} = EventLog.record("durable-session", event_type, payload, server)
+    assert {:persisted, event_id} = EventLog.await(receipt)
+    event_id
+  end
+
+  @spec start_event_log(atom(), keyword(), atom()) :: pid()
+  defp start_event_log(name, opts, child_id \\ unique_name("event-log-child")) do
+    spec =
+      Supervisor.child_spec(
+        {EventLog, [name: name, retention_sweep?: false, health_check: :none] ++ opts},
+        id: child_id
+      )
+
+    start_supervised!(spec)
+  end
+
+  @spec start_controlled_event_log(atom(), keyword(), atom()) :: pid()
+  defp start_controlled_event_log(name, opts \\ [], child_id \\ unique_name("controlled-child")) do
+    start_event_log(
+      name,
+      [
+        store_backend: ControllableStore,
+        store_backend_opts: [controller: self()]
+      ] ++ opts,
+      child_id
+    )
+  end
+
+  @spec open_controlled_writer() :: pid()
+  defp open_controlled_writer do
+    assert_receive {:event_log_store_open, writer, _path}, @event_timeout
+    send(writer, {:event_log_store_open_result, :ok})
+    writer
   end
 
   @spec unique_name(String.t()) :: atom()

--- a/test/minga_agent/event_log_test.exs
+++ b/test/minga_agent/event_log_test.exs
@@ -3,6 +3,7 @@ defmodule MingaAgent.EventLogTest do
 
   alias MingaAgent.EventLog
   alias MingaAgent.EventLog.ControllableStore
+  alias MingaAgent.EventLog.EventRecord
   alias MingaAgent.EventLog.Store
 
   @moduletag :tmp_dir
@@ -28,7 +29,9 @@ defmodule MingaAgent.EventLogTest do
                name
              )
 
-    assert_receive {:event_log_commit, ^receipt, :tool_call_started, {:persisted, event_id}}
+    assert_receive {:event_log_commit, ^receipt, :tool_call_started, {:persisted, event_id}},
+                   @event_timeout
+
     assert is_integer(event_id)
 
     {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
@@ -79,6 +82,94 @@ defmodule MingaAgent.EventLogTest do
     assert final_record.payload["sequence"] == 4
     send(writer, {:event_log_store_insert_result, {:ok, 13}})
     assert {:persisted, 13} = EventLog.await(final_receipt)
+  end
+
+  test "oversized and invalid payloads are rejected before reaching the writer" do
+    name = unique_name("payload-limits-log")
+    start_controlled_event_log(name)
+    writer = open_controlled_writer()
+
+    assert {:error, :payload_too_large} =
+             EventLog.record(
+               "session",
+               :system_message,
+               %{message: String.duplicate("x", 300_000)},
+               name
+             )
+
+    assert {:error, :invalid_payload} =
+             EventLog.record("session", :system_message, %{message: <<255>>}, name)
+
+    assert {:error, :invalid_payload} =
+             EventLog.record("session", :system_message, %{callback: fn -> :ok end}, name)
+
+    refute_receive {:event_log_store_insert, ^writer, _record}
+  end
+
+  test "outstanding byte accounting includes best-effort work and releases terminal events" do
+    name = unique_name("byte-bounds-log")
+    start_controlled_event_log(name, max_queue_bytes: 48)
+    writer = open_controlled_writer()
+
+    assert :queued =
+             EventLog.record_best_effort(
+               "session",
+               :assistant_delta,
+               %{delta: "1234567890"},
+               name
+             )
+
+    assert_receive {:event_log_store_insert, ^writer, _record}
+
+    assert {:error, :overloaded} =
+             EventLog.record("session", :system_message, %{message: "1234567890"}, name)
+
+    send(writer, {:event_log_store_insert_result, {:ok, 1}})
+    assert :ok = EventLog.await_idle(name)
+
+    assert {:queued, failed_receipt} =
+             EventLog.record("session", :system_message, %{message: "1234567890"}, name)
+
+    assert_receive {:event_log_store_insert, ^writer, _record}
+    send(writer, {:event_log_store_insert_result, {:error, :disk_full}})
+
+    assert {:error, {:persistence_failed, :disk_full}} = EventLog.await(failed_receipt)
+
+    assert {:queued, final_receipt} =
+             EventLog.record("session", :system_message, %{message: "1234567890"}, name)
+
+    assert_receive {:event_log_store_insert, ^writer, _record}
+    send(writer, {:event_log_store_insert_result, {:ok, 2}})
+    assert {:persisted, 2} = EventLog.await(final_receipt)
+  end
+
+  test "serialization failure is terminal and later FIFO work still persists", %{tmp_dir: tmp_dir} do
+    name = unique_name("poison-log")
+    start_event_log(name, db_dir: tmp_dir)
+
+    poison = EventRecord.new("session", :system_message, %{"callback" => fn -> :ok end})
+
+    assert {:queued, poison_receipt} =
+             GenServer.call(
+               name,
+               {:admit, :critical, poison, :erlang.external_size(poison.payload)},
+               :infinity
+             )
+
+    assert {:queued, valid_receipt} =
+             EventLog.record("session", :system_message, %{message: "valid"}, name)
+
+    assert {:error, {:persistence_failed, {:serialization_failed, _exception}}} =
+             EventLog.await(poison_receipt)
+
+    assert {:persisted, _id} = EventLog.await(valid_receipt)
+
+    {:ok, db} = EventLog.open_read_connection(db_dir: tmp_dir)
+
+    assert {:ok, [%{payload: %{"message" => "valid"}}]} =
+             EventLog.events_after(db, "session", 0, 10)
+
+    :ok = Store.close(db)
   end
 
   test "insert failure produces an explicit post-store persistence failure" do
@@ -184,6 +275,29 @@ defmodule MingaAgent.EventLogTest do
     assert recovered_record.payload["sequence"] == 3
     send(second_writer, {:event_log_store_insert_result, {:ok, 31}})
     assert {:persisted, 31} = EventLog.await(recovered_receipt)
+  end
+
+  test "retention survives writer death followed by replacement open failure" do
+    name = unique_name("retention-recovery-log")
+    log = start_controlled_event_log(name, writer_restart_delay_ms: 60_000)
+    first_writer = open_controlled_writer()
+
+    send(log, :retention_sweep)
+    assert_receive {:event_log_store_delete_before, ^first_writer, _cutoff}
+    Process.exit(first_writer, :kill)
+
+    assert_receive {:event_log_store_open, second_writer, _path}, @event_timeout
+    second_ref = Process.monitor(second_writer)
+    send(second_writer, {:event_log_store_open_result, {:error, :permission_denied}})
+    assert_receive {:DOWN, ^second_ref, :process, ^second_writer, _reason}
+    assert %{status: :unavailable, pending_retention: true} = :sys.get_state(log)
+
+    assert :ok = EventLog.restart_writer(name)
+    third_writer = open_controlled_writer()
+
+    assert_receive {:event_log_store_delete_before, ^third_writer, _cutoff}
+    send(third_writer, {:event_log_store_delete_before_result, {:ok, 0}})
+    assert :ok = EventLog.await_idle(name)
   end
 
   test "acknowledged critical boundaries remain ordered and unique after a full log restart", %{

--- a/test/minga_agent/tools/shell_test.exs
+++ b/test/minga_agent/tools/shell_test.exs
@@ -90,20 +90,22 @@ defmodule MingaAgent.Tools.ShellTest do
         :ok
       end
 
-      # Sleep for 0.5s (longer than the 250ms running indicator threshold).
-      # The debounce cycle is 200ms, so the indicator fires at ~400ms.
-      assert {:ok, _output} =
-               Shell.execute("sleep 0.5 && echo done", dir, 5,
-                 on_output: on_output,
-                 running_indicator_ms: 250
-               )
+      fifo = Path.join(dir, "silent-command-release")
+      assert {"", 0} = System.cmd("mkfifo", [fifo])
 
-      chunks = collect_shell_chunks()
-      combined = IO.iodata_to_binary(chunks)
+      task =
+        Task.async(fn ->
+          Shell.execute("cat #{inspect(fifo)} >/dev/null && echo done", dir, 5,
+            on_output: on_output,
+            running_indicator_ms: 250
+          )
+        end)
 
-      # Should have received at least one running indicator
-      assert combined =~ "[running...]"
-      # And the final output
+      assert_receive {:shell_chunk, "[running...]\n"}, 2_000
+      File.write!(fifo, "release\n")
+      assert {:ok, _output} = Task.await(task)
+
+      combined = collect_shell_chunks() |> IO.iodata_to_binary()
       assert combined =~ "done"
     end
 

--- a/test/minga_editor/commands/formatting_async_test.exs
+++ b/test/minga_editor/commands/formatting_async_test.exs
@@ -111,7 +111,7 @@ defmodule MingaEditor.Commands.FormattingAsyncTest do
     )
 
     :ok = :sys.resume(buffer)
-    assert_receive {^insert_tag, :ok}
+    assert_receive {^insert_tag, :ok}, @effect_timeout
     {new_state, outcome} = Task.await(task)
 
     assert Buffer.content(buffer) == "!FORMATTED\n"

--- a/test/support/minga_agent/event_log_controllable_store.ex
+++ b/test/support/minga_agent/event_log_controllable_store.ex
@@ -1,0 +1,68 @@
+defmodule MingaAgent.EventLog.ControllableStore do
+  @moduledoc "Deterministic event-log store backend controlled by the owning test process."
+
+  @behaviour MingaAgent.EventLog.StoreBackend
+
+  alias MingaAgent.EventLog.EventRecord
+
+  @doc "Requests an open result from the configured test controller."
+  @impl MingaAgent.EventLog.StoreBackend
+  @spec open_writer(String.t(), keyword()) :: {:ok, map()} | {:error, term()}
+  def open_writer(path, opts) do
+    controller = Keyword.fetch!(opts, :controller)
+    send(controller, {:event_log_store_open, self(), path})
+
+    receive do
+      {:event_log_store_open_result, result} -> normalize_open_result(result, controller)
+    end
+  end
+
+  @doc "Reports that the controlled connection closed."
+  @impl MingaAgent.EventLog.StoreBackend
+  @spec close(map()) :: :ok
+  def close(%{controller: controller}) do
+    send(controller, {:event_log_store_closed, self()})
+    :ok
+  end
+
+  @doc "Requests a deterministic insert result from the test controller."
+  @impl MingaAgent.EventLog.StoreBackend
+  @spec insert(map(), EventRecord.t()) :: {:ok, pos_integer()} | {:error, term()}
+  def insert(%{controller: controller}, %EventRecord{} = record) do
+    send(controller, {:event_log_store_insert, self(), record})
+
+    receive do
+      {:event_log_store_insert_result, {:committed, event_id}} ->
+        wait_after_commit(controller, record, event_id)
+
+      {:event_log_store_insert_result, result} ->
+        result
+    end
+  end
+
+  @doc "Requests a deterministic retention result from the test controller."
+  @impl MingaAgent.EventLog.StoreBackend
+  @spec delete_before(map(), DateTime.t()) :: {:ok, non_neg_integer()} | {:error, term()}
+  def delete_before(%{controller: controller}, %DateTime{} = cutoff) do
+    send(controller, {:event_log_store_delete_before, self(), cutoff})
+
+    receive do
+      {:event_log_store_delete_before_result, result} -> result
+    end
+  end
+
+  @spec wait_after_commit(pid(), EventRecord.t(), pos_integer()) ::
+          {:ok, pos_integer()} | {:error, term()}
+  defp wait_after_commit(controller, record, event_id) do
+    send(controller, {:event_log_store_committed, self(), record, event_id})
+
+    receive do
+      {:event_log_store_publish_result, result} -> result
+    end
+  end
+
+  @spec normalize_open_result(:ok | {:error, term()}, pid()) ::
+          {:ok, map()} | {:error, term()}
+  defp normalize_open_result(:ok, controller), do: {:ok, %{controller: controller}}
+  defp normalize_open_result({:error, _reason} = error, _controller), do: error
+end


### PR DESCRIPTION
# TL;DR

Agent event persistence now distinguishes bounded queue admission from durable SQLite commitment. Critical events receive post-commit acknowledgments, uncertain writes retry idempotently after writer failure, and slow storage no longer blocks Session processing.

Closes #2830

## Context

The previous EventLog API returned `:ok` after a cast, before SQLite accepted the event. That allowed callers to treat mailbox admission as durability, while a stalled writer could accumulate an unbounded mailbox and a crash could discard supposedly recorded session history.

This change makes admission, commitment, overload, and persistence failure separate observable outcomes. It also establishes the control-event ordering contract needed by #2831.

## Changes

- Replace cast-based recording with definitive bounded admission that returns `{:queued, receipt}`, `{:error, :overloaded}`, or `{:error, :unavailable}` without performing SQLite work in the caller.
- Bound outstanding work by both event count and serialized bytes, reject oversized or invalid payloads before recursive sanitization, and let terminal serialization failures advance FIFO work.
- Add a monitored single-writer process that owns the SQLite connection, serializes inserts and retention, and publishes `{:persisted, event_id}` only after commit.
- Give every event a stable idempotency key, migrate schema version 1 databases, and retry uncertain in-flight events safely across writer failure without duplication or reordering.
- Preserve pending retention across writer death and replacement-open failure.
- Establish private database directory and file permissions before SQLite opens, reject unsafe paths, and quarantine corrupt database files before recreation.
- Add an explicit best-effort path for assistant and thinking deltas while keeping accepted deltas in the same FIFO queue as control events.
- Update Session to classify critical boundaries, remain responsive during stalled persistence, publish typed failures, and retain unrepaired failures for later subscribers.
- Add a controllable Store backend for deterministic pre-commit, post-commit, overload, byte-bound, poison-event, failure, restart, retention, ordering, uniqueness, and responsiveness tests.
- Correct load-sensitive tests to use deterministic synchronization contracts rather than wall-clock sleeps, 100 ms receive defaults, or race-specific process exit reasons.

## Verification

Validated commit `2fd239e42619fc1a2d31106d9db477c023c4545b` after rebasing onto current `main`:

- `make lint` (format, changed Credo, compile with warnings as errors, incremental Dialyzer): pass
- `mix test.llm`: pass, 9,278 tests, 58 doctests, 97 properties, 0 failures, 1 skipped
- GitHub Elixir CI parity with runner-equivalent `max_cases: 8`: pass, 9,734 checks, 0 failures, 1 skipped
- Focused EventLog, Store, and Session integration suites: pass, 30 tests
- Session recovery, lifecycle, approval, and EventLog integration suites: pass, 67 tests
- Shell heavy suite: pass, 18 tests
- Review DAG: correctness, test, security, synthesis, fix, and final verification stages completed
- Final targeted callback-spec review: PASS

## Acceptance Criteria Addressed

- Admission and durable commitment are explicitly distinct. ✅
- Acknowledged critical boundaries survive writer and full log restart. ✅
- Admission is finite by count and bytes, and overload is observable. ✅
- Stream deltas have an explicit weaker contract without bypassing control ordering. ✅
- Sessions remain responsive and persistence failures are observable after reconnect. ✅
- Deterministic tests cover admission boundaries, recovery, ordering, uniqueness, and overload. ✅

---
**Updated after review:** Added definitive admission, byte-bounded queues, terminal poison-event handling, retention recovery, private SQLite path handling, corruption quarantine, and deterministic shell CI synchronization.
