### PR TITLE
feat(macos): partition native frame publication

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		00F5A6B58392069C8645B12C /* PresentationScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */; };
 		01EA03A621B455B253E6C7B3 /* MingaUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		021E5E13E2F6CA9FEEA6D175 /* GUIFramePresentationMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18683C638D0F417500DAF924 /* GUIFramePresentationMetrics.swift */; };
 		03C97AFD225BCEA6E7A8E0BF /* PreparedFrameTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */; };
 		058481A528AFB6C7225A067D /* MouseInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */; };
 		05EC70C811170EE160C5E4D9 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
@@ -32,6 +33,7 @@
 		1631D7B76B33CD897C48F263 /* IMECompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */; };
 		172D7B7EC516CC0CA76797AC /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D4C9BE8CA9DC30BCE6ED49 /* WorkspaceHeaderView.swift */; };
 		18F0DDA03D08C0B4302DCCF4 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
+		19117A3BA17ACBBD58E55A9E /* GUIFrameStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6577A488A042D7974A1EA661 /* GUIFrameStoreTests.swift */; };
 		1936219891B87FD4AB49795B /* StatusBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575815EBAD4E1DFE0BE3DE57 /* StatusBarState.swift */; };
 		19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		1A2DA0CD8DD4B1C1F30C9098 /* MingaProtocol.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; };
@@ -302,6 +304,7 @@
 		E8DAC5BD5013095E550BF4E8 /* CompletionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124E376C3B8F6EC62765F5C1 /* CompletionState.swift */; };
 		E986DB2DA0989A52D16B1E69 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60980E90FDD864409144BA5B /* PickerState.swift */; };
 		EA49ADC46692D8613D80EA2D /* NativeSidebarRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2269E199608D475AB34F10 /* NativeSidebarRegistryTests.swift */; };
+		EC052D491677191783FF978E /* GUIFrameStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5066C470DAA195F0DA9FE491 /* GUIFrameStore.swift */; };
 		ED8592B57E8A2A3EAAE24295 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DB822E0C8D06C7B45D329F /* EditorNSView.swift */; };
 		EE84DA1BF4952359DD0DC343 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
 		EFB02B33864584C42AD0038E /* MingaUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; };
@@ -438,6 +441,7 @@
 		124E376C3B8F6EC62765F5C1 /* CompletionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionState.swift; sourceTree = "<group>"; };
 		13C8650724242FD0A50EC3CA /* EditorGeometry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorGeometry.swift; sourceTree = "<group>"; };
 		13E89640A29C207B9040DC67 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
+		18683C638D0F417500DAF924 /* GUIFramePresentationMetrics.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIFramePresentationMetrics.swift; sourceTree = "<group>"; };
 		19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolEncoderDisconnectTests.swift; sourceTree = "<group>"; };
 		1BA08D322A0BCE2491D4489D /* MessagesContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentView.swift; sourceTree = "<group>"; };
 		1BB45C5B630FDEDFD0BD6BE0 /* EditTimelineState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTimelineState.swift; sourceTree = "<group>"; };
@@ -489,6 +493,7 @@
 		4BB5DAD0EAB1AE583E45AF5C /* PreviewRegistry+GitStatus.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreviewRegistry+GitStatus.swift"; sourceTree = "<group>"; };
 		4BC98120D82BD7548347875E /* FontFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFace.swift; sourceTree = "<group>"; };
 		4CDC572B6F7D2CD90E07CA61 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
+		5066C470DAA195F0DA9FE491 /* GUIFrameStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIFrameStore.swift; sourceTree = "<group>"; };
 		51E88C12915EC4EBE96165AF /* FileTreeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeHeaderView.swift; sourceTree = "<group>"; };
 		53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Instrumentation.swift; sourceTree = "<group>"; };
 		54D2036E3609EB1C3E575CFC /* BottomPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelView.swift; sourceTree = "<group>"; };
@@ -512,6 +517,7 @@
 		63D118F59FBCA463A52B84FA /* AgentContextBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentContextBar.swift; sourceTree = "<group>"; };
 		644384B6B8FE5F11CD0DB713 /* GUIState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIState.swift; sourceTree = "<group>"; };
 		64CEFB02A774E5E8EF19029F /* MingaTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = MingaTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		6577A488A042D7974A1EA661 /* GUIFrameStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIFrameStoreTests.swift; sourceTree = "<group>"; };
 		65B982679577E3DBD4E7A69D /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		671A222860B90E08D7975099 /* WorkspaceIconPicker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WorkspaceIconPicker.swift; sourceTree = "<group>"; };
 		67B23834E6FEB75E891AAFE2 /* ObservatoryState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObservatoryState.swift; sourceTree = "<group>"; };
@@ -885,6 +891,8 @@
 				13C8650724242FD0A50EC3CA /* EditorGeometry.swift */,
 				1BB45C5B630FDEDFD0BD6BE0 /* EditTimelineState.swift */,
 				EE173FAAAC37ACFF47EE03B8 /* EditTimelineView.swift */,
+				18683C638D0F417500DAF924 /* GUIFramePresentationMetrics.swift */,
+				5066C470DAA195F0DA9FE491 /* GUIFrameStore.swift */,
 				644384B6B8FE5F11CD0DB713 /* GUIState.swift */,
 				8A733EF649EF21A761608D75 /* MingaWindow.swift */,
 				9D721181E284AD8BA34F0354 /* SparklineView.swift */,
@@ -1050,6 +1058,7 @@
 				BD2DE335B00721CBB29329F9 /* FontTests.swift */,
 				E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */,
 				754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */,
+				6577A488A042D7974A1EA661 /* GUIFrameStoreTests.swift */,
 				F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */,
 				7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */,
 				DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */,
@@ -1538,6 +1547,8 @@
 				C6BCAF6C4605DD682B8BC442 /* FloatPopupOverlay.swift in Sources */,
 				D016856873812B1D5433960E /* FloatPopupState.swift in Sources */,
 				FCC1D0710DF8573446AA5EAB /* FrontendExtensionRuntime.swift in Sources */,
+				021E5E13E2F6CA9FEEA6D175 /* GUIFramePresentationMetrics.swift in Sources */,
+				EC052D491677191783FF978E /* GUIFrameStore.swift in Sources */,
 				94C474B5B4938F72E9A5070B /* GUIState.swift in Sources */,
 				45B4C421739CB97B638B385C /* GitStatusHeaderView.swift in Sources */,
 				BA87497E73BB694BE1FCE77E /* GitStatusState.swift in Sources */,
@@ -1632,6 +1643,7 @@
 				63F3CF3A4746901FDF1C3356 /* FrameState.swift in Sources */,
 				CD2952CCEB2FD594B269A75D /* GUIActionEncoderTests.swift in Sources */,
 				30E31170A79F30413D15D858 /* GUIChromeDecoderTests.swift in Sources */,
+				19117A3BA17ACBBD58E55A9E /* GUIFrameStoreTests.swift in Sources */,
 				312DC4940992B35ED9EE7648 /* IMEComposition.swift in Sources */,
 				1631D7B76B33CD897C48F263 /* IMECompositionTests.swift in Sources */,
 				25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */,

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -1,4 +1,3 @@
-import MingaUI
 import AppKit
 import SwiftUI
 import MingaProtocol
@@ -98,37 +97,134 @@ private struct PaneWidthKey: PreferenceKey {
     }
 }
 
