### PR TITLE
fix(lsp): own formatting request lifecycle

### DIFF
--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -155,10 +155,10 @@ defmodule Minga.LSP.Client do
     ref
   end
 
-  @doc "Cancels an asynchronous request by the opaque reference returned from `request/3`."
-  @spec cancel_request(GenServer.server(), reference()) :: :ok | {:error, :not_found}
+  @doc "Queues cancellation of an asynchronous request by the reference returned from `request/3`."
+  @spec cancel_request(GenServer.server(), reference()) :: :ok
   def cancel_request(server, ref) when is_reference(ref) do
-    GenServer.call(server, {:cancel_request, ref})
+    GenServer.cast(server, {:cancel_request, ref})
   end
 
   @doc """
@@ -381,13 +381,6 @@ defmodule Minga.LSP.Client do
     {:reply, state.started_at, state}
   end
 
-  def handle_call({:cancel_request, ref}, _from, state) do
-    case cancel_request_by_ref(state, ref) do
-      {:ok, state} -> {:reply, :ok, state}
-      {:error, :not_found, state} -> {:reply, {:error, :not_found}, state}
-    end
-  end
-
   def handle_call(:shutdown, from, %{status: :ready} = state) do
     {id, state} = send_request(state, "shutdown", %{})
     state = put_pending(state, id, "shutdown", from)
@@ -494,6 +487,17 @@ defmodule Minga.LSP.Client do
     {id, state} = send_request(state, method, params)
     state = put_pending(state, id, method, {:async, caller, ref})
     {:noreply, state}
+  end
+
+  def handle_cast({:cancel_request, ref}, state) do
+    case cancel_request_by_ref(state, ref) do
+      {:ok, state} ->
+        {:noreply, state}
+
+      {:error, :not_found, state} ->
+        Log.debug(:lsp, "Skipping cancellation for unknown LSP request ref=#{inspect(ref)}")
+        {:noreply, state}
+    end
   end
 
   def handle_cast({:notify_file_changes, changes}, %{status: :ready} = state) do

--- a/lib/minga/lsp/client.ex
+++ b/lib/minga/lsp/client.ex
@@ -30,6 +30,7 @@ defmodule Minga.LSP.Client do
   alias Minga.Config
   alias Minga.Diagnostics
   alias Minga.Diagnostics.Diagnostic
+  alias Minga.LSP.Client.RequestRegistry
   alias Minga.LSP.Client.State
   alias Minga.LSP.GlobMatcher
   alias Minga.LSP.JsonRpc
@@ -38,6 +39,7 @@ defmodule Minga.LSP.Client do
   alias Minga.Log
 
   @request_timeout 30_000
+  @canceled_request_tombstone_ttl 30_000
 
   # ── Client API ─────────────────────────────────────────────────────────────
 
@@ -151,6 +153,12 @@ defmodule Minga.LSP.Client do
     ref = make_ref()
     GenServer.cast(server, {:async_request, method, params, self(), ref})
     ref
+  end
+
+  @doc "Cancels an asynchronous request by the opaque reference returned from `request/3`."
+  @spec cancel_request(GenServer.server(), reference()) :: :ok | {:error, :not_found}
+  def cancel_request(server, ref) when is_reference(ref) do
+    GenServer.call(server, {:cancel_request, ref})
   end
 
   @doc """
@@ -335,6 +343,8 @@ defmodule Minga.LSP.Client do
   end
 
   @impl true
+  @spec handle_call(term(), GenServer.from(), State.t()) ::
+          {:reply, term(), State.t()} | {:noreply, State.t()}
   def handle_call(:capabilities, _from, state) do
     {:reply, state.capabilities, state}
   end
@@ -369,6 +379,13 @@ defmodule Minga.LSP.Client do
 
   def handle_call(:started_at, _from, state) do
     {:reply, state.started_at, state}
+  end
+
+  def handle_call({:cancel_request, ref}, _from, state) do
+    case cancel_request_by_ref(state, ref) do
+      {:ok, state} -> {:reply, :ok, state}
+      {:error, :not_found, state} -> {:reply, {:error, :not_found}, state}
+    end
   end
 
   def handle_call(:shutdown, from, %{status: :ready} = state) do
@@ -495,6 +512,8 @@ defmodule Minga.LSP.Client do
   end
 
   @impl true
+  @spec handle_info(term(), State.t()) ::
+          {:noreply, State.t()} | {:stop, term(), State.t()}
   def handle_info(:send_initialize, state) do
     root_uri = "file://#{state.root_path}"
 
@@ -553,14 +572,27 @@ defmodule Minga.LSP.Client do
   end
 
   def handle_info({:request_timeout, id}, state) do
-    case Map.pop(state.pending, id) do
-      {nil, _pending} ->
+    case RequestRegistry.fetch(state.requests, id) do
+      :error ->
         {:noreply, state}
 
-      {%{from: from, method: method}, pending} ->
+      {:ok, %{from: from, method: method}} ->
         Log.warning(:lsp, "LSP request #{method} (id=#{id}) timed out")
+        state = cancel_request_by_id(state, id)
         reply_to_caller(from, {:error, :timeout})
-        {:noreply, %{state | pending: pending}}
+        {:noreply, state}
+    end
+  end
+
+  def handle_info({:expire_canceled_request, id}, state) do
+    requests = RequestRegistry.drop_canceled(state.requests, id)
+    {:noreply, %{state | requests: requests}}
+  end
+
+  def handle_info({:DOWN, monitor, :process, _caller, _reason}, state) do
+    case RequestRegistry.id_for_monitor(state.requests, monitor) do
+      {:ok, id} -> {:noreply, cancel_request_by_id(state, id)}
+      :error -> {:noreply, state}
     end
   end
 
@@ -613,13 +645,12 @@ defmodule Minga.LSP.Client do
 
   @spec handle_response(JsonRpc.id(), {:ok, term()} | {:error, map()}, State.t()) :: State.t()
   defp handle_response(id, result, state) do
-    case Map.pop(state.pending, id) do
-      {nil, _pending} ->
-        Log.warning(:lsp, "Received response for unknown request id=#{id}")
-        state
+    case RequestRegistry.fetch(state.requests, id) do
+      :error ->
+        discard_or_log_unknown_response(state, id)
 
-      {%{method: method, from: from, timer: timer}, pending} ->
-        if timer, do: Process.cancel_timer(timer)
+      {:ok, %{method: method, from: from}} ->
+        state = drop_pending(state, id)
 
         case result do
           {:ok, _} ->
@@ -629,7 +660,6 @@ defmodule Minga.LSP.Client do
             Log.debug(:lsp, "← #{method} (id: #{id}, error: #{inspect(err)})")
         end
 
-        state = %{state | pending: pending}
         handle_method_response(method, result, from, state)
     end
   end
@@ -1086,9 +1116,79 @@ defmodule Minga.LSP.Client do
   @spec put_pending(State.t(), integer(), String.t(), State.pending_from()) :: State.t()
   defp put_pending(state, id, method, from) do
     timer = Process.send_after(self(), {:request_timeout, id}, @request_timeout)
+    {request_ref, caller_monitor} = pending_identity(from)
 
-    entry = %{method: method, from: from, timer: timer}
-    %{state | pending: Map.put(state.pending, id, entry)}
+    entry = %{
+      method: method,
+      from: from,
+      timer: timer,
+      request_ref: request_ref,
+      caller_monitor: caller_monitor
+    }
+
+    %{state | requests: RequestRegistry.put(state.requests, id, entry)}
+  end
+
+  @spec pending_identity(State.pending_from()) :: {reference() | nil, reference() | nil}
+  defp pending_identity({:async, caller, request_ref}) do
+    {request_ref, Process.monitor(caller)}
+  end
+
+  defp pending_identity(_from), do: {nil, nil}
+
+  @spec cancel_request_by_ref(State.t(), reference()) ::
+          {:ok, State.t()} | {:error, :not_found, State.t()}
+  defp cancel_request_by_ref(state, ref) do
+    case RequestRegistry.id_for_ref(state.requests, ref) do
+      {:ok, id} -> {:ok, cancel_request_by_id(state, id)}
+      :error -> {:error, :not_found, state}
+    end
+  end
+
+  @spec cancel_request_by_id(State.t(), integer()) :: State.t()
+  defp cancel_request_by_id(state, id) do
+    case RequestRegistry.fetch(state.requests, id) do
+      {:ok, _entry} ->
+        send_notification(state, "$/cancelRequest", %{"id" => id})
+        state |> drop_pending(id) |> put_canceled_tombstone(id)
+
+      :error ->
+        state
+    end
+  end
+
+  @spec drop_pending(State.t(), integer()) :: State.t()
+  defp drop_pending(state, id) do
+    case RequestRegistry.pop(state.requests, id) do
+      {nil, _requests} ->
+        state
+
+      {entry, requests} ->
+        if entry.timer, do: Process.cancel_timer(entry.timer)
+        if entry.caller_monitor, do: Process.demonitor(entry.caller_monitor, [:flush])
+        %{state | requests: requests}
+    end
+  end
+
+  @spec put_canceled_tombstone(State.t(), integer()) :: State.t()
+  defp put_canceled_tombstone(state, id) do
+    timer =
+      Process.send_after(self(), {:expire_canceled_request, id}, @canceled_request_tombstone_ttl)
+
+    %{state | requests: RequestRegistry.put_canceled(state.requests, id, timer)}
+  end
+
+  @spec discard_or_log_unknown_response(State.t(), integer()) :: State.t()
+  defp discard_or_log_unknown_response(state, id) do
+    case RequestRegistry.pop_canceled(state.requests, id) do
+      {nil, _requests} ->
+        Log.warning(:lsp, "Received response for unknown request id=#{id}")
+        state
+
+      {timer, requests} ->
+        Process.cancel_timer(timer)
+        %{state | requests: requests}
+    end
   end
 
   @spec client_capabilities() :: map()

--- a/lib/minga/lsp/client/request_registry.ex
+++ b/lib/minga/lsp/client/request_registry.ex
@@ -1,0 +1,99 @@
+defmodule Minga.LSP.Client.RequestRegistry do
+  @moduledoc "Pure correlation indexes for pending and recently canceled LSP requests."
+
+  defstruct pending: %{}, ids_by_ref: %{}, ids_by_monitor: %{}, canceled_ids: %{}
+
+  @typedoc "Caller for a pending request: a GenServer reply target, an async caller, or nil."
+  @type pending_from :: GenServer.from() | {:async, pid(), reference()} | nil
+
+  @typedoc "A pending request awaiting a response."
+  @type pending_entry :: %{
+          method: String.t(),
+          from: pending_from(),
+          timer: reference() | nil,
+          request_ref: reference() | nil,
+          caller_monitor: reference() | nil
+        }
+
+  @type t :: %__MODULE__{
+          pending: %{integer() => pending_entry()},
+          ids_by_ref: %{reference() => integer()},
+          ids_by_monitor: %{reference() => integer()},
+          canceled_ids: %{integer() => reference()}
+        }
+
+  @doc "Returns an empty request registry."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Tracks one pending request across all correlation indexes."
+  @spec put(t(), integer(), pending_entry()) :: t()
+  def put(%__MODULE__{} = registry, id, entry) when is_integer(id) and is_map(entry) do
+    %__MODULE__{
+      registry
+      | pending: Map.put(registry.pending, id, entry),
+        ids_by_ref: maybe_put(registry.ids_by_ref, entry.request_ref, id),
+        ids_by_monitor: maybe_put(registry.ids_by_monitor, entry.caller_monitor, id)
+    }
+  end
+
+  @doc "Fetches a pending request by JSON-RPC id."
+  @spec fetch(t(), integer()) :: {:ok, pending_entry()} | :error
+  def fetch(%__MODULE__{} = registry, id), do: Map.fetch(registry.pending, id)
+
+  @doc "Returns the JSON-RPC id for an opaque caller request reference."
+  @spec id_for_ref(t(), reference()) :: {:ok, integer()} | :error
+  def id_for_ref(%__MODULE__{} = registry, ref), do: Map.fetch(registry.ids_by_ref, ref)
+
+  @doc "Returns the JSON-RPC id owned by a caller monitor."
+  @spec id_for_monitor(t(), reference()) :: {:ok, integer()} | :error
+  def id_for_monitor(%__MODULE__{} = registry, monitor) do
+    Map.fetch(registry.ids_by_monitor, monitor)
+  end
+
+  @doc "Drops one pending request from every correlation index."
+  @spec pop(t(), integer()) :: {pending_entry() | nil, t()}
+  def pop(%__MODULE__{} = registry, id) do
+    case Map.pop(registry.pending, id) do
+      {nil, _pending} ->
+        {nil, registry}
+
+      {entry, pending} ->
+        updated = %__MODULE__{
+          registry
+          | pending: pending,
+            ids_by_ref: maybe_delete(registry.ids_by_ref, entry.request_ref),
+            ids_by_monitor: maybe_delete(registry.ids_by_monitor, entry.caller_monitor)
+        }
+
+        {entry, updated}
+    end
+  end
+
+  @doc "Tracks a bounded canceled-request tombstone timer."
+  @spec put_canceled(t(), integer(), reference()) :: t()
+  def put_canceled(%__MODULE__{} = registry, id, timer) do
+    %{registry | canceled_ids: Map.put(registry.canceled_ids, id, timer)}
+  end
+
+  @doc "Drops a canceled-request tombstone without returning it."
+  @spec drop_canceled(t(), integer()) :: t()
+  def drop_canceled(%__MODULE__{} = registry, id) do
+    %{registry | canceled_ids: Map.delete(registry.canceled_ids, id)}
+  end
+
+  @doc "Pops a canceled-request tombstone timer."
+  @spec pop_canceled(t(), integer()) :: {reference() | nil, t()}
+  def pop_canceled(%__MODULE__{} = registry, id) do
+    {timer, canceled_ids} = Map.pop(registry.canceled_ids, id)
+    {timer, %{registry | canceled_ids: canceled_ids}}
+  end
+
+  @spec maybe_put(map(), reference() | nil, integer()) :: map()
+  defp maybe_put(index, nil, _id), do: index
+  defp maybe_put(index, key, id), do: Map.put(index, key, id)
+
+  @spec maybe_delete(map(), reference() | nil) :: map()
+  defp maybe_delete(index, nil), do: index
+  defp maybe_delete(index, key), do: Map.delete(index, key)
+end

