### PR TITLE
refactor(editor): own file-tree refresh lifecycle

### DIFF
--- a/docs/adr/0002-editor-state-transitions-have-explicit-owners.md
+++ b/docs/adr/0002-editor-state-transitions-have-explicit-owners.md
@@ -1,0 +1,70 @@
+# ADR-0002: Editor state transitions have explicit behavioral owners
+
+**Status:** Accepted (2026-07-12). Epic: #2861. First implementation slice: #2862.
+
+## Decision
+
+`MingaEditor` remains the single GenServer that serializes interactive editor state. Its state is decomposed into immutable values with explicit behavioral owners, not additional processes. A transition belongs to the lowest owner that contains its complete invariant, and external work belongs to the workflow that requested it.
+
+The ownership levels are:
+
+1. **Leaf owner:** A focused value module owns its representation and every transition that can be decided from that value alone. Its public API names user or domain intent, such as `request_debounce/2`, `dismiss/1`, or `activate/2`, rather than exposing setters or generic mappers.
+2. **Aggregate owner:** An immediate parent coordinates its children through their APIs when one invariant spans those children. It may read child values, but it does not update a foreign struct directly.
+3. **Workflow owner:** A focused handler coordinates value owners with process calls, timers, supervised work, rendering, logging, persistence, or services. It may accept the root Editor state when the operation crosses top-level owners, but it still calls each owner API instead of performing deep updates.
+4. **Root owner:** `MingaEditor.State` retains only transitions whose atomic invariant genuinely spans at least two top-level owners. Root functions are not forwarding delegates for leaf or aggregate operations.
+
+## One Editor mailbox
+
+State decomposition does not create one process per substate. Ordered input, shell transitions, workspace changes, renderer feedback, and other atomic editor operations continue through one `MingaEditor` mailbox. A new process is justified only when work needs an independent failure boundary, lifecycle, or mailbox, not because a struct gained a focused owner.
+
+The Editor process creates every timer and monitor whose result returns to the Editor mailbox. This keeps message ownership and cleanup aligned. Slow resource-bound work runs under the existing generation-owned `MingaEditor.EffectScheduler` and its supervised workers, so an old Editor generation cannot deliver authority into a replacement generation.
+
+## External actions
+
+An external action is work that crosses the pure value boundary: timer or monitor creation, process calls, rendering submission, frontend communication, persistence, logging, event broadcasts, filesystem or service access, and supervised asynchronous work. Mode, status, buffer, overlay, spinner, focus, and similar state changes are ordinary transitions, not effects.
+
+Ordinary workflows return an updated value, aggregate, root state, or focused tagged result directly. Slow resource-bound workflows submit a typed `MingaEditor.Effect.Request`, receive `MingaEditor.Effect.Outcome` values, and apply them through the originating domain module. `MingaEditor.EffectScheduler` owns admission, bounded queueing, worker supervision, cancellation, and terminal delivery. It does not own domain transitions, staleness policy, rendering policy, or user feedback.
+
+## Correlation and stale results
+
+Every timer message and asynchronous result carries a token that can be compared with current semantic state. A value owner accepts a result only when the token and stable resource identity still match. Closing, replacing, or rerooting a value invalidates the old result even if the worker later completes successfully.
+
+Scheduler lifecycle state is not copied into Editor values. A domain value may remember only the semantic request whose result is currently allowed to change that domain. Queued, running, canceled, failed, and completed worker facts remain in `MingaEditor.EffectScheduler`.
+
+File-tree refresh is the first application of this rule. `MingaEditor.State.FileTree.Refresh` owns debounce and current-result correlation, `MingaEditor.State.FileTree` owns tree/root acceptance, `MingaEditor.FileTree.Freshness` owns the workflow and external ordering, and `MingaEditor.FileTree.Refresh` owns typed scan execution and outcome application. The scheduler owns the running scan and at most one coalesced follow-up.
+
+## Migration ledger
+
+The epic assigns every broad ownership area to a committed convergence slice:
+
+| Area | Destination |
+|---|---|
+| File-tree refresh correlation and workflow | #2862 |
+| Active shell identity, implementation, current state, and stash | #2863 |
+| Render scheduling and receipt correlation | #2864 |
+| Buffer activation and window focus invariants | #2865 |
+| Traditional feedback and overlay lifecycles | #2866 |
+| Traditional sidebars, agent presentation, and input state | #2867 |
+| Workflow-specific external action execution | #2868 |
+| Mechanical ownership and purity checks | #2869 |
+| Every remaining root field and public transition, including documented root-wide invariants | #2870 |
+
+The detailed field-and-transition ledger is maintained through these slices and is audited in #2870. No field or transition may remain under an unspecified future-cleanup category.
+
+## Convergence requirements
+
+A migration slice is not accepted while its old root fields, forwarding delegates, bare-map compatibility clauses, generic mappers, duplicate effect variants, or direct foreign-struct writes remain. Temporary ownership-check allowlists must be bounded to named pre-existing sites and shrink as each slice lands.
+
+The migration finishes only when `MingaEditor.State` and `MingaEditor.Shell.Traditional.State` meet the project field-count guidance, retained root transitions coordinate real top-level invariants, the universal domain effect dispatcher is gone, ownership checks run without unexplained exceptions, and architecture documentation matches the code.
+
+## Alternatives rejected
+
+- **One GenServer per substate:** This would replace cheap immutable transitions with mailbox coordination, introduce ordering races, and weaken the Editor's atomic input authority.
+- **Move existing setters into smaller modules:** Relocated setters do not own invariants. They preserve the same invalid combinations behind more files.
+- **Keep a universal root facade:** Forwarding every leaf operation through `MingaEditor.State` leaves contributors with two mutation paths and lets the root API grow without bound.
+- **Use one universal action interpreter:** Domain transitions, timers, filesystem work, rendering, persistence, and agent lifecycle do not share one ordering or failure policy. The scheduler is a bounded lifecycle service, not a domain interpreter.
+- **Store worker lifecycle in domain values:** Duplicating queued and running state creates contradictory authorities. The scheduler already owns those facts.
+
+## Consequences
+
+Contributors must locate the behavioral owner before adding a field or transition. Pure owner tests can prove invariants without processes, while workflow tests focus on ordering, correlation, and failure handling. Some root workflows remain intentionally broad when atomicity spans top-level owners, but each retained operation must document that invariant instead of acting as a compatibility delegate.

--- a/lib/minga/project/file_tree.ex
+++ b/lib/minga/project/file_tree.ex
@@ -369,6 +369,10 @@ defmodule Minga.Project.FileTree do
     }
   end
 
+  @doc "Starts filtering without invalidating the currently visible unfiltered entries."
+  @spec begin_filter(t()) :: t()
+  def begin_filter(%__MODULE__{} = tree), do: %{tree | filter: ""}
+
   @doc "Sets the active substring filter and resets selection to the first match."
   @spec set_filter(t(), String.t()) :: t()
   def set_filter(%__MODULE__{} = tree, filter) when is_binary(filter) do

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -724,25 +724,9 @@ defmodule MingaEditor do
     {:noreply, RenderHandler.handle_debounced_render(state)}
   end
 
