### PR TITLE
feat(tui): render structured operation feedback

### DIFF
--- a/go/tui/internal/protocol/chrome_editor.go
+++ b/go/tui/internal/protocol/chrome_editor.go
@@ -3,6 +3,8 @@ package protocol
 import (
 	"fmt"
 	"strings"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
 )
 
 func decodeTabBar(payload []byte) (TabBar, string, int) {
@@ -341,6 +343,11 @@ func decodeStatus(payload []byte) (StatusBar, string, int) {
 		case 0x0E:
 			if keys, _, ok := readString16(section, 0); ok {
 				status.PendingKeys = keys
+			}
+		case 0x0F:
+			operation, _, err := generated.DecodeGuiStatusBarOperation(section, 0, len(section))
+			if err == nil {
+				status.Operation = &operation
 			}
 		}
 	}

--- a/go/tui/internal/protocol/chrome_types.go
+++ b/go/tui/internal/protocol/chrome_types.go
@@ -1,5 +1,7 @@
 package protocol
 
+import "github.com/jsmestad/minga/go/tui/internal/generated"
+
 type TabBar struct {
 	ActiveIndex byte
 	Tabs        []Tab
@@ -187,6 +189,7 @@ type StatusBar struct {
 	Filetype    string
 	Message     string
 	PendingKeys string
+	Operation   *generated.GuiStatusBarOperation
 	Left        []StatusSegment
 	Right       []StatusSegment
 }

--- a/go/tui/internal/protocol/commands_test.go
+++ b/go/tui/internal/protocol/commands_test.go
@@ -759,6 +759,42 @@ func TestDecodeStatusChrome(t *testing.T) {
 	}
 }
 