--- a/lib/minga/lsp/client/state.ex
+++ b/lib/minga/lsp/client/state.ex
@@ -3,6 +3,7 @@ defmodule Minga.LSP.Client.State do
   Internal state for an `LSP.Client` GenServer.
   """
 
+  alias Minga.LSP.Client.RequestRegistry
   alias Minga.LSP.ServerConfig
 
   @enforce_keys [:server_config, :root_path]
@@ -14,7 +15,7 @@ defmodule Minga.LSP.Client.State do
     buffer: "",
     next_id: 1,
     started_at: nil,
-    pending: %{},
+    requests: RequestRegistry.new(),
     pending_document_opens: %{},
     open_documents: %{},
     capabilities: %{},
@@ -27,14 +28,10 @@ defmodule Minga.LSP.Client.State do
   @type status :: :starting | :initializing | :ready | :shutdown
 
   @typedoc "Caller for a pending request: a GenServer reply target, an async caller, or nil."
-  @type pending_from :: GenServer.from() | {:async, pid(), reference()} | nil
+  @type pending_from :: RequestRegistry.pending_from()
 
   @typedoc "A pending request awaiting a response."
-  @type pending_entry :: %{
-          method: String.t(),
-          from: pending_from(),
-          timer: reference() | nil
-        }
+  @type pending_entry :: RequestRegistry.pending_entry()
 
   @typedoc "A document open notification queued until the client is ready."
   @type pending_document_open :: %{
@@ -64,7 +61,7 @@ defmodule Minga.LSP.Client.State do
           buffer: binary(),
           started_at: integer() | nil,
           next_id: pos_integer(),
-          pending: %{integer() => pending_entry()},
+          requests: RequestRegistry.t(),
           pending_document_opens: %{String.t() => pending_document_open()},
           open_documents: %{String.t() => open_doc()},
           capabilities: map(),

--- a/lib/minga/lsp/text_edit.ex
+++ b/lib/minga/lsp/text_edit.ex
@@ -1,0 +1,208 @@
+defmodule Minga.LSP.TextEdit do
+  @moduledoc """
+  Applies LSP text edits to one immutable content snapshot.
+
+  Ranges are converted with the negotiated position encoding, validated against the original content, checked for overlap, and assembled in one pass. Invalid server output never produces partial content.
+  """
+
+  alias Minga.LSP.PositionEncoding
+
+  @enforce_keys [:start_offset, :end_offset, :new_text, :response_index]
+  defstruct [:start_offset, :end_offset, :new_text, :response_index]
+
+  @type t :: %__MODULE__{
+          start_offset: non_neg_integer(),
+          end_offset: non_neg_integer(),
+          new_text: String.t(),
+          response_index: non_neg_integer()
+        }
+
+  @type line_meta :: %{start_offset: non_neg_integer(), text: String.t()}
+  @type error :: :invalid_edit | :overlapping_edits
+
+  @doc "Applies a list of LSP TextEdit maps to `content` using `encoding`."
+  @spec apply(String.t(), [map()], PositionEncoding.encoding()) ::
+          {:ok, String.t()} | {:error, error()}
+  def apply(content, edits, encoding)
+      when is_binary(content) and is_list(edits) and encoding in [:utf8, :utf16, :utf32] do
+    lines = index_lines(content)
+
+    with {:ok, normalized} <- normalize_all(edits, lines, encoding),
+         :ok <- validate_non_overlapping(normalized) do
+      {:ok, assemble(content, normalized)}
+    end
+  end
+
+  @spec normalize_all([map()], tuple(), PositionEncoding.encoding()) ::
+          {:ok, [t()]} | {:error, :invalid_edit}
+  defp normalize_all(edits, lines, encoding) do
+    edits
+    |> Enum.with_index()
+    |> Enum.reduce_while({:ok, []}, fn {edit, response_index}, {:ok, normalized} ->
+      case normalize(edit, response_index, lines, encoding) do
+        {:ok, value} -> {:cont, {:ok, [value | normalized]}}
+        {:error, :invalid_edit} = error -> {:halt, error}
+      end
+    end)
+    |> case do
+      {:ok, normalized} ->
+        {:ok, Enum.sort_by(normalized, &{&1.start_offset, &1.end_offset, &1.response_index})}
+
+      error ->
+        error
+    end
+  end
+
+  @spec normalize(map(), non_neg_integer(), tuple(), PositionEncoding.encoding()) ::
+          {:ok, t()} | {:error, :invalid_edit}
+  defp normalize(
+         %{
+           "range" => %{
+             "start" => %{"line" => start_line, "character" => start_character},
+             "end" => %{"line" => end_line, "character" => end_character}
+           },
+           "newText" => new_text
+         },
+         response_index,
+         lines,
+         encoding
+       )
+       when is_integer(start_line) and start_line >= 0 and is_integer(start_character) and
+              start_character >= 0 and is_integer(end_line) and end_line >= 0 and
+              is_integer(end_character) and end_character >= 0 and is_binary(new_text) do
+    with {:ok, start_offset} <- absolute_offset(lines, start_line, start_character, encoding),
+         {:ok, end_offset} <- absolute_offset(lines, end_line, end_character, encoding),
+         true <- start_offset <= end_offset do
+      {:ok,
+       %__MODULE__{
+         start_offset: start_offset,
+         end_offset: end_offset,
+         new_text: new_text,
+         response_index: response_index
+       }}
+    else
+      _ -> {:error, :invalid_edit}
+    end
+  end
+
+  defp normalize(_edit, _response_index, _lines, _encoding), do: {:error, :invalid_edit}
+
+  @spec absolute_offset(
+          tuple(),
+          non_neg_integer(),
+          non_neg_integer(),
+          PositionEncoding.encoding()
+        ) ::
+          {:ok, non_neg_integer()} | {:error, :invalid_edit}
+  defp absolute_offset(lines, line, character, encoding) when line < tuple_size(lines) do
+    %{start_offset: start_offset, text: line_text} = elem(lines, line)
+
+    with {:ok, byte_col} <- byte_column(line_text, character, encoding) do
+      {:ok, start_offset + byte_col}
+    end
+  end
+
+  defp absolute_offset(_lines, _line, _character, _encoding), do: {:error, :invalid_edit}
+
+  @spec byte_column(String.t(), non_neg_integer(), PositionEncoding.encoding()) ::
+          {:ok, non_neg_integer()} | {:error, :invalid_edit}
+  defp byte_column(line, character, :utf8) when character <= byte_size(line) do
+    prefix = binary_part(line, 0, character)
+    if String.valid?(prefix), do: {:ok, character}, else: {:error, :invalid_edit}
+  end
+
+  defp byte_column(_line, _character, :utf8), do: {:error, :invalid_edit}
+  defp byte_column(line, character, :utf32), do: walk_units(line, character, :utf32, 0)
+  defp byte_column(line, character, :utf16), do: walk_units(line, character, :utf16, 0)
+
+  @spec walk_units(String.t(), integer(), :utf16 | :utf32, non_neg_integer()) ::
+          {:ok, non_neg_integer()} | {:error, :invalid_edit}
+  defp walk_units(_line, 0, _encoding, byte_offset), do: {:ok, byte_offset}
+  defp walk_units(<<>>, _remaining, _encoding, _byte_offset), do: {:error, :invalid_edit}
+
+  defp walk_units(<<codepoint::utf8, rest::binary>>, remaining, encoding, byte_offset) do
+    units = units(codepoint, encoding)
+
+    if remaining < units do
+      {:error, :invalid_edit}
+    else
+      bytes = byte_size(<<codepoint::utf8>>)
+      walk_units(rest, remaining - units, encoding, byte_offset + bytes)
+    end
+  end
+
+  @spec units(non_neg_integer(), :utf16 | :utf32) :: 1 | 2
+  defp units(_codepoint, :utf32), do: 1
+  defp units(codepoint, :utf16) when codepoint <= 0xFFFF, do: 1
+  defp units(_codepoint, :utf16), do: 2
+
+  @spec index_lines(String.t()) :: tuple()
+  defp index_lines(content) do
+    content
+    |> scan_lines(content, 0, 0, [])
+    |> Enum.reverse()
+    |> List.to_tuple()
+  end
+
+  @spec scan_lines(binary(), String.t(), non_neg_integer(), non_neg_integer(), [line_meta()]) ::
+          [line_meta()]
+  defp scan_lines(<<>>, content, offset, line_start, lines) do
+    [
+      %{start_offset: line_start, text: binary_part(content, line_start, offset - line_start)}
+      | lines
+    ]
+  end
+
+  defp scan_lines(<<"\r\n", rest::binary>>, content, offset, line_start, lines) do
+    line = %{
+      start_offset: line_start,
+      text: binary_part(content, line_start, offset - line_start)
+    }
+
+    scan_lines(rest, content, offset + 2, offset + 2, [line | lines])
+  end
+
+  defp scan_lines(<<separator, rest::binary>>, content, offset, line_start, lines)
+       when separator in [?\n, ?\r] do
+    line = %{
+      start_offset: line_start,
+      text: binary_part(content, line_start, offset - line_start)
+    }
+
+    scan_lines(rest, content, offset + 1, offset + 1, [line | lines])
+  end
+
+  defp scan_lines(<<_byte, rest::binary>>, content, offset, line_start, lines) do
+    scan_lines(rest, content, offset + 1, line_start, lines)
+  end
+
+  @spec validate_non_overlapping([t()]) :: :ok | {:error, :overlapping_edits}
+  defp validate_non_overlapping([]), do: :ok
+  defp validate_non_overlapping([_edit]), do: :ok
+
+  defp validate_non_overlapping([left, right | rest]) do
+    if overlaps?(left, right) do
+      {:error, :overlapping_edits}
+    else
+      validate_non_overlapping([right | rest])
+    end
+  end
+
+  @spec overlaps?(t(), t()) :: boolean()
+  defp overlaps?(%__MODULE__{} = left, %__MODULE__{} = right) do
+    right.start_offset < left.end_offset or
+      (right.start_offset == left.start_offset and left.end_offset > left.start_offset)
+  end
+
+  @spec assemble(String.t(), [t()]) :: String.t()
+  defp assemble(content, edits) do
+    {chunks, cursor} =
+      Enum.reduce(edits, {[], 0}, fn edit, {chunks, cursor} ->
+        untouched = binary_part(content, cursor, edit.start_offset - cursor)
+        {[edit.new_text, untouched | chunks], edit.end_offset}
+      end)
+
+    suffix = binary_part(content, cursor, byte_size(content) - cursor)
+    [suffix | chunks] |> Enum.reverse() |> IO.iodata_to_binary()
+  end
+end

--- a/lib/minga_editor/commands/formatting.ex
+++ b/lib/minga_editor/commands/formatting.ex
@@ -10,9 +10,12 @@ defmodule MingaEditor.Commands.Formatting do
   use MingaEditor.Commands.Provider
 
   alias Minga.Buffer
+  alias Minga.LSP.TextEdit
   alias MingaEditor.EffectScheduler
   alias MingaEditor.Effects.ExternalFormat
+  alias MingaEditor.LSP.FormatLifecycle
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.LSP, as: LSPState
   alias Minga.Mode.ToolConfirmState
   alias Minga.Tool.Recipe.Registry, as: RecipeRegistry
   alias Minga.LSP.Client
@@ -20,7 +23,7 @@ defmodule MingaEditor.Commands.Formatting do
 
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
-  @type format_commit_error :: :not_alive | :read_only | :stale
+  @type format_commit_error :: :invalid_edits | :not_alive | :read_only | :stale
 
   @spec format_buffer(state()) :: state()
   def format_buffer(%{workspace: %{buffers: %{active: buf}}} = state) when is_pid(buf) do
@@ -39,33 +42,35 @@ defmodule MingaEditor.Commands.Formatting do
 
   @spec try_lsp_format(state(), pid()) :: {:ok, state()} | :not_available
   defp try_lsp_format(state, buf) when is_pid(buf) do
-    clients = SyncServer.clients_for_buffer(buf)
+    buf
+    |> SyncServer.clients_for_buffer()
+    |> Enum.find_value(:not_available, fn client ->
+      case formatting_encoding(client) do
+        {:ok, encoding} -> {:ok, request_lsp_format(state, buf, client, encoding)}
+        :not_available -> false
+      end
+    end)
+  end
 
-    case Enum.find(clients, &supports_formatting?/1) do
-      nil ->
-        :not_available
+  @spec formatting_encoding(pid()) ::
+          {:ok, Minga.LSP.PositionEncoding.encoding()} | :not_available
+  defp formatting_encoding(client) do
+    capabilities = Client.capabilities(client)
+    provider = get_in(capabilities, ["documentFormattingProvider"])
 
-      client ->
-        {:ok, request_lsp_format(state, buf, client)}
+    if match?(%{}, provider) or provider == true do
+      {:ok, Client.encoding(client)}
+    else
+      :not_available
     end
+  catch
+    :exit, _reason -> :not_available
   end
 
-  @spec supports_formatting?(pid()) :: boolean()
-  defp supports_formatting?(client) do
-    caps = Client.capabilities(client)
-
-    match?(%{}, get_in(caps, ["documentFormattingProvider"])) or
-      get_in(caps, ["documentFormattingProvider"]) == true
-  end
-
-  @lsp_format_timeout 5_000
-  @lsp_format_spinner_delay 100
-  @lsp_format_cancel_delay 1_000
-
-  @spec request_lsp_format(state(), pid(), pid()) :: state()
-  defp request_lsp_format(state, buf, client) do
-    state = cancel_pending_format(state)
-
+  @spec request_lsp_format(state(), pid(), pid(), Minga.LSP.PositionEncoding.encoding()) ::
+          state()
+  defp request_lsp_format(state, buf, client, encoding) do
+    state = cancel_buffer_format(state, buf)
     file_path = Buffer.file_path(buf)
     uri = SyncServer.path_to_uri(file_path)
     tab_width = Buffer.get_option(buf, :tab_width) || 2
@@ -78,87 +83,52 @@ defmodule MingaEditor.Commands.Formatting do
 
     version = Buffer.version(buf)
     ref = Client.request(client, "textDocument/formatting", params)
-    Process.send_after(self(), {:lsp_format_spinner, ref}, @lsp_format_spinner_delay)
-    Process.send_after(self(), {:lsp_format_cancellable, ref}, @lsp_format_cancel_delay)
-    Process.send_after(self(), {:lsp_format_timeout, ref}, @lsp_format_timeout)
-    EditorState.put_lsp_pending(state, ref, {:format, buf, version})
+    operation = FormatLifecycle.arm(client, ref, buf, version, encoding)
+    EditorState.update_lsp(state, &LSPState.track_format(&1, operation))
   end
 
-  @spec cancel_pending_format(state()) :: state()
-  defp cancel_pending_format(state) do
-    case find_pending_format(state) do
-      nil -> state
-      {ref, _kind} -> EditorState.delete_lsp_pending(state, ref)
+  @doc "Cancels the newest active LSP formatting request, if one exists."
+  @spec cancel_pending_format(state()) :: {:canceled, state()} | :none
+  def cancel_pending_format(state) do
+    case LSPState.newest_format(state.lsp) do
+      nil ->
+        :none
+
+      operation ->
+        state = EditorState.update_lsp(state, &LSPState.drop_format(&1, operation.ref))
+        FormatLifecycle.cancel(operation)
+        {:canceled, state}
     end
   end
 
-  @doc "Finds the active pending LSP formatting request, if one exists."
-  @spec find_pending_format(state()) :: {reference(), tuple()} | nil
-  def find_pending_format(state) do
-    Enum.find(state.workspace.lsp_pending, fn
-      {_ref, {:format, _buf, _version}} -> true
-      _ -> false
-    end)
-  end
-
   @doc "Applies LSP text edits only when the buffer still has `expected_version`."
-  @spec apply_lsp_edits(pid(), [map()], non_neg_integer()) ::
+  @spec apply_lsp_edits(pid(), [map()], non_neg_integer(), Minga.LSP.PositionEncoding.encoding()) ::
           :ok | {:error, format_commit_error()}
-  def apply_lsp_edits(_buf, [], _expected_version), do: :ok
+  def apply_lsp_edits(_buf, [], _expected_version, _encoding), do: :ok
 
-  def apply_lsp_edits(buf, edits, expected_version)
+  def apply_lsp_edits(buf, edits, expected_version, encoding)
       when is_pid(buf) and is_list(edits) and is_integer(expected_version) and
-             expected_version >= 0 do
+             expected_version >= 0 and encoding in [:utf8, :utf16, :utf32] do
     safely_commit(fn ->
       content = Buffer.content(buf)
 
-      new_content =
-        Enum.reduce(Enum.reverse(edits), content, fn edit, acc ->
-          range = Map.get(edit, "range", %{})
-          new_text = Map.get(edit, "newText", "")
-          start_line = get_in(range, ["start", "line"]) || 0
-          start_col = get_in(range, ["start", "character"]) || 0
-          end_line = get_in(range, ["end", "line"]) || 0
-          end_col = get_in(range, ["end", "character"]) || 0
-
-          apply_single_edit(acc, start_line, start_col, end_line, end_col, new_text)
-        end)
-
-      commit_formatted_content(buf, expected_version, new_content, :lsp)
+      case TextEdit.apply(content, edits, encoding) do
+        {:ok, new_content} -> commit_formatted_content(buf, expected_version, new_content, :lsp)
+        {:error, _reason} -> {:error, :invalid_edits}
+      end
     end)
   end
 
-  @spec apply_single_edit(
-          String.t(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer(),
-          String.t()
-        ) :: String.t()
-  defp apply_single_edit(content, start_line, start_col, end_line, end_col, new_text) do
-    lines = String.split(content, "\n")
-
-    case Enum.at(lines, start_line) do
+  @spec cancel_buffer_format(state(), pid()) :: state()
+  defp cancel_buffer_format(state, buffer) do
+    case LSPState.format_for_buffer(state.lsp, buffer) do
       nil ->
-        content
+        state
 
-      start_text ->
-        case Enum.at(lines, end_line) do
-          nil ->
-            content
-
-          end_text ->
-            before = String.slice(start_text, 0, start_col)
-            after_end = String.slice(end_text, end_col..-1//1)
-            replacement = before <> new_text <> after_end
-
-            {before_lines, rest} = Enum.split(lines, start_line)
-            {_removed, after_lines} = Enum.split(rest, end_line - start_line + 1)
-
-            new_lines = before_lines ++ [replacement] ++ after_lines
-            Enum.join(new_lines, "\n")
-        end
+      operation ->
+        state = EditorState.update_lsp(state, &LSPState.drop_format(&1, operation.ref))
+        FormatLifecycle.cancel(operation)
+        state
     end
   end
 

--- a/lib/minga_editor/handlers/lsp_event_handler.ex
+++ b/lib/minga_editor/handlers/lsp_event_handler.ex
@@ -7,6 +7,7 @@ defmodule MingaEditor.Handlers.LspEventHandler do
 
   alias MingaEditor.CompletionHandling
   alias MingaEditor.CompletionTrigger
+  alias MingaEditor.LSP.FormatLifecycle
   alias MingaEditor.LspActions
   alias MingaEditor.SemanticTokenSync
   alias MingaEditor.State, as: EditorState
@@ -35,7 +36,13 @@ defmodule MingaEditor.Handlers.LspEventHandler do
   end
 
   def handle(state, {:lsp_response, ref, result}) do
-    dispatch_tracked_response(state, ref, result, Map.fetch(state.workspace.lsp_pending, ref))
+    case LSPState.fetch_format(state.lsp, ref) do
+      {:ok, _operation} ->
+        dispatch_format_response(state, ref, result)
+
+      :error ->
+        dispatch_tracked_response(state, ref, result, Map.fetch(state.workspace.lsp_pending, ref))
+    end
   end
 
   def handle(state, :inlay_hint_scroll_debounce) do
@@ -58,7 +65,7 @@ defmodule MingaEditor.Handlers.LspEventHandler do
   end
 
   def handle(state, {:lsp_format_spinner, ref}) do
-    if Map.has_key?(state.workspace.lsp_pending, ref) do
+    if LSPState.format_active?(state.lsp, ref) do
       {EditorState.set_status(state, "Formatting…"), [:render_now]}
     else
       {state, []}
@@ -66,7 +73,7 @@ defmodule MingaEditor.Handlers.LspEventHandler do
   end
 
   def handle(state, {:lsp_format_cancellable, ref}) do
-    if Map.has_key?(state.workspace.lsp_pending, ref) do
+    if LSPState.format_active?(state.lsp, ref) do
       {EditorState.set_status(state, "Formatting… [Esc to cancel]"), [:render_now]}
     else
       {state, []}
@@ -74,15 +81,42 @@ defmodule MingaEditor.Handlers.LspEventHandler do
   end
 
   def handle(state, {:lsp_format_timeout, ref}) do
-    if Map.has_key?(state.workspace.lsp_pending, ref) do
-      state = delete_lsp_pending(state, ref)
-      {EditorState.set_status(state, "Format timed out [r to retry]"), [:render_now]}
-    else
-      {state, []}
+    case LSPState.fetch_format(state.lsp, ref) do
+      :error ->
+        {state, []}
+
+      {:ok, operation} ->
+        state = EditorState.update_lsp(state, &LSPState.drop_format(&1, ref))
+        FormatLifecycle.cancel(operation)
+        {EditorState.set_status(state, "Format timed out [r to retry]"), [:render_now]}
     end
   end
 
   def handle(state, _msg), do: {state, []}
+
+  @spec dispatch_format_response(EditorState.t(), reference(), term()) ::
+          {EditorState.t(), [lsp_effect()]}
+  defp dispatch_format_response(state, ref, result) do
+    case LSPState.fetch_format(state.lsp, ref) do
+      :error ->
+        {state, []}
+
+      {:ok, operation} ->
+        state = EditorState.update_lsp(state, &LSPState.drop_format(&1, ref))
+        FormatLifecycle.finish(operation)
+
+        state =
+          LspActions.handle_formatting_response(
+            state,
+            result,
+            operation.buffer,
+            operation.version,
+            operation.encoding
+          )
+
+        {state, [:render_now]}
+    end
+  end
 
   @spec dispatch_tracked_response(EditorState.t(), reference(), term(), {:ok, term()} | :error) ::
           {EditorState.t(), [lsp_effect()]}
@@ -129,9 +163,6 @@ defmodule MingaEditor.Handlers.LspEventHandler do
 
   defp dispatch_lsp_response(:hover, state, result),
     do: LspActions.handle_hover_response(state, result)
-
-  defp dispatch_lsp_response({:format, buf, version}, state, result),
-    do: LspActions.handle_formatting_response(state, result, buf, version)
 
   defp dispatch_lsp_response({:hover_mouse, row, col}, state, result),
     do: LspActions.handle_hover_mouse_response(state, result, row, col)

--- a/lib/minga_editor/input/global_bindings.ex
+++ b/lib/minga_editor/input/global_bindings.ex
@@ -43,13 +43,11 @@ defmodule MingaEditor.Input.GlobalBindings do
   @escape 27
 
   def handle_key(state, @escape, 0) do
-    case MingaEditor.Commands.Formatting.find_pending_format(state) do
-      nil ->
-        {:passthrough, state}
+    case MingaEditor.Commands.Formatting.cancel_pending_format(state) do
+      {:canceled, state} ->
+        {:passthrough, MingaEditor.State.set_status(state, "Format canceled")}
 
-      {ref, _kind} ->
-        state = MingaEditor.State.delete_lsp_pending(state, ref)
-        state = MingaEditor.State.set_status(state, "Format cancelled")
+      :none ->
         {:passthrough, state}
     end
   end

--- a/lib/minga_editor/lsp/format_lifecycle.ex
+++ b/lib/minga_editor/lsp/format_lifecycle.ex
@@ -38,14 +38,6 @@ defmodule MingaEditor.LSP.FormatLifecycle do
   @spec cancel(FormatOperation.t()) :: :ok
   def cancel(%FormatOperation{} = operation) do
     finish(operation)
-
-    try do
-      case Client.cancel_request(operation.client, operation.ref) do
-        :ok -> :ok
-        {:error, :not_found} -> :ok
-      end
-    catch
-      :exit, _reason -> :ok
-    end
+    Client.cancel_request(operation.client, operation.ref)
   end
 end

--- a/lib/minga_editor/lsp/format_lifecycle.ex
+++ b/lib/minga_editor/lsp/format_lifecycle.ex
@@ -1,0 +1,51 @@
+defmodule MingaEditor.LSP.FormatLifecycle do
+  @moduledoc "Coordinates timers and LSP cancellation for formatting operations."
+
+  alias Minga.LSP.Client
+  alias Minga.LSP.PositionEncoding
+  alias MingaEditor.State.LSP.FormatOperation
+
+  @spinner_delay 100
+  @cancel_delay 1_000
+  @timeout 5_000
+
+  @doc "Arms Editor feedback timers and builds one operation value."
+  @spec arm(pid(), reference(), pid(), non_neg_integer(), PositionEncoding.encoding()) ::
+          FormatOperation.t()
+  def arm(client, ref, buffer, version, encoding)
+      when is_pid(client) and is_reference(ref) and is_pid(buffer) and is_integer(version) and
+             version >= 0 and encoding in [:utf8, :utf16, :utf32] do
+    FormatOperation.new(
+      client: client,
+      ref: ref,
+      buffer: buffer,
+      version: version,
+      encoding: encoding,
+      spinner_timer: Process.send_after(self(), {:lsp_format_spinner, ref}, @spinner_delay),
+      cancellable_timer:
+        Process.send_after(self(), {:lsp_format_cancellable, ref}, @cancel_delay),
+      timeout_timer: Process.send_after(self(), {:lsp_format_timeout, ref}, @timeout)
+    )
+  end
+
+  @doc "Finishes Editor-owned timer lifecycle after a response."
+  @spec finish(FormatOperation.t()) :: :ok
+  def finish(%FormatOperation{} = operation) do
+    Enum.each(FormatOperation.timer_refs(operation), &Process.cancel_timer/1)
+  end
+
+  @doc "Finishes timers and cancels the underlying LSP request."
+  @spec cancel(FormatOperation.t()) :: :ok
+  def cancel(%FormatOperation{} = operation) do
+    finish(operation)
+
+    try do
+      case Client.cancel_request(operation.client, operation.ref) do
+        :ok -> :ok
+        {:error, :not_found} -> :ok
+      end
+    catch
+      :exit, _reason -> :ok
+    end
+  end
+end

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -1023,7 +1023,8 @@ defmodule MingaEditor.LspActions do
     EditorState.set_status(state, "Format error: LSP request failed")
   end
 
-  def handle_formatting_response(state, {:ok, nil}, _buf, _version, _encoding) do
+  def handle_formatting_response(state, {:ok, response}, _buf, _version, _encoding)
+      when response in [nil, []] do
     EditorState.set_status(state, "No formatting changes")
   end
 
@@ -1045,6 +1046,11 @@ defmodule MingaEditor.LspActions do
       {:error, :not_alive} ->
         EditorState.set_status(state, "Buffer closed, format skipped")
     end
+  end
+
+  def handle_formatting_response(state, {:ok, malformed}, _buf, _version, _encoding) do
+    Log.warning(:lsp, "Invalid LSP formatting response: #{inspect(malformed)}")
+    EditorState.set_status(state, "Invalid LSP formatting response skipped")
   end
 
   # ── Type definition / Implementation responses ────────────────────────────

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -1015,23 +1015,35 @@ defmodule MingaEditor.LspActions do
           state(),
           {:ok, term()} | {:error, term()},
           pid(),
-          non_neg_integer()
+          non_neg_integer(),
+          Minga.LSP.PositionEncoding.encoding()
         ) :: state()
-  def handle_formatting_response(state, {:error, reason}, _buf, _version) do
+  def handle_formatting_response(state, {:error, reason}, _buf, _version, _encoding) do
     Log.warning(:lsp, "LSP formatting error: #{inspect(reason)}")
     EditorState.set_status(state, "Format error: LSP request failed")
   end
 
-  def handle_formatting_response(state, {:ok, nil}, _buf, _version) do
+  def handle_formatting_response(state, {:ok, nil}, _buf, _version, _encoding) do
     EditorState.set_status(state, "No formatting changes")
   end
 
-  def handle_formatting_response(state, {:ok, edits}, buf, version) when is_list(edits) do
-    case Commands.Formatting.apply_lsp_edits(buf, edits, version) do
-      :ok -> EditorState.set_status(state, "Formatted (LSP)")
-      {:error, :stale} -> EditorState.set_status(state, "Buffer changed, format skipped")
-      {:error, :read_only} -> EditorState.set_status(state, "Buffer is read-only, format skipped")
-      {:error, :not_alive} -> EditorState.set_status(state, "Buffer closed, format skipped")
+  def handle_formatting_response(state, {:ok, edits}, buf, version, encoding)
+      when is_list(edits) do
+    case Commands.Formatting.apply_lsp_edits(buf, edits, version, encoding) do
+      :ok ->
+        EditorState.set_status(state, "Formatted (LSP)")
+
+      {:error, :invalid_edits} ->
+        EditorState.set_status(state, "Invalid LSP formatting edits skipped")
+
+      {:error, :stale} ->
+        EditorState.set_status(state, "Buffer changed, format skipped")
+
+      {:error, :read_only} ->
+        EditorState.set_status(state, "Buffer is read-only, format skipped")
+
+      {:error, :not_alive} ->
+        EditorState.set_status(state, "Buffer closed, format skipped")
     end
   end
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -13,7 +13,7 @@ defmodule MingaEditor.State do
   **Shell runtime** lives in `state.shell_runtime` and owns the resolved active entry, shell-specific presentation state, and exact-identity state stash. See `MingaEditor.Shell.Runtime`.
 
   **Global fields** are shared across all tabs and never snapshotted:
-  `port_manager`, `parser_manager`, `highlighting`, `injection_ranges`, `theme`, `render_correlation`, `focus_stack`, and `capabilities`.
+  `port_manager`, `parser_manager`, `highlighting`, `injection_ranges`, `theme`, `render_correlation`, `focus_stack`, `lsp`, and `capabilities`.
 
   ## Composed sub-structs
 

--- a/lib/minga_editor/state/lsp.ex
+++ b/lib/minga_editor/state/lsp.ex
@@ -11,6 +11,9 @@ defmodule MingaEditor.State.LSP do
   read fields directly but never do `%{lsp | field: value}`.
   """
 