+private struct ShellFramePresentationHost<Content: View>: View {
+    let channel: GUIFrameChannel
+    let metrics: GUIFramePresentationMetrics
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        _ = channel.value
+        return content()
+            .frameNativeDrawProbe(domain: .shell, version: channel.value, metrics: metrics)
+    }
+}
+
+private struct UnifiedToolbarHost<Content: View>: View {
+    let channel: GUIFrameChannel
+    let input: ShellHostInput
+    @ViewBuilder let content: (ShellHostInput) -> Content
+
+    var body: some View {
+        _ = channel.value
+        return content(input).environment(\.themeColors, input.currentTheme)
+    }
+}
+
+private struct SidebarHost<Content: View>: View {
+    let channel: GUIFrameChannel
+    let input: ShellHostInput
+    @ViewBuilder let content: (ShellHostInput) -> Content
+
+    var body: some View {
+        _ = channel.value
+        return content(input).environment(\.themeColors, input.currentTheme)
+    }
+}
+
+private struct EditorColumnHost<Content: View>: View {
+    let channel: GUIFrameChannel
+    let input: ShellHostInput
+    @ViewBuilder let content: (ShellHostInput) -> Content
+
+    var body: some View {
+        _ = channel.value
+        return content(input).environment(\.themeColors, input.currentTheme)
+    }
+}
+
+private struct EditorSurfaceHost<Content: View>: View {
+    let channel: GUIFrameChannel
+    let input: EditorHostInput
+    @ViewBuilder let content: (EditorHostInput) -> Content
+
+    var body: some View {
+        _ = channel.value
+        return content(input).environment(\.themeColors, input.currentTheme)
+    }
+}
+
+private struct StatusBarHost<Content: View>: View {
+    let channel: GUIFrameChannel
+    let input: ShellHostInput
+    @ViewBuilder let content: (ShellHostInput) -> Content
+
+    var body: some View {
+        _ = channel.value
+        return content(input).environment(\.themeColors, input.currentTheme)
+    }
+}
+
+private struct FrontendExtensionRuntimeHost<Content: View>: View {
+    let channel: GUIFrameChannel
+    let input: WindowOverlayHostInput
+    @ViewBuilder let content: (WindowOverlayHostInput) -> Content
+
+    var body: some View {
+        _ = channel.value
+        return content(input).environment(\.themeColors, input.currentTheme)
+    }
+}
+
+private struct WindowOverlayHost<Content: View>: View {
+    let channel: GUIFrameChannel
+    let input: WindowOverlayHostInput
+    let metrics: GUIFramePresentationMetrics
+    @ViewBuilder let content: (WindowOverlayHostInput) -> Content
+
+    var body: some View {
+        _ = channel.value
+        return content(input)
+            .environment(\.themeColors, input.currentTheme)
+            .frameNativeDrawProbe(domain: .windowOverlay, version: channel.value, metrics: metrics)
+    }
+}
+
 private struct EditorOverlayHost: View {
-    let gui: GUIState
+    let channel: GUIFrameChannel
+    let input: EditorOverlayHostInput
+    let metrics: GUIFramePresentationMetrics
     let geometry: EditorGeometry
     let viewportHeight: CGFloat
     let encoder: InputEncoder?
 
     var body: some View {
-        ZStack(alignment: .topLeading) {
-            if gui.signatureHelpState.visible {
-                anchoredOverlay(row: gui.signatureHelpState.anchorRow, col: gui.signatureHelpState.anchorCol, preferredSide: .above, maxHeight: 220) { _ in
-                    SignatureHelpOverlay(state: gui.signatureHelpState)
+        _ = channel.value
+        return ZStack(alignment: .topLeading) {
+            if input.signatureHelpState.visible {
+                anchoredOverlay(row: input.signatureHelpState.anchorRow, col: input.signatureHelpState.anchorCol, preferredSide: .above, maxHeight: 220) { _ in
+                    SignatureHelpOverlay(state: input.signatureHelpState)
                         .allowsHitTesting(false)
                 }
                 .zIndex(10)
             }
 
-            if gui.hoverPopupState.visible {
-                anchoredOverlay(row: gui.hoverPopupState.anchorRow, col: gui.hoverPopupState.anchorCol, preferredSide: .above, maxHeight: 300) { _ in
-                    HoverPopupOverlay(state: gui.hoverPopupState, encoder: encoder)
+            if input.hoverPopupState.visible {
+                anchoredOverlay(row: input.hoverPopupState.anchorRow, col: input.hoverPopupState.anchorCol, preferredSide: .above, maxHeight: 300) { _ in
+                    HoverPopupOverlay(state: input.hoverPopupState, encoder: encoder)
                         .allowsHitTesting(true)
                 }
                 .zIndex(20)
             }
 
-            if gui.completionState.visible {
-                anchoredOverlay(row: gui.completionState.anchorRow, col: gui.completionState.anchorCol, preferredSide: .below, maxHeight: 420, gap: 2) { _ in
-                    CompletionOverlay(state: gui.completionState, encoder: encoder)
+            if input.completionState.visible {
+                anchoredOverlay(row: input.completionState.anchorRow, col: input.completionState.anchorCol, preferredSide: .below, maxHeight: 420, gap: 2) { _ in
+                    CompletionOverlay(state: input.completionState, encoder: encoder)
                 }
                 .zIndex(30)
             }
         }
+        .environment(\.themeColors, input.currentTheme)
+        .frameNativeDrawProbe(domain: .editorOverlay, version: channel.value, metrics: metrics)
     }
 
     private func anchoredOverlay<Content: View>(
@@ -419,16 +515,6 @@ public struct ContentView<EditorSurface: View>: View {
 
     private let activityBarWidth: CGFloat = 32
 
-    private var showSidebarContent: Bool {
-        gui.sidebarHostState.hasVisibleSidebar
-    }
-
-    private var showChangeSummary: Bool {
-        gui.changeSummaryState.visible
-    }
-
-    private var theme: ThemeColors { gui.themeColors }
-
     private var titleBarLeadingPadding: CGFloat {
         chrome.isFullScreen ? 10 : 84
     }
@@ -437,24 +523,20 @@ public struct ContentView<EditorSurface: View>: View {
         chrome.isFullScreen ? 12 : 36
     }
 
-    private var projectName: String {
-        if !gui.fileTreeState.projectRoot.isEmpty {
-            return (gui.fileTreeState.projectRoot as NSString).lastPathComponent
+    private func projectName(_ input: ShellHostInput) -> String {
+        if !input.fileTreeState.projectRoot.isEmpty {
+            return (input.fileTreeState.projectRoot as NSString).lastPathComponent
         }
         return "Minga"
     }
 
-    private var gitBranch: String {
-        gui.statusBarState.gitBranch
-    }
-
-    private var notificationCenterBottomInset: CGFloat {
+    private func notificationCenterBottomInset(_ input: WindowOverlayHostInput) -> CGFloat {
         let statusBarHeight: CGFloat = 24
         let panelHeight: CGFloat
 
-        if gui.bottomPanelState.visible {
+        if input.bottomPanelState.visible {
             let maxPanelHeight = rightPaneHeight * 0.6
-            panelHeight = min(max(gui.bottomPanelState.userHeight, 100), maxPanelHeight)
+            panelHeight = min(max(input.bottomPanelState.userHeight, 100), maxPanelHeight)
         } else {
             panelHeight = 0
         }
@@ -463,38 +545,61 @@ public struct ContentView<EditorSurface: View>: View {
     }
 
     public var body: some View {
-        // Protocol-driven child State objects publish through these aggregate
-        // swaps, never through independent nested observation notifications.
-        _ = gui.framePublication
-        _ = gui.outOfBandPublication
+        let frameStore = gui.frameStore
+        let metrics = gui.presentationMetrics
+        let shellInput = gui.shellInput
+        let editorInput = gui.editorInput
+        let editorOverlayInput = gui.editorOverlayInput
+        let windowOverlayInput = gui.windowOverlayInput
 
         return ZStack {
-            VStack(spacing: 0) {
-                unifiedToolbar
-                HStack(spacing: 0) {
-                    sidebarBody
-                    editorBody
+            ShellFramePresentationHost(channel: frameStore.shell, metrics: metrics) {
+                VStack(spacing: 0) {
+                    UnifiedToolbarHost(channel: frameStore.shell, input: shellInput) { input in
+                        unifiedToolbar(input)
+                    }
+                    HStack(spacing: 0) {
+                        SidebarHost(channel: frameStore.shell, input: shellInput) { input in
+                            sidebarBody(input)
+                                .onAppear { applyActiveSidebarPreferredWidth(input) }
+                                .onChange(of: input.sidebarHostState.activeSidebar) { _, _ in
+                                    applyActiveSidebarPreferredWidth(input)
+                                }
+                        }
+                        EditorColumnHost(channel: frameStore.shell, input: shellInput) { input in
+                            editorBody(
+                                input,
+                                editorInput: editorInput,
+                                editorChannel: frameStore.editor,
+                                editorOverlayInput: editorOverlayInput,
+                                editorOverlayChannel: frameStore.editorOverlay,
+                                metrics: metrics
+                            )
+                        }
+                    }
+                    StatusBarHost(channel: frameStore.shell, input: shellInput) { input in
+                        statusBar(input)
+                    }
                 }
-                statusBar
             }
-            frontendExtensionRuntimeLayer
-            windowOverlays
+            FrontendExtensionRuntimeHost(
+                channel: frameStore.windowOverlay,
+                input: windowOverlayInput
+            ) { input in
+                frontendExtensionRuntimeLayer(input)
+            }
+            WindowOverlayHost(channel: frameStore.windowOverlay, input: windowOverlayInput, metrics: metrics) { input in
+                windowOverlays(input)
+            }
         }
-        .environment(\.themeColors, gui.themeColors)
         .navigationTitle(chrome.title)
         .ignoresSafeArea(.container, edges: .top)
         .preferredColorScheme(chrome.backgroundIsDark ? .dark : .light)
-        .onAppear {
-            applyActiveSidebarPreferredWidth()
-        }
-        .onChange(of: gui.sidebarHostState.activeSidebar) { _, _ in
-            applyActiveSidebarPreferredWidth()
-        }
     }
 
-    private func applyActiveSidebarPreferredWidth() {
+    private func applyActiveSidebarPreferredWidth(_ input: ShellHostInput) {
         sidebarWidth = SidebarSizing.widthByApplyingPreferred(
-            for: gui.sidebarHostState.activeSidebar,
+            for: input.sidebarHostState.activeSidebar,
             currentWidth: sidebarWidth
         )
     }
@@ -506,12 +611,10 @@ public struct ContentView<EditorSurface: View>: View {
     private let contentHeight: CGFloat = 28
     private let workspaceHeaderHeight: CGFloat = 30
 
-    private var showsWorkspaceHeader: Bool {
-        gui.workspaceState.shouldShowHeader
-    }
-
-    private var toolbarContentHeight: CGFloat {
-        showsWorkspaceHeader ? contentHeight + workspaceHeaderHeight : contentHeight
+    private func toolbarContentHeight(_ input: ShellHostInput) -> CGFloat {
+        input.workspaceState.shouldShowHeader
+            ? contentHeight + workspaceHeaderHeight
+            : contentHeight
     }
 
     private var toolbarTopPadding: CGFloat {
@@ -519,37 +622,38 @@ public struct ContentView<EditorSurface: View>: View {
     }
 
     @ViewBuilder
-    private var unifiedToolbar: some View {
+    private func unifiedToolbar(_ input: ShellHostInput) -> some View {
+        let theme = input.currentTheme
+        let toolbarHeight = toolbarContentHeight(input)
         ZStack(alignment: .bottom) {
             HStack(spacing: 0) {
-                if showSidebarContent {
+                if input.sidebarHostState.hasVisibleSidebar {
                     HStack(spacing: 0) {
                         Color.clear
                             .frame(width: activityBarWidth)
 
-                        sidebarHeaderContent
+                        sidebarHeaderContent(input)
                             .frame(width: sidebarWidth + 8) // +8 aligns with resize handle
                     }
 
-                    // Thin vertical separator between sidebar header and tab bar
                     Rectangle()
                         .fill(theme.tabSeparatorFg.opacity(0.4))
                         .frame(width: 1, height: 16)
                 } else {
-                    compactProjectBranchHeader
+                    compactProjectBranchHeader(input)
                 }
 
                 VStack(spacing: 0) {
-                    if showsWorkspaceHeader {
+                    if input.workspaceState.shouldShowHeader {
                         WorkspaceHeaderView(
-                            workspaceState: gui.workspaceState,
+                            workspaceState: input.workspaceState,
                             encoder: encoder
                         )
                     }
 
-                    if !gui.tabBarState.tabs.isEmpty || !gui.workspaceState.visibleTabs.isEmpty {
+                    if !input.tabBarState.tabs.isEmpty || !input.workspaceState.visibleTabs.isEmpty {
                         TabBarView(
-                            tabBarState: gui.tabBarState,
+                            tabBarState: input.tabBarState,
                             encoder: encoder
                         )
                         .accessibilityIdentifier("workspace-tabbar")
@@ -558,7 +662,7 @@ public struct ContentView<EditorSurface: View>: View {
                     }
                 }
             }
-            .frame(height: toolbarContentHeight)
+            .frame(height: toolbarHeight)
             .padding(.top, toolbarTopPadding)
             .frame(maxHeight: .infinity, alignment: .top)
 
@@ -566,7 +670,7 @@ public struct ContentView<EditorSurface: View>: View {
                 .fill(theme.tabSeparatorFg.opacity(0.3))
                 .frame(height: 1)
         }
-        .frame(height: toolbarContentHeight + toolbarTopPadding + 4)
+        .frame(height: toolbarHeight + toolbarTopPadding + 4)
         .background {
             ZStack {
                 theme.tabBg
@@ -578,43 +682,45 @@ public struct ContentView<EditorSurface: View>: View {
 
     /// Renders the header for the BEAM-selected semantic sidebar.
     @ViewBuilder
-    private var sidebarHeaderContent: some View {
-        if let activeSidebar = gui.sidebarHostState.activeSidebar {
+    private func sidebarHeaderContent(_ input: ShellHostInput) -> some View {
+        if let activeSidebar = input.sidebarHostState.activeSidebar {
             NativeSidebarRegistry
                 .adapterOrFallback(for: activeSidebar.semanticKind)
-                .makeHeader(sidebarContext, activeSidebar)
+                .makeHeader(sidebarContext(input), activeSidebar)
         }
     }
 
-    private var sidebarContext: NativeSidebarContext {
+    private func sidebarContext(_ input: ShellHostInput) -> NativeSidebarContext {
         NativeSidebarContext(
-            guiState: gui,
-            theme: theme,
+            input: input,
+            theme: input.currentTheme,
             encoder: encoder,
-            projectName: projectName,
-            gitBranch: gitBranch,
+            projectName: projectName(input),
+            gitBranch: input.statusBarState.gitBranch,
             leadingPadding: sidebarHeaderLeadingPadding
         )
     }
 
-    private var compactProjectBranchHeader: some View {
-        HStack(spacing: 6) {
+    private func compactProjectBranchHeader(_ input: ShellHostInput) -> some View {
+        let theme = input.currentTheme
+        let branch = input.statusBarState.gitBranch
+        return HStack(spacing: 6) {
             Text("\u{F0256}")
                 .font(.custom("Symbols Nerd Font Mono", size: 12))
                 .foregroundStyle(theme.treeDirFg.opacity(0.7))
 
-            Text(projectName)
+            Text(projectName(input))
                 .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(theme.tabActiveFg.opacity(0.7))
                 .lineLimit(1)
                 .truncationMode(.tail)
 
-            if !gitBranch.isEmpty {
+            if !branch.isEmpty {
                 Text("\u{E725}")
                     .font(.custom("Symbols Nerd Font Mono", size: 12))
                     .foregroundStyle(theme.treeDirFg.opacity(0.7))
 
-                Text(gitBranch)
+                Text(branch)
                     .font(.system(size: 12, weight: .regular))
                     .foregroundStyle(theme.tabActiveFg.opacity(0.7))
                     .lineLimit(1)
@@ -628,21 +734,21 @@ public struct ContentView<EditorSurface: View>: View {
     // MARK: - Sidebar Body
 
     @ViewBuilder
-    private var sidebarBody: some View {
+    private func sidebarBody(_ input: ShellHostInput) -> some View {
         HStack(spacing: 0) {
             ActivityBar(
-                guiState: gui,
-                sidebarHostState: gui.sidebarHostState,
+                input: input,
+                sidebarHostState: input.sidebarHostState,
                 encoder: encoder
             )
 
-            if let activeSidebar = gui.sidebarHostState.activeSidebar {
+            if let activeSidebar = input.sidebarHostState.activeSidebar {
                 SidebarContainer(
-                    guiState: gui,
+                    input: input,
                     activeSidebar: activeSidebar,
                     encoder: encoder,
-                    projectName: projectName,
-                    gitBranch: gitBranch,
+                    projectName: projectName(input),
+                    gitBranch: input.statusBarState.gitBranch,
                     leadingPadding: titleBarLeadingPadding,
                     sidebarWidth: $sidebarWidth
                 )
@@ -653,9 +759,9 @@ public struct ContentView<EditorSurface: View>: View {
     // MARK: - Change Summary Sidebar
 
     @ViewBuilder
-    private var changeSummarySidebar: some View {
+    private func changeSummarySidebar(_ input: ShellHostInput) -> some View {
         ChangeSummarySidebarView(
-            changeSummaryState: gui.changeSummaryState,
+            changeSummaryState: input.changeSummaryState,
             encoder: encoder,
             width: $changeSummaryWidth
         )
@@ -664,27 +770,30 @@ public struct ContentView<EditorSurface: View>: View {
     // MARK: - Editor Body
 
 
-    private var editorBody: some View {
+    private func editorBody(
+        _ input: ShellHostInput,
+        editorInput: EditorHostInput,
+        editorChannel: GUIFrameChannel,
+        editorOverlayInput: EditorOverlayHostInput,
+        editorOverlayChannel: GUIFrameChannel,
+        metrics: GUIFramePresentationMetrics
+    ) -> some View {
         VStack(spacing: 0) {
-
-            // Conditionally show agent context bar (when zoomed into an agent card)
-            // or breadcrumb bar (when in traditional editor or zoomed into You card)
-            if gui.agentContextBarState.visible {
+            if input.agentContextBarState.visible {
                 AgentContextBar(
-                    state: gui.agentContextBarState,
+                    state: input.agentContextBarState,
                     encoder: encoder
                 )
             } else {
                 BreadcrumbBar(
-                    state: gui.breadcrumbState,
+                    state: input.breadcrumbState,
                     encoder: encoder
                 )
             }
 
-            // Search toolbar (appears below breadcrumb bar when active)
-            if gui.searchState.visible {
+            if input.searchState.visible {
                 SearchToolbar(
-                    searchState: gui.searchState,
+                    searchState: input.searchState,
                     encoder: encoder
                 )
                 .transition(
@@ -696,42 +805,44 @@ public struct ContentView<EditorSurface: View>: View {
                 )
             }
 
-            // HStack: change summary sidebar (when zoomed into agent card) + editor
             HStack(spacing: 0) {
-                if showChangeSummary {
-                    changeSummarySidebar
+                if input.changeSummaryState.visible {
+                    changeSummarySidebar(input)
                 }
 
-                editorSurface
+                EditorSurfaceHost(channel: editorChannel, input: editorInput) { focusedInput in
+                    editorSurface(
+                        focusedInput,
+                        overlayInput: editorOverlayInput,
+                        overlayChannel: editorOverlayChannel,
+                        metrics: metrics
+                    )
+                }
 
-                extensionRightPanels
+                extensionRightPanels(input)
             }
-            .onChange(of: gui.agentChatState.visible) { _, visible in
+            .onChange(of: input.agentChatState.visible) { _, visible in
                 onAgentChatVisibleChange(visible)
             }
 
-            // Edit timeline scrubber (between editor and bottom panel)
             EditTimelineView(
-                state: gui.editTimelineState,
+                state: input.editTimelineState,
                 encoder: encoder
             )
 
-            // Bottom panel (between editor and status bar)
-            if gui.bottomPanelState.visible {
+            if input.bottomPanelState.visible {
                 BottomPanelView(
-                    state: gui.bottomPanelState,
+                    state: input.bottomPanelState,
                     encoder: encoder,
                     availableHeight: rightPaneHeight
                 )
             }
 
-            // Extension-registered bottom panels (gui_extension_panel, 0x9D, position 0)
-            extensionBottomPanels
+            extensionBottomPanels(input)
 
-            // Native minibuffer (appears above status bar when active)
-            if gui.minibufferState.visible {
+            if input.minibufferState.visible {
                 MinibufferView(
-                    state: gui.minibufferState,
+                    state: input.minibufferState,
                     encoder: encoder
                 )
                 .transition(
@@ -760,43 +871,44 @@ public struct ContentView<EditorSurface: View>: View {
 
     // MARK: - Editor Surface (Metal + editor-local overlays)
 
-    private var editorSurface: some View {
+    private func editorSurface(
+        _ input: EditorHostInput,
+        overlayInput: EditorOverlayHostInput,
+        overlayChannel: GUIFrameChannel,
+        metrics: GUIFramePresentationMetrics
+    ) -> some View {
         let geo = editorGeometry()
         return ZStack(alignment: .topLeading) {
-            // Metal editor surface (always present for input handling).
-            // Hidden when agent chat is visible so the SwiftUI chat overlay
-            // is not occluded by the NSView layer (AppKit NSViews render
-            // above SwiftUI views in a ZStack regardless of child order).
+            // The Metal surface is unconditional so its AppKit and resident identity survives.
             makeEditorSurface()
-                .opacity(gui.agentChatState.visible || gui.emptyStateState.visible ? 0 : 1)
+                .opacity(input.agentChatState.visible || input.emptyStateState.visible ? 0 : 1)
 
-            if gui.agentChatState.visible {
+            if input.agentChatState.visible {
                 AgentChatView(
-                    state: gui.agentChatState,
-                    isInsertMode: gui.statusBarState.isInsertMode,
+                    state: input.agentChatState,
+                    isInsertMode: input.statusBarState.isInsertMode,
                     encoder: encoder,
                     cellHeight: geo.cellHeight
                 )
             }
 
-            // Launchpad empty state (zero buffers). Swapped in over the Metal
-            // surface exactly like AgentChatView; keys still flow to the BEAM.
-            if gui.emptyStateState.visible {
+            if input.emptyStateState.visible {
                 EmptyStateView(
-                    state: gui.emptyStateState,
+                    state: input.emptyStateState,
                     encoder: encoder
                 )
             }
 
             EditorOverlayHost(
-                gui: gui,
+                channel: overlayChannel,
+                input: overlayInput,
+                metrics: metrics,
                 geometry: geo,
                 viewportHeight: rightPaneHeight,
                 encoder: encoder
             )
 
-            // Extension-registered overlays (positioned per window on the editor surface)
-            extensionOverlayLayer
+            extensionOverlayLayer(overlayInput)
         }
     }
 
@@ -825,8 +937,8 @@ public struct ContentView<EditorSurface: View>: View {
     /// keeps overlays aligned in split panes and under horizontal scroll. Falls back to the
     /// active window's gutter column when pane geometry has not been retained yet.
     @ViewBuilder
-    private var extensionOverlayLayer: some View {
-        if !gui.extensionOverlayState.entries.isEmpty {
+    private func extensionOverlayLayer(_ input: EditorOverlayHostInput) -> some View {
+        if !input.extensionOverlayState.entries.isEmpty {
             let geo = editorGeometry()
             let cw = geo.cellWidth
             let ch = geo.cellHeight
@@ -835,8 +947,8 @@ public struct ContentView<EditorSurface: View>: View {
                 ? geo.gutterLeftMargin + geo.gutterRightGap
                 : 0
 
-            ForEach(gui.extensionOverlayState.windowIDs, id: \.self) { wid in
-                let content = gui.windowContents[wid]
+            ForEach(input.extensionOverlayState.windowIDs, id: \.self) { wid in
+                let content = input.windowContent(for: wid)
                 let geometry = content?.paneGeometry
                 let scrollLeft = content?.scrollLeft ?? 0
                 let origin = Self.overlayContentOrigin(
@@ -849,7 +961,7 @@ public struct ContentView<EditorSurface: View>: View {
                 )
 
                 ExtensionOverlayView(
-                    overlayState: gui.extensionOverlayState,
+                    overlayState: input.extensionOverlayState,
                     windowID: wid,
                     cellWidth: cw,
                     cellHeight: ch,
@@ -866,7 +978,10 @@ public struct ContentView<EditorSurface: View>: View {
 
     /// One extension panel rendered as a themed card.
     @ViewBuilder
-    private func extensionPanelCard(_ panel: Wire.ExtensionPanelEntry) -> some View {
+    private func extensionPanelCard(
+        _ panel: Wire.ExtensionPanelEntry,
+        theme: ThemeColors
+    ) -> some View {
         ExtensionPanelView(panel: panel)
             .frame(maxWidth: .infinity, alignment: .leading)
             .background(theme.treeBg)
@@ -907,13 +1022,11 @@ public struct ContentView<EditorSurface: View>: View {
     /// Right-docked extension panels (position 1), shown as a sidebar column sized to
     /// the widest panel's requested size.
     @ViewBuilder
-    private var extensionRightPanels: some View {
-        let panels = gui.extensionPanelState.panels(forPosition: 1)
+    private func extensionRightPanels(_ input: ShellHostInput) -> some View {
+        let panels = input.extensionPanelState.panels(forPosition: 1)
+        let theme = input.currentTheme
         if !panels.isEmpty {
             let cw = editorGeometry().cellWidth
-            // Percent panels size against the stable editor-column width, not the editor
-            // NSView (which is the surface left over after the panel takes space, causing
-            // a 30% request to converge to ~23% and oscillate as layout settles).
             let basis = workspaceWidth
             let width = panels
                 .map { panelCrossSize($0, cellExtent: cw, basis: basis, minimum: 160) }
@@ -922,7 +1035,7 @@ public struct ContentView<EditorSurface: View>: View {
             ScrollView {
                 VStack(alignment: .leading, spacing: 0) {
                     ForEach(panels) { panel in
-                        extensionPanelCard(panel)
+                        extensionPanelCard(panel, theme: theme)
                         Divider()
                     }
                 }
@@ -940,8 +1053,9 @@ public struct ContentView<EditorSurface: View>: View {
     /// Bottom-docked extension panels (position 0), shown above the status bar, sized to
     /// the tallest panel's requested size.
     @ViewBuilder
-    private var extensionBottomPanels: some View {
-        let panels = gui.extensionPanelState.panels(forPosition: 0)
+    private func extensionBottomPanels(_ input: ShellHostInput) -> some View {
+        let panels = input.extensionPanelState.panels(forPosition: 0)
+        let theme = input.currentTheme
         if !panels.isEmpty {
             let ch = editorGeometry().cellHeight
             let height = panels
@@ -951,7 +1065,7 @@ public struct ContentView<EditorSurface: View>: View {
             ScrollView {
                 VStack(spacing: 0) {
                     ForEach(panels) { panel in
-                        extensionPanelCard(panel)
+                        extensionPanelCard(panel, theme: theme)
                     }
                 }
             }
@@ -967,12 +1081,13 @@ public struct ContentView<EditorSurface: View>: View {
 
     /// Floating extension panels (position 2), centered over the workspace.
     @ViewBuilder
-    private var extensionFloatPanels: some View {
-        let panels = gui.extensionPanelState.panels(forPosition: 2)
+    private func extensionFloatPanels(_ input: WindowOverlayHostInput) -> some View {
+        let panels = input.extensionPanelState.panels(forPosition: 2)
+        let theme = input.currentTheme
         if !panels.isEmpty {
             VStack(spacing: 12) {
                 ForEach(panels) { panel in
-                    extensionPanelCard(panel)
+                    extensionPanelCard(panel, theme: theme)
                         .frame(maxWidth: 500)
                         .clipShape(RoundedRectangle(cornerRadius: 8))
                         .overlay(
@@ -987,26 +1102,30 @@ public struct ContentView<EditorSurface: View>: View {
 
     // MARK: - Status Bar (full window width)
 
-    private var statusBar: some View {
+    private func statusBar(_ input: ShellHostInput) -> some View {
         StatusBarView(
-            state: gui.statusBarState,
-            feedbackState: gui.feedbackState,
+            state: input.statusBarState,
+            feedbackState: input.feedbackState,
             encoder: encoder,
-            isFileTreeVisible: gui.fileTreeState.visible,
-            isGitStatusVisible: gui.gitStatusState.visible,
-            isBottomPanelVisible: gui.bottomPanelState.visible,
-            isAgentChatVisible: gui.agentChatState.visible,
-            gitSyncing: gui.gitStatusState.syncing
+            isFileTreeVisible: input.fileTreeState.visible,
+            isGitStatusVisible: input.gitStatusState.visible,
+            isBottomPanelVisible: input.bottomPanelState.visible,
+            isAgentChatVisible: input.agentChatState.visible,
+            gitSyncing: input.gitStatusState.syncing
         )
     }
 
     // MARK: - Frontend Extension Runtime
 
     @ViewBuilder
-    private var frontendExtensionRuntimeLayer: some View {
-        let context = FrontendExtensionViewContext(theme: gui.themeColors, encoder: encoder, namespace: frontendExtensionNamespace)
-        ForEach(gui.frontendExtensions.activeExtensionIDs, id: \.self) { extensionID in
-            if let view = gui.frontendExtensions.view(for: extensionID, context: context) {
+    private func frontendExtensionRuntimeLayer(_ input: WindowOverlayHostInput) -> some View {
+        let context = FrontendExtensionViewContext(
+            theme: input.currentTheme,
+            encoder: encoder,
+            namespace: frontendExtensionNamespace
+        )
+        ForEach(input.frontendExtensions.activeExtensionIDs, id: \.self) { extensionID in
+            if let view = input.frontendExtensions.view(for: extensionID, context: context) {
                 view
             }
         }
@@ -1015,84 +1134,59 @@ public struct ContentView<EditorSurface: View>: View {
     // MARK: - Window Overlays (floating UI on top of everything)
 
     @ViewBuilder
-    private var windowOverlays: some View {
-        // Which-key overlay (center bottom of full window)
+    private func windowOverlays(_ input: WindowOverlayHostInput) -> some View {
         VStack {
             Spacer()
             HStack {
                 Spacer()
-                WhichKeyOverlay(
-                    state: gui.whichKeyState
-                )
+                WhichKeyOverlay(state: input.whichKeyState)
                 Spacer()
             }
         }
 
-        // Picker overlay (floats over entire window)
         PickerOverlay(
-            state: gui.pickerState,
+            state: input.pickerState,
             encoder: encoder
         )
 
-        // Tool manager overlay (floats over entire window)
         ToolManagerView(
-            state: gui.toolManagerState,
+            state: input.toolManagerState,
             encoder: encoder
         )
 
-        // Float popup overlay (centered, like picker)
-        if gui.floatPopupState.visible {
+        if input.floatPopupState.visible {
             let geo = editorGeometry()
-            let cw = geo.cellWidth
-            let ch = geo.cellHeight
-
             FloatPopupOverlay(
-                state: gui.floatPopupState,
-                cellWidth: cw,
-                cellHeight: ch
+                state: input.floatPopupState,
+                cellWidth: geo.cellWidth,
+                cellHeight: geo.cellHeight
             )
         }
 
-        // Extension-registered floating panels (gui_extension_panel, 0x9D, position 2)
-        extensionFloatPanels
+        extensionFloatPanels(input)
 
-        // Notification stack (bottom-right, above regular workspace content).
         NotificationCenterView(
-            state: gui.notificationCenterState,
+            state: input.notificationCenterState,
             encoder: encoder,
-            bottomInset: notificationCenterBottomInset
+            bottomInset: notificationCenterBottomInset(input)
         )
 
-        // Keystroke-to-present latency HUD (ticket #2215). Top-right, client-local
-        // debug overlay; visibility is owned by LatencyHUDState.
-        LatencyHUDOverlay(
-            state: gui.latencyHUDState
-        )
+        LatencyHUDOverlay(state: input.latencyHUDState)
 
-        // Frame-transaction resync hint (#2219 child D). Bottom-trailing badge
-        // shown while a keyframe is in flight after an invalidation; the editor keeps showing the last good frame underneath.
-        // If recovery stalls, the badge becomes a small manual retry control.
         ResyncOverlay(
-            state: gui.resyncState,
+            state: input.resyncState,
             onRetry: { lastGoodFrameSeq, generation in
                 encoder?.sendRequestKeyframe(lastGoodFrameSeq: lastGoodFrameSeq, generation: generation)
             }
         )
 
-        // Startup overlay: covers the empty Metal framebuffer with a
-        // spinner while the BEAM boots. Fades out on first commit_frame.
         if !chrome.hasReceivedFirstFrame {
             StartupOverlay()
                 .transition(.opacity)
         }
 
-        // Protocol error overlay: blocks the whole window when the BEAM rejects
-        // this frontend's handshake protocol_version (0x18). Highest z-order so
-        // it takes precedence over the startup overlay and all content.
-        if gui.protocolErrorState.isPresented {
-            ProtocolErrorOverlay(
-                state: gui.protocolErrorState
-            )
+        if input.protocolErrorState.isPresented {
+            ProtocolErrorOverlay(state: input.protocolErrorState)
         }
     }
 }

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -337,7 +337,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         disp.onLinkCursorChanged = { [weak nsView] active in
             nsView?.setLinkCursorActive(active)
         }
-        nsView.guiState = appState.gui
+        nsView.editorInput = appState.gui.editorInput
+        ctRenderer.presentationMetrics = appState.gui.presentationMetrics
         nsView.statusBarState = appState.gui.statusBarState
         appState.gui.settingsState.encoder = enc
         appState.gui.settingsState.onCursorBlinkChanged = { [weak nsView] enabled in

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -296,7 +296,7 @@ enum PreviewRegistry {
         populateEditorFrame(dispatcher: dispatcher, guiState: appState.gui)
 
         let nsView = EditorNSView(encoder: encoder, fontFace: fontFace, dispatcher: dispatcher, coreTextRenderer: renderer, fontManager: fontManager)
-        nsView.guiState = appState.gui
+        nsView.editorInput = appState.gui.editorInput
         nsView.statusBarState = appState.gui.statusBarState
         nsView.renderFrame()
         return nsView
@@ -452,7 +452,7 @@ enum PreviewRegistry {
         populateDiagnosticsEditorFrame(dispatcher: dispatcher, guiState: appState.gui)
 
         let nsView = EditorNSView(encoder: encoder, fontFace: fontFace, dispatcher: dispatcher, coreTextRenderer: renderer, fontManager: fontManager)
-        nsView.guiState = appState.gui
+        nsView.editorInput = appState.gui.editorInput
         nsView.statusBarState = appState.gui.statusBarState
         nsView.renderFrame()
         return nsView

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -138,11 +138,19 @@ final class CommandDispatcher {
         return seq
     }
 
+    /// Returns the committed editor frame waiting for native Metal presentation.
+    func pendingPresentationFrameSeq() -> UInt32? {
+        guiState.presentationMetrics.pendingEditorFrameSeq()
+    }
+
     /// Discards an applied frame that cannot acquire a drawable/presentation path.
     func discardPendingPresentation(reason: LatencyRecorder.DiscardReason) {
-        guard pendingPresentationInputSeq != 0 else { return }
-        latency.discard(seq: pendingPresentationInputSeq, reason: reason)
-        pendingPresentationInputSeq = 0
+        if pendingPresentationInputSeq != 0 {
+            latency.discard(seq: pendingPresentationInputSeq, reason: reason)
+            pendingPresentationInputSeq = 0
+        }
+        let outcome: GUIFramePresentationMetrics.Outcome = reason == .hidden ? .hidden : .unavailable
+        guiState.presentationMetrics.discard(domain: .editor, outcome: outcome)
     }
 
     /// Window ids that arrived in the current frame batch. Used for input hit testing so stale
@@ -278,20 +286,15 @@ final class CommandDispatcher {
         //   config emitted before the first frame (equivalent to Go's CommandNoop
         //   for font commands, but Swift actually applies them).
         case .guiConfigState:
-            // Settings is an independently interactive scene. Its config stream
-            // is startup/out-of-band state and never participates in a render frame.
-            guiState.performOutOfBandPublication {
-                apply(command)
-            }
+            // Settings is an independently interactive scene and has no frame consumer.
+            apply(command)
 
         case .setTitle, .setWindowBg, .setLinkCursor, .protocolError,
              .setFont, .setFontFallback, .registerFont, .clipboardWrite:
             if openFrameSeq != nil {
                 transactionBuilder?.stage(command, resourceWeight: resourceWeight)
             } else {
-                guiState.performOutOfBandPublication {
-                    apply(command)
-                }
+                publishLocal(command)
             }
 
         default:
@@ -399,19 +402,19 @@ final class CommandDispatcher {
             reject(rejection, frameSeq: frameSeq, logReason: rejection.logDescription)
             return
         case .success(let transaction):
-            if openBaseFrameSeq == 0 && resyncRecoveryState == .keyframeInFlight {
-                resyncRecoveryState = .clean
-                guiState.resyncState.clear()
-            }
-            publish(transaction)
-        }
+            let clearsResync = openBaseFrameSeq == 0 && resyncRecoveryState == .keyframeInFlight
+            if clearsResync { resyncRecoveryState = .clean }
 
-        lastCommittedFrameSeq = frameSeq
-        lastCommittedGeneration = openGeneration
-        hasCommitted = true
-        lastTerminalRejection = nil
-        openFrameSeq = nil
-        self.transactionBuilder = nil
+            // Install committed identity before publication. Observation callbacks
+            // may run from channel assignment and must see this same transaction.
+            lastCommittedFrameSeq = frameSeq
+            lastCommittedGeneration = openGeneration
+            hasCommitted = true
+            lastTerminalRejection = nil
+            openFrameSeq = nil
+            self.transactionBuilder = nil
+            publish(transaction, clearsResync: clearsResync)
+        }
 
         os_signpost(.event, log: renderLog, name: "SemanticApply", "frame=%{public}u input=%{public}u", frameSeq, inputSeq)
         if pendingPresentationInputSeq != 0, pendingPresentationInputSeq != inputSeq {
@@ -429,8 +432,18 @@ final class CommandDispatcher {
     }
 
     /// The sole committed-GUI publication boundary.
-    private func publish(_ transaction: PreparedFrameTransaction) {
-        guiState.performFramePublication(frameSeq: transaction.frameSeq) {
+    private func publish(_ transaction: PreparedFrameTransaction, clearsResync: Bool) {
+        var finalImpact = transaction.impact
+        if clearsResync { finalImpact.formUnion(.windowOverlay) }
+        let committed = GUICommittedFrame(
+            generation: transaction.generation,
+            frameSeq: transaction.frameSeq
+        )
+        guiState.frameStore.publishCommitted(
+            generation: committed.generation,
+            frameSeq: committed.frameSeq,
+            impact: finalImpact
+        ) {
             if let theme = transaction.theme { apply(.guiTheme(slots: theme.slots)) }
             if let resources = transaction.resources { resources.commands.forEach(apply) }
             if let windows = transaction.windows { apply(windows) }
@@ -443,9 +456,22 @@ final class CommandDispatcher {
             }
             if let overlays = transaction.overlays { overlays.commands.forEach(apply) }
             if let focus = transaction.focus { focus.commands.forEach(apply) }
+            if clearsResync { guiState.resyncState.clear() }
         }
+        guiState.presentationMetrics.beginCommitted(frame: committed, impact: finalImpact)
         publicationCount += 1
         lastPublicationOperationCounts = transaction.operationCounts
+    }
+
+    private func publishLocal(_ command: RenderCommand) {
+        let impact = GUIFrameImpact.impact(for: command)
+        guard !impact.isEmpty else {
+            apply(command)
+            return
+        }
+        guiState.frameStore.publishLocal(impact: impact) {
+            apply(command)
+        }
     }
 
     private func apply(_ updates: PreparedWindowUpdates) {
@@ -527,7 +553,7 @@ final class CommandDispatcher {
         if terminal {
             resyncRecoveryState = .clean
             if guiState.resyncState.pending {
-                guiState.performOutOfBandPublication {
+                guiState.frameStore.publishLocal(impact: .windowOverlay) {
                     guiState.resyncState.clear()
                 }
             }
@@ -536,7 +562,7 @@ final class CommandDispatcher {
             let shouldRequestKeyframe = resyncRecoveryState != .awaitingKeyframe
             resyncRecoveryState = .awaitingKeyframe
             PortLogger.warn("Frame transaction rejected (\(logReason)\(opcodeContext)); awaiting BEAM recovery from \(lastCommittedFrameSeq)")
-            guiState.performOutOfBandPublication {
+            guiState.frameStore.publishLocal(impact: .windowOverlay) {
                 guiState.resyncState.markPending(
                     lastGoodFrameSeq: lastCommittedFrameSeq,
                     generation: openGeneration,
@@ -658,17 +684,18 @@ final class CommandDispatcher {
     func previewFileTreeNavigation(codepoint: UInt32, modifiers: UInt8) -> Bool {
         guard modifiers == 0 else { return false }
 
-        let changed: Bool
+        let delta: Int
         switch codepoint {
         case FileTreeNavigationCodepoints.downKey, FileTreeNavigationCodepoints.downArrow:
-            changed = guiState.fileTreeState.previewNavigation(delta: 1)
+            delta = 1
         case FileTreeNavigationCodepoints.upKey, FileTreeNavigationCodepoints.upArrow:
-            changed = guiState.fileTreeState.previewNavigation(delta: -1)
+            delta = -1
         default:
             return false
         }
-        if changed { guiState.performOutOfBandPublication {} }
-        return changed
+        return guiState.frameStore.publishLocalIfChanged(impact: .shell) {
+            guiState.fileTreeState.previewNavigation(delta: delta)
+        }
     }
 
     @discardableResult
@@ -695,26 +722,27 @@ final class CommandDispatcher {
         } else {
             return false
         }
-        let changed = guiState.completionState.previewNavigation(delta: delta)
-        if changed { guiState.performOutOfBandPublication {} }
-        return changed
+        return guiState.frameStore.publishLocalIfChanged(impact: .editorOverlay) {
+            guiState.completionState.previewNavigation(delta: delta)
+        }
     }
 
     @discardableResult
     func previewPickerNavigation(codepoint: UInt32, modifiers: UInt8) -> Bool {
         guard modifiers == 0 else { return false }
 
-        let changed: Bool
+        let delta: Int
         switch codepoint {
         case PickerNavigationCodepoints.downKey, PickerNavigationCodepoints.downArrow:
-            changed = guiState.pickerState.previewNavigation(delta: 1)
+            delta = 1
         case PickerNavigationCodepoints.upKey, PickerNavigationCodepoints.upArrow:
-            changed = guiState.pickerState.previewNavigation(delta: -1)
+            delta = -1
         default:
             return false
         }
-        if changed { guiState.performOutOfBandPublication {} }
-        return changed
+        return guiState.frameStore.publishLocalIfChanged(impact: .windowOverlay) {
+            guiState.pickerState.previewNavigation(delta: delta)
+        }
     }
 
     /// Apply one domain command to the presented FrameState/GUIState. This is

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -105,6 +105,8 @@ final class CoreTextMetalRenderer {
     private var configurationEpoch: UInt64 = 0
     /// Most recent renderer-local presentation failure. Semantic publication is unaffected.
     private(set) var lastNativePresentationFailure: NativePresentationFailure?
+    /// Domain-frame presentation telemetry owned by the GUI state.
+    weak var presentationMetrics: GUIFramePresentationMetrics?
     /// Generation of the last GPU-completed presentation whose candidate resources were promoted.
     private(set) var lastCompletedPresentationGeneration: UInt64 = 0
     private let bgPipeline: MTLRenderPipelineState
@@ -346,6 +348,7 @@ final class CoreTextMetalRenderer {
                 contentScale: Float, scrollOffset: SIMD2<Float> = .zero,
                 presentationWindowId: UInt16? = nil,
                 presentationInputSeq: UInt32 = 0,
+                presentationFrameSeq: UInt32? = nil,
                 latencyRecorder: LatencyRecorder? = nil) {
         let renderSignpostID = OSSignpostID(log: renderLog)
         os_signpost(.begin, log: renderLog, name: "Frame", signpostID: renderSignpostID)
@@ -442,7 +445,7 @@ final class CoreTextMetalRenderer {
             recordNativeFailure(NativePresentationFailure(
                 phase: .atlas, dimension: .texture,
                 frameSequence: presentationInputSeq, reason: .unavailable
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
         let candidateConfigurationEpoch = configurationEpoch
@@ -459,7 +462,7 @@ final class CoreTextMetalRenderer {
         case .success:
             break
         case .failure(let failure):
-            recordNativeFailure(failure, latencyRecorder: latencyRecorder)
+            recordNativeFailure(failure, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
 
@@ -846,7 +849,7 @@ final class CoreTextMetalRenderer {
 
         if let failure = windowContentRenderer?.nativePresentationFailure ?? candidateAtlas.nativePresentationFailure {
             recordNativeFailure(failure, frameSequence: presentationInputSeq,
-                                latencyRecorder: latencyRecorder)
+                                latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
 
@@ -880,13 +883,13 @@ final class CoreTextMetalRenderer {
                 frameSequence: presentationInputSeq
             )
         } catch let failure as NativePresentationFailure {
-            recordNativeFailure(failure, latencyRecorder: latencyRecorder)
+            recordNativeFailure(failure, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         } catch {
             recordNativeFailure(NativePresentationFailure(
                 phase: .buffers, dimension: .arithmetic,
                 frameSequence: presentationInputSeq, reason: .overflow
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
         let candidateInstanceBuffer: MTLBuffer?
@@ -896,7 +899,7 @@ final class CoreTextMetalRenderer {
                     phase: .buffers, dimension: .lineBuffer,
                     requested: bufferDemand.lineBytes,
                     frameSequence: presentationInputSeq, reason: .allocation
-                ), latencyRecorder: latencyRecorder)
+                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                 return
             }
             candidateInstanceBuffer = buffer
@@ -913,7 +916,7 @@ final class CoreTextMetalRenderer {
                         phase: .buffers, dimension: dimensions[index],
                         requested: bufferDemand.quadBytesPerBuffer,
                         frameSequence: presentationInputSeq, reason: .allocation
-                    ), latencyRecorder: latencyRecorder)
+                    ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                     return
                 }
                 candidateQuadBuffers.append(buffer)
@@ -927,7 +930,7 @@ final class CoreTextMetalRenderer {
             recordNativeFailure(NativePresentationFailure(
                 phase: .drawable, dimension: .renderTarget,
                 frameSequence: presentationInputSeq, reason: .overflow
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
         let deviceDimensionLimit = nativeDeviceTextureDimensionLimit(device)
@@ -940,7 +943,7 @@ final class CoreTextMetalRenderer {
                 phase: .drawable, dimension: .textureWidth,
                 requested: requested, limit: targetWidthLimit,
                 frameSequence: presentationInputSeq, reason: .limit
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
         guard viewportSize.height <= CGFloat(targetHeightLimit) else {
@@ -950,7 +953,7 @@ final class CoreTextMetalRenderer {
                 phase: .drawable, dimension: .textureHeight,
                 requested: requested, limit: targetHeightLimit,
                 frameSequence: presentationInputSeq, reason: .limit
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
         let targetWidth = Int(viewportSize.width.rounded(.up))
@@ -964,13 +967,13 @@ final class CoreTextMetalRenderer {
                 frameSequence: presentationInputSeq
             )
         } catch let failure as NativePresentationFailure {
-            recordNativeFailure(failure, latencyRecorder: latencyRecorder)
+            recordNativeFailure(failure, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         } catch {
             recordNativeFailure(NativePresentationFailure(
                 phase: .drawable, dimension: .arithmetic,
                 frameSequence: presentationInputSeq, reason: .overflow
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
         let targetDescriptor = MTLTextureDescriptor.texture2DDescriptor(
@@ -986,7 +989,7 @@ final class CoreTextMetalRenderer {
                 phase: .drawable, dimension: .renderTarget,
                 requested: targetDemand.byteCount, limit: resourcePolicy.renderTargetBytes,
                 frameSequence: presentationInputSeq, reason: .allocation
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
 
@@ -1001,14 +1004,14 @@ final class CoreTextMetalRenderer {
             recordNativeFailure(NativePresentationFailure(
                 phase: .command, dimension: .commandBuffer,
                 frameSequence: presentationInputSeq, reason: .unavailable
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
         guard let encoder = factories.makeEncoder(cmdBuf, renderDesc) else {
             recordNativeFailure(NativePresentationFailure(
                 phase: .command, dimension: .encoder,
                 frameSequence: presentationInputSeq, reason: .unavailable
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
 
@@ -1453,7 +1456,7 @@ final class CoreTextMetalRenderer {
         if let failure = windowContentRenderer?.nativePresentationFailure ?? candidateAtlas.nativePresentationFailure {
             encoder.endEncoding()
             recordNativeFailure(failure, frameSequence: presentationInputSeq,
-                                latencyRecorder: latencyRecorder)
+                                latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
 
@@ -1466,7 +1469,7 @@ final class CoreTextMetalRenderer {
             recordNativeFailure(NativePresentationFailure(
                 phase: .submission, dimension: .submission,
                 frameSequence: presentationInputSeq, reason: .submission
-            ), latencyRecorder: latencyRecorder)
+            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
             return
         }
 
@@ -1483,7 +1486,7 @@ final class CoreTextMetalRenderer {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .completion, dimension: .completion,
                     frameSequence: presentationInputSeq, reason: .completion
-                ), discardLatency: false, latencyRecorder: latencyRecorder)
+                ), discardLatency: false, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                 latencyRecorder?.discard(seq: presentationInputSeq, reason: .gpuFailure)
                 os_signpost(.event, log: renderLog, name: "PresentationDropped", signpostID: renderSignpostID,
                             "input=%{public}u status=%{public}d", presentationInputSeq, status)
@@ -1491,13 +1494,18 @@ final class CoreTextMetalRenderer {
             }
             guard self.configurationEpoch == candidateConfigurationEpoch else {
                 latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
+                if let presentationFrameSeq {
+                    self.presentationMetrics?.discard(
+                        domain: .editor, outcome: .superseded, frameSeq: presentationFrameSeq
+                    )
+                }
                 return
             }
             guard let drawable = drawableProvider() else {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .drawable, dimension: .drawable,
                     frameSequence: presentationInputSeq, reason: .unavailable
-                ), latencyRecorder: latencyRecorder)
+                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                 return
             }
             guard drawable.texture.width == candidateRenderTarget.width else {
@@ -1505,7 +1513,7 @@ final class CoreTextMetalRenderer {
                     phase: .drawable, dimension: .textureWidth,
                     requested: drawable.texture.width, limit: candidateRenderTarget.width,
                     frameSequence: presentationInputSeq, reason: .mismatch
-                ), latencyRecorder: latencyRecorder)
+                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                 return
             }
             guard drawable.texture.height == candidateRenderTarget.height else {
@@ -1513,28 +1521,28 @@ final class CoreTextMetalRenderer {
                     phase: .drawable, dimension: .textureHeight,
                     requested: drawable.texture.height, limit: candidateRenderTarget.height,
                     frameSequence: presentationInputSeq, reason: .mismatch
-                ), latencyRecorder: latencyRecorder)
+                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                 return
             }
             guard drawable.texture.pixelFormat == candidateRenderTarget.pixelFormat else {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .drawable, dimension: .renderTarget,
                     frameSequence: presentationInputSeq, reason: .mismatch
-                ), latencyRecorder: latencyRecorder)
+                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                 return
             }
             guard let presentationBuffer = self.factories.makeCommandBuffer(self.commandQueue) else {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .command, dimension: .presentationCommandBuffer,
                     frameSequence: presentationInputSeq, reason: .unavailable
-                ), latencyRecorder: latencyRecorder)
+                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                 return
             }
             guard let blit = self.factories.makeBlitEncoder(presentationBuffer) else {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .command, dimension: .presentationEncoder,
                     frameSequence: presentationInputSeq, reason: .unavailable
-                ), latencyRecorder: latencyRecorder)
+                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                 return
             }
             blit.copy(
@@ -1554,7 +1562,7 @@ final class CoreTextMetalRenderer {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .submission, dimension: .presentationCopy,
                     frameSequence: presentationInputSeq, reason: .submission
-                ), latencyRecorder: latencyRecorder)
+                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                 return
             }
 
@@ -1564,13 +1572,18 @@ final class CoreTextMetalRenderer {
                     self.recordNativeFailure(NativePresentationFailure(
                         phase: .completion, dimension: .presentationCopy,
                         frameSequence: presentationInputSeq, reason: .completion
-                    ), discardLatency: false, latencyRecorder: latencyRecorder)
+                    ), discardLatency: false, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                     latencyRecorder?.discard(seq: presentationInputSeq, reason: .gpuFailure)
                     return
                 }
                 guard self.configurationEpoch == candidateConfigurationEpoch,
                       generation > self.presentationGeneration.completed else {
                     latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
+                    if let presentationFrameSeq {
+                        self.presentationMetrics?.discard(
+                            domain: .editor, outcome: .superseded, frameSeq: presentationFrameSeq
+                        )
+                    }
                     return
                 }
                 do {
@@ -1579,11 +1592,16 @@ final class CoreTextMetalRenderer {
                     self.recordNativeFailure(NativePresentationFailure(
                         phase: .submission, dimension: .drawable,
                         frameSequence: presentationInputSeq, reason: .submission
-                    ), latencyRecorder: latencyRecorder)
+                    ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
                     return
                 }
                 guard self.presentationGeneration.complete(generation) else {
                     latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
+                    if let presentationFrameSeq {
+                        self.presentationMetrics?.discard(
+                            domain: .editor, outcome: .superseded, frameSeq: presentationFrameSeq
+                        )
+                    }
                     return
                 }
 
@@ -1596,16 +1614,25 @@ final class CoreTextMetalRenderer {
                 self.quadBufferCapacity = candidateQuadCapacity
                 self.lastCompletedPresentationGeneration = generation
                 latencyRecorder?.markPresented(seq: presentationInputSeq)
+                if let presentationFrameSeq {
+                    self.presentationMetrics?.recordMetalPresented(frameSeq: presentationFrameSeq)
+                }
                 os_signpost(.event, log: renderLog, name: "PresentationComplete",
                             signpostID: renderSignpostID,
                             "input=%{public}u", presentationInputSeq)
             }
             presentationBuffer.commit()
+            if let presentationFrameSeq {
+                self.presentationMetrics?.recordMetalSubmission(frameSeq: presentationFrameSeq)
+            }
+            os_signpost(.event, log: renderLog, name: "MetalPresentationSubmit", signpostID: renderSignpostID,
+                        "input=%{public}u frame=%{public}u", presentationInputSeq,
+                        presentationFrameSeq ?? 0)
         }
+        cmdBuf.commit()
         latencyRecorder?.markSubmitted(seq: presentationInputSeq)
         os_signpost(.event, log: renderLog, name: "MetalSubmit", signpostID: renderSignpostID,
                     "input=%{public}u", presentationInputSeq)
-        cmdBuf.commit()
     }
 
     func activeResourceSnapshot() -> NativeActiveResourceSnapshot {
@@ -1625,7 +1652,8 @@ final class CoreTextMetalRenderer {
         _ failure: NativePresentationFailure,
         frameSequence: UInt32? = nil,
         discardLatency: Bool = true,
-        latencyRecorder: LatencyRecorder?
+        latencyRecorder: LatencyRecorder?,
+        presentationFrameSeq: UInt32? = nil
     ) {
         let recorded = NativePresentationFailure(
             phase: failure.phase,
@@ -1639,6 +1667,13 @@ final class CoreTextMetalRenderer {
         factories.reportFailure(recorded)
         if discardLatency {
             latencyRecorder?.discard(seq: recorded.frameSequence, reason: .nativeResourceFailure)
+        }
+        if let presentationFrameSeq {
+            let outcome: GUIFramePresentationMetrics.Outcome =
+                recorded.reason == .unavailable ? .unavailable : .failed
+            presentationMetrics?.discard(
+                domain: .editor, outcome: outcome, frameSeq: presentationFrameSeq
+            )
         }
     }
 

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -8,6 +8,51 @@ import Foundation
 import MingaProtocol
 import MingaUI
 
+extension GUIFrameImpact {
+    /// Exhaustive semantic dependency graph from protocol commands to consumer regions.
+    static func impact(for command: RenderCommand) -> GUIFrameImpact {
+        switch command {
+        case .guiTheme:
+            return .all
+
+        case .guiWindowContent, .guiWindowOverlayDelta, .guiWindowViewportDelta,
+             .guiWindowRowsDelta, .guiLineSpacing, .setFont, .setFontFallback,
+             .registerFont:
+            return [.editor, .editorOverlay]
+
+        case .setCursorShape, .setLinkCursor, .guiGutterSeparator, .guiCursorline,
+             .guiGutter, .guiIndentGuides, .guiCursorAnimation,
+             .guiSplitSeparators, .guiAgentTranscript:
+            return .editor
+
+        case .guiCompletion, .guiHoverPopup, .guiHoverAction, .guiSignatureHelp,
+             .guiExtensionOverlay:
+            return .editorOverlay
+
+        case .guiWhichKey, .guiPicker, .guiPickerPreview, .guiFloatPopup,
+             .guiToolManager, .guiNotifications, .guiExtensionRuntime,
+             .protocolError:
+            return .windowOverlay
+
+        case .guiTabBar, .guiFileTree, .guiFileTreeSelection, .guiObservatory,
+             .guiBreadcrumb, .guiGitStatus, .guiWorkspaces, .guiAgentContext,
+             .guiChangeSummary, .guiEditTimeline, .guiMinibuffer,
+             .guiSearchState, .guiSidebars:
+            return .shell
+
+        case .guiStatusBar, .guiAgentChat, .guiEmptyState:
+            return [.shell, .editor]
+
+        case .guiBottomPanel, .guiExtensionPanel:
+            return [.shell, .windowOverlay]
+
+        case .beginFrame, .commitFrame, .setTitle, .setWindowBg,
+             .clipboardWrite, .guiConfigState:
+            return []
+        }
+    }
+}
+
 /// The single typed result consumed by the frame-status protocol in #2739.
 enum FrameTransactionResult: Sendable, Equatable {
     case applied(generation: UInt32, frameSeq: UInt32)
@@ -147,6 +192,8 @@ struct PreparedFrameTransaction {
     let frameSeq: UInt32
     let baseFrameSeq: UInt32
     let generation: UInt32
+    /// Final consumer impact, including effects introduced while freezing the transaction.
+    let impact: GUIFrameImpact
     let theme: PreparedThemeUpdate?
     let windows: PreparedWindowUpdates?
     let chrome: PreparedChromeUpdates?
@@ -220,6 +267,7 @@ struct PreparedFrameTransactionBuilder {
     let generation: UInt32
 
     private var theme: PreparedThemeUpdate?
+    private var semanticImpact: GUIFrameImpact = []
     private var workingWindows: [UInt16: GUIWindowContent]
     private var changedWindows: [UInt16: GUIWindowContent] = [:]
     private var referencedWindowIds: Set<UInt16> = []
@@ -280,6 +328,7 @@ struct PreparedFrameTransactionBuilder {
         resourceWeight: FrameResourceWeight = FrameResourceWeight(commands: 1)
     ) {
         guard rejection == nil else { return }
+        semanticImpact.formUnion(GUIFrameImpact.impact(for: command))
         switch command {
         case .guiTheme(let slots):
             guard replaceStagingWeight(removing: themeWeight, adding: resourceWeight) else { return }
@@ -397,10 +446,17 @@ struct PreparedFrameTransactionBuilder {
         }
 
         let windowsChanged = !changedWindows.isEmpty || !windowCommands.isEmpty || baseFrameSeq == 0
+        var finalImpact = semanticImpact
+        if windowsChanged {
+            // Includes authoritative pruning, pane geometry, scroll reset, and
+            // local AppKit scroll-presentation discard performed during promotion.
+            finalImpact.formUnion([.editor, .editorOverlay])
+        }
         let transaction = PreparedFrameTransaction(
             frameSeq: frameSeq,
             baseFrameSeq: baseFrameSeq,
             generation: generation,
+            impact: finalImpact,
             theme: theme,
             windows: windowsChanged ? PreparedWindowUpdates(
                 replacements: changedWindows,
@@ -615,24 +671,19 @@ struct PreparedFrameTransactionBuilder {
     }
 
     private mutating func stageWindow(_ content: GUIWindowContent) -> Bool {
-        do {
-            let residentWeight = content.exactResourceWeight()
-            if residentWeight.firstExceeded(limit: residentLimit) != nil {
-                rejection = .resourcePolicy
-                return false
-            }
-            let previousWeight = try workingWindows[content.windowId]?.exactResourceWeight()
-                ?? FrameResourceWeight()
-            guard replaceStagingWeight(
-                removing: previousWeight, adding: residentWeight
-            ) else { return false }
-            workingWindows[content.windowId] = content
-            changedWindows[content.windowId] = content
-            return true
-        } catch {
+        let residentWeight = content.exactResourceWeight()
+        if residentWeight.firstExceeded(limit: residentLimit) != nil {
             rejection = .resourcePolicy
             return false
         }
+        let previousWeight = workingWindows[content.windowId]?.exactResourceWeight()
+            ?? FrameResourceWeight()
+        guard replaceStagingWeight(
+            removing: previousWeight, adding: residentWeight
+        ) else { return false }
+        workingWindows[content.windowId] = content
+        changedWindows[content.windowId] = content
+        return true
     }
 
     private func aggregatingOperationCounters(for content: GUIWindowContent) -> GUIWindowContent {

--- a/macos/Sources/Renderer/ResidentRowStore.swift
+++ b/macos/Sources/Renderer/ResidentRowStore.swift
@@ -323,6 +323,13 @@ public struct ResidentRowStore: Sendable {
     /// Exact cached ownership of resident row strings, spans, and locators.
     public var resourceWeight: FrameResourceWeight { storage.resourceWeight }
 
+    #if DEBUG
+    /// Test-only identity seam for proving resident COW storage sharing.
+    public func sharesStorage(with other: ResidentRowStore) -> Bool {
+        storage === other.storage
+    }
+    #endif
+
     /// Replaces the complete sequence and records one explicit full reset.
     public mutating func replaceAll(
         with rows: [GUIVisualRow], limit: FrameResourceWeight? = nil

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -46,8 +46,8 @@ final class EditorNSView: MTKView {
     /// Font manager for per-span font family support.
     let fontManager: FontManager
 
-    /// GUI state for semantic window content (0x80) and theme colors.
-    var guiState: GUIState?
+    /// Editor-scoped backing references for semantic content and theme.
+    var editorInput: EditorHostInput?
 
     /// Notifies SwiftUI app state when the NSWindow enters or exits full-screen mode.
     var onFullScreenChanged: ((Bool) -> Void)?
@@ -574,11 +574,12 @@ final class EditorNSView: MTKView {
         let validMouseInGutter = isMouseInGutter && validGutterHoverWindowId != nil
         let cursorAnimationGeneration = coreTextRenderer.cursorAnimationGeneration
         let presentationInputSeq = dispatcher.takePresentationInputSeq()
+        let presentationFrameSeq = dispatcher.pendingPresentationFrameSeq()
         let localScrollPresentation = localScrollPresentation
         coreTextRenderer.render(frameState: fs, fontManager: fontManager,
                                 cursorBlinkVisible: cursorBlinkVisible,
-                                windowContents: guiState?.windowContents ?? [:],
-                                themeColors: guiState?.themeColors,
+                                windowContents: editorInput?.currentWindowContents ?? [:],
+                                themeColors: editorInput?.currentTheme,
                                 isMouseInGutter: validMouseInGutter,
                                 gutterHoverWindowId: validGutterHoverWindowId,
                                 gutterHoverRow: validGutterHoverRow,
@@ -597,6 +598,7 @@ final class EditorNSView: MTKView {
                                 ),
                                 presentationWindowId: localScrollPresentation?.windowId,
                                 presentationInputSeq: presentationInputSeq,
+                                presentationFrameSeq: presentationFrameSeq,
                                 latencyRecorder: dispatcher.latency)
         if coreTextRenderer.cursorAnimationGeneration != cursorAnimationGeneration {
             resetCursorBlink()
@@ -1125,7 +1127,7 @@ final class EditorNSView: MTKView {
 
     private var activeWindowIsResident: Bool {
         guard let windowId = activeWindowId,
-              let content = guiState?.windowContents[windowId] else { return false }
+              let content = editorInput?.currentWindowContents[windowId] else { return false }
         return Self.thumbDragCanPresentLocally(
             scrollPresentation: content.scrollPresentation,
             totalLines: content.paneGeometry?.viewport.totalLines ?? dispatcher.frameState.totalLineCount
@@ -1142,7 +1144,7 @@ final class EditorNSView: MTKView {
         // round-trip path cannot leave an old settle or rebound visible either.
         resetSmoothScrollState()
         guard let windowId = activeWindowId,
-              let content = guiState?.windowContents[windowId],
+              let content = editorInput?.currentWindowContents[windowId],
               Self.thumbDragCanPresentLocally(
                   scrollPresentation: content.scrollPresentation,
                   totalLines: content.paneGeometry?.viewport.totalLines ?? dispatcher.frameState.totalLineCount
@@ -1207,7 +1209,7 @@ final class EditorNSView: MTKView {
 
     /// The committed scroll presentation of the thumb-drag pane, or nil when it is gone.
     private func committedThumbDrag(for windowId: UInt16) -> ThumbDragSession.Committed? {
-        guard let sp = guiState?.windowContents[windowId]?.scrollPresentation else { return nil }
+        guard let sp = editorInput?.currentWindowContents[windowId]?.scrollPresentation else { return nil }
         return ThumbDragSession.Committed(anchorTop: sp.anchorTop, scrollSeq: sp.scrollSeq, contentEpoch: sp.contentEpoch, layoutGeneration: sp.layoutGeneration)
     }
 
@@ -2037,7 +2039,7 @@ final class EditorNSView: MTKView {
         for e in hEvents {
             sendScrollEvent(e, row: targetCell.row, col: targetCell.col, mods: mods)
         }
-        let targetWindowContent = scrollTargetWindowId.flatMap { guiState?.windowContents[$0] }
+        let targetWindowContent = scrollTargetWindowId.flatMap { editorInput?.currentWindowContents[$0] }
         let targetScrollPresentation = targetWindowContent?.scrollPresentation
         let scrollBounds = Self.presentationScrollBounds(
             for: targetWindowContent,
@@ -2167,7 +2169,7 @@ final class EditorNSView: MTKView {
         }
         scrollSettleWindowId = windowId
         if scrollLastConfirmedAnchorTop == nil {
-            scrollLastConfirmedAnchorTop = guiState?.windowContents[windowId]?.scrollPresentation?.anchorTop
+            scrollLastConfirmedAnchorTop = editorInput?.currentWindowContents[windowId]?.scrollPresentation?.anchorTop
         }
         scrollSettleAnimator.start(offset: residual, duration: duration)
         // Reflect the seeded offset immediately so this frame is continuous with the last.
@@ -2199,7 +2201,7 @@ final class EditorNSView: MTKView {
         var keepAnimating = false
 
         if let windowId = scrollSettleWindowId {
-            if let sp = guiState?.windowContents[windowId]?.scrollPresentation {
+            if let sp = editorInput?.currentWindowContents[windowId]?.scrollPresentation {
                 reconcileUnconfirmedLines(against: sp)
             }
             let residual = scrollSettleAnimator.offset(now: now)
@@ -2321,7 +2323,7 @@ final class EditorNSView: MTKView {
         // outlive it: if any pane owning presentation state has closed, drop the offset and cancel
         // its animation so a stale whole-cell offset can't linger after the animator finishes on a
         // vanished pane.
-        let available = Set(dispatcher.currentFrameWindowIds.filter { guiState?.windowContents[$0] != nil })
+        let available = Set(dispatcher.currentFrameWindowIds.filter { editorInput?.currentWindowContents[$0] != nil })
         if Self.missingPresentationWindow(
             candidateWindowIds: [scrollTargetWindowId, thumbDragSession?.windowId, scrollSettleWindowId, scrollElasticWindowId],
             availableWindowIds: available
@@ -2343,7 +2345,7 @@ final class EditorNSView: MTKView {
     }
 
     private func smoothScrollTargetWindowId(row: Int16, col: Int16) -> UInt16? {
-        if let contents = guiState?.windowContents {
+        if let contents = editorInput?.currentWindowContents {
             let rowValue = Int(row)
             let colValue = Int(col)
             let geometry = contents.values
@@ -2623,7 +2625,7 @@ final class EditorNSView: MTKView {
 
         // A tick into a document boundary can't be committed by the BEAM, so predicting it would
         // park content one cell off-grid; suppress the seed (the scroll intent already sent above).
-        let windowContent = guiState?.windowContents[windowId]
+        let windowContent = editorInput?.currentWindowContents[windowId]
         let boundary = Self.presentationScrollBoundaryAvailability(
             for: windowContent,
             scrollPresentation: windowContent?.scrollPresentation
@@ -2877,14 +2879,14 @@ final class EditorNSView: MTKView {
         let point = Self.presentationNormalizedGutterPoint(
             point,
             presentation: presentation,
-            targetGutterRect: presentation.flatMap { guiState?.windowContents[$0.windowId]?.paneGeometry?.gutterRect },
+            targetGutterRect: presentation.flatMap { editorInput?.currentWindowContents[$0.windowId]?.paneGeometry?.gutterRect },
             cellWidth: cellWidth,
             cellHeight: effectiveCellHeight
         )
         guard let (gutter, rowIndex) = gutterHit(at: point) else { return nil }
         guard Int(gutter.signColWidth) >= 3 else { return nil }
 
-        let content = guiState?.windowContents[gutter.windowId]
+        let content = editorInput?.currentWindowContents[gutter.windowId]
         let presentationBeforeRows = Self.presentationScrollPayloadOverscanBounds(
             for: content,
             scrollPresentation: content?.scrollPresentation
@@ -2911,7 +2913,7 @@ final class EditorNSView: MTKView {
         let point = Self.presentationNormalizedGutterPoint(
             point,
             presentation: presentation,
-            targetGutterRect: presentation.flatMap { guiState?.windowContents[$0.windowId]?.paneGeometry?.gutterRect },
+            targetGutterRect: presentation.flatMap { editorInput?.currentWindowContents[$0.windowId]?.paneGeometry?.gutterRect },
             cellWidth: cellWidth,
             cellHeight: effectiveCellHeight
         )
@@ -2976,7 +2978,7 @@ final class EditorNSView: MTKView {
         let rawRow = Int16(point.y / effectiveCellHeight)
         let rawCol = max(0, Int16(point.x / cellWidth))
         let rawPointWindowId = smoothScrollTargetWindowId(row: rawRow, col: rawCol)
-        let content = presentation.flatMap { guiState?.windowContents[$0.windowId] }
+        let content = presentation.flatMap { editorInput?.currentWindowContents[$0.windowId] }
         return Self.presentationNormalizedPoint(
             point,
             rawPointWindowId: rawPointWindowId,
@@ -3114,7 +3116,7 @@ final class EditorNSView: MTKView {
     }
 
     private func paneGeometries(at point: NSPoint, screenRow: Int) -> [GUIPaneGeometry] {
-        guard let contents = guiState?.windowContents else { return [] }
+        guard let contents = editorInput?.currentWindowContents else { return [] }
         let rawCol = Int(point.x / cellWidth)
 
         return contents.values.compactMap(\.paneGeometry).filter { geometry in
@@ -3123,7 +3125,7 @@ final class EditorNSView: MTKView {
     }
 
     private func hitRegion(at point: NSPoint, kind: GUIHitRegion.Kind) -> GUIHitRegion? {
-        guard let contents = guiState?.windowContents else { return nil }
+        guard let contents = editorInput?.currentWindowContents else { return nil }
         let screenRow = Int(point.y / effectiveCellHeight)
         let rawCol = Int(point.x / cellWidth)
 
@@ -3137,7 +3139,7 @@ final class EditorNSView: MTKView {
     }
 
     private func dividerHitRegion(at point: NSPoint) -> GUIHitRegion? {
-        guard let contents = guiState?.windowContents else { return nil }
+        guard let contents = editorInput?.currentWindowContents else { return nil }
         let screenRow = Int(point.y / effectiveCellHeight)
         let rawCol = Int(point.x / cellWidth)
 
@@ -3380,7 +3382,7 @@ extension EditorNSView {
     /// Returns the full text content of all visible lines.
     /// Reads from GUIWindowContent (0x80 opcode) semantic data.
     override func accessibilityValue() -> Any? {
-        guard let contents = guiState?.windowContents else { return "" }
+        guard let contents = editorInput?.currentWindowContents else { return "" }
         var lines: [String] = []
         for (_, content) in contents.sorted(by: { $0.key < $1.key }) {
             for row in content.rows {
@@ -3391,7 +3393,7 @@ extension EditorNSView {
     }
 
     override func accessibilityNumberOfCharacters() -> Int {
-        guard let contents = guiState?.windowContents else { return 0 }
+        guard let contents = editorInput?.currentWindowContents else { return 0 }
         var count = 0
         for (_, content) in contents.sorted(by: { $0.key < $1.key }) {
             for (i, row) in content.rows.enumerated() {

--- a/macos/Sources/Views/Shared/GUIFramePresentationMetrics.swift
+++ b/macos/Sources/Views/Shared/GUIFramePresentationMetrics.swift
@@ -1,0 +1,223 @@
+import AppKit
+import Observation
+import os
+import SwiftUI
+
+/// Release telemetry for commit-to-first-affected-native-presentation.
+@MainActor
+public final class GUIFramePresentationMetrics {
+    public enum Outcome: String, CaseIterable, Sendable {
+        case submitted
+        case presented
+        case nativeDraw = "native_draw"
+        case superseded
+        case hidden
+        case unavailable
+        case failed
+    }
+
+    public struct Sample: Equatable, Sendable {
+        public let frame: GUICommittedFrame
+        public let domain: GUIFrameImpact
+        public let outcome: Outcome
+    }
+
+    private struct Pending {
+        let frame: GUICommittedFrame
+        let started: ContinuousClock.Instant
+        var submitted: Bool
+    }
+
+    private let log = OSLog(subsystem: "com.minga.editor", category: "GUIFramePresentation")
+    private var pending: [GUIFrameImpact: Pending] = [:]
+    #if DEBUG
+    private var samples: [Sample] = []
+    #endif
+
+    public init() {}
+
+    /// Starts one ticket per affected domain after semantic publication completes.
+    public func beginCommitted(frame: GUICommittedFrame, impact: GUIFrameImpact) {
+        for domain in Self.domains where impact.contains(domain) {
+            if let prior = pending.removeValue(forKey: domain) {
+                record(frame: prior.frame, domain: domain, outcome: .superseded)
+            }
+            pending[domain] = Pending(frame: frame, started: .now, submitted: false)
+        }
+    }
+
+    /// Returns the committed editor frame currently waiting for Metal submission.
+    public func pendingEditorFrameSeq() -> UInt32? {
+        pending[.editor]?.frame.frameSeq
+    }
+
+    /// Resolves a native SwiftUI/AppKit consumer only from its NSView draw callback.
+    public func recordNativeDraw(domain: GUIFrameImpact, version: GUIFrameVersion) {
+        guard domain != .editor,
+              let committed = version.lastCommitted,
+              let ticket = pending[domain], ticket.frame == committed else { return }
+        pending.removeValue(forKey: domain)
+        record(frame: committed, domain: domain, outcome: .nativeDraw, started: ticket.started)
+    }
+
+    /// Records native submission only after `MTLCommandBuffer.commit()` returned.
+    /// The ticket stays pending until drawable presentation succeeds or is discarded.
+    public func recordMetalSubmission(frameSeq: UInt32) {
+        guard var ticket = pending[.editor], ticket.frame.frameSeq == frameSeq,
+              !ticket.submitted else { return }
+        ticket.submitted = true
+        pending[.editor] = ticket
+        record(frame: ticket.frame, domain: .editor, outcome: .submitted, started: ticket.started)
+    }
+
+    /// Resolves the resident editor after its drawable was presented successfully.
+    public func recordMetalPresented(frameSeq: UInt32) {
+        guard let ticket = pending[.editor], ticket.frame.frameSeq == frameSeq else { return }
+        pending.removeValue(forKey: .editor)
+        record(frame: ticket.frame, domain: .editor, outcome: .presented, started: ticket.started)
+    }
+
+    /// Resolves a ticket that cannot reach its domain's native presentation path.
+    public func discard(domain: GUIFrameImpact, outcome: Outcome, frame: GUICommittedFrame? = nil) {
+        guard outcome == .superseded || outcome == .hidden || outcome == .unavailable || outcome == .failed,
+              let ticket = pending[domain], frame == nil || ticket.frame == frame else { return }
+        resolveDiscard(domain: domain, ticket: ticket, outcome: outcome)
+    }
+
+    /// Resolves an editor ticket from renderer code that carries the committed frame sequence.
+    public func discard(domain: GUIFrameImpact, outcome: Outcome, frameSeq: UInt32) {
+        guard let ticket = pending[domain], ticket.frame.frameSeq == frameSeq else { return }
+        resolveDiscard(domain: domain, ticket: ticket, outcome: outcome)
+    }
+
+    #if DEBUG
+    /// Deterministic test snapshot. Production telemetry is emitted only as signposts.
+    public func snapshot() -> [Sample] { samples }
+    #endif
+
+    private func resolveDiscard(domain: GUIFrameImpact, ticket: Pending, outcome: Outcome) {
+        pending.removeValue(forKey: domain)
+        record(frame: ticket.frame, domain: domain, outcome: outcome, started: ticket.started)
+    }
+
+    private func record(
+        frame: GUICommittedFrame,
+        domain: GUIFrameImpact,
+        outcome: Outcome,
+        started: ContinuousClock.Instant? = nil
+    ) {
+        #if DEBUG
+        samples.append(Sample(frame: frame, domain: domain, outcome: outcome))
+        #else
+        let elapsed = started.map { $0.duration(to: .now) } ?? .zero
+        let micros = elapsed.components.seconds * 1_000_000
+            + elapsed.components.attoseconds / 1_000_000_000_000
+        os_signpost(
+            .event, log: log, name: "GUIFramePresentation",
+            "generation=%{public}u frame=%{public}u domain=%{public}u outcome=%{public}s micros=%{public}lld",
+            frame.generation, frame.frameSeq, domain.rawValue, outcome.rawValue, micros
+        )
+        #endif
+    }
+
+    private static let domains: [GUIFrameImpact] = [
+        .shell, .editor, .editorOverlay, .windowOverlay
+    ]
+}
+
+/// Stable NSView bridge that treats only AppKit drawing as native presentation.
+private struct GUIFrameNativeDrawProbe: NSViewRepresentable {
+    let domain: GUIFrameImpact
+    let version: GUIFrameVersion
+    let metrics: GUIFramePresentationMetrics
+
+    func makeNSView(context: Context) -> GUIFrameDrawNSView {
+        GUIFrameDrawNSView(domain: domain, version: version, metrics: metrics)
+    }
+
+    func updateNSView(_ nsView: GUIFrameDrawNSView, context: Context) {
+        nsView.update(domain: domain, version: version, metrics: metrics)
+    }
+}
+
+@MainActor
+private final class GUIFrameDrawNSView: NSView {
+    private var domain: GUIFrameImpact
+    private var version: GUIFrameVersion
+    private weak var metrics: GUIFramePresentationMetrics?
+    private var availabilityCheck: Task<Void, Never>?
+
+    init(domain: GUIFrameImpact, version: GUIFrameVersion, metrics: GUIFramePresentationMetrics) {
+        self.domain = domain
+        self.version = version
+        self.metrics = metrics
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) { nil }
+
+    func update(domain: GUIFrameImpact, version: GUIFrameVersion, metrics: GUIFramePresentationMetrics) {
+        self.domain = domain
+        self.version = version
+        self.metrics = metrics
+        schedulePresentation()
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        schedulePresentation()
+    }
+
+    override func viewDidHide() {
+        super.viewDidHide()
+        availabilityCheck?.cancel()
+        metrics?.discard(domain: domain, outcome: .hidden, frame: version.lastCommitted)
+    }
+
+    override func draw(_ dirtyRect: NSRect) {
+        super.draw(dirtyRect)
+        availabilityCheck?.cancel()
+        metrics?.recordNativeDraw(domain: domain, version: version)
+    }
+
+    private func schedulePresentation() {
+        availabilityCheck?.cancel()
+        if isHiddenOrHasHiddenAncestor {
+            metrics?.discard(domain: domain, outcome: .hidden, frame: version.lastCommitted)
+            return
+        }
+        if window != nil {
+            needsDisplay = true
+            return
+        }
+
+        let expectedFrame = version.lastCommitted
+        availabilityCheck = Task { @MainActor [weak self] in
+            await Task.yield()
+            guard !Task.isCancelled, let self, self.version.lastCommitted == expectedFrame else { return }
+            if self.isHiddenOrHasHiddenAncestor {
+                self.metrics?.discard(domain: self.domain, outcome: .hidden, frame: expectedFrame)
+            } else if self.window == nil {
+                self.metrics?.discard(domain: self.domain, outcome: .unavailable, frame: expectedFrame)
+            } else {
+                self.needsDisplay = true
+            }
+        }
+    }
+}
+
+extension View {
+    /// Installs a zero-sized stable native draw probe for one focused host.
+    func frameNativeDrawProbe(
+        domain: GUIFrameImpact,
+        version: GUIFrameVersion,
+        metrics: GUIFramePresentationMetrics
+    ) -> some View {
+        background {
+            GUIFrameNativeDrawProbe(domain: domain, version: version, metrics: metrics)
+                .frame(width: 1, height: 1)
+                .allowsHitTesting(false)
+        }
+    }
+}

--- a/macos/Sources/Views/Shared/GUIFrameStore.swift
+++ b/macos/Sources/Views/Shared/GUIFrameStore.swift
@@ -1,0 +1,218 @@
+import Observation
+
+/// Consumer regions invalidated by one atomic GUI publication.
+public struct GUIFrameImpact: OptionSet, Sendable, Equatable, Hashable {
+    public let rawValue: UInt8
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+
+    public static let shell = GUIFrameImpact(rawValue: 1 << 0)
+    public static let editor = GUIFrameImpact(rawValue: 1 << 1)
+    public static let editorOverlay = GUIFrameImpact(rawValue: 1 << 2)
+    public static let windowOverlay = GUIFrameImpact(rawValue: 1 << 3)
+    public static let all: GUIFrameImpact = [.shell, .editor, .editorOverlay, .windowOverlay]
+}
+
+/// Identity of the latest transaction committed by the BEAM.
+public struct GUICommittedFrame: Equatable, Sendable {
+    public let generation: UInt32
+    public let frameSeq: UInt32
+
+    public init(generation: UInt32, frameSeq: UInt32) {
+        self.generation = generation
+        self.frameSeq = frameSeq
+    }
+}
+
+/// Immutable version visible to one consumer domain.
+public struct GUIFrameVersion: Equatable, Sendable {
+    public enum Source: Equatable, Sendable {
+        case committed
+        case local
+    }
+
+    public let revision: UInt64
+    public let lastCommitted: GUICommittedFrame?
+    public let source: Source
+
+    public init(revision: UInt64, lastCommitted: GUICommittedFrame?, source: Source) {
+        self.revision = revision
+        self.lastCommitted = lastCommitted
+        self.source = source
+    }
+}
+
+/// One atomically installed version bundle for all consumer domains.
+public struct GUIFrameVersions: Equatable, Sendable {
+    public let shell: GUIFrameVersion
+    public let editor: GUIFrameVersion
+    public let editorOverlay: GUIFrameVersion
+    public let windowOverlay: GUIFrameVersion
+
+    public init(
+        shell: GUIFrameVersion,
+        editor: GUIFrameVersion,
+        editorOverlay: GUIFrameVersion,
+        windowOverlay: GUIFrameVersion
+    ) {
+        self.shell = shell
+        self.editor = editor
+        self.editorOverlay = editorOverlay
+        self.windowOverlay = windowOverlay
+    }
+}
+
+/// Observable invalidation channel for exactly one consumer domain.
+@MainActor
+@Observable
+public final class GUIFrameChannel {
+    public private(set) var value: GUIFrameVersion
+
+    fileprivate init(value: GUIFrameVersion) {
+        self.value = value
+    }
+
+    fileprivate func install(_ value: GUIFrameVersion) {
+        self.value = value
+    }
+}
+
+/// Atomically publishes backing-state mutations through focused invalidation channels.
+@MainActor
+public final class GUIFrameStore {
+    /// Deterministic publication phases exposed to unit tests without making application code rely on callbacks.
+    enum PublicationEvent: Equatable {
+        case mutated
+        case installed
+        case channel(GUIFrameImpact)
+    }
+
+    @ObservationIgnored public private(set) var installed: GUIFrameVersions
+    public let shell: GUIFrameChannel
+    public let editor: GUIFrameChannel
+    public let editorOverlay: GUIFrameChannel
+    public let windowOverlay: GUIFrameChannel
+
+    @ObservationIgnored var onPublicationEvent: ((PublicationEvent) -> Void)?
+    @ObservationIgnored private var isPublishing = false
+
+    public init() {
+        let initial = GUIFrameVersion(revision: 0, lastCommitted: nil, source: .local)
+        let versions = GUIFrameVersions(
+            shell: initial,
+            editor: initial,
+            editorOverlay: initial,
+            windowOverlay: initial
+        )
+        installed = versions
+        shell = GUIFrameChannel(value: versions.shell)
+        editor = GUIFrameChannel(value: versions.editor)
+        editorOverlay = GUIFrameChannel(value: versions.editorOverlay)
+        windowOverlay = GUIFrameChannel(value: versions.windowOverlay)
+    }
+
+    /// Publishes one validated committed transaction.
+    public func publishCommitted(
+        generation: UInt32,
+        frameSeq: UInt32,
+        impact: GUIFrameImpact,
+        mutation: () -> Void
+    ) {
+        publish(
+            committed: GUICommittedFrame(generation: generation, frameSeq: frameSeq),
+            source: .committed,
+            impact: impact
+        ) {
+            mutation()
+            return true
+        }
+    }
+
+    /// Publishes one synchronous client-local or recovery mutation without replacing the latest committed frame.
+    public func publishLocal(impact: GUIFrameImpact, mutation: () -> Void) {
+        publish(
+            committed: installed.shell.lastCommitted,
+            source: .local,
+            impact: impact
+        ) {
+            mutation()
+            return true
+        }
+    }
+
+    /// Publishes a local mutation only when the mutation reports a visible change.
+    @discardableResult
+    public func publishLocalIfChanged(
+        impact: GUIFrameImpact,
+        mutation: () -> Bool
+    ) -> Bool {
+        publish(
+            committed: installed.shell.lastCommitted,
+            source: .local,
+            impact: impact,
+            mutation: mutation
+        )
+    }
+
+    @discardableResult
+    private func publish(
+        committed: GUICommittedFrame?,
+        source: GUIFrameVersion.Source,
+        impact: GUIFrameImpact,
+        mutation: () -> Bool
+    ) -> Bool {
+        precondition(!isPublishing, "GUI frame publication cannot recurse")
+        isPublishing = true
+        defer { isPublishing = false }
+
+        guard mutation() else { return false }
+        onPublicationEvent?(.mutated)
+
+        let prior = installed
+        let next = GUIFrameVersions(
+            shell: version(after: prior.shell, committed: committed, source: source, affected: impact.contains(.shell)),
+            editor: version(after: prior.editor, committed: committed, source: source, affected: impact.contains(.editor)),
+            editorOverlay: version(after: prior.editorOverlay, committed: committed, source: source, affected: impact.contains(.editorOverlay)),
+            windowOverlay: version(after: prior.windowOverlay, committed: committed, source: source, affected: impact.contains(.windowOverlay))
+        )
+        installed = next
+        onPublicationEvent?(.installed)
+
+        // This order is part of the publication contract.
+        if impact.contains(.shell) {
+            shell.install(next.shell)
+            onPublicationEvent?(.channel(.shell))
+        }
+        if impact.contains(.editor) {
+            editor.install(next.editor)
+            onPublicationEvent?(.channel(.editor))
+        }
+        if impact.contains(.editorOverlay) {
+            editorOverlay.install(next.editorOverlay)
+            onPublicationEvent?(.channel(.editorOverlay))
+        }
+        if impact.contains(.windowOverlay) {
+            windowOverlay.install(next.windowOverlay)
+            onPublicationEvent?(.channel(.windowOverlay))
+        }
+        return true
+    }
+
+    private func version(
+        after prior: GUIFrameVersion,
+        committed: GUICommittedFrame?,
+        source: GUIFrameVersion.Source,
+        affected: Bool
+    ) -> GUIFrameVersion {
+        if source == .local, !affected {
+            return prior
+        }
+        return GUIFrameVersion(
+            revision: affected ? prior.revision &+ 1 : prior.revision,
+            lastCommitted: committed,
+            source: source
+        )
+    }
+}

--- a/macos/Sources/Views/Shared/GUIFrameStore.swift
+++ b/macos/Sources/Views/Shared/GUIFrameStore.swift
@@ -132,11 +132,7 @@ public final class GUIFrameStore {
 
     /// Publishes one synchronous client-local or recovery mutation without replacing the latest committed frame.
     public func publishLocal(impact: GUIFrameImpact, mutation: () -> Void) {
-        publish(
-            committed: installed.shell.lastCommitted,
-            source: .local,
-            impact: impact
-        ) {
+        publish(committed: nil, source: .local, impact: impact) {
             mutation()
             return true
         }
@@ -148,12 +144,7 @@ public final class GUIFrameStore {
         impact: GUIFrameImpact,
         mutation: () -> Bool
     ) -> Bool {
-        publish(
-            committed: installed.shell.lastCommitted,
-            source: .local,
-            impact: impact,
-            mutation: mutation
-        )
+        publish(committed: nil, source: .local, impact: impact, mutation: mutation)
     }
 
     @discardableResult
@@ -171,11 +162,19 @@ public final class GUIFrameStore {
         onPublicationEvent?(.mutated)
 
         let prior = installed
+        // Focused commits can leave channel identities divergent from the complete installed bundle.
+        // A local publication stays correlated with what each affected consumer currently displays.
+        let published = GUIFrameVersions(
+            shell: shell.value,
+            editor: editor.value,
+            editorOverlay: editorOverlay.value,
+            windowOverlay: windowOverlay.value
+        )
         let next = GUIFrameVersions(
-            shell: version(after: prior.shell, committed: committed, source: source, affected: impact.contains(.shell)),
-            editor: version(after: prior.editor, committed: committed, source: source, affected: impact.contains(.editor)),
-            editorOverlay: version(after: prior.editorOverlay, committed: committed, source: source, affected: impact.contains(.editorOverlay)),
-            windowOverlay: version(after: prior.windowOverlay, committed: committed, source: source, affected: impact.contains(.windowOverlay))
+            shell: version(after: prior.shell, published: published.shell, committed: committed, source: source, affected: impact.contains(.shell)),
+            editor: version(after: prior.editor, published: published.editor, committed: committed, source: source, affected: impact.contains(.editor)),
+            editorOverlay: version(after: prior.editorOverlay, published: published.editorOverlay, committed: committed, source: source, affected: impact.contains(.editorOverlay)),
+            windowOverlay: version(after: prior.windowOverlay, published: published.windowOverlay, committed: committed, source: source, affected: impact.contains(.windowOverlay))
         )
         installed = next
         onPublicationEvent?(.installed)
@@ -202,12 +201,18 @@ public final class GUIFrameStore {
 
     private func version(
         after prior: GUIFrameVersion,
+        published: GUIFrameVersion,
         committed: GUICommittedFrame?,
         source: GUIFrameVersion.Source,
         affected: Bool
     ) -> GUIFrameVersion {
-        if source == .local, !affected {
-            return prior
+        if source == .local {
+            guard affected else { return prior }
+            return GUIFrameVersion(
+                revision: prior.revision &+ 1,
+                lastCommitted: published.lastCommitted,
+                source: source
+            )
         }
         return GUIFrameVersion(
             revision: affected ? prior.revision &+ 1 : prior.revision,

--- a/macos/Sources/Views/Shared/GUIState.swift
+++ b/macos/Sources/Views/Shared/GUIState.swift
@@ -1,75 +1,83 @@
-/// Container for all GUI chrome sub-states.
-///
-/// Owns the protocol-driven State + View objects behind one observable aggregate
-/// publication value. The child states are deliberately non-observable: a frame
-/// mutates them while hidden, then swaps `framePublication` exactly once.
-/// Injected once into `CommandDispatcher` and `ContentView`, eliminating
-/// the 9 optional property wiring that previously required individual
-/// assignment in `AppDelegate`.
-///
-/// All sub-states are initialized at creation time; no optional nil-checks
-/// needed in dispatch handlers.
+/// Container for stable protocol-backed GUI state and focused publication inputs.
 import MingaProtocol
 import Observation
 
-/// Immutable observation token published after one complete GUI state transition.
-public struct GUIStatePublication: Equatable, Sendable {
-    public let generation: UInt64
-    public let frameSeq: UInt32?
+@MainActor
+fileprivate final class GUIThemeBacking {
+    var current = ThemeColors()
+}
+
+@MainActor
+fileprivate final class GUIWindowContentBacking {
+    var current: [UInt16: GUIWindowContent]
+
+    init(_ current: [UInt16: GUIWindowContent]) {
+        self.current = current
+    }
 }
 
 @MainActor
 @Observable
 public final class GUIState {
+    @ObservationIgnored private let themeBacking = GUIThemeBacking()
+    @ObservationIgnored private let windowContentBacking: GUIWindowContentBacking
+
+    public let frameStore = GUIFrameStore()
+    public let presentationMetrics = GUIFramePresentationMetrics()
+
     public init(windowContents: [UInt16: GUIWindowContent] = [:]) {
-        self.windowContents = windowContents
-        feedbackState.onPresentationChanged = { [weak self] in
-            self?.performOutOfBandPublication {}
+        windowContentBacking = GUIWindowContentBacking(windowContents)
+        feedbackState.onPresentationChanged = { [weak frameStore] in
+            frameStore?.publishLocal(impact: .shell) {}
         }
     }
 
-    /// Immutable aggregate token swapped after every complete prepared frame.
-    /// Reading this token is the only observation dependency views need for
-    /// protocol-driven child state.
-    public private(set) var framePublication = GUIStatePublication(generation: 0, frameSeq: nil)
+    /// Stable shell-scoped input created and owned by this GUI state.
+    @ObservationIgnored public lazy private(set) var shellInput = ShellHostInput(
+        theme: themeBacking,
+        tabBarState: tabBarState, emptyStateState: emptyStateState,
+        workspaceState: workspaceState, sidebarHostState: sidebarHostState,
+        fileTreeState: fileTreeState, gitStatusState: gitStatusState,
+        observatoryState: observatoryState, breadcrumbState: breadcrumbState,
+        statusBarState: statusBarState, feedbackState: feedbackState,
+        agentChatState: agentChatState, bottomPanelState: bottomPanelState,
+        minibufferState: minibufferState, agentContextBarState: agentContextBarState,
+        changeSummaryState: changeSummaryState, editTimelineState: editTimelineState,
+        extensionPanelState: extensionPanelState, searchState: searchState
+    )
 
-    /// Out-of-band/recovery state has a separate publication stream so rejecting
-    /// a frame never masquerades as a committed frame publication.
-    public private(set) var outOfBandPublication = GUIStatePublication(generation: 0, frameSeq: nil)
+    /// Stable editor-scoped input created and owned by this GUI state.
+    @ObservationIgnored public lazy private(set) var editorInput = EditorHostInput(
+        theme: themeBacking, windows: windowContentBacking,
+        statusBarState: statusBarState, agentChatState: agentChatState,
+        emptyStateState: emptyStateState, extensionPanelState: extensionPanelState
+    )
 
-    /// Number of complete prepared frames published since this GUI state was created.
-    public var framePublicationCount: UInt64 { framePublication.generation }
+    /// Stable editor-overlay-scoped input created and owned by this GUI state.
+    @ObservationIgnored public lazy private(set) var editorOverlayInput = EditorOverlayHostInput(
+        theme: themeBacking, windows: windowContentBacking,
+        completionState: completionState, hoverPopupState: hoverPopupState,
+        signatureHelpState: signatureHelpState, extensionOverlayState: extensionOverlayState
+    )
 
-    /// Child state cannot notify while this closure runs because protocol-driven
-    /// State objects are non-observable. The immutable aggregate swap is therefore
-    /// the sole frame observation point.
-    public func performFramePublication(frameSeq: UInt32, _ mutation: () -> Void) {
-        mutation()
-        framePublication = GUIStatePublication(
-            generation: framePublication.generation + 1,
-            frameSeq: frameSeq
-        )
-    }
+    /// Stable window-overlay-scoped input created and owned by this GUI state.
+    @ObservationIgnored public lazy private(set) var windowOverlayInput = WindowOverlayHostInput(
+        theme: themeBacking, notificationCenterState: notificationCenterState,
+        whichKeyState: whichKeyState, pickerState: pickerState,
+        bottomPanelState: bottomPanelState, toolManagerState: toolManagerState,
+        floatPopupState: floatPopupState, extensionPanelState: extensionPanelState,
+        frontendExtensions: frontendExtensions, protocolErrorState: protocolErrorState,
+        latencyHUDState: latencyHUDState, resyncState: resyncState
+    )
 
-    /// Applies one recovery or local-presentation mutation and publishes it separately from committed frames.
-    public func performOutOfBandPublication(_ mutation: () -> Void) {
-        mutation()
-        outOfBandPublication = GUIStatePublication(
-            generation: outOfBandPublication.generation + 1,
-            frameSeq: nil
-        )
-    }
-
-    /// Theme remains Observable because SwiftUI environment injection requires
-    /// that conformance. Frame publication replaces the whole instance, so the
-    /// published instance is never mutated under active observers.
-    @ObservationIgnored public private(set) var themeColors = ThemeColors()
+    /// Current theme reference. Replacement is published through all four domains.
+    public var themeColors: ThemeColors { themeBacking.current }
 
     /// Builds and installs a complete theme value without mutating the observed prior instance.
     public func replaceTheme(slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)]) {
         let replacement = ThemeColors()
         replacement.applySlots(slots)
-        themeColors = replacement
+        themeBacking.current = replacement
     }
 
     /// Native settings panel state.
@@ -174,6 +182,164 @@ public final class GUIState {
     /// Keyed by windowId. NOT cleared between frames; the guiWindowContent
     /// dispatch overwrites per-window data each frame. Stale entries serve
     /// as fallback to prevent blank viewport flashes.
-    @ObservationIgnored public var windowContents: [UInt16: GUIWindowContent] = [:]
+    public var windowContents: [UInt16: GUIWindowContent] {
+        get { windowContentBacking.current }
+        set { windowContentBacking.current = newValue }
+    }
+}
 
+/// Stable explicit references used only by shell consumers.
+@MainActor
+public final class ShellHostInput {
+    fileprivate let theme: GUIThemeBacking
+    public let tabBarState: TabBarState
+    public let emptyStateState: EmptyStateState
+    public let workspaceState: WorkspaceState
+    public let sidebarHostState: SidebarHostState
+    public let fileTreeState: FileTreeState
+    public let gitStatusState: GitStatusState
+    public let observatoryState: ObservatoryState
+    public let breadcrumbState: BreadcrumbState
+    public let statusBarState: StatusBarState
+    public let feedbackState: FeedbackState
+    public let agentChatState: AgentChatState
+    public let bottomPanelState: BottomPanelState
+    public let minibufferState: MinibufferState
+    public let agentContextBarState: AgentContextBarState
+    public let changeSummaryState: ChangeSummaryState
+    public let editTimelineState: EditTimelineState
+    public let extensionPanelState: ExtensionPanelState
+    public let searchState: SearchState
+
+    public var currentTheme: ThemeColors { theme.current }
+
+    fileprivate init(
+        theme: GUIThemeBacking,
+        tabBarState: TabBarState, emptyStateState: EmptyStateState,
+        workspaceState: WorkspaceState, sidebarHostState: SidebarHostState,
+        fileTreeState: FileTreeState, gitStatusState: GitStatusState,
+        observatoryState: ObservatoryState, breadcrumbState: BreadcrumbState,
+        statusBarState: StatusBarState, feedbackState: FeedbackState,
+        agentChatState: AgentChatState, bottomPanelState: BottomPanelState,
+        minibufferState: MinibufferState, agentContextBarState: AgentContextBarState,
+        changeSummaryState: ChangeSummaryState, editTimelineState: EditTimelineState,
+        extensionPanelState: ExtensionPanelState, searchState: SearchState
+    ) {
+        self.theme = theme
+        self.tabBarState = tabBarState
+        self.emptyStateState = emptyStateState
+        self.workspaceState = workspaceState
+        self.sidebarHostState = sidebarHostState
+        self.fileTreeState = fileTreeState
+        self.gitStatusState = gitStatusState
+        self.observatoryState = observatoryState
+        self.breadcrumbState = breadcrumbState
+        self.statusBarState = statusBarState
+        self.feedbackState = feedbackState
+        self.agentChatState = agentChatState
+        self.bottomPanelState = bottomPanelState
+        self.minibufferState = minibufferState
+        self.agentContextBarState = agentContextBarState
+        self.changeSummaryState = changeSummaryState
+        self.editTimelineState = editTimelineState
+        self.extensionPanelState = extensionPanelState
+        self.searchState = searchState
+    }
+}
+
+/// Stable explicit references used only by the resident editor surface.
+@MainActor
+public final class EditorHostInput {
+    fileprivate let theme: GUIThemeBacking
+    fileprivate let windows: GUIWindowContentBacking
+    public let statusBarState: StatusBarState
+    public let agentChatState: AgentChatState
+    public let emptyStateState: EmptyStateState
+    public let extensionPanelState: ExtensionPanelState
+
+    public var currentTheme: ThemeColors { theme.current }
+    public var currentWindowContents: [UInt16: GUIWindowContent] { windows.current }
+    public func windowContent(for windowID: UInt16) -> GUIWindowContent? { windows.current[windowID] }
+
+    fileprivate init(
+        theme: GUIThemeBacking, windows: GUIWindowContentBacking,
+        statusBarState: StatusBarState, agentChatState: AgentChatState,
+        emptyStateState: EmptyStateState, extensionPanelState: ExtensionPanelState
+    ) {
+        self.theme = theme
+        self.windows = windows
+        self.statusBarState = statusBarState
+        self.agentChatState = agentChatState
+        self.emptyStateState = emptyStateState
+        self.extensionPanelState = extensionPanelState
+    }
+}
+
+/// Stable explicit references used only by editor-anchored overlays.
+@MainActor
+public final class EditorOverlayHostInput {
+    fileprivate let theme: GUIThemeBacking
+    fileprivate let windows: GUIWindowContentBacking
+    public let completionState: CompletionState
+    public let hoverPopupState: HoverPopupState
+    public let signatureHelpState: SignatureHelpState
+    public let extensionOverlayState: ExtensionOverlayState
+
+    public var currentTheme: ThemeColors { theme.current }
+    public func windowContent(for windowID: UInt16) -> GUIWindowContent? { windows.current[windowID] }
+
+    fileprivate init(
+        theme: GUIThemeBacking, windows: GUIWindowContentBacking,
+        completionState: CompletionState, hoverPopupState: HoverPopupState,
+        signatureHelpState: SignatureHelpState, extensionOverlayState: ExtensionOverlayState
+    ) {
+        self.theme = theme
+        self.windows = windows
+        self.completionState = completionState
+        self.hoverPopupState = hoverPopupState
+        self.signatureHelpState = signatureHelpState
+        self.extensionOverlayState = extensionOverlayState
+    }
+}
+
+/// Stable explicit references used only by whole-window overlays.
+@MainActor
+public final class WindowOverlayHostInput {
+    fileprivate let theme: GUIThemeBacking
+    public let notificationCenterState: NotificationCenterState
+    public let whichKeyState: WhichKeyState
+    public let pickerState: PickerState
+    public let bottomPanelState: BottomPanelState
+    public let toolManagerState: ToolManagerState
+    public let floatPopupState: FloatPopupState
+    public let extensionPanelState: ExtensionPanelState
+    public let frontendExtensions: FrontendExtensionRuntimeRegistry
+    public let protocolErrorState: ProtocolErrorState
+    public let latencyHUDState: LatencyHUDState
+    public let resyncState: ResyncState
+
+    public var currentTheme: ThemeColors { theme.current }
+
+    fileprivate init(
+        theme: GUIThemeBacking, notificationCenterState: NotificationCenterState,
+        whichKeyState: WhichKeyState, pickerState: PickerState,
+        bottomPanelState: BottomPanelState, toolManagerState: ToolManagerState,
+        floatPopupState: FloatPopupState, extensionPanelState: ExtensionPanelState,
+        frontendExtensions: FrontendExtensionRuntimeRegistry,
+        protocolErrorState: ProtocolErrorState, latencyHUDState: LatencyHUDState,
+        resyncState: ResyncState
+    ) {
+        self.theme = theme
+        self.notificationCenterState = notificationCenterState
+        self.whichKeyState = whichKeyState
+        self.pickerState = pickerState
+        self.bottomPanelState = bottomPanelState
+        self.toolManagerState = toolManagerState
+        self.floatPopupState = floatPopupState
+        self.extensionPanelState = extensionPanelState
+        self.frontendExtensions = frontendExtensions
+        self.protocolErrorState = protocolErrorState
+        self.latencyHUDState = latencyHUDState
+        self.resyncState = resyncState
+    }
 }

--- a/macos/Sources/Views/Sidebar/ActivityBar.swift
+++ b/macos/Sources/Views/Sidebar/ActivityBar.swift
@@ -6,12 +6,12 @@ import SwiftUI
 
 /// Thin VS Code-style icon strip for sidebar panel discovery and switching.
 public struct ActivityBar: View {
-    public init(guiState: GUIState, sidebarHostState: SidebarHostState, encoder: InputEncoder? = nil) {
-        self.guiState = guiState
+    public init(input: ShellHostInput, sidebarHostState: SidebarHostState, encoder: InputEncoder? = nil) {
+        self.input = input
         self.sidebarHostState = sidebarHostState
         self.encoder = encoder
     }
-    public let guiState: GUIState
+    public let input: ShellHostInput
     public let sidebarHostState: SidebarHostState
     @Environment(\.themeColors) private var theme
     public let encoder: InputEncoder?
@@ -106,7 +106,7 @@ public struct ActivityBar: View {
 
     private func badgeText(for item: SidebarItem) -> String? {
         let context = NativeSidebarContext(
-            guiState: guiState,
+            input: input,
             theme: theme,
             encoder: encoder,
             projectName: "",

--- a/macos/Sources/Views/Sidebar/NativeSidebarRegistry.swift
+++ b/macos/Sources/Views/Sidebar/NativeSidebarRegistry.swift
@@ -5,15 +5,15 @@ import SwiftUI
 /// Context passed to native sidebar adapter builders.
 @MainActor
 public struct NativeSidebarContext {
-    public init(guiState: GUIState, theme: ThemeColors, encoder: InputEncoder? = nil, projectName: String, gitBranch: String, leadingPadding: CGFloat) {
-        self.guiState = guiState
+    public init(input: ShellHostInput, theme: ThemeColors, encoder: InputEncoder? = nil, projectName: String, gitBranch: String, leadingPadding: CGFloat) {
+        self.input = input
         self.theme = theme
         self.encoder = encoder
         self.projectName = projectName
         self.gitBranch = gitBranch
         self.leadingPadding = leadingPadding
     }
-    public let guiState: GUIState
+    public let input: ShellHostInput
     public let theme: ThemeColors
     public let encoder: InputEncoder?
     public let projectName: String
@@ -62,7 +62,7 @@ public enum NativeSidebarRegistry {
         fallbackIcon: "folder",
         makeHeader: { context, _ in
             AnyView(FileTreeHeaderView(
-                fileTreeState: context.guiState.fileTreeState,
+                fileTreeState: context.input.fileTreeState,
                 encoder: context.encoder,
                 branchName: context.gitBranch,
                 leadingPadding: context.leadingPadding
@@ -70,7 +70,7 @@ public enum NativeSidebarRegistry {
         },
         makeBody: { context, _ in
             AnyView(FileTreeView(
-                fileTreeState: context.guiState.fileTreeState,
+                fileTreeState: context.input.fileTreeState,
                 encoder: context.encoder
             ))
         },
@@ -85,14 +85,14 @@ public enum NativeSidebarRegistry {
         fallbackIcon: "point.3.filled.connected.trianglepath.dotted",
         makeHeader: { context, _ in
             AnyView(GitStatusHeaderView(
-                state: context.guiState.gitStatusState,
+                state: context.input.gitStatusState,
                 projectName: context.projectName,
                 leadingPadding: context.leadingPadding
             ))
         },
         makeBody: { context, _ in
             AnyView(GitStatusView(
-                state: context.guiState.gitStatusState,
+                state: context.input.gitStatusState,
                 encoder: context.encoder
             ))
         },
@@ -100,7 +100,7 @@ public enum NativeSidebarRegistry {
             encoder?.sendSidebarAction(sidebarId: item.id, kind: item.semanticKind, action: isActive ? "toggle" : "activate")
         },
         badgeText: { context, item in
-            let count = item.badgeCount.map(Int.init) ?? context.guiState.gitStatusState.totalCount
+            let count = item.badgeCount.map(Int.init) ?? context.input.gitStatusState.totalCount
             guard count > 0 else { return nil }
             return count > 99 ? "99+" : String(count)
         }
@@ -110,11 +110,11 @@ public enum NativeSidebarRegistry {
         kind: "observatory",
         fallbackIcon: "network",
         makeHeader: { context, item in
-            AnyView(ObservatorySidebarHeader(item: item, state: context.guiState.observatoryState, leadingPadding: context.leadingPadding))
+            AnyView(ObservatorySidebarHeader(item: item, state: context.input.observatoryState, leadingPadding: context.leadingPadding))
         },
         makeBody: { context, _ in
             AnyView(ObservatoryView(
-                state: context.guiState.observatoryState,
+                state: context.input.observatoryState,
                 encoder: context.encoder
             ))
         },

--- a/macos/Sources/Views/Sidebar/SidebarContainer.swift
+++ b/macos/Sources/Views/Sidebar/SidebarContainer.swift
@@ -33,8 +33,8 @@ public enum SidebarSizing {
 }
 
 public struct SidebarContainer: View {
-    public init(guiState: GUIState, activeSidebar: SidebarItem, encoder: InputEncoder? = nil, projectName: String, gitBranch: String, leadingPadding: CGFloat, sidebarWidth: Binding<CGFloat>) {
-        self.guiState = guiState
+    public init(input: ShellHostInput, activeSidebar: SidebarItem, encoder: InputEncoder? = nil, projectName: String, gitBranch: String, leadingPadding: CGFloat, sidebarWidth: Binding<CGFloat>) {
+        self.input = input
         self.activeSidebar = activeSidebar
         self.encoder = encoder
         self.projectName = projectName
@@ -42,7 +42,7 @@ public struct SidebarContainer: View {
         self.leadingPadding = leadingPadding
         self._sidebarWidth = sidebarWidth
     }
-    public let guiState: GUIState
+    public let input: ShellHostInput
     public let activeSidebar: SidebarItem
     @Environment(\.themeColors) private var theme
     public let encoder: InputEncoder?
@@ -70,7 +70,7 @@ public struct SidebarContainer: View {
 
     private var context: NativeSidebarContext {
         NativeSidebarContext(
-            guiState: guiState,
+            input: input,
             theme: theme,
             encoder: encoder,
             projectName: projectName,

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -1867,7 +1867,6 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("prepared.ex")]))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        #expect(gui.framePublicationCount == 1)
         #expect(dispatcher.publicationCount == 1)
         #expect(results == [.applied(generation: 1, frameSeq: 1)])
         #expect(gui.windowContents[7]?.rows.first?.text == "old")
@@ -1882,7 +1881,7 @@ struct CommandDispatcherStagingTests {
         dispatcher.onFrameReady = { readyCount += 1 }
         dispatcher.onTransactionResult = { result in
             guard case .applied(generation: 4, frameSeq: 8) = result else { return }
-            publicationSeenByApplied = gui.framePublicationCount == 1 &&
+            publicationSeenByApplied = dispatcher.publicationCount == 1 &&
                 gui.tabBarState.tabs.first?.label == "semantic.ex" && readyCount == 0
         }
 
@@ -1895,16 +1894,13 @@ struct CommandDispatcherStagingTests {
         #expect(readyCount == 1)
     }
 
-    @Test("one aggregate observation callback sees all sibling domains committed")
-    @MainActor func aggregateObservationIsAtomic() throws {
+    @Test("focused channel callback sees the complete installed transaction")
+    @MainActor func focusedObservationIsAtomic() throws {
         let (dispatcher, gui) = makeDispatcher()
         let notificationCount = Mutex(0)
 
         withObservationTracking {
-            _ = gui.framePublication
-            // Reading the siblings documents the observation's consistency contract.
-            _ = gui.tabBarState.tabs
-            _ = gui.agentChatState.model
+            _ = gui.frameStore.shell.value
         } onChange: {
             notificationCount.withLock { $0 += 1 }
         }
@@ -1923,6 +1919,7 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
         #expect(notificationCount.withLock { $0 } == 1)
+        #expect(gui.frameStore.installed.shell.lastCommitted?.frameSeq == 1)
         #expect(gui.tabBarState.tabs.first?.label == "atomic.ex")
         #expect(gui.agentChatState.model == "prepared-model")
     }
@@ -2053,7 +2050,7 @@ struct CommandDispatcherStagingTests {
         ))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        #expect(gui.framePublicationCount == 0)
+        #expect(dispatcher.publicationCount == 0)
         #expect(results == [.rejected(
             generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0,
             reason: .resourcePolicy
@@ -2209,7 +2206,7 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiWindowOverlayDelta(data: overlayDelta(windowId: 99)))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        #expect(gui.framePublicationCount == 0)
+        #expect(dispatcher.publicationCount == 0)
         #expect(gui.tabBarState.tabs.isEmpty)
         #expect(gui.resyncState.pending == false)
         #expect(results == [.windowRefMiss(generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0, windowId: 99)])
@@ -2248,7 +2245,7 @@ struct CommandDispatcherStagingTests {
                 dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
             }
 
-            let baselinePublications = gui.framePublicationCount
+            let baselinePublications = dispatcher.publicationCount
             let frameSeq = UInt32(index > 0 ? 2 : 1)
             let baseSeq = UInt32(index > 0 ? 1 : 0)
             dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseSeq, generation: 1))
@@ -2257,7 +2254,7 @@ struct CommandDispatcherStagingTests {
             dispatcher.dispatch(invalid.0)
             dispatcher.dispatch(.commitFrame(frameSeq: frameSeq, seq: 0))
 
-            #expect(gui.framePublicationCount == baselinePublications)
+            #expect(dispatcher.publicationCount == baselinePublications)
             #expect(gui.tabBarState.tabs.first?.label == (index > 0 ? "baseline.ex" : nil))
             #expect(results.last == .rejected(generation: 1, frameSeq: frameSeq, lastAppliedFrameSeq: UInt32(index > 0 ? 1 : 0), reason: invalid.1))
             #expect(gui.agentChatState.messages.map(\.id) == (index > 0 ? [1] : []))
@@ -2298,14 +2295,14 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiWindowOverlayDelta(data: overlayDelta(epoch: 41)))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
 
-        #expect(gui.framePublicationCount == 1)
+        #expect(dispatcher.publicationCount == 1)
         #expect(results.last == .rejected(generation: 1, frameSeq: 2, lastAppliedFrameSeq: 1, reason: .windowEpochMismatch(windowId: 7, expected: 42, actual: 41)))
         #expect(gui.windowContents[7]?.cursorShape == .block)
     }
 
     @Test("unsorted full content fails before resident construction or publication")
     @MainActor func unsortedContentIsTransactional() throws {
-        let (_, gui) = makeDispatcher()
+        let (dispatcher, gui) = makeDispatcher()
         let high = GUIVisualRow(rowType: .normal, rowId: 1, bufLine: 2,
             contentHash: 11, text: "high", spans: [])
         let low = GUIVisualRow(rowType: .normal, rowId: 2, bufLine: 1,
@@ -2317,7 +2314,7 @@ struct CommandDispatcherStagingTests {
                 selection: nil, searchMatches: [], diagnosticUnderlines: [],
                 documentHighlights: [])
         }
-        #expect(gui.framePublicationCount == 0)
+        #expect(dispatcher.publicationCount == 0)
         #expect(gui.windowContents.isEmpty)
     }
 
@@ -2349,7 +2346,7 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiWindowRowsDelta(data: missing))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
 
-        #expect(gui.framePublicationCount == 1)
+        #expect(dispatcher.publicationCount == 1)
         #expect(gui.tabBarState.tabs.first?.label == "baseline.ex")
         #expect(gui.windowContents[7]?.rows.first?.text == "old")
         #expect(results.last == .windowRefMiss(generation: 1, frameSeq: 2, lastAppliedFrameSeq: 1, windowId: 7))
@@ -2357,7 +2354,7 @@ struct CommandDispatcherStagingTests {
 
     @Test("unregistered font resources reject a prepared frame")
     @MainActor func missingFontResourceRejects() throws {
-        let (dispatcher, gui) = makeDispatcher()
+        let (dispatcher, _) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
@@ -2366,13 +2363,13 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiWindowContent(data: try windowContent(fontId: 3)))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        #expect(gui.framePublicationCount == 0)
+        #expect(dispatcher.publicationCount == 0)
         #expect(results == [.rejected(generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0, reason: .missingFontResource(fontId: 3))])
     }
 
     @Test("unregistered font resources in row splices reject a prepared frame")
     @MainActor func missingSpliceFontResourceRejects() throws {
-        let (dispatcher, gui) = makeDispatcher()
+        let (dispatcher, _) = makeDispatcher()
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
 
@@ -2404,7 +2401,7 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiWindowRowsDelta(data: delta))
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
 
-        #expect(gui.framePublicationCount == 1)
+        #expect(dispatcher.publicationCount == 1)
         #expect(results.last == .rejected(
             generation: 1, frameSeq: 2, lastAppliedFrameSeq: 1,
             reason: .missingFontResource(fontId: 3)
@@ -2428,7 +2425,7 @@ struct CommandDispatcherStagingTests {
             theme: 0, windows: 0, chrome: 1, overlays: 0,
             resources: 0, focus: 0, metadata: 0
         ))
-        #expect(gui.framePublicationCount == 2)
+        #expect(dispatcher.publicationCount == 2)
         #expect(gui.tabBarState.tabs.first?.label == "99.ex")
     }
 

--- a/macos/Tests/MingaTests/ConformanceTranscriptTests.swift
+++ b/macos/Tests/MingaTests/ConformanceTranscriptTests.swift
@@ -286,7 +286,7 @@ struct ConformanceTranscriptTests {
         dispatcher.dispatch(.guiTheme(slots: theme))
         dispatcher.dispatch(.guiWindowContent(data: epochContent))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
-        let keyframePublication = gui.framePublicationCount
+        let keyframePublication = dispatcher.publicationCount
 
         let ordinaryDelta = GUIWindowRowsDelta(
             windowId: 1, contentEpoch: epoch, cursorVisible: true,
@@ -329,7 +329,7 @@ struct ConformanceTranscriptTests {
         dispatcher.dispatch(.guiWindowRowsDelta(data: retainedDelta))
         dispatcher.dispatch(.commitFrame(frameSeq: 4, seq: 0))
         #expect(gui.windowContents[1]?.rowStore.count == rowCount + 1)
-        let committedPublication = gui.framePublicationCount
+        let committedPublication = dispatcher.publicationCount
         #expect(committedPublication == keyframePublication + 3)
 
         let missing = GUIWindowRowsDelta(
@@ -352,7 +352,7 @@ struct ConformanceTranscriptTests {
         dispatcher.dispatch(.guiWindowOverlayDelta(data: staleOverlay))
         dispatcher.dispatch(.commitFrame(frameSeq: 6, seq: 0))
         let staleEpochStatus: ProductionCorpusStatus =
-            gui.framePublicationCount == committedPublication ? .staleDiscarded : .accepted
+            dispatcher.publicationCount == committedPublication ? .staleDiscarded : .accepted
 
         dispatcher.dispatch(.beginFrame(frameSeq: 7, baseFrameSeq: 4, generation: staleGeneration))
         dispatcher.dispatch(.guiWindowContent(data: try GUIWindowContent(
@@ -364,7 +364,7 @@ struct ConformanceTranscriptTests {
         )))
         dispatcher.dispatch(.commitFrame(frameSeq: 7, seq: 0))
         let staleGenerationStatus: ProductionCorpusStatus =
-            gui.framePublicationCount == committedPublication
+            dispatcher.publicationCount == committedPublication
                 && dispatcher.lastCommittedGeneration == generation ? .staleDiscarded : .accepted
 
         #expect(expectedStatus("reference_miss", operations) == referenceMissStatus)

--- a/macos/Tests/MingaTests/ContentViewTests.swift
+++ b/macos/Tests/MingaTests/ContentViewTests.swift
@@ -1,7 +1,81 @@
+import AppKit
+import Foundation
 import MingaProtocol
 @testable import MingaUI
 import SwiftUI
 import Testing
+
+@MainActor
+private final class MountedEditorRecorder {
+    weak var view: MountedEditorNSView?
+
+    private let updates: AsyncStream<Void>
+    private let updateContinuation: AsyncStream<Void>.Continuation
+
+    init() {
+        let updateStream = AsyncStream.makeStream(of: Void.self, bufferingPolicy: .bufferingNewest(1))
+        updates = updateStream.stream
+        updateContinuation = updateStream.continuation
+    }
+
+    func record(_ view: MountedEditorNSView) {
+        self.view = view
+        updateContinuation.yield()
+    }
+
+    func waitForPublishedValue(_ value: String) async {
+        if view?.publishedValue == value {
+            return
+        }
+
+        for await _ in updates where view?.publishedValue == value {
+            return
+        }
+    }
+}
+
+@MainActor
+private final class MountedEditorNSView: NSView {
+    var publishedValue = ""
+    var swiftUILocalState = UUID()
+    var editorLocalState = ""
+
+    override var acceptsFirstResponder: Bool { true }
+}
+
+private struct MountedEditorRepresentable: NSViewRepresentable {
+    let publishedValue: String
+    let swiftUILocalState: UUID
+    let recorder: MountedEditorRecorder
+
+    func makeNSView(context: Context) -> MountedEditorNSView {
+        let view = MountedEditorNSView(frame: .zero)
+        view.publishedValue = publishedValue
+        view.swiftUILocalState = swiftUILocalState
+        recorder.record(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: MountedEditorNSView, context: Context) {
+        nsView.publishedValue = publishedValue
+        nsView.swiftUILocalState = swiftUILocalState
+        recorder.record(nsView)
+    }
+}
+
+private struct MountedEditorSurface: View {
+    let publishedValue: String
+    let recorder: MountedEditorRecorder
+    @State private var localState = UUID()
+
+    var body: some View {
+        MountedEditorRepresentable(
+            publishedValue: publishedValue,
+            swiftUILocalState: localState,
+            recorder: recorder
+        )
+    }
+}
 
 @Suite("Content view")
 @MainActor
@@ -25,5 +99,58 @@ struct ContentViewTests {
         #expect(view.encoder === first)
         current = second
         #expect(view.encoder === second)
+    }
+
+    @Test(
+        "focused publication updates the mounted editor without replacing native or local identity",
+        .timeLimit(.minutes(1))
+    )
+    func focusedMountedPublicationPreservesEditorIdentity() async throws {
+        let gui = GUIState()
+        gui.statusBarState.message = "before"
+        let recorder = MountedEditorRecorder()
+        let root = ContentView(
+            gui: gui,
+            encoder: { nil },
+            editorGeometry: { .preview },
+            chrome: .preview,
+            onAgentChatVisibleChange: { _ in }
+        ) {
+            MountedEditorSurface(
+                publishedValue: gui.statusBarState.message,
+                recorder: recorder
+            )
+        }
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let hostingView = NSHostingView(rootView: root)
+        hostingView.frame = frame
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
+        defer { window.contentView = nil }
+        hostingView.layoutSubtreeIfNeeded()
+
+        let editorView = try #require(recorder.view)
+        let localState = editorView.swiftUILocalState
+        editorView.editorLocalState = "selected editor range"
+        #expect(editorView.publishedValue == "before")
+        #expect(window.makeFirstResponder(editorView))
+
+        gui.frameStore.publishLocal(impact: .editor) {
+            gui.statusBarState.message = "after"
+        }
+        await recorder.waitForPublishedValue("after")
+        hostingView.layoutSubtreeIfNeeded()
+
+        let updatedEditorView = try #require(recorder.view)
+        #expect(updatedEditorView === editorView)
+        #expect(updatedEditorView.publishedValue == "after")
+        #expect(updatedEditorView.swiftUILocalState == localState)
+        #expect(updatedEditorView.editorLocalState == "selected editor range")
+        #expect(window.firstResponder === editorView)
     }
 }

--- a/macos/Tests/MingaTests/GUIFrameStoreTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameStoreTests.swift
@@ -1,0 +1,292 @@
+import MingaProtocol
+@testable import MingaUI
+import Observation
+import Synchronization
+import Testing
+
+@Suite("GUI frame publication domains")
+struct GUIFrameStoreTests {
+    @Test("mutation and complete bundle precede channels in fixed order")
+    @MainActor func publicationOrdering() {
+        let store = GUIFrameStore()
+        var backingValue = 0
+        var events: [GUIFrameStore.PublicationEvent] = []
+        var everyChannelSawFreshState = true
+
+        store.onPublicationEvent = { event in
+            events.append(event)
+            if case .channel = event {
+                everyChannelSawFreshState = everyChannelSawFreshState
+                    && backingValue == 42
+                    && store.installed.shell.lastCommitted?.frameSeq == 9
+                    && store.installed.editor.lastCommitted?.frameSeq == 9
+                    && store.installed.editorOverlay.lastCommitted?.frameSeq == 9
+                    && store.installed.windowOverlay.lastCommitted?.frameSeq == 9
+            }
+        }
+
+        store.publishCommitted(generation: 3, frameSeq: 9, impact: .all) {
+            backingValue = 42
+        }
+
+        #expect(events == [
+            .mutated,
+            .installed,
+            .channel(.shell),
+            .channel(.editor),
+            .channel(.editorOverlay),
+            .channel(.windowOverlay)
+        ])
+        #expect(everyChannelSawFreshState)
+        #expect(store.shell.value.revision == 1)
+        #expect(store.editor.value.revision == 1)
+        #expect(store.editorOverlay.value.revision == 1)
+        #expect(store.windowOverlay.value.revision == 1)
+    }
+
+    @Test("focused publication leaves unrelated observable channels silent")
+    @MainActor func unaffectedChannelsStaySilent() {
+        let store = GUIFrameStore()
+        let shellChanges = Mutex(0)
+        let editorChanges = Mutex(0)
+        let editorOverlayChanges = Mutex(0)
+        let windowOverlayChanges = Mutex(0)
+
+        withObservationTracking { _ = store.shell.value } onChange: { shellChanges.withLock { $0 += 1 } }
+        withObservationTracking { _ = store.editor.value } onChange: { editorChanges.withLock { $0 += 1 } }
+        withObservationTracking { _ = store.editorOverlay.value } onChange: { editorOverlayChanges.withLock { $0 += 1 } }
+        withObservationTracking { _ = store.windowOverlay.value } onChange: { windowOverlayChanges.withLock { $0 += 1 } }
+
+        store.publishCommitted(generation: 1, frameSeq: 1, impact: .editorOverlay) {}
+
+        #expect(shellChanges.withLock { $0 } == 0)
+        #expect(editorChanges.withLock { $0 } == 0)
+        #expect(editorOverlayChanges.withLock { $0 } == 1)
+        #expect(windowOverlayChanges.withLock { $0 } == 0)
+        #expect(store.installed.shell.lastCommitted?.frameSeq == 1)
+        #expect(store.installed.editor.lastCommitted?.frameSeq == 1)
+        #expect(store.installed.editorOverlay.lastCommitted?.frameSeq == 1)
+        #expect(store.installed.windowOverlay.lastCommitted?.frameSeq == 1)
+        #expect(store.shell.value.lastCommitted == nil)
+        #expect(store.editor.value.lastCommitted == nil)
+        #expect(store.editorOverlay.value.lastCommitted?.frameSeq == 1)
+        #expect(store.windowOverlay.value.lastCommitted == nil)
+    }
+
+    @Test("impact-free valid commit installs identity without notifying channels")
+    @MainActor func impactFreeCommit() {
+        let store = GUIFrameStore()
+        let channelValues = [
+            store.shell.value,
+            store.editor.value,
+            store.editorOverlay.value,
+            store.windowOverlay.value
+        ]
+        var events: [GUIFrameStore.PublicationEvent] = []
+        store.onPublicationEvent = { events.append($0) }
+
+        store.publishCommitted(generation: 2, frameSeq: 7, impact: []) {}
+
+        #expect(events == [.mutated, .installed])
+        #expect(store.installed.shell.lastCommitted?.frameSeq == 7)
+        #expect(store.installed.editor.lastCommitted?.frameSeq == 7)
+        #expect(store.installed.editorOverlay.lastCommitted?.frameSeq == 7)
+        #expect(store.installed.windowOverlay.lastCommitted?.frameSeq == 7)
+        #expect(store.shell.value == channelValues[0])
+        #expect(store.editor.value == channelValues[1])
+        #expect(store.editorOverlay.value == channelValues[2])
+        #expect(store.windowOverlay.value == channelValues[3])
+    }
+
+    @Test("local publication preserves committed identity and false preview stays silent")
+    @MainActor func localPublication() {
+        let store = GUIFrameStore()
+        store.publishCommitted(generation: 4, frameSeq: 12, impact: .shell) {}
+        let shell = store.shell.value
+        var events: [GUIFrameStore.PublicationEvent] = []
+        store.onPublicationEvent = { events.append($0) }
+
+        store.publishLocal(impact: .editorOverlay) {}
+
+        #expect(store.editorOverlay.value.source == .local)
+        #expect(store.editorOverlay.value.lastCommitted?.frameSeq == 12)
+        #expect(store.shell.value == shell)
+        #expect(events == [.mutated, .installed, .channel(.editorOverlay)])
+
+        events.removeAll()
+        let changed = store.publishLocalIfChanged(impact: .windowOverlay) { false }
+        #expect(!changed)
+        #expect(events.isEmpty)
+    }
+
+    @Test("shell and overlay publication preserve 65,536-row resident storage")
+    @MainActor func focusedPublicationPreservesResidentStorage() throws {
+        var rows: [GUIVisualRow] = []
+        rows.reserveCapacity(65_536)
+        for index in 0..<65_536 {
+            let identity = UInt64(index + 1)
+            let text = String(index)
+            rows.append(GUIVisualRow(
+                rowType: .normal,
+                rowId: identity,
+                bufLine: UInt32(index),
+                contentHash: UInt32(index + 1),
+                text: text,
+                spans: []
+            ))
+        }
+        let content = try GUIWindowContent(
+            windowId: 1,
+            fullRefresh: true,
+            cursorRow: 0,
+            cursorCol: 0,
+            cursorShape: .block,
+            rows: rows,
+            selection: nil,
+            searchMatches: [],
+            diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+        let gui = GUIState(windowContents: [1: content])
+        guard let original = gui.editorInput.windowContent(for: 1)?.rowStore else {
+            Issue.record("resident window content missing before publication")
+            return
+        }
+
+        gui.frameStore.publishLocal(impact: GUIFrameImpact.shell) {}
+        guard let afterShell = gui.editorInput.windowContent(for: 1)?.rowStore else {
+            Issue.record("resident window content missing after shell publication")
+            return
+        }
+        #expect(afterShell.sharesStorage(with: original))
+
+        gui.frameStore.publishLocal(impact: GUIFrameImpact.editorOverlay) {}
+        guard let afterOverlay = gui.editorInput.windowContent(for: 1)?.rowStore else {
+            Issue.record("resident window content missing after overlay publication")
+            return
+        }
+        #expect(afterOverlay.sharesStorage(with: original))
+    }
+
+    @Test("semantic impact maps focused and implicit cross-region commands")
+    func semanticImpact() throws {
+        let content = try GUIWindowContent(
+            windowId: 1,
+            fullRefresh: true,
+            cursorRow: 0,
+            cursorCol: 0,
+            cursorShape: .block,
+            rows: [],
+            selection: nil,
+            searchMatches: [],
+            diagnosticUnderlines: [],
+            documentHighlights: []
+        )
+        let cases: [(String, RenderCommand, GUIFrameImpact)] = [
+            ("theme", .guiTheme(slots: []), .all),
+            ("resident rows and geometry", .guiWindowContent(data: content), [.editor, .editorOverlay]),
+            ("line spacing", .guiLineSpacing(spacing: 1.2), [.editor, .editorOverlay]),
+            ("completion", .guiCompletion(visible: false, anchorRow: 0, anchorCol: 0, selectedIndex: 0, items: [], documentation: ""), .editorOverlay),
+            ("hover", .guiHoverPopup(visible: false, anchorRow: 0, anchorCol: 0, focused: false, scrollOffset: 0, lines: []), .editorOverlay),
+            ("sidebar", .guiFileTree(version: 1, treeFlags: 0, treeState: 0, selectedId: "", treeWidth: 0, rootPath: "", errorReason: "", entries: []), .shell),
+            ("status", .guiStatusBar(status()), [.shell, .editor]),
+            ("bottom panel inset", .guiBottomPanel(visible: false, activeTabIndex: 0, heightPercent: 0, filterPreset: 0, tabs: [], entries: []), [.shell, .windowOverlay]),
+            ("extension panels", .guiExtensionPanel([]), [.shell, .windowOverlay]),
+            ("resync overlay", .protocolError(message: "mismatch"), .windowOverlay),
+            ("frame marker", .beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1), []),
+            ("window callback", .setWindowBg(r: 0, g: 0, b: 0), [])
+        ]
+
+        for (name, command, expected) in cases {
+            #expect(GUIFrameImpact.impact(for: command) == expected, Comment(rawValue: name))
+        }
+    }
+
+    private func status() -> StatusBarUpdate {
+        StatusBarUpdate(
+            contentKind: 0,
+            mode: 0,
+            cursorLine: 1,
+            cursorCol: 1,
+            lineCount: 1,
+            flags: 0,
+            lspStatus: 0,
+            gitBranch: "",
+            message: "",
+            filetype: "",
+            errorCount: 0,
+            warningCount: 0,
+            modelName: "",
+            messageCount: 0,
+            sessionStatus: 0,
+            infoCount: 0,
+            hintCount: 0,
+            macroRecording: 0,
+            parserStatus: 0,
+            agentStatus: 0,
+            gitAdded: 0,
+            gitModified: 0,
+            gitDeleted: 0,
+            icon: "",
+            iconColorR: 0,
+            iconColorG: 0,
+            iconColorB: 0,
+            filename: "",
+            diagnosticHint: "",
+            backgroundSubagentCount: 0,
+            backgroundSubagentLabel: ""
+        )
+    }
+}
+
+@Suite("GUI frame presentation metrics")
+struct GUIFramePresentationMetricsTests {
+    @Test("successful native draw and Metal milestones keep committed frame identity")
+    @MainActor func successfulOutcomes() {
+        let metrics = GUIFramePresentationMetrics()
+        let frame = GUICommittedFrame(generation: 2, frameSeq: 8)
+        let version = GUIFrameVersion(revision: 1, lastCommitted: frame, source: .committed)
+
+        metrics.beginCommitted(frame: frame, impact: .all)
+        #expect(metrics.snapshot().isEmpty)
+
+        metrics.recordNativeDraw(domain: .shell, version: version)
+        metrics.recordNativeDraw(domain: .editorOverlay, version: version)
+        metrics.recordNativeDraw(domain: .windowOverlay, version: version)
+        metrics.recordMetalSubmission(frameSeq: 7)
+        #expect(metrics.snapshot().count == 3)
+
+        metrics.recordMetalSubmission(frameSeq: 8)
+        metrics.recordMetalPresented(frameSeq: 8)
+
+        #expect(metrics.snapshot() == [
+            .init(frame: frame, domain: .shell, outcome: .nativeDraw),
+            .init(frame: frame, domain: .editorOverlay, outcome: .nativeDraw),
+            .init(frame: frame, domain: .windowOverlay, outcome: .nativeDraw),
+            .init(frame: frame, domain: .editor, outcome: .submitted),
+            .init(frame: frame, domain: .editor, outcome: .presented)
+        ])
+    }
+
+    @Test("superseded hidden unavailable and failed samples remain distinct")
+    @MainActor func discardedOutcomes() {
+        let metrics = GUIFramePresentationMetrics()
+        let first = GUICommittedFrame(generation: 1, frameSeq: 1)
+        let second = GUICommittedFrame(generation: 1, frameSeq: 2)
+
+        metrics.beginCommitted(frame: first, impact: .all)
+        metrics.beginCommitted(frame: second, impact: .shell)
+        metrics.discard(domain: .shell, outcome: .hidden, frameSeq: 2)
+        metrics.discard(domain: .editor, outcome: .unavailable, frameSeq: 1)
+        metrics.discard(domain: .editorOverlay, outcome: .failed, frameSeq: 1)
+        metrics.discard(domain: .windowOverlay, outcome: .superseded, frameSeq: 1)
+
+        #expect(metrics.snapshot() == [
+            .init(frame: first, domain: .shell, outcome: .superseded),
+            .init(frame: second, domain: .shell, outcome: .hidden),
+            .init(frame: first, domain: .editor, outcome: .unavailable),
+            .init(frame: first, domain: .editorOverlay, outcome: .failed),
+            .init(frame: first, domain: .windowOverlay, outcome: .superseded)
+        ])
+    }
+}

--- a/macos/Tests/MingaTests/GUIFrameStoreTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameStoreTests.swift
@@ -98,24 +98,51 @@ struct GUIFrameStoreTests {
         #expect(store.windowOverlay.value == channelValues[3])
     }
 
-    @Test("local publication preserves committed identity and false preview stays silent")
-    @MainActor func localPublication() {
+    @Test("local publication preserves each affected domain's published committed identity")
+    @MainActor func localPublicationPreservesDivergentDomains() {
         let store = GUIFrameStore()
         store.publishCommitted(generation: 4, frameSeq: 12, impact: .shell) {}
-        let shell = store.shell.value
+        store.publishCommitted(generation: 4, frameSeq: 13, impact: .editorOverlay) {}
+        #expect(store.shell.value.lastCommitted?.frameSeq == 12)
+        #expect(store.editorOverlay.value.lastCommitted?.frameSeq == 13)
+        #expect(store.installed.shell.lastCommitted?.frameSeq == 13)
+
         var events: [GUIFrameStore.PublicationEvent] = []
         store.onPublicationEvent = { events.append($0) }
+        store.publishLocal(impact: [.shell, .editorOverlay]) {}
 
-        store.publishLocal(impact: .editorOverlay) {}
-
+        #expect(store.shell.value.source == .local)
+        #expect(store.shell.value.lastCommitted?.frameSeq == 12)
         #expect(store.editorOverlay.value.source == .local)
-        #expect(store.editorOverlay.value.lastCommitted?.frameSeq == 12)
-        #expect(store.shell.value == shell)
-        #expect(events == [.mutated, .installed, .channel(.editorOverlay)])
+        #expect(store.editorOverlay.value.lastCommitted?.frameSeq == 13)
+        #expect(events == [
+            .mutated,
+            .installed,
+            .channel(.shell),
+            .channel(.editorOverlay)
+        ])
+    }
 
-        events.removeAll()
-        let changed = store.publishLocalIfChanged(impact: .windowOverlay) { false }
-        #expect(!changed)
+    @Test("changed local publication preserves divergent domains and rejected preview stays silent")
+    @MainActor func changedLocalPublicationPreservesDivergentDomains() {
+        let store = GUIFrameStore()
+        store.publishCommitted(generation: 5, frameSeq: 20, impact: .editor) {}
+        store.publishCommitted(generation: 5, frameSeq: 21, impact: .windowOverlay) {}
+        #expect(store.editor.value.lastCommitted?.frameSeq == 20)
+        #expect(store.windowOverlay.value.lastCommitted?.frameSeq == 21)
+        #expect(store.installed.editor.lastCommitted?.frameSeq == 21)
+
+        let changed = store.publishLocalIfChanged(impact: [.editor, .windowOverlay]) { true }
+        #expect(changed)
+        #expect(store.editor.value.source == .local)
+        #expect(store.editor.value.lastCommitted?.frameSeq == 20)
+        #expect(store.windowOverlay.value.source == .local)
+        #expect(store.windowOverlay.value.lastCommitted?.frameSeq == 21)
+
+        var events: [GUIFrameStore.PublicationEvent] = []
+        store.onPublicationEvent = { events.append($0) }
+        let rejected = store.publishLocalIfChanged(impact: .windowOverlay) { false }
+        #expect(!rejected)
         #expect(events.isEmpty)
     }
 
@@ -241,6 +268,36 @@ struct GUIFrameStoreTests {
 
 @Suite("GUI frame presentation metrics")
 struct GUIFramePresentationMetricsTests {
+    @Test("local publication keeps divergent native-draw correlation")
+    @MainActor func localPublicationNativeDrawCorrelation() {
+        let store = GUIFrameStore()
+        let metrics = GUIFramePresentationMetrics()
+        let shellFrame = GUICommittedFrame(generation: 7, frameSeq: 30)
+        let overlayFrame = GUICommittedFrame(generation: 7, frameSeq: 31)
+
+        store.publishCommitted(
+            generation: shellFrame.generation,
+            frameSeq: shellFrame.frameSeq,
+            impact: .shell
+        ) {}
+        metrics.beginCommitted(frame: shellFrame, impact: .shell)
+        store.publishCommitted(
+            generation: overlayFrame.generation,
+            frameSeq: overlayFrame.frameSeq,
+            impact: .editorOverlay
+        ) {}
+        metrics.beginCommitted(frame: overlayFrame, impact: .editorOverlay)
+
+        store.publishLocal(impact: [.shell, .editorOverlay]) {}
+        metrics.recordNativeDraw(domain: .shell, version: store.shell.value)
+        metrics.recordNativeDraw(domain: .editorOverlay, version: store.editorOverlay.value)
+
+        #expect(metrics.snapshot() == [
+            .init(frame: shellFrame, domain: .shell, outcome: .nativeDraw),
+            .init(frame: overlayFrame, domain: .editorOverlay, outcome: .nativeDraw)
+        ])
+    }
+
     @Test("successful native draw and Metal milestones keep committed frame identity")
     @MainActor func successfulOutcomes() {
         let metrics = GUIFramePresentationMetrics()

--- a/macos/Tests/MingaTests/LiveResizeDebounceTests.swift
+++ b/macos/Tests/MingaTests/LiveResizeDebounceTests.swift
@@ -234,7 +234,7 @@ struct LiveResizeWiringTests {
         ctRenderer.setupRenderers(fontManager: fm)
         let view = EditorNSView(encoder: spy, fontFace: face, dispatcher: disp,
                                 coreTextRenderer: ctRenderer, fontManager: fm)
-        view.guiState = guiState
+        view.editorInput = guiState.editorInput
         view.frame = NSRect(x: 0, y: 0,
                             width: CGFloat(face.cellWidth) * 80,
                             height: CGFloat(face.cellHeight) * 24)

--- a/macos/Tests/MingaTests/MouseInputTests.swift
+++ b/macos/Tests/MingaTests/MouseInputTests.swift
@@ -30,7 +30,7 @@ struct MouseInputTests {
         ctRenderer.setupRenderers(fontManager: fm)
         let view = EditorNSView(encoder: spy, fontFace: face, dispatcher: disp,
                                 coreTextRenderer: ctRenderer, fontManager: fm)
-        view.guiState = guiState
+        view.editorInput = guiState.editorInput
         // Give the view a real frame so cellPosition math works.
         // Without a window, convert(_:from:) returns the point unchanged,
         // so locationInWindow IS the local point.
@@ -75,14 +75,14 @@ struct MouseInputTests {
             ]
         )
 
-        view.guiState?.windowContents[1] = try GUIWindowContent(
+        view.dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
             searchMatches: [], diagnosticUnderlines: [],
             documentHighlights: [],
             paneGeometry: geometry
-        )
+        )))
     }
 
     /// Creates a mouse event at the given pixel position.
@@ -354,7 +354,7 @@ struct MouseInputTests {
         )
         view.dispatcher.applyForTesting(.guiGutter(data: activeGutter))
         view.dispatcher.applyForTesting(.guiGutter(data: inactiveGutter))
-        view.guiState?.windowContents[7] = try GUIWindowContent(
+        view.dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
@@ -365,7 +365,7 @@ struct MouseInputTests {
                 visibleStartLine: 42, visibleEndLine: 43, overscanStartLine: 41, overscanEndLine: 43,
                 contentEpoch: 1, layoutGeneration: 1
             )
-        )
+        )))
 
         guard let event = mouseEvent(type: .leftMouseDown,
                                      location: NSPoint(x: cw * 22.2, y: ch * 0.5)) else { return }
@@ -404,7 +404,7 @@ struct MouseInputTests {
         )
 
         view.dispatcher.applyForTesting(.guiGutter(data: gutter))
-        view.guiState?.windowContents[7] = try GUIWindowContent(
+        view.dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
             windowId: 7, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [
@@ -419,7 +419,7 @@ struct MouseInputTests {
                 visibleStartLine: 10, visibleEndLine: 12, overscanStartLine: 10, overscanEndLine: 12,
                 contentEpoch: 1, layoutGeneration: 1
             )
-        )
+        )))
 
         guard let event = mouseEvent(type: .leftMouseDown,
                                      location: NSPoint(x: cw * 6.2, y: ch * 0.5)) else { return }

--- a/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
+++ b/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
@@ -1,6 +1,7 @@
 import CoreText
 import Metal
 import MingaProtocol
+@testable import MingaUI
 import QuartzCore
 import Testing
 
@@ -671,10 +672,14 @@ struct NativeRenderResourcesTests {
         typealias Completion = @MainActor @Sendable (Bool, Int) -> Void
         var completions: [Completion] = []
         var presentCalls = 0
+        let metrics = GUIFramePresentationMetrics()
+        let committedFrame = GUICommittedFrame(generation: 3, frameSeq: 42)
+        metrics.beginCommitted(frame: committedFrame, impact: .editor)
         var factories = nativeTestFactories()
         factories.observeCompletion = { _, completion in completions.append(completion) }
         factories.present = { _ in presentCalls += 1 }
         guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        renderer.presentationMetrics = metrics
         let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
         renderer.setupRenderers(fontManager: fontManager)
         let before = renderer.activeResourceSnapshot()
@@ -683,19 +688,27 @@ struct NativeRenderResourcesTests {
             frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
             drawableProvider: { NativeTestDrawable(texture: texture) },
             viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
-            presentationInputSeq: 302
+            presentationInputSeq: 302, presentationFrameSeq: 42
         )
         #expect(completions.count == 1)
         #expect(presentCalls == 0)
+        #expect(metrics.snapshot().isEmpty)
         #expect(renderer.activeResourceSnapshot() == before)
 
         completions[0](true, Int(MTLCommandBufferStatus.completed.rawValue))
         #expect(completions.count == 2)
         #expect(presentCalls == 0)
+        #expect(metrics.snapshot() == [
+            .init(frame: committedFrame, domain: .editor, outcome: .submitted)
+        ])
         #expect(renderer.activeResourceSnapshot() == before)
 
         completions[1](true, Int(MTLCommandBufferStatus.completed.rawValue))
         #expect(presentCalls == 1)
+        #expect(metrics.snapshot() == [
+            .init(frame: committedFrame, domain: .editor, outcome: .submitted),
+            .init(frame: committedFrame, domain: .editor, outcome: .presented)
+        ])
         #expect(renderer.lastCompletedPresentationGeneration == 1)
         #expect(renderer.activeResourceSnapshot() != before)
     }

--- a/macos/Tests/MingaTests/ResidentRowStoreTests.swift
+++ b/macos/Tests/MingaTests/ResidentRowStoreTests.swift
@@ -230,6 +230,7 @@ struct ResidentRowStoreTests {
     func batchReplacementCopyOnWriteAndCounters() throws {
         let committed = try ResidentRowStore(rows: rows(0..<65_536))
         var staged = committed
+        #expect(staged.sharesStorage(with: committed))
         let before = staged.counters
         let replacement = row(32_769, bufferLine: 32_768, text: "edited", hash: 900_001)
 
@@ -241,6 +242,7 @@ struct ResidentRowStoreTests {
 
         #expect(committed.row(at: 32_768)?.text == "row 32769")
         #expect(staged.row(at: 32_768) == replacement)
+        #expect(!staged.sharesStorage(with: committed))
         let work = staged.counters - before
         #expect(work.rowsVisited == 2)
         #expect(work.chunksTouched == 1)

--- a/macos/Tests/MingaTests/SidebarViewTests.swift
+++ b/macos/Tests/MingaTests/SidebarViewTests.swift
@@ -31,7 +31,7 @@ struct ActivityBarViewTests {
     @MainActor func rendersPanelIcons() throws {
         let guiState = GUIState()
         guiState.sidebarHostState.update(activeId: "file_tree", sidebars: sidebarMetadata())
-        let sut = ActivityBar(guiState: guiState, sidebarHostState: guiState.sidebarHostState, encoder: nil)
+        let sut = ActivityBar(input: guiState.shellInput, sidebarHostState: guiState.sidebarHostState, encoder: nil)
             .environment(\.themeColors, ThemeColors())
         let body = try sut.inspect()
         let buttons = body.findAll(ViewType.Button.self)
@@ -44,7 +44,7 @@ struct ActivityBarViewTests {
         let guiState = GUIState()
         guiState.sidebarHostState.update(activeId: "file_tree", sidebars: sidebarMetadata())
         let spy = SpyEncoder()
-        let sut = ActivityBar(guiState: guiState, sidebarHostState: guiState.sidebarHostState, encoder: spy)
+        let sut = ActivityBar(input: guiState.shellInput, sidebarHostState: guiState.sidebarHostState, encoder: spy)
             .environment(\.themeColors, ThemeColors())
         let body = try sut.inspect()
         let buttons = body.findAll(ViewType.Button.self)
@@ -67,7 +67,7 @@ struct ActivityBarViewTests {
             GitStatusEntry(pathHash: UInt32(index), section: .changed, status: .modified, path: "file_\(index).ex")
         }
         guiState.sidebarHostState.update(activeId: "git_status", sidebars: sidebarMetadata())
-        let sut = ActivityBar(guiState: guiState, sidebarHostState: guiState.sidebarHostState, encoder: nil)
+        let sut = ActivityBar(input: guiState.shellInput, sidebarHostState: guiState.sidebarHostState, encoder: nil)
             .environment(\.themeColors, ThemeColors())
         let body = try sut.inspect()
         let strings = body.findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
@@ -79,7 +79,7 @@ struct ActivityBarViewTests {
     @MainActor func gitBadgeAndLabels() throws {
         let guiState = GUIState()
         guiState.sidebarHostState.update(activeId: "git_status", sidebars: sidebarMetadata(gitBadgeCount: 7))
-        let sut = ActivityBar(guiState: guiState, sidebarHostState: guiState.sidebarHostState, encoder: nil)
+        let sut = ActivityBar(input: guiState.shellInput, sidebarHostState: guiState.sidebarHostState, encoder: nil)
             .environment(\.themeColors, ThemeColors())
         let body = try sut.inspect()
         let buttons = body.findAll(ViewType.Button.self)
@@ -128,7 +128,7 @@ struct SidebarContainerViewTests {
         let item = Wire.SidebarMetadata(id: "custom", displayName: "Custom Tools", semanticKind: "custom_sidebar", icon: "sparkles", order: 40, visible: true, focused: true, preferredWidth: 30, badgeCount: nil)
         guiState.sidebarHostState.update(activeId: "custom", sidebars: [item])
         let active = try #require(guiState.sidebarHostState.activeSidebar)
-        let sut = SidebarContainer(guiState: guiState, activeSidebar: active, encoder: nil, projectName: "minga", gitBranch: "main", leadingPadding: 10, sidebarWidth: .constant(240))
+        let sut = SidebarContainer(input: guiState.shellInput, activeSidebar: active, encoder: nil, projectName: "minga", gitBranch: "main", leadingPadding: 10, sidebarWidth: .constant(240))
             .environment(\.themeColors, ThemeColors())
         let strings = try sut.inspect().findAll(ViewInspectorQuery.text).compactMap { try? $0.string() }
 

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -72,6 +72,10 @@ targets:
         type: file
       - path: Sources/Views/Shared/EditorGeometry.swift
         type: file
+      - path: Sources/Views/Shared/GUIFramePresentationMetrics.swift
+        type: file
+      - path: Sources/Views/Shared/GUIFrameStore.swift
+        type: file
       - path: Sources/Views/Shared/GUIState.swift
         type: file
       - path: Sources/Views/Shared/SparklineView.swift
@@ -142,6 +146,8 @@ targets:
           - "Views/Sidebar/**"
           - "Views/Shared/EditTimelineState.swift"
           - "Views/Shared/EditTimelineView.swift"
+          - "Views/Shared/GUIFramePresentationMetrics.swift"
+          - "Views/Shared/GUIFrameStore.swift"
           - "Views/Shared/GUIState.swift"
           - "Views/Shared/SparklineView.swift"
           - "Views/Shared/TextHighlighting.swift"
@@ -263,6 +269,8 @@ targets:
           - "Views/Sidebar/**"
           - "Views/Shared/EditTimelineState.swift"
           - "Views/Shared/EditTimelineView.swift"
+          - "Views/Shared/GUIFramePresentationMetrics.swift"
+          - "Views/Shared/GUIFrameStore.swift"
           - "Views/Shared/GUIState.swift"
           - "Views/Shared/SparklineView.swift"
           - "Views/Shared/TextHighlighting.swift"
@@ -339,6 +347,8 @@ targets:
           - "Views/Sidebar/**"
           - "Views/Shared/EditTimelineState.swift"
           - "Views/Shared/EditTimelineView.swift"
+          - "Views/Shared/GUIFramePresentationMetrics.swift"
+          - "Views/Shared/GUIFrameStore.swift"
           - "Views/Shared/GUIState.swift"
           - "Views/Shared/SparklineView.swift"
           - "Views/Shared/TextHighlighting.swift"


### PR DESCRIPTION
# TL;DR
SwiftUI frame publication is now partitioned into shell, editor, editor-overlay, and window-overlay domains, so focused updates no longer invalidate unrelated native view trees. The change preserves atomic frame publication, resident row storage, Metal view identity, and owner-local interaction state while adding commit-to-native-presentation telemetry.

Closes #2748

## Context
The prepared-frame transaction boundary already guaranteed that protocol-backed state changed atomically, but `ContentView` observed aggregate publication tokens that reevaluated the entire shell after every committed or local update. This PR keeps `GUIState` as the main-actor owner and publishes immutable version channels instead of copying domain data into a second state model.

## Changes
- Add `GUIFrameStore` with immutable installed version bundles and four privately advanced observable channels in fixed publication order.
- Classify every `RenderCommand` through a compiler-exhaustive semantic impact switch, including conservative multi-domain and implicit transaction effects.
- Introduce domain-scoped host inputs and stable host boundaries without exposing unrestricted `GUIState` or changing the structural identity of the Metal editor surface.
- Remove aggregate frame and out-of-band publication tokens and migrate local previews, recovery, sidebar, overlays, and editor rendering to focused channels.
- Add release signposts that correlate committed frame identity and domain impact with AppKit draw, Metal presentation submission, presentation success, and typed discard outcomes.
- Add deterministic coverage for publication ordering, fresh backing visibility, unaffected-channel silence, local and rejected updates, impact mapping, 65,536-row storage sharing, and two-stage Metal submission ordering.

## Verification
- `mix swift.build`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO test`
- `xcodebuild build -project macos/Minga.xcodeproj -scheme Minga -configuration Release -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO`
- `scripts/check_render_performance`, combined p95 0.131 ms for the 65,536-row fixture
- `make lint`
- `mix test.llm`, 9,218 tests and 0 failures

## Acceptance Criteria Addressed
- Four-domain committed and local publication with atomic version installation and rejected-frame silence ✅
- Exhaustive semantic impact classification, including implicit cross-region effects ✅
- Stable focused hosts with explicit domain-scoped backing references ✅
- No aggregate root publication observation, while preserving Metal, resident, and local state identity ✅
- Precise focused and conservative multi-domain invalidation ✅
- Deterministic ordering, visibility, rejection, preview, and resident-sharing tests ✅
- Release commit-to-native-presentation instrumentation with typed outcomes ✅
- Compatibility aggregate publication path removed without a DTO mirror or generic presentation registry ✅
