### PR TITLE
fix(editor): serialize shell registry publication

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -136,12 +136,13 @@ BEAM processes are organized into supervision trees that encode dependency relat
 
 ### High-level overview
 
-The top-level supervisor splits the system into four tiers. Each tier is isolated so that a crash in one doesn't cascade into the others. `rest_for_one` means tiers restart in order: if Foundation restarts, everything below it restarts too (they depend on config and events). But a crash in Runtime doesn't touch Services, Buffers, or Foundation.
+The top-level supervisor splits the system into four tiers and starts `MingaEditor.Shell.Registry` as the serialized publisher that all shell selection paths depend on. Each tier is isolated so that a crash in one doesn't cascade into the others. `rest_for_one` means tiers restart in order: if the shell registry or Foundation restarts, everything below it restarts too. A Runtime crash does not touch Services, Buffers, Foundation, or the shell registry.
 
 ```mermaid
 graph TD
     SUP["Minga.Supervisor<br/><i>rest_for_one</i>"]
 
+    SUP --> SHELLS["Shell.Registry<br/><i>serialized shell publication</i>"]
     SUP --> FOUND["Foundation.Supervisor<br/><i>config, keymaps, events, registries</i>"]
     SUP --> BUFSUP["Buffer.Supervisor<br/><i>one process per open file + git tracking</i>"]
     SUP --> SVC["Services.Supervisor<br/><i>LSP, extensions, diagnostics, agents</i>"]
@@ -151,6 +152,7 @@ graph TD
     RT -. "stdin/stdout" .-> PARSER["Parser Process<br/><i>Zig + tree-sitter</i>"]
 
     style SUP fill:#6c3483,stroke:#4a235a,color:#fff
+    style SHELLS fill:#6c3483,stroke:#4a235a,color:#fff
     style FOUND fill:#6c3483,stroke:#4a235a,color:#fff
     style BUFSUP fill:#1a5276,stroke:#154360,color:#fff
     style SVC fill:#6c3483,stroke:#4a235a,color:#fff

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -10,6 +10,7 @@ defmodule Minga.Application do
   ## Supervision Tree
 
       Minga.Supervisor (rest_for_one)
+      ├── MingaEditor.Shell.Registry         (serialized shell publication)
       ├── Minga.Foundation.Supervisor (rest_for_one)
       │   ├── Minga.Language.Registry
       │   ├── Minga.Extensions.LanguagePacks
@@ -82,7 +83,6 @@ defmodule Minga.Application do
     Grammar.init_registry()
     DevHandler.attach()
     Minga.Config.ThemeRegistry.seed_builtin()
-    MingaEditor.Shell.Registry.seed_builtin()
 
     # Prepend managed tools bin directory to PATH so System.find_executable
     # discovers managed tools. Done before supervisors start so LSP and
@@ -107,6 +107,7 @@ defmodule Minga.Application do
 
     base_children =
       [
+        MingaEditor.Shell.Registry,
         Minga.Foundation.Supervisor,
         {Registry, keys: :unique, name: Minga.Buffer.Registry},
         {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},

--- a/lib/minga_editor/shell/registry.ex
+++ b/lib/minga_editor/shell/registry.ex
@@ -1,58 +1,66 @@
 defmodule MingaEditor.Shell.Registry do
   @moduledoc """
-  Source-owned registry for workspace shells.
+  Serialized source-owned registry for workspace shells.
 
-  The active editor shell is read on input and render hot paths, so the registry stores a validated, sorted snapshot in `persistent_term`. Registration and cleanup may do validation work; reads are simple map/list lookups and never call extension code.
+  One GenServer validates every duplicate decision, source-owned removal, generation assignment, and cleanup transition. It publishes the complete validated snapshot through one `persistent_term` key so input and render hot paths never observe separately updated module and source metadata.
   """
+
+  use GenServer
 
   alias Minga.Extension.ContributionCleanup
   alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Registry.Snapshot
 
   @type shell_id :: atom()
   @type source :: ContributionCleanup.contribution_source()
   @type register_attrs :: keyword() | map()
+  @type server :: GenServer.server()
   @type register_error ::
-          {:duplicate_id, shell_id()}
-          | {:duplicate_module, module(), shell_id()}
-          | {:duplicate_default, shell_id()}
+          Snapshot.register_error()
           | {:missing_default, term()}
           | {:invalid_entry, term()}
           | :source_required
           | :not_owner
+  @type snapshot :: Snapshot.t()
 
   @state_key {__MODULE__, :state}
-  @cleanup_key {__MODULE__, :cleanup_registered?}
+
+  @doc "Starts the sole shell-registry publisher."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    GenServer.start_link(__MODULE__, opts, name: name)
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, snapshot()}
+  def init(_opts) do
+    :ok = ContributionCleanup.register(:shells, &__MODULE__.unregister_source/1)
+
+    state =
+      Snapshot.new()
+      |> seed_builtin_snapshot()
+      |> publish()
+
+    {:ok, state}
+  end
 
   @doc "Registers the built-in shell contributions. Safe to call more than once."
   @spec seed_builtin() :: :ok
-  def seed_builtin do
-    :ok = ensure_cleanup_registered()
-
-    :ok =
-      register_builtin(
-        :traditional,
-        MingaEditor.Shell.Traditional,
-        "Traditional",
-        "Tab-based editor with file tree, modeline, picker, and agent panel.",
-        true
-      )
-
-    :ok
-  end
+  def seed_builtin, do: GenServer.call(__MODULE__, :seed_builtin)
 
   @doc "Registers a shell contribution."
   @spec register(source(), register_attrs()) :: :ok | {:error, register_error()}
   def register(source, attrs) do
-    :ok = ensure_cleanup_registered()
     attrs = attrs |> Map.new() |> Map.put(:source, source)
 
     case Entry.new(attrs) do
-      {:ok, entry} -> put_entry(entry, replace?: false)
+      {:ok, entry} -> GenServer.call(__MODULE__, {:register, entry})
       {:error, reason} -> {:error, {:invalid_entry, reason}}
     end
   end
 
-  @doc "Unregisters a shell by id. Built-in shells are intentionally preserved. Extension shells must use unregister/2."
+  @doc "Unregisters a shell by id. Built-in shells are preserved and extension shells require their source."
   @spec unregister(shell_id()) :: :ok | {:error, :builtin_shell | :source_required}
   def unregister(id) when is_atom(id) do
     case get(id) do
@@ -67,39 +75,36 @@ defmodule MingaEditor.Shell.Registry do
   def unregister(:builtin, _id), do: {:error, :builtin_shell}
 
   def unregister(source, id) when is_atom(id) do
-    case get(id) do
-      %Entry{source: ^source} -> put_state(remove_entry(state(), id))
-      %Entry{} -> {:error, :not_owner}
-      nil -> :ok
-    end
+    GenServer.call(__MODULE__, {:unregister, source, id})
   end
 
-  @doc "Unregisters all shells owned by a source. Built-in shells are intentionally preserved."
+  @doc "Unregisters all shells owned by a source as one publication."
   @spec unregister_source(source()) :: :ok
   def unregister_source(:builtin), do: :ok
+  def unregister_source(source), do: GenServer.call(__MODULE__, {:unregister_source, source})
 
-  def unregister_source(source) do
-    current = state()
-
-    current.entries
-    |> Enum.filter(fn {_id, %Entry{source: entry_source}} -> entry_source == source end)
-    |> Enum.map(fn {id, _entry} -> id end)
-    |> Enum.reduce(current, &remove_entry(&2, &1))
-    |> put_state()
-  end
+  @doc "Returns one coherent registry publication."
+  @spec snapshot() :: snapshot()
+  def snapshot, do: :persistent_term.get(@state_key, Snapshot.new())
 
   @doc "Returns registered shells in deterministic display order."
   @spec list() :: [Entry.t()]
-  def list, do: state().ordered
+  def list, do: snapshot().ordered
 
   @doc "Returns a shell entry by id."
   @spec get(shell_id()) :: Entry.t() | nil
-  def get(id) when is_atom(id), do: Map.get(state().entries, id)
+  def get(id) when is_atom(id), do: Map.get(snapshot().entries, id)
+
+  @doc "Resolves an id or implementation module from one coherent snapshot."
+  @spec resolve(shell_id() | module()) :: Entry.t() | nil
+  def resolve(id_or_module) when is_atom(id_or_module) do
+    snapshot() |> Snapshot.resolve(id_or_module)
+  end
 
   @doc "Returns the default shell entry, falling back to Traditional when the registry is empty."
   @spec default() :: Entry.t()
   def default do
-    current = state()
+    current = snapshot()
     Map.get(current.entries, current.default_id) || builtin_traditional_entry()
   end
 
@@ -115,9 +120,7 @@ defmodule MingaEditor.Shell.Registry do
   @doc "Returns the shell id registered for a module, or nil."
   @spec id_for_module(module()) :: shell_id() | nil
   def id_for_module(module) when is_atom(module) do
-    list()
-    |> Enum.find(fn %Entry{module: entry_module} -> entry_module == module end)
-    |> case do
+    case snapshot() |> Snapshot.entry_for_module(module) do
       %Entry{id: id} -> id
       nil -> nil
     end
@@ -139,139 +142,58 @@ defmodule MingaEditor.Shell.Registry do
   @doc "Resets registry state. Intended for tests that need isolated registry setup."
   @spec reset_for_test([Entry.t()]) :: :ok
   def reset_for_test(entries \\ []) when is_list(entries) do
-    entries
-    |> Enum.reduce(empty_state(), fn %Entry{} = entry, acc -> add_entry(acc, entry) end)
-    |> put_state()
+    GenServer.call(__MODULE__, {:reset_for_test, entries})
   end
 
-  @spec register_builtin(shell_id(), module(), String.t(), String.t(), boolean()) :: :ok
-  defp register_builtin(id, module, display_name, description, default?) do
-    entry = Entry.builtin!(id, module, display_name, description, default?)
-
-    :ok = put_entry(entry, replace?: true)
+  @impl true
+  @spec handle_call(term(), GenServer.from(), snapshot()) ::
+          {:reply, :ok | {:error, register_error()}, snapshot()}
+  def handle_call(:seed_builtin, _from, state) do
+    state = state |> seed_builtin_snapshot() |> publish()
+    {:reply, :ok, state}
   end
 
-  @spec put_entry(Entry.t(), keyword()) :: :ok | {:error, register_error()}
-  defp put_entry(%Entry{} = entry, opts) do
-    current = state()
-    replace? = Keyword.fetch!(opts, :replace?)
-
-    with :ok <- check_duplicate_id(current, entry, replace?),
-         :ok <- check_duplicate_module(current, entry, replace?),
-         :ok <- check_duplicate_default(current, entry, replace?) do
-      {current, entry} = assign_generation(current, entry, replace?)
-
-      current
-      |> remove_entry(entry.id)
-      |> add_entry(entry)
-      |> put_state()
+  def handle_call({:register, %Entry{} = entry}, _from, state) do
+    case Snapshot.register(state, entry) do
+      {:ok, updated} -> {:reply, :ok, publish(updated)}
+      {:error, reason} -> {:reply, {:error, reason}, state}
     end
   end
 
-  @spec check_duplicate_id(map(), Entry.t(), boolean()) :: :ok | {:error, register_error()}
-  defp check_duplicate_id(_current, _entry, true), do: :ok
-
-  defp check_duplicate_id(current, %Entry{id: id}, false) do
-    if Map.has_key?(current.entries, id), do: {:error, {:duplicate_id, id}}, else: :ok
-  end
-
-  @spec check_duplicate_module(map(), Entry.t(), boolean()) :: :ok | {:error, register_error()}
-  defp check_duplicate_module(current, %Entry{id: id, module: module}, replace?) do
-    current.entries
-    |> Enum.find(fn {entry_id, %Entry{module: entry_module}} ->
-      entry_module == module and (not replace? or entry_id != id)
-    end)
-    |> case do
-      {existing_id, _entry} -> {:error, {:duplicate_module, module, existing_id}}
-      nil -> :ok
+  def handle_call({:unregister, source, id}, _from, state) do
+    case Snapshot.unregister(state, source, id) do
+      {:ok, updated, true} -> {:reply, :ok, publish(updated)}
+      {:ok, _unchanged, false} -> {:reply, :ok, state}
+      {:error, :not_owner} -> {:reply, {:error, :not_owner}, state}
     end
   end
 
-  @spec check_duplicate_default(map(), Entry.t(), boolean()) :: :ok | {:error, register_error()}
-  defp check_duplicate_default(_current, %Entry{default?: false}, _replace?), do: :ok
-
-  defp check_duplicate_default(current, %Entry{id: id}, replace?) do
-    existing_default = current.default_id
-
-    if existing_default != nil and (not replace? or existing_default != id) do
-      {:error, {:duplicate_default, existing_default}}
-    else
-      :ok
+  def handle_call({:unregister_source, source}, _from, state) do
+    case Snapshot.unregister_source(state, source) do
+      {updated, true} -> {:reply, :ok, publish(updated)}
+      {_unchanged, false} -> {:reply, :ok, state}
     end
   end
 
-  @spec assign_generation(map(), Entry.t(), boolean()) :: {map(), Entry.t()}
-  defp assign_generation(current, %Entry{id: id} = entry, true) do
-    case Map.get(current.entries, id) do
-      %Entry{source: source, module: module, generation: generation}
-      when source == entry.source and module == entry.module ->
-        {current, Entry.with_generation(entry, generation)}
+  def handle_call({:reset_for_test, entries}, _from, _state) do
+    state = entries |> Snapshot.from_entries() |> publish()
+    {:reply, :ok, state}
+  end
 
-      _other ->
-        assign_next_generation(current, entry)
+  @spec seed_builtin_snapshot(snapshot()) :: snapshot()
+  defp seed_builtin_snapshot(snapshot) do
+    case Snapshot.put_builtin(snapshot, builtin_traditional_entry()) do
+      {:ok, updated} -> updated
+      {:error, reason} -> raise "failed to seed built-in shell: #{inspect(reason)}"
     end
   end
 
-  defp assign_generation(current, %Entry{} = entry, _replace?),
-    do: assign_next_generation(current, entry)
-
-  @spec assign_next_generation(map(), Entry.t()) :: {map(), Entry.t()}
-  defp assign_next_generation(current, %Entry{} = entry) do
-    generation = Map.get(current, :next_generation, 1)
-    {%{current | next_generation: generation + 1}, Entry.with_generation(entry, generation)}
+  @spec publish(snapshot()) :: snapshot()
+  defp publish(snapshot) do
+    published = Snapshot.advance(snapshot)
+    :persistent_term.put(@state_key, published)
+    published
   end
-
-  @spec add_entry(map(), Entry.t()) :: map()
-  defp add_entry(current, %Entry{} = entry) do
-    entries = Map.put(current.entries, entry.id, entry)
-    default_id = if entry.default?, do: entry.id, else: current.default_id
-    %{current | entries: entries, ordered: sort_entries(entries), default_id: default_id}
-  end
-
-  @spec remove_entry(map(), shell_id()) :: map()
-  defp remove_entry(current, id) do
-    entries = Map.delete(current.entries, id)
-    default_id = next_default_id(entries, current.default_id, id)
-    %{current | entries: entries, ordered: sort_entries(entries), default_id: default_id}
-  end
-
-  @spec next_default_id(%{shell_id() => Entry.t()}, shell_id() | nil, shell_id()) ::
-          shell_id() | nil
-  defp next_default_id(_entries, current_default, removed_id)
-       when current_default != removed_id do
-    current_default
-  end
-
-  defp next_default_id(entries, _current_default, _removed_id) do
-    entries
-    |> Enum.find(fn {_id, %Entry{default?: default?}} -> default? end)
-    |> default_entry_id()
-  end
-
-  @spec default_entry_id({shell_id(), Entry.t()} | nil) :: shell_id() | nil
-  defp default_entry_id({id, _entry}), do: id
-  defp default_entry_id(nil), do: nil
-
-  @spec sort_entries(%{shell_id() => Entry.t()}) :: [Entry.t()]
-  defp sort_entries(entries) do
-    entries
-    |> Map.values()
-    |> Enum.sort_by(fn %Entry{default?: default?, display_name: display_name, id: id} ->
-      {if(default?, do: 0, else: 1), String.downcase(display_name), Atom.to_string(id)}
-    end)
-  end
-
-  @spec state() :: map()
-  defp state, do: :persistent_term.get(@state_key, empty_state())
-
-  @spec put_state(map()) :: :ok
-  defp put_state(current) do
-    :persistent_term.put(@state_key, current)
-    :ok
-  end
-
-  @spec empty_state() :: map()
-  defp empty_state, do: %{entries: %{}, ordered: [], default_id: nil, next_generation: 1}
 
   @spec builtin_traditional_entry() :: Entry.t()
   defp builtin_traditional_entry do
@@ -282,15 +204,5 @@ defmodule MingaEditor.Shell.Registry do
       "Tab-based editor with file tree, modeline, picker, and agent panel.",
       true
     )
-  end
-
-  @spec ensure_cleanup_registered() :: :ok
-  defp ensure_cleanup_registered do
-    unless :persistent_term.get(@cleanup_key, false) do
-      ContributionCleanup.register(:shells, &__MODULE__.unregister_source/1)
-      :persistent_term.put(@cleanup_key, true)
-    end
-
-    :ok
   end
 end

--- a/lib/minga_editor/shell/registry/snapshot.ex
+++ b/lib/minga_editor/shell/registry/snapshot.ex
@@ -1,0 +1,210 @@
+defmodule MingaEditor.Shell.Registry.Snapshot do
+  @moduledoc "Pure coherent publication value for the serialized shell registry."
+
+  alias MingaEditor.Shell.Entry
+
+  @type shell_id :: atom()
+  @type register_error ::
+          {:duplicate_id, shell_id()}
+          | {:duplicate_module, module(), shell_id()}
+          | {:duplicate_default, shell_id()}
+
+  @enforce_keys [:entries, :ordered, :default_id, :next_generation, :generation]
+  defstruct [:entries, :ordered, :default_id, :next_generation, :generation]
+
+  @type t :: %__MODULE__{
+          entries: %{optional(shell_id()) => Entry.t()},
+          ordered: [Entry.t()],
+          default_id: shell_id() | nil,
+          next_generation: pos_integer(),
+          generation: non_neg_integer()
+        }
+
+  @doc "Builds an empty unpublished snapshot."
+  @spec new() :: t()
+  def new do
+    %__MODULE__{
+      entries: %{},
+      ordered: [],
+      default_id: nil,
+      next_generation: 1,
+      generation: 0
+    }
+  end
+
+  @doc "Builds an unpublished snapshot from validated entries."
+  @spec from_entries([Entry.t()]) :: t()
+  def from_entries(entries) when is_list(entries) do
+    entries
+    |> Enum.reduce(new(), &add_entry(&2, &1))
+    |> set_next_generation()
+  end
+
+  @doc "Registers a new contribution after coherent duplicate checks."
+  @spec register(t(), Entry.t()) :: {:ok, t()} | {:error, register_error()}
+  def register(%__MODULE__{} = snapshot, %Entry{} = entry) do
+    put_entry(snapshot, entry, false)
+  end
+
+  @doc "Adds or refreshes a built-in contribution while preserving stable identity."
+  @spec put_builtin(t(), Entry.t()) :: {:ok, t()} | {:error, register_error()}
+  def put_builtin(%__MODULE__{} = snapshot, %Entry{source: :builtin} = entry) do
+    put_entry(snapshot, entry, true)
+  end
+
+  @doc "Removes one contribution only when the source owns it."
+  @spec unregister(t(), Entry.source(), shell_id()) ::
+          {:ok, t(), boolean()} | {:error, :not_owner}
+  def unregister(%__MODULE__{} = snapshot, source, id) when is_atom(id) do
+    case Map.get(snapshot.entries, id) do
+      %Entry{source: ^source} -> {:ok, remove_entry(snapshot, id), true}
+      %Entry{} -> {:error, :not_owner}
+      nil -> {:ok, snapshot, false}
+    end
+  end
+
+  @doc "Removes every contribution owned by one source in one value transition."
+  @spec unregister_source(t(), Entry.source()) :: {t(), boolean()}
+  def unregister_source(%__MODULE__{} = snapshot, source) do
+    ids =
+      snapshot.entries
+      |> Enum.filter(fn {_id, %Entry{source: entry_source}} -> entry_source == source end)
+      |> Enum.map(fn {id, _entry} -> id end)
+
+    case ids do
+      [] -> {snapshot, false}
+      _ids -> {Enum.reduce(ids, snapshot, &remove_entry(&2, &1)), true}
+    end
+  end
+
+  @doc "Advances the coherent publication generation."
+  @spec advance(t()) :: t()
+  def advance(%__MODULE__{} = snapshot) do
+    %{snapshot | generation: snapshot.generation + 1}
+  end
+
+  @doc "Resolves a shell id or implementation module from this publication."
+  @spec resolve(t(), shell_id() | module()) :: Entry.t() | nil
+  def resolve(%__MODULE__{} = snapshot, id_or_module) when is_atom(id_or_module) do
+    Map.get(snapshot.entries, id_or_module) || entry_for_module(snapshot, id_or_module)
+  end
+
+  @doc "Returns the entry registered for an implementation module."
+  @spec entry_for_module(t(), module()) :: Entry.t() | nil
+  def entry_for_module(%__MODULE__{} = snapshot, module) when is_atom(module) do
+    Enum.find(snapshot.ordered, fn %Entry{module: entry_module} -> entry_module == module end)
+  end
+
+  @spec put_entry(t(), Entry.t(), boolean()) :: {:ok, t()} | {:error, register_error()}
+  defp put_entry(snapshot, entry, replace?) do
+    with :ok <- check_duplicate_id(snapshot, entry, replace?),
+         :ok <- check_duplicate_module(snapshot, entry, replace?),
+         :ok <- check_duplicate_default(snapshot, entry, replace?) do
+      {snapshot, entry} = assign_generation(snapshot, entry, replace?)
+      {:ok, snapshot |> remove_entry(entry.id) |> add_entry(entry)}
+    end
+  end
+
+  @spec check_duplicate_id(t(), Entry.t(), boolean()) :: :ok | {:error, register_error()}
+  defp check_duplicate_id(_snapshot, _entry, true), do: :ok
+
+  defp check_duplicate_id(snapshot, %Entry{id: id}, false) do
+    if Map.has_key?(snapshot.entries, id), do: {:error, {:duplicate_id, id}}, else: :ok
+  end
+
+  @spec check_duplicate_module(t(), Entry.t(), boolean()) :: :ok | {:error, register_error()}
+  defp check_duplicate_module(snapshot, %Entry{id: id, module: module}, replace?) do
+    snapshot.entries
+    |> Enum.find(fn {entry_id, %Entry{module: entry_module}} ->
+      entry_module == module and (not replace? or entry_id != id)
+    end)
+    |> case do
+      {existing_id, _entry} -> {:error, {:duplicate_module, module, existing_id}}
+      nil -> :ok
+    end
+  end
+
+  @spec check_duplicate_default(t(), Entry.t(), boolean()) :: :ok | {:error, register_error()}
+  defp check_duplicate_default(_snapshot, %Entry{default?: false}, _replace?), do: :ok
+
+  defp check_duplicate_default(snapshot, %Entry{id: id}, replace?) do
+    existing_default = snapshot.default_id
+
+    if existing_default != nil and (not replace? or existing_default != id) do
+      {:error, {:duplicate_default, existing_default}}
+    else
+      :ok
+    end
+  end
+
+  @spec assign_generation(t(), Entry.t(), boolean()) :: {t(), Entry.t()}
+  defp assign_generation(snapshot, %Entry{id: id} = entry, true) do
+    case Map.get(snapshot.entries, id) do
+      %Entry{source: source, module: module, generation: generation}
+      when source == entry.source and module == entry.module ->
+        {snapshot, Entry.with_generation(entry, generation)}
+
+      _other ->
+        assign_next_generation(snapshot, entry)
+    end
+  end
+
+  defp assign_generation(snapshot, entry, _replace?), do: assign_next_generation(snapshot, entry)
+
+  @spec assign_next_generation(t(), Entry.t()) :: {t(), Entry.t()}
+  defp assign_next_generation(snapshot, entry) do
+    generation = snapshot.next_generation
+
+    {%{snapshot | next_generation: generation + 1}, Entry.with_generation(entry, generation)}
+  end
+
+  @spec add_entry(t(), Entry.t()) :: t()
+  defp add_entry(snapshot, entry) do
+    entries = Map.put(snapshot.entries, entry.id, entry)
+    default_id = if entry.default?, do: entry.id, else: snapshot.default_id
+    %{snapshot | entries: entries, ordered: sort_entries(entries), default_id: default_id}
+  end
+
+  @spec remove_entry(t(), shell_id()) :: t()
+  defp remove_entry(snapshot, id) do
+    entries = Map.delete(snapshot.entries, id)
+    default_id = next_default_id(entries, snapshot.default_id, id)
+    %{snapshot | entries: entries, ordered: sort_entries(entries), default_id: default_id}
+  end
+
+  @spec next_default_id(%{shell_id() => Entry.t()}, shell_id() | nil, shell_id()) ::
+          shell_id() | nil
+  defp next_default_id(_entries, current_default, removed_id)
+       when current_default != removed_id,
+       do: current_default
+
+  defp next_default_id(entries, _current_default, _removed_id) do
+    entries
+    |> Enum.find(fn {_id, %Entry{default?: default?}} -> default? end)
+    |> case do
+      {id, _entry} -> id
+      nil -> nil
+    end
+  end
+
+  @spec sort_entries(%{shell_id() => Entry.t()}) :: [Entry.t()]
+  defp sort_entries(entries) do
+    entries
+    |> Map.values()
+    |> Enum.sort_by(fn %Entry{default?: default?, display_name: display_name, id: id} ->
+      {if(default?, do: 0, else: 1), String.downcase(display_name), Atom.to_string(id)}
+    end)
+  end
+
+  @spec set_next_generation(t()) :: t()
+  defp set_next_generation(snapshot) do
+    next_generation =
+      snapshot.entries
+      |> Map.values()
+      |> Enum.map(& &1.generation)
+      |> Enum.max(fn -> 0 end)
+      |> Kernel.+(1)
+
+    %{snapshot | next_generation: next_generation}
+  end
+end

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -604,17 +604,7 @@ defmodule MingaEditor.Startup do
   end
 
   @spec resolve_shell_entry(atom()) :: MingaEditor.Shell.Entry.t() | nil
-  defp resolve_shell_entry(id_or_module) do
-    MingaEditor.Shell.Registry.get(id_or_module) || resolve_shell_module(id_or_module)
-  end
-
-  @spec resolve_shell_module(module()) :: MingaEditor.Shell.Entry.t() | nil
-  defp resolve_shell_module(module) do
-    case MingaEditor.Shell.Registry.id_for_module(module) do
-      nil -> nil
-      id -> MingaEditor.Shell.Registry.get(id)
-    end
-  end
+  defp resolve_shell_entry(id_or_module), do: MingaEditor.Shell.Registry.resolve(id_or_module)
 
   @spec init_shell_state(module(), keyword()) :: term()
   defp init_shell_state(MingaEditor.Shell.Traditional, opts) do

--- a/test/minga/architecture_test.exs
+++ b/test/minga/architecture_test.exs
@@ -7,7 +7,16 @@ defmodule Minga.ArchitectureTest do
   they must not run concurrently with tests that stop/restart supervisors.
   """
 
+  # Serial because this inspects the process-global application supervision tree.
   use ExUnit.Case, async: false
+
+  test "Shell.Registry is a top-level serialized publisher" do
+    top_children = Supervisor.which_children(Minga.Supervisor)
+    top_ids = Enum.map(top_children, &elem(&1, 0))
+
+    assert MingaEditor.Shell.Registry in top_ids
+    assert Process.whereis(MingaEditor.Shell.Registry) != nil
+  end
 
   test "MingaAgent.Supervisor is a top-level peer, not nested under Services" do
     top_children = Supervisor.which_children(Minga.Supervisor)

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -41,6 +41,15 @@ defmodule MingaEditor.Shell.RegistryTest do
     assert Registry.id_for_module(MingaEditor.Shell.Traditional) == :traditional
   end
 
+  test "resolve reads ids and modules from one publication" do
+    Registry.seed_builtin()
+    assert :ok = Registry.register({:extension, :fake}, shell_attrs(:fake, FakeShell, "Fake"))
+
+    snapshot = Registry.snapshot()
+    assert Registry.resolve(:fake) == snapshot.entries.fake
+    assert Registry.resolve(FakeShell) == snapshot.entries.fake
+  end
+
   test "register rejects duplicate shell ids" do
     assert :ok =
              Registry.register({:extension, :fake}, %{
@@ -91,6 +100,148 @@ defmodule MingaEditor.Shell.RegistryTest do
     assert Registry.available?(:fake)
     assert :ok = ContributionCleanup.unregister_source({:extension, :fake})
     refute Registry.available?(:fake)
+  end
+
+  test "concurrent non-conflicting registrations preserve both contributions" do
+    Registry.seed_builtin()
+    parent = self()
+
+    first =
+      Task.async(fn ->
+        send(parent, {:writer_ready, self()})
+
+        receive do: (:publish ->
+                       Registry.register(
+                         {:extension, :first},
+                         shell_attrs(:first, FakeShell, "First")
+                       ))
+      end)
+
+    second =
+      Task.async(fn ->
+        send(parent, {:writer_ready, self()})
+
+        receive do: (:publish ->
+                       Registry.register(
+                         {:extension, :second},
+                         shell_attrs(:second, FakeShellAlt, "Second")
+                       ))
+      end)
+
+    assert_receive {:writer_ready, first_pid}
+    assert_receive {:writer_ready, second_pid}
+    send(first_pid, :publish)
+    send(second_pid, :publish)
+
+    assert Task.await(first) == :ok
+    assert Task.await(second) == :ok
+
+    snapshot = Registry.snapshot()
+    assert snapshot.entries.first.source == {:extension, :first}
+    assert snapshot.entries.first.module == FakeShell
+    assert snapshot.entries.second.source == {:extension, :second}
+    assert snapshot.entries.second.module == FakeShellAlt
+  end
+
+  test "concurrent duplicate decisions publish exactly one coherent owner" do
+    Registry.seed_builtin()
+    parent = self()
+
+    writers = [
+      {{:extension, :first}, FakeShell, "First"},
+      {{:extension, :second}, FakeShellAlt, "Second"}
+    ]
+
+    tasks =
+      Enum.map(writers, fn {source, module, label} ->
+        Task.async(fn ->
+          send(parent, {:duplicate_writer_ready, self()})
+          receive do: (:publish -> Registry.register(source, shell_attrs(:shared, module, label)))
+        end)
+      end)
+
+    pids =
+      Enum.map(tasks, fn _task ->
+        assert_receive {:duplicate_writer_ready, pid}
+        pid
+      end)
+
+    Enum.each(pids, &send(&1, :publish))
+    results = Enum.map(tasks, &Task.await/1)
+
+    assert Enum.count(results, &(&1 == :ok)) == 1
+    assert Enum.count(results, &match?({:error, {:duplicate_id, :shared}}, &1)) == 1
+
+    entry = Registry.snapshot().entries.shared
+
+    assert {entry.source, entry.module} in [
+             {{:extension, :first}, FakeShell},
+             {{:extension, :second}, FakeShellAlt}
+           ]
+  end
+
+  test "source cleanup removes all owned shells in one generation and preserves fallback" do
+    Registry.seed_builtin()
+    source = {:extension, :owned}
+    assert :ok = Registry.register(source, shell_attrs(:first, FakeShell, "First"))
+    assert :ok = Registry.register(source, shell_attrs(:second, FakeShellAlt, "Second"))
+    before_cleanup = Registry.snapshot()
+
+    assert :ok = Registry.unregister_source(source)
+
+    after_cleanup = Registry.snapshot()
+    assert after_cleanup.generation == before_cleanup.generation + 1
+    refute Map.has_key?(after_cleanup.entries, :first)
+    refute Map.has_key?(after_cleanup.entries, :second)
+    assert after_cleanup.entries.traditional.source == :builtin
+    assert after_cleanup.default_id == :traditional
+  end
+
+  test "readers observe coherent cleanup and reload publication boundaries" do
+    Registry.seed_builtin()
+    parent = self()
+    old_source = {:extension, :old}
+    new_source = {:extension, :new}
+    assert :ok = Registry.register(old_source, shell_attrs(:first, FakeShell, "First"))
+    assert :ok = Registry.register(old_source, shell_attrs(:second, FakeShellAlt, "Second"))
+    before_cleanup = Registry.snapshot()
+
+    writer =
+      Task.async(fn ->
+        assert :ok = Registry.unregister_source(old_source)
+        send(parent, :cleanup_published)
+
+        receive do
+          :cleanup_observed -> :ok
+        end
+
+        assert :ok = Registry.register(new_source, shell_attrs(:first, FakeShellAlt, "Reloaded"))
+        send(parent, :reload_published)
+
+        receive do
+          :reload_observed -> :ok
+        end
+      end)
+
+    assert_receive :cleanup_published
+    cleanup = Registry.snapshot()
+    assert cleanup.generation == before_cleanup.generation + 1
+    refute Map.has_key?(cleanup.entries, :first)
+    refute Map.has_key?(cleanup.entries, :second)
+    assert cleanup.entries.traditional.source == :builtin
+    assert cleanup.default_id == :traditional
+    send(writer.pid, :cleanup_observed)
+
+    assert_receive :reload_published
+    reload = Registry.snapshot()
+    assert reload.generation == cleanup.generation + 1
+    assert reload.entries.first.source == new_source
+    assert reload.entries.first.module == FakeShellAlt
+    refute Map.has_key?(reload.entries, :second)
+    assert Enum.find(reload.ordered, &(&1.id == :first)) == reload.entries.first
+    send(writer.pid, :reload_observed)
+
+    assert Task.await(writer) == :ok
   end
 
   test "shell state stash does not restore after shell id is re-registered with a new identity" do
@@ -451,8 +602,9 @@ defmodule MingaEditor.Shell.RegistryTest do
              })
 
     valid_entry = Registry.get(:valid)
-    dead_ingest = spawn(fn -> :ok end)
+    dead_ingest = spawn(fn -> receive do: (:stop -> :ok) end)
     monitor = Process.monitor(dead_ingest)
+    send(dead_ingest, :stop)
     assert_receive {:DOWN, ^monitor, :process, ^dead_ingest, :normal}
 
     state =
@@ -751,5 +903,15 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     assert result.shell_id == :traditional
     assert result.shell == MingaEditor.Shell.Traditional
+  end
+
+  defp shell_attrs(id, module, label) do
+    %{
+      id: id,
+      module: module,
+      display_name: label,
+      description: "#{label} shell",
+      capabilities: [:tui]
+    }
   end
 end


### PR DESCRIPTION
# TL;DR
Shell registrations, source ownership, duplicate decisions, and cleanup now publish through one serialized registry generation. Hot-path readers consume one typed snapshot, so concurrent extension lifecycle work cannot lose unrelated shells or pair a module with stale source metadata.

Closes #2837

## Context
Shell runtime ownership in #2863 depends on coherent registry data. The previous read-modify-write `persistent_term` registry allowed concurrent writers to overwrite each other and allowed multi-read resolution to cross publication generations.

## Changes
- Made `MingaEditor.Shell.Registry` a supervised GenServer and the sole publisher of shell declarations.
- Added the enforced `Registry.Snapshot` value to own pure duplicate checks, entry identity generation, source removal, ordering, and module resolution.
- Published the complete snapshot under one `persistent_term` key while preserving lock-free input and render reads.
- Added single-snapshot ID-or-module resolution and updated Editor startup to use it.
- Started the registry before Foundation and Services so extension registration and cleanup always have one live publisher in GUI, headless, and minimal modes.
- Added deterministic concurrent registration, duplicate, cleanup-boundary, reload-boundary, fallback, and supervision tests.

## Verification
- Focused registry, cleanup, and supervision suites: 27 tests passed
- `mix test.quick`: 6,181 tests passed
- `make lint`: Credo, compilation, and incremental Dialyzer passed
- `mix test.llm`: 9,234 tests passed
- Final Minga reviewer: PASS after targeted corrections

## Acceptance Criteria Addressed
- Concurrent non-conflicting registrations preserve every contribution. ✅
- Module, source identity, duplicate decisions, cleanup, and generations publish coherently. ✅
- Removing one source leaves unrelated shells and the Traditional fallback unchanged. ✅
- Deterministic concurrency tests verify coherent register, duplicate, cleanup, and reload boundaries. ✅