+  alias MingaEditor.State.LSP.FormatOperation
+  alias MingaEditor.State.LSP.FormatOperations
+
   @type server_status :: :starting | :initializing | :ready | :crashed
 
   @type t :: %__MODULE__{
@@ -20,6 +23,7 @@ defmodule MingaEditor.State.LSP do
           inlay_hints: [map()],
           selection_ranges: [map()] | nil,
           selection_range_index: non_neg_integer(),
+          format_operations: FormatOperations.t(),
           highlight_debounce_timer: reference() | nil,
           inlay_hint_debounce_timer: reference() | nil,
           last_inlay_viewport_top: non_neg_integer() | nil
@@ -31,6 +35,7 @@ defmodule MingaEditor.State.LSP do
             inlay_hints: [],
             selection_ranges: nil,
             selection_range_index: 0,
+            format_operations: FormatOperations.new(),
             highlight_debounce_timer: nil,
             inlay_hint_debounce_timer: nil,
             last_inlay_viewport_top: nil
@@ -99,6 +104,43 @@ defmodule MingaEditor.State.LSP do
   @spec shrink_selection(t()) :: t()
   def shrink_selection(%__MODULE__{selection_range_index: idx} = lsp) when idx > 0 do
     %{lsp | selection_range_index: idx - 1}
+  end
+
+  # ── Formatting operations ────────────────────────────────────────────────
+
+  @doc "Tracks an Editor-global formatting operation."
+  @spec track_format(t(), FormatOperation.t()) :: t()
+  def track_format(%__MODULE__{} = lsp, %FormatOperation{} = operation) do
+    {:ok, operations} = FormatOperations.track(lsp.format_operations, operation)
+    %{lsp | format_operations: operations}
+  end
+
+  @doc "Fetches a formatting operation by request reference."
+  @spec fetch_format(t(), reference()) :: {:ok, FormatOperation.t()} | :error
+  def fetch_format(%__MODULE__{} = lsp, ref) when is_reference(ref) do
+    FormatOperations.fetch(lsp.format_operations, ref)
+  end
+
+  @doc "Returns the formatting operation for one Buffer."
+  @spec format_for_buffer(t(), pid()) :: FormatOperation.t() | nil
+  def format_for_buffer(%__MODULE__{} = lsp, buffer) when is_pid(buffer) do
+    FormatOperations.for_buffer(lsp.format_operations, buffer)
+  end
+
+  @doc "Returns the newest active formatting operation."
+  @spec newest_format(t()) :: FormatOperation.t() | nil
+  def newest_format(%__MODULE__{} = lsp), do: FormatOperations.newest(lsp.format_operations)
+
+  @doc "Drops a formatting operation by request reference."
+  @spec drop_format(t(), reference()) :: t()
+  def drop_format(%__MODULE__{} = lsp, ref) when is_reference(ref) do
+    %{lsp | format_operations: FormatOperations.drop(lsp.format_operations, ref)}
+  end
+
+  @doc "Returns whether a formatting operation is active."
+  @spec format_active?(t(), reference()) :: boolean()
+  def format_active?(%__MODULE__{} = lsp, ref) when is_reference(ref) do
+    match?({:ok, %FormatOperation{}}, fetch_format(lsp, ref))
   end
 
   # ── Highlight debounce timer ─────────────────────────────────────────────

--- a/lib/minga_editor/state/lsp/format_operation.ex
+++ b/lib/minga_editor/state/lsp/format_operation.ex
@@ -1,0 +1,49 @@
+defmodule MingaEditor.State.LSP.FormatOperation do
+  @moduledoc "Lifecycle data for one asynchronous LSP formatting request."
+
+  alias Minga.LSP.PositionEncoding
+
+  @enforce_keys [
+    :client,
+    :ref,
+    :buffer,
+    :version,
+    :encoding,
+    :spinner_timer,
+    :cancellable_timer,
+    :timeout_timer
+  ]
+  defstruct [
+    :client,
+    :ref,
+    :buffer,
+    :version,
+    :encoding,
+    :spinner_timer,
+    :cancellable_timer,
+    :timeout_timer
+  ]
+
+  @type t :: %__MODULE__{
+          client: pid(),
+          ref: reference(),
+          buffer: pid(),
+          version: non_neg_integer(),
+          encoding: PositionEncoding.encoding(),
+          spinner_timer: reference(),
+          cancellable_timer: reference(),
+          timeout_timer: reference()
+        }
+
+  @doc "Builds a formatting operation from captured request data."
+  @spec new(keyword()) :: t()
+  def new(attrs) when is_list(attrs) do
+    struct!(__MODULE__, attrs)
+  end
+
+  @doc "Returns every Editor-owned timer reference for this operation."
+  @spec timer_refs(t()) :: [reference()]
+  def timer_refs(%__MODULE__{} = operation) do
+    [operation.spinner_timer, operation.cancellable_timer, operation.timeout_timer]
+  end
+end

--- a/lib/minga_editor/state/lsp/format_operations.ex
+++ b/lib/minga_editor/state/lsp/format_operations.ex
@@ -1,0 +1,78 @@
+defmodule MingaEditor.State.LSP.FormatOperations do
+  @moduledoc """
+  Pure indexes for current Editor-global LSP formatting operations.
+
+  One operation may be current per Buffer. The newest active operation is tracked for Esc cancellation while requests for unrelated buffers remain independent.
+  """
+
+  alias MingaEditor.State.LSP.FormatOperation
+
+  defstruct by_ref: %{}, by_buffer: %{}, newest_first: []
+
+  @type t :: %__MODULE__{
+          by_ref: %{reference() => FormatOperation.t()},
+          by_buffer: %{pid() => reference()},
+          newest_first: [reference()]
+        }
+
+  @doc "Returns an empty operation collection."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Tracks an operation when its Buffer has no current request."
+  @spec track(t(), FormatOperation.t()) :: {:ok, t()} | {:error, :buffer_busy}
+  def track(%__MODULE__{} = operations, %FormatOperation{} = operation) do
+    case Map.fetch(operations.by_buffer, operation.buffer) do
+      {:ok, _ref} ->
+        {:error, :buffer_busy}
+
+      :error ->
+        {:ok,
+         %__MODULE__{
+           operations
+           | by_ref: Map.put(operations.by_ref, operation.ref, operation),
+             by_buffer: Map.put(operations.by_buffer, operation.buffer, operation.ref),
+             newest_first: [operation.ref | operations.newest_first]
+         }}
+    end
+  end
+
+  @doc "Fetches an operation by its external request reference."
+  @spec fetch(t(), reference()) :: {:ok, FormatOperation.t()} | :error
+  def fetch(%__MODULE__{} = operations, ref) when is_reference(ref) do
+    Map.fetch(operations.by_ref, ref)
+  end
+
+  @doc "Returns the operation for one Buffer."
+  @spec for_buffer(t(), pid()) :: FormatOperation.t() | nil
+  def for_buffer(%__MODULE__{} = operations, buffer) when is_pid(buffer) do
+    case Map.fetch(operations.by_buffer, buffer) do
+      {:ok, ref} -> Map.get(operations.by_ref, ref)
+      :error -> nil
+    end
+  end
+
+  @doc "Returns the newest active operation."
+  @spec newest(t()) :: FormatOperation.t() | nil
+  def newest(%__MODULE__{newest_first: [ref | _]} = operations),
+    do: Map.get(operations.by_ref, ref)
+
+  def newest(%__MODULE__{}), do: nil
+
+  @doc "Drops an operation by request reference."
+  @spec drop(t(), reference()) :: t()
+  def drop(%__MODULE__{} = operations, ref) when is_reference(ref) do
+    case Map.pop(operations.by_ref, ref) do
+      {nil, _by_ref} ->
+        operations
+
+      {%FormatOperation{} = operation, by_ref} ->
+        %__MODULE__{
+          operations
+          | by_ref: by_ref,
+            by_buffer: Map.delete(operations.by_buffer, operation.buffer),
+            newest_first: List.delete(operations.newest_first, ref)
+        }
+    end
+  end
+end

--- a/test/minga/lsp/client_test.exs
+++ b/test/minga/lsp/client_test.exs
@@ -22,13 +22,15 @@ defmodule Minga.LSP.ClientTest do
         request_unknown: Map.get(context, :request_unknown, false),
         show_message: Map.get(context, :show_message, false),
         show_message_request: Map.get(context, :show_message_request, false),
+        report_cancellations: Map.get(context, :report_cancellations, false),
         position_encoding: Map.get(context, :position_encoding, "utf-8"),
         settings: server_settings
       )
 
     if Map.get(context, :request_configuration, false) or
          Map.get(context, :request_unknown, false) or