-  # Debounced file-tree refresh timer fired — spawn an off-process rescan (#2632)
-  # so the recursive filesystem walk never blocks the Editor mailbox.
-  def handle_info(:file_tree_refresh_timer, state) do
-    {state, effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
-    {:noreply, EffectHandler.apply_effects(state, effects)}
-  end
-
-  # Async file-tree rescan finished — apply the refreshed tree with a cheap,
-  # atomic whole-tree swap, discarding it if the tree was re-rooted or closed.
-  def handle_info({:file_tree_refresh_result, _refreshed_tree, _token} = msg, state) do
-    {state, effects} = FileEventHandler.handle(state, msg)
-    {:noreply, EffectHandler.apply_effects(state, effects)}
-  end
-
-  # Async file-tree rescan crashed — clear in-flight tracking and honour a
-  # coalesced refresh so the refresh loop never wedges (#2632).
-  def handle_info({:file_tree_refresh_failed, _token} = msg, state) do
-    {state, effects} = FileEventHandler.handle(state, msg)
-    {:noreply, EffectHandler.apply_effects(state, effects)}
+  # Correlated file-tree debounce timers enter the domain workflow directly.
+  def handle_info({:file_tree_refresh_timer, token}, state) when is_reference(token) do
+    {:noreply, MingaEditor.FileTree.Freshness.begin_refresh(state, token)}
   end
 
   # Renderer.Server writeback after each async frame completes.
@@ -967,8 +951,8 @@ defmodule MingaEditor do
   # Slow-effect lifecycle and terminal candidates dispatch through the typed
   # request's domain handler. The Editor has no resource- or lane-specific switch.
   def handle_info({:effect_lifecycle, %Outcome{} = outcome}, state) do
-    {new_state, _outcome} = apply_effect_outcome(state, outcome)
-    {:noreply, Renderer.render_or_async(new_state)}
+    {new_state, final_outcome} = apply_effect_outcome(state, outcome)
+    {:noreply, maybe_render_effect_outcome(new_state, final_outcome)}
   end
 
   def handle_info({:effect_result, scheduler, %Outcome{} = outcome}, state) do
@@ -976,7 +960,7 @@ defmodule MingaEditor do
       :ok ->
         {new_state, final_outcome} = apply_effect_outcome(state, outcome)
         EffectScheduler.finalize(scheduler, final_outcome)
-        {:noreply, Renderer.render_or_async(new_state)}
+        {:noreply, maybe_render_effect_outcome(new_state, final_outcome)}
 
       {:error, :not_pending} ->
         {:noreply, state}
@@ -990,6 +974,11 @@ defmodule MingaEditor do
   @spec apply_effect_outcome(state(), Outcome.t()) :: {state(), Outcome.t()}
   defp apply_effect_outcome(state, %Outcome{request: %Request{handler: handler}} = outcome) do
     handler.apply(state, outcome)
+  end
+
+  @spec maybe_render_effect_outcome(state(), Outcome.t()) :: state()
+  defp maybe_render_effect_outcome(state, %Outcome{request: %Request{handler: handler}} = outcome) do
+    if handler.render?(outcome), do: Renderer.render_or_async(state), else: state
   end
 
   # Identifies the GUI action for the dispatch telemetry span (issue #2357 AC7),

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -18,10 +18,13 @@ defmodule MingaEditor.Commands.FileTree do
   alias Minga.Project.FileTree.BufferSync
   alias MingaEditor.FileTree.DropIntent
   alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
+  alias MingaEditor.FileTree.Refresh, as: FileTreeRefresh
+  alias MingaEditor.FileTree.Refresh.FilesystemScanner
   alias Minga.Log
 
   @typedoc "Internal editor state."
   @type state :: EditorState.t()
+  @typep tree_resolution :: {:ok, FileTree.t()} | {:error, File.posix()}
 
   @doc "Handles semantic sidebar actions from native frontends or generic sidebar input."
   @spec handle_sidebar_action(state(), String.t(), map()) :: state()
@@ -165,13 +168,7 @@ defmodule MingaEditor.Commands.FileTree do
   def collapse_all(state), do: with_tree(state, &FileTree.collapse_all/1)
 
   @spec refresh(state()) :: state()
-  def refresh(state) do
-    with_tree(state, fn tree ->
-      tree
-      |> FileTree.refresh()
-      |> FileTreeFreshness.refresh_tree_git_status_from_cache(EditorState.events_registry(state))
-    end)
-  end
+  def refresh(state), do: FileTreeFreshness.request_refresh(state, 0)
 
   @spec with_tree(state(), (FileTree.t() -> FileTree.t())) :: state()
   defp with_tree(state, fun) do
@@ -267,6 +264,43 @@ defmodule MingaEditor.Commands.FileTree do
     update_file_tree(state, fn _ -> file_tree end)
   end
 
+  @doc "Restores unfiltered rows while keeping the filter input active."
+  @spec reset_filter_query(state()) :: state()
+  def reset_filter_query(state), do: restore_unfiltered_filter(state, :keep_open)
+
+  @doc "Restores unfiltered rows and dismisses filter input."
+  @spec clear_filter(state()) :: state()
+  def clear_filter(state), do: restore_unfiltered_filter(state, :dismiss)
+
+  @spec restore_unfiltered_filter(state(), :keep_open | :dismiss) :: state()
+  defp restore_unfiltered_filter(state, disposition) do
+    case file_tree_state(state).tree do
+      %FileTree{} = tree ->
+        tree = tree |> FileTree.put_cached_files(nil) |> FileTree.clear_filter()
+        restore_resolved_filter(resolve_tree_entries(tree), state, disposition)
+
+      nil ->
+        state
+    end
+  end
+
+  @spec restore_resolved_filter(tree_resolution(), state(), :keep_open | :dismiss) :: state()
+  defp restore_resolved_filter({:error, reason}, state, _disposition) do
+    update_file_tree(state, &FileTreeState.refresh_failed(&1, reason))
+  end
+
+  defp restore_resolved_filter({:ok, tree}, state, disposition) do
+    tree = if disposition == :keep_open, do: FileTree.begin_filter(tree), else: tree
+    file_tree = FileTreeState.replace_tree(file_tree_state(state), tree)
+    file_tree = dismiss_filter(file_tree, disposition)
+    state = set_file_tree(state, file_tree)
+    sync_buffer(state)
+  end
+
+  @spec dismiss_filter(FileTreeState.t(), :keep_open | :dismiss) :: FileTreeState.t()
+  defp dismiss_filter(file_tree, :keep_open), do: file_tree
+  defp dismiss_filter(file_tree, :dismiss), do: FileTreeState.accept_filter(file_tree)
+
   # Spawns the async no-cache filesystem walk when re-entering filtering carries
   # a pre-existing filter on a root the project cache does not cover (#2377 AC4).
   @spec maybe_spawn_filter_walk(FileTreeState.t()) :: :ok
@@ -312,21 +346,45 @@ defmodule MingaEditor.Commands.FileTree do
 
   @spec start_new_entry_edit(state(), :new_file | :new_folder) :: state()
   defp start_new_entry_edit(state, type) do
-    case file_tree_state(state) do
-      %FileTreeState{tree: nil} ->
-        state
+    state |> file_tree_state() |> prepare_new_entry_edit(state, type)
+  end
 
-      %FileTreeState{tree: tree} ->
-        {index, tree} = editing_insertion_index(tree)
+  @spec prepare_new_entry_edit(FileTreeState.t(), state(), :new_file | :new_folder) :: state()
+  defp prepare_new_entry_edit(%FileTreeState{tree: nil}, state, _type), do: state
 
-        ft =
-          file_tree_state(state)
-          |> FileTreeState.start_editing(index, type)
-          |> FileTreeState.replace_tree(tree)
+  defp prepare_new_entry_edit(%FileTreeState{tree: tree}, state, type) do
+    continue_new_entry_edit(resolve_tree_entries(tree), state, type)
+  end
 
-        state = set_file_tree(state, ft)
-        sync_buffer(state)
-    end
+  @spec continue_new_entry_edit(tree_resolution(), state(), :new_file | :new_folder) :: state()
+  defp continue_new_entry_edit({:error, reason}, state, _type) do
+    update_file_tree(state, &FileTreeState.refresh_failed(&1, reason))
+  end
+
+  defp continue_new_entry_edit({:ok, tree}, state, type) do
+    {index, tree} = editing_insertion_index(tree)
+    install_new_entry_edit(resolve_tree_entries(tree), state, index, type)
+  end
+
+  @spec install_new_entry_edit(
+          tree_resolution(),
+          state(),
+          non_neg_integer(),
+          :new_file | :new_folder
+        ) :: state()
+  defp install_new_entry_edit({:error, reason}, state, _index, _type) do
+    update_file_tree(state, &FileTreeState.refresh_failed(&1, reason))
+  end
+
+  defp install_new_entry_edit({:ok, tree}, state, index, type) do
+    ft =
+      state
+      |> file_tree_state()
+      |> FileTreeState.start_editing(index, type)
+      |> FileTreeState.replace_tree(tree)
+
+    state = set_file_tree(state, ft)
+    sync_buffer(state)
   end
 
   @doc """
@@ -613,6 +671,11 @@ defmodule MingaEditor.Commands.FileTree do
 
   @spec close(state()) :: state()
   def close(state) do
+    case file_tree_state(state).tree do
+      %FileTree{} = tree -> FileTreeFreshness.unwatch_expanded_dirs(tree)
+      nil -> :ok
+    end
+
     case file_tree_state(state).buffer do
       buf when is_pid(buf) -> GenServer.stop(buf, :normal)
       _ -> :ok
@@ -831,16 +894,22 @@ defmodule MingaEditor.Commands.FileTree do
     case file_tree_state(state).tree do
       %FileTree{} = tree ->
         FileTreeFreshness.unwatch_expanded_dirs(tree)
+        new_tree = FileTree.reroot(tree, root)
 
-        new_tree =
-          tree
-          |> FileTree.reroot(root)
-          |> FileTreeFreshness.refresh_tree_git_status_from_cache(
-            EditorState.events_registry(state)
-          )
+        case resolve_tree_entries(new_tree) do
+          {:ok, new_tree} ->
+            new_tree =
+              FileTreeRefresh.with_cached_git_status(
+                new_tree,
+                EditorState.events_registry(state)
+              )
 
-        FileTreeFreshness.watch_expanded_dirs(new_tree)
-        sync_and_update(state, new_tree)
+            FileTreeFreshness.watch_expanded_dirs(new_tree)
+            sync_and_update(state, new_tree)
+
+          {:error, reason} ->
+            install_tree_error(state, new_tree, reason)
+        end
 
       nil ->
         state
@@ -909,26 +978,19 @@ defmodule MingaEditor.Commands.FileTree do
   @spec open(state()) :: state()
   defp open(state) do
     state = close_git_status_if_open(state)
-
     root = file_tree_state(state).project_root || Minga.Project.root() || File.cwd!()
     tree = FileTree.new(root)
 
-    tree =
-      FileTreeFreshness.refresh_tree_git_status_from_cache(
-        tree,
-        EditorState.events_registry(state)
-      )
+    case resolve_tree_entries(tree) do
+      {:ok, tree} ->
+        tree = FileTreeRefresh.with_cached_git_status(tree, EditorState.events_registry(state))
+        tree = reveal_active(tree, state.workspace.buffers.active)
+        FileTreeFreshness.watch_expanded_dirs(tree)
+        install_open_tree(state, tree, nil)
 
-    tree = reveal_active(tree, state.workspace.buffers.active)
-    FileTreeFreshness.watch_expanded_dirs(tree)
-    buf = BufferSync.start_buffer(tree, EditorState.options_server(state))
-
-    state
-    |> EditorState.update_file_tree(&FileTreeState.open(&1, tree, buf))
-    |> EditorState.set_keymap_scope(:file_tree)
-    |> EditorState.set_sidebar_active_id("file_tree")
-    |> Layout.invalidate()
-    |> EditorState.invalidate_all_windows()
+      {:error, reason} ->
+        install_open_tree(state, FileTree.put_entries(tree, []), reason)
+    end
   end
 
   @spec reveal_active(FileTree.t(), pid() | nil) :: FileTree.t()
@@ -943,14 +1005,61 @@ defmodule MingaEditor.Commands.FileTree do
 
   @spec sync_and_update(state(), FileTree.t()) :: state()
   defp sync_and_update(state, new_tree) do
-    FileTreeFreshness.watch_expanded_dirs(new_tree)
+    case resolve_tree_entries(new_tree) do
+      {:ok, new_tree} ->
+        FileTreeFreshness.watch_expanded_dirs(new_tree)
+        sync_tree_buffer(state, new_tree)
+        update_file_tree(state, &FileTreeState.set_tree(&1, new_tree))
 
+      {:error, reason} ->
+        install_tree_error(state, new_tree, reason)
+    end
+  end
+
+  @spec resolve_tree_entries(FileTree.t()) :: tree_resolution()
+  defp resolve_tree_entries(%FileTree{entries: entries} = tree) when is_list(entries),
+    do: {:ok, tree}
+
+  defp resolve_tree_entries(%FileTree{} = tree) do
+    case FilesystemScanner.scan(tree, nil) do
+      %FileTree{} = resolved -> {:ok, resolved}
+      {:error, {:root_unavailable, reason}} -> {:error, reason}
+    end
+  end
+
+  @spec install_open_tree(state(), FileTree.t(), File.posix() | nil) :: state()
+  defp install_open_tree(state, tree, error_reason) do
+    buf = BufferSync.start_buffer(tree, EditorState.options_server(state))
+
+    state
+    |> EditorState.update_file_tree(fn file_tree ->
+      file_tree = FileTreeState.open(file_tree, tree, buf)
+      if error_reason, do: FileTreeState.refresh_failed(file_tree, error_reason), else: file_tree
+    end)
+    |> EditorState.set_keymap_scope(:file_tree)
+    |> EditorState.set_sidebar_active_id("file_tree")
+    |> Layout.invalidate()
+    |> EditorState.invalidate_all_windows()
+  end
+
+  @spec install_tree_error(state(), FileTree.t(), File.posix()) :: state()
+  defp install_tree_error(state, tree, reason) do
+    failed_tree = FileTree.put_entries(tree, [])
+    sync_tree_buffer(state, failed_tree)
+
+    update_file_tree(state, fn file_tree ->
+      file_tree
+      |> FileTreeState.set_tree(failed_tree)
+      |> FileTreeState.refresh_failed(reason)
+    end)
+  end
+
+  @spec sync_tree_buffer(state(), FileTree.t()) :: :ok
+  defp sync_tree_buffer(state, tree) do
     case file_tree_state(state).buffer do
-      buf when is_pid(buf) -> BufferSync.sync(buf, new_tree)
+      buf when is_pid(buf) -> BufferSync.sync(buf, tree)
       _ -> :ok
     end
-
-    update_file_tree(state, &FileTreeState.set_tree(&1, new_tree))
   end
 
   # Computes the insertion index for a new file/folder.

--- a/lib/minga_editor/effect.ex
+++ b/lib/minga_editor/effect.ex
@@ -16,4 +16,5 @@ defmodule MingaEditor.Effect do
   @callback run(request()) :: {:ok, term()} | {:error, term()}
   @callback coalesce(request(), request()) :: request()
   @callback apply(EditorState.t(), Outcome.t()) :: {EditorState.t(), Outcome.t()}
+  @callback render?(Outcome.t()) :: boolean()
 end

--- a/lib/minga_editor/effects/external_format.ex
+++ b/lib/minga_editor/effects/external_format.ex
@@ -84,6 +84,10 @@ defmodule MingaEditor.Effects.ExternalFormat do
     {EditorState.set_status(state, "Buffer changed, format skipped"), outcome}
   end
 
+  @impl true
+  @spec render?(Outcome.t()) :: boolean()
+  def render?(%Outcome{}), do: true
+
   @spec apply_formatted_content(EditorState.t(), Outcome.t(), ExternalFormatResult.t()) ::
           {EditorState.t(), Outcome.t()}
   defp apply_formatted_content(state, outcome, result) do

--- a/lib/minga_editor/effects/git_mutation.ex
+++ b/lib/minga_editor/effects/git_mutation.ex
@@ -108,6 +108,10 @@ defmodule MingaEditor.Effects.GitMutation do
     {EditorState.set_status(state, "Git action skipped"), outcome}
   end
 
+  @impl true
+  @spec render?(Outcome.t()) :: boolean()
+  def render?(%Outcome{}), do: true
+
   @spec perform(t()) :: :ok | {:ok, String.t()} | {:error, term()}
   defp perform(%__MODULE__{operation: :stage, git_root: root, path: path}) do
     Minga.Git.stage(root, path)

--- a/lib/minga_editor/effects/git_mutation_admission.ex
+++ b/lib/minga_editor/effects/git_mutation_admission.ex
@@ -136,6 +136,10 @@ defmodule MingaEditor.Effects.GitMutationAdmission do
     {EditorState.set_status(state, "Git action skipped"), outcome}
   end
 
+  @impl true
+  @spec render?(Outcome.t()) :: boolean()
+  def render?(%Outcome{}), do: true
+
   @spec mutation_request(t(), GitRepositoryIdentity.t()) :: Request.t()
   defp mutation_request(effect, identity) do
     opts =

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -7,20 +7,18 @@ defmodule MingaEditor.FileTree.Freshness do
 
   alias Minga.Buffer
   alias Minga.LSP.SyncServer
-  alias Minga.Git.Repo, as: GitRepo
-  alias Minga.Git.Repo.StatusSnapshot
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
   alias Minga.Project.FileTree.GitStatus
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.Effect.Request
+  alias MingaEditor.EffectScheduler
+  alias MingaEditor.FileTree.Refresh
+  alias MingaEditor.FileTree.Refresh.FilesystemScanner
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
 
   @type state :: EditorState.t()
-
-  @typedoc "Effects emitted by the async refresh orchestration (interpreted by EffectHandler)."
-  @type effect ::
-          {:render, pos_integer()}
-          | {:start_file_tree_refresh, FileTree.t(), reference()}
 
   @doc "Returns true when the file tree is open."
   @spec open?(state()) :: boolean()
@@ -61,188 +59,143 @@ defmodule MingaEditor.FileTree.Freshness do
     :exit, _ -> false
   end
 
-  @doc "Marks a debounced filesystem refresh as scheduled."
-  @spec schedule_refresh(state(), reference()) :: state()
-  def schedule_refresh(state, ref) when is_reference(ref) do
-    set_file_tree(state, FileTreeState.schedule_refresh(file_tree_state(state), ref))
+  @doc "Debounces one refresh request in the Editor mailbox."
+  @spec request_refresh(state(), non_neg_integer()) :: state()
+  def request_refresh(state, delay_ms) when is_integer(delay_ms) and delay_ms >= 0 do
+    token = make_ref()
+    file_tree = file_tree_state(state)
+
+    case FileTreeState.request_refresh_debounce(file_tree, token) do
+      {:already_scheduled, file_tree} ->
+        set_file_tree(state, file_tree)
+
+      {:scheduled, file_tree} ->
+        Process.send_after(self(), {:file_tree_refresh_timer, token}, delay_ms)
+        set_file_tree(state, file_tree)
+    end
   end
 
-  @doc "Returns true when a filesystem refresh timer is already pending."
-  @spec refresh_scheduled?(state()) :: boolean()
-  def refresh_scheduled?(state) do
+  @doc "Consumes a correlated debounce timer and admits a typed refresh request."
+  @spec begin_refresh(state(), reference()) :: state()
+  def begin_refresh(state, timer_token) when is_reference(timer_token) do
+    case FileTreeState.refresh_debounce_elapsed(file_tree_state(state), timer_token) do
+      {:ready, tree, file_tree} ->
+        state
+        |> set_file_tree(file_tree)
+        |> schedule_refresh(tree)
+
+      {_status, file_tree} ->
+        set_file_tree(state, file_tree)
+    end
+  end
+
+  @doc "Applies one scheduler lifecycle or terminal outcome for the file-tree domain."
+  @spec apply_refresh_outcome(state(), Outcome.t()) :: {state(), Outcome.t()}
+  def apply_refresh_outcome(
+        state,
+        %Outcome{
+          status: :completed,
+          request: %Request{effect: %Refresh{} = effect},
+          result: %FileTree{} = tree
+        } =
+          outcome
+      ) do
+    apply_completed_refresh(state, effect, tree, outcome)
+  end
+
+  def apply_refresh_outcome(
+        state,
+        %Outcome{
+          status: :failed,
+          request: %Request{effect: %Refresh{} = effect} = request,
+          reason: {:root_unavailable, reason}
+        } = outcome
+      ) do
+    {finish_failed_refresh(state, effect, request.id, reason), outcome}
+  end
+
+  def apply_refresh_outcome(
+        state,
+        %Outcome{status: status, request: %Request{effect: %Refresh{} = effect} = request} =
+          outcome
+      )
+      when status in [:failed, :canceled, :stale] do
+    {finish_terminal_refresh(state, effect, request.id), outcome}
+  end
+
+  def apply_refresh_outcome(state, %Outcome{} = outcome), do: {state, outcome}
+
+  @spec schedule_refresh(state(), FileTree.t()) :: state()
+  defp schedule_refresh(%EditorState{effect_scheduler: nil} = state, _tree) do
+    Minga.Log.warning(:editor, "File tree refresh scheduler unavailable")
     state
-    |> file_tree_state()
-    |> FileTreeState.refresh_scheduled?()
   end
 
-  @doc """
-  Starts an async filesystem rescan after the debounce timer fires (#2632).
+  defp schedule_refresh(state, %FileTree{} = tree) do
+    request = Refresh.request(tree, EditorState.events_registry(state))
 
-  The heavy recursive `File.ls`/`File.lstat` walk must not run on the Editor
-  GenServer. This clears the debounce timer and, unless a rescan is already in
-  flight, mints a token and emits a `{:start_file_tree_refresh, tree, token}`
-  effect so `EffectHandler` can spawn the work off-process. The Task replies with
-  `{:file_tree_refresh_result, refreshed_tree, token}`, handled by
-  `apply_refresh_result/3`.
+    case EffectScheduler.schedule(state.effect_scheduler, request) do
+      {:ok, _request_id, _disposition} ->
+        file_tree =
+          state
+          |> file_tree_state()
+          |> FileTreeState.track_refresh_request(tree.root, request.id)
 
-  If a rescan is already in flight, the request is coalesced into a single
-  follow-up (`refresh_pending?`) instead of piling up Tasks (AC3): the in-flight
-  walk finishes, then exactly one fresh rescan starts.
-  """
-  @spec begin_refresh(state()) :: {state(), [effect()]}
-  def begin_refresh(state) do
-    state |> file_tree_state() |> begin_refresh(state)
+        set_file_tree(state, file_tree)
+
+      {:error, reason} ->
+        Minga.Log.warning(:editor, "File tree refresh not scheduled: #{inspect(reason)}")
+        state
+    end
   end
 
-  # No open tree: just drop the debounce timer.
-  @spec begin_refresh(FileTreeState.t(), state()) :: {state(), [effect()]}
-  defp begin_refresh(%FileTreeState{tree: nil} = file_tree, state) do
-    {set_file_tree(state, FileTreeState.clear_refresh(file_tree)), []}
+  @spec apply_completed_refresh(state(), Refresh.t(), FileTree.t(), Outcome.t()) ::
+          {state(), Outcome.t()}
+  defp apply_completed_refresh(state, effect, refreshed_tree, outcome) do
+    file_tree = file_tree_state(state)
+
+    case FileTreeState.accept_refresh_result(
+           file_tree,
+           effect.root,
+           outcome.request.id,
+           refreshed_tree
+         ) do
+      {:accepted, file_tree} ->
+        state = set_file_tree(state, file_tree)
+        watch_expanded_dirs(refreshed_tree)
+
+        state =
+          state
+          |> sync_buffer(refreshed_tree)
+          |> MingaEditor.schedule_render(16)
+
+        {state, outcome}
+
+      {reason, file_tree} ->
+        {set_file_tree(state, file_tree), Outcome.stale(outcome, reason)}
+    end
   end
 
-  # A rescan is already running: coalesce instead of spawning another Task.
-  defp begin_refresh(%FileTreeState{tree: %FileTree{}, refresh_inflight: ref} = file_tree, state)
-       when is_reference(ref) do
-    file_tree =
-      file_tree
-      |> FileTreeState.clear_refresh()
-      |> FileTreeState.mark_refresh_pending()
-
-    {set_file_tree(state, file_tree), []}
-  end
-
-  # Idle: mint a token, mark in-flight, and emit the spawn effect.
-  defp begin_refresh(%FileTreeState{tree: %FileTree{} = tree} = file_tree, state) do
-    token = make_ref()
-    file_tree = FileTreeState.begin_inflight_refresh(file_tree, token)
-    {set_file_tree(state, file_tree), [{:start_file_tree_refresh, tree, token}]}
-  end
-
-  @doc """
-  Applies a finished async rescan, swapping the whole tree atomically (#2632 AC4).
-
-  The result is discarded when stale: the token no longer matches the in-flight
-  refresh, or the user re-rooted/closed the tree while the walk ran, so the
-  refreshed tree's root no longer matches the live tree (AC3/AC4 staleness
-  guard). After applying or dropping, a coalesced `refresh_pending?` request, if
-  any, starts exactly one fresh rescan.
-  """
-  @spec apply_refresh_result(state(), FileTree.t(), reference()) :: {state(), [effect()]}
-  def apply_refresh_result(state, %FileTree{} = refreshed_tree, token) when is_reference(token) do
-    state |> file_tree_state() |> apply_refresh_result(state, refreshed_tree, token)
-  end
-
-  # Fresh: the in-flight token matches and the tree is still rooted where the
-  # walk ran. Swap the whole tree in one cheap assignment (no FS walk here).
-  @spec apply_refresh_result(FileTreeState.t(), state(), FileTree.t(), reference()) ::
-          {state(), [effect()]}
-  defp apply_refresh_result(
-         %FileTreeState{refresh_inflight: token, tree: %FileTree{root: root}} = file_tree,
-         state,
-         %FileTree{root: root} = refreshed_tree,
-         token
-       ) do
-    watch_expanded_dirs(refreshed_tree)
-
-    file_tree = FileTreeState.replace_tree(file_tree, refreshed_tree)
-
-    state =
-      state
-      |> set_file_tree(file_tree)
-      |> sync_buffer(refreshed_tree)
-
-    finish_refresh(state, refreshed_tree, [{:render, 16}])
-  end
-
-  # Current in-flight refresh completed, but the tree was re-rooted/closed while
-  # the walk ran so its root no longer matches. Drop the tree, but still finish
-  # the in-flight bookkeeping (clear in-flight, honour a coalesced refresh).
-  defp apply_refresh_result(
-         %FileTreeState{refresh_inflight: token},
-         state,
-         _refreshed_tree,
-         token
-       ) do
-    finish_refresh(state, current_tree(state), [])
-  end
-
-  # Superseded result: the token is no longer the current in-flight refresh
-  # (a newer refresh replaced it). Ignore it without touching in-flight tracking.
-  defp apply_refresh_result(%FileTreeState{}, state, _refreshed_tree, _token) do
-    {state, []}
-  end
-
-  @doc """
-  Handles a failed async rescan (#2632): the Task raised/threw or could not
-  finish, so no tree is applied. Clears in-flight tracking and honours a
-  coalesced refresh so the refresh loop never wedges. Ignored when the token is
-  no longer the current in-flight refresh.
-  """
-  @spec apply_refresh_failure(state(), reference()) :: {state(), [effect()]}
-  def apply_refresh_failure(state, token) when is_reference(token) do
-    state |> file_tree_state() |> apply_refresh_failure(state, token)
-  end
-
-  @spec apply_refresh_failure(FileTreeState.t(), state(), reference()) :: {state(), [effect()]}
-  defp apply_refresh_failure(%FileTreeState{refresh_inflight: token}, state, token) do
-    finish_refresh(state, current_tree(state), [])
-  end
-
-  defp apply_refresh_failure(%FileTreeState{}, state, _token) do
-    {state, []}
-  end
-
-  @doc """
-  Clears in-flight tracking when a refresh Task could not be spawned (#2632), so
-  a later timer can retry instead of wedging. No-op when the token is not the
-  current in-flight refresh.
-  """
-  @spec cancel_inflight_refresh(state(), reference()) :: state()
-  def cancel_inflight_refresh(state, token) when is_reference(token) do
-    state |> file_tree_state() |> cancel_inflight_refresh(state, token)
-  end
-
-  @spec cancel_inflight_refresh(FileTreeState.t(), state(), reference()) :: state()
-  defp cancel_inflight_refresh(%FileTreeState{refresh_inflight: token} = file_tree, state, token) do
-    set_file_tree(state, FileTreeState.clear_inflight_refresh(file_tree))
-  end
-
-  defp cancel_inflight_refresh(%FileTreeState{}, state, _token), do: state
-
-  # Clears in-flight tracking and, when a refresh was coalesced while the Task
-  # ran, starts exactly one fresh rescan of the current tree (#2632 AC3).
-  @spec finish_refresh(state(), FileTree.t() | nil, [effect()]) :: {state(), [effect()]}
-  defp finish_refresh(state, tree, effects) do
-    state |> file_tree_state() |> finish_refresh(state, tree, effects)
-  end
-
-  @spec finish_refresh(FileTreeState.t(), state(), FileTree.t() | nil, [effect()]) ::
-          {state(), [effect()]}
-  defp finish_refresh(%FileTreeState{refresh_pending?: true}, state, %FileTree{} = tree, effects) do
-    token = make_ref()
-
-    file_tree =
+  @spec finish_terminal_refresh(state(), Refresh.t(), reference()) :: state()
+  defp finish_terminal_refresh(state, effect, request_token) do
+    {_status, file_tree} =
       state
       |> file_tree_state()
-      |> FileTreeState.begin_inflight_refresh(token)
+      |> FileTreeState.finish_refresh(effect.root, request_token)
 
-    {set_file_tree(state, file_tree), [{:start_file_tree_refresh, tree, token} | effects]}
+    set_file_tree(state, file_tree)
   end
 
-  defp finish_refresh(%FileTreeState{}, state, _tree, effects) do
-    file_tree =
-      state
-      |> file_tree_state()
-      |> FileTreeState.clear_inflight_refresh()
+  @spec finish_failed_refresh(state(), Refresh.t(), reference(), term()) :: state()
+  defp finish_failed_refresh(state, effect, request_token, reason) do
+    case FileTreeState.finish_refresh(file_tree_state(state), effect.root, request_token) do
+      {:current, file_tree} ->
+        state
+        |> set_file_tree(FileTreeState.refresh_failed(file_tree, reason))
+        |> MingaEditor.schedule_render(16)
 
-    {set_file_tree(state, file_tree), effects}
-  end
-
-  @spec current_tree(state()) :: FileTree.t() | nil
-  defp current_tree(state) do
-    case file_tree_state(state) do
-      %FileTreeState{tree: %FileTree{} = tree} -> tree
-      %FileTreeState{} -> nil
+      {_status, file_tree} ->
+        set_file_tree(state, file_tree)
     end
   end
 
@@ -269,25 +222,6 @@ defmodule MingaEditor.FileTree.Freshness do
   end
 
   @doc "Refreshes tree git badges from the cached Git.Repo snapshot without shelling out to git."
-  @spec refresh_tree_git_status_from_cache(FileTree.t(), Minga.Events.registry()) :: FileTree.t()
-  def refresh_tree_git_status_from_cache(
-        %FileTree{} = tree,
-        events_registry \\ Minga.Events.default_registry()
-      ) do
-    case GitRepo.cached_status_for_path(tree.root) do
-      {:ok, %StatusSnapshot{entry_base_path: entry_base_path, entries: entries}} ->
-        status = GitStatus.from_entries(entries, entry_base_path, tree.root)
-        FileTree.replace_git_status(tree, status)
-
-      :not_tracked ->
-        ensure_repo_started(tree.root, events_registry)
-        tree
-    end
-  catch
-    :exit, _ -> tree
-  end
-
-  @doc "Refreshes tree git badges from the cached Git.Repo snapshot without shelling out to git."
   @spec refresh_git_status_from_cache(state()) :: state()
   def refresh_git_status_from_cache(state) do
     case file_tree_state(state) do
@@ -295,8 +229,7 @@ defmodule MingaEditor.FileTree.Freshness do
         state
 
       %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
-        updated_tree =
-          refresh_tree_git_status_from_cache(tree, EditorState.events_registry(state))
+        updated_tree = Refresh.with_cached_git_status(tree, EditorState.events_registry(state))
 
         file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
 
@@ -321,22 +254,37 @@ defmodule MingaEditor.FileTree.Freshness do
 
       %FileTree{} = old_tree ->
         unwatch_expanded_dirs(old_tree)
+        new_tree = FileTree.new(expanded_root, width: old_tree.width)
 
-        new_tree =
-          expanded_root
-          |> FileTree.new(width: old_tree.width)
-          |> refresh_tree_git_status_from_cache(EditorState.events_registry(state))
+        case FilesystemScanner.scan(new_tree, nil) do
+          %FileTree{} = new_tree ->
+            new_tree =
+              Refresh.with_cached_git_status(new_tree, EditorState.events_registry(state))
 
-        watch_expanded_dirs(new_tree)
+            watch_expanded_dirs(new_tree)
 
-        file_tree =
-          file_tree
-          |> FileTreeState.set_project_root(expanded_root)
-          |> FileTreeState.replace_tree(new_tree)
+            file_tree =
+              file_tree
+              |> FileTreeState.set_project_root(expanded_root)
+              |> FileTreeState.replace_tree(new_tree)
 
-        state
-        |> set_file_tree(file_tree)
-        |> sync_buffer(new_tree)
+            state
+            |> set_file_tree(file_tree)
+            |> sync_buffer(new_tree)
+
+          {:error, {:root_unavailable, reason}} ->
+            failed_tree = FileTree.put_entries(new_tree, [])
+
+            file_tree =
+              file_tree
+              |> FileTreeState.set_project_root(expanded_root)
+              |> FileTreeState.replace_tree(failed_tree)
+              |> FileTreeState.refresh_failed(reason)
+
+            state
+            |> set_file_tree(file_tree)
+            |> sync_buffer(failed_tree)
+        end
 
       nil ->
         set_file_tree(state, FileTreeState.set_project_root(file_tree, expanded_root))
@@ -364,37 +312,6 @@ defmodule MingaEditor.FileTree.Freshness do
   @spec unwatch_expanded_dirs(FileTree.t()) :: :ok
   def unwatch_expanded_dirs(%FileTree{root: root}) do
     safe_unwatch_directory_tree(root)
-  end
-
-  @spec ensure_repo_started(String.t(), Minga.Events.registry()) :: :ok
-  defp ensure_repo_started(root, events_registry) when is_binary(root) do
-    case Minga.Git.root_for(root) do
-      {:ok, git_root} ->
-        case GitRepo.ensure_started(git_root, root, events_registry) do
-          {:ok, _pid} ->
-            :ok
-
-          {:error, {:already_started, _pid}} ->
-            :ok
-
-          {:error, reason} ->
-            Minga.Log.warning(
-              :editor,
-              "File tree git repo start failed for #{root}: #{inspect(reason)}"
-            )
-        end
-
-      :not_git ->
-        :ok
-    end
-  catch
-    :exit, reason ->
-      Minga.Log.warning(
-        :editor,
-        "File tree git repo lookup failed for #{root}: #{inspect(reason)}"
-      )
-
-      :ok
   end
 
   @spec sync_buffer(state(), FileTree.t()) :: state()

--- a/lib/minga_editor/file_tree/refresh.ex
+++ b/lib/minga_editor/file_tree/refresh.ex
@@ -1,111 +1,129 @@
 defmodule MingaEditor.FileTree.Refresh do
   @moduledoc """
-  Async filesystem rescan for the open file tree (#2632).
+  Typed, bounded filesystem rescan for one file-tree root.
 
-  A burst of filesystem events debounces into one `:file_tree_refresh_timer`.
-  When that timer fires the Editor must *not* run `FileTree.refresh/1` inline:
-  the rescan does recursive `File.ls`/`File.lstat` per expanded directory and
-  would block the Editor mailbox for all that I/O on projects with many
-  expanded dirs.
-
-  Instead the Editor spawns this Task. It captures the current tree, runs the
-  filesystem rescan and the cached git-status refresh off the Editor process,
-  then sends `{:file_tree_refresh_result, refreshed_tree, token}` back. The
-  Editor applies the result with a cheap, atomic whole-tree swap and discards
-  it if the user re-rooted or closed the tree while the walk was running (the
-  `token` plus root comparison in `MingaEditor.FileTree.Freshness`).
+  The expanded root is the scheduler resource identity. One scan may run while
+  at most one follow-up waits; newer bursts coalesce into that queued request.
+  Execution, coalescing, and application remain owned by this domain effect.
   """
 
+  @behaviour MingaEditor.Effect
+
+  alias Minga.Git.Repo, as: GitRepo
+  alias Minga.Git.Repo.StatusSnapshot
   alias Minga.Project.FileTree
+  alias Minga.Project.FileTree.GitStatus
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.Effect.Policy
+  alias MingaEditor.Effect.Request
   alias MingaEditor.FileTree.Freshness
+  alias MingaEditor.State, as: EditorState
 
-  @typedoc "Opaque token identifying one in-flight refresh; minted per spawn."
-  @type token :: reference()
+  @enforce_keys [:root, :tree, :events_registry, :scanner, :scanner_context]
+  defstruct [:root, :tree, :events_registry, :scanner, :scanner_context]
 
-  @typedoc "The result message the Editor receives when a refresh Task finishes."
-  @type result ::
-          {:file_tree_refresh_result, FileTree.t(), token()}
-          | {:file_tree_refresh_failed, token()}
+  @typedoc "Scanner module input kept as data in the scheduler request."
+  @type scanner_context :: term()
 
-  @doc """
-  Spawns a supervised Task that rescans `tree` off the calling process.
+  @type t :: %__MODULE__{
+          root: String.t(),
+          tree: FileTree.t(),
+          events_registry: Minga.Events.registry(),
+          scanner: module(),
+          scanner_context: scanner_context()
+        }
 
-  The Task runs `FileTree.refresh/1` (filesystem I/O) followed by the cached
-  git-status refresh, then sends `{:file_tree_refresh_result, refreshed_tree,
-  token}` to `reply_to`.
+  @doc "Builds a coalescing request keyed by the expanded file-tree root."
+  @spec request(FileTree.t(), Minga.Events.registry(), keyword()) :: Request.t()
+  def request(%FileTree{root: root} = tree, events_registry, opts \\ []) when is_binary(root) do
+    expanded_root = Path.expand(root)
 
-  The Task body is wrapped in `try/rescue/catch` so it *always* replies, even
-  when the filesystem walk or git-status decode raises or throws. On failure it
-  sends `{:file_tree_refresh_failed, token}` so the Editor can clear its
-  in-flight tracking and honour a coalesced refresh; the in-flight flag is never
-  left stuck (which would otherwise wedge all future refreshes, since the
-  coalescing path never spawns while one is "in flight").
+    effect = %__MODULE__{
+      root: expanded_root,
+      tree: tree,
+      events_registry: events_registry,
+      scanner: Keyword.get(opts, :scanner, MingaEditor.FileTree.Refresh.FilesystemScanner),
+      scanner_context: Keyword.get(opts, :scanner_context)
+    }
 
-  Returns `:ok` when the Task was spawned, or `{:error, reason}` when the
-  supervisor refused (e.g. max children); the caller clears in-flight so a later
-  timer can retry rather than wedging.
-  """
-  @spec start(FileTree.t(), token(), Minga.Events.registry(), pid()) :: :ok | {:error, term()}
-  def start(%FileTree{} = tree, token, events_registry, reply_to)
-      when is_reference(token) and is_pid(reply_to) do
-    case Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
-           run(tree, token, events_registry, reply_to)
-         end) do
-      {:ok, _pid} -> :ok
-      {:ok, _pid, _info} -> :ok
-      {:error, reason} -> {:error, reason}
+    Request.new(effect, {:file_tree_root, expanded_root}, Policy.coalescing(1))
+  end
+
+  @impl true
+  @spec run(t()) :: {:ok, FileTree.t()} | {:error, term()}
+  def run(%__MODULE__{} = effect) do
+    case effect.scanner.scan(effect.tree, effect.scanner_context) do
+      %FileTree{} = refreshed_tree ->
+        {:ok, with_cached_git_status(refreshed_tree, effect.events_registry)}
+
+      {:error, reason} ->
+        {:error, reason}
+
+      other ->
+        {:error, {:invalid_refresh_result, other}}
     end
   end
 
-  # Runs the rescan and ALWAYS sends a reply, converting any raise/throw/exit
-  # into a failure sentinel so the Editor's in-flight flag is always cleared.
-  #
-  # The reply is computed with NO risky work (just building a tuple) and sent
-  # BEFORE any logging. Logging a failure can itself raise (a custom exception's
-  # `message/1` callback, or the logger), so it is deferred to an isolated,
-  # self-guarding helper after the send — the terminal message is guaranteed to
-  # go out no matter what the logging does, preserving the no-wedge invariant.
-  @spec run(FileTree.t(), token(), Minga.Events.registry(), pid()) :: :ok
-  defp run(tree, token, events_registry, reply_to) do
-    {message, failure} =
-      try do
-        refreshed_tree =
-          tree
-          |> FileTree.refresh()
-          |> Freshness.refresh_tree_git_status_from_cache(events_registry)
+  @impl true
+  @spec coalesce(t(), t()) :: t()
+  def coalesce(%__MODULE__{}, %__MODULE__{} = newer), do: newer
 
-        {{:file_tree_refresh_result, refreshed_tree, token}, nil}
-      rescue
-        e -> {{:file_tree_refresh_failed, token}, {:rescue, e}}
-      catch
-        kind, reason -> {{:file_tree_refresh_failed, token}, {:catch, kind, reason}}
-      end
-
-    send(reply_to, message)
-    log_failure(failure)
-    :ok
+  @impl true
+  @spec apply(EditorState.t(), Outcome.t()) :: {EditorState.t(), Outcome.t()}
+  def apply(%EditorState{} = state, %Outcome{} = outcome) do
+    Freshness.apply_refresh_outcome(state, outcome)
   end
 
-  # Logs a failure after the reply is already sent. Self-guarded so a raising
-  # `Exception.message/1` or logger can never propagate out of `run/4`.
-  @spec log_failure(nil | {:rescue, Exception.t()} | {:catch, atom(), term()}) :: :ok
-  defp log_failure(nil), do: :ok
+  @impl true
+  @spec render?(Outcome.t()) :: boolean()
+  def render?(%Outcome{}), do: false
 
-  defp log_failure({:rescue, exception}) do
-    Minga.Log.warning(:editor, "File tree refresh failed: #{Exception.message(exception)}")
-    :ok
-  rescue
-    _ -> :ok
+  @doc "Adds cached git badges without performing a synchronous git status query."
+  @spec with_cached_git_status(FileTree.t(), Minga.Events.registry()) :: FileTree.t()
+  def with_cached_git_status(%FileTree{} = tree, events_registry) do
+    case GitRepo.cached_status_for_path(tree.root) do
+      {:ok, %StatusSnapshot{entry_base_path: entry_base_path, entries: entries}} ->
+        status = GitStatus.from_entries(entries, entry_base_path, tree.root)
+        FileTree.replace_git_status(tree, status)
+
+      :not_tracked ->
+        ensure_repo_started(tree.root, events_registry)
+        tree
+    end
   catch
-    _, _ -> :ok
+    :exit, _reason -> tree
   end
 
-  defp log_failure({:catch, kind, reason}) do
-    Minga.Log.warning(:editor, "File tree refresh #{kind}: #{inspect(reason)}")
-    :ok
-  rescue
-    _ -> :ok
+  @spec ensure_repo_started(String.t(), Minga.Events.registry()) :: :ok
+  defp ensure_repo_started(root, events_registry) when is_binary(root) do
+    case Minga.Git.root_for(root) do
+      {:ok, git_root} -> start_repo(git_root, root, events_registry)
+      :not_git -> :ok
+    end
   catch
-    _, _ -> :ok
+    :exit, reason ->
+      Minga.Log.warning(
+        :editor,
+        "File tree git repo lookup failed for #{root}: #{inspect(reason)}"
+      )
+
+      :ok
+  end
+
+  @spec start_repo(String.t(), String.t(), Minga.Events.registry()) :: :ok
+  defp start_repo(git_root, root, events_registry) do
+    case GitRepo.ensure_started(git_root, root, events_registry) do
+      {:ok, _pid} ->
+        :ok
+
+      {:error, {:already_started, _pid}} ->
+        :ok
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :editor,
+          "File tree git repo start failed for #{root}: #{inspect(reason)}"
+        )
+    end
   end
 end

--- a/lib/minga_editor/file_tree/refresh/filesystem_scanner.ex
+++ b/lib/minga_editor/file_tree/refresh/filesystem_scanner.ex
@@ -1,0 +1,16 @@
+defmodule MingaEditor.FileTree.Refresh.FilesystemScanner do
+  @moduledoc "Filesystem scanner used by the typed file-tree refresh effect."
+
+  @behaviour MingaEditor.FileTree.Refresh.Scanner
+
+  alias Minga.Project.FileTree
+
+  @impl true
+  @spec scan(FileTree.t(), term()) :: FileTree.t() | {:error, {:root_unavailable, File.posix()}}
+  def scan(%FileTree{root: root} = tree, _context) do
+    case File.ls(root) do
+      {:ok, _entries} -> FileTree.refresh(tree)
+      {:error, reason} -> {:error, {:root_unavailable, reason}}
+    end
+  end
+end

--- a/lib/minga_editor/file_tree/refresh/scanner.ex
+++ b/lib/minga_editor/file_tree/refresh/scanner.ex
@@ -1,0 +1,7 @@
+defmodule MingaEditor.FileTree.Refresh.Scanner do
+  @moduledoc "Contract for filesystem scanners used by the typed file-tree refresh effect."
+
+  alias Minga.Project.FileTree
+
+  @callback scan(FileTree.t(), term()) :: FileTree.t() | {:error, term()}
+end

--- a/lib/minga_editor/handlers/effect_handler.ex
+++ b/lib/minga_editor/handlers/effect_handler.ex
@@ -60,8 +60,6 @@ defmodule MingaEditor.Handlers.EffectHandler do
   * `{:request_inlay_hints}` — request fresh inlay hints from LSP
   * `:render_now` — render immediately after a handler updates state
   * `{:save_session_deferred}` — send :save_session to self
-  * `{:schedule_file_tree_refresh, delay}` — debounce one filesystem tree refresh
-  * `{:start_file_tree_refresh, tree, token}` — spawn the async tree rescan Task
   * `{:handle_git_remote_result, ref, result}` — process git remote result
   """
   @type effect ::
@@ -99,8 +97,6 @@ defmodule MingaEditor.Handlers.EffectHandler do
           | {:request_code_lens}
           | {:request_inlay_hints}
           | {:save_session_deferred}
-          | {:schedule_file_tree_refresh, non_neg_integer()}
-          | {:start_file_tree_refresh, Minga.Project.FileTree.t(), reference()}
           | {:handle_git_remote_result, reference(), term()}
 
   @doc """
@@ -209,33 +205,6 @@ defmodule MingaEditor.Handlers.EffectHandler do
     end
 
     state
-  end
-
-  defp apply_effect(state, {:schedule_file_tree_refresh, delay}) when is_integer(delay) do
-    if MingaEditor.FileTree.Freshness.refresh_scheduled?(state) do
-      state
-    else
-      ref = Process.send_after(self(), :file_tree_refresh_timer, delay)
-      MingaEditor.FileTree.Freshness.schedule_refresh(state, ref)
-    end
-  end
-
-  defp apply_effect(state, {:start_file_tree_refresh, tree, token}) when is_reference(token) do
-    case MingaEditor.FileTree.Refresh.start(
-           tree,
-           token,
-           EditorState.events_registry(state),
-           self()
-         ) do
-      :ok ->
-        state
-
-      {:error, reason} ->
-        # The supervisor refused the Task (e.g. max children). Clear in-flight so
-        # a later timer can retry instead of wedging the refresh loop (#2632).
-        Minga.Log.warning(:editor, "File tree refresh spawn failed: #{inspect(reason)}")
-        MingaEditor.FileTree.Freshness.cancel_inflight_refresh(state, token)
-    end
   end
 
   defp apply_effect(state, {:conceal_spans, pid, spans}) when is_pid(pid) do

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -1,14 +1,12 @@
 defmodule MingaEditor.Handlers.FileEventHandler do
   @moduledoc """
-  Pure handler for file and git status events.
+  Handler for file and git status events.
 
-  Extracts the `{:minga_event, :git_status_changed, ...}`,
-  `{:minga_event, :buffer_saved, ...}`, and `{:git_remote_result, ...}`
-  clauses from the Editor GenServer into pure `{state, [effect]}`
-  functions.
+  File-tree events enter their workflow directly so timer and scheduler
+  correlation stay in the Editor process. Unrelated generic editor effects are
+  still returned for the existing universal dispatcher.
   """
 
-  alias Minga.Project.FileTree
   alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.State, as: EditorState
@@ -18,8 +16,6 @@ defmodule MingaEditor.Handlers.FileEventHandler do
           :render
           | {:render, pos_integer()}
           | {:log_message, String.t()}
-          | {:schedule_file_tree_refresh, non_neg_integer()}
-          | {:start_file_tree_refresh, FileTree.t(), reference()}
           | {:request_code_lens}
           | {:request_inlay_hints}
           | {:save_session_deferred}
@@ -73,19 +69,6 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   def handle(state, {:file_tree_filter_walk, root, filter, entries})
       when is_binary(root) and is_binary(filter) and is_list(entries) do
     handle_filter_walk_result(state, root, filter, entries)
-  end
-
-  def handle(state, :file_tree_refresh_timer) do
-    FileTreeFreshness.begin_refresh(state)
-  end
-
-  def handle(state, {:file_tree_refresh_result, %FileTree{} = refreshed_tree, token})
-      when is_reference(token) do
-    FileTreeFreshness.apply_refresh_result(state, refreshed_tree, token)
-  end
-
-  def handle(state, {:file_tree_refresh_failed, token}) when is_reference(token) do
-    FileTreeFreshness.apply_refresh_failure(state, token)
   end
 
   def handle(state, {:git_remote_result, ref, result}) when is_reference(ref) do
@@ -222,7 +205,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   @spec handle_file_changed(EditorState.t(), String.t()) :: {EditorState.t(), [file_effect()]}
   defp handle_file_changed(state, path) do
     if FileTreeFreshness.path_under_tree?(state, path) do
-      {state, [{:schedule_file_tree_refresh, 50}]}
+      {FileTreeFreshness.request_refresh(state, 50), []}
     else
       {state, []}
     end

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -376,9 +376,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
     set_file_tree(state, FileTreeState.accept_filter(file_tree_state(state)))
   end
 
-  defp handle_filter_key(state, @escape, 0) do
-    set_file_tree(state, FileTreeState.clear_filter(file_tree_state(state)))
-  end
+  defp handle_filter_key(state, @escape, 0), do: Commands.FileTree.clear_filter(state)
 
   defp handle_filter_key(state, ??, 0), do: Commands.FileTree.toggle_help(state)
 
@@ -386,7 +384,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
     text = current_filter_text(state)
 
     if text == "" do
-      set_file_tree(state, FileTreeState.clear_filter(file_tree_state(state)))
+      Commands.FileTree.clear_filter(state)
     else
       new_text = String.slice(text, 0, max(String.length(text) - 1, 0))
       apply_filter_update(state, new_text)
@@ -414,6 +412,8 @@ defmodule MingaEditor.Input.FileTreeHandler do
   # only spawned for other roots. The walk result arrives as a
   # {:file_tree_filter_walk, ...} message handled by the editor.
   @spec apply_filter_update(EditorState.t(), String.t()) :: EditorState.t()
+  defp apply_filter_update(state, ""), do: Commands.FileTree.reset_filter_query(state)
+
   defp apply_filter_update(state, filter_text) do
     file_tree = FileTreeState.update_filter(file_tree_state(state), filter_text)
     maybe_spawn_filter_walk(file_tree)

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.State.FileTree do
   alias MingaEditor.FileTree.FilterWalk
   alias MingaEditor.FileTree.ProjectCache
   alias MingaEditor.State.FileTree.ClipboardMark
+  alias MingaEditor.State.FileTree.Refresh
 
   @typedoc """
   Inline editing state for creating files/folders or renaming entries.
@@ -46,9 +47,7 @@ defmodule MingaEditor.State.FileTree do
           original_root: String.t() | nil,
           tree_status: tree_status(),
           tree_width: pos_integer(),
-          refresh_timer: reference() | nil,
-          refresh_inflight: reference() | nil,
-          refresh_pending?: boolean(),
+          refresh: Refresh.t(),
           clipboard_mark: clipboard_mark() | nil,
           filtering: boolean(),
           help_visible: boolean()
@@ -63,9 +62,7 @@ defmodule MingaEditor.State.FileTree do
             original_root: nil,
             tree_status: :hidden,
             tree_width: 30,
-            refresh_timer: nil,
-            refresh_inflight: nil,
-            refresh_pending?: false,
+            refresh: %Refresh{},
             clipboard_mark: nil,
             filtering: false,
             help_visible: false
@@ -150,8 +147,6 @@ defmodule MingaEditor.State.FileTree do
   @doc "Opens the tree with the given data, buffer, and focused state."
   @spec open(t(), FileTree.t(), pid() | nil) :: t()
   def open(%__MODULE__{} = ft, tree, buffer) do
-    tree = ensure_tree_entries(tree)
-
     %{
       ft
       | tree: tree,
@@ -161,21 +156,23 @@ defmodule MingaEditor.State.FileTree do
         project_root: tree.root,
         original_root: ft.original_root || tree.root,
         tree_status: classify_tree(tree),
-        tree_width: tree.width
+        tree_width: tree.width,
+        refresh: refresh_for_tree(ft, tree.root)
     }
   end
 
   @doc "Replaces the backing tree and refreshes the presentation status."
   @spec replace_tree(t(), FileTree.t()) :: t()
   def replace_tree(%__MODULE__{} = ft, %FileTree{} = tree) do
-    tree = ensure_tree_entries(tree)
+    refresh = refresh_for_tree(ft, tree.root)
 
     %{
       ft
       | tree: tree,
         project_root: tree.root,
-        tree_status: classify_tree(tree),
-        tree_width: tree.width
+        tree_status: replacement_status(ft, tree),
+        tree_width: tree.width,
+        refresh: refresh
     }
   end
 
@@ -201,58 +198,69 @@ defmodule MingaEditor.State.FileTree do
     %{ft | project_root: expanded, original_root: expanded}
   end
 
-  @doc "Returns true when a filesystem refresh timer is pending."
-  @spec refresh_scheduled?(t()) :: boolean()
-  def refresh_scheduled?(%__MODULE__{refresh_timer: ref}) when is_reference(ref), do: true
-  def refresh_scheduled?(%__MODULE__{}), do: false
-
-  @doc "Stores the pending filesystem refresh timer reference."
-  @spec schedule_refresh(t(), reference()) :: t()
-  def schedule_refresh(%__MODULE__{} = ft, ref) when is_reference(ref) do
-    %{ft | refresh_timer: ref}
+  @doc "Records one debounced request to refresh the open tree."
+  @spec request_refresh_debounce(t(), Refresh.debounce_token()) ::
+          {:scheduled | :already_scheduled, t()}
+  def request_refresh_debounce(%__MODULE__{} = ft, token) when is_reference(token) do
+    {status, refresh} = Refresh.request_debounce(ft.refresh, token)
+    {status, %{ft | refresh: refresh}}
   end
 
-  @doc "Clears the pending filesystem refresh timer reference."
-  @spec clear_refresh(t()) :: t()
-  def clear_refresh(%__MODULE__{} = ft), do: %{ft | refresh_timer: nil}
+  @doc "Consumes a correlated debounce message and focuses the result on the live tree."
+  @spec refresh_debounce_elapsed(t(), Refresh.debounce_token()) ::
+          {:ready, FileTree.t(), t()} | {:closed | :stale, t()}
+  def refresh_debounce_elapsed(%__MODULE__{} = ft, token) when is_reference(token) do
+    case Refresh.debounce_elapsed(ft.refresh, token) do
+      {:stale, refresh} ->
+        {:stale, %{ft | refresh: refresh}}
 
-  @doc "Returns true when an async refresh Task is currently in flight."
-  @spec refresh_inflight?(t()) :: boolean()
-  def refresh_inflight?(%__MODULE__{refresh_inflight: ref}) when is_reference(ref), do: true
-  def refresh_inflight?(%__MODULE__{}), do: false
-
-  @doc "Returns the token of the in-flight refresh Task, or nil when none is running."
-  @spec refresh_inflight_token(t()) :: reference() | nil
-  def refresh_inflight_token(%__MODULE__{refresh_inflight: ref}), do: ref
-
-  @doc "Returns true when another refresh was requested while one was in flight."
-  @spec refresh_pending?(t()) :: boolean()
-  def refresh_pending?(%__MODULE__{refresh_pending?: pending?}), do: pending?
-
-  @doc """
-  Marks an async refresh as in flight under `token` and clears the debounce timer.
-
-  Also clears any `refresh_pending?` flag: the freshly spawned Task supersedes a
-  request that was coalesced while a previous Task was running.
-  """
-  @spec begin_inflight_refresh(t(), reference()) :: t()
-  def begin_inflight_refresh(%__MODULE__{} = ft, token) when is_reference(token) do
-    %{ft | refresh_inflight: token, refresh_pending?: false, refresh_timer: nil}
+      {:current, refresh} ->
+        refresh_debounce_tree(%{ft | refresh: refresh})
+    end
   end
 
-  @doc "Records that a refresh was requested while one was already in flight."
-  @spec mark_refresh_pending(t()) :: t()
-  def mark_refresh_pending(%__MODULE__{} = ft), do: %{ft | refresh_pending?: true}
+  @doc "Correlates an admitted typed refresh request with the root it scans."
+  @spec track_refresh_request(t(), String.t(), Refresh.request_token()) :: t()
+  def track_refresh_request(%__MODULE__{} = ft, root, token)
+      when is_binary(root) and is_reference(token) do
+    %{ft | refresh: Refresh.request_admitted(ft.refresh, root, token)}
+  end
 
-  @doc "Clears in-flight and pending refresh tracking once a Task result is handled."
-  @spec clear_inflight_refresh(t()) :: t()
-  def clear_inflight_refresh(%__MODULE__{} = ft),
-    do: %{ft | refresh_inflight: nil, refresh_pending?: false}
+  @doc "Atomically accepts a current refresh result or identifies why it cannot apply."
+  @spec accept_refresh_result(t(), String.t(), Refresh.request_token(), FileTree.t()) ::
+          {:accepted | :closed | :rerooted | :stale, t()}
+  def accept_refresh_result(%__MODULE__{} = ft, root, token, %FileTree{} = refreshed_tree)
+      when is_binary(root) and is_reference(token) do
+    case Refresh.request_finished(ft.refresh, root, token) do
+      {:stale, refresh} ->
+        {:stale, %{ft | refresh: refresh}}
+
+      {:current, refresh} ->
+        accept_current_refresh(%{ft | refresh: refresh}, root, refreshed_tree)
+    end
+  end
+
+  @doc "Finishes a failed or canceled current request without changing tree content."
+  @spec finish_refresh(t(), String.t(), Refresh.request_token()) ::
+          {:current | :closed | :rerooted | :stale, t()}
+  def finish_refresh(%__MODULE__{} = ft, root, token)
+      when is_binary(root) and is_reference(token) do
+    case Refresh.request_finished(ft.refresh, root, token) do
+      {:stale, refresh} -> {:stale, %{ft | refresh: refresh}}
+      {:current, refresh} -> classify_current_tree(%{ft | refresh: refresh}, root)
+    end
+  end
 
   @doc "Marks the sidebar as failed with a displayable reason."
   @spec error(t(), term()) :: t()
   def error(%__MODULE__{} = ft, reason) do
     %{ft | focused: false, editing: nil, tree_status: {:error, format_error_reason(reason)}}
+  end
+
+  @doc "Reports a refresh failure while preserving the open tree interaction state."
+  @spec refresh_failed(t(), term()) :: t()
+  def refresh_failed(%__MODULE__{} = ft, reason) do
+    %{ft | tree_status: {:error, format_error_reason(reason)}}
   end
 
   @doc "Closes the tree and clears the buffer."
@@ -269,8 +277,7 @@ defmodule MingaEditor.State.FileTree do
         clipboard_mark: nil,
         filtering: false,
         help_visible: false,
-        refresh_inflight: nil,
-        refresh_pending?: false
+        refresh: Refresh.invalidate(ft.refresh)
     }
   end
 
@@ -316,9 +323,13 @@ defmodule MingaEditor.State.FileTree do
 
   @doc "Starts inline file tree filtering."
   @spec start_filtering(t()) :: t()
+  def start_filtering(%__MODULE__{tree: %FileTree{filter: filter} = tree} = ft)
+      when filter in [nil, ""] do
+    %{ft | tree: FileTree.begin_filter(tree), filtering: true, editing: nil, help_visible: false}
+  end
+
   def start_filtering(%__MODULE__{tree: %FileTree{} = tree} = ft) do
-    filter = tree.filter || ""
-    {tree, status} = filtered_tree(tree, filter)
+    {tree, status} = filtered_tree(tree, tree.filter)
 
     %{
       ft
@@ -344,7 +355,8 @@ defmodule MingaEditor.State.FileTree do
   reports a `:loading` pending state instead of silently re-shelling out.
   """
   @spec update_filter(t(), String.t()) :: t()
-  def update_filter(%__MODULE__{tree: %FileTree{} = tree} = ft, filter) when is_binary(filter) do
+  def update_filter(%__MODULE__{tree: %FileTree{} = tree} = ft, filter)
+      when is_binary(filter) and filter != "" do
     {tree, status} = filtered_tree(tree, filter)
     %{ft | tree: tree, tree_status: status}
   end
@@ -389,11 +401,6 @@ defmodule MingaEditor.State.FileTree do
   # rebuilding (empty) cache reports `:loading`; other roots defer to an async
   # filesystem walk (`:loading` until the walk result arrives).
   @spec filtered_tree(FileTree.t(), String.t()) :: {FileTree.t(), tree_status()}
-  defp filtered_tree(%FileTree{} = tree, "") do
-    tree = tree |> FileTree.put_cached_files(nil) |> FileTree.set_filter("")
-    {tree, classify_tree(tree)}
-  end
-
   defp filtered_tree(%FileTree{root: root} = tree, filter) do
     if ProjectCache.active_root?(root) do
       filtered_from_cache(tree, filter, ProjectCache.files())
@@ -430,16 +437,6 @@ defmodule MingaEditor.State.FileTree do
   @spec accept_filter(t()) :: t()
   def accept_filter(%__MODULE__{} = ft), do: %{ft | filtering: false}
 
-  @doc "Clears the active filter and exits filtering mode."
-  @spec clear_filter(t()) :: t()
-  def clear_filter(%__MODULE__{tree: %FileTree{} = tree} = ft) do
-    # Drop the cache so non-filtered browsing resumes lazy filesystem walking.
-    tree = tree |> FileTree.put_cached_files(nil) |> FileTree.clear_filter()
-    %{ft | tree: tree, filtering: false, tree_status: classify_tree(tree)}
-  end
-
-  def clear_filter(%__MODULE__{} = ft), do: %{ft | filtering: false}
-
   @doc "Toggles the file tree help overlay."
   @spec toggle_help(t()) :: t()
   def toggle_help(%__MODULE__{} = ft),
@@ -457,19 +454,60 @@ defmodule MingaEditor.State.FileTree do
 
   @doc "Replaces the tree data."
   @spec set_tree(t(), FileTree.t() | nil) :: t()
-  def set_tree(%__MODULE__{} = ft, nil), do: %{ft | tree: nil, tree_status: :hidden}
+  def set_tree(%__MODULE__{} = ft, nil) do
+    %{ft | tree: nil, tree_status: :hidden, refresh: Refresh.invalidate(ft.refresh)}
+  end
+
   def set_tree(%__MODULE__{} = ft, %FileTree{} = tree), do: replace_tree(ft, tree)
 
-  @spec ensure_tree_entries(FileTree.t()) :: FileTree.t()
-  defp ensure_tree_entries(%FileTree{} = tree), do: FileTree.ensure_entries(tree)
+  @spec refresh_debounce_tree(t()) :: {:ready, FileTree.t(), t()} | {:closed, t()}
+  defp refresh_debounce_tree(%__MODULE__{tree: %FileTree{} = tree} = ft), do: {:ready, tree, ft}
+  defp refresh_debounce_tree(%__MODULE__{} = ft), do: {:closed, ft}
 
-  @spec classify_tree(FileTree.t()) :: tree_status()
-  defp classify_tree(%FileTree{} = tree) do
-    case File.ls(tree.root) do
-      {:ok, _names} -> classify_entries(FileTree.visible_entries(tree))
-      {:error, reason} -> {:error, format_error_reason(reason)}
+  @spec accept_current_refresh(t(), String.t(), FileTree.t()) ::
+          {:accepted | :closed | :rerooted | :stale, t()}
+  defp accept_current_refresh(%__MODULE__{tree: nil} = ft, _root, _tree), do: {:closed, ft}
+
+  defp accept_current_refresh(
+         %__MODULE__{tree: %FileTree{root: live_root}} = ft,
+         root,
+         %FileTree{root: result_root} = refreshed_tree
+       ) do
+    case {Path.expand(live_root) == Path.expand(root),
+          Path.expand(result_root) == Path.expand(root)} do
+      {false, _result_matches?} -> {:rerooted, ft}
+      {true, false} -> {:stale, ft}
+      {true, true} -> {:accepted, replace_tree(ft, refreshed_tree)}
     end
   end
+
+  @spec classify_current_tree(t(), String.t()) :: {:current | :closed | :rerooted, t()}
+  defp classify_current_tree(%__MODULE__{tree: nil} = ft, _root), do: {:closed, ft}
+
+  defp classify_current_tree(%__MODULE__{tree: %FileTree{root: live_root}} = ft, root) do
+    if Path.expand(live_root) == Path.expand(root), do: {:current, ft}, else: {:rerooted, ft}
+  end
+
+  @spec refresh_for_tree(t(), String.t()) :: Refresh.t()
+  defp refresh_for_tree(
+         %__MODULE__{tree: %FileTree{root: root}, refresh: refresh},
+         root
+       ),
+       do: refresh
+
+  defp refresh_for_tree(%__MODULE__{refresh: refresh}, _root), do: Refresh.invalidate(refresh)
+
+  @spec replacement_status(t(), FileTree.t()) :: tree_status()
+  defp replacement_status(%__MODULE__{tree: %FileTree{}, tree_status: status}, %FileTree{
+         entries: nil
+       }),
+       do: status
+
+  defp replacement_status(%__MODULE__{}, %FileTree{} = tree), do: classify_tree(tree)
+
+  @spec classify_tree(FileTree.t()) :: tree_status()
+  defp classify_tree(%FileTree{entries: nil}), do: :loading
+  defp classify_tree(%FileTree{entries: entries}), do: classify_entries(entries)
 
   @spec classify_entries([FileTree.entry()]) :: tree_status()
   defp classify_entries([]), do: :empty

--- a/lib/minga_editor/state/file_tree/refresh.ex
+++ b/lib/minga_editor/state/file_tree/refresh.ex
@@ -1,0 +1,73 @@
+defmodule MingaEditor.State.FileTree.Refresh do
+  @moduledoc """
+  Pure semantic ownership for file-tree refresh intent.
+
+  The effect scheduler owns worker lifecycle, queueing, cancellation, and terminal
+  delivery. This value owns only the current debounce token and the newest
+  request whose result may still update the file tree.
+  """
+
+  @typedoc "A token carried by one debounce timer message."
+  @type debounce_token :: reference()
+
+  @typedoc "A scheduler request token correlated with the root it scanned."
+  @type request_token :: reference()
+
+  @typedoc "Semantic correlation for the newest admitted refresh request."
+  @type current_request :: %{token: request_token(), root: String.t()}
+
+  @type t :: %__MODULE__{
+          debounce: debounce_token() | nil,
+          current: current_request() | nil
+        }
+
+  defstruct debounce: nil, current: nil
+
+  @doc "Records one debounce intent, leaving an existing timer authoritative."
+  @spec request_debounce(t(), debounce_token()) :: {:scheduled | :already_scheduled, t()}
+  def request_debounce(%__MODULE__{debounce: nil} = refresh, token) when is_reference(token) do
+    {:scheduled, %{refresh | debounce: token}}
+  end
+
+  def request_debounce(%__MODULE__{} = refresh, token) when is_reference(token) do
+    {:already_scheduled, refresh}
+  end
+
+  @doc "Consumes only the currently correlated debounce timer message."
+  @spec debounce_elapsed(t(), debounce_token()) :: {:current | :stale, t()}
+  def debounce_elapsed(%__MODULE__{debounce: token} = refresh, token) when is_reference(token) do
+    {:current, %{refresh | debounce: nil}}
+  end
+
+  def debounce_elapsed(%__MODULE__{} = refresh, token) when is_reference(token) do
+    {:stale, refresh}
+  end
+
+  @doc "Correlates the newest admitted scheduler request with its scanned root."
+  @spec request_admitted(t(), String.t(), request_token()) :: t()
+  def request_admitted(%__MODULE__{} = refresh, root, token)
+      when is_binary(root) and is_reference(token) do
+    %{refresh | current: %{root: Path.expand(root), token: token}}
+  end
+
+  @doc "Classifies and consumes a terminal result for the semantic current request."
+  @spec request_finished(t(), String.t(), request_token()) ::
+          {:current | :stale, t()}
+  def request_finished(
+        %__MODULE__{current: %{root: root, token: token}} = refresh,
+        root,
+        token
+      )
+      when is_binary(root) and is_reference(token) do
+    {:current, %{refresh | current: nil}}
+  end
+
+  def request_finished(%__MODULE__{} = refresh, root, token)
+      when is_binary(root) and is_reference(token) do
+    {:stale, refresh}
+  end
+
+  @doc "Invalidates every timer and result correlation when the tree lifecycle changes."
+  @spec invalidate(t()) :: t()
+  def invalidate(%__MODULE__{} = refresh), do: %{refresh | debounce: nil, current: nil}
+end

--- a/test/minga_editor/file_tree/feature_test.exs
+++ b/test/minga_editor/file_tree/feature_test.exs
@@ -73,6 +73,22 @@ defmodule MingaEditor.FileTree.FeatureTest do
     assert %{id: "file_tree", visible?: false} = Sidebar.get(table, "file_tree")
   end
 
+  test "opening an unavailable project root exposes an error instead of an empty tree", %{
+    sidebar_registry: table
+  } do
+    missing_root =
+      Path.join(System.tmp_dir!(), "minga-missing-tree-#{System.unique_integer([:positive])}")
+
+    state = base_state(cols: 80, rows: 24, sidebar_registry: table)
+    state = EditorState.set_file_tree(state, %FileTreeState{project_root: missing_root})
+    state = MingaEditor.Commands.FileTree.toggle(state)
+    file_tree = EditorState.file_tree_state(state)
+
+    assert file_tree.tree.root == Path.expand(missing_root)
+    assert {:error, reason} = FileTreeState.status(file_tree)
+    assert reason != ""
+  end
+
   test "dropping FileTree feature state is safe and toggle recreates it", %{
     sidebar_registry: table
   } do

--- a/test/minga_editor/file_tree/freshness_test.exs
+++ b/test/minga_editor/file_tree/freshness_test.exs
@@ -1,5 +1,6 @@
 defmodule MingaEditor.FileTree.FreshnessTest do
-  @moduledoc "Tests for file tree freshness git-cache integration."
+  @moduledoc "Behavior tests for file-tree refresh workflow coordination."
+
   use ExUnit.Case, async: true
 
   alias Minga.Events
@@ -7,7 +8,15 @@ defmodule MingaEditor.FileTree.FreshnessTest do
   alias Minga.Git.StatusEntry
   alias Minga.Git.Stub, as: GitStub
   alias Minga.Project.FileTree
+  alias Minga.Project.FileTree.BufferSync
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.EffectScheduler
   alias MingaEditor.FileTree.Freshness
+  alias MingaEditor.FileTree.Refresh
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  import MingaEditor.RenderPipeline.TestHelpers
 
   @moduletag :tmp_dir
 
@@ -24,11 +33,170 @@ defmodule MingaEditor.FileTree.FreshnessTest do
 
     tree = FileTree.new(dir)
 
-    assert %FileTree{} = Freshness.refresh_tree_git_status_from_cache(tree, events_registry)
+    assert %FileTree{} = Refresh.with_cached_git_status(tree, events_registry)
     assert repo = Repo.lookup(dir)
 
     Repo.await_refresh(repo)
     assert Repo.status(repo) == [entry]
+  end
+
+  test "only the current debounce timer admits a typed scheduler request", %{tmp_dir: root} do
+    scheduler = start_scheduler()
+    state = state_with_tree(root, scheduler)
+    state = Freshness.request_refresh(state, 60_000)
+    timer_token = file_tree(state).refresh.debounce
+
+    stale_state = Freshness.begin_refresh(state, make_ref())
+    assert stale_state == state
+    assert EffectScheduler.stats(scheduler).admitted == 0
+
+    scheduled_state = Freshness.begin_refresh(state, timer_token)
+    current = file_tree(scheduled_state).refresh.current
+
+    assert is_reference(current.token)
+    assert current.root == Path.expand(root)
+    assert EffectScheduler.active?(scheduler, Refresh)
+  end
+
+  test "accepted completion updates owner, syncs the buffer, then requests rendering", %{
+    tmp_dir: root
+  } do
+    original = tree(root, [])
+    buffer = BufferSync.start_buffer(original)
+
+    state = state_with_tree(root, nil, buffer)
+    state = %{state | backend: :tui}
+    request = Refresh.request(original, EditorState.events_registry(state))
+    tracked = track(state, request)
+    refreshed = tree(root, [entry(root, "fresh.ex")])
+
+    assert {accepted, %Outcome{status: :completed}} =
+             Refresh.apply(tracked, Outcome.completed(request, refreshed))
+
+    assert file_tree(accepted).tree == refreshed
+    assert Minga.Buffer.content(buffer) =~ "fresh.ex"
+    assert is_reference(accepted.render_timer)
+    Process.cancel_timer(accepted.render_timer)
+  end
+
+  test "failed and canceled outcomes clear current correlation without requesting rendering", %{
+    tmp_dir: root
+  } do
+    state = state_with_tree(root)
+    state = %{state | backend: :tui}
+    request = Refresh.request(file_tree(state).tree, EditorState.events_registry(state))
+    tracked = track(state, request)
+
+    assert {failed, %Outcome{status: :failed}} =
+             Refresh.apply(tracked, Outcome.failed(request, :unreadable))
+
+    assert failed.render_timer == nil
+    assert failed |> file_tree() |> then(& &1.refresh.current) == nil
+
+    retry = Refresh.request(file_tree(failed).tree, EditorState.events_registry(failed))
+    retracked = track(failed, retry)
+
+    assert {canceled, %Outcome{status: :canceled}} =
+             Refresh.apply(retracked, Outcome.canceled(retry, :requested))
+
+    assert canceled.render_timer == nil
+    assert canceled |> file_tree() |> then(& &1.refresh.current) == nil
+  end
+
+  test "closed and rerooted completions are stale and never request rendering", %{tmp_dir: root} do
+    old_root = Path.join(root, "old")
+    new_root = Path.join(root, "new")
+    request = Refresh.request(tree(old_root, []), Minga.Events.default_registry())
+    refreshed = tree(old_root, [entry(old_root, "old.ex")])
+
+    closed = state_with_tree(old_root) |> track(request) |> close_tree()
+
+    assert {closed_state, %Outcome{status: :stale, reason: :stale}} =
+             Refresh.apply(closed, Outcome.completed(request, refreshed))
+
+    assert file_tree(closed_state).tree == nil
+    assert closed_state.render_timer == nil
+
+    rerooted =
+      state_with_tree(old_root)
+      |> track(request)
+      |> EditorState.update_file_tree(&FileTreeState.replace_tree(&1, tree(new_root, [])))
+
+    assert {rerooted_state, %Outcome{status: :stale, reason: :stale}} =
+             Refresh.apply(rerooted, Outcome.completed(request, refreshed))
+
+    assert file_tree(rerooted_state).tree.root == Path.expand(new_root)
+    assert rerooted_state.render_timer == nil
+  end
+
+  test "project-root replacement exposes unavailable roots as errors", %{tmp_dir: root} do
+    old_root = Path.join(root, "old")
+    missing_root = Path.join(root, "missing")
+    File.mkdir_p!(old_root)
+
+    updated = old_root |> state_with_tree() |> Freshness.update_project_root(missing_root)
+
+    assert file_tree(updated).tree.root == Path.expand(missing_root)
+    assert {:error, reason} = FileTreeState.status(file_tree(updated))
+    assert reason != ""
+  end
+
+  test "current root failures preserve the tree and expose an error state", %{tmp_dir: root} do
+    state = %{state_with_tree(root) | backend: :tui}
+    request = Refresh.request(file_tree(state).tree, EditorState.events_registry(state))
+    tracked = track(state, request)
+
+    assert {failed, %Outcome{status: :failed}} =
+             Refresh.apply(tracked, Outcome.failed(request, {:root_unavailable, :enoent}))
+
+    assert file_tree(failed).tree.root == Path.expand(root)
+    assert {:error, reason} = FileTreeState.status(file_tree(failed))
+    assert reason != ""
+    assert file_tree(failed).refresh.current == nil
+    assert is_reference(failed.render_timer)
+    Process.cancel_timer(failed.render_timer)
+  end
+
+  defp state_with_tree(root, scheduler \\ nil, buffer \\ nil) do
+    file_tree = FileTreeState.open(%FileTreeState{}, tree(root, []), buffer)
+    state = EditorState.set_file_tree(base_state(), file_tree)
+    %{state | effect_scheduler: scheduler}
+  end
+
+  defp tree(root, entries), do: root |> FileTree.new() |> FileTree.put_entries(entries)
+
+  defp entry(root, name) do
+    %{
+      name: name,
+      path: Path.join(root, name),
+      dir?: false,
+      depth: 0,
+      last_child?: true,
+      guides: []
+    }
+  end
+
+  defp track(state, request) do
+    EditorState.update_file_tree(
+      state,
+      &FileTreeState.track_refresh_request(&1, request.effect.root, request.id)
+    )
+  end
+
+  defp close_tree(state), do: EditorState.update_file_tree(state, &FileTreeState.close/1)
+  defp file_tree(state), do: EditorState.file_tree_state(state)
+
+  defp start_scheduler do
+    task_supervisor =
+      start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
+
+    scheduler =
+      start_supervised!(
+        Supervisor.child_spec({EffectScheduler, task_supervisor: task_supervisor}, id: make_ref())
+      )
+
+    :ok = EffectScheduler.attach(scheduler, self())
+    scheduler
   end
 
   @spec start_events_registry() :: atom()

--- a/test/minga_editor/file_tree/refresh_test.exs
+++ b/test/minga_editor/file_tree/refresh_test.exs
@@ -1,40 +1,168 @@
 defmodule MingaEditor.FileTree.RefreshTest do
-  @moduledoc "Tests for the async file-tree rescan Task (#2632)."
+  @moduledoc "Behavior tests for the typed, coalescing file-tree refresh effect."
+
   use ExUnit.Case, async: true
 
   alias Minga.Project.FileTree
+  alias Minga.Test.FileTreeRefreshScanner
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.EffectScheduler
   alias MingaEditor.FileTree.Refresh
 
   @moduletag :tmp_dir
+  @timeout 2_000
 
-  test "start/4 rescans off-process and replies with the refreshed tree and token",
-       %{tmp_dir: tmp_dir} do
-    File.write!(Path.join(tmp_dir, "alpha.ex"), "")
-    tree = FileTree.new(tmp_dir) |> FileTree.ensure_entries()
+  test "request uses stable root identity and one bounded coalesced follow-up", %{tmp_dir: root} do
+    tree = tree(root)
+    request = Refresh.request(tree, Minga.Events.default_registry())
 
-    # A file created after the tree snapshot must show up in the rescan result.
-    File.write!(Path.join(tmp_dir, "beta.ex"), "")
-
-    token = make_ref()
-    assert :ok = Refresh.start(tree, token, Minga.Events.default_registry(), self())
-
-    assert_receive {:file_tree_refresh_result, %FileTree{} = refreshed, ^token}, 2_000
-
-    names = refreshed |> FileTree.visible_entries() |> Enum.map(& &1.name)
-    assert "alpha.ex" in names
-    assert "beta.ex" in names
+    assert request.resource == {:file_tree_root, Path.expand(root)}
+    assert request.policy.mode == :coalescing
+    assert request.policy.max_queued == 1
+    assert request.effect.root == Path.expand(root)
   end
 
-  test "start/4 always replies with a failure sentinel when the rescan raises" do
-    # A nil root makes the filesystem walk raise (`File.ls(nil)`); the Task must
-    # still reply so the Editor's in-flight flag is cleared and never wedges
-    # (#2632). The sentinel carries the same token for staleness matching.
-    bad_tree = %FileTree{root: nil}
-    token = make_ref()
+  test "run rescans through the typed effect and returns a completed tree", %{tmp_dir: root} do
+    File.write!(Path.join(root, "alpha.ex"), "")
+    request = request(tree(root), :completed, {:return, tree(root)})
 
-    assert :ok = Refresh.start(bad_tree, token, Minga.Events.default_registry(), self())
+    assert {:ok, %FileTree{root: refreshed_root}} = Refresh.run(request.effect)
+    assert refreshed_root == Path.expand(root)
+    assert_receive {:file_tree_scan_started, :completed, _worker}, @timeout
+  end
 
-    assert_receive {:file_tree_refresh_failed, ^token}, 2_000
-    refute_receive {:file_tree_refresh_result, _tree, ^token}, 100
+  test "run preserves scanner failures as domain failures", %{tmp_dir: root} do
+    request = request(tree(root), :failed, {:error, :unreadable})
+
+    assert Refresh.run(request.effect) == {:error, :unreadable}
+    assert_receive {:file_tree_scan_started, :failed, _worker}, @timeout
+  end
+
+  test "filesystem scanner reports an unavailable root instead of an empty tree", %{tmp_dir: root} do
+    missing_root = Path.join(root, "missing")
+    request = Refresh.request(tree(missing_root), Minga.Events.default_registry())
+
+    assert Refresh.run(request.effect) == {:error, {:root_unavailable, :enoent}}
+  end
+
+  test "scheduler exposes running, queued, and exactly one coalesced follow-up", %{tmp_dir: root} do
+    scheduler = start_scheduler()
+    tree = tree(root)
+    first = request(tree, :first, :wait)
+    second = request(tree, :second, :wait)
+    third = request(tree, :third, :wait)
+
+    assert EffectScheduler.schedule(scheduler, first) == {:ok, first.id, :running}
+    assert_lifecycle(first.id, :running)
+    assert_receive {:file_tree_scan_started, :first, first_worker}, @timeout
+
+    assert EffectScheduler.schedule(scheduler, second) == {:ok, second.id, :queued}
+    assert_lifecycle(second.id, :queued)
+
+    assert EffectScheduler.schedule(scheduler, third) == {:ok, third.id, :queued}
+    assert_lifecycle(second.id, :stale)
+    assert_lifecycle(third.id, :queued)
+    assert_terminal(second.id, :stale)
+    assert EffectScheduler.stats(scheduler).queued == 1
+
+    send(first_worker, {:release_file_tree_scan, :first, {:return, tree}})
+    first_outcome = receive_outcome(scheduler, first.id, :completed)
+    :ok = EffectScheduler.claim(scheduler, first_outcome)
+    EffectScheduler.finalize(scheduler, first_outcome)
+
+    assert_receive {:file_tree_scan_started, :third, third_worker}, @timeout
+    send(third_worker, {:release_file_tree_scan, :third, {:return, tree}})
+    third_outcome = receive_outcome(scheduler, third.id, :completed)
+    :ok = EffectScheduler.claim(scheduler, third_outcome)
+    EffectScheduler.finalize(scheduler, third_outcome)
+    assert_terminal(third.id, :completed)
+  end
+
+  test "failed work terminalizes and leaves the root schedulable", %{tmp_dir: root} do
+    scheduler = start_scheduler()
+    failed = request(tree(root), :failed_work, {:error, :gone})
+
+    assert EffectScheduler.schedule(scheduler, failed) == {:ok, failed.id, :running}
+    assert_lifecycle(failed.id, :running)
+    assert_receive {:file_tree_scan_started, :failed_work, _worker}, @timeout
+    outcome = receive_outcome(scheduler, failed.id, :failed)
+    assert outcome.reason == :gone
+    :ok = EffectScheduler.claim(scheduler, outcome)
+    EffectScheduler.finalize(scheduler, outcome)
+    assert_terminal(failed.id, :failed)
+
+    retry = request(tree(root), :retry, {:return, tree(root)})
+    assert EffectScheduler.schedule(scheduler, retry) == {:ok, retry.id, :running}
+    assert_lifecycle(retry.id, :running)
+    assert_receive {:file_tree_scan_started, :retry, _worker}, @timeout
+    retry_outcome = receive_outcome(scheduler, retry.id, :completed)
+    :ok = EffectScheduler.claim(scheduler, retry_outcome)
+    EffectScheduler.finalize(scheduler, retry_outcome)
+  end
+
+  test "canceled work terminalizes and leaves the root schedulable", %{tmp_dir: root} do
+    scheduler = start_scheduler()
+    canceled = request(tree(root), :canceled, :wait)
+
+    assert EffectScheduler.schedule(scheduler, canceled) == {:ok, canceled.id, :running}
+    assert_lifecycle(canceled.id, :running)
+    assert_receive {:file_tree_scan_started, :canceled, worker}, @timeout
+    monitor = Process.monitor(worker)
+
+    assert :ok = EffectScheduler.cancel(scheduler, canceled.id)
+    outcome = receive_outcome(scheduler, canceled.id, :canceled)
+    assert outcome.reason == :requested
+    assert_receive {:DOWN, ^monitor, :process, ^worker, _reason}
+    :ok = EffectScheduler.claim(scheduler, outcome)
+    EffectScheduler.finalize(scheduler, outcome)
+    assert_terminal(canceled.id, :canceled)
+
+    retry = request(tree(root), :after_cancel, {:return, tree(root)})
+    assert EffectScheduler.schedule(scheduler, retry) == {:ok, retry.id, :running}
+    assert_lifecycle(retry.id, :running)
+    assert_receive {:file_tree_scan_started, :after_cancel, _worker}, @timeout
+  end
+
+  defp tree(root), do: root |> FileTree.new() |> FileTree.put_entries([])
+
+  defp request(tree, label, action) do
+    Refresh.request(tree, Minga.Events.default_registry(),
+      scanner: FileTreeRefreshScanner,
+      scanner_context: {self(), label, action}
+    )
+  end
+
+  defp start_scheduler do
+    task_supervisor =
+      start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
+
+    scheduler =
+      start_supervised!(
+        Supervisor.child_spec(
+          {EffectScheduler, task_supervisor: task_supervisor, observer: self()},
+          id: make_ref()
+        )
+      )
+
+    :ok = EffectScheduler.attach(scheduler, self())
+    scheduler
+  end
+
+  defp assert_lifecycle(request_id, status) do
+    assert_receive {:effect_lifecycle, %Outcome{request: %{id: ^request_id}, status: ^status}},
+                   @timeout
+  end
+
+  defp receive_outcome(scheduler, request_id, status) do
+    assert_receive {:effect_result, ^scheduler,
+                    %Outcome{request: %{id: ^request_id}, status: ^status} = outcome},
+                   @timeout
+
+    outcome
+  end
+
+  defp assert_terminal(request_id, status) do
+    assert_receive {:effect_terminal, %Outcome{request: %{id: ^request_id}, status: ^status}},
+                   @timeout
   end
 end

--- a/test/minga_editor/file_tree/rows_test.exs
+++ b/test/minga_editor/file_tree/rows_test.exs
@@ -280,7 +280,7 @@ defmodule MingaEditor.FileTree.RowsTest do
     test "distinguishes hidden, empty, ready, loading, and error states", %{tmp_dir: tmp_dir} do
       assert FileTreeState.status(%FileTreeState{}) == :hidden
 
-      empty_tree = FileTree.new(tmp_dir)
+      empty_tree = tmp_dir |> FileTree.new() |> FileTree.ensure_entries()
       assert FileTreeState.status(FileTreeState.open(%FileTreeState{}, empty_tree, nil)) == :empty
 
       ready_tree = flat_tree(tmp_dir)
@@ -289,11 +289,8 @@ defmodule MingaEditor.FileTree.RowsTest do
       loading = FileTreeState.loading(%FileTreeState{project_root: tmp_dir})
       assert FileTreeState.status(loading) == :loading
 
-      missing_tree = FileTree.new(Path.join(tmp_dir, "missing"))
-
-      assert {:error, reason} =
-               FileTreeState.status(FileTreeState.open(%FileTreeState{}, missing_tree, nil))
-
+      errored = FileTreeState.error(%FileTreeState{}, :enoent)
+      assert {:error, reason} = FileTreeState.status(errored)
       assert reason != ""
     end
 
@@ -313,6 +310,16 @@ defmodule MingaEditor.FileTree.RowsTest do
         |> FileTreeState.replace_tree(ready_tree)
 
       assert FileTreeState.status(errored) == :ready
+    end
+
+    test "entry-invalidating transitions preserve the current visible status", %{tmp_dir: tmp_dir} do
+      file_tree = FileTreeState.open(%FileTreeState{}, flat_tree(tmp_dir), nil)
+      invalidated = FileTree.collapse_all(file_tree.tree)
+
+      assert invalidated.entries == nil
+
+      assert file_tree |> FileTreeState.replace_tree(invalidated) |> FileTreeState.status() ==
+               :ready
     end
 
     test "open and replace_tree keep cached visible entries on the stored tree", %{
@@ -343,11 +350,11 @@ defmodule MingaEditor.FileTree.RowsTest do
   defp flat_tree(tmp_dir) do
     File.write!(Path.join(tmp_dir, "alpha.ex"), "")
     File.write!(Path.join(tmp_dir, "beta.ex"), "")
-    FileTree.new(tmp_dir)
+    tmp_dir |> FileTree.new() |> FileTree.ensure_entries()
   end
 
   defp state_with_tree(root) do
-    tree = FileTree.new(root)
+    tree = root |> FileTree.new() |> FileTree.ensure_entries()
     file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
 
     EditorState.set_file_tree(base_state(), file_tree)

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -14,7 +14,6 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
   alias Minga.Git.StatusEntry
   alias Minga.Project.FileRef
   alias Minga.Project.FileTree
-  alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.Handlers.FileEventHandler
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
@@ -134,13 +133,22 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
   describe "file tree freshness" do
     @describetag :tmp_dir
 
-    test "file change under the tree root schedules one debounced refresh", %{tmp_dir: tmp_dir} do
+    test "file change under the tree root starts one correlated debounce at its origin", %{
+      tmp_dir: tmp_dir
+    } do
       state = state_with_tree(tmp_dir)
       changed_path = Path.join(tmp_dir, "created.ex")
 
-      {_state, effects} = FileEventHandler.handle(state, {:file_changed_on_disk, changed_path})
+      {scheduled, effects} = FileEventHandler.handle(state, {:file_changed_on_disk, changed_path})
+      token = ft(scheduled).refresh.debounce
 
-      assert effects == [{:schedule_file_tree_refresh, 50}]
+      {repeated, repeated_effects} =
+        FileEventHandler.handle(scheduled, {:file_changed_on_disk, changed_path})
+
+      assert is_reference(token)
+      assert ft(repeated).refresh.debounce == token
+      assert effects == []
+      assert repeated_effects == []
     end
 
     test "file change outside the tree root does not refresh", %{tmp_dir: tmp_dir} do
@@ -156,14 +164,15 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       state = state_with_tree(tmp_dir)
       changed_path = Path.join(tmp_dir, "created_by_agent.ex")
 
-      {_state, effects} =
+      {scheduled, effects} =
         FileEventHandler.handle(state, {
           :minga_event,
           :file_written,
           %Minga.Events.FileWrittenEvent{path: changed_path, change_type: :created}
         })
 
-      assert effects == [{:schedule_file_tree_refresh, 50}]
+      assert is_reference(ft(scheduled).refresh.debounce)
+      assert effects == []
     end
 
     test "file_written outside the tree root does not refresh", %{tmp_dir: tmp_dir} do
@@ -178,251 +187,6 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
         })
 
       assert effects == []
-    end
-
-    test "applying repeated refresh effects keeps one pending timer", %{tmp_dir: tmp_dir} do
-      state = state_with_tree(tmp_dir)
-
-      first_state =
-        MingaEditor.Handlers.EffectHandler.apply_effects(state, [
-          {:schedule_file_tree_refresh, 1_000}
-        ])
-
-      first_ref = ft(first_state).refresh_timer
-
-      second_state =
-        MingaEditor.Handlers.EffectHandler.apply_effects(first_state, [
-          {:schedule_file_tree_refresh, 1_000}
-        ])
-
-      assert is_reference(first_ref)
-      assert ft(second_state).refresh_timer == first_ref
-      Process.cancel_timer(first_ref)
-    end
-
-    test "refresh timer spawns an async rescan without blocking I/O in the handler",
-         %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
-
-      state =
-        tmp_dir
-        |> state_with_tree()
-        |> FileTreeFreshness.schedule_refresh(make_ref())
-
-      # A new file appears after the tree was opened. The handler must NOT rescan
-      # inline, so the returned tree still does not see it (#2632 AC1).
-      File.write!(Path.join(tmp_dir, "beta.ex"), "")
-
-      {new_state, effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      assert [{:start_file_tree_refresh, %FileTree{root: root}, token}] = effects
-      assert root == Path.expand(tmp_dir)
-      assert is_reference(token)
-
-      names = ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
-      refute "beta.ex" in names
-
-      # Debounce timer cleared, refresh now tracked as in-flight.
-      refute FileTreeFreshness.refresh_scheduled?(new_state)
-      assert FileTreeState.refresh_inflight?(ft(new_state))
-    end
-
-    test "refresh result swaps the whole tree atomically and clears in-flight",
-         %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
-      state = state_with_tree(tmp_dir)
-
-      {pending_state, [{:start_file_tree_refresh, captured_tree, token}]} =
-        FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      # Simulate the Task's off-process rescan picking up a newly created file.
-      File.write!(Path.join(tmp_dir, "beta.ex"), "")
-      refreshed_tree = FileTree.refresh(captured_tree)
-
-      {new_state, effects} =
-        FileEventHandler.handle(
-          pending_state,
-          {:file_tree_refresh_result, refreshed_tree, token}
-        )
-
-      names = ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
-      assert "beta.ex" in names
-      assert {:render, 16} in effects
-      refute FileTreeState.refresh_inflight?(ft(new_state))
-    end
-
-    test "a stale result for a superseded token is discarded", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
-      state = state_with_tree(tmp_dir)
-
-      {pending_state, [{:start_file_tree_refresh, captured_tree, _token}]} =
-        FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      File.write!(Path.join(tmp_dir, "beta.ex"), "")
-      refreshed_tree = FileTree.refresh(captured_tree)
-
-      {new_state, effects} =
-        FileEventHandler.handle(
-          pending_state,
-          {:file_tree_refresh_result, refreshed_tree, make_ref()}
-        )
-
-      names = ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
-      refute "beta.ex" in names
-      assert effects == []
-    end
-
-    test "a result for a re-rooted tree is discarded", %{tmp_dir: tmp_dir} do
-      old_root = Path.join(tmp_dir, "old")
-      new_root = Path.join(tmp_dir, "new")
-      File.mkdir_p!(old_root)
-      File.mkdir_p!(new_root)
-      File.write!(Path.join(old_root, "old.ex"), "")
-
-      state = state_with_tree(old_root)
-
-      {pending_state, [{:start_file_tree_refresh, captured_tree, token}]} =
-        FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      # User re-roots the tree while the walk runs. The in-flight token is still
-      # set, but the live tree root no longer matches the captured walk's root.
-      rerooted = FileTreeState.replace_tree(ft(pending_state), FileTree.new(new_root))
-      rerooted_state = EditorState.set_file_tree(pending_state, rerooted)
-
-      refreshed_tree = FileTree.refresh(captured_tree)
-
-      {new_state, effects} =
-        FileEventHandler.handle(
-          rerooted_state,
-          {:file_tree_refresh_result, refreshed_tree, token}
-        )
-
-      assert ft(new_state).tree.root == Path.expand(new_root)
-      assert effects == []
-
-      # The re-root discard path still completes the in-flight bookkeeping:
-      # clearing in-flight is what lets a later timer spawn a new rescan. If it
-      # stayed set, every later timer would coalesce-only and the tree would
-      # never refresh again after a re-root (#2632 AC3 — no permanent wedge).
-      refute FileTreeState.refresh_inflight?(ft(new_state))
-      refute FileTreeState.refresh_pending?(ft(new_state))
-    end
-
-    test "overlapping events coalesce into one follow-up rescan, not piled Tasks",
-         %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
-      state = state_with_tree(tmp_dir)
-
-      # First timer spawns one rescan.
-      {state, [{:start_file_tree_refresh, captured_tree, token}]} =
-        FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      # A second burst arrives while the first rescan is still in flight. No new
-      # Task is spawned; the request is coalesced (#2632 AC3).
-      {state, second_effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
-      assert second_effects == []
-      assert FileTreeState.refresh_pending?(ft(state))
-
-      # When the in-flight rescan completes, exactly one fresh rescan starts.
-      refreshed_tree = FileTree.refresh(captured_tree)
-
-      {state, effects} =
-        FileEventHandler.handle(state, {:file_tree_refresh_result, refreshed_tree, token})
-
-      assert [{:start_file_tree_refresh, _tree, follow_up_token}] =
-               Enum.filter(effects, &match?({:start_file_tree_refresh, _, _}, &1))
-
-      assert follow_up_token != token
-      assert FileTreeState.refresh_inflight?(ft(state))
-      refute FileTreeState.refresh_pending?(ft(state))
-
-      # The follow-up completing with no further pending request clears in-flight.
-      {state, follow_up_effects} =
-        FileEventHandler.handle(
-          state,
-          {:file_tree_refresh_result, FileTree.refresh(refreshed_tree), follow_up_token}
-        )
-
-      refute Enum.any?(follow_up_effects, &match?({:start_file_tree_refresh, _, _}, &1))
-      refute FileTreeState.refresh_inflight?(ft(state))
-    end
-
-    test "a failed rescan clears in-flight so a later timer is not wedged",
-         %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
-      state = state_with_tree(tmp_dir)
-
-      {state, [{:start_file_tree_refresh, _tree, token}]} =
-        FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      # The Task crashed and sent the failure sentinel instead of a tree.
-      {state, fail_effects} =
-        FileEventHandler.handle(state, {:file_tree_refresh_failed, token})
-
-      assert fail_effects == []
-      refute FileTreeState.refresh_inflight?(ft(state))
-
-      # A later timer must spawn a brand new rescan — the loop is not wedged.
-      {_state, retry_effects} = FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      assert [{:start_file_tree_refresh, _retry_tree, retry_token}] = retry_effects
-      assert retry_token != token
-    end
-
-    test "a failed rescan still honours a coalesced refresh", %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
-      state = state_with_tree(tmp_dir)
-
-      {state, [{:start_file_tree_refresh, _tree, token}]} =
-        FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      # A burst arrived while the rescan ran; it coalesced into refresh_pending?.
-      {state, []} = FileEventHandler.handle(state, :file_tree_refresh_timer)
-      assert FileTreeState.refresh_pending?(ft(state))
-
-      # Even though the rescan failed, the coalesced request starts exactly one
-      # fresh rescan (#2632 AC3) — no tree was applied, but the loop continues.
-      {state, fail_effects} =
-        FileEventHandler.handle(state, {:file_tree_refresh_failed, token})
-
-      assert [{:start_file_tree_refresh, _retry_tree, follow_up_token}] = fail_effects
-      assert follow_up_token != token
-      assert FileTreeState.refresh_inflight?(ft(state))
-      refute FileTreeState.refresh_pending?(ft(state))
-    end
-
-    test "a stale failure sentinel for a superseded token is ignored",
-         %{tmp_dir: tmp_dir} do
-      File.write!(Path.join(tmp_dir, "alpha.ex"), "")
-      state = state_with_tree(tmp_dir)
-
-      {state, [{:start_file_tree_refresh, _tree, token}]} =
-        FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      # A failure for some other (already superseded) refresh must not clear the
-      # genuine in-flight refresh.
-      {new_state, effects} =
-        FileEventHandler.handle(state, {:file_tree_refresh_failed, make_ref()})
-
-      assert effects == []
-      assert FileTreeState.refresh_inflight_token(ft(new_state)) == token
-    end
-
-    test "cancel_inflight_refresh clears only the matching in-flight token",
-         %{tmp_dir: tmp_dir} do
-      state = state_with_tree(tmp_dir)
-
-      {state, [{:start_file_tree_refresh, _tree, token}]} =
-        FileEventHandler.handle(state, :file_tree_refresh_timer)
-
-      # A non-matching token (a newer refresh) must be left untouched.
-      untouched = FileTreeFreshness.cancel_inflight_refresh(state, make_ref())
-      assert FileTreeState.refresh_inflight_token(ft(untouched)) == token
-
-      # The matching token (e.g. a failed Task.Supervisor.start_child) is cleared
-      # so a later timer can retry instead of wedging (#2632).
-      cleared = FileTreeFreshness.cancel_inflight_refresh(state, token)
-      refute FileTreeState.refresh_inflight?(ft(cleared))
     end
 
     test "diagnostics under the tree root schedule render", %{tmp_dir: tmp_dir} do

--- a/test/minga_editor/input/file_tree_editing_input_test.exs
+++ b/test/minga_editor/input/file_tree_editing_input_test.exs
@@ -184,6 +184,28 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
       assert ft(state).tree.filter == nil
     end
 
+    test "clearing a no-match filter restores existing rows", %{tmp_dir: dir} do
+      state = make_state(dir)
+      File.write!(Path.join(dir, "visible.txt"), "visible")
+      tree = FileTree.refresh(ft(state).tree)
+      state = EditorState.update_file_tree(state, &FileTreeState.replace_tree(&1, tree))
+
+      {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
+      {:handled, state} = FileTreeHandler.handle_key(state, ?z, 0)
+
+      no_matches = FileTreeState.apply_filter_walk(ft(state), tree.root, "z", [])
+      state = EditorState.set_file_tree(state, no_matches)
+      assert FileTreeState.status(ft(state)) == :empty
+
+      {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
+
+      assert ft(state).filtering == false
+      assert ft(state).tree.filter == nil
+      assert FileTreeState.status(ft(state)) == :ready
+      assert Enum.any?(FileTree.visible_entries(ft(state).tree), &(&1.name == "visible.txt"))
+      assert BufferProcess.content(ft(state).buffer) =~ "visible.txt"
+    end
+
     test "/ while help is open starts filtering and hides help", %{tmp_dir: dir} do
       state = make_state(dir)
 

--- a/test/minga_editor/state/file_tree_filter_test.exs
+++ b/test/minga_editor/state/file_tree_filter_test.exs
@@ -27,8 +27,9 @@ defmodule MingaEditor.State.FileTreeFilterTest do
   end
 
   test "an empty filter never needs an async walk" do
-    ft = open_tree("/nonexistent_root") |> FileTreeState.update_filter("")
+    ft = open_tree("/nonexistent_root") |> FileTreeState.start_filtering()
 
+    assert ft.tree.filter == ""
     refute FileTreeState.needs_filter_walk?(ft)
   end
 

--- a/test/minga_editor/state/file_tree_refresh_test.exs
+++ b/test/minga_editor/state/file_tree_refresh_test.exs
@@ -1,0 +1,137 @@
+defmodule MingaEditor.State.FileTree.RefreshTest do
+  @moduledoc "Behavior tests for pure file-tree refresh ownership and correlation."
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  test "one debounce intent is consumed only by its correlated timer" do
+    file_tree = open_tree("/tmp/minga-refresh-debounce")
+    timer = make_ref()
+
+    assert {:scheduled, file_tree} = FileTreeState.request_refresh_debounce(file_tree, timer)
+
+    assert {:already_scheduled, ^file_tree} =
+             FileTreeState.request_refresh_debounce(file_tree, make_ref())
+
+    assert {:stale, ^file_tree} = FileTreeState.refresh_debounce_elapsed(file_tree, make_ref())
+
+    assert {:ready, %FileTree{}, elapsed} =
+             FileTreeState.refresh_debounce_elapsed(file_tree, timer)
+
+    assert {:stale, ^elapsed} = FileTreeState.refresh_debounce_elapsed(elapsed, timer)
+  end
+
+  test "a current request atomically replaces the tree and clears correlation" do
+    root = "/tmp/minga-refresh-current"
+    original = open_tree(root)
+    request = make_ref()
+    refreshed = tree(root, [entry(root, "new.ex")])
+
+    tracked = FileTreeState.track_refresh_request(original, root, request)
+
+    assert {:accepted, accepted} =
+             FileTreeState.accept_refresh_result(tracked, root, request, refreshed)
+
+    assert accepted.tree == refreshed
+
+    assert {:stale, ^accepted} =
+             FileTreeState.accept_refresh_result(accepted, root, request, refreshed)
+  end
+
+  test "a stale result cannot consume or replace the semantic current request" do
+    root = "/tmp/minga-refresh-stale"
+    current = make_ref()
+    stale = make_ref()
+    file_tree = open_tree(root) |> FileTreeState.track_refresh_request(root, current)
+    refreshed = tree(root, [entry(root, "fresh.ex")])
+
+    assert {:stale, unchanged} =
+             FileTreeState.accept_refresh_result(file_tree, root, stale, refreshed)
+
+    assert unchanged.tree == file_tree.tree
+
+    assert {:accepted, accepted} =
+             FileTreeState.accept_refresh_result(unchanged, root, current, refreshed)
+
+    assert accepted.tree == refreshed
+  end
+
+  test "closing and reopening the same root invalidates the old result" do
+    root = "/tmp/minga-refresh-closed"
+    request = make_ref()
+
+    closed =
+      root
+      |> open_tree()
+      |> FileTreeState.track_refresh_request(root, request)
+      |> FileTreeState.close()
+
+    assert {:stale, unchanged} =
+             FileTreeState.accept_refresh_result(closed, root, request, tree(root, []))
+
+    assert unchanged.tree == nil
+
+    reopened = FileTreeState.open(closed, tree(root, [entry(root, "current.ex")]), nil)
+    old_result = tree(root, [entry(root, "old.ex")])
+
+    assert {:stale, still_current} =
+             FileTreeState.accept_refresh_result(reopened, root, request, old_result)
+
+    assert Enum.map(still_current.tree.entries, & &1.name) == ["current.ex"]
+  end
+
+  test "rerooting away and back invalidates the old result" do
+    old_root = "/tmp/minga-refresh-old-root"
+    new_root = "/tmp/minga-refresh-new-root"
+    request = make_ref()
+
+    file_tree =
+      old_root
+      |> open_tree()
+      |> FileTreeState.track_refresh_request(old_root, request)
+      |> FileTreeState.replace_tree(tree(new_root, []))
+      |> FileTreeState.replace_tree(tree(old_root, [entry(old_root, "current.ex")]))
+
+    assert {:stale, current} =
+             FileTreeState.accept_refresh_result(
+               file_tree,
+               old_root,
+               request,
+               tree(old_root, [entry(old_root, "old.ex")])
+             )
+
+    assert Enum.map(current.tree.entries, & &1.name) == ["current.ex"]
+  end
+
+  test "failed and canceled terminals clear only the matching request" do
+    root = "/tmp/minga-refresh-terminal"
+    first = make_ref()
+    second = make_ref()
+
+    file_tree = open_tree(root) |> FileTreeState.track_refresh_request(root, first)
+    assert {:stale, ^file_tree} = FileTreeState.finish_refresh(file_tree, root, second)
+    assert {:current, finished} = FileTreeState.finish_refresh(file_tree, root, first)
+
+    reusable = FileTreeState.track_refresh_request(finished, root, second)
+    assert {:current, _finished_again} = FileTreeState.finish_refresh(reusable, root, second)
+  end
+
+  defp open_tree(root) do
+    FileTreeState.open(%FileTreeState{}, tree(root, []), nil)
+  end
+
+  defp tree(root, entries), do: root |> FileTree.new() |> FileTree.put_entries(entries)
+
+  defp entry(root, name) do
+    %{
+      name: name,
+      path: Path.join(root, name),
+      dir?: false,
+      depth: 0,
+      last_child?: true,
+      guides: []
+    }
+  end
+end

--- a/test/support/effect_probe.ex
+++ b/test/support/effect_probe.ex
@@ -54,6 +54,10 @@ defmodule Minga.Test.EffectProbe do
     {state, outcome}
   end
 
+  @impl true
+  @spec render?(Outcome.t()) :: boolean()
+  def render?(%Outcome{}), do: false
+
   @spec perform(t()) :: {:ok, term()} | {:error, term()}
   defp perform(%__MODULE__{action: :wait} = effect) do
     receive do

--- a/test/support/file_tree_refresh_scanner.ex
+++ b/test/support/file_tree_refresh_scanner.ex
@@ -1,0 +1,31 @@
+defmodule Minga.Test.FileTreeRefreshScanner do
+  @moduledoc "Deterministic scanner used by typed file-tree refresh scheduler tests."
+
+  @behaviour MingaEditor.FileTree.Refresh.Scanner
+
+  alias Minga.Project.FileTree
+
+  @type action ::
+          :wait | :refresh | {:return, FileTree.t()} | {:error, term()} | {:raise, String.t()}
+  @type context :: {pid(), term(), action()}
+
+  @doc "Notifies the test and performs or waits for its data-only instruction."
+  @impl true
+  @spec scan(FileTree.t(), context()) :: FileTree.t() | {:error, term()}
+  def scan(%FileTree{} = tree, {test_pid, label, action}) when is_pid(test_pid) do
+    send(test_pid, {:file_tree_scan_started, label, self()})
+    perform(tree, label, action)
+  end
+
+  @spec perform(FileTree.t(), term(), action()) :: FileTree.t() | {:error, term()}
+  defp perform(tree, label, :wait) do
+    receive do
+      {:release_file_tree_scan, ^label, action} -> perform(tree, label, action)
+    end
+  end
+
+  defp perform(tree, _label, :refresh), do: FileTree.refresh(tree)
+  defp perform(_tree, _label, {:return, %FileTree{} = result}), do: result
+  defp perform(_tree, _label, {:error, reason}), do: {:error, reason}
+  defp perform(_tree, _label, {:raise, message}), do: raise(message)
+end


### PR DESCRIPTION
# TL;DR
File-tree refresh now has one semantic lifecycle owner, while the existing Editor effect scheduler exclusively owns bounded worker lifecycle. Correlated timers and typed outcomes prevent stale, rerooted, or closed-tree scans from restoring obsolete state.

Closes #2862

## Context
This is the first ownership slice in #2861. It establishes the contract used by later Editor state decomposition: pure value owners hold semantic invariants, focused workflows perform external actions, and `MingaEditor.EffectScheduler` owns only bounded asynchronous lifecycle.

## Changes
- Added `MingaEditor.State.FileTree.Refresh` for debounce and current-result correlation, removing duplicated timer, in-flight, and pending fields from `State.FileTree`.
- Replaced bespoke refresh tasks and universal effect tuples with a typed, root-keyed, coalescing `MingaEditor.FileTree.Refresh` effect and scanner contract.
- Moved timer creation, scheduler admission, outcome application, watcher and buffer synchronization, and render ordering into the file-tree workflow.
- Removed file-tree variants from `MingaEditor.Handlers.EffectHandler` and routed correlated timer messages directly from the Editor mailbox.
- Preserved root errors, filtering, structure invalidation, close/reopen, and reroot behavior while rejecting obsolete outcomes.
- Added ADR-0002 to document behavioral ownership levels, the single Editor mailbox, external-action boundaries, stale-token policy, scheduler responsibilities, migration ledger, and convergence requirements.

## Verification
- `mix test.debug test/minga_editor/state/file_tree_refresh_test.exs test/minga_editor/file_tree/freshness_test.exs test/minga_editor/file_tree/refresh_test.exs test/minga_editor/handlers/file_event_handler_test.exs`
- Expanded file-tree command, input, row, root-error, and event suites: 89 tests passed
- `mix test.quick --seed 196509`: 6,175 tests passed
- `make lint`: Credo, compilation, and incremental Dialyzer passed
- `mix test.llm`: 9,228 tests passed
- Final Minga reviewer: PASS after one targeted filter-clear correction

## Acceptance Criteria Addressed
- Refresh debounce and semantic result correlation have one owner without duplicating scheduler lifecycle. ✅
- Repeated requests coalesce to one follow-up; stale, rerooted, closed, failed, and canceled work cannot wedge or restore obsolete state. ✅
- Pure owners contain no process, timer, task, logging, rendering, watcher, buffer-sync, or filesystem actions. ✅
- The file-tree workflow owns correlated external execution and accepted-result ordering. ✅
- Universal file-tree effect variants and old compatibility fields are removed. ✅
- File-tree visibility, focus, filtering, Git status, rows, root errors, and rendered behavior remain compatible. ✅
- Pure and workflow/scheduler tests cover every required lifecycle path without sleeps. ✅