+func TestDecodeStatusOperationUsesGeneratedMappingAndKeepsNoticeSeparate(t *testing.T) {
+	operation := make([]byte, 8)
+	binary.BigEndian.PutUint64(operation, 4_294_967_297)
+	operation = append(operation,
+		byte(generated.OperationKindLspRename),
+		byte(generated.OperationStatusRunning),
+		0x07,
+	)
+	operation = append(operation, string16("Renaming...")...)
+	operation = append(operation, 0, 2, 0, 5)
+	operation = append(operation, 0, 0, 0, 7, 0, 0, 0, 10)
+
+	packet := []byte{generated.OPGuiStatusBar, 2}
+	packet = append(packet, section(0x07, string16("ordinary notice"))...)
+	packet = append(packet, section(0x0F, operation)...)
+
+	command, err := DecodeCommand(packet)
+	if err != nil {
+		t.Fatalf("DecodeCommand returned error: %v", err)
+	}
+	status := command.Chrome.Status
+	if status.Message != "ordinary notice" {
+		t.Fatalf("plain message was conflated with operation: %+v", status)
+	}
+	if status.Operation == nil {
+		t.Fatal("structured operation was not decoded")
+	}
+	got := *status.Operation
+	if got.OperationID != 4_294_967_297 || got.Kind != generated.OperationKindLspRename || got.Status != generated.OperationStatusRunning || got.Flags != 0x07 || got.Message != "Renaming..." {
+		t.Fatalf("operation identity/semantic mapping = %+v", got)
+	}
+	if got.QueuePosition != 2 || got.QueueTotal != 5 || got.ProgressCurrent != 7 || got.ProgressTotal != 10 {
+		t.Fatalf("operation metadata mapping = %+v", got)
+	}
+}
+
 func TestDecodeStatusModelineSegments(t *testing.T) {
 	left := []byte{2, 0, 1, 0, 1}
 	left = append(left, string8("mode")...)

--- a/go/tui/internal/ui/feedback.go
+++ b/go/tui/internal/ui/feedback.go
@@ -1,50 +1,194 @@
 package ui
 
 import (
+	"fmt"
 	"strings"
 	"time"
 
 	tea "charm.land/bubbletea/v2"
+	"github.com/jsmestad/minga/go/tui/internal/generated"
 )
 
 const (
 	feedbackTickInterval = 80 * time.Millisecond
-	spinnerDelayMs       = 100 * time.Millisecond
-	spinnerHoldMs        = 500 * time.Millisecond
+	spinnerDelay         = 100 * time.Millisecond
+	spinnerHold          = 500 * time.Millisecond
+	waitingDelay         = time.Second
+	terminalDwell        = 1500 * time.Millisecond
+
+	operationCancelableFlag = byte(0x01)
+	operationQueueFlag      = byte(0x02)
+	operationProgressFlag   = byte(0x04)
 )
 
 var spinnerFrames = []string{"⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"}
 
-type feedbackTickMsg struct{}
+type feedbackTickMsg struct {
+	at time.Time
+}
 
-func feedbackTick() tea.Cmd {
-	return tea.Tick(feedbackTickInterval, func(time.Time) tea.Msg {
-		return feedbackTickMsg{}
+func feedbackTick(after time.Duration) tea.Cmd {
+	return tea.Tick(after, func(at time.Time) tea.Msg {
+		return feedbackTickMsg{at: at}
 	})
 }
 
+// feedbackState owns only local presentation timing. The latest operation is a
+// value copy of the BEAM projection; presentation never mutates or clears the
+// semantic StatusBar operation itself.
 type feedbackState struct {
-	frame       uint64
-	ticking     bool
-	onset       time.Time
-	spinnerOn   bool
-	spinnerOnAt time.Time
-	lastMessage string
+	frame   uint64
+	ticking bool
+	now     time.Time
+
+	latest      generated.GuiStatusBarOperation
+	hasLatest   bool
+	displayed   generated.GuiStatusBarOperation
+	hasDisplay  bool
+	deferred    generated.GuiStatusBarOperation
+	hasDeferred bool
+
+	onset         time.Time
+	runningOnset  time.Time
+	spinnerOnAt   time.Time
+	terminalUntil time.Time
 }
 
-func (f *feedbackState) tick() {
-	f.frame++
-	now := time.Now()
-	if !f.onset.IsZero() && now.Sub(f.onset) >= spinnerDelayMs {
-		if !f.spinnerOn {
-			f.spinnerOn = true
-			f.spinnerOnAt = now
+func (f *feedbackState) transition(operation *generated.GuiStatusBarOperation, now time.Time) {
+	now = f.monotonic(now)
+	if operation == nil {
+		f.advance(now)
+		f.hasLatest = false
+		if !f.hasDisplay || !terminalDwells(f.displayed.Status) {
+			f.resetDisplay()
 		}
+		return
 	}
-	if f.onset.IsZero() && f.spinnerOn && !f.spinnerOnAt.IsZero() {
-		if now.Sub(f.spinnerOnAt) >= spinnerHoldMs {
-			f.spinnerOn = false
+
+	incoming := *operation
+	if !f.hasLatest || incoming.OperationID != f.latest.OperationID {
+		f.replaceIdentity(incoming, now)
+		return
+	}
+
+	f.advance(now)
+	previousStatus := f.latest.Status
+	f.latest = incoming
+	if incoming.Status == previousStatus {
+		f.refreshSameStatus(incoming)
+		return
+	}
+
+	f.hasDeferred = false
+	f.terminalUntil = time.Time{}
+	switch incoming.Status {
+	case generated.OperationStatusPending, generated.OperationStatusQueued:
+		f.displayed = incoming
+		f.hasDisplay = true
+		f.runningOnset = time.Time{}
+		f.spinnerOnAt = time.Time{}
+	case generated.OperationStatusRunning:
+		f.displayed = incoming
+		f.hasDisplay = true
+		f.runningOnset = now
+		f.spinnerOnAt = time.Time{}
+	case generated.OperationStatusSuccess:
+		if f.hasDisplay && f.displayed.OperationID == incoming.OperationID &&
+			f.displayed.Status == generated.OperationStatusRunning && !f.spinnerOnAt.IsZero() &&
+			now.Before(f.spinnerOnAt.Add(spinnerHold)) {
+			f.deferred = incoming
+			f.hasDeferred = true
+			return
 		}
+		f.showTerminal(incoming, now)
+	case generated.OperationStatusCanceled, generated.OperationStatusStale:
+		f.showTerminal(incoming, now)
+	default:
+		// Error and timeout remain exactly as long as the BEAM projects them.
+		f.displayed = incoming
+		f.hasDisplay = true
+		f.runningOnset = time.Time{}
+		f.spinnerOnAt = time.Time{}
+	}
+}
+
+func (f *feedbackState) replaceIdentity(operation generated.GuiStatusBarOperation, now time.Time) {
+	f.latest = operation
+	f.hasLatest = true
+	f.displayed = operation
+	f.hasDisplay = true
+	f.hasDeferred = false
+	f.onset = now
+	f.runningOnset = time.Time{}
+	f.spinnerOnAt = time.Time{}
+	f.terminalUntil = time.Time{}
+
+	switch operation.Status {
+	case generated.OperationStatusRunning:
+		f.runningOnset = now
+	case generated.OperationStatusSuccess, generated.OperationStatusCanceled, generated.OperationStatusStale:
+		f.terminalUntil = now.Add(terminalDwell)
+	}
+}
+
+func (f *feedbackState) refreshSameStatus(operation generated.GuiStatusBarOperation) {
+	if f.hasDeferred {
+		f.deferred = operation
+		return
+	}
+	if f.hasDisplay && f.displayed.OperationID == operation.OperationID && f.displayed.Status == operation.Status {
+		f.displayed = operation
+	}
+}
+
+func (f *feedbackState) showTerminal(operation generated.GuiStatusBarOperation, now time.Time) {
+	f.displayed = operation
+	f.hasDisplay = true
+	f.runningOnset = time.Time{}
+	f.spinnerOnAt = time.Time{}
+	if terminalDwells(operation.Status) {
+		f.terminalUntil = now.Add(terminalDwell)
+	}
+}
+
+func (f *feedbackState) tick(now time.Time) {
+	f.frame++
+	f.advance(f.monotonic(now))
+}
+
+func (f *feedbackState) advance(now time.Time) {
+	if f.hasDisplay && f.displayed.Status == generated.OperationStatusRunning && f.spinnerOnAt.IsZero() &&
+		!f.runningOnset.IsZero() && !now.Before(f.runningOnset.Add(spinnerDelay)) {
+		f.spinnerOnAt = now
+	}
+
+	if f.hasDeferred && !f.spinnerOnAt.IsZero() && !now.Before(f.spinnerOnAt.Add(spinnerHold)) {
+		deferred := f.deferred
+		f.hasDeferred = false
+		f.showTerminal(deferred, now)
+	}
+
+	if f.hasDisplay && !f.terminalUntil.IsZero() && !now.Before(f.terminalUntil) {
+		f.resetDisplay()
+	}
+}
+
+func (f *feedbackState) monotonic(now time.Time) time.Time {
+	if now.Before(f.now) {
+		return f.now
+	}
+	f.now = now
+	return now
+}
+
+func (f *feedbackState) resetDisplay() {
+	f.hasDisplay = false
+	f.hasDeferred = false
+	f.runningOnset = time.Time{}
+	f.spinnerOnAt = time.Time{}
+	f.terminalUntil = time.Time{}
+	if !f.hasLatest {
+		f.onset = time.Time{}
 	}
 }
 
@@ -52,38 +196,152 @@ func (f feedbackState) spinner() string {
 	return spinnerFrames[int(f.frame)%len(spinnerFrames)]
 }
 
-// inflight returns true when the status message indicates a pending operation.
-// The BEAM convention is to suffix pending messages with "…".
-func inflight(message string) bool {
-	return strings.HasSuffix(message, "…") ||
-		strings.HasSuffix(message, "… [Esc to cancel]")
-}
-
-// updateStatus tracks in-flight status transitions.
-func (f *feedbackState) updateStatus(message string) {
-	if message == f.lastMessage {
-		return
+func (f feedbackState) presentation() (string, generated.OperationStatus, bool) {
+	if !f.hasDisplay {
+		return "", 0, false
 	}
-	f.lastMessage = message
-	if inflight(message) {
-		if f.onset.IsZero() {
-			f.onset = time.Now()
+
+	operation := f.displayed
+	message := operation.Message
+	if message == "" {
+		message = operationKindLabel(operation.Kind)
+	}
+
+	var text string
+	switch operation.Status {
+	case generated.OperationStatusPending:
+		text = message
+		if f.deadlineReached(f.onset.Add(waitingDelay)) {
+			text = "Waiting · " + message
 		}
-	} else {
-		f.onset = time.Time{}
+	case generated.OperationStatusQueued:
+		if operation.Flags&operationQueueFlag != 0 {
+			text = fmt.Sprintf("Queued %d/%d · %s", operation.QueuePosition, operation.QueueTotal, message)
+		} else {
+			text = "Queued · " + message
+		}
+	case generated.OperationStatusRunning:
+		text = message
+		if !f.spinnerOnAt.IsZero() {
+			text = f.spinner() + " " + message
+		}
+	case generated.OperationStatusSuccess:
+		text = "✓ " + message
+	case generated.OperationStatusError:
+		text = "✕ Error · " + message
+	case generated.OperationStatusTimeout:
+		text = "! Timed out · " + message
+	case generated.OperationStatusCanceled:
+		text = "× Canceled · " + message
+	case generated.OperationStatusStale:
+		text = "↷ Stale · " + message
+	default:
+		text = message
 	}
+
+	metadata := make([]string, 0, 2)
+	if operation.Flags&operationProgressFlag != 0 {
+		metadata = append(metadata, fmt.Sprintf("%d/%d", operation.ProgressCurrent, operation.ProgressTotal))
+	}
+	if activeOperation(operation.Status) && operation.Flags&operationCancelableFlag != 0 && f.deadlineReached(f.onset.Add(waitingDelay)) {
+		metadata = append(metadata, "Esc cancel")
+	}
+	if len(metadata) > 0 {
+		text += " · " + strings.Join(metadata, " · ")
+	}
+	return text, operation.Status, true
 }
 
-// active returns true when the feedback system needs the animation tick running.
-func (f feedbackState) active() bool {
-	return !f.onset.IsZero() || f.spinnerOn
+func (f feedbackState) deadlineReached(deadline time.Time) bool {
+	return !deadline.IsZero() && !f.now.Before(deadline)
 }
 
-// formatMessage prefixes the status message with a braille spinner when the
-// spinner is visible, or returns it unchanged. This is read-only (value receiver).
-func (f feedbackState) formatMessage(message string) string {
-	if f.spinnerOn && inflight(message) {
-		return f.spinner() + " " + message
+func (f *feedbackState) nextTick(now time.Time, pickerLoading bool) (time.Duration, bool) {
+	now = f.monotonic(now)
+	f.advance(now)
+	deadline := time.Time{}
+	animated := pickerLoading
+
+	if f.hasDisplay {
+		operation := f.displayed
+		switch operation.Status {
+		case generated.OperationStatusPending:
+			if now.Before(f.onset.Add(waitingDelay)) {
+				deadline = f.onset.Add(waitingDelay)
+			}
+		case generated.OperationStatusQueued:
+			if operation.Flags&operationCancelableFlag != 0 && now.Before(f.onset.Add(waitingDelay)) {
+				deadline = f.onset.Add(waitingDelay)
+			}
+		case generated.OperationStatusRunning:
+			animated = true
+			if f.spinnerOnAt.IsZero() {
+				deadline = f.runningOnset.Add(spinnerDelay)
+			} else if f.hasDeferred {
+				deadline = f.spinnerOnAt.Add(spinnerHold)
+			}
+			if operation.Flags&operationCancelableFlag != 0 && now.Before(f.onset.Add(waitingDelay)) {
+				deadline = earlierDeadline(deadline, f.onset.Add(waitingDelay))
+			}
+		case generated.OperationStatusSuccess, generated.OperationStatusCanceled, generated.OperationStatusStale:
+			if !f.terminalUntil.IsZero() && now.Before(f.terminalUntil) {
+				deadline = f.terminalUntil
+			}
+		}
 	}
-	return message
+
+	if !animated && deadline.IsZero() {
+		return 0, false
+	}
+	delay := feedbackTickInterval
+	if !deadline.IsZero() {
+		until := deadline.Sub(now)
+		if until < delay {
+			delay = until
+		}
+	}
+	if delay <= 0 {
+		delay = time.Nanosecond
+	}
+	return delay, true
+}
+
+func earlierDeadline(current time.Time, candidate time.Time) time.Time {
+	if current.IsZero() || candidate.Before(current) {
+		return candidate
+	}
+	return current
+}
+
+func terminalDwells(status generated.OperationStatus) bool {
+	return status == generated.OperationStatusSuccess || status == generated.OperationStatusCanceled || status == generated.OperationStatusStale
+}
+
+func activeOperation(status generated.OperationStatus) bool {
+	return status == generated.OperationStatusPending || status == generated.OperationStatusQueued || status == generated.OperationStatusRunning
+}
+
+func operationKindLabel(kind generated.OperationKind) string {
+	switch kind {
+	case generated.OperationKindExternalFormat:
+		return "Formatting"
+	case generated.OperationKindGitStage:
+		return "Staging changes"
+	case generated.OperationKindGitUnstage:
+		return "Unstaging changes"
+	case generated.OperationKindGitDiscard:
+		return "Discarding changes"
+	case generated.OperationKindGitStageAll:
+		return "Staging all changes"
+	case generated.OperationKindGitUnstageAll:
+		return "Unstaging all changes"
+	case generated.OperationKindGitCommit:
+		return "Committing changes"
+	case generated.OperationKindLspReferences:
+		return "Finding references"
+	case generated.OperationKindLspRename:
+		return "Renaming"
+	default:
+		return "Operation"
+	}
 }

--- a/go/tui/internal/ui/feedback_test.go
+++ b/go/tui/internal/ui/feedback_test.go
@@ -1,180 +1,357 @@
 package ui
 
 import (
+	"fmt"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/jsmestad/minga/go/tui/internal/generated"
 )
 
-func TestInflight(t *testing.T) {
-	tests := []struct {
-		message string
-		want    bool
-	}{
-		{"Formatting…", true},
-		{"Finding references…", true},
-		{"Renaming…", true},
-		{"Formatting… [Esc to cancel]", true},
-		{"Formatted", false},
-		{"Format error: LSP request failed", false},
-		{"", false},
+var feedbackTestStart = time.Date(2026, 7, 13, 12, 0, 0, 0, time.UTC)
+
+func testOperation(id uint64, status generated.OperationStatus, message string) generated.GuiStatusBarOperation {
+	return generated.GuiStatusBarOperation{
+		OperationID: id,
+		Kind:        generated.OperationKindExternalFormat,
+		Status:      status,
+		Message:     message,
 	}
-	for _, tt := range tests {
-		t.Run(tt.message, func(t *testing.T) {
-			if got := inflight(tt.message); got != tt.want {
-				t.Errorf("inflight(%q) = %v, want %v", tt.message, got, tt.want)
+}
+
+func presented(t *testing.T, feedback feedbackState) string {
+	t.Helper()
+	text, _, ok := feedback.presentation()
+	if !ok {
+		t.Fatal("expected visible operation presentation")
+	}
+	return text
+}
+
+func TestFeedbackPresentsEverySemanticStatus(t *testing.T) {
+	tests := []struct {
+		status generated.OperationStatus
+		want   string
+	}{
+		{generated.OperationStatusPending, "Working..."},
+		{generated.OperationStatusQueued, "Queued · Working..."},
+		{generated.OperationStatusRunning, "Working..."},
+		{generated.OperationStatusSuccess, "✓ Working..."},
+		{generated.OperationStatusError, "✕ Error · Working..."},
+		{generated.OperationStatusTimeout, "! Timed out · Working..."},
+		{generated.OperationStatusCanceled, "× Canceled · Working..."},
+		{generated.OperationStatusStale, "↷ Stale · Working..."},
+	}
+
+	for _, test := range tests {
+		t.Run(test.want, func(t *testing.T) {
+			var feedback feedbackState
+			operation := testOperation(1, test.status, "Working...")
+			feedback.transition(&operation, feedbackTestStart)
+			if got := presented(t, feedback); got != test.want {
+				t.Fatalf("presentation = %q, want %q", got, test.want)
 			}
 		})
 	}
 }
 
-func TestFeedbackUpdateStatus(t *testing.T) {
-	var f feedbackState
-	f.updateStatus("Formatting…")
-	if f.onset.IsZero() {
-		t.Error("onset should be set for in-flight message")
-	}
-	if f.lastMessage != "Formatting…" {
-		t.Errorf("lastMessage = %q, want %q", f.lastMessage, "Formatting…")
-	}
+func TestFeedbackRunningSpinnerExactBoundaryAndPunctuationIndependence(t *testing.T) {
+	for _, message := range []string{"Formatting", "Formatting…", "Formatting..."} {
+		t.Run(message, func(t *testing.T) {
+			var feedback feedbackState
+			operation := testOperation(1, generated.OperationStatusRunning, message)
+			feedback.transition(&operation, feedbackTestStart)
+			feedback.tick(feedbackTestStart.Add(spinnerDelay - time.Nanosecond))
+			if got := presented(t, feedback); got != message {
+				t.Fatalf("before 100ms = %q, want %q", got, message)
+			}
 
-	f.updateStatus("Formatted")
-	if !f.onset.IsZero() {
-		t.Error("onset should be cleared for non-in-flight message")
+			feedback.tick(feedbackTestStart.Add(spinnerDelay))
+			if got := presented(t, feedback); got != feedback.spinner()+" "+message {
+				t.Fatalf("at 100ms = %q", got)
+			}
+			if !feedback.spinnerOnAt.Equal(feedbackTestStart.Add(spinnerDelay)) {
+				t.Fatalf("spinner visibility = %v", feedback.spinnerOnAt)
+			}
+		})
 	}
 }
 
-func TestFeedbackSpinnerDelay(t *testing.T) {
-	var f feedbackState
-	f.updateStatus("Formatting…")
+func TestFeedbackPendingWaitingCancelAndMetadataExactBoundary(t *testing.T) {
+	var feedback feedbackState
+	operation := testOperation(1, generated.OperationStatusPending, "Formatting…")
+	operation.Flags = operationCancelableFlag | operationProgressFlag
+	operation.ProgressCurrent = 3
+	operation.ProgressTotal = 10
+	feedback.transition(&operation, feedbackTestStart)
 
-	f.tick()
-	if f.spinnerOn {
-		t.Error("spinner should not be on before delay threshold")
+	feedback.tick(feedbackTestStart.Add(waitingDelay - time.Nanosecond))
+	if got := presented(t, feedback); got != "Formatting… · 3/10" {
+		t.Fatalf("before waiting boundary = %q", got)
 	}
-
-	f.onset = time.Now().Add(-spinnerDelayMs - time.Millisecond)
-	f.tick()
-	if !f.spinnerOn {
-		t.Error("spinner should be on after delay threshold")
+	feedback.tick(feedbackTestStart.Add(waitingDelay))
+	if got := presented(t, feedback); got != "Waiting · Formatting… · 3/10 · Esc cancel" {
+		t.Fatalf("at waiting boundary = %q", got)
 	}
 }
 
-func TestFeedbackFormatMessage(t *testing.T) {
-	var f feedbackState
+func TestFeedbackQueuedFormattingAndKindFallback(t *testing.T) {
+	var feedback feedbackState
+	operation := testOperation(1, generated.OperationStatusQueued, "")
+	operation.Kind = generated.OperationKindGitCommit
+	operation.Flags = operationQueueFlag | operationProgressFlag | operationCancelableFlag
+	operation.QueuePosition = 2
+	operation.QueueTotal = 5
+	operation.ProgressCurrent = 7
+	operation.ProgressTotal = 10
+	feedback.transition(&operation, feedbackTestStart)
 
-	result := f.formatMessage("Formatting…")
-	if result != "Formatting…" {
-		t.Errorf("should not prefix spinner when not active, got %q", result)
+	if got := presented(t, feedback); got != "Queued 2/5 · Committing changes · 7/10" {
+		t.Fatalf("queued presentation = %q", got)
+	}
+	feedback.tick(feedbackTestStart.Add(waitingDelay))
+	if got := presented(t, feedback); got != "Queued 2/5 · Committing changes · 7/10 · Esc cancel" {
+		t.Fatalf("queued cancel presentation = %q", got)
 	}
 
-	f.spinnerOn = true
-	f.frame = 0
-	result = f.formatMessage("Formatting…")
-	want := spinnerFrames[0] + " " + "Formatting…"
-	if result != want {
-		t.Errorf("should prefix spinner, got %q want %q", result, want)
-	}
-
-	result = f.formatMessage("Formatted")
-	if result != "Formatted" {
-		t.Errorf("should not prefix non-inflight message, got %q", result)
+	operation.Flags &^= operationQueueFlag
+	feedback.transition(&operation, feedbackTestStart.Add(waitingDelay+time.Millisecond))
+	if got := presented(t, feedback); !strings.HasPrefix(got, "Queued · Committing changes") {
+		t.Fatalf("queue numbers should be omitted when unavailable: %q", got)
 	}
 }
 
-func TestFeedbackActive(t *testing.T) {
-	var f feedbackState
-	if f.active() {
-		t.Error("idle state should not be active")
+func TestFeedbackSameIdentityUpdatesDoNotRestartDeadlines(t *testing.T) {
+	var feedback feedbackState
+	operation := testOperation(7, generated.OperationStatusRunning, "Formatting")
+	feedback.transition(&operation, feedbackTestStart)
+	runningOnset := feedback.runningOnset
+	onset := feedback.onset
+
+	updated := operation
+	updated.Message = "Formatting buffer"
+	updated.Flags = operationProgressFlag | operationCancelableFlag
+	updated.ProgressCurrent = 4
+	updated.ProgressTotal = 8
+	feedback.transition(&updated, feedbackTestStart.Add(90*time.Millisecond))
+	if !feedback.runningOnset.Equal(runningOnset) || !feedback.onset.Equal(onset) {
+		t.Fatalf("same-ID update restarted deadlines: onset=%v running=%v", feedback.onset, feedback.runningOnset)
 	}
 
-	f.updateStatus("Formatting…")
-	if !f.active() {
-		t.Error("in-flight state should be active")
-	}
-
-	f.updateStatus("Formatted")
-	if f.active() {
-		t.Error("cleared state should not be active")
+	feedback.tick(feedbackTestStart.Add(spinnerDelay))
+	if got := presented(t, feedback); !strings.Contains(got, "Formatting buffer · 4/8") || !strings.HasPrefix(got, feedback.spinner()+" ") {
+		t.Fatalf("updated running presentation = %q", got)
 	}
 }
 
-func TestFeedbackSpinnerHold(t *testing.T) {
-	var f feedbackState
-	f.updateStatus("Formatting…")
-	f.onset = time.Now().Add(-spinnerDelayMs - time.Millisecond)
-	f.tick()
-	if !f.spinnerOn {
-		t.Fatal("spinner should be on")
-	}
+func TestFeedbackRunningDelayStartsWhenSameIdentityEntersRunning(t *testing.T) {
+	var feedback feedbackState
+	pending := testOperation(1, generated.OperationStatusPending, "Waiting")
+	feedback.transition(&pending, feedbackTestStart)
+	runningAt := feedbackTestStart.Add(2 * time.Second)
+	running := testOperation(1, generated.OperationStatusRunning, "Running")
+	feedback.transition(&running, runningAt)
 
-	f.updateStatus("Formatted")
-	if !f.spinnerOn {
-		t.Error("spinner should hold after status clears (hold floor)")
+	feedback.tick(runningAt.Add(spinnerDelay - time.Nanosecond))
+	if got := presented(t, feedback); got != "Running" {
+		t.Fatalf("running spinner started from operation onset: %q", got)
 	}
-	if !f.active() {
-		t.Error("should be active during hold period")
-	}
-
-	f.spinnerOnAt = time.Now().Add(-spinnerHoldMs - time.Millisecond)
-	f.tick()
-	if f.spinnerOn {
-		t.Error("spinner should clear after hold floor elapsed")
+	feedback.tick(runningAt.Add(spinnerDelay))
+	if got := presented(t, feedback); !strings.HasPrefix(got, feedback.spinner()+" ") {
+		t.Fatalf("running spinner missing at phase boundary: %q", got)
 	}
 }
 
-func TestFeedbackSpinnerRotates(t *testing.T) {
-	var f feedbackState
-	first := f.spinner()
-	f.frame++
-	second := f.spinner()
-	if first == second {
-		t.Error("spinner should rotate on frame advance")
+func TestFeedbackSpinnerHoldAndSuccessDwellExactBoundaries(t *testing.T) {
+	var feedback feedbackState
+	running := testOperation(1, generated.OperationStatusRunning, "Formatting")
+	feedback.transition(&running, feedbackTestStart)
+	feedback.tick(feedbackTestStart.Add(spinnerDelay))
+
+	success := testOperation(1, generated.OperationStatusSuccess, "Formatted")
+	feedback.transition(&success, feedbackTestStart.Add(spinnerDelay+spinnerHold-time.Nanosecond))
+	if got := presented(t, feedback); !strings.HasPrefix(got, feedback.spinner()+" Formatting") {
+		t.Fatalf("success replaced spinner before hold: %q", got)
+	}
+
+	visibleAt := feedbackTestStart.Add(spinnerDelay + spinnerHold)
+	feedback.tick(visibleAt)
+	if got := presented(t, feedback); got != "✓ Formatted" {
+		t.Fatalf("success at hold boundary = %q", got)
+	}
+	feedback.tick(visibleAt.Add(terminalDwell - time.Nanosecond))
+	if got := presented(t, feedback); got != "✓ Formatted" {
+		t.Fatalf("success disappeared before dwell: %q", got)
+	}
+	feedback.tick(visibleAt.Add(terminalDwell))
+	if _, _, ok := feedback.presentation(); ok {
+		t.Fatal("success should disappear at the 1500ms dwell boundary")
 	}
 }
 
-func TestFeedbackTickAdvancesFrame(t *testing.T) {
-	var f feedbackState
-	if f.frame != 0 {
-		t.Fatalf("initial frame should be 0, got %d", f.frame)
+func TestFeedbackNonSuccessTerminalsReplaceSpinnerImmediately(t *testing.T) {
+	statuses := []generated.OperationStatus{
+		generated.OperationStatusError,
+		generated.OperationStatusTimeout,
+		generated.OperationStatusCanceled,
+		generated.OperationStatusStale,
 	}
-	f.tick()
-	if f.frame != 1 {
-		t.Errorf("frame after one tick should be 1, got %d", f.frame)
+	for _, status := range statuses {
+		t.Run(presentedStatusName(status), func(t *testing.T) {
+			var feedback feedbackState
+			running := testOperation(1, generated.OperationStatusRunning, "Running")
+			feedback.transition(&running, feedbackTestStart)
+			feedback.tick(feedbackTestStart.Add(spinnerDelay))
+
+			terminal := testOperation(1, status, "Stopped")
+			feedback.transition(&terminal, feedbackTestStart.Add(spinnerDelay+time.Nanosecond))
+			_, gotStatus, ok := feedback.presentation()
+			if !ok || gotStatus != status || feedback.hasDeferred {
+				t.Fatalf("terminal did not replace spinner immediately: status=%d feedback=%+v", gotStatus, feedback)
+			}
+		})
 	}
-	f.tick()
-	f.tick()
-	if f.frame != 3 {
-		t.Errorf("frame after three ticks should be 3, got %d", f.frame)
+}
+
+func TestFeedbackSuccessBeforeSpinnerIsImmediate(t *testing.T) {
+	var feedback feedbackState
+	running := testOperation(1, generated.OperationStatusRunning, "Formatting")
+	feedback.transition(&running, feedbackTestStart)
+	success := testOperation(1, generated.OperationStatusSuccess, "Formatted")
+	visibleAt := feedbackTestStart.Add(spinnerDelay - time.Nanosecond)
+	feedback.transition(&success, visibleAt)
+	if got := presented(t, feedback); got != "✓ Formatted" {
+		t.Fatalf("fast success = %q", got)
 	}
-	// Verify the spinner output changes across consecutive ticks, covering the
-	// picker-loading case where tick() is the only driver of spinner animation.
-	frames := make([]string, len(spinnerFrames)+1)
-	f.frame = 0
-	for i := range frames {
-		frames[i] = f.spinner()
-		f.tick()
+	if !feedback.terminalUntil.Equal(visibleAt.Add(terminalDwell)) {
+		t.Fatalf("success dwell deadline = %v", feedback.terminalUntil)
 	}
-	// The first len(spinnerFrames) entries should all be distinct (one full cycle).
-	seen := map[string]bool{}
-	for _, s := range frames[:len(spinnerFrames)] {
-		if seen[s] {
-			t.Errorf("duplicate spinner frame %q within one cycle", s)
+}
+
+func TestFeedbackTerminalReplacementAndDwellPolicies(t *testing.T) {
+	for _, status := range []generated.OperationStatus{generated.OperationStatusError, generated.OperationStatusTimeout} {
+		t.Run(presentedStatusName(status), func(t *testing.T) {
+			var feedback feedbackState
+			operation := testOperation(1, status, "Failed")
+			feedback.transition(&operation, feedbackTestStart)
+			feedback.tick(feedbackTestStart.Add(10 * terminalDwell))
+			if _, _, ok := feedback.presentation(); !ok {
+				t.Fatal("error/timeout must remain while BEAM projects it")
+			}
+			feedback.transition(nil, feedbackTestStart.Add(10*terminalDwell))
+			if _, _, ok := feedback.presentation(); ok {
+				t.Fatal("error/timeout must clear when BEAM stops projecting it")
+			}
+		})
+	}
+
+	for _, status := range []generated.OperationStatus{generated.OperationStatusCanceled, generated.OperationStatusStale} {
+		t.Run(presentedStatusName(status), func(t *testing.T) {
+			var feedback feedbackState
+			operation := testOperation(1, status, "Stopped")
+			feedback.transition(&operation, feedbackTestStart)
+			feedback.transition(nil, feedbackTestStart.Add(time.Millisecond))
+			feedback.tick(feedbackTestStart.Add(terminalDwell - time.Nanosecond))
+			if _, _, ok := feedback.presentation(); !ok {
+				t.Fatal("canceled/stale should dwell after projection disappears")
+			}
+			feedback.tick(feedbackTestStart.Add(terminalDwell))
+			if _, _, ok := feedback.presentation(); ok {
+				t.Fatal("canceled/stale should clear at dwell boundary")
+			}
+		})
+	}
+}
+
+func TestFeedbackDifferentIdentityImmediatelyInvalidatesHoldAndDwell(t *testing.T) {
+	t.Run("spinner hold", func(t *testing.T) {
+		var feedback feedbackState
+		running := testOperation(1, generated.OperationStatusRunning, "Old operation")
+		feedback.transition(&running, feedbackTestStart)
+		feedback.tick(feedbackTestStart.Add(spinnerDelay))
+		success := testOperation(1, generated.OperationStatusSuccess, "Old success")
+		feedback.transition(&success, feedbackTestStart.Add(spinnerDelay+time.Millisecond))
+		if !feedback.hasDeferred {
+			t.Fatal("expected same-ID success to be deferred")
 		}
-		seen[s] = true
-	}
-	// After a full cycle the spinner wraps: frame[0] == frame[len(spinnerFrames)].
-	if frames[0] != frames[len(spinnerFrames)] {
-		t.Errorf("spinner should wrap after full cycle: frame[0]=%q, frame[%d]=%q", frames[0], len(spinnerFrames), frames[len(spinnerFrames)])
+
+		replacement := testOperation(2, generated.OperationStatusPending, "New operation")
+		feedback.transition(&replacement, feedbackTestStart.Add(spinnerDelay+2*time.Millisecond))
+		if feedback.hasDeferred || !feedback.terminalUntil.IsZero() || feedback.displayed.OperationID != 2 {
+			t.Fatalf("replacement retained prior identity state: %+v", feedback)
+		}
+		if got := presented(t, feedback); got != "New operation" {
+			t.Fatalf("replacement presentation = %q", got)
+		}
+	})
+
+	t.Run("terminal dwell", func(t *testing.T) {
+		var feedback feedbackState
+		terminal := testOperation(1, generated.OperationStatusSuccess, "Old success")
+		feedback.transition(&terminal, feedbackTestStart)
+		oldDeadline := feedback.terminalUntil
+		if oldDeadline.IsZero() {
+			t.Fatal("expected terminal result to establish a dwell deadline")
+		}
+
+		replacement := testOperation(2, generated.OperationStatusPending, "New operation")
+		feedback.transition(&replacement, feedbackTestStart.Add(time.Millisecond))
+		if !feedback.terminalUntil.IsZero() {
+			t.Fatalf("replacement retained terminal deadline %v", feedback.terminalUntil)
+		}
+		if got := presented(t, feedback); got != "New operation" {
+			t.Fatalf("replacement presentation = %q", got)
+		}
+
+		feedback.tick(oldDeadline)
+		if got := presented(t, feedback); got != "Waiting · New operation" {
+			t.Fatalf("replacement did not promote at old dwell deadline: %q", got)
+		}
+		if feedback.displayed.OperationID != replacement.OperationID {
+			t.Fatalf("old dwell deadline restored operation %d", feedback.displayed.OperationID)
+		}
+	})
+}
+
+func TestFeedbackStaleTickCannotRestoreOldIdentity(t *testing.T) {
+	var feedback feedbackState
+	old := testOperation(1, generated.OperationStatusRunning, "Old")
+	feedback.transition(&old, feedbackTestStart)
+	replacementAt := feedbackTestStart.Add(200 * time.Millisecond)
+	replacement := testOperation(2, generated.OperationStatusPending, "New")
+	feedback.transition(&replacement, replacementAt)
+
+	feedback.tick(feedbackTestStart.Add(80 * time.Millisecond))
+	if feedback.displayed.OperationID != 2 || presented(t, feedback) != "New" {
+		t.Fatalf("stale tick restored old identity: %+v", feedback)
 	}
 }
 
-func TestFeedbackDuplicateMessage(t *testing.T) {
-	var f feedbackState
-	f.updateStatus("Formatting…")
-	onset := f.onset
-
-	f.updateStatus("Formatting…")
-	if !f.onset.Equal(onset) {
-		t.Error("duplicate message should not reset onset")
+func TestFeedbackTickCadenceShortensToExactDeadlines(t *testing.T) {
+	var feedback feedbackState
+	running := testOperation(1, generated.OperationStatusRunning, "Running")
+	feedback.transition(&running, feedbackTestStart)
+	if delay, ok := feedback.nextTick(feedbackTestStart, false); !ok || delay != feedbackTickInterval {
+		t.Fatalf("first running tick = %v, %v", delay, ok)
 	}
+	if delay, ok := feedback.nextTick(feedbackTestStart.Add(80*time.Millisecond), false); !ok || delay != 20*time.Millisecond {
+		t.Fatalf("deadline tick = %v, %v", delay, ok)
+	}
+
+	var queued feedbackState
+	operation := testOperation(2, generated.OperationStatusQueued, "Queued")
+	queued.transition(&operation, feedbackTestStart)
+	if _, ok := queued.nextTick(feedbackTestStart, false); ok {
+		t.Fatal("non-cancelable queued operation has no animation deadline")
+	}
+	operation.Flags = operationCancelableFlag
+	queued.transition(&operation, feedbackTestStart)
+	if delay, ok := queued.nextTick(feedbackTestStart.Add(990*time.Millisecond), false); !ok || delay != 10*time.Millisecond {
+		t.Fatalf("cancel deadline tick = %v, %v", delay, ok)
+	}
+}
+
+func presentedStatusName(status generated.OperationStatus) string {
+	return fmt.Sprintf("status_%d", status)
 }

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -65,6 +65,7 @@ type Model struct {
 	bottomPanelScrollback int
 	agent                 agentPanel
 	feedback              feedbackState
+	now                   func() time.Time
 	// latency records end-to-end keystroke-to-write samples (ticket #2215).
 	// It is a pointer so the recorder persists across value-copied Model
 	// updates. hudVisible toggles the on-screen p50/p99 overlay at runtime.
@@ -178,12 +179,20 @@ func New(width, height uint16, out chan<- []byte, filter *InputFilter) Model {
 		localPresentation: newLocalPresentation(),
 		inputFilter:       filter,
 		transcript:        newResidentTranscript(),
+		now:               time.Now,
 	}
 	// Seed the layout so the first mouse event lands in the correct
 	// region before the first BEAM frame arrives.
 	m.layout = m.computeLayout()
 	m.viewport.SetHeight(m.layout.body.Height)
 	return m
+}
+
+func (m Model) currentTime() time.Time {
+	if m.now != nil {
+		return m.now()
+	}
+	return time.Now()
 }
 
 // latencyHUDEnvEnabled reports whether MINGA_LATENCY_HUD requests the overlay on
@@ -212,6 +221,7 @@ func agentAnimationTick() tea.Cmd {
 func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 	m.pendingClipboard = ""
 	var cmd tea.Cmd
+	transitionNow := time.Time{}
 	switch msg := msg.(type) {
 	case tea.WindowSizeMsg:
 		m.width = msg.Width
@@ -291,19 +301,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 			m.agent.animationRunning = false
 		}
 	case feedbackTickMsg:
-		m.feedback.tick()
-		if status, ok := m.statusBar(); ok {
-			m.feedback.updateStatus(status.Message)
-		}
-		pickerLoading := false
-		if picker, ok := m.chrome[generated.OPGuiPicker]; ok && picker.Picker.LoadStatus == 1 {
-			pickerLoading = true
-		}
-		if m.feedback.active() || pickerLoading {
-			cmd = feedbackTick()
-		} else {
-			m.feedback.ticking = false
-		}
+		// The command that produced this message owns the frame timestamp. Using
+		// it here keeps every threshold deterministic and lets a final late tick
+		// drain without consulting the wall clock.
+		transitionNow = msg.at
+		m.feedback.ticking = false
+		m.feedback.tick(msg.at)
 	case port.PacketMsg:
 		cmd = m.applyCommands(msg.Commands)
 		m.layout = m.computeLayout()
@@ -319,18 +322,21 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		cmd = tea.Batch(cmd, agentAnimationTick())
 	}
 
+	if transitionNow.IsZero() {
+		transitionNow = m.currentTime()
+	}
 	if status, ok := m.statusBar(); ok {
-		m.feedback.updateStatus(status.Message)
+		m.feedback.transition(status.Operation, transitionNow)
+	} else {
+		m.feedback.transition(nil, transitionNow)
 	}
-	needsTick := m.feedback.active()
-	if !needsTick {
-		if picker, ok := m.chrome[generated.OPGuiPicker]; ok && picker.Picker.LoadStatus == 1 {
-			needsTick = true
-		}
+	pickerLoading := false
+	if picker, ok := m.chrome[generated.OPGuiPicker]; ok && picker.Picker.LoadStatus == 1 {
+		pickerLoading = true
 	}
-	if needsTick && !m.feedback.ticking {
+	if delay, needsTick := m.feedback.nextTick(transitionNow, pickerLoading); needsTick && !m.feedback.ticking {
 		m.feedback.ticking = true
-		cmd = tea.Batch(cmd, feedbackTick())
+		cmd = tea.Batch(cmd, feedbackTick(delay))
 	}
 
 	m.viewport.SetWidth(max(m.width, 1))

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -7,6 +7,7 @@ import (
 	"reflect"
 	"strings"
 	"testing"
+	"time"
 
 	tea "charm.land/bubbletea/v2"
 	"charm.land/lipgloss/v2"
@@ -312,6 +313,150 @@ func TestFooterRendersStatusMessageWithModelineSegments(t *testing.T) {
 	footer := ansi.Strip(strings.Join(model.footerLines(), "\n"))
 	if !strings.Contains(footer, "Modified buffers exist. Really quit? (y/n)") {
 		t.Fatalf("footer should render status message with modeline segments: %q", footer)
+	}
+}
+
+func TestOperationOnlyStatusIsDiscoverableAfterCommittedFrame(t *testing.T) {
+	model := New(80, 24, nil, nil)
+	model.now = func() time.Time { return feedbackTestStart }
+	operation := testOperation(42, generated.OperationStatusPending, "Formatting")
+	statusCommand := protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{
+		Opcode: generated.OPGuiStatusBar,
+		Status: protocol.StatusBar{Operation: &operation},
+	}}
+
+	updated, _ := model.Update(port.PacketMsg{Commands: []protocol.Command{
+		{Kind: protocol.CommandBeginFrame, FrameSeq: 1, BaseFrameSeq: 0},
+		testThemeCommand(),
+		statusCommand,
+	}})
+	model = updated.(Model)
+	if _, ok := model.statusBar(); ok || model.feedback.hasDisplay {
+		t.Fatal("operation must not be observed before its frame commits")
+	}
+
+	updated, _ = model.Update(port.PacketMsg{Commands: []protocol.Command{{Kind: protocol.CommandCommitFrame, FrameSeq: 1}}})
+	model = updated.(Model)
+	status, ok := model.statusBar()
+	if !ok || status.Operation == nil || status.Operation.OperationID != 42 {
+		t.Fatalf("operation-only status was not discoverable: %+v, %v", status, ok)
+	}
+	if got := ansi.Strip(strings.Join(model.footerLines(), "\n")); !strings.Contains(got, "Formatting") {
+		t.Fatalf("operation-only footer = %q", got)
+	}
+}
+
+func TestOperationFeedbackUsesOneOutstandingChromeTickAndTickTimestamp(t *testing.T) {
+	model := New(80, 24, nil, nil)
+	model.now = func() time.Time { return feedbackTestStart }
+	operation := testOperation(1, generated.OperationStatusRunning, "Formatting")
+	updated, firstTick := model.Update(port.PacketMsg{Commands: frame(protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{
+		Opcode: generated.OPGuiStatusBar,
+		Status: protocol.StatusBar{Operation: &operation},
+	}})})
+	model = updated.(Model)
+	if firstTick == nil || !model.feedback.ticking {
+		t.Fatal("running operation should schedule one chrome tick")
+	}
+
+	updated, duplicate := model.Update(struct{}{})
+	model = updated.(Model)
+	if duplicate != nil {
+		t.Fatal("an outstanding chrome tick must not be duplicated")
+	}
+
+	clockCalled := false
+	model.now = func() time.Time {
+		clockCalled = true
+		return feedbackTestStart.Add(time.Hour)
+	}
+	updated, rearmed := model.Update(feedbackTickMsg{at: feedbackTestStart.Add(spinnerDelay)})
+	model = updated.(Model)
+	if clockCalled {
+		t.Fatal("feedback tick consulted the wall clock instead of its message timestamp")
+	}
+	if rearmed == nil || !model.feedback.ticking || model.feedback.spinnerOnAt.IsZero() {
+		t.Fatalf("tick should use its timestamp and re-arm running animation: %+v", model.feedback)
+	}
+}
+
+func TestOperationFeedbackFinalTickDrainsWithoutRearming(t *testing.T) {
+	model := New(80, 24, nil, nil)
+	model.now = func() time.Time { return feedbackTestStart }
+	operation := testOperation(1, generated.OperationStatusCanceled, "Canceled")
+	updated, scheduled := model.Update(port.PacketMsg{Commands: frame(protocol.Command{Kind: protocol.CommandChrome, Chrome: protocol.ChromePayload{
+		Opcode: generated.OPGuiStatusBar,
+		Status: protocol.StatusBar{Operation: &operation},
+	}})})
+	model = updated.(Model)
+	if scheduled == nil || !model.feedback.ticking {
+		t.Fatal("terminal dwell should schedule a chrome tick")
+	}
+
+	updated, rearmed := model.Update(feedbackTickMsg{at: feedbackTestStart.Add(terminalDwell)})
+	model = updated.(Model)
+	if rearmed != nil || model.feedback.ticking || model.feedback.hasDisplay {
+		t.Fatalf("final dwell tick should drain cleanly: cmd=%v feedback=%+v", rearmed, model.feedback)
+	}
+}
+
+func TestChromeTickCoexistsWithPickerLoadingWithoutDuplication(t *testing.T) {
+	model := New(80, 24, nil, nil)
+	model.now = func() time.Time { return feedbackTestStart }
+	model.chrome[generated.OPGuiPicker] = protocol.ChromePayload{Picker: protocol.Picker{LoadStatus: 1}}
+
+	updated, scheduled := model.Update(struct{}{})
+	model = updated.(Model)
+	if scheduled == nil || !model.feedback.ticking {
+		t.Fatal("picker loading should schedule the shared chrome tick")
+	}
+	updated, duplicate := model.Update(struct{}{})
+	model = updated.(Model)
+	if duplicate != nil {
+		t.Fatal("picker and feedback must share one outstanding tick")
+	}
+
+	updated, rearmed := model.Update(feedbackTickMsg{at: feedbackTestStart.Add(feedbackTickInterval)})
+	model = updated.(Model)
+	if rearmed == nil || !model.feedback.ticking || model.feedback.frame != 1 {
+		t.Fatalf("picker loading should re-arm shared tick: %+v", model.feedback)
+	}
+
+	model.chrome[generated.OPGuiPicker] = protocol.ChromePayload{Picker: protocol.Picker{LoadStatus: 2}}
+	updated, final := model.Update(feedbackTickMsg{at: feedbackTestStart.Add(2 * feedbackTickInterval)})
+	model = updated.(Model)
+	if final != nil || model.feedback.ticking {
+		t.Fatal("last picker tick should drain after loading finishes")
+	}
+}
+
+func TestTypedFeedbackNarrowWidthKeepsDecorationAndPlainEllipsisStaysPlain(t *testing.T) {
+	model := New(20, 8, nil, nil)
+	operation := testOperation(1, generated.OperationStatusError, "A very long formatting failure")
+	model.feedback.transition(&operation, feedbackTestStart)
+	status := protocol.StatusBar{
+		Left:  []protocol.StatusSegment{{Text: " N "}},
+		Right: []protocol.StatusSegment{{Text: "1:1"}},
+	}
+	line := model.renderStatusSegments(status)
+	plain := ansi.Strip(line)
+	if lipgloss.Width(line) > model.width {
+		t.Fatalf("narrow feedback width = %d, want <= %d: %q", lipgloss.Width(line), model.width, plain)
+	}
+	if !strings.Contains(plain, "✕") || strings.Contains(plain, "ordinary notice") {
+		t.Fatalf("narrow status discarded typed decoration: %q", plain)
+	}
+
+	model.feedback = feedbackState{}
+	status.Message = "ordinary notice…"
+	plain = ansi.Strip(model.renderStatusSegments(status))
+	if !strings.Contains(plain, "ordinary") {
+		t.Fatalf("plain ellipsis notice was not rendered independently: %q", plain)
+	}
+	for _, spinner := range spinnerFrames {
+		if strings.Contains(plain, spinner) {
+			t.Fatalf("ordinary ellipsis notice inferred spinner %q: %q", spinner, plain)
+		}
 	}
 }
 

--- a/go/tui/internal/ui/render_chrome.go
+++ b/go/tui/internal/ui/render_chrome.go
@@ -5,9 +5,11 @@ import (
 	"image/color"
 	"sort"
 	"strings"
+	"unicode"
 
 	"charm.land/lipgloss/v2"
 	"github.com/charmbracelet/x/ansi"
+	"github.com/jsmestad/minga/go/tui/internal/generated"
 	"github.com/jsmestad/minga/go/tui/internal/protocol"
 )
 
@@ -226,9 +228,11 @@ func (m Model) footerLines() []string {
 				prefix = icon.glyph + " " + chromeStatus.Filename
 			}
 			status = fmt.Sprintf("%s  %d:%d", prefix, chromeStatus.Line, chromeStatus.Column)
-			if chromeStatus.Message != "" {
-				status += "  " + chromeStatus.Message
+			if message := m.renderStatusMessage(chromeStatus.Message); message != "" {
+				status += "  " + message
 			}
+		} else if message := m.renderStatusMessage(chromeStatus.Message); message != "" {
+			status = message
 		}
 	}
 	if m.lastError != "" {
@@ -297,7 +301,9 @@ func (m Model) renderStatusSegments(status protocol.StatusBar) string {
 	messageWidth := lipgloss.Width(message)
 	available := max(m.width-leftWidth-rightWidth, 1)
 	if messageWidth > available {
-		message = m.renderStatusMessage(fit(status.Message, available))
+		// Feedback decoration and metadata are already styled. Truncate that one
+		// finalized value so narrow widths cannot fall back to the raw notice.
+		message = fitStyled(message, available)
 		messageWidth = lipgloss.Width(message)
 	}
 	leftSpacer := strings.Repeat(" ", max((available-messageWidth)/2, 0))
@@ -325,11 +331,43 @@ func (m Model) extensionRuntimeStatus() string {
 }
 
 func (m Model) renderStatusMessage(message string) string {
-	if message == "" {
+	text, status, hasOperationPresentation := m.feedback.presentation()
+	operationOwnsLane := hasOperationPresentation && (activeOperation(status) || message == "")
+	foreground := m.palette().Warning()
+	if operationOwnsLane {
+		switch status {
+		case generated.OperationStatusPending, generated.OperationStatusQueued:
+			foreground = m.palette().ChromeText()
+		case generated.OperationStatusRunning:
+			foreground = m.palette().Accent()
+		case generated.OperationStatusSuccess:
+			foreground = m.palette().Hint()
+		case generated.OperationStatusError:
+			foreground = m.palette().Error()
+		case generated.OperationStatusTimeout:
+			foreground = m.palette().Warning()
+		case generated.OperationStatusCanceled:
+			foreground = m.palette().Muted()
+		case generated.OperationStatusStale:
+			foreground = m.palette().Info()
+		}
+	} else {
+		text = message
+	}
+	text = sanitizeTerminalText(text)
+	if text == "" {
 		return ""
 	}
-	displayed := m.feedback.formatMessage(message)
-	return lipgloss.NewStyle().Bold(true).Foreground(m.palette().Warning()).Background(m.palette().ChromeSurface()).Render(displayed)
+	return lipgloss.NewStyle().Bold(true).Foreground(foreground).Background(m.palette().ChromeSurface()).Render(text)
+}
+
+func sanitizeTerminalText(text string) string {
+	return strings.Map(func(r rune) rune {
+		if unicode.IsControl(r) {
+			return ' '
+		}
+		return r
+	}, ansi.Strip(text))
 }
 
 func (m Model) renderSegmentList(segments []protocol.StatusSegment) string {

--- a/go/tui/internal/ui/render_chrome_test.go
+++ b/go/tui/internal/ui/render_chrome_test.go
@@ -1,0 +1,137 @@
+package ui
+
+import (
+	"image/color"
+	"strings"
+	"testing"
+	"unicode"
+
+	"charm.land/lipgloss/v2"
+	"github.com/charmbracelet/x/ansi"
+	"github.com/jsmestad/minga/go/tui/internal/generated"
+	"github.com/jsmestad/minga/go/tui/internal/protocol"
+)
+
+func TestRenderStatusMessageSanitizesTerminalText(t *testing.T) {
+	tests := []struct {
+		name    string
+		payload string
+		want    string
+	}{
+		{name: "CSI color", payload: "before\x1b[31mred\x1b[0mafter", want: "beforeredafter"},
+		{name: "OSC 8 hyperlink", payload: "see \x1b]8;;https://example.com\x1b\\link\x1b]8;;\x1b\\ now", want: "see link now"},
+		{name: "OSC 52 clipboard", payload: "copy\x1b]52;c;Y2xpcGJvYXJk\x07done", want: "copydone"},
+		{name: "DCS", payload: "before\x1bP1;2|payload\x1b\\after", want: "beforeafter"},
+		{name: "carriage return", payload: "left\rright", want: "left right"},
+		{name: "line feed", payload: "left\nright", want: "left right"},
+		{name: "standalone controls", payload: "a\tb\x07c\x7fd\u0085e", want: "a b c d e"},
+		{name: "printable Unicode and markers", payload: "✓ Привет · 世界 ↷", want: "✓ Привет · 世界 ↷"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sanitizeTerminalText(tt.payload); got != tt.want {
+				t.Fatalf("sanitizeTerminalText() = %q, want %q", got, tt.want)
+			}
+
+			for _, source := range []string{"notice", "operation"} {
+				t.Run(source, func(t *testing.T) {
+					model := New(120, 8, nil, nil)
+					foreground := model.palette().Warning()
+					statusMessage := tt.payload
+					wantText := tt.want
+					if source == "operation" {
+						operation := testOperation(1, generated.OperationStatusError, tt.payload)
+						model.feedback.transition(&operation, feedbackTestStart)
+						foreground = model.palette().Error()
+						statusMessage = ""
+						wantText = "✕ Error · " + tt.want
+					}
+
+					want := lipgloss.NewStyle().Bold(true).Foreground(foreground).Background(model.palette().ChromeSurface()).Render(wantText)
+					if got := model.renderStatusMessage(statusMessage); got != want {
+						t.Fatalf("renderStatusMessage() = %q, want %q", got, want)
+					}
+
+					line := ansi.Strip(model.renderStatusSegments(protocol.StatusBar{Message: statusMessage}))
+					if strings.ContainsAny(line, "\r\n") {
+						t.Fatalf("footer rendered multiple lines: %q", line)
+					}
+					for _, r := range line {
+						if unicode.IsControl(r) {
+							t.Fatalf("footer retained control rune %U: %q", r, line)
+						}
+					}
+				})
+			}
+		})
+	}
+}
+
+func TestRenderStatusMessagePrefersNewNoticeOverRetainedTerminalOperation(t *testing.T) {
+	model := New(80, 8, nil, nil)
+	palette := model.palette()
+
+	for _, tt := range []struct {
+		name   string
+		status generated.OperationStatus
+	}{
+		{name: "success", status: generated.OperationStatusSuccess},
+		{name: "error", status: generated.OperationStatusError},
+		{name: "timeout", status: generated.OperationStatusTimeout},
+		{name: "canceled", status: generated.OperationStatusCanceled},
+		{name: "stale", status: generated.OperationStatusStale},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			model.feedback = feedbackState{}
+			operation := testOperation(1, tt.status, "Old terminal result")
+			model.feedback.transition(&operation, feedbackTestStart)
+
+			want := lipgloss.NewStyle().Bold(true).Foreground(palette.Warning()).Background(palette.ChromeSurface()).Render("Saved")
+			if got := model.renderStatusMessage("Saved"); got != want {
+				t.Fatalf("terminal operation suppressed notice: got %q, want %q", got, want)
+			}
+		})
+	}
+}
+
+func TestRenderStatusMessageUsesSemanticPaletteRoles(t *testing.T) {
+	model := New(80, 8, nil, nil)
+	palette := model.palette()
+	tests := []struct {
+		name       string
+		status     generated.OperationStatus
+		foreground color.Color
+	}{
+		{name: "pending", status: generated.OperationStatusPending, foreground: palette.ChromeText()},
+		{name: "queued", status: generated.OperationStatusQueued, foreground: palette.ChromeText()},
+		{name: "running", status: generated.OperationStatusRunning, foreground: palette.Accent()},
+		{name: "success", status: generated.OperationStatusSuccess, foreground: palette.Hint()},
+		{name: "error", status: generated.OperationStatusError, foreground: palette.Error()},
+		{name: "timeout", status: generated.OperationStatusTimeout, foreground: palette.Warning()},
+		{name: "canceled", status: generated.OperationStatusCanceled, foreground: palette.Muted()},
+		{name: "stale", status: generated.OperationStatusStale, foreground: palette.Info()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model.feedback = feedbackState{}
+			operation := testOperation(1, tt.status, "Formatting")
+			model.feedback.transition(&operation, feedbackTestStart)
+			text, _, visible := model.feedback.presentation()
+			if !visible {
+				t.Fatal("operation presentation is not visible")
+			}
+
+			statusMessage := "fallback notice"
+			if !activeOperation(tt.status) {
+				statusMessage = ""
+			}
+
+			want := lipgloss.NewStyle().Bold(true).Foreground(tt.foreground).Background(palette.ChromeSurface()).Render(text)
+			if got := model.renderStatusMessage(statusMessage); got != want {
+				t.Fatalf("raw styled output = %q, want palette-styled %q", got, want)
+			}
+		})
+	}
+}

--- a/go/tui/internal/ui/selectors.go
+++ b/go/tui/internal/ui/selectors.go
@@ -76,7 +76,7 @@ func (m Model) fileTree() (protocol.FileTree, bool) {
 
 func (m Model) statusBar() (protocol.StatusBar, bool) {
 	for _, payload := range m.chrome {
-		if payload.Status.Filename != "" || payload.Status.Message != "" || payload.Status.Line != 0 || len(payload.Status.Left) > 0 || len(payload.Status.Right) > 0 {
+		if payload.Status.Filename != "" || payload.Status.Message != "" || payload.Status.Operation != nil || payload.Status.Line != 0 || len(payload.Status.Left) > 0 || len(payload.Status.Right) > 0 {
 			return payload.Status, true
 		}
 	}


### PR DESCRIPTION
# TL;DR
The Go TUI now consumes BEAM-authored operation feedback and renders identity-safe queued, running, and terminal states without inferring semantics from punctuation. Bubble Tea owns only local animation timing through one shared chrome tick.

Closes #2453

## Context
This PR is stacked on [#2878](https://github.com/jsmestad/minga/pull/2878), which adds the structured operation section to the existing status-bar protocol. Review this PR against `feat/2452-operation-feedback-authority` until #2878 lands.

The previous TUI path treated an ellipsis suffix as an in-flight operation. That could animate ordinary notices, restart timing when text changed, and let stale presentation state outlive the operation identity.

## Changes
- Decode status section `0x0F` with generated operation types and expose it as an optional typed status-bar value while keeping plain notices separate.
- Replace punctuation-driven feedback with an identity-keyed presentation state using explicit timestamps.
- Implement the 100ms spinner delay, 500ms same-operation success hold, 1s waiting and cancel hints, and 1500ms terminal dwell rules.
- Share one at-most-80ms chrome tick between operation feedback and picker loading while keeping agent animation independently paced.
- Render compact queue, progress, cancelability, fallback labels, semantic terminal markers, and theme-aware styles.
- Truncate the finalized decorated value once so narrow terminals retain semantic markers instead of falling back to raw text.
- Replace the old punctuation tests with deterministic protocol, transition, timing, committed-frame, rendering, and tick-lifecycle coverage.

## Verification
- `cd go/tui && go test ./internal/protocol ./internal/ui` (566 passed)
- `cd go/tui && go test ./...` (664 passed)
- `mix protocol.gen --check`
- `mix compile --warnings-as-errors`
- `make lint`
- `mix test.llm` (9,225 tests, 0 failures, 1 skipped)
- `git diff --check`

## Acceptance Criteria Addressed
- Structured operation feedback is decoded with generated types, selected after frame commit, and kept separate from plain notices. ✅
- Typed semantic status is the only operation-presentation authority; punctuation inference is removed. ✅
- Identity-keyed spinner, hold, waiting, cancel-hint, and terminal-dwell timing matches the specified boundaries. ✅
- One chrome tick drives operation and picker animation without coupling to agent animation. ✅
- Every semantic state renders compactly with queue, progress, cancelability, fallback labels, and width-safe decoration. ✅
- Deterministic tests cover the complete protocol, timing, identity, rendering, and tick contract without sleeps. ✅