-         Map.get(context, :show_message_request, false) do
+         Map.get(context, :show_message_request, false) or
+         Map.get(context, :report_cancellations, false) do
       Minga.Events.subscribe(:diagnostics_updated)
     end
 
@@ -293,6 +295,52 @@ defmodule Minga.LSP.ClientTest do
       assert ref1 != ref2
       assert Client.status(client) == :ready
     end
+
+    @tag report_cancellations: true
+    test "cancel_request/2 maps the opaque ref to a wire cancellation and suppresses delivery", %{
+      client: client,
+      diag_server: diag_server
+    } do
+      ref = Client.request(client, "mock/stall", %{})
+
+      assert Client.cancel_request(client, ref) == :ok
+      assert Client.cancel_request(client, ref) == {:error, :not_found}
+      assert_cancel_diagnostic(diag_server)
+      refute_receive {:lsp_response, ^ref, _result}, 100
+    end
+
+    @tag report_cancellations: true
+    test "an async caller exit cancels its outstanding wire request", %{
+      client: client,
+      diag_server: diag_server
+    } do
+      parent = self()
+
+      caller =
+        spawn(fn ->
+          ref = Client.request(client, "mock/stall", %{})
+          send(parent, {:request_ref, ref})
+          receive do: (:stop -> :ok)
+        end)
+
+      assert_receive {:request_ref, ref}
+      monitor = Process.monitor(caller)
+      Process.exit(caller, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^caller, :killed}
+      assert_cancel_diagnostic(diag_server)
+      refute_receive {:lsp_response, ^ref, _result}, 100
+    end
+  end
+
+  defp assert_cancel_diagnostic(diag_server) do
+    assert_receive {:minga_event, :diagnostics_updated,
+                    %Minga.Events.DiagnosticsUpdatedEvent{
+                      uri: "file:///tmp/cancel-request-test.ex"
+                    }},
+                   @event_timeout
+
+    assert [%{code: "CANCEL"}] =
+             Diagnostics.for_uri(diag_server, "file:///tmp/cancel-request-test.ex")
   end
 
   defp wait_until_ready(client) do

--- a/test/minga/lsp/client_test.exs
+++ b/test/minga/lsp/client_test.exs
@@ -281,36 +281,41 @@ defmodule Minga.LSP.ClientTest do
   end
 
   describe "async request/response" do
-    test "request/3 returns unique references while the client stays ready", %{client: client} do
-      ref1 =
-        Client.request(client, "textDocument/completion", %{
-          "textDocument" => %{"uri" => @uri},
-          "position" => %{"line" => 0, "character" => 0}
-        })
+    @tag report_cancellations: true
+    test "completing one concurrent request preserves the other's ref correlation", %{
+      client: client,
+      diag_server: diag_server
+    } do
+      stalled_ref = Client.request(client, "mock/stall", %{})
+      completed_ref = Client.request(client, "textDocument/hover", %{})
 
-      ref2 = Client.request(client, "textDocument/hover", %{})
+      assert is_reference(stalled_ref)
+      assert is_reference(completed_ref)
+      assert stalled_ref != completed_ref
+      assert_receive {:lsp_response, ^completed_ref, {:ok, nil}}
 
-      assert is_reference(ref1)
-      assert is_reference(ref2)
-      assert ref1 != ref2
+      assert Client.cancel_request(client, stalled_ref) == :ok
+      assert_cancel_diagnostic(diag_server)
+      refute_receive {:lsp_response, ^stalled_ref, _result}, 100
       assert Client.status(client) == :ready
     end
 
     @tag report_cancellations: true
-    test "cancel_request/2 maps the opaque ref to a wire cancellation and suppresses delivery", %{
+    test "canceling one concurrent request preserves the other's ref correlation", %{
       client: client,
       diag_server: diag_server
     } do
-      ref = Client.request(client, "mock/stall", %{})
+      canceled_ref = Client.request(client, "mock/stall", %{})
+      assert Client.cancel_request(client, canceled_ref) == :ok
+      completed_ref = Client.request(client, "textDocument/hover", %{})
 
-      assert Client.cancel_request(client, ref) == :ok
-      assert Client.cancel_request(client, ref) == {:error, :not_found}
+      assert_receive {:lsp_response, ^completed_ref, {:ok, nil}}
       assert_cancel_diagnostic(diag_server)
-      refute_receive {:lsp_response, ^ref, _result}, 100
+      refute_receive {:lsp_response, ^canceled_ref, _result}, 100
     end
 
     @tag report_cancellations: true
-    test "an async caller exit cancels its outstanding wire request", %{
+    test "an async caller exit cancels only its request", %{
       client: client,
       diag_server: diag_server
     } do
@@ -323,12 +328,14 @@ defmodule Minga.LSP.ClientTest do
           receive do: (:stop -> :ok)
         end)
 
-      assert_receive {:request_ref, ref}
+      assert_receive {:request_ref, abandoned_ref}
+      completed_ref = Client.request(client, "textDocument/hover", %{})
       monitor = Process.monitor(caller)
       Process.exit(caller, :kill)
       assert_receive {:DOWN, ^monitor, :process, ^caller, :killed}
+      assert_receive {:lsp_response, ^completed_ref, {:ok, nil}}
       assert_cancel_diagnostic(diag_server)
-      refute_receive {:lsp_response, ^ref, _result}, 100
+      refute_receive {:lsp_response, ^abandoned_ref, _result}, 100
     end
   end
 

--- a/test/minga/lsp/text_edit_test.exs
+++ b/test/minga/lsp/text_edit_test.exs
@@ -1,0 +1,77 @@
+defmodule Minga.LSP.TextEditTest do
+  @moduledoc "Protocol-correct LSP text edit application tests."
+
+  use ExUnit.Case, async: true
+
+  alias Minga.LSP.TextEdit
+
+  test "applies unordered edits against the original snapshot without positional shift" do
+    edits = [edit(0, 4, 0, 6, "EF"), edit(0, 0, 0, 2, "AB")]
+
+    assert TextEdit.apply("abcdef", edits, :utf8) == {:ok, "ABcdEF"}
+  end
+
+  test "applies an edit spanning multiple lines" do
+    edits = [edit(0, 2, 2, 2, "X\nY")]
+
+    assert TextEdit.apply("abc\ndef\nghi", edits, :utf8) == {:ok, "abX\nYi"}
+  end
+
+  test "converts non-ASCII positions for every negotiated encoding" do
+    content = "a😀éb"
+
+    assert TextEdit.apply(content, [edit(0, 1, 0, 5, "X")], :utf8) == {:ok, "aXéb"}
+    assert TextEdit.apply(content, [edit(0, 1, 0, 3, "X")], :utf16) == {:ok, "aXéb"}
+    assert TextEdit.apply(content, [edit(0, 1, 0, 2, "X")], :utf32) == {:ok, "aXéb"}
+  end
+
+  test "rejects overlapping ranges without producing partial content" do
+    edits = [edit(0, 0, 0, 3, "first"), edit(0, 2, 0, 4, "second")]
+
+    assert TextEdit.apply("abcdef", edits, :utf8) == {:error, :overlapping_edits}
+  end
+
+  test "preserves response order for multiple insertions at the same position" do
+    edits = [edit(0, 2, 0, 2, "first"), edit(0, 2, 0, 2, "second")]
+
+    assert TextEdit.apply("abcdef", edits, :utf8) == {:ok, "abfirstsecondcdef"}
+  end
+
+  test "preserves CRLF and lone-CR line endings while resolving logical lines" do
+    assert TextEdit.apply("a\r\nb", [edit(1, 0, 1, 1, "B")], :utf8) == {:ok, "a\r\nB"}
+    assert TextEdit.apply("a\rb", [edit(1, 0, 1, 1, "B")], :utf8) == {:ok, "a\rB"}
+    assert TextEdit.apply("a\r\nb", [edit(0, 2, 0, 2, "X")], :utf8) == {:error, :invalid_edit}
+  end
+
+  test "rejects invalid lines, reversed ranges, and malformed edits" do
+    assert TextEdit.apply("abc", [edit(1, 0, 1, 0, "x")], :utf8) ==
+             {:error, :invalid_edit}
+
+    assert TextEdit.apply("abc", [edit(0, 2, 0, 1, "x")], :utf8) ==
+             {:error, :invalid_edit}
+
+    assert TextEdit.apply("abc", [%{"newText" => "x"}], :utf8) ==
+             {:error, :invalid_edit}
+  end
+
+  test "rejects positions outside encoding boundaries" do
+    assert TextEdit.apply("é", [edit(0, 1, 0, 2, "x")], :utf8) ==
+             {:error, :invalid_edit}
+
+    assert TextEdit.apply("😀", [edit(0, 1, 0, 2, "x")], :utf16) ==
+             {:error, :invalid_edit}
+
+    assert TextEdit.apply("é", [edit(0, 2, 0, 3, "x")], :utf32) ==
+             {:error, :invalid_edit}
+  end
+
+  defp edit(start_line, start_character, end_line, end_character, new_text) do
+    %{
+      "range" => %{
+        "start" => %{"line" => start_line, "character" => start_character},
+        "end" => %{"line" => end_line, "character" => end_character}
+      },
+      "newText" => new_text
+    }
+  end
+end

--- a/test/minga_editor/commands/formatting_lsp_test.exs
+++ b/test/minga_editor/commands/formatting_lsp_test.exs
@@ -117,9 +117,8 @@ defmodule MingaEditor.Commands.FormattingLSPTest do
         GenServer.reply(from, :utf16)
         fake_client_loop(parent)
 
-      {:"$gen_call", from, {:cancel_request, ref}} ->
+      {:"$gen_cast", {:cancel_request, ref}} ->
         send(parent, {:cancel_request, ref})
-        GenServer.reply(from, :ok)
         fake_client_loop(parent)
 
       {:"$gen_cast", {:async_request, "textDocument/formatting", _params, caller, ref}} ->

--- a/test/minga_editor/commands/formatting_lsp_test.exs
+++ b/test/minga_editor/commands/formatting_lsp_test.exs
@@ -1,0 +1,156 @@
+defmodule MingaEditor.Commands.FormattingLSPTest do
+  @moduledoc "LSP formatting dispatch, replacement, and lifecycle ownership tests."
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Commands.Formatting
+  alias MingaEditor.Handlers.LspEventHandler
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.LSP, as: LSPState
+  alias MingaEditor.State.Windows
+  alias MingaEditor.VimState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Window
+  alias MingaEditor.WindowTree
+
+  test "dispatch returns while the server remains stalled" do
+    state = base_state()
+    buffer = state.workspace.buffers.active
+    client = fake_client(self())
+    register_client(buffer, client)
+
+    new_state = Formatting.format_buffer(state)
+
+    assert_receive {:format_request, ref, caller}
+    assert caller == self()
+    assert {:ok, operation} = LSPState.fetch_format(new_state.lsp, ref)
+    assert operation.buffer == buffer
+    assert operation.version == Minga.Buffer.version(buffer)
+    assert operation.encoding == :utf16
+  end
+
+  test "client exit between capability and encoding lookup does not crash the Editor transition" do
+    state = base_state()
+    buffer = state.workspace.buffers.active
+
+    client =
+      start_supervised!(
+        {Task,
+         fn ->
+           receive do
+             {:"$gen_call", from, :capabilities} ->
+               GenServer.reply(from, %{"documentFormattingProvider" => true})
+           end
+         end},
+        id: {:exiting_client, make_ref()}
+      )
+
+    register_client(buffer, client)
+
+    new_state = Formatting.format_buffer(state)
+
+    assert LSPState.newest_format(new_state.lsp) == nil
+  end
+
+  test "a newer request for the same Buffer cancels and replaces the old request" do
+    state = base_state()
+    buffer = state.workspace.buffers.active
+    client = fake_client(self())
+    register_client(buffer, client)
+
+    first_state = Formatting.format_buffer(state)
+    assert_receive {:format_request, first_ref, _caller}
+
+    second_state = Formatting.format_buffer(first_state)
+    assert_receive {:cancel_request, ^first_ref}
+    assert_receive {:format_request, second_ref, _caller}
+    refute first_ref == second_ref
+    refute LSPState.format_active?(second_state.lsp, first_ref)
+    assert LSPState.format_active?(second_state.lsp, second_ref)
+
+    edits = [
+      %{
+        "range" => %{
+          "start" => %{"line" => 0, "character" => 0},
+          "end" => %{"line" => 0, "character" => 5}
+        },
+        "newText" => "LATE"
+      }
+    ]
+
+    {after_late, effects} =
+      LspEventHandler.handle(second_state, {:lsp_response, first_ref, {:ok, edits}})
+
+    assert effects == [:render_now]
+    assert Minga.Buffer.content(buffer) == "hello\n"
+    assert LSPState.format_active?(after_late.lsp, second_ref)
+  end
+
+  defp register_client(buffer, client) do
+    Minga.LSP.SyncServer.put_clients(buffer, [client])
+
+    on_exit(fn ->
+      try do
+        Minga.LSP.SyncServer.remove_buffer(buffer)
+      rescue
+        ArgumentError -> :ok
+      end
+    end)
+  end
+
+  defp fake_client(parent) do
+    start_supervised!(
+      {Task, fn -> fake_client_loop(parent) end},
+      id: {:fake_client, make_ref()}
+    )
+  end
+
+  defp fake_client_loop(parent) do
+    receive do
+      {:"$gen_call", from, :capabilities} ->
+        GenServer.reply(from, %{"documentFormattingProvider" => true})
+        fake_client_loop(parent)
+
+      {:"$gen_call", from, :encoding} ->
+        GenServer.reply(from, :utf16)
+        fake_client_loop(parent)
+
+      {:"$gen_call", from, {:cancel_request, ref}} ->
+        send(parent, {:cancel_request, ref})
+        GenServer.reply(from, :ok)
+        fake_client_loop(parent)
+
+      {:"$gen_cast", {:async_request, "textDocument/formatting", _params, caller, ref}} ->
+        send(parent, {:format_request, ref, caller})
+        fake_client_loop(parent)
+    end
+  end
+
+  defp base_state do
+    path = Path.join(System.tmp_dir!(), "format-lsp-#{System.unique_integer([:positive])}.ex")
+    File.write!(path, "hello\n")
+    on_exit(fn -> File.rm(path) end)
+
+    buffer =
+      start_supervised!(
+        {BufferProcess, file_path: path, content: "hello\n"},
+        id: {:buffer, make_ref()}
+      )
+
+    workspace = %MingaEditor.Session.State{
+      viewport: Viewport.new(24, 80),
+      editing: VimState.new(),
+      buffers: %Buffers{active: buffer, list: [buffer], active_index: 0},
+      windows: %Windows{
+        tree: WindowTree.new(1),
+        map: %{1 => Window.new(1, buffer, 24, 80)},
+        active: 1,
+        next_id: 2
+      }
+    }
+
+    %EditorState{port_manager: self(), workspace: workspace}
+  end
+end

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -13,6 +13,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
   alias MingaEditor.Handlers.LspEventHandler
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.LSP.FormatOperation
   alias MingaEditor.State.Buffers
   alias MingaEditor.SignatureHelp
   alias MingaEditor.State.Highlighting
@@ -222,7 +223,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       buf = state.workspace.buffers.active
       version = Minga.Buffer.version(buf)
       ref = make_ref()
-      state = put_lsp_pending(state, ref, {:format, buf, version})
+      state = track_format(state, ref, buf, version)
 
       edits = [
         %{
@@ -238,7 +239,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
         LspEventHandler.handle(state, {:lsp_response, ref, {:ok, edits}})
 
       assert effects == [:render_now]
-      assert new_state.workspace.lsp_pending == %{}
+      refute LSPState.format_active?(new_state.lsp, ref)
       assert Minga.Buffer.content(buf) =~ "LINE ONE"
     end
 
@@ -247,7 +248,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       buf = state.workspace.buffers.active
       old_version = Minga.Buffer.version(buf)
       ref = make_ref()
-      state = put_lsp_pending(state, ref, {:format, buf, old_version})
+      state = track_format(state, ref, buf, old_version)
 
       Minga.Buffer.replace_content(buf, "modified content\n")
 
@@ -274,7 +275,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       buf = state.workspace.buffers.active
       version = Minga.Buffer.version(buf)
       ref = make_ref()
-      state = put_lsp_pending(state, ref, {:format, buf, version})
+      state = track_format(state, ref, buf, version)
 
       edits = [
         %{
@@ -324,7 +325,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       version = Minga.Buffer.version(buf)
       :ok = Minga.Buffer.set_read_only(buf, true)
       ref = make_ref()
-      state = put_lsp_pending(state, ref, {:format, buf, version})
+      state = track_format(state, ref, buf, version)
 
       edits = [
         %{
@@ -349,7 +350,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       buf = state.workspace.buffers.active
       version = Minga.Buffer.version(buf)
       ref = make_ref()
-      state = put_lsp_pending(state, ref, {:format, buf, version})
+      state = track_format(state, ref, buf, version)
       monitor = Process.monitor(buf)
       Process.exit(buf, :kill)
       assert_receive {:DOWN, ^monitor, :process, ^buf, :killed}
@@ -375,7 +376,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       state = base_state()
       buf = state.workspace.buffers.active
       ref = make_ref()
-      state = put_lsp_pending(state, ref, {:format, buf, Minga.Buffer.version(buf)})
+      state = track_format(state, ref, buf, Minga.Buffer.version(buf))
 
       {new_state, effects} =
         LspEventHandler.handle(state, {:lsp_response, ref, {:ok, nil}})
@@ -388,13 +389,44 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       state = base_state()
       buf = state.workspace.buffers.active
       ref = make_ref()
-      state = put_lsp_pending(state, ref, {:format, buf, Minga.Buffer.version(buf)})
+      state = track_format(state, ref, buf, Minga.Buffer.version(buf))
 
       {new_state, effects} =
         LspEventHandler.handle(state, {:lsp_response, ref, {:error, :timeout}})
 
       assert effects == [:render_now]
       assert EditorState.status_msg(new_state) =~ "Format error"
+    end
+
+    test "rejects invalid or overlapping server edits without changing content" do
+      state = base_state()
+      buf = state.workspace.buffers.active
+      ref = make_ref()
+      state = track_format(state, ref, buf, Minga.Buffer.version(buf))
+
+      edits = [
+        %{
+          "range" => %{
+            "start" => %{"line" => 0, "character" => 0},
+            "end" => %{"line" => 0, "character" => 8}
+          },
+          "newText" => "first"
+        },
+        %{
+          "range" => %{
+            "start" => %{"line" => 0, "character" => 4},
+            "end" => %{"line" => 0, "character" => 9}
+          },
+          "newText" => "second"
+        }
+      ]
+
+      {new_state, effects} =
+        LspEventHandler.handle(state, {:lsp_response, ref, {:ok, edits}})
+
+      assert effects == [:render_now]
+      assert Minga.Buffer.content(buf) == "line one\nline two\nline three"
+      assert new_state.shell_state.status_msg =~ "Invalid LSP"
     end
   end
 
@@ -403,7 +435,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       state = base_state()
       ref = make_ref()
       buf = state.workspace.buffers.active
-      state = put_lsp_pending(state, ref, {:format, buf, 0})
+      state = track_format(state, ref, buf, 0)
 
       {new_state, effects} = LspEventHandler.handle(state, {:lsp_format_spinner, ref})
 
@@ -425,7 +457,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       state = base_state()
       ref = make_ref()
       buf = state.workspace.buffers.active
-      state = put_lsp_pending(state, ref, {:format, buf, 0})
+      state = track_format(state, ref, buf, 0)
 
       {new_state, effects} = LspEventHandler.handle(state, {:lsp_format_cancellable, ref})
 
@@ -437,13 +469,43 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       state = base_state()
       ref = make_ref()
       buf = state.workspace.buffers.active
-      state = put_lsp_pending(state, ref, {:format, buf, 0})
+      state = track_format(state, ref, buf, 0)
 
       {new_state, effects} = LspEventHandler.handle(state, {:lsp_format_timeout, ref})
 
       assert effects == [:render_now]
-      assert new_state.workspace.lsp_pending == %{}
+      refute LSPState.format_active?(new_state.lsp, ref)
       assert EditorState.status_msg(new_state) =~ "timed out"
+      assert_receive {:lsp_cancel, ^ref}
+    end
+
+    test "late response after timeout is ignored" do
+      state = base_state()
+      ref = make_ref()
+      buf = state.workspace.buffers.active
+      state = track_format(state, ref, buf, Minga.Buffer.version(buf))
+
+      {timed_out, [:render_now]} =
+        LspEventHandler.handle(state, {:lsp_format_timeout, ref})
+
+      assert_receive {:lsp_cancel, ^ref}
+
+      edits = [
+        %{
+          "range" => %{
+            "start" => %{"line" => 0, "character" => 0},
+            "end" => %{"line" => 0, "character" => 8}
+          },
+          "newText" => "LATE"
+        }
+      ]
+
+      {after_late, effects} =
+        LspEventHandler.handle(timed_out, {:lsp_response, ref, {:ok, edits}})
+
+      assert effects == [:render_now]
+      assert Minga.Buffer.content(buf) == "line one\nline two\nline three"
+      assert EditorState.status_msg(after_late) =~ "timed out"
     end
 
     test "timeout is no-op when format already completed" do
@@ -459,6 +521,22 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
   defp put_lsp_pending(state, ref, kind) do
     EditorState.put_lsp_pending(state, ref, kind)
+  end
+
+  defp track_format(state, ref, buffer, version, opts \\ []) do
+    operation =
+      FormatOperation.new(
+        client: Keyword.get(opts, :client, start_fake_lsp_client()),
+        ref: ref,
+        buffer: buffer,
+        version: version,
+        encoding: Keyword.get(opts, :encoding, :utf8),
+        spinner_timer: make_ref(),
+        cancellable_timer: make_ref(),
+        timeout_timer: make_ref()
+      )
+
+    EditorState.update_lsp(state, &LSPState.track_format(&1, operation))
   end
 
   defp base_state do
@@ -535,6 +613,11 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       {:"$gen_call", from, :encoding} ->
         GenServer.reply(from, :utf16)
+        fake_lsp_client_loop(parent)
+
+      {:"$gen_call", from, {:cancel_request, ref}} ->
+        send(parent, {:lsp_cancel, ref})
+        GenServer.reply(from, :ok)
         fake_lsp_client_loop(parent)
 
       {:"$gen_cast", {:async_request, method, params, caller, ref}} ->

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -218,29 +218,34 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
   end
 
   describe "formatting response" do
-    test "applies edits when buffer version matches" do
-      state = base_state()
-      buf = state.workspace.buffers.active
-      version = Minga.Buffer.version(buf)
-      ref = make_ref()
-      state = track_format(state, ref, buf, version)
+    for {encoding, start_col, end_col} <- [utf8: {5, 6}, utf16: {3, 4}, utf32: {2, 3}] do
+      test "applies emoji-adjacent edits using negotiated #{encoding}" do
+        encoding = unquote(encoding)
+        start_col = unquote(start_col)
+        end_col = unquote(end_col)
+        state = buffer_state("a😀b\n")
+        buf = state.workspace.buffers.active
+        version = Minga.Buffer.version(buf)
+        ref = make_ref()
+        state = track_format(state, ref, buf, version, encoding: encoding)
 
-      edits = [
-        %{
-          "range" => %{
-            "start" => %{"line" => 0, "character" => 0},
-            "end" => %{"line" => 0, "character" => 8}
-          },
-          "newText" => "LINE ONE"
-        }
-      ]
+        edits = [
+          %{
+            "range" => %{
+              "start" => %{"line" => 0, "character" => start_col},
+              "end" => %{"line" => 0, "character" => end_col}
+            },
+            "newText" => "B"
+          }
+        ]
 
-      {new_state, effects} =
-        LspEventHandler.handle(state, {:lsp_response, ref, {:ok, edits}})
+        {new_state, effects} =
+          LspEventHandler.handle(state, {:lsp_response, ref, {:ok, edits}})
 
-      assert effects == [:render_now]
-      refute LSPState.format_active?(new_state.lsp, ref)
-      assert Minga.Buffer.content(buf) =~ "LINE ONE"
+        assert effects == [:render_now]
+        assert Minga.Buffer.content(buf) == "a😀B\n"
+        refute LSPState.format_active?(new_state.lsp, ref)
+      end
     end
 
     test "skips edits when buffer version changed (staleness guard)" do
@@ -315,7 +320,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       {new_state, effects} = Task.await(task)
 
       assert effects == [:render_now]
-      assert Minga.Buffer.content(buf) =~ "!line one"
+      assert Minga.Buffer.content(buf) == "!line one\nline two\nline three"
       assert EditorState.status_msg(new_state) =~ "Buffer changed"
     end
 
@@ -385,6 +390,45 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       assert EditorState.status_msg(new_state) =~ "No formatting changes"
     end
 
+    test "empty edits release ownership without changing buffer state" do
+      state = base_state()
+      buf = state.workspace.buffers.active
+      ref = make_ref()
+      content = Minga.Buffer.content(buf)
+      version = Minga.Buffer.version(buf)
+      dirty? = Minga.Buffer.dirty?(buf)
+      cursor = Minga.Buffer.cursor(buf)
+      undo_source = BufferProcess.last_undo_source(buf)
+      state = track_format(state, ref, buf, version)
+
+      {new_state, effects} =
+        LspEventHandler.handle(state, {:lsp_response, ref, {:ok, []}})
+
+      assert effects == [:render_now]
+      assert Minga.Buffer.content(buf) == content
+      assert Minga.Buffer.version(buf) == version
+      assert Minga.Buffer.dirty?(buf) == dirty?
+      assert Minga.Buffer.cursor(buf) == cursor
+      assert BufferProcess.last_undo_source(buf) == undo_source
+      refute LSPState.format_active?(new_state.lsp, ref)
+      assert EditorState.status_msg(new_state) == "No formatting changes"
+    end
+
+    test "malformed successful response is skipped without crashing the handler" do
+      state = base_state()
+      buf = state.workspace.buffers.active
+      ref = make_ref()
+      state = track_format(state, ref, buf, Minga.Buffer.version(buf))
+
+      {new_state, effects} =
+        LspEventHandler.handle(state, {:lsp_response, ref, {:ok, %{"edits" => :invalid}}})
+
+      assert effects == [:render_now]
+      assert Minga.Buffer.content(buf) == "line one\nline two\nline three"
+      refute LSPState.format_active?(new_state.lsp, ref)
+      assert EditorState.status_msg(new_state) == "Invalid LSP formatting response skipped"
+    end
+
     test "handles error response" do
       state = base_state()
       buf = state.workspace.buffers.active
@@ -426,7 +470,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       assert effects == [:render_now]
       assert Minga.Buffer.content(buf) == "line one\nline two\nline three"
-      assert new_state.shell_state.status_msg =~ "Invalid LSP"
+      assert EditorState.status_msg(new_state) =~ "Invalid LSP"
     end
   end
 
@@ -615,9 +659,8 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
         GenServer.reply(from, :utf16)
         fake_lsp_client_loop(parent)
 
-      {:"$gen_call", from, {:cancel_request, ref}} ->
+      {:"$gen_cast", {:cancel_request, ref}} ->
         send(parent, {:lsp_cancel, ref})
-        GenServer.reply(from, :ok)
         fake_lsp_client_loop(parent)
 
       {:"$gen_cast", {:async_request, method, params, caller, ref}} ->

--- a/test/minga_editor/input/global_bindings_test.exs
+++ b/test/minga_editor/input/global_bindings_test.exs
@@ -53,9 +53,8 @@ defmodule MingaEditor.Input.GlobalBindingsTest do
       {Task,
        fn ->
          receive do
-           {:"$gen_call", from, {:cancel_request, ref}} ->
+           {:"$gen_cast", {:cancel_request, ref}} ->
              send(parent, {:cancel_request, ref})
-             GenServer.reply(from, :ok)
          end
        end},
       id: {:fake_client, make_ref()}

--- a/test/minga_editor/input/global_bindings_test.exs
+++ b/test/minga_editor/input/global_bindings_test.exs
@@ -1,0 +1,82 @@
+defmodule MingaEditor.Input.GlobalBindingsTest do
+  @moduledoc "Global input behavior for canceling LSP formatting."
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Input.GlobalBindings
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.LSP, as: LSPState
+  alias MingaEditor.State.LSP.FormatOperation
+  alias MingaEditor.State.Windows
+  alias MingaEditor.VimState
+  alias MingaEditor.Viewport
+  alias MingaEditor.Window
+  alias MingaEditor.WindowTree
+
+  test "Esc cancels the newest underlying LSP format request and drops ownership" do
+    state = base_state()
+    buffer = state.workspace.buffers.active
+    client = fake_client(self())
+    ref = make_ref()
+    operation = operation(client, ref, buffer)
+    state = EditorState.update_lsp(state, &LSPState.track_format(&1, operation))
+
+    assert {:passthrough, new_state} = GlobalBindings.handle_key(state, 27, 0)
+    assert_receive {:cancel_request, ^ref}
+    refute LSPState.format_active?(new_state.lsp, ref)
+    assert EditorState.status_msg(new_state) == "Format canceled"
+  end
+
+  test "Esc remains a passthrough when no format is active" do
+    state = base_state()
+
+    assert GlobalBindings.handle_key(state, 27, 0) == {:passthrough, state}
+  end
+
+  defp operation(client, ref, buffer) do
+    FormatOperation.new(
+      client: client,
+      ref: ref,
+      buffer: buffer,
+      version: 0,
+      encoding: :utf8,
+      spinner_timer: make_ref(),
+      cancellable_timer: make_ref(),
+      timeout_timer: make_ref()
+    )
+  end
+
+  defp fake_client(parent) do
+    start_supervised!(
+      {Task,
+       fn ->
+         receive do
+           {:"$gen_call", from, {:cancel_request, ref}} ->
+             send(parent, {:cancel_request, ref})
+             GenServer.reply(from, :ok)
+         end
+       end},
+      id: {:fake_client, make_ref()}
+    )
+  end
+
+  defp base_state do
+    buffer = start_supervised!({BufferProcess, content: "hello\n"}, id: {:buffer, make_ref()})
+
+    workspace = %MingaEditor.Session.State{
+      viewport: Viewport.new(24, 80),
+      editing: VimState.new(),
+      buffers: %Buffers{active: buffer, list: [buffer], active_index: 0},
+      windows: %Windows{
+        tree: WindowTree.new(1),
+        map: %{1 => Window.new(1, buffer, 24, 80)},
+        active: 1,
+        next_id: 2
+      }
+    }
+
+    %EditorState{port_manager: self(), workspace: workspace}
+  end
+end

--- a/test/minga_editor/state/lsp/format_operations_test.exs
+++ b/test/minga_editor/state/lsp/format_operations_test.exs
@@ -1,0 +1,63 @@
+defmodule MingaEditor.State.LSP.FormatOperationsTest do
+  @moduledoc "Pure lifecycle index invariants for LSP formatting operations."
+
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.State.LSP.FormatOperation
+  alias MingaEditor.State.LSP.FormatOperations
+
+  test "tracks unrelated buffers independently and returns the newest operation" do
+    first = operation(spawn_process(), make_ref())
+    second = operation(spawn_process(), make_ref())
+
+    assert {:ok, operations} = FormatOperations.track(FormatOperations.new(), first)
+    assert {:ok, operations} = FormatOperations.track(operations, second)
+    assert FormatOperations.fetch(operations, first.ref) == {:ok, first}
+    assert FormatOperations.for_buffer(operations, second.buffer) == second
+    assert FormatOperations.newest(operations) == second
+  end
+
+  test "refuses to replace a Buffer operation without an explicit cancel and drop workflow" do
+    buffer = spawn_process()
+    first = operation(buffer, make_ref())
+    replacement = operation(buffer, make_ref())
+
+    assert {:ok, operations} = FormatOperations.track(FormatOperations.new(), first)
+    assert FormatOperations.track(operations, replacement) == {:error, :buffer_busy}
+
+    operations = FormatOperations.drop(operations, first.ref)
+    assert {:ok, operations} = FormatOperations.track(operations, replacement)
+    assert FormatOperations.for_buffer(operations, buffer) == replacement
+  end
+
+  test "dropping the newest operation reveals the previous active operation" do
+    first = operation(spawn_process(), make_ref())
+    second = operation(spawn_process(), make_ref())
+    {:ok, operations} = FormatOperations.track(FormatOperations.new(), first)
+    {:ok, operations} = FormatOperations.track(operations, second)
+
+    operations = FormatOperations.drop(operations, second.ref)
+
+    assert FormatOperations.newest(operations) == first
+    assert FormatOperations.fetch(operations, second.ref) == :error
+  end
+
+  defp operation(buffer, ref) do
+    FormatOperation.new(
+      client: self(),
+      ref: ref,
+      buffer: buffer,
+      version: 0,
+      encoding: :utf8,
+      spinner_timer: make_ref(),
+      cancellable_timer: make_ref(),
+      timeout_timer: make_ref()
+    )
+  end
+
+  defp spawn_process do
+    pid = spawn(fn -> receive do: (:stop -> :ok) end)
+    on_exit(fn -> send(pid, :stop) end)
+    pid
+  end
+end

--- a/test/minga_editor/state/tab_switch_test.exs
+++ b/test/minga_editor/state/tab_switch_test.exs
@@ -12,6 +12,7 @@ defmodule MingaEditor.State.TabSwitchTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Handlers.LspEventHandler
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.LSP, as: LSPState
@@ -336,7 +337,7 @@ defmodule MingaEditor.State.TabSwitchTest do
 
     test "tab switch preserves Editor-global formatting ownership" do
       {state, buf1, _buf2} = state_with_two_file_tabs()
-      tb = state.shell_state.tab_bar
+      tb = EditorState.tab_bar(state)
       current_id = tb.active_id
       target_id = Enum.find(tb.tabs, &(&1.id != current_id)).id
       ref = make_ref()
@@ -360,6 +361,68 @@ defmodule MingaEditor.State.TabSwitchTest do
       {switched_back, _effects} = EditorState.switch_tab_pure(switched, current_id)
 
       assert {:ok, ^operation} = LSPState.fetch_format(switched_back.lsp, ref)
+    end
+
+    test "format responses remain isolated across a tab switch" do
+      {state, buf_a, buf_b} = state_with_two_file_tabs()
+      tab_bar = EditorState.tab_bar(state)
+      target_id = Enum.find(tab_bar.tabs, &(&1.id != 1)).id
+      ref_a = make_ref()
+      ref_b = make_ref()
+
+      operation_a = %FormatOperation{
+        client: self(),
+        ref: ref_a,
+        buffer: buf_a,
+        version: Minga.Buffer.version(buf_a),
+        encoding: :utf8,
+        spinner_timer: make_ref(),
+        cancellable_timer: make_ref(),
+        timeout_timer: make_ref()
+      }
+
+      state = EditorState.update_lsp(state, &LSPState.track_format(&1, operation_a))
+      {state, _effects} = EditorState.switch_tab_pure(state, target_id)
+
+      operation_b = %FormatOperation{
+        client: self(),
+        ref: ref_b,
+        buffer: buf_b,
+        version: Minga.Buffer.version(buf_b),
+        encoding: :utf8,
+        spinner_timer: make_ref(),
+        cancellable_timer: make_ref(),
+        timeout_timer: make_ref()
+      }
+
+      state = EditorState.update_lsp(state, &LSPState.track_format(&1, operation_b))
+
+      edits_a = [
+        %{
+          "range" => %{
+            "start" => %{"line" => 0, "character" => 0},
+            "end" => %{"line" => 0, "character" => 8}
+          },
+          "newText" => "formatted A"
+        }
+      ]
+
+      {after_a, effects} =
+        LspEventHandler.handle(state, {:lsp_response, ref_a, {:ok, edits_a}})
+
+      assert effects == [:render_now]
+      assert Minga.Buffer.content(buf_a) == "formatted A"
+      assert Minga.Buffer.content(buf_b) == "file two"
+      refute LSPState.format_active?(after_a.lsp, ref_a)
+      assert LSPState.format_active?(after_a.lsp, ref_b)
+
+      {after_timeout, timeout_effects} =
+        LspEventHandler.handle(after_a, {:lsp_format_timeout, ref_b})
+
+      assert timeout_effects == [:render_now]
+      refute LSPState.format_active?(after_timeout.lsp, ref_b)
+      assert Minga.Buffer.content(buf_b) == "file two"
+      assert_receive {:"$gen_cast", {:cancel_request, ^ref_b}}
     end
 
     test "tab switch preserves live highlighting and ignores stale target parser state" do

--- a/test/minga_editor/state/tab_switch_test.exs
+++ b/test/minga_editor/state/tab_switch_test.exs
@@ -14,6 +14,8 @@ defmodule MingaEditor.State.TabSwitchTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.LSP, as: LSPState
+  alias MingaEditor.State.LSP.FormatOperation
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context
   alias MingaEditor.State.TabBar
@@ -330,6 +332,34 @@ defmodule MingaEditor.State.TabSwitchTest do
 
       assert TabBar.get(EditorState.tab_bar(switched_back), target_id).context.lsp_pending ==
                pending_target
+    end
+
+    test "tab switch preserves Editor-global formatting ownership" do
+      {state, buf1, _buf2} = state_with_two_file_tabs()
+      tb = state.shell_state.tab_bar
+      current_id = tb.active_id
+      target_id = Enum.find(tb.tabs, &(&1.id != current_id)).id
+      ref = make_ref()
+
+      operation = %FormatOperation{
+        client: self(),
+        ref: ref,
+        buffer: buf1,
+        version: 0,
+        encoding: :utf8,
+        spinner_timer: make_ref(),
+        cancellable_timer: make_ref(),
+        timeout_timer: make_ref()
+      }
+
+      state = EditorState.update_lsp(state, &LSPState.track_format(&1, operation))
+      {switched, _effects} = EditorState.switch_tab_pure(state, target_id)
+
+      assert {:ok, ^operation} = LSPState.fetch_format(switched.lsp, ref)
+
+      {switched_back, _effects} = EditorState.switch_tab_pure(switched, current_id)
+
+      assert {:ok, ^operation} = LSPState.fetch_format(switched_back.lsp, ref)
     end
 
     test "tab switch preserves live highlighting and ignores stale target parser state" do

--- a/test/support/mock_lsp_server.ex
+++ b/test/support/mock_lsp_server.ex
@@ -29,6 +29,7 @@ defmodule Minga.Test.MockLSPServer do
           | {:request_unknown, boolean()}
           | {:show_message, boolean()}
           | {:show_message_request, boolean()}
+          | {:report_cancellations, boolean()}
           | {:stderr_banner, boolean()}
           | {:position_encoding, String.t()}
           | {:settings, map()}
@@ -46,6 +47,7 @@ defmodule Minga.Test.MockLSPServer do
         {Keyword.get(opts, :request_unknown, false), "--request-unknown"},
         {Keyword.get(opts, :show_message, false), "--show-message"},
         {Keyword.get(opts, :show_message_request, false), "--show-message-request"},
+        {Keyword.get(opts, :report_cancellations, false), "--report-cancellations"},
         {Keyword.get(opts, :stderr_banner, false), "--stderr-banner"},
         {true, "--position-encoding=#{Keyword.get(opts, :position_encoding, "utf-8")}"}
       ]

--- a/test/support/mock_lsp_server_script.exs
+++ b/test/support/mock_lsp_server_script.exs
@@ -130,6 +130,19 @@ defmodule MockServer do
     :ok
   end
 
+  defp handle_message(%{"method" => "mock/stall", "id" => _id}) do
+    :ok
+  end
+
+  defp handle_message(%{"method" => "$/cancelRequest", "params" => %{"id" => id}}) do
+    if report_cancellations?() do
+      send_test_diagnostic("file:///tmp/cancel-request-test.ex", "CANCEL", inspect(id))
+      send_response(id, "late response after cancellation")
+    end
+
+    :ok
+  end
+
   defp handle_message(%{"id" => "configuration-900", "result" => result}) when is_list(result) do
     send_test_diagnostic("file:///tmp/configuration-test.ex", "CONFIG", JSON.encode!(result))
   end
@@ -232,6 +245,10 @@ defmodule MockServer do
 
   defp show_message_request? do
     "--show-message-request" in System.argv()
+  end
+
+  defp report_cancellations? do
+    "--report-cancellations" in System.argv()
   end
 
   defp position_encoding do


### PR DESCRIPTION
# TL;DR

LSP formatting now remains responsive and safely owned across tab switches, cancellation, timeout, client exit, and late responses. Formatting edits are validated against the original buffer snapshot with negotiated position encoding and committed through one atomic Buffer version check.

Closes #2449

## Context

The original async conversion removed the server round-trip from the Editor process, and #2811 closed the Buffer check-then-write race. The remaining lifecycle still lived in per-tab state, cancellation did not reach the language server, and edit application trusted response order and grapheme-based columns.

This change follows #2861's state-ownership direction without adding another root `MingaEditor.State` facade or misusing the worker-oriented `EffectScheduler`.

## Changes

- Move formatting lifecycle correlation into Editor-global `State.LSP` values so tab snapshots cannot hide an active operation.
- Add a focused `FormatLifecycle` workflow for feedback timers and underlying LSP cancellation while keeping operation values and indexes pure.
- Add `Client.cancel_request/2`, opaque-ref to JSON-RPC-id correlation, caller monitoring, bounded canceled-request tombstones, and late-response suppression.
- Cancel same-buffer replacements, Esc requests, timeouts, and requests whose owning Editor process exits.
- Normalize LSP edits against indexed original content with strict UTF-8, UTF-16, and UTF-32 positions across LF, CRLF, and lone-CR line endings.
- Reject invalid or overlapping ranges, preserve legal same-position insertion order, and assemble formatted content in one linear pass after sorting.
- Keep the final write behind `Buffer.replace_content_if_version/4` so stale, read-only, and exited targets remain unchanged.

## Verification

Validated commit `4e5aedf36391b6ee8bd9c85200b0814ed70af591` after rebasing onto current `main`.

- `make lint`: PASS, Credo clean, warnings-as-errors compilation clean, incremental Dialyzer 0 errors.
- `mix test.llm`: PASS, 9,302 tests, 58 doctests, 97 properties, 0 failures, 1 skipped.
- `mix test.debug test/minga/lsp/client_test.exs`: PASS, 15 heavy wire-lifecycle tests.
- Focused formatting, edit, lifecycle, tab-switch, cancellation, and race suites: PASS.
- `git diff origin/main...HEAD --check`: PASS.
- Focused bug-hunting review: PASS after correcting line-ending, insertion-order, algorithmic, client-exit, state-shape, and test-concurrency findings.
- Full Review DAG: correctness, test-quality, and security reviews completed; accepted lifecycle and coverage fixes applied; final rebase compatibility blockers resolved and revalidated.

## Acceptance Criteria Addressed

- Formatting lifecycle remains owned across tab and workspace switches. ✅
- Esc, timeout, same-buffer replacement, and owner exit cancel the underlying LSP request. ✅
- Terminal outcomes reject late responses and timer messages. ✅
- Text edits honor negotiated encoding, line endings, range validity, overlap rules, and insertion order without positional shift. ✅
- Buffer replacement remains atomic and stale-safe. ✅
- Deterministic tests cover dispatch, completion, races, switches, cancellation, timeout, replacement, late responses, process exits, ordering, invalid edits, and all negotiated encodings. ✅

---
**Updated after review:** Added cross-tab response isolation, end-to-end negotiated-encoding coverage, concurrent Client correlation tests, malformed and empty response handling, and non-blocking ordered cancellation. Rebasing onto current `main` also migrated the changed tests to the new `shell_runtime` public helpers.
