### PR TITLE
refactor(editor): own shell runtime state

### DIFF
--- a/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
@@ -19,7 +19,6 @@ defmodule MingaGitPorcelain.Input.GitStatus do
   alias MingaEditor.Input
   alias MingaEditor.Layout
   alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
-  alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias Minga.Keymap
   alias MingaEditor.PromptUI
   alias MingaGitPorcelain.UI.Prompt.GitCommit, as: CommitPrompt
@@ -370,7 +369,8 @@ defmodule MingaGitPorcelain.Input.GitStatus do
 
   @spec update_tui_state(EditorState.t(), (TuiState.t(), [Git.StatusEntry.t()] -> TuiState.t())) ::
           EditorState.t()
-  defp update_tui_state(%{shell_state: %{git_status_panel: nil}} = state, _fun), do: state
+  defp update_tui_state(%{shell_runtime: %{state: %{git_status_panel: nil}}} = state, _fun),
+    do: state
 
   defp update_tui_state(state, fun) do
     panel = EditorState.git_status_panel(state)
@@ -381,7 +381,7 @@ defmodule MingaGitPorcelain.Input.GitStatus do
       fun.(tui, entries)
       |> TuiState.clamp_cursor(entries)
 
-    EditorState.update_shell_state(state, &ShellState.set_git_status_tui_state(&1, updated))
+    EditorState.set_git_status_tui_state(state, updated)
   end
 
   @spec with_selected_file(EditorState.t(), (Git.StatusEntry.t(), String.t() -> EditorState.t())) ::

--- a/extensions/git_porcelain/test/minga_git_porcelain/commands/branch_delete_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/commands/branch_delete_test.exs
@@ -41,11 +41,11 @@ defmodule MingaGitPorcelain.CommandsBranchDeleteTest do
 
     result = Commands.execute(state, {:branch_delete_confirm, git_root, "feature", false})
 
-    assert result.shell_state.status_msg == "Deleted branch feature"
+    assert EditorState.status_msg(result) == "Deleted branch feature"
 
     assert {:picker,
             %{picker_ui: %{source: MingaGitPorcelain.UI.Picker.GitBranchSource, picker: picker}}} =
-             result.shell_state.modal
+             EditorState.modal(result)
 
     assert %Picker{items: items} = picker
     refute Enum.any?(items, fn item -> item.label == "feature" end)
@@ -58,7 +58,7 @@ defmodule MingaGitPorcelain.CommandsBranchDeleteTest do
 
     result = Commands.execute(state, {:branch_delete_confirm, git_root, "feature", false})
 
-    assert result.shell_state.status_msg == "Delete failed: not fully merged"
+    assert EditorState.status_msg(result) == "Delete failed: not fully merged"
     assert result.workspace.editing.mode == :branch_delete_confirm
 
     assert %BranchDeleteConfirmState{name: "feature", phase: :force, reason: "not fully merged"} =
@@ -72,7 +72,7 @@ defmodule MingaGitPorcelain.CommandsBranchDeleteTest do
 
     result = Commands.execute(state, {:branch_delete_confirm, git_root, "feature", true})
 
-    assert result.shell_state.status_msg == "Force delete failed: branch not found"
+    assert EditorState.status_msg(result) == "Force delete failed: branch not found"
   end
 
   defp build_state do

--- a/extensions/git_porcelain/test/minga_git_porcelain/commands/conflict_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/commands/conflict_test.exs
@@ -58,7 +58,7 @@ defmodule MingaGitPorcelain.CommandsConflictTest do
     state = GitCommands.execute(state, :git_accept_current_conflict)
 
     assert BufferProcess.content(buffer) == "before\nours\nafter"
-    assert state.shell_state.status_msg == "Resolved all merge conflicts"
+    assert EditorState.status_msg(state) == "Resolved all merge conflicts"
   end
 
   test "click command accepts incoming for the current conflict start line" do
@@ -84,7 +84,7 @@ defmodule MingaGitPorcelain.CommandsConflictTest do
     assert File.read!(path) == content
     assert GitStub.staged_paths(root) == []
     refute_receive {:minga_event, :buffer_saved, _}
-    assert state.shell_state.status_msg == "Resolved merge conflict"
+    assert EditorState.status_msg(state) == "Resolved merge conflict"
   end
 
   test "click command rejects stale start lines" do
@@ -95,7 +95,7 @@ defmodule MingaGitPorcelain.CommandsConflictTest do
     state = GitCommands.execute(state, {:git_accept_conflict, :incoming, 0})
 
     assert BufferProcess.content(buffer) == content
-    assert state.shell_state.status_msg == "Merge conflict action is stale"
+    assert EditorState.status_msg(state) == "Merge conflict action is stale"
   end
 
   test "resolving the final file-backed conflict saves, stages, and publishes buffer_saved", %{
@@ -116,7 +116,7 @@ defmodule MingaGitPorcelain.CommandsConflictTest do
 
     assert File.read!(path) == "ours\ntheirs"
     assert GitStub.staged_paths(root) == ["conflict.txt"]
-    assert state.shell_state.status_msg == "Resolved all merge conflicts and staged conflict.txt"
+    assert EditorState.status_msg(state) == "Resolved all merge conflicts and staged conflict.txt"
   end
 
   defp start_buffer(content) do

--- a/extensions/git_porcelain/test/minga_git_porcelain/commands/remote_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/commands/remote_test.exs
@@ -7,6 +7,7 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor
   alias MingaGitPorcelain.Commands, as: GitCommands
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
 
@@ -36,7 +37,7 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
 
       result = GitCommands.handle_remote_result(state, ref, :ok)
 
-      assert result.shell_state.status_msg == "Pushed"
+      assert EditorState.status_msg(result) == "Pushed"
       assert result.git_remote_op == nil
     end
 
@@ -54,7 +55,7 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
                message: "Push failed: non-fast-forward rejected",
                level: :error,
                action: :pull_and_retry
-             } = result.shell_state.git_toast
+             } = Runtime.state(result.shell_runtime).git_toast
     end
 
     test "stale results leave the current operation untouched" do
@@ -64,7 +65,7 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
 
       result = GitCommands.handle_remote_result(state, make_ref(), :ok)
 
-      assert result.shell_state.status_msg == "Pushing…"
+      assert EditorState.status_msg(result) == "Pushing…"
       assert result.git_remote_op == op
     end
   end
@@ -81,10 +82,10 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
       result = GitCommands.handle_remote_task_down(state, task_monitor, :killed)
 
       assert result.git_remote_op == nil
-      assert result.shell_state.status_msg == "Git operation failed unexpectedly: killed"
+      assert EditorState.status_msg(result) == "Git operation failed unexpectedly: killed"
 
       assert %{message: "Git operation failed unexpectedly: killed", level: :error, action: nil} =
-               result.shell_state.git_toast
+               Runtime.state(result.shell_runtime).git_toast
     end
 
     test "normal task exit waits for the result message" do
@@ -95,8 +96,8 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
       result = GitCommands.handle_remote_task_down(state, task_monitor, :normal)
 
       assert result.git_remote_op == op
-      assert result.shell_state.status_msg == "Pushing…"
-      assert result.shell_state.git_toast == nil
+      assert EditorState.status_msg(result) == "Pushing…"
+      assert Runtime.state(result.shell_runtime).git_toast == nil
     end
   end
 
@@ -109,7 +110,7 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
       send(editor, {:git_remote_result, ref, :ok})
       state = get_state(editor)
 
-      assert state.shell_state.status_msg == "Fetched"
+      assert EditorState.status_msg(state) == "Fetched"
       assert state.git_remote_op == nil
     end
 
@@ -123,8 +124,8 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
       state = get_state(editor)
 
       assert state.git_remote_op == nil
-      assert state.shell_state.status_msg == "Git operation failed unexpectedly: killed"
-      assert %{level: :error, action: nil} = state.shell_state.git_toast
+      assert EditorState.status_msg(state) == "Git operation failed unexpectedly: killed"
+      assert %{level: :error, action: nil} = Runtime.state(state.shell_runtime).git_toast
     end
   end
 
@@ -135,7 +136,7 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
 
       result = GitCommands.execute(state, :git_pull)
 
-      assert result.shell_state.status_msg == "Git operation already in progress"
+      assert EditorState.status_msg(result) == "Git operation already in progress"
       assert result.git_remote_op == op
     end
   end

--- a/extensions/git_porcelain/test/minga_git_porcelain/commands/stash_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/commands/stash_test.exs
@@ -94,7 +94,7 @@ defmodule MingaGitPorcelain.CommandsStashTest do
 
       result = GitCommands.execute(build_state(), :git_stash_list)
 
-      assert {:picker, %{picker_ui: %{source: GitStashSource}}} = result.shell_state.modal
+      assert {:picker, %{picker_ui: %{source: GitStashSource}}} = EditorState.modal(result)
     end
 
     test "drop opens the stash picker in drop mode", %{root: dir} do
@@ -103,7 +103,7 @@ defmodule MingaGitPorcelain.CommandsStashTest do
       result = GitCommands.execute(build_state(), :git_stash_drop)
 
       assert {:picker, %{picker_ui: %{source: GitStashSource, context: context}}} =
-               result.shell_state.modal
+               EditorState.modal(result)
 
       assert context == %{git_root: dir, action: :drop}
     end

--- a/extensions/git_porcelain/test/minga_git_porcelain/input/status_input_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/input/status_input_test.exs
@@ -11,6 +11,7 @@ defmodule MingaGitPorcelain.Input.GitStatusInputTest do
   alias Minga.Git
   alias MingaGitPorcelain.Input.GitStatus
   alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
@@ -59,7 +60,7 @@ defmodule MingaGitPorcelain.Input.GitStatusInputTest do
     assert panel != nil
     refute Map.has_key?(panel, :tui_state)
 
-    tui = ShellState.git_status_tui_state(state.shell_state)
+    tui = ShellState.git_status_tui_state(Runtime.state(state.shell_runtime))
     assert tui != nil
     assert tui.cursor_index == 0
     assert tui.amend_mode == false

--- a/extensions/git_porcelain/test/minga_git_porcelain/picker_branch_delete_shortcut_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/picker_branch_delete_shortcut_test.exs
@@ -48,7 +48,7 @@ defmodule MingaGitPorcelain.PickerBranchDeleteShortcutTest do
 
     result = PickerUI.handle_key(state, ?d, MingaEditor.Input.mod_ctrl())
 
-    assert result.shell_state.modal == :none
+    assert EditorState.modal(result) == :none
     assert result.workspace.editing.mode == :branch_delete_confirm
 
     assert %Minga.Mode.BranchDeleteConfirmState{git_root: ^git_root, name: "feature"} =
@@ -65,8 +65,8 @@ defmodule MingaGitPorcelain.PickerBranchDeleteShortcutTest do
 
     result = PickerUI.handle_key(state, ?d, MingaEditor.Input.mod_ctrl())
 
-    assert result.shell_state.modal == :none
-    assert result.shell_state.status_msg == "Cannot delete current branch"
+    assert EditorState.modal(result) == :none
+    assert EditorState.status_msg(result) == "Cannot delete current branch"
     assert result.workspace.editing.mode == :normal
   end
 

--- a/extensions/git_porcelain/test/minga_git_porcelain/ui/picker/branch_source_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/ui/picker/branch_source_test.exs
@@ -32,7 +32,7 @@ defmodule MingaGitPorcelain.UI.Picker.GitBranchSourceTest do
 
     result = GitBranchSource.on_action(:delete, item, state)
 
-    assert result.shell_state.status_msg == "Cannot delete current branch"
+    assert EditorState.status_msg(result) == "Cannot delete current branch"
     assert result.workspace.editing.mode == :normal
   end
 end

--- a/extensions/git_porcelain/test/minga_git_porcelain/ui/picker/log_source_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/ui/picker/log_source_test.exs
@@ -3,6 +3,7 @@ defmodule MingaGitPorcelain.UI.Picker.GitLogSourceTest do
 
   use ExUnit.Case, async: true
 
+  alias MingaEditor.State, as: EditorState
   alias Minga.Buffer
   alias Minga.Git
   alias Minga.Git.Stub, as: GitStub
@@ -76,7 +77,7 @@ defmodule MingaGitPorcelain.UI.Picker.GitLogSourceTest do
     state = PickerUI.open(state, GitLogSource, %{git_root: root})
 
     state = Enum.reduce(1..50, state, fn _, acc -> PickerUI.handle_key(acc, 57_353, 0) end)
-    {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+    {:picker, %{picker_ui: picker_ui}} = EditorState.modal(state)
 
     assert picker_ui.source == GitLogSource
     assert picker_ui.context == %{git_root: root}
@@ -84,7 +85,7 @@ defmodule MingaGitPorcelain.UI.Picker.GitLogSourceTest do
     assert Picker.selected_item(picker_ui.picker).label == "Load more..."
 
     state = PickerUI.handle_key(state, 13, 0)
-    {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+    {:picker, %{picker_ui: picker_ui}} = EditorState.modal(state)
 
     assert picker_ui.source == GitLogSource
     assert picker_ui.context.source == GitLogSource
@@ -188,14 +189,14 @@ defmodule MingaGitPorcelain.UI.Picker.GitLogSourceTest do
     state = PickerUI.open(state, GitLogFileSource)
 
     state = Enum.reduce(1..50, state, fn _, acc -> PickerUI.handle_key(acc, 57_353, 0) end)
-    {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+    {:picker, %{picker_ui: picker_ui}} = EditorState.modal(state)
 
     assert picker_ui.source == GitLogFileSource
     assert Picker.count(picker_ui.picker) == 51
     assert Picker.selected_item(picker_ui.picker).label == "Load more..."
 
     state = PickerUI.handle_key(state, 13, 0)
-    {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+    {:picker, %{picker_ui: picker_ui}} = EditorState.modal(state)
 
     assert picker_ui.source == GitLogFileSource
     assert picker_ui.context.source == GitLogFileSource

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -585,7 +585,7 @@ defmodule MingaEditor do
   end
 
   def handle_info({:whichkey_timeout, ref}, state) do
-    if ref == state.shell_state.whichkey.timer do
+    if ref == state.shell_runtime.state.whichkey.timer do
       wk = EditorState.whichkey(state)
       new_state = EditorState.set_whichkey(state, %{wk | show: true})
       {:noreply, Renderer.render_or_async(new_state)}
@@ -923,7 +923,7 @@ defmodule MingaEditor do
   # here as stale and are discarded. Picker fetches retain this read-only
   # latest-wins path; #2805 migrates external formatting and git mutations.
   def handle_info({:picker_candidates_result, source_module, revision, result}, state) do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       {:picker, %{picker_ui: %{source: ^source_module} = picker_ui} = payload} ->
         if MingaEditor.State.Picker.current_fetch?(picker_ui, revision) do
           new_state = handle_picker_candidates(state, payload, result)
@@ -1044,7 +1044,11 @@ defmodule MingaEditor do
 
   @spec current_observatory_token?(state(), reference()) :: boolean()
   defp current_observatory_token?(
-         %{shell_state: %{observatory_visible: true, observatory_timer: {_timer, token}}},
+         %{
+           shell_runtime: %{
+             state: %{observatory_visible: true, observatory_timer: {_timer, token}}
+           }
+         },
          token
        ),
        do: true
@@ -1245,7 +1249,7 @@ defmodule MingaEditor do
   end
 
   defp route_agent_event(state, session_pid, event, :background) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
     state = route_active_shell_agent_event(state, session_pid, event)
     state = route_stashed_shell_agent_event(state, session_pid, event)
     {:noreply, schedule_render(state, 16)}
@@ -1253,85 +1257,58 @@ defmodule MingaEditor do
 
   @spec route_active_shell_agent_event(EditorState.t(), pid(), term()) :: EditorState.t()
   defp route_active_shell_agent_event(state, session_pid, event) do
-    {shell_state, workspace, shell_effects} =
-      EditorState.active_shell_module(state).on_agent_event(
-        state.shell_state,
+    {runtime, workspace, effects, persistence_change} =
+      MingaEditor.Shell.Runtime.route_agent_event(
+        state.shell_runtime,
         state.workspace,
         session_pid,
         event
       )
 
+    runtime = persist_shell_changes(runtime, List.wrap(persistence_change))
+
     state
-    |> EditorState.update_shell_state(fn _shell_state -> shell_state end)
+    |> EditorState.apply_shell_runtime_transition(runtime)
     |> EditorState.set_workspace(workspace)
-    |> EffectHandler.apply_effects(shell_effects)
+    |> EffectHandler.apply_effects(effects)
   end
 
   @spec route_stashed_shell_agent_event(EditorState.t(), pid(), term()) :: EditorState.t()
   defp route_stashed_shell_agent_event(state, session_pid, event) do
-    {state, _changed?} =
-      EditorState.transform_stashed_shell_states(state, fn module, shell_state, state_acc ->
-        transform_stashed_shell_agent_event(module, shell_state, state_acc, session_pid, event)
-      end)
+    {runtime, workspace, effects, persistence_changes} =
+      MingaEditor.Shell.Runtime.route_stashed_agent_event(
+        state.shell_runtime,
+        MingaEditor.Shell.Workflow.resolved_entries(),
+        state.workspace,
+        session_pid,
+        event
+      )
+
+    runtime = persist_shell_changes(runtime, persistence_changes)
 
     state
+    |> EditorState.apply_shell_runtime_transition(runtime)
+    |> EditorState.set_workspace(workspace)
+    |> EffectHandler.apply_effects(effects)
   end
 
-  @spec transform_stashed_shell_agent_event(
-          module(),
-          MingaEditor.Shell.shell_state(),
-          EditorState.t(),
-          pid(),
-          term()
-        ) :: {MingaEditor.Shell.StateStash.transformation(), EditorState.t()}
-  defp transform_stashed_shell_agent_event(module, shell_state, state, session_pid, event) do
-    if function_exported?(module, :on_agent_event, 4) do
-      apply_stashed_shell_agent_event(module, shell_state, state, session_pid, event)
-    else
-      {:unchanged, state}
-    end
+  @spec persist_shell_changes(
+          MingaEditor.Shell.Runtime.t(),
+          [MingaEditor.Shell.Runtime.persistence_change()]
+        ) :: MingaEditor.Shell.Runtime.t()
+  defp persist_shell_changes(runtime, changes) do
+    Enum.reduce(changes, runtime, fn {entry, _old_state, new_state}, runtime_acc ->
+      persisted_state = persist_shell_state(entry.module, new_state)
+      MingaEditor.Shell.Runtime.accept_persisted_state(runtime_acc, entry, persisted_state)
+    end)
   end
 
-  @spec apply_stashed_shell_agent_event(
-          module(),
-          MingaEditor.Shell.shell_state(),
-          EditorState.t(),
-          pid(),
-          term()
-        ) :: {MingaEditor.Shell.StateStash.transformation(), EditorState.t()}
-  defp apply_stashed_shell_agent_event(module, shell_state, state, session_pid, event) do
-    {updated_shell_state, workspace, effects} =
-      module.on_agent_event(shell_state, state.workspace, session_pid, event)
-
-    updated_shell_state =
-      maybe_persist_stashed_shell_state(module, shell_state, updated_shell_state)
-
-    state =
-      state
-      |> EditorState.set_workspace(workspace)
-      |> EffectHandler.apply_effects(effects)
-
-    stashed_shell_agent_transformation(shell_state, updated_shell_state, state)
-  end
-
-  @spec stashed_shell_agent_transformation(
-          MingaEditor.Shell.shell_state(),
-          MingaEditor.Shell.shell_state(),
-          EditorState.t()
-        ) :: {MingaEditor.Shell.StateStash.transformation(), EditorState.t()}
-  defp stashed_shell_agent_transformation(shell_state, shell_state, state),
-    do: {:unchanged, state}
-
-  defp stashed_shell_agent_transformation(_old_shell_state, updated_shell_state, state),
-    do: {{:updated, updated_shell_state}, state}
-
-  @spec maybe_persist_stashed_shell_state(module(), term(), term()) :: term()
-  defp maybe_persist_stashed_shell_state(module, old_state, new_state) do
-    if old_state != new_state and function_exported?(module, :persist_shell_state, 1) do
-      module.persist_shell_state(new_state)
-    else
-      new_state
-    end
+  @spec persist_shell_state(module(), MingaEditor.Shell.shell_state()) ::
+          MingaEditor.Shell.shell_state()
+  defp persist_shell_state(module, shell_state) do
+    if function_exported?(module, :persist_shell_state, 1),
+      do: module.persist_shell_state(shell_state),
+      else: shell_state
   end
 
   @spec agent_event_owner(EditorState.t(), pid()) ::
@@ -1454,7 +1431,7 @@ defmodule MingaEditor do
 
   # Cancels any active nav-flash. Called on every keypress.
   @spec cancel_nav_flash(state()) :: state()
-  def cancel_nav_flash(%{shell_state: %{nav_flash: nil}} = state), do: state
+  def cancel_nav_flash(%{shell_runtime: %{state: %{nav_flash: nil}}} = state), do: state
 
   def cancel_nav_flash(state) do
     effects = NavFlash.cancel_effects(EditorState.nav_flash(state))
@@ -1463,9 +1440,9 @@ defmodule MingaEditor do
   end
 
   @spec cancel_yank_flash(state()) :: state()
-  def cancel_yank_flash(%{shell_state: %{yank_flash: nil}} = state), do: state
+  def cancel_yank_flash(%{shell_runtime: %{state: %{yank_flash: nil}}} = state), do: state
 
-  def cancel_yank_flash(%{shell_state: %{yank_flash: flash}} = state) do
+  def cancel_yank_flash(%{shell_runtime: %{state: %{yank_flash: flash}}} = state) do
     effects = YankFlash.cancel_effects(flash)
     MingaEditor.FlashEffects.execute(state, effects)
 
@@ -1533,8 +1510,10 @@ defmodule MingaEditor do
   @spec maybe_refresh_tool_picker(state()) :: state()
   def maybe_refresh_tool_picker(
         %{
-          shell_state: %{
-            modal: {:picker, %{picker_ui: %{source: MingaEditor.UI.Picker.Sources.Tool}}}
+          shell_runtime: %{
+            state: %{
+              modal: {:picker, %{picker_ui: %{source: MingaEditor.UI.Picker.Sources.Tool}}}
+            }
           }
         } = state
       ) do
@@ -1566,7 +1545,9 @@ defmodule MingaEditor do
   @warning_popup_debounce_ms 200
 
   @spec maybe_schedule_warning_popup(state()) :: state()
-  def maybe_schedule_warning_popup(%{shell_state: %{warning_popup_timer: ref}} = state)
+  def maybe_schedule_warning_popup(
+        %{shell_runtime: %{state: %{warning_popup_timer: ref}}} = state
+      )
       when is_reference(ref) do
     # Timer already running; the pending timeout will open the popup.
     state
@@ -1576,7 +1557,7 @@ defmodule MingaEditor do
 
   def maybe_schedule_warning_popup(state) do
     ref = Process.send_after(self(), :warning_popup_timeout, @warning_popup_debounce_ms)
-    EditorState.update_shell_state(state, &%{&1 | warning_popup_timer: ref})
+    EditorState.set_warning_popup_timer(state, ref)
   end
 
   # buffer_visible_in_window? moved to HighlightHandler

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -18,7 +18,6 @@ defmodule MingaEditor.Agent.Events do
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Agent.View.Preview
   alias MingaEditor.PickerUI
-  alias MingaEditor.Shell.StateStash
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -713,68 +712,35 @@ defmodule MingaEditor.Agent.Events do
   defp update_shell_for_session(state, _callback, [session | _args]) when not is_pid(session),
     do: state
 
-  defp update_shell_for_session(state, callback, args) do
-    state
-    |> update_active_shell_for_session(callback, args)
-    |> update_stashed_shells_for_session(callback, args)
+  defp update_shell_for_session(state, :sync_agent_status, [session, status]) do
+    runtime =
+      MingaEditor.Shell.Runtime.sync_agent_status(
+        state.shell_runtime,
+        MingaEditor.Shell.Workflow.resolved_entries(),
+        session,
+        status
+      )
+
+    EditorState.apply_shell_runtime_transition(state, runtime)
   end
 
-  @spec update_active_shell_for_session(EditorState.t(), atom(), [term()]) :: EditorState.t()
-  defp update_active_shell_for_session(state, callback, args) do
-    shell = EditorState.active_shell_module(state)
+  defp update_shell_for_session(state, :track_agent_file, [session, path]) do
+    runtime =
+      MingaEditor.Shell.Runtime.track_agent_file(
+        state.shell_runtime,
+        MingaEditor.Shell.Workflow.resolved_entries(),
+        session,
+        path
+      )
 
-    if function_exported?(shell, callback, Enum.count(args) + 1) do
-      EditorState.update_shell_state(state, fn shell_state ->
-        apply(shell, callback, [shell_state | args])
-      end)
-    else
-      state
-    end
-  end
-
-  @spec update_stashed_shells_for_session(EditorState.t(), atom(), [term()]) :: EditorState.t()
-  defp update_stashed_shells_for_session(state, callback, args) do
-    {state, _changed?} =
-      EditorState.transform_stashed_shell_states(state, fn module, shell_state, state_acc ->
-        transform_stashed_shell_for_session(module, shell_state, state_acc, callback, args)
-      end)
-
-    state
-  end
-
-  @spec transform_stashed_shell_for_session(
-          module(),
-          MingaEditor.Shell.shell_state(),
-          EditorState.t(),
-          atom(),
-          [term()]
-        ) :: {StateStash.transformation(), EditorState.t()}
-  defp transform_stashed_shell_for_session(module, shell_state, state, callback, args) do
-    if function_exported?(module, callback, Enum.count(args) + 1) do
-      transformed_shell_for_session(module, shell_state, state, callback, args)
-    else
-      {:unchanged, state}
-    end
-  end
-
-  @spec transformed_shell_for_session(
-          module(),
-          MingaEditor.Shell.shell_state(),
-          EditorState.t(),
-          atom(),
-          [term()]
-        ) :: {StateStash.transformation(), EditorState.t()}
-  defp transformed_shell_for_session(module, shell_state, state, callback, args) do
-    case apply(module, callback, [shell_state | args]) do
-      ^shell_state -> {:unchanged, state}
-      updated -> {{:updated, updated}, state}
-    end
+    EditorState.apply_shell_runtime_transition(state, runtime)
   end
 
   # Syncs the agent_status field on the current agent tab so the tab bar
   # can render status indicators without querying the Session process.
   @spec sync_tab_agent_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
-  defp sync_tab_agent_status(%{shell_state: %{tab_bar: nil}} = state, _status), do: state
+  defp sync_tab_agent_status(%{shell_runtime: %{state: %{tab_bar: nil}}} = state, _status),
+    do: state
 
   defp sync_tab_agent_status(state, status) do
     session = AgentAccess.session(state)
@@ -806,8 +772,11 @@ defmodule MingaEditor.Agent.Events do
   # Associates a file tab with the agent's workspace when the agent modifies the file.
   # Uses the tab's logical file ref so duplicate basenames route to the exact file.
   @spec associate_file_with_agent_workspace(EditorState.t(), String.t()) :: EditorState.t()
-  defp associate_file_with_agent_workspace(%{shell_state: %{tab_bar: nil}} = state, _path),
-    do: state
+  defp associate_file_with_agent_workspace(
+         %{shell_runtime: %{state: %{tab_bar: nil}}} = state,
+         _path
+       ),
+       do: state
 
   defp associate_file_with_agent_workspace(state, path) do
     session = AgentAccess.session(state)
@@ -833,7 +802,8 @@ defmodule MingaEditor.Agent.Events do
   # Auto-names the agent workspace from the prompt text (first line, 30 chars).
   # Skips if the workspace has a custom name set by the user.
   @spec maybe_auto_name_workspace(EditorState.t(), String.t()) :: EditorState.t()
-  defp maybe_auto_name_workspace(%{shell_state: %{tab_bar: nil}} = state, _), do: state
+  defp maybe_auto_name_workspace(%{shell_runtime: %{state: %{tab_bar: nil}}} = state, _),
+    do: state
 
   defp maybe_auto_name_workspace(state, prompt) do
     session = AgentAccess.session(state)

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -278,7 +278,9 @@ defmodule MingaEditor.AgentLifecycle do
   Only updates if the current label is the default "New Agent" or "minga".
   """
   @spec maybe_update_tab_label(state()) :: state()
-  def maybe_update_tab_label(%{shell_state: %{tab_bar: %{active_id: active_id} = tb}} = state) do
+  def maybe_update_tab_label(
+        %{shell_runtime: %{state: %{tab_bar: %{active_id: active_id} = tb}}} = state
+      ) do
     session = AgentAccess.session(state)
 
     with true <- is_pid(session),

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -259,17 +259,18 @@ defmodule MingaEditor.Commands do
 
   def execute(state, {:tool_confirm_decline, name}) do
     state =
-      EditorState.update_shell_state(
+      EditorState.set_tool_prompt_state(
         state,
-        &%{&1 | tool_declined: MapSet.put(state.shell_state.tool_declined, name)}
+        state.shell_runtime.state.tool_prompt_queue,
+        MapSet.put(state.shell_runtime.state.tool_declined, name)
       )
 
     drain_tool_prompt_queue(state)
   end
 
   def execute(state, {:tool_confirm_dismiss, declined_set}) do
-    declined = MapSet.union(state.shell_state.tool_declined, declined_set)
-    EditorState.update_shell_state(state, &%{&1 | tool_declined: declined, tool_prompt_queue: []})
+    declined = MapSet.union(state.shell_runtime.state.tool_declined, declined_set)
+    EditorState.set_tool_prompt_state(state, [], declined)
   end
 
   # ── File tree delete confirmation commands ─────────────────────────────────
@@ -877,8 +878,8 @@ defmodule MingaEditor.Commands do
   end
 
   defp drain_tool_prompt_queue(state) do
-    case state.shell_state.tool_prompt_queue do
-      [_current | rest] -> EditorState.update_shell_state(state, &%{&1 | tool_prompt_queue: rest})
+    case state.shell_runtime.state.tool_prompt_queue do
+      [_current | rest] -> EditorState.set_tool_prompt_queue(state, rest)
       [] -> state
     end
   end

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -235,8 +235,10 @@ defmodule MingaEditor.Commands.Agent do
   def cycle_agent_tabs(state), do: toggle_agent_split(state)
 
   @spec find_agent_tab(state()) :: Tab.t() | nil
-  defp find_agent_tab(%{shell_state: %{tab_bar: nil}}), do: nil
-  defp find_agent_tab(%{shell_state: %{tab_bar: tb}}), do: TabBar.find_by_kind(tb, :agent)
+  defp find_agent_tab(%{shell_runtime: %{state: %{tab_bar: nil}}}), do: nil
+
+  defp find_agent_tab(%{shell_runtime: %{state: %{tab_bar: tb}}}),
+    do: TabBar.find_by_kind(tb, :agent)
 
   # Starts an agent session after switching into the agent tab.
   # Called only after the tab switch so AgentAccess.session/1 sees the tab's pid.
@@ -911,7 +913,7 @@ defmodule MingaEditor.Commands.Agent do
   end
 
   @spec create_active_agent_tab(state()) :: state()
-  defp create_active_agent_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp create_active_agent_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     rows = max(state.terminal_viewport.rows, 1)
     cols = max(state.terminal_viewport.cols, 1)
     windows = agent_tab_windows(rows, cols)

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -13,6 +13,8 @@ defmodule MingaEditor.Commands.AgentSession do
   alias MingaEditor.AgentLifecycle
   alias MingaEditor.Remote.EventReplay
   alias MingaEditor.Remote.SessionClient
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -35,7 +37,10 @@ defmodule MingaEditor.Commands.AgentSession do
   Traditional-shell only: restart cycles the session pid on the active tab. Extension shells may own their own per-surface lifecycle, so a generic "restart" without shell-specific context is not meaningful there. Extension callers go through their active shell's session-start callback for new sessions and rely on `:agent_session_stopped` events for cleanup.
   """
   @spec restart_session(state(), String.t()) :: state()
-  def restart_session(%{shell_id: :traditional} = state, message) do
+  def restart_session(
+        %EditorState{shell_runtime: %Runtime{entry: %Entry{id: :traditional}}} = state,
+        message
+      ) do
     session = AgentAccess.session(state)
 
     if session do
@@ -58,7 +63,10 @@ defmodule MingaEditor.Commands.AgentSession do
   @spec clear_restart_session(state(), pid() | nil) :: state()
   defp clear_restart_session(state, nil), do: state
 
-  defp clear_restart_session(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, session) do
+  defp clear_restart_session(
+         %EditorState{shell_runtime: %Runtime{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         session
+       ) do
     tb = tb |> clear_tab_sessions(session) |> clear_workspace_sessions(session)
     EditorState.set_tab_bar(state, tb)
   end
@@ -335,7 +343,7 @@ defmodule MingaEditor.Commands.AgentSession do
   # ── Private helpers ────────────────────────────────────────────────────────
 
   @spec assign_session_to_tab(state(), pid()) :: state()
-  defp assign_session_to_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, pid) do
+  defp assign_session_to_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state, pid) do
     case TabBar.find_sessionless_agent(tb) do
       %Tab{id: agent_tab_id} -> EditorState.set_tab_session(state, agent_tab_id, pid)
       nil -> state
@@ -434,7 +442,10 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   @spec create_remote_agent_tab(state(), String.t()) :: {state(), Tab.id()}
-  defp create_remote_agent_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, _server_name) do
+  defp create_remote_agent_tab(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         _server_name
+       ) do
     rows = max(state.terminal_viewport.rows, 1)
     cols = max(state.terminal_viewport.cols, 1)
     win_id = 1
@@ -460,7 +471,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
   @spec set_remote_tab(state(), Tab.id(), String.t(), String.t(), pid()) :: state()
   defp set_remote_tab(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          tab_id,
          server_name,
          session_id,
@@ -487,7 +498,7 @@ defmodule MingaEditor.Commands.AgentSession do
           non_neg_integer()
         ) :: state()
   defp set_remote_workspace(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          server_name,
          session_id,
          remote_pid,
@@ -523,7 +534,10 @@ defmodule MingaEditor.Commands.AgentSession do
        do: state
 
   @spec rebuild_agent_from_tab(state(), Tab.id()) :: state()
-  defp rebuild_agent_from_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, tab_id) do
+  defp rebuild_agent_from_tab(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         tab_id
+       ) do
     case TabBar.get(tb, tab_id) do
       %Tab{} = tab -> EditorState.rebuild_agent_from_session(state, tab)
       nil -> state
@@ -553,7 +567,10 @@ defmodule MingaEditor.Commands.AgentSession do
   end
 
   @spec detach_remote_session(state(), pid()) :: state()
-  defp detach_remote_session(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, session) do
+  defp detach_remote_session(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         session
+       ) do
     case TabBar.find_by_session(tb, session) do
       %Tab{remote_session_id: session_id} when is_binary(session_id) ->
         case detach_remote_session_by_id(node(session), session_id) do
@@ -581,7 +598,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
   @spec mark_remote_session_disconnected(state(), String.t()) :: state()
   defp mark_remote_session_disconnected(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          session_id
        ) do
     tb =
@@ -603,7 +620,10 @@ defmodule MingaEditor.Commands.AgentSession do
   defp mark_remote_session_disconnected(state, _session_id), do: state
 
   @spec stop_remote_session(state(), pid()) :: state()
-  defp stop_remote_session(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, session) do
+  defp stop_remote_session(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         session
+       ) do
     case TabBar.find_by_session(tb, session) do
       %Tab{remote_session_id: session_id} when is_binary(session_id) ->
         case stop_remote_session_by_id(node(session), session_id) do
@@ -687,7 +707,7 @@ defmodule MingaEditor.Commands.AgentSession do
   # a workspace (e.g., session restart).
   @spec ensure_agent_workspace(state(), pid(), ProjectView.t() | nil) :: state()
   defp ensure_agent_workspace(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          session_pid,
          project_view
        ) do
@@ -826,7 +846,7 @@ defmodule MingaEditor.Commands.AgentSession do
   @spec maybe_update_bound_workspace_project_view(state(), pid(), ProjectView.t() | nil) ::
           state()
   defp maybe_update_bound_workspace_project_view(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          session_pid,
          project_view
        ) do
@@ -842,7 +862,7 @@ defmodule MingaEditor.Commands.AgentSession do
   defp maybe_update_bound_workspace_project_view(state, _session_pid, _project_view), do: state
 
   @spec session_project_view(state()) :: {ProjectView.t() | nil, boolean()}
-  defp session_project_view(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp session_project_view(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     case TabBar.active_workspace(tb) do
       %Workspace{kind: :agent} = workspace ->
         if Workspace.project_view_active?(workspace) do
@@ -901,7 +921,7 @@ defmodule MingaEditor.Commands.AgentSession do
   @spec update_workspace_project_view(state(), non_neg_integer(), ProjectView.t() | nil) ::
           state()
   defp update_workspace_project_view(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          workspace_id,
          project_view
        ) do

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -628,7 +628,7 @@ defmodule MingaEditor.Commands.AgentSubStates do
   end
 
   @spec active_project_view(state()) :: ProjectView.t() | nil
-  defp active_project_view(%{shell_state: %{tab_bar: %TabBar{} = tab_bar}}) do
+  defp active_project_view(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tab_bar}}}) do
     case TabBar.active_workspace(tab_bar) do
       %{project_view: %ProjectView{} = project_view} -> project_view
       _workspace -> nil

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -32,7 +32,8 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
-  alias MingaEditor.Shell.StateStash
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Workflow
   alias MingaEditor.State.Workspace, as: WorkspaceModel
   alias MingaEditor.State.WorkspaceReview
   alias MingaEditor.Window
@@ -670,7 +671,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   # ── Tab goto ──────────────────────────────────────────────────────────────
 
   @spec tab_goto(state(), atom()) :: state()
-  def tab_goto(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, cmd) do
+  def tab_goto(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state, cmd) do
     case parse_tab_goto(cmd) do
       {:ok, n} -> switch_tab_by_visible_index(state, tb, n)
       :error -> state
@@ -710,7 +711,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec open_file_in_active_workspace(state(), String.t()) :: state()
   defp open_file_in_active_workspace(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          file_path
        ) do
     file_ref = ProjectFileRef.from_file_path(file_path)
@@ -764,8 +765,10 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec switch_to_buffer(state(), non_neg_integer()) :: state()
   defp switch_to_buffer(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}, workspace: %{buffers: %{list: buffers}}} =
-           state,
+         %{
+           shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}},
+           workspace: %{buffers: %{list: buffers}}
+         } = state,
          idx
        ) do
     target_buf = Enum.at(buffers, idx)
@@ -809,7 +812,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp cycle_buffer_from_active(_buffers, state, _active, _step), do: state
 
   @spec buffer_cycle_order([pid()], state()) :: [pid()]
-  defp buffer_cycle_order(buffers, %{shell_state: %{tab_bar: %TabBar{} = tb}}) do
+  defp buffer_cycle_order(buffers, %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}}) do
     tab_buffers = visible_file_tab_buffers(tb)
     buffers ++ Enum.reject(tab_buffers, &(&1 in buffers))
   end
@@ -827,7 +830,10 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   @spec cycle_buffer_in_tab(state(), pid() | nil) :: state()
-  defp cycle_buffer_in_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, target_buf) do
+  defp cycle_buffer_in_tab(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         target_buf
+       ) do
     case find_tab_for_buffer(tb, target_buf) do
       nil -> switch_to_buffer_pid(state, target_buf)
       tab_id when tab_id == tb.active_id -> switch_to_buffer_pid(state, target_buf)
@@ -883,7 +889,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   @spec next_tab(state()) :: state()
-  defp next_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp next_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     next_tb = TabBar.next(tb)
 
     if next_tb.active_id != tb.active_id do
@@ -896,7 +902,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp next_tab(state), do: state
 
   @spec prev_tab(state()) :: state()
-  defp prev_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp prev_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     prev_tb = TabBar.prev(tb)
 
     if prev_tb.active_id != tb.active_id do
@@ -909,7 +915,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp prev_tab(state), do: state
 
   @spec toggle_tab_pin(state()) :: state()
-  defp toggle_tab_pin(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp toggle_tab_pin(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     state
     |> EditorState.set_tab_bar(TabBar.toggle_active_pin(tb))
     |> EditorState.set_status(tab_pin_status(tb))
@@ -918,7 +924,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp toggle_tab_pin(state), do: state
 
   @spec unpin_active_tab(state()) :: state()
-  defp unpin_active_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp unpin_active_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     state
     |> EditorState.set_tab_bar(TabBar.unpin_tab(tb, tb.active_id))
     |> EditorState.set_status("Tab unpinned")
@@ -927,7 +933,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp unpin_active_tab(state), do: state
 
   @spec move_active_tab(state(), :left | :right) :: state()
-  defp move_active_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, direction) do
+  defp move_active_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state, direction) do
     EditorState.set_tab_bar(state, move_tab_bar(tb, direction))
   end
 
@@ -1032,7 +1038,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   # Workspace and tab removal are handled by the caller so ProjectView-aware
   # close paths can decide whether to release or preserve the workspace first.
   @spec cleanup_agent_session(state()) :: state()
-  defp cleanup_agent_session(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
+  defp cleanup_agent_session(%{shell_runtime: %{state: %{tab_bar: %TabBar{}}}} = state) do
     session = AgentAccess.session(state)
 
     if session do
@@ -1061,24 +1067,24 @@ defmodule MingaEditor.Commands.BufferManagement do
   @spec handle_agent_session_down(state(), pid(), term()) :: state()
   def handle_agent_session_down(state, session_pid, :noconnection) do
     state
-    |> EditorState.ensure_shell_available()
+    |> Workflow.ensure_available()
     |> handle_remote_session_disconnected(session_pid)
   end
 
   def handle_agent_session_down(state, session_pid, {:nodedown, _node}) do
     state
-    |> EditorState.ensure_shell_available()
+    |> Workflow.ensure_available()
     |> handle_remote_session_disconnected(session_pid)
   end
 
   def handle_agent_session_down(state, session_pid, {:noconnection, _node}) do
     state
-    |> EditorState.ensure_shell_available()
+    |> Workflow.ensure_available()
     |> handle_remote_session_disconnected(session_pid)
   end
 
   def handle_agent_session_down(state, session_pid, reason) do
-    state = EditorState.ensure_shell_available(state)
+    state = Workflow.ensure_available(state)
     {state, owned?} = update_active_shell_session_down(state, session_pid, reason)
 
     if owned? do
@@ -1093,10 +1099,12 @@ defmodule MingaEditor.Commands.BufferManagement do
   @doc "Normalizes shell identity and returns whether the old session is still owned."
   @spec prepare_agent_session_restart(state(), pid()) :: session_restart_ownership()
   def prepare_agent_session_restart(state, old_pid) when is_pid(old_pid) do
-    state = EditorState.ensure_shell_available(state)
-    shell_owned? = shell_state_restart_owned?(state.shell_state, old_pid)
-    stash_owned? = stashed_shell_restart_owned?(state.shell_state_stash, old_pid)
-    session_restart_ownership(state, shell_owned? or stash_owned?)
+    state = Workflow.ensure_available(state)
+
+    owned? =
+      Runtime.owns_agent_session?(state.shell_runtime, Workflow.resolved_entries(), old_pid)
+
+    session_restart_ownership(state, owned?)
   end
 
   @spec session_restart_ownership(state(), boolean()) :: session_restart_ownership()
@@ -1105,102 +1113,37 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @doc "Refreshes editor state after SessionManager restarts a managed session."
   @spec handle_agent_session_restarted(state(), String.t(), pid(), pid(), term()) :: state()
-  def handle_agent_session_restarted(state, session_id, old_pid, new_pid, reason) do
-    state = EditorState.ensure_shell_available(state)
-    state = update_active_shell_session_restarted(state, session_id, old_pid, new_pid, reason)
-    state = update_stashed_shell_session_restarted(state, session_id, old_pid, new_pid, reason)
-    maybe_rebuild_active_agent_after_restart(state, new_pid)
-  end
+  def handle_agent_session_restarted(state, _session_id, old_pid, new_pid, reason) do
+    state = Workflow.ensure_available(state)
 
-  @spec shell_state_restart_owned?(term(), pid()) :: boolean()
-  defp shell_state_restart_owned?(%{cards: cards} = shell_state, old_pid) when is_map(cards) do
-    card_owned? = Enum.any?(cards, fn {_card_id, card} -> Map.get(card, :session) == old_pid end)
+    {runtime, _handled?, persistence_changes} =
+      Runtime.route_session_restarted(
+        state.shell_runtime,
+        Workflow.resolved_entries(),
+        old_pid,
+        new_pid,
+        reason
+      )
 
-    tab_owned? =
-      case Map.get(shell_state, :tab_bar) do
-        %TabBar{} = tb ->
-          not is_nil(TabBar.find_by_session(tb, old_pid)) or
-            not is_nil(TabBar.find_workspace_by_session(tb, old_pid))
+    runtime = persist_shell_changes(runtime, persistence_changes)
 
-        _ ->
-          false
-      end
-
-    card_owned? or tab_owned?
-  end
-
-  defp shell_state_restart_owned?(%{tab_bar: %TabBar{} = tb}, old_pid) do
-    not is_nil(TabBar.find_by_session(tb, old_pid)) or
-      not is_nil(TabBar.find_workspace_by_session(tb, old_pid))
-  end
-
-  defp shell_state_restart_owned?(_shell_state, _old_pid), do: false
-
-  @spec stashed_shell_restart_owned?(EditorState.shell_state_stash(), pid()) :: boolean()
-  defp stashed_shell_restart_owned?(stash, old_pid) do
-    Enum.any?(stash, fn {shell_id, %StateStash{} = stashed} ->
-      case MingaEditor.Shell.Registry.get(shell_id) do
-        %MingaEditor.Shell.Entry{} = entry ->
-          case StateStash.restore(stashed, entry) do
-            {:ok, shell_state} -> shell_state_restart_owned?(shell_state, old_pid)
-            :mismatch -> false
-          end
-
-        nil ->
-          false
-      end
-    end)
+    state
+    |> EditorState.apply_shell_runtime_transition(runtime)
+    |> maybe_rebuild_active_agent_after_restart(new_pid)
   end
 
   @spec update_active_shell_session_down(state(), pid(), term()) :: {state(), boolean()}
   defp update_active_shell_session_down(state, session_pid, reason) do
-    shell = EditorState.active_shell_module(state)
+    {runtime, owned?, persistence_change} =
+      Runtime.route_session_down(state.shell_runtime, session_pid, reason)
 
-    if function_exported?(shell, :handle_agent_session_down, 3) do
-      {shell_state, owned?} =
-        shell.handle_agent_session_down(state.shell_state, session_pid, reason)
-
-      shell_state = maybe_persist_owned_shell_state(shell, shell_state, owned?)
-      {EditorState.update_shell_state(state, fn _ -> shell_state end), owned?}
-    else
-      {state, false}
-    end
-  end
-
-  @spec update_active_shell_session_restarted(state(), String.t(), pid(), pid(), term()) ::
-          state()
-  defp update_active_shell_session_restarted(state, _session_id, old_pid, new_pid, reason) do
-    shell = EditorState.active_shell_module(state)
-
-    if function_exported?(shell, :handle_agent_session_restarted, 4) do
-      {shell_state, handled?} =
-        shell.handle_agent_session_restarted(state.shell_state, old_pid, new_pid, reason)
-
-      shell_state = maybe_persist_owned_shell_state(shell, shell_state, handled?)
-      EditorState.update_shell_state(state, fn _ -> shell_state end)
-    else
-      state
-    end
-  end
-
-  @spec update_stashed_shell_session_restarted(state(), String.t(), pid(), pid(), term()) ::
-          state()
-  defp update_stashed_shell_session_restarted(state, _session_id, old_pid, new_pid, reason) do
-    {state, _handled?} =
-      update_stashed_shell_for_session(state, :handle_agent_session_restarted, [
-        old_pid,
-        new_pid,
-        reason
-      ])
-
-    state
+    runtime = persist_shell_changes(runtime, List.wrap(persistence_change))
+    {EditorState.apply_shell_runtime_transition(state, runtime), owned?}
   end
 
   @spec maybe_rebuild_active_agent_after_restart(state(), pid()) :: state()
   defp maybe_rebuild_active_agent_after_restart(state, new_pid) do
-    shell = EditorState.active_shell_module(state)
-
-    case function_exported?(shell, :active_tab, 1) && shell.active_tab(state.shell_state) do
+    case Runtime.active_tab(state.shell_runtime) do
       %Tab{kind: :agent, session: ^new_pid} = tab ->
         EditorState.rebuild_agent_from_session(state, tab)
 
@@ -1233,12 +1176,26 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec update_stashed_shell_session_down(state(), pid(), term()) :: {state(), boolean()}
   defp update_stashed_shell_session_down(state, session_pid, reason) do
-    update_stashed_shell_for_session(state, :handle_agent_session_down, [session_pid, reason])
+    {runtime, handled?, persistence_changes} =
+      Runtime.route_stashed_session_down(
+        state.shell_runtime,
+        Workflow.resolved_entries(),
+        session_pid,
+        reason
+      )
+
+    runtime = persist_shell_changes(runtime, persistence_changes)
+
+    if handled? do
+      Minga.Log.info(:agent, "Agent session update applied to a stashed shell")
+    end
+
+    {EditorState.apply_shell_runtime_transition(state, runtime), handled?}
   end
 
   @spec handle_agent_session_down_for_tabs(state(), pid(), term()) :: state()
   defp handle_agent_session_down_for_tabs(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          session_pid,
          reason
        ) do
@@ -1383,7 +1340,9 @@ defmodule MingaEditor.Commands.BufferManagement do
 
     state =
       state
-      |> EditorState.set_tab_bar(TabBar.remove_workspace(state.shell_state.tab_bar, workspace.id))
+      |> EditorState.set_tab_bar(
+        TabBar.remove_workspace(state.shell_runtime.state.tab_bar, workspace.id)
+      )
       |> EditorState.sync_agent_ui_from_active_workspace()
 
     msg =
@@ -1427,7 +1386,7 @@ defmodule MingaEditor.Commands.BufferManagement do
       |> WorkspaceModel.set_review(review)
 
     tb =
-      TabBar.update_workspace(state.shell_state.tab_bar, workspace.id, fn _ ->
+      TabBar.update_workspace(state.shell_runtime.state.tab_bar, workspace.id, fn _ ->
         updated_workspace
       end)
 
@@ -1509,7 +1468,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec handle_remote_session_disconnected(state(), pid()) :: state()
   defp handle_remote_session_disconnected(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          session_pid
        ) do
     case TabBar.find_by_session(tb, session_pid) do
@@ -1539,25 +1498,31 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec update_active_shell_remote_disconnected(state(), pid()) :: {state(), boolean()}
   defp update_active_shell_remote_disconnected(state, session_pid) do
-    shell = EditorState.active_shell_module(state)
+    {runtime, handled?, persistence_change} =
+      Runtime.route_remote_session_disconnected(state.shell_runtime, session_pid)
 
-    if function_exported?(shell, :handle_remote_session_disconnected, 2) do
-      {shell_state, handled?} =
-        shell.handle_remote_session_disconnected(state.shell_state, session_pid)
-
-      shell_state = maybe_persist_owned_shell_state(shell, shell_state, handled?)
-      {EditorState.update_shell_state(state, fn _ -> shell_state end), handled?}
-    else
-      {state, false}
-    end
+    runtime = persist_shell_changes(runtime, List.wrap(persistence_change))
+    {EditorState.apply_shell_runtime_transition(state, runtime), handled?}
   end
 
   @spec handle_stashed_remote_session_disconnected(state(), pid()) :: state()
   defp handle_stashed_remote_session_disconnected(state, session_pid) do
-    {state, handled?} =
-      update_stashed_shell_for_session(state, :handle_remote_session_disconnected, [session_pid])
+    {runtime, handled?, persistence_changes} =
+      Runtime.route_stashed_remote_session_disconnected(
+        state.shell_runtime,
+        Workflow.resolved_entries(),
+        session_pid
+      )
 
-    if handled?, do: finish_remote_session_disconnected(state), else: state
+    runtime = persist_shell_changes(runtime, persistence_changes)
+    state = EditorState.apply_shell_runtime_transition(state, runtime)
+
+    if handled? do
+      Minga.Log.info(:agent, "Remote disconnect applied to a stashed shell")
+      finish_remote_session_disconnected(state)
+    else
+      state
+    end
   end
 
   @spec finish_remote_session_disconnected(state()) :: state()
@@ -1567,40 +1532,20 @@ defmodule MingaEditor.Commands.BufferManagement do
     |> EditorState.set_status("Remote agent disconnected, reconnecting...")
   end
 
-  @spec maybe_persist_owned_shell_state(module(), term(), boolean()) :: term()
-  defp maybe_persist_owned_shell_state(module, shell_state, true) do
-    if function_exported?(module, :persist_shell_state, 1) do
-      module.persist_shell_state(shell_state)
-    else
-      shell_state
-    end
+  @spec persist_shell_changes(Runtime.t(), [Runtime.persistence_change()]) :: Runtime.t()
+  defp persist_shell_changes(runtime, changes) do
+    Enum.reduce(changes, runtime, fn {entry, _old_state, new_state}, runtime_acc ->
+      persisted_state = persist_shell_state(entry.module, new_state)
+      Runtime.accept_persisted_state(runtime_acc, entry, persisted_state)
+    end)
   end
 
-  defp maybe_persist_owned_shell_state(_module, shell_state, false), do: shell_state
-
-  @spec update_stashed_shell_for_session(state(), atom(), [term()]) :: {state(), boolean()}
-  defp update_stashed_shell_for_session(state, callback, args) do
-    EditorState.transform_first_stashed_shell_state(state, fn module, shell_state, state_acc ->
-      if function_exported?(module, callback, length(args) + 1) do
-        case apply(module, callback, [shell_state | args]) do
-          {updated_shell_state, true} ->
-            Minga.Log.info(
-              :agent,
-              "Agent session update applied to stashed #{inspect(module)} shell"
-            )
-
-            updated_shell_state =
-              maybe_persist_owned_shell_state(module, updated_shell_state, true)
-
-            {{:updated, updated_shell_state}, state_acc}
-
-          {_updated_shell_state, false} ->
-            {:unchanged, state_acc}
-        end
-      else
-        {:unchanged, state_acc}
-      end
-    end)
+  @spec persist_shell_state(module(), MingaEditor.Shell.shell_state()) ::
+          MingaEditor.Shell.shell_state()
+  defp persist_shell_state(module, shell_state) do
+    if function_exported?(module, :persist_shell_state, 1),
+      do: module.persist_shell_state(shell_state),
+      else: shell_state
   end
 
   # Shared state cleanup for agent sessions: stops spinner, clears agent state session,
@@ -1613,11 +1558,11 @@ defmodule MingaEditor.Commands.BufferManagement do
     # Clear session and status on any tab that referenced this session.
     state = clear_session_from_tabs(state, session, tab_status)
 
-    case TabBar.find_workspace_by_session(state.shell_state.tab_bar, session) do
+    case TabBar.find_workspace_by_session(state.shell_runtime.state.tab_bar, session) do
       %{id: workspace_id} ->
         EditorState.set_tab_bar(
           state,
-          TabBar.remove_workspace(state.shell_state.tab_bar, workspace_id)
+          TabBar.remove_workspace(state.shell_runtime.state.tab_bar, workspace_id)
         )
 
       _ ->
@@ -1628,7 +1573,11 @@ defmodule MingaEditor.Commands.BufferManagement do
   # Clears session pid and sets agent_status on all tabs that reference
   # the given session pid.
   @spec clear_session_from_tabs(state(), pid(), Tab.agent_status()) :: state()
-  defp clear_session_from_tabs(%{shell_state: %{tab_bar: tb}} = state, session_pid, status) do
+  defp clear_session_from_tabs(
+         %{shell_runtime: %{state: %{tab_bar: tb}}} = state,
+         session_pid,
+         status
+       ) do
     updated_tb =
       Enum.reduce(tb.tabs, tb, fn tab, acc ->
         if tab.session == session_pid do
@@ -1645,7 +1594,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec clear_session_from_workspace(state(), non_neg_integer(), Tab.agent_status()) :: state()
   defp clear_session_from_workspace(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          workspace_id,
          status
        ) do
@@ -1667,7 +1616,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   # cleanup/preservation pass first, and only cleanly closed workspaces have
   # their tab removed.
   @spec close_agent_tab(state()) :: state()
-  defp close_agent_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp close_agent_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     workspace = TabBar.active_workspace(tb)
 
     session_pid =
@@ -1754,7 +1703,10 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   @spec finish_agent_tab_close(state(), non_neg_integer()) :: state()
-  defp finish_agent_tab_close(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, workspace_id) do
+  defp finish_agent_tab_close(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         workspace_id
+       ) do
     if TabBar.get_workspace(tb, workspace_id) == nil do
       Minga.Log.info(:editor, "Closed agent tab")
 
@@ -1840,7 +1792,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   @spec close_tab_or_quit(state()) :: state()
-  defp close_tab_or_quit(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
+  defp close_tab_or_quit(%{shell_runtime: %{state: %{tab_bar: %TabBar{}}}} = state) do
     case EditorState.active_tab(state) do
       %Tab{kind: :agent} -> close_agent_tab_or_quit(state)
       %Tab{kind: :file, id: active_id} -> close_file_tab_or_quit(state, active_id)
@@ -1851,7 +1803,9 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp close_tab_or_quit(state), do: shutdown_editor(state)
 
   @spec close_agent_tab_or_quit(state()) :: state()
-  defp close_agent_tab_or_quit(%{shell_state: %{tab_bar: %TabBar{tabs: [_single]}}} = state) do
+  defp close_agent_tab_or_quit(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{tabs: [_single]}}}} = state
+       ) do
     state
     |> cleanup_agent_session()
     |> shutdown_editor()
@@ -1889,7 +1843,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   @spec quit_would_exit_editor?(state()) :: boolean()
-  defp quit_would_exit_editor?(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp quit_would_exit_editor?(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     case EditorState.active_tab(state) do
       %Tab{kind: :file} -> TabBar.count(tb) == 1 and quit_last_tab_option(state) == :quit
       %Tab{kind: :agent} -> TabBar.count(tb) == 1
@@ -1900,7 +1854,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp quit_would_exit_editor?(_state), do: true
 
   @spec close_other_tabs(state()) :: state()
-  defp close_other_tabs(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp close_other_tabs(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     active_id = tb.active_id
     closed_tabs = Enum.reject(TabBar.visible_file_tabs(tb), &(&1.id == active_id))
     tb = remove_tabs(tb, closed_tabs)
@@ -1912,7 +1866,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp close_other_tabs(state), do: state
 
   @spec close_tabs_to_right(state()) :: state()
-  defp close_tabs_to_right(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp close_tabs_to_right(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     visible = TabBar.visible_file_tabs(tb)
 
     case Enum.find_index(visible, &(&1.id == tb.active_id)) do
@@ -1935,7 +1889,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp close_tabs_to_right(state), do: state
 
   @spec close_all_file_tabs(state()) :: state()
-  defp close_all_file_tabs(%{shell_state: %{tab_bar: %TabBar{}}} = state) do
+  defp close_all_file_tabs(%{shell_runtime: %{state: %{tab_bar: %TabBar{}}}} = state) do
     state
     |> close_other_tabs()
     |> execute(:kill_buffer)
@@ -1993,7 +1947,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   # stays in the buffer pool (matching Neovim's `:q` which closes the
   # window but leaves the buffer in the background buffer list).
   @spec close_file_tab(state()) :: state()
-  defp close_file_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp close_file_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     active_tab = EditorState.active_tab(state)
     label = if active_tab, do: active_tab.label, else: "tab"
     replacement_id = active_tab && replacement_tab_id(tb, active_tab)
@@ -2005,7 +1959,9 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   @spec has_neighbor_tab?(state()) :: boolean()
-  defp has_neighbor_tab?(%{shell_state: %{tab_bar: %TabBar{tabs: [_, _ | _]}}}), do: true
+  defp has_neighbor_tab?(%{shell_runtime: %{state: %{tab_bar: %TabBar{tabs: [_, _ | _]}}}}),
+    do: true
+
   defp has_neighbor_tab?(_state), do: false
 
   @spec restore_neighbor_tab_or_create_fallback(
@@ -2030,7 +1986,10 @@ defmodule MingaEditor.Commands.BufferManagement do
   @spec remove_current_tab(state(), Tab.id() | nil) :: state()
   defp remove_current_tab(state, replacement_id \\ nil)
 
-  defp remove_current_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, replacement_id) do
+  defp remove_current_tab(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         replacement_id
+       ) do
     case TabBar.remove(tb, tb.active_id) do
       {:ok, new_tb} ->
         EditorState.set_tab_bar(state, maybe_switch_to_replacement(new_tb, replacement_id))
@@ -2370,8 +2329,8 @@ defmodule MingaEditor.Commands.BufferManagement do
         if EditorState.skip_tool_prompt?(state, recipe.name) do
           state
         else
-          queue = Enum.concat(state.shell_state.tool_prompt_queue, [recipe.name])
-          state = EditorState.update_shell_state(state, &%{&1 | tool_prompt_queue: queue})
+          queue = Enum.concat(state.shell_runtime.state.tool_prompt_queue, [recipe.name])
+          state = EditorState.set_tool_prompt_queue(state, queue)
           show_tool_prompt_if_normal(state)
         end
     end
@@ -2379,11 +2338,13 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec show_tool_prompt_if_normal(state()) :: state()
   defp show_tool_prompt_if_normal(
-         %{workspace: %{editing: %{mode: :normal}}, shell_state: %{tool_prompt_queue: pending}} =
-           state
+         %{
+           workspace: %{editing: %{mode: :normal}},
+           shell_runtime: %{state: %{tool_prompt_queue: pending}}
+         } = state
        )
        when pending != [] do
-    ms = %ToolConfirmState{pending: pending, declined: state.shell_state.tool_declined}
+    ms = %ToolConfirmState{pending: pending, declined: state.shell_runtime.state.tool_declined}
     EditorState.transition_mode(state, :tool_confirm, ms)
   end
 

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -920,7 +920,8 @@ defmodule MingaEditor.Commands.FileTree do
   # Explicitly resets keymap_scope to :editor so we don't leave orphaned
   # :git_status scope if a future refactor separates the open steps.
   @spec close_git_status_if_open(state()) :: state()
-  defp close_git_status_if_open(%{shell_state: %{git_status_panel: nil}} = state), do: state
+  defp close_git_status_if_open(%{shell_runtime: %{state: %{git_status_panel: nil}}} = state),
+    do: state
 
   defp close_git_status_if_open(state),
     do:

--- a/lib/minga_editor/commands/formatting.ex
+++ b/lib/minga_editor/commands/formatting.ex
@@ -241,16 +241,16 @@ defmodule MingaEditor.Commands.Formatting do
 
   @spec queue_and_show_prompt(state(), atom()) :: state()
   defp queue_and_show_prompt(%{workspace: %{editing: %{mode: :normal}}} = state, tool_name) do
-    queue = Enum.concat(state.shell_state.tool_prompt_queue, [tool_name])
-    state = EditorState.update_shell_state(state, &%{&1 | tool_prompt_queue: queue})
-    ms = %ToolConfirmState{pending: queue, declined: state.shell_state.tool_declined}
+    queue = Enum.concat(state.shell_runtime.state.tool_prompt_queue, [tool_name])
+    state = EditorState.set_tool_prompt_queue(state, queue)
+    ms = %ToolConfirmState{pending: queue, declined: state.shell_runtime.state.tool_declined}
     EditorState.transition_mode(state, :tool_confirm, ms)
   end
 
   defp queue_and_show_prompt(state, tool_name) do
-    EditorState.update_shell_state(
+    EditorState.set_tool_prompt_queue(
       state,
-      &%{&1 | tool_prompt_queue: Enum.concat(state.shell_state.tool_prompt_queue, [tool_name])}
+      Enum.concat(state.shell_runtime.state.tool_prompt_queue, [tool_name])
     )
   end
 

--- a/lib/minga_editor/commands/inline_ask.ex
+++ b/lib/minga_editor/commands/inline_ask.ex
@@ -87,7 +87,7 @@ defmodule MingaEditor.Commands.InlineAsk do
   end
 
   @spec create_agent_tab(state()) :: state()
-  defp create_agent_tab(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp create_agent_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     win_id = 1
     rows = max(state.terminal_viewport.rows, 1)
     cols = max(state.terminal_viewport.cols, 1)
@@ -128,7 +128,7 @@ defmodule MingaEditor.Commands.InlineAsk do
 
   @spec add_file_to_active_workspace(state(), FileRef.t()) :: state()
   defp add_file_to_active_workspace(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          %FileRef{} = file_ref
        ) do
     case TabBar.active_workspace(tb) do

--- a/lib/minga_editor/commands/ui.ex
+++ b/lib/minga_editor/commands/ui.ex
@@ -131,7 +131,7 @@ defmodule MingaEditor.Commands.UI do
   @spec close_beam_observatory(EditorState.t()) :: EditorState.t()
   defp close_beam_observatory(state) do
     unsubscribe_observatory()
-    cancel_timer(state.shell_state.observatory_timer)
+    cancel_timer(state.shell_runtime.state.observatory_timer)
 
     state
     |> EditorState.close_observatory()
@@ -169,7 +169,7 @@ defmodule MingaEditor.Commands.UI do
   end
 
   @spec observatory_shell_supported?(EditorState.t()) :: boolean()
-  defp observatory_shell_supported?(%{shell_state: shell_state}) do
+  defp observatory_shell_supported?(%{shell_runtime: %{state: shell_state}}) do
     Map.has_key?(shell_state, :observatory_visible) and
       Map.has_key?(shell_state, :observatory_timer) and
       Map.has_key?(shell_state, :observatory_data) and

--- a/lib/minga_editor/commands/workspace.ex
+++ b/lib/minga_editor/commands/workspace.ex
@@ -25,19 +25,19 @@ defmodule MingaEditor.Commands.Workspace do
 
   @doc "Switch to the next workspace's first tab."
   @spec workspace_next(state()) :: state()
-  def workspace_next(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  def workspace_next(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     switch_via_workspace(state, TabBar.next_agent_workspace(tb))
   end
 
   @doc "Switch to the previous workspace's first tab."
   @spec workspace_prev(state()) :: state()
-  def workspace_prev(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  def workspace_prev(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     switch_via_workspace(state, TabBar.prev_agent_workspace(tb))
   end
 
   @doc "Switch to the first manual workspace tab."
   @spec switch_to_manual_workspace(state()) :: state()
-  def switch_to_manual_workspace(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  def switch_to_manual_workspace(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     case TabBar.tabs_in_workspace(tb, 0) do
       [first | _] -> EditorState.switch_tab(state, first.id)
       [] -> state
@@ -46,7 +46,7 @@ defmodule MingaEditor.Commands.Workspace do
 
   @doc "Toggle between manual workspace tabs and the last agent workspace."
   @spec workspace_toggle(state()) :: state()
-  def workspace_toggle(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  def workspace_toggle(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     current_ws = TabBar.active_workspace_id(tb)
     target_workspace_id = if current_ws == 0, do: last_agent_id(tb), else: 0
     target_tb = TabBar.switch_to_workspace(tb, target_workspace_id)
@@ -59,7 +59,7 @@ defmodule MingaEditor.Commands.Workspace do
   The manual workspace (id 0) cannot be closed.
   """
   @spec workspace_close(state()) :: state()
-  def workspace_close(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  def workspace_close(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     workspace = TabBar.active_workspace(tb)
 
     if workspace_closure_requires_review?(workspace) do
@@ -77,7 +77,7 @@ defmodule MingaEditor.Commands.Workspace do
 
   @doc "Shows the active workspace draft summary."
   @spec workspace_review_drafts(state()) :: state()
-  def workspace_review_drafts(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  def workspace_review_drafts(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     workspace_id = TabBar.active_workspace_id(tb)
 
     case TabBar.get_workspace(tb, workspace_id) do
@@ -124,7 +124,7 @@ defmodule MingaEditor.Commands.Workspace do
 
   @doc "Discards drafts and then closes the active workspace."
   @spec workspace_discard_and_close(state()) :: state()
-  def workspace_discard_and_close(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  def workspace_discard_and_close(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     workspace_id = TabBar.active_workspace_id(tb)
 
     case TabBar.get_workspace(tb, workspace_id) do
@@ -194,7 +194,7 @@ defmodule MingaEditor.Commands.Workspace do
   (minibuffer) and GUI (native prompt rendering).
   """
   @spec workspace_rename(state()) :: state()
-  def workspace_rename(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  def workspace_rename(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     ws = TabBar.active_workspace(tb)
     current_name = if ws, do: ws.label, else: ""
 
@@ -203,11 +203,11 @@ defmodule MingaEditor.Commands.Workspace do
 
   @doc "Jump to workspace by number (1-based, 0 = manual workspace)."
   @spec workspace_goto(state(), non_neg_integer()) :: state()
-  def workspace_goto(%{shell_state: %{tab_bar: %TabBar{}}} = state, 0) do
+  def workspace_goto(%{shell_runtime: %{state: %{tab_bar: %TabBar{}}}} = state, 0) do
     switch_to_manual_workspace(state)
   end
 
-  def workspace_goto(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, number) do
+  def workspace_goto(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state, number) do
     case Enum.at(agent_workspaces(tb), number - 1) do
       nil -> state
       %{id: id} -> switch_via_workspace(state, TabBar.switch_to_workspace(tb, id))
@@ -216,12 +216,18 @@ defmodule MingaEditor.Commands.Workspace do
 
   @doc "Jump directly to a workspace by id."
   @spec workspace_goto_by_id(state(), non_neg_integer()) :: state()
-  def workspace_goto_by_id(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, workspace_id) do
+  def workspace_goto_by_id(
+        %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+        workspace_id
+      ) do
     switch_via_workspace(state, TabBar.switch_to_workspace(tb, workspace_id))
   end
 
   @spec open_workspace_target_picker(state(), :move | :copy) :: state()
-  defp open_workspace_target_picker(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, operation) do
+  defp open_workspace_target_picker(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         operation
+       ) do
     with {:ok, file_ref} <- active_file_ref(state, tb),
          :ok <- other_workspace_available?(tb) do
       MingaEditor.PickerUI.open(state, MingaEditor.UI.Picker.WorkspaceTargetSource, %{
@@ -283,7 +289,7 @@ defmodule MingaEditor.Commands.Workspace do
   end
 
   @spec close_active_workspace(state()) :: state()
-  defp close_active_workspace(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp close_active_workspace(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     workspace_id = TabBar.active_workspace_id(tb)
 
     case TabBar.get_workspace(tb, workspace_id) do
@@ -360,7 +366,9 @@ defmodule MingaEditor.Commands.Workspace do
   end
 
   @spec close_discarded_active_workspace(state()) :: state()
-  defp close_discarded_active_workspace(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp close_discarded_active_workspace(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state
+       ) do
     workspace_id = TabBar.active_workspace_id(tb)
 
     case TabBar.get_workspace(tb, workspace_id) do
@@ -432,7 +440,10 @@ defmodule MingaEditor.Commands.Workspace do
           state(),
           (WorkspaceModel.t() -> {:ok, WorkspaceModel.t()} | {:error, term()})
         ) :: state()
-  defp update_active_workspace_review(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, fun)
+  defp update_active_workspace_review(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         fun
+       )
        when is_function(fun, 1) do
     workspace_id = TabBar.active_workspace_id(tb)
     workspace = TabBar.get_workspace(tb, workspace_id)
@@ -624,7 +635,7 @@ defmodule MingaEditor.Commands.Workspace do
   # No-op if the active tab didn't change.
   @spec switch_via_workspace(state(), TabBar.t()) :: state()
   defp switch_via_workspace(state, %TabBar{active_id: new_id}) do
-    if new_id == state.shell_state.tab_bar.active_id do
+    if new_id == state.shell_runtime.state.tab_bar.active_id do
       state
     else
       EditorState.switch_tab(state, new_id)

--- a/lib/minga_editor/completion_handling.ex
+++ b/lib/minga_editor/completion_handling.ex
@@ -155,7 +155,7 @@ defmodule MingaEditor.CompletionHandling do
     else
       state = dismiss(state)
       # Dismiss signature help when leaving insert mode
-      EditorState.update_shell_state(state, &%{&1 | signature_help: nil})
+      EditorState.set_signature_help(state, nil)
     end
   end
 
@@ -168,7 +168,7 @@ defmodule MingaEditor.CompletionHandling do
   """
   @spec dismiss(EditorState.t()) :: EditorState.t()
   def dismiss(state) do
-    if ModalOverlay.match(state.shell_state.modal, :completion) do
+    if ModalOverlay.match(state.shell_runtime.state.modal, :completion) do
       # Cancel any pending resolve timer and dismiss the trigger to cancel
       # debounce timers and forget pending refs before the modal closes.
       case ModalOverlay.completion(state) do
@@ -438,7 +438,7 @@ defmodule MingaEditor.CompletionHandling do
   end
 
   @spec active_tab_id(EditorState.t()) :: term() | nil
-  defp active_tab_id(%{shell_state: %{tab_bar: %{active_id: id}}}), do: id
+  defp active_tab_id(%{shell_runtime: %{state: %{tab_bar: %{active_id: id}}}}), do: id
   defp active_tab_id(_), do: nil
 
   @typedoc "Config contexts that produce completion items (excludes :none)."
@@ -672,7 +672,7 @@ defmodule MingaEditor.CompletionHandling do
   def apply_processed(state, gen, mode, payload, trigger_pos) do
     trigger = ModalOverlay.completion_trigger(state)
 
-    if ModalOverlay.match(state.shell_state.modal, :completion) and trigger.gen == gen do
+    if ModalOverlay.match(state.shell_runtime.state.modal, :completion) and trigger.gen == gen do
       apply_processed_current(state, mode, payload, trigger_pos)
     else
       # Stale generation or the menu was dismissed/replaced; discard.
@@ -779,12 +779,12 @@ defmodule MingaEditor.CompletionHandling do
   def handle_signature_help_response(state, {:error, _}), do: state
 
   def handle_signature_help_response(state, {:ok, nil}),
-    do: EditorState.update_shell_state(state, &%{&1 | signature_help: nil})
+    do: EditorState.set_signature_help(state, nil)
 
   def handle_signature_help_response(state, {:ok, result}) when is_map(result) do
     {cursor_row, cursor_col} = approximate_cursor_screen_pos(state)
     sh = SignatureHelp.from_response(result, cursor_row, cursor_col)
-    EditorState.update_shell_state(state, &%{&1 | signature_help: sh})
+    EditorState.set_signature_help(state, sh)
   end
 
   def handle_signature_help_response(state, _), do: state
@@ -797,7 +797,7 @@ defmodule MingaEditor.CompletionHandling do
     cond do
       # ) always dismisses signature help
       codepoint == ?) ->
-        EditorState.update_shell_state(state, &%{&1 | signature_help: nil})
+        EditorState.set_signature_help(state, nil)
 
       # Check if the character is a server-declared signature trigger
       char != nil and signature_trigger_char?(state, buf, char) ->

--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -188,13 +188,33 @@ defmodule MingaEditor.FocusTree do
   defp bottom_panel_rect(_layout, nil), do: nil
 
   defp bottom_panel_rect(
-         %Layout{terminal: {row, col, width, rows}},
+         %Layout{} = layout,
+         %{
+           shell_runtime: %{
+             state: %{
+               bottom_panel: %BottomPanel{visible: true, height_percent: height_percent}
+             }
+           }
+         }
+       ),
+       do: bottom_panel_rect(layout, height_percent)
+
+  defp bottom_panel_rect(
+         %Layout{} = layout,
          %{
            shell_state: %{
              bottom_panel: %BottomPanel{visible: true, height_percent: height_percent}
            }
          }
-       ) do
+       ),
+       do: bottom_panel_rect(layout, height_percent)
+
+  @spec bottom_panel_rect(Layout.t(), non_neg_integer()) :: Layout.rect()
+  defp bottom_panel_rect(
+         %Layout{terminal: {row, col, width, rows}},
+         height_percent
+       )
+       when is_integer(height_percent) and height_percent >= 0 do
     panel_height = bottom_panel_height(rows, height_percent)
     {row + rows - panel_height, col, width, panel_height}
   end
@@ -385,6 +405,14 @@ defmodule MingaEditor.FocusTree do
 
   @spec maybe_add_hover_overlay(t(), map()) :: t()
   defp maybe_add_hover_overlay(%TreeNode{} = root, %{
+         shell_runtime: %{state: shell_state},
+         terminal_viewport: vp,
+         theme: theme
+       }) do
+    maybe_add_hover_overlay(root, %{shell_state: shell_state, terminal_viewport: vp, theme: theme})
+  end
+
+  defp maybe_add_hover_overlay(%TreeNode{} = root, %{
          shell_state: %{hover_popup: %HoverPopup{} = popup},
          terminal_viewport: vp,
          theme: theme
@@ -409,6 +437,18 @@ defmodule MingaEditor.FocusTree do
 
   @spec maybe_add_signature_overlay(t(), map()) :: t()
   defp maybe_add_signature_overlay(%TreeNode{} = root, %{
+         shell_runtime: %{state: shell_state},
+         terminal_viewport: vp,
+         theme: theme
+       }) do
+    maybe_add_signature_overlay(root, %{
+      shell_state: shell_state,
+      terminal_viewport: vp,
+      theme: theme
+    })
+  end
+
+  defp maybe_add_signature_overlay(%TreeNode{} = root, %{
          shell_state: %{signature_help: %SignatureHelp{} = sh},
          terminal_viewport: vp,
          theme: theme
@@ -430,6 +470,14 @@ defmodule MingaEditor.FocusTree do
   # ── Overlay builders ──────────────────────────────────────────────────────
 
   @spec add_modal_overlays(t(), map(), Layout.t()) :: t()
+  defp add_modal_overlays(
+         %TreeNode{} = root,
+         %{shell_runtime: %{state: %{modal: {:picker, payload}}}},
+         layout
+       ) do
+    add_picker_overlay(root, payload.picker_ui, layout)
+  end
+
   defp add_modal_overlays(
          %TreeNode{} = root,
          %{shell_state: %{modal: {:picker, payload}}},

--- a/lib/minga_editor/frontend/emit/context.ex
+++ b/lib/minga_editor/frontend/emit/context.ex
@@ -26,6 +26,8 @@ defmodule MingaEditor.Frontend.Emit.Context do
   alias MingaEditor.UI.FontRegistry
   alias MingaEditor.UI.NotificationCenter
   alias MingaEditor.UI.Theme
+  alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State
 
   @type t :: %__MODULE__{
@@ -107,10 +109,21 @@ defmodule MingaEditor.Frontend.Emit.Context do
             config_state: nil,
             link_cursor: false
 
-  @doc "Builds an emit context from render pipeline input."
-  @spec from_editor_state(map()) :: t()
-  def from_editor_state(state) do
-    title = compute_title(state)
+  @doc "Builds an emit context from editor state or its render-pipeline transfer value."
+  @spec from_editor_state(State.t() | Input.t()) :: t()
+  def from_editor_state(%State{shell_runtime: %Runtime{} = runtime} = state) do
+    build(state, Runtime.id(runtime), Runtime.module(runtime), Runtime.state(runtime))
+  end
+
+  def from_editor_state(
+        %Input{shell_id: shell_id, shell: shell, shell_state: shell_state} = input
+      ) do
+    build(input, shell_id, shell, shell_state)
+  end
+
+  @spec build(map(), atom(), module(), term()) :: t()
+  defp build(state, shell_id, shell, shell_state) do
+    title = compute_title(state, shell, shell_state)
     gui? = MingaEditor.Frontend.gui?(state.capabilities)
 
     %__MODULE__{
@@ -120,10 +133,10 @@ defmodule MingaEditor.Frontend.Emit.Context do
       font_registry: Map.get(state, :font_registry, FontRegistry.new()),
       windows: state.workspace.windows,
       layout: MingaEditor.Layout.get(state),
-      shell_id: State.active_shell_id(state),
-      shell: State.active_shell_module(state),
-      shell_state: state.shell_state,
-      tab_bar: Map.get(state.shell_state, :tab_bar),
+      shell_id: shell_id,
+      shell: shell,
+      shell_state: shell_state,
+      tab_bar: Map.get(shell_state, :tab_bar),
       buffers: state.workspace.buffers,
       viewport: state.terminal_viewport,
       file_tree: State.file_tree_state(state),
@@ -137,11 +150,12 @@ defmodule MingaEditor.Frontend.Emit.Context do
       editing: state.workspace.editing,
       message_store: state.message_store,
       notifications: state.notifications,
-      sidebar_registry: State.sidebar_registry(state),
+      sidebar_registry:
+        Map.get(state, :sidebar_registry, MingaEditor.Extension.Sidebar.default_table()),
       title: title,
       status_bar_data: MingaEditor.StatusBar.Data.from_state(state),
       git_syncing: Map.get(state, :git_remote_op) != nil or git_effect_active?(state),
-      git_toast: Map.get(state.shell_state, :git_toast),
+      git_toast: Map.get(shell_state, :git_toast),
       search: state.workspace.search,
       last_input_seq: Map.get(state, :last_input_seq, 0),
       frame_seq: Map.get(state, :frame_seq),
@@ -182,11 +196,11 @@ defmodule MingaEditor.Frontend.Emit.Context do
   defp gui_only(true, value), do: value
   defp gui_only(false, _value), do: nil
 
-  @spec compute_title(map()) :: String.t()
-  defp compute_title(%{shell: shell} = state) do
+  @spec compute_title(State.t() | Input.t(), module(), term()) :: String.t()
+  defp compute_title(state, shell, shell_state) do
     case shell.gui_payload(state) do
       nil ->
-        compute_standard_title(state)
+        compute_standard_title(state, shell_state)
 
       other ->
         Minga.Log.warning(
@@ -194,20 +208,18 @@ defmodule MingaEditor.Frontend.Emit.Context do
           "Unsupported GUI shell payload #{inspect(other)}; using standard title"
         )
 
-        compute_standard_title(state)
+        compute_standard_title(state, shell_state)
     end
   end
 
-  defp compute_title(state), do: compute_standard_title(state)
-
-  @spec compute_standard_title(map()) :: String.t()
-  defp compute_standard_title(state) do
+  @spec compute_standard_title(State.t() | Input.t(), term()) :: String.t()
+  defp compute_standard_title(state, shell_state) do
     if MingaEditor.Frontend.gui?(state.capabilities) do
       MingaEditor.Title.format_gui(state)
     else
       format = Minga.Config.get(:title_format) |> to_string()
       title = MingaEditor.Title.format(state, format)
-      tb = state.shell_state && Map.get(state.shell_state, :tab_bar)
+      tb = is_map(shell_state) && Map.get(shell_state, :tab_bar)
 
       if tb && TabBar.any_attention?(tb) do
         "[!] " <> title

--- a/lib/minga_editor/handlers/buffer_registry.ex
+++ b/lib/minga_editor/handlers/buffer_registry.ex
@@ -64,7 +64,7 @@ defmodule MingaEditor.Handlers.BufferRegistry do
 
   @spec file_tab_for_path_in_active_workspace(state(), String.t()) :: Tab.t() | nil
   def file_tab_for_path_in_active_workspace(
-        %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+        %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
         path
       ) do
     file_ref = FileRef.from_file_path(path)
@@ -133,7 +133,7 @@ defmodule MingaEditor.Handlers.BufferRegistry do
   # ── Private helpers ──────────────────────────────────────────────────
 
   @spec buffer_tracked_in_tabs?(state(), pid()) :: boolean()
-  defp buffer_tracked_in_tabs?(%{shell_state: %{tab_bar: %{tabs: tabs}}}, pid) do
+  defp buffer_tracked_in_tabs?(%{shell_runtime: %{state: %{tab_bar: %{tabs: tabs}}}}, pid) do
     Enum.any?(tabs, fn tab -> pid in tab_buffer_list(tab) end)
   end
 

--- a/lib/minga_editor/handlers/event_dispatcher.ex
+++ b/lib/minga_editor/handlers/event_dispatcher.ex
@@ -22,6 +22,8 @@ defmodule MingaEditor.Handlers.EventDispatcher do
   alias MingaEditor.Remote.EventReplay
   alias MingaEditor.Remote.SessionClient
   alias MingaEditor.Renderer
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Workflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -216,16 +218,20 @@ defmodule MingaEditor.Handlers.EventDispatcher do
       ) do
     case subscribe_to_session(state, handle.pid) do
       :ok ->
-        state = EditorState.ensure_shell_available(state)
+        state = Workflow.ensure_available(state)
 
-        {shell_state, workspace} =
-          EditorState.active_shell_module(state).handle_event(
-            state.shell_state,
+        {runtime, workspace} =
+          Runtime.route_event(
+            state.shell_runtime,
             state.workspace,
             {:background_subagent_started, handle}
           )
 
-        state = %{state | shell_state: shell_state, workspace: workspace}
+        state =
+          state
+          |> EditorState.apply_shell_runtime_transition(runtime)
+          |> EditorState.set_workspace(workspace)
+
         MingaEditor.schedule_render(state, 16)
 
       {:error, reason} ->
@@ -471,7 +477,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
 
   @spec reconnect_remote_tabs(EditorState.t(), String.t(), node()) :: EditorState.t()
   defp reconnect_remote_tabs(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          server_name,
          remote_node
        ) do
@@ -533,7 +539,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
   @spec restore_ended_remote_workspace(EditorState.t(), Workspace.t(), [term()]) ::
           EditorState.t()
   defp restore_ended_remote_workspace(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          %Workspace{id: workspace_id} = workspace,
          messages
        ) do
@@ -554,7 +560,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
 
   @spec restore_remote_workspace(EditorState.t(), Workspace.t(), node(), pid()) :: EditorState.t()
   defp restore_remote_workspace(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          %Workspace{
            id: workspace_id,
            remote_session: %RemoteSession{session_id: session_id, last_seen_event_id: last_seen}
@@ -602,7 +608,11 @@ defmodule MingaEditor.Handlers.EventDispatcher do
   defp restore_remote_workspace(state, %Workspace{}, _remote_node, _pid), do: state
 
   @spec mark_remote_tabs(EditorState.t(), String.t(), Tab.connection_status()) :: EditorState.t()
-  defp mark_remote_tabs(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state, server_name, status) do
+  defp mark_remote_tabs(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
+         server_name,
+         status
+       ) do
     EditorState.set_tab_bar(state, TabBar.set_remote_connection_status(tb, server_name, status))
   end
 
@@ -619,7 +629,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
   end
 
   defp mark_remote_workspace_status(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          %Workspace{} = workspace,
          status
        ) do
@@ -637,7 +647,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
           :unavailable
         ) :: EditorState.t()
   defp mark_remote_workspace_without_live_session(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          %Workspace{} = workspace,
          status
        ) do
@@ -715,7 +725,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
 
   @spec maybe_rebuild_agent_from_workspace(EditorState.t(), non_neg_integer()) :: EditorState.t()
   defp maybe_rebuild_agent_from_workspace(
-         %{shell_state: %{tab_bar: %TabBar{} = tb}} = state,
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state,
          workspace_id
        ) do
     case workspace_agent_tab(tb, workspace_id) do
@@ -738,7 +748,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
     do: TabBar.active_workspace_id(tb) == workspace_id
 
   @spec active_remote_server?(EditorState.t(), String.t()) :: boolean()
-  defp active_remote_server?(%{shell_state: %{tab_bar: %TabBar{} = tb}}, server_name) do
+  defp active_remote_server?(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}}, server_name) do
     case TabBar.active_workspace(tb) do
       %Workspace{} = workspace -> Workspace.remote_server?(workspace, server_name)
       _workspace -> false
@@ -746,9 +756,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
   end
 
   defp active_remote_server?(%EditorState{} = state, server_name) do
-    state = EditorState.ensure_shell_available(state)
-
-    case EditorState.active_shell_module(state).active_tab(state.shell_state) do
+    case Runtime.active_tab(state.shell_runtime) do
       %Tab{server_name: ^server_name} -> true
       _ -> false
     end

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -9,6 +9,8 @@ defmodule MingaEditor.Handlers.FileEventHandler do
 
   alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Workflow
   alias MingaEditor.State, as: EditorState
 
   @typedoc "Effects that the file event handler may return."
@@ -114,16 +116,19 @@ defmodule MingaEditor.Handlers.FileEventHandler do
         state =
           state
           |> EditorState.set_git_status_panel(GitStatusPanel.new(git_status_data))
-          |> EditorState.ensure_shell_available()
+          |> Workflow.ensure_available()
 
-        {shell_state, workspace} =
-          EditorState.active_shell_module(state).handle_event(
-            state.shell_state,
+        {runtime, workspace} =
+          Runtime.route_event(
+            state.shell_runtime,
             state.workspace,
             {:git_status_changed, entries}
           )
 
-        new_state = %{state | shell_state: shell_state, workspace: workspace}
+        new_state =
+          state
+          |> EditorState.apply_shell_runtime_transition(runtime)
+          |> EditorState.set_workspace(workspace)
 
         {new_state, [{:render, 16}]}
     end

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -219,7 +219,10 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     EditorState.reset_frontend_render_state(state)
   end
 
-  defp dispatch_action(%{shell_state: shell_state} = state, {:observatory_inspect, pid_string}) do
+  defp dispatch_action(
+         %{shell_runtime: %{state: shell_state}} = state,
+         {:observatory_inspect, pid_string}
+       ) do
     if Map.has_key?(shell_state, :observatory_inspection) do
       Observatory.inspect_process(state, pid_string)
     else
@@ -891,7 +894,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   end
 
   @spec last_file_tab?(EditorState.t()) :: boolean()
-  defp last_file_tab?(%{shell_state: %{tab_bar: %MingaEditor.State.TabBar{} = tb}}) do
+  defp last_file_tab?(%{shell_runtime: %{state: %{tab_bar: %MingaEditor.State.TabBar{} = tb}}}) do
     match?([_single], MingaEditor.State.TabBar.visible_file_tabs(tb))
   end
 
@@ -899,29 +902,20 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec dispatch_to_active_shell(EditorState.t(), term()) :: EditorState.t()
   defp dispatch_to_active_shell(state, action) do
-    state = EditorState.ensure_shell_available(state)
-    shell = EditorState.active_shell_module(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
+    shell = MingaEditor.Shell.Runtime.module(state.shell_runtime)
 
-    if function_exported?(shell, :handle_gui_action, 3) do
-      {shell_state, workspace} =
-        shell.handle_gui_action(
-          state.shell_state,
-          state.workspace,
-          action
-        )
-
-      state
-      |> EditorState.update_shell_state(fn _ -> shell_state end)
-      |> EditorState.set_workspace(workspace)
-      |> after_shell_gui_action(shell, action)
-    else
-      Minga.Log.warning(
-        :editor,
-        "GUI action ignored because active shell cannot handle it: #{inspect(action)}"
+    {runtime, workspace} =
+      MingaEditor.Shell.Runtime.route_gui_action(
+        state.shell_runtime,
+        state.workspace,
+        action
       )
 
-      EditorState.set_status(state, "GUI action is unavailable")
-    end
+    state
+    |> EditorState.apply_shell_runtime_transition(runtime)
+    |> EditorState.set_workspace(workspace)
+    |> after_shell_gui_action(shell, action)
   end
 
   @spec after_shell_gui_action(EditorState.t(), module(), term()) :: EditorState.t()
@@ -1408,17 +1402,17 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec handle_shell_gui_action(EditorState.t(), term()) :: EditorState.t()
   defp handle_shell_gui_action(state, action) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
-    {shell_state, workspace} =
-      EditorState.active_shell_module(state).handle_gui_action(
-        state.shell_state,
+    {runtime, workspace} =
+      MingaEditor.Shell.Runtime.route_gui_action(
+        state.shell_runtime,
         state.workspace,
         action
       )
 
     state
-    |> EditorState.update_shell_state(fn _shell_state -> shell_state end)
+    |> EditorState.apply_shell_runtime_transition(runtime)
     |> EditorState.set_workspace(workspace)
   end
 
@@ -1431,7 +1425,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec update_tab_bar(state(), (TabBar.t() -> TabBar.t())) :: state()
   defp update_tab_bar(state, fun) when is_function(fun, 1) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     case EditorState.tab_bar(state) do
       %TabBar{} = tb -> EditorState.set_tab_bar(state, fun.(tb))
@@ -1443,7 +1437,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec copy_tab_path(state(), Tab.id()) :: state()
   defp copy_tab_path(state, id) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     case tab_file_path(state, id) do
       nil ->
@@ -1465,7 +1459,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec tab_file_path(state(), Tab.id()) :: String.t() | nil
   defp tab_file_path(state, id) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     case EditorState.tab_bar(state) do
       %TabBar{} = tb -> tab_file_path_from_tab(state, tb, TabBar.get(tb, id))
@@ -1726,7 +1720,9 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   # (the builder checks it first); otherwise close the :float popup window via
   # the popup lifecycle. Returns state unchanged when neither is present.
   @spec dismiss_float_popup(state()) :: state()
-  defp dismiss_float_popup(%{shell_state: %{observatory_inspection: %{visible: true}}} = state) do
+  defp dismiss_float_popup(
+         %{shell_runtime: %{state: %{observatory_inspection: %{visible: true}}}} = state
+       ) do
     Observatory.inspect_process(state, "")
   end
 

--- a/lib/minga_editor/handlers/render_handler.ex
+++ b/lib/minga_editor/handlers/render_handler.ex
@@ -20,6 +20,7 @@ defmodule MingaEditor.Handlers.RenderHandler do
   alias MingaEditor.FlashEffects
   alias MingaEditor.NavFlash
   alias MingaEditor.Renderer
+  alias MingaEditor.Shell.Workflow
   alias MingaEditor.YankFlash
 
   alias MingaEditor.State, as: EditorState
@@ -49,7 +50,10 @@ defmodule MingaEditor.Handlers.RenderHandler do
   @spec handle_render_done(state(), map()) :: state()
   def handle_render_done(state, writeback) do
     emit_render_done_hop(writeback)
-    EditorState.apply_renderer_writeback(state, writeback)
+
+    state
+    |> Workflow.ensure_available()
+    |> EditorState.apply_renderer_writeback(writeback)
   end
 
   # Measures the Renderer.Server → Editor writeback scheduling delay using the
@@ -65,10 +69,10 @@ defmodule MingaEditor.Handlers.RenderHandler do
   Handles the `:nav_flash_step` timer, advancing the fade or clearing the flash.
   """
   @spec handle_nav_flash_step(state()) :: state()
-  def handle_nav_flash_step(%{shell_state: %{nav_flash: nil}} = state), do: state
+  def handle_nav_flash_step(%{shell_runtime: %{state: %{nav_flash: nil}}} = state), do: state
 
   def handle_nav_flash_step(state) do
-    flash = state.shell_state.nav_flash
+    flash = state.shell_runtime.state.nav_flash
 
     case NavFlash.advance(flash) do
       {:continue, updated, effects} ->
@@ -84,10 +88,10 @@ defmodule MingaEditor.Handlers.RenderHandler do
   Handles the `:yank_flash_step` timer, advancing the fade or clearing the flash.
   """
   @spec handle_yank_flash_step(state()) :: state()
-  def handle_yank_flash_step(%{shell_state: %{yank_flash: nil}} = state), do: state
+  def handle_yank_flash_step(%{shell_runtime: %{state: %{yank_flash: nil}}} = state), do: state
 
   def handle_yank_flash_step(state) do
-    %YankFlash{buf: buf} = flash = state.shell_state.yank_flash
+    %YankFlash{buf: buf} = flash = state.shell_runtime.state.yank_flash
 
     case YankFlash.advance(flash) do
       {:continue, updated, effects} ->
@@ -107,7 +111,7 @@ defmodule MingaEditor.Handlers.RenderHandler do
   """
   @spec handle_warning_popup_timeout(state()) :: state()
   def handle_warning_popup_timeout(state) do
-    state = EditorState.update_shell_state(state, &%{&1 | warning_popup_timer: nil})
+    state = EditorState.set_warning_popup_timer(state, nil)
     open_warnings_popup_if_needed(state)
   end
 
@@ -155,7 +159,7 @@ defmodule MingaEditor.Handlers.RenderHandler do
   end
 
   @spec cancel_flash_if_active(state()) :: state()
-  defp cancel_flash_if_active(%{shell_state: %{nav_flash: nil}} = state), do: state
+  defp cancel_flash_if_active(%{shell_runtime: %{state: %{nav_flash: nil}}} = state), do: state
 
   defp cancel_flash_if_active(state) do
     effects = NavFlash.cancel_effects(EditorState.nav_flash(state))
@@ -209,11 +213,14 @@ defmodule MingaEditor.Handlers.RenderHandler do
   end
 
   @spec open_warnings_popup_if_needed(state()) :: state()
-  defp open_warnings_popup_if_needed(%{shell_state: %{bottom_panel: %{dismissed: true}}} = state),
-    do: state
+  defp open_warnings_popup_if_needed(
+         %{shell_runtime: %{state: %{bottom_panel: %{dismissed: true}}}} = state
+       ),
+       do: state
 
   defp open_warnings_popup_if_needed(
-         %{shell_state: %{bottom_panel: %{visible: true, active_tab: :messages}}} = state
+         %{shell_runtime: %{state: %{bottom_panel: %{visible: true, active_tab: :messages}}}} =
+           state
        ) do
     # Panel already visible on Messages tab; don't change the user's filter.
     MingaEditor.schedule_render(state, 16)

--- a/lib/minga_editor/handlers/tool_handler.ex
+++ b/lib/minga_editor/handlers/tool_handler.ex
@@ -7,7 +7,7 @@ defmodule MingaEditor.Handlers.ToolHandler do
   to this module via catch-all clauses and applies the returned effects.
 
   Each function reads and writes only tool-related state slices
-  (`state.shell_state.tool_prompt_queue`, `state.shell_state.tool_declined`,
+  (`state.shell_runtime.state.tool_prompt_queue`, `state.shell_runtime.state.tool_declined`,
   status messages).
   """
 
@@ -103,7 +103,7 @@ defmodule MingaEditor.Handlers.ToolHandler do
   # ── Tool missing prompt (suppressed) ─────────────────────────────────────
 
   def handle(
-        %{shell_state: %{suppress_tool_prompts: true}} = state,
+        %{shell_runtime: %{state: %{suppress_tool_prompts: true}}} = state,
         {:minga_event, :tool_missing, %Minga.Events.ToolMissingEvent{command: command}}
       ) do
     {state, [{:log, :editor, :debug, "[Editor] tool_missing suppressed for #{command}"}]}
@@ -119,10 +119,10 @@ defmodule MingaEditor.Handlers.ToolHandler do
 
     new_state =
       if recipe && not EditorState.skip_tool_prompt?(state, recipe.name) do
-        queue = Enum.concat(state.shell_state.tool_prompt_queue, [recipe.name])
+        queue = Enum.concat(state.shell_runtime.state.tool_prompt_queue, [recipe.name])
 
         state_with_queue =
-          EditorState.update_shell_state(state, &%{&1 | tool_prompt_queue: queue})
+          EditorState.set_tool_prompt_queue(state, queue)
 
         maybe_show_tool_prompt(state_with_queue)
       else
@@ -145,11 +145,17 @@ defmodule MingaEditor.Handlers.ToolHandler do
   # returns to normal mode.
   @spec maybe_show_tool_prompt(EditorState.t()) :: EditorState.t()
   defp maybe_show_tool_prompt(
-         %{workspace: %{editing: %{mode: :normal}}, shell_state: %{tool_prompt_queue: pending}} =
-           state
+         %{
+           workspace: %{editing: %{mode: :normal}},
+           shell_runtime: %{state: %{tool_prompt_queue: pending}}
+         } = state
        )
        when pending != [] do
-    ms = %Minga.Mode.ToolConfirmState{pending: pending, declined: state.shell_state.tool_declined}
+    ms = %Minga.Mode.ToolConfirmState{
+      pending: pending,
+      declined: state.shell_runtime.state.tool_declined
+    }
+
     EditorState.transition_mode(state, :tool_confirm, ms)
   end
 

--- a/lib/minga_editor/inline_ask/events.ex
+++ b/lib/minga_editor/inline_ask/events.ex
@@ -41,7 +41,7 @@ defmodule MingaEditor.InlineAsk.Events do
   end
 
   @spec store(state()) :: InlineAsk.store() | nil
-  defp store(%{shell_state: %{inline_asks: asks}}) when is_map(asks), do: asks
+  defp store(%{shell_runtime: %{state: %{inline_asks: asks}}}) when is_map(asks), do: asks
   defp store(_state), do: nil
 
   @spec fail(InlineAsk.t(), term()) :: InlineAsk.t()

--- a/lib/minga_editor/inline_ask/render.ex
+++ b/lib/minga_editor/inline_ask/render.ex
@@ -80,6 +80,7 @@ defmodule MingaEditor.InlineAsk.Render do
   defp face(:help), do: Face.new(fg: 0x808080)
 
   @spec inline_asks(term()) :: InlineAsk.store()
+  defp inline_asks(%{shell_runtime: %{state: %{inline_asks: asks}}}) when is_map(asks), do: asks
   defp inline_asks(%{shell_state: %{inline_asks: asks}}) when is_map(asks), do: asks
   defp inline_asks(_state), do: %{}
 end

--- a/lib/minga_editor/inline_edit/events.ex
+++ b/lib/minga_editor/inline_edit/events.ex
@@ -41,7 +41,7 @@ defmodule MingaEditor.InlineEdit.Events do
   end
 
   @spec store(state()) :: InlineEdit.store() | nil
-  defp store(%{shell_state: %{inline_edits: edits}}) when is_map(edits), do: edits
+  defp store(%{shell_runtime: %{state: %{inline_edits: edits}}}) when is_map(edits), do: edits
   defp store(_state), do: nil
 
   @spec fail(InlineEdit.t(), term()) :: InlineEdit.t()

--- a/lib/minga_editor/inline_edit/render.ex
+++ b/lib/minga_editor/inline_edit/render.ex
@@ -80,6 +80,9 @@ defmodule MingaEditor.InlineEdit.Render do
   defp face(:help), do: Face.new(fg: 0x808080)
 
   @spec inline_edits(term()) :: InlineEdit.store()
+  defp inline_edits(%{shell_runtime: %{state: %{inline_edits: edits}}}) when is_map(edits),
+    do: edits
+
   defp inline_edits(%{shell_state: %{inline_edits: edits}}) when is_map(edits), do: edits
   defp inline_edits(_state), do: %{}
 end

--- a/lib/minga_editor/input/conflict_prompt.ex
+++ b/lib/minga_editor/input/conflict_prompt.ex
@@ -6,7 +6,7 @@ defmodule MingaEditor.Input.ConflictPrompt do
   responded yet, this handler intercepts all keys. `r` reloads the buffer
   from disk, `k` keeps the local version, and all other keys are swallowed.
 
-  The conflict prompt lives on `state.shell_state.modal` as
+  The conflict prompt lives on `state.shell_runtime.state.modal` as
   `{:conflict, %ModalOverlay.Conflict{}}`. While active, the gate's
   conflict-sticky rule prevents other modals from opening on top.
   """
@@ -23,7 +23,7 @@ defmodule MingaEditor.Input.ConflictPrompt do
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
   def handle_key(
-        %{shell_state: %{modal: {:conflict, %{buffer: buf}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:conflict, %{buffer: buf}}}}} = state,
         ?r,
         _mods
       )
@@ -38,7 +38,7 @@ defmodule MingaEditor.Input.ConflictPrompt do
   end
 
   def handle_key(
-        %{shell_state: %{modal: {:conflict, %{buffer: buf}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:conflict, %{buffer: buf}}}}} = state,
         ?k,
         _mods
       )
@@ -48,7 +48,7 @@ defmodule MingaEditor.Input.ConflictPrompt do
     {:handled, state |> ModalOverlay.dismiss() |> EditorState.clear_status()}
   end
 
-  def handle_key(%{shell_state: %{modal: {:conflict, _}}} = state, _cp, _mods) do
+  def handle_key(%{shell_runtime: %{state: %{modal: {:conflict, _}}}} = state, _cp, _mods) do
     # Swallow all other keys while conflict prompt is active
     {:handled, state}
   end

--- a/lib/minga_editor/input/cua/tui_space_leader.ex
+++ b/lib/minga_editor/input/cua/tui_space_leader.ex
@@ -30,7 +30,6 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
   alias Minga.Buffer
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias Minga.Keymap
   alias Minga.Keymap.Bindings
 
@@ -139,7 +138,7 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
   # ── Private ──────────────────────────────────────────────────────────────
 
   @spec pending?(map()) :: boolean()
-  defp pending?(%{shell_state: %{space_leader_pending: true}}), do: true
+  defp pending?(%{shell_runtime: %{state: %{space_leader_pending: true}}}), do: true
   defp pending?(_state), do: false
 
   @spec active_leader_node(EditorState.t()) :: Bindings.node_t() | nil
@@ -149,18 +148,18 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
 
   @spec put_space_leader_pending(EditorState.t(), boolean()) :: EditorState.t()
   defp put_space_leader_pending(state, value) do
-    EditorState.update_shell_state(state, &ShellState.set_space_leader_pending(&1, value))
+    EditorState.set_space_leader_pending(state, value)
   end
 
   @spec put_space_leader_timer(EditorState.t(), reference() | nil) :: EditorState.t()
   defp put_space_leader_timer(state, timer) do
-    EditorState.update_shell_state(state, &ShellState.set_space_leader_timer(&1, timer))
+    EditorState.set_space_leader_timer(state, timer)
   end
 
   @spec cancel_timer(EditorState.t()) :: EditorState.t()
-  defp cancel_timer(%{shell_state: %{space_leader_timer: nil}} = state), do: state
+  defp cancel_timer(%{shell_runtime: %{state: %{space_leader_timer: nil}}} = state), do: state
 
-  defp cancel_timer(%{shell_state: %{space_leader_timer: timer}} = state) do
+  defp cancel_timer(%{shell_runtime: %{state: %{space_leader_timer: timer}}} = state) do
     Process.cancel_timer(timer)
     put_space_leader_timer(state, nil)
   end

--- a/lib/minga_editor/input/hover.ex
+++ b/lib/minga_editor/input/hover.ex
@@ -29,33 +29,53 @@ defmodule MingaEditor.Input.Hover do
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
-  def handle_key(%{shell_state: %{hover_popup: nil}} = state, _codepoint, _modifiers) do
+  def handle_key(%{shell_runtime: %{state: %{hover_popup: nil}}} = state, _codepoint, _modifiers) do
     {:passthrough, state}
   end
 
   # K pressed while hover is visible but not focused: focus into it.
   # The frontend sends uppercase K as codepoint ?K (75) with no shift modifier,
   # matching how normal.ex binds {?K, 0} to :hover.
-  def handle_key(%{shell_state: %{hover_popup: %HoverPopup{focused: false}}} = state, ?K, 0) do
+  def handle_key(
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{focused: false}}}} = state,
+        ?K,
+        0
+      ) do
     {:handled,
-     EditorState.set_hover_popup(state, HoverPopup.focus(state.shell_state.hover_popup))}
+     EditorState.set_hover_popup(state, HoverPopup.focus(state.shell_runtime.state.hover_popup))}
   end
 
   # When focused, j scrolls down
-  def handle_key(%{shell_state: %{hover_popup: %HoverPopup{focused: true}}} = state, ?j, 0) do
+  def handle_key(
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{focused: true}}}} = state,
+        ?j,
+        0
+      ) do
     {:handled,
-     EditorState.set_hover_popup(state, HoverPopup.scroll_down(state.shell_state.hover_popup))}
+     EditorState.set_hover_popup(
+       state,
+       HoverPopup.scroll_down(state.shell_runtime.state.hover_popup)
+     )}
   end
 
   # When focused, k scrolls up
-  def handle_key(%{shell_state: %{hover_popup: %HoverPopup{focused: true}}} = state, ?k, 0) do
+  def handle_key(
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{focused: true}}}} = state,
+        ?k,
+        0
+      ) do
     {:handled,
-     EditorState.set_hover_popup(state, HoverPopup.scroll_up(state.shell_state.hover_popup))}
+     EditorState.set_hover_popup(
+       state,
+       HoverPopup.scroll_up(state.shell_runtime.state.hover_popup)
+     )}
   end
 
   # When focused, Enter accepts the popup's Open action when one exists.
   def handle_key(
-        %{shell_state: %{hover_popup: %HoverPopup{focused: true, open_action: action}}} = state,
+        %{
+          shell_runtime: %{state: %{hover_popup: %HoverPopup{focused: true, open_action: action}}}
+        } = state,
         @key_enter,
         _mods
       )
@@ -66,7 +86,7 @@ defmodule MingaEditor.Input.Hover do
 
   # When focused, o toggles an expandable popup (e.g. full vs truncated thinking).
   def handle_key(
-        %{shell_state: %{hover_popup: %HoverPopup{focused: true} = popup}} = state,
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{focused: true} = popup}}} = state,
         ?o,
         0
       ) do
@@ -78,12 +98,16 @@ defmodule MingaEditor.Input.Hover do
   end
 
   # When focused, q or Escape dismisses
-  def handle_key(%{shell_state: %{hover_popup: %HoverPopup{focused: true}}} = state, ?q, 0) do
+  def handle_key(
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{focused: true}}}} = state,
+        ?q,
+        0
+      ) do
     {:handled, EditorState.dismiss_hover_popup(state)}
   end
 
   def handle_key(
-        %{shell_state: %{hover_popup: %HoverPopup{focused: true}}} = state,
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{focused: true}}}} = state,
         @key_escape,
         _mods
       ) do
@@ -91,12 +115,20 @@ defmodule MingaEditor.Input.Hover do
   end
 
   # When focused, any other key dismisses and passes through
-  def handle_key(%{shell_state: %{hover_popup: %HoverPopup{focused: true}}} = state, _cp, _mods) do
+  def handle_key(
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{focused: true}}}} = state,
+        _cp,
+        _mods
+      ) do
     {:passthrough, EditorState.dismiss_hover_popup(state)}
   end
 
   # Not focused: any key dismisses and passes through
-  def handle_key(%{shell_state: %{hover_popup: %HoverPopup{focused: false}}} = state, _cp, _mods) do
+  def handle_key(
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{focused: false}}}} = state,
+        _cp,
+        _mods
+      ) do
     {:passthrough, EditorState.dismiss_hover_popup(state)}
   end
 
@@ -130,7 +162,7 @@ defmodule MingaEditor.Input.Hover do
         ) :: MingaEditor.Input.Handler.result()
 
   def handle_mouse(
-        %{shell_state: %{hover_popup: nil}} = state,
+        %{shell_runtime: %{state: %{hover_popup: nil}}} = state,
         _row,
         _col,
         _btn,
@@ -145,7 +177,7 @@ defmodule MingaEditor.Input.Hover do
   # wheel events when the pointer is inside its rect (scroll routing), so scrolling
   # works whether or not the popup is keyboard-focused (#2629, AC-3).
   def handle_mouse(
-        %{shell_state: %{hover_popup: %HoverPopup{}}} = state,
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{}}}} = state,
         _r,
         _c,
         :wheel_down,
@@ -154,11 +186,14 @@ defmodule MingaEditor.Input.Hover do
         _cc
       ) do
     {:handled,
-     EditorState.set_hover_popup(state, HoverPopup.scroll_down(state.shell_state.hover_popup))}
+     EditorState.set_hover_popup(
+       state,
+       HoverPopup.scroll_down(state.shell_runtime.state.hover_popup)
+     )}
   end
 
   def handle_mouse(
-        %{shell_state: %{hover_popup: %HoverPopup{}}} = state,
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{}}}} = state,
         _r,
         _c,
         :wheel_up,
@@ -167,14 +202,17 @@ defmodule MingaEditor.Input.Hover do
         _cc
       ) do
     {:handled,
-     EditorState.set_hover_popup(state, HoverPopup.scroll_up(state.shell_state.hover_popup))}
+     EditorState.set_hover_popup(
+       state,
+       HoverPopup.scroll_up(state.shell_runtime.state.hover_popup)
+     )}
   end
 
   # A click inside the popup focuses it for scrolling rather than dismissing it
   # (#2629, AC-4). This clause only runs when the pointer hit the popup rect, so a
   # click outside still falls through to the buffer (which dismisses on motion).
   def handle_mouse(
-        %{shell_state: %{hover_popup: %HoverPopup{}}} = state,
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{}}}} = state,
         _r,
         _c,
         :left,
@@ -183,13 +221,13 @@ defmodule MingaEditor.Input.Hover do
         _cc
       ) do
     {:handled,
-     EditorState.set_hover_popup(state, HoverPopup.focus(state.shell_state.hover_popup))}
+     EditorState.set_hover_popup(state, HoverPopup.focus(state.shell_runtime.state.hover_popup))}
   end
 
   # Pointer motion inside the popup keeps it alive (#2629, AC-1). Swallowing the
   # event here stops it bubbling to the buffer handler that would dismiss it.
   def handle_mouse(
-        %{shell_state: %{hover_popup: %HoverPopup{}}} = state,
+        %{shell_runtime: %{state: %{hover_popup: %HoverPopup{}}}} = state,
         _r,
         _c,
         _btn,

--- a/lib/minga_editor/input/interrupt.ex
+++ b/lib/minga_editor/input/interrupt.ex
@@ -123,7 +123,7 @@ defmodule MingaEditor.Input.Interrupt do
 
   @spec maybe_clear_whichkey(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
   defp maybe_clear_whichkey(
-         %{shell_state: %{whichkey: %WhichKey{node: nil, show: false}}} = state,
+         %{shell_runtime: %{state: %{whichkey: %WhichKey{node: nil, show: false}}}} = state,
          resets
        ),
        do: {state, resets}
@@ -146,7 +146,8 @@ defmodule MingaEditor.Input.Interrupt do
   end
 
   @spec maybe_clear_status(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
-  defp maybe_clear_status(%{shell_state: %{status_msg: nil}} = state, resets), do: {state, resets}
+  defp maybe_clear_status(%{shell_runtime: %{state: %{status_msg: nil}}} = state, resets),
+    do: {state, resets}
 
   defp maybe_clear_status(state, resets) do
     {EditorState.clear_status(state), ["status cleared" | resets]}

--- a/lib/minga_editor/input/observatory.ex
+++ b/lib/minga_editor/input/observatory.ex
@@ -59,7 +59,7 @@ defmodule MingaEditor.Input.Observatory do
   end
 
   @spec find_process_class(state(), pid()) :: process_class()
-  defp find_process_class(%{shell_state: %{observatory_data: %{tree: tree}}}, pid) do
+  defp find_process_class(%{shell_runtime: %{state: %{observatory_data: %{tree: tree}}}}, pid) do
     tree
     |> Minga.SystemObserver.TreeNode.flatten()
     |> Enum.find_value(:worker, fn node ->

--- a/lib/minga_editor/input/picker.ex
+++ b/lib/minga_editor/input/picker.ex
@@ -23,7 +23,7 @@ defmodule MingaEditor.Input.Picker do
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
   def handle_key(state, codepoint, modifiers) do
-    if ModalOverlay.match(state.shell_state.modal, :picker) do
+    if ModalOverlay.match(state.shell_runtime.state.modal, :picker) do
       new_state =
         case PickerUI.handle_key(state, codepoint, modifiers) do
           {s, {:execute_command, cmd}} -> MingaEditor.dispatch_command(s, cmd)
@@ -72,8 +72,10 @@ defmodule MingaEditor.Input.Picker do
   # Picker active: intercept scroll and clicks routed by the focus tree.
   def handle_mouse_at_node(
         %{
-          shell_state: %{
-            modal: {:picker, %{picker_ui: %{picker: %PickerData{} = picker, source: source}}}
+          shell_runtime: %{
+            state: %{
+              modal: {:picker, %{picker_ui: %{picker: %PickerData{} = picker, source: source}}}
+            }
           }
         } = state,
         %FocusNode{} = node,
@@ -134,7 +136,7 @@ defmodule MingaEditor.Input.Picker do
          _source,
          _row
        ) do
-    {:picker, %{picker_ui: %{layout: layout}}} = state.shell_state.modal
+    {:picker, %{picker_ui: %{layout: layout}}} = state.shell_runtime.state.modal
 
     case layout do
       :centered -> PickerUI.close(state)
@@ -149,7 +151,7 @@ defmodule MingaEditor.Input.Picker do
   @spec handle_picker_click(EditorState.t(), FocusNode.t(), PickerData.t(), module(), integer()) ::
           EditorState.t()
   defp handle_picker_click(state, node, picker, source, row) do
-    {:picker, %{picker_ui: %{layout: layout}}} = state.shell_state.modal
+    {:picker, %{picker_ui: %{layout: layout}}} = state.shell_runtime.state.modal
 
     case clicked_item(layout, state, node, picker, row) do
       nil -> state

--- a/lib/minga_editor/input/prompt.ex
+++ b/lib/minga_editor/input/prompt.ex
@@ -19,8 +19,10 @@ defmodule MingaEditor.Input.Prompt do
           MingaEditor.Input.Handler.result()
   def handle_key(
         %{
-          shell_state: %{
-            modal: {:prompt, %{prompt_ui: %PromptState{handler: handler}}}
+          shell_runtime: %{
+            state: %{
+              modal: {:prompt, %{prompt_ui: %PromptState{handler: handler}}}
+            }
           }
         } = state,
         codepoint,

--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -21,6 +21,8 @@ defmodule MingaEditor.Input.Router do
   alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.KeystrokeHistory
   alias MingaEditor.LspActions
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Traditional
   alias MingaEditor.State, as: EditorState
 
   @typedoc "Pre-action snapshot for housekeeping comparisons."
@@ -126,10 +128,10 @@ defmodule MingaEditor.Input.Router do
   # If none consume the key, delegates to surface handlers (Scoped, GlobalBindings, ModeFSM).
   @spec dispatch_split(EditorState.t(), non_neg_integer(), non_neg_integer()) :: EditorState.t()
   defp dispatch_split(%EditorState{} = state, codepoint, modifiers) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     %{overlay: overlay_handlers, surface: _surface} =
-      EditorState.active_shell_module(state).input_handlers(state)
+      MingaEditor.Shell.Runtime.module(state.shell_runtime).input_handlers(state)
 
     case walk_handlers_until_passthrough(overlay_handlers, state, codepoint, modifiers) do
       {:handled, new_state} ->
@@ -152,7 +154,8 @@ defmodule MingaEditor.Input.Router do
          codepoint,
          modifiers
        ) do
-    %{surface: surface_handlers} = EditorState.active_shell_module(state).input_handlers(state)
+    %{surface: surface_handlers} =
+      MingaEditor.Shell.Runtime.module(state.shell_runtime).input_handlers(state)
 
     Enum.reduce_while(surface_handlers, state, fn handler, acc ->
       case handler.handle_key(acc, codepoint, modifiers) do
@@ -212,9 +215,21 @@ defmodule MingaEditor.Input.Router do
     }
 
     state
-    |> MingaEditor.do_maybe_handle_completion(was_inserting, codepoint, modifiers)
+    |> maybe_handle_completion(was_inserting, codepoint, modifiers)
     |> post_action_housekeeping(snapshot)
   end
+
+  @spec maybe_handle_completion(EditorState.t(), boolean(), non_neg_integer(), non_neg_integer()) ::
+          EditorState.t()
+  defp maybe_handle_completion(
+         %EditorState{shell_runtime: %{entry: %Entry{module: Traditional}}} = state,
+         was_inserting,
+         codepoint,
+         modifiers
+       ),
+       do: MingaEditor.do_maybe_handle_completion(state, was_inserting, codepoint, modifiers)
+
+  defp maybe_handle_completion(state, _was_inserting, _codepoint, _modifiers), do: state
 
   # Clears selection range state when leaving visual mode by any means.
   # This ensures the stored selection range chain doesn't linger after
@@ -322,7 +337,7 @@ defmodule MingaEditor.Input.Router do
         click_count
       )
       when event_type in [:drag, :release] do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
     MingaEditor.Mouse.handle(state, row, col, :left, mods, event_type, click_count)
   end
 
@@ -332,7 +347,7 @@ defmodule MingaEditor.Input.Router do
   end
 
   def dispatch_mouse(state, row, col, button, mods, event_type, click_count) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     event = %{
       row: row,

--- a/lib/minga_editor/input/signature_help.ex
+++ b/lib/minga_editor/input/signature_help.ex
@@ -22,27 +22,29 @@ defmodule MingaEditor.Input.SignatureHelp do
   @impl true
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) ::
           MingaEditor.Input.Handler.result()
-  def handle_key(%{shell_state: %{signature_help: nil}} = state, _cp, _mods) do
+  def handle_key(%{shell_runtime: %{state: %{signature_help: nil}}} = state, _cp, _mods) do
     {:passthrough, state}
   end
 
   # C-j: next signature overload
-  def handle_key(%{shell_state: %{signature_help: %SigHelp{} = sh}} = state, ?j, mods)
+  def handle_key(%{shell_runtime: %{state: %{signature_help: %SigHelp{} = sh}}} = state, ?j, mods)
       when band(mods, @ctrl) != 0 do
-    {:handled,
-     EditorState.update_shell_state(state, &%{&1 | signature_help: SigHelp.next_signature(sh)})}
+    {:handled, EditorState.set_signature_help(state, SigHelp.next_signature(sh))}
   end
 
   # C-k: previous signature overload
-  def handle_key(%{shell_state: %{signature_help: %SigHelp{} = sh}} = state, ?k, mods)
+  def handle_key(%{shell_runtime: %{state: %{signature_help: %SigHelp{} = sh}}} = state, ?k, mods)
       when band(mods, @ctrl) != 0 do
-    {:handled,
-     EditorState.update_shell_state(state, &%{&1 | signature_help: SigHelp.prev_signature(sh)})}
+    {:handled, EditorState.set_signature_help(state, SigHelp.prev_signature(sh))}
   end
 
   # Escape: dismiss signature help
-  def handle_key(%{shell_state: %{signature_help: %SigHelp{}}} = state, @key_escape, _mods) do
-    {:handled, EditorState.update_shell_state(state, &%{&1 | signature_help: nil})}
+  def handle_key(
+        %{shell_runtime: %{state: %{signature_help: %SigHelp{}}}} = state,
+        @key_escape,
+        _mods
+      ) do
+    {:handled, EditorState.set_signature_help(state, nil)}
   end
 
   # All other keys: pass through (signature help stays visible while typing)

--- a/lib/minga_editor/key_dispatch.ex
+++ b/lib/minga_editor/key_dispatch.ex
@@ -109,10 +109,10 @@ defmodule MingaEditor.KeyDispatch do
     # When leaving :tool_confirm, check if more tools were queued during
     # the session and re-enter :tool_confirm to prompt for them.
     if old_mode == :tool_confirm and CoreEditing.mode(result) == :normal and
-         result.shell_state.tool_prompt_queue != [] do
+         result.shell_runtime.state.tool_prompt_queue != [] do
       ms = %Minga.Mode.ToolConfirmState{
-        pending: result.shell_state.tool_prompt_queue,
-        declined: result.shell_state.tool_declined
+        pending: result.shell_runtime.state.tool_prompt_queue,
+        declined: result.shell_runtime.state.tool_declined
       }
 
       EditorState.transition_mode(result, :tool_confirm, ms)
@@ -254,7 +254,7 @@ defmodule MingaEditor.KeyDispatch do
   end
 
   defp sync_command_completion_overlay(state, :command, new_mode) when new_mode != :command do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       {:command_completion, _} -> ModalOverlay.close(state)
       _ -> state
     end

--- a/lib/minga_editor/layout.ex
+++ b/lib/minga_editor/layout.ex
@@ -95,16 +95,16 @@ defmodule MingaEditor.Layout do
   """
   @spec get(EditorState.t() | map()) :: t()
   def get(%EditorState{} = state) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     case state.layout do
       %__MODULE__{} = cached -> cached
-      _other -> EditorState.active_shell_module(state).compute_layout(state)
+      _other -> MingaEditor.Shell.Runtime.module(state.shell_runtime).compute_layout(state)
     end
   end
 
   def get(%{layout: %__MODULE__{} = cached}), do: cached
-  def get(state), do: EditorState.active_shell_module(state).compute_layout(state)
+  def get(%{shell: shell} = state) when is_atom(shell), do: shell.compute_layout(state)
 
   @doc """
   Computes the layout and stores it in state for reuse within the same frame.
@@ -114,14 +114,14 @@ defmodule MingaEditor.Layout do
   """
   @spec put(EditorState.t() | map()) :: map()
   def put(%EditorState{} = state) do
-    state = EditorState.ensure_shell_available(state)
-    layout = EditorState.active_shell_module(state).compute_layout(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
+    layout = MingaEditor.Shell.Runtime.module(state.shell_runtime).compute_layout(state)
     state = %{state | layout: layout}
     %{state | focus_tree: FocusTree.from_state(state)}
   end
 
-  def put(state) do
-    layout = EditorState.active_shell_module(state).compute_layout(state)
+  def put(%{shell: shell} = state) when is_atom(shell) do
+    layout = shell.compute_layout(state)
     state = %{state | layout: layout}
     %{state | focus_tree: FocusTree.from_state(state)}
   end
@@ -141,13 +141,11 @@ defmodule MingaEditor.Layout do
   """
   @spec compute(EditorState.t() | map()) :: t()
   def compute(%EditorState{} = state) do
-    state = EditorState.ensure_shell_available(state)
-    EditorState.active_shell_module(state).compute_layout(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
+    MingaEditor.Shell.Runtime.module(state.shell_runtime).compute_layout(state)
   end
 
-  def compute(state) do
-    EditorState.active_shell_module(state).compute_layout(state)
-  end
+  def compute(%{shell: shell} = state) when is_atom(shell), do: shell.compute_layout(state)
 
   # ── Shared helpers (used by Layout.GUI) ────────────────────────────────────
 

--- a/lib/minga_editor/layout/footer_overlays.ex
+++ b/lib/minga_editor/layout/footer_overlays.ex
@@ -136,6 +136,10 @@ defmodule MingaEditor.Layout.FooterOverlays do
   defp notification_actions?(_item), do: false
 
   @spec content_height_observatory(map()) :: non_neg_integer()
+  defp content_height_observatory(%{shell_runtime: %{state: shell_state}}) do
+    content_height_observatory(%{shell_state: shell_state})
+  end
+
   defp content_height_observatory(%{shell_state: %{observatory_data: %{tree: tree}}}) do
     1 + Enum.count(Minga.SystemObserver.TreeNode.flatten(tree))
   end
@@ -169,7 +173,15 @@ defmodule MingaEditor.Layout.FooterOverlays do
   # Float popup: an observatory inspection float, or a window carrying a :float
   # popup rule. Mirrors MingaEditor.RenderModel.UI.FloatPopupBuilder.
   @spec float_popup_visible?(map()) :: boolean()
-  defp float_popup_visible?(%{shell_state: %{observatory_inspection: %{visible: true}}}), do: true
+  defp float_popup_visible?(%{shell_runtime: %{state: shell_state}} = state) do
+    state
+    |> Map.delete(:shell_runtime)
+    |> Map.put(:shell_state, shell_state)
+    |> float_popup_visible?()
+  end
+
+  defp float_popup_visible?(%{shell_state: %{observatory_inspection: %{visible: true}}}),
+    do: true
 
   defp float_popup_visible?(%{workspace: %{windows: %{map: map}}}) when is_map(map) do
     Enum.any?(map, fn
@@ -212,6 +224,9 @@ defmodule MingaEditor.Layout.FooterOverlays do
   # Observatory: the BEAM observatory panel is toggled on in shell_state.
   # Mirrors MingaEditor.RenderModel.UI.ObservatoryBuilder.
   @spec observatory_visible?(map()) :: boolean()
+  defp observatory_visible?(%{shell_runtime: %{state: shell_state}}),
+    do: observatory_visible?(%{shell_state: shell_state})
+
   defp observatory_visible?(%{shell_state: %{observatory_visible: true}}), do: true
   defp observatory_visible?(_state), do: false
 

--- a/lib/minga_editor/minibuffer_data.ex
+++ b/lib/minga_editor/minibuffer_data.ex
@@ -12,6 +12,7 @@ defmodule MingaEditor.MinibufferData do
   """
 
   alias Minga.Command
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Prompt, as: PromptState
   alias Minga.Keymap
@@ -89,21 +90,27 @@ defmodule MingaEditor.MinibufferData do
   Returns a `t()` struct ready for protocol encoding via
   `MingaEditor.Frontend.Protocol.GUI.encode_gui_minibuffer/1`.
   """
-  @spec from_state(EditorState.t()) :: t()
+  @spec from_state(EditorState.t() | map()) :: t()
+
+  def from_state(%EditorState{pending_quit: kind, shell_runtime: %Runtime{state: shell_state}})
+      when kind in [:quit, :quit_all] do
+    confirmation_prompt(kind, shell_state)
+  end
 
   def from_state(%{pending_quit: kind, shell_state: shell_state})
       when kind in [:quit, :quit_all] do
-    %__MODULE__{
-      visible: true,
-      mode: @mode_extension_confirm,
-      cursor_pos: 0xFFFF,
-      prompt: quit_confirmation_prompt(kind, shell_state),
-      input: "",
-      context: "",
-      selected_index: 0,
-      candidates: [],
-      total_candidates: 0
-    }
+    confirmation_prompt(kind, shell_state)
+  end
+
+  def from_state(%EditorState{
+        shell_runtime: %Runtime{
+          state: %{
+            modal: {:prompt, %{prompt_ui: %PromptState{handler: handler} = prompt_state}}
+          }
+        }
+      })
+      when handler != nil do
+    text_prompt(prompt_state)
   end
 
   def from_state(%{
@@ -112,17 +119,7 @@ defmodule MingaEditor.MinibufferData do
         }
       })
       when handler != nil do
-    %__MODULE__{
-      visible: true,
-      mode: @mode_text_prompt,
-      cursor_pos: prompt_state.cursor,
-      prompt: prompt_state.label,
-      input: prompt_state.text,
-      context: "",
-      selected_index: 0,
-      candidates: [],
-      total_candidates: 0
-    }
+    text_prompt(prompt_state)
   end
 
   def from_state(%{workspace: %{editing: %{mode: :command, mode_state: ms}}} = state) do
@@ -277,6 +274,36 @@ defmodule MingaEditor.MinibufferData do
 
   # ── Private helpers ────────────────────────────────────────────────────────
 
+  @spec confirmation_prompt(:quit | :quit_all, term()) :: t()
+  defp confirmation_prompt(kind, shell_state) do
+    %__MODULE__{
+      visible: true,
+      mode: @mode_extension_confirm,
+      cursor_pos: 0xFFFF,
+      prompt: quit_confirmation_prompt(kind, shell_state),
+      input: "",
+      context: "",
+      selected_index: 0,
+      candidates: [],
+      total_candidates: 0
+    }
+  end
+
+  @spec text_prompt(PromptState.t()) :: t()
+  defp text_prompt(prompt_state) do
+    %__MODULE__{
+      visible: true,
+      mode: @mode_text_prompt,
+      cursor_pos: prompt_state.cursor,
+      prompt: prompt_state.label,
+      input: prompt_state.text,
+      context: "",
+      selected_index: 0,
+      candidates: [],
+      total_candidates: 0
+    }
+  end
+
   @spec search_mode_and_prefix(:forward | :backward) ::
           {non_neg_integer(), String.t()}
   defp search_mode_and_prefix(:forward), do: {@mode_search_forward, "/"}
@@ -349,6 +376,9 @@ defmodule MingaEditor.MinibufferData do
   # back to computing only when the overlay is absent or stale (e.g. the first
   # frame on entry, or a programmatic input change the dispatcher hasn't synced).
   @spec command_candidates(map(), String.t()) :: {[candidate()], non_neg_integer()}
+  defp command_candidates(%{shell_runtime: %{state: shell_state}}, input),
+    do: command_candidates(%{shell_state: shell_state}, input)
+
   defp command_candidates(
          %{
            shell_state: %{

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -502,7 +502,7 @@ defmodule MingaEditor.Mouse do
   # thrash and dismissing it would defeat the point. Anywhere else, motion
   # (re)starts the hover debounce, dismissing a stale popup first.
   @spec handle_hover_motion(state(), integer(), integer()) :: state()
-  defp handle_hover_motion(%{shell_state: %{hover_popup: nil}} = state, row, col) do
+  defp handle_hover_motion(%{shell_runtime: %{state: %{hover_popup: nil}}} = state, row, col) do
     update_mouse(state, &MouseState.set_hover(&1, row, col, backend: state.backend))
   end
 
@@ -1793,7 +1793,7 @@ defmodule MingaEditor.Mouse do
 
   @spec close_tab_at(state(), non_neg_integer(), non_neg_integer()) :: state()
   defp close_tab_at(state, row, col) do
-    case find_tab_bar_region(state.shell_state.tab_bar_click_regions, row, col) do
+    case find_tab_bar_region(state.shell_runtime.state.tab_bar_click_regions, row, col) do
       {:command, cmd} -> close_tab_by_command(state, cmd)
       :not_tab_bar -> state
     end
@@ -1847,7 +1847,7 @@ defmodule MingaEditor.Mouse do
           {:command, tab_command()} | :not_tab_bar
   defp tab_bar_click(state, row, col) do
     if SurfaceRegistry.within?(state, :tab_bar, row, col) do
-      find_tab_bar_region(state.shell_state.tab_bar_click_regions, row, col)
+      find_tab_bar_region(state.shell_runtime.state.tab_bar_click_regions, row, col)
     else
       :not_tab_bar
     end
@@ -1897,7 +1897,7 @@ defmodule MingaEditor.Mouse do
       end)
 
     if is_modeline do
-      find_click_region(state.shell_state.modeline_click_regions, col)
+      find_click_region(state.shell_runtime.state.modeline_click_regions, col)
     else
       :not_modeline
     end

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -168,7 +168,11 @@ defmodule MingaEditor.PickerUI do
 
   # Esc or C-g in action menu → close menu, return to picker
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {_actions, _sel}}}}}} =
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %{action_menu: {_actions, _sel}}}}}
+          }
+        } =
           state,
         @escape,
         _mods
@@ -177,7 +181,11 @@ defmodule MingaEditor.PickerUI do
   end
 
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {_actions, _sel}}}}}} =
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %{action_menu: {_actions, _sel}}}}}
+          }
+        } =
           state,
         ?g,
         mods
@@ -189,10 +197,12 @@ defmodule MingaEditor.PickerUI do
   # Enter in action menu → execute selected action
   def handle_key(
         %{
-          shell_state: %{
-            modal:
-              {:picker,
-               %{picker_ui: %{action_menu: {actions, sel}, picker: picker, source: source}}}
+          shell_runtime: %{
+            state: %{
+              modal:
+                {:picker,
+                 %{picker_ui: %{action_menu: {actions, sel}, picker: picker, source: source}}}
+            }
           }
         } = state,
         @enter,
@@ -214,7 +224,11 @@ defmodule MingaEditor.PickerUI do
 
   # Arrow down / C-j / C-n in action menu → move selection down
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {actions, sel}}}}}} = state,
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %{action_menu: {actions, sel}}}}}
+          }
+        } = state,
         cp,
         mods
       )
@@ -227,7 +241,11 @@ defmodule MingaEditor.PickerUI do
 
   # Arrow up / C-k / C-p in action menu → move selection up
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {actions, sel}}}}}} = state,
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %{action_menu: {actions, sel}}}}}
+          }
+        } = state,
         cp,
         mods
       )
@@ -240,7 +258,11 @@ defmodule MingaEditor.PickerUI do
 
   # Ignore all other keys while action menu is open
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{action_menu: {_actions, _sel}}}}}} =
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %{action_menu: {_actions, _sel}}}}}
+          }
+        } =
           state,
         _cp,
         _mods
@@ -250,7 +272,7 @@ defmodule MingaEditor.PickerUI do
   # ── Normal picker handlers ─────────────────────────────────────────────────
 
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{source: source}}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{source: source}}}}}} = state,
         @escape,
         _mods
       ) do
@@ -260,7 +282,7 @@ defmodule MingaEditor.PickerUI do
 
   # C-g → cancel (Emacs-style)
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{source: source}}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{source: source}}}}}} = state,
         ?g,
         mods
       )
@@ -270,7 +292,11 @@ defmodule MingaEditor.PickerUI do
   end
 
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}
+          }
+        } =
           state,
         @enter,
         _mods
@@ -283,7 +309,7 @@ defmodule MingaEditor.PickerUI do
 
   # C-j, C-n, or arrow down → move selection down
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}}} = state,
         cp,
         mods
       )
@@ -297,7 +323,7 @@ defmodule MingaEditor.PickerUI do
 
   # C-k, C-p, or arrow up → move selection up
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}}} = state,
         cp,
         mods
       )
@@ -311,7 +337,7 @@ defmodule MingaEditor.PickerUI do
 
   # C-v → page down
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}}} = state,
         ?v,
         mods
       )
@@ -323,7 +349,7 @@ defmodule MingaEditor.PickerUI do
 
   # M-v (Alt+v) → page up
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}}} = state,
         ?v,
         mods
       )
@@ -335,7 +361,7 @@ defmodule MingaEditor.PickerUI do
 
   # Tab → toggle multi-select mark on current item, then move down
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}}} = state,
         9,
         _mods
       ) do
@@ -345,7 +371,11 @@ defmodule MingaEditor.PickerUI do
 
   # C-o → open action menu for the selected item
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}
+          }
+        } =
           state,
         ?o,
         mods
@@ -369,7 +399,11 @@ defmodule MingaEditor.PickerUI do
   # normal picker filtering, including sources that define alternative delete
   # actions for other purposes.
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}
+          }
+        } =
           state,
         ?d,
         mods
@@ -394,10 +428,12 @@ defmodule MingaEditor.PickerUI do
   # Backspace (with mode-switch detection: if query becomes empty and we're in a switched mode, switch back)
   def handle_key(
         %{
-          shell_state: %{
-            modal:
-              {:picker,
-               %{picker_ui: %{picker: picker, mode_prefix: prefix, original_source: orig}}}
+          shell_runtime: %{
+            state: %{
+              modal:
+                {:picker,
+                 %{picker_ui: %{picker: picker, mode_prefix: prefix, original_source: orig}}}
+            }
           }
         } = state,
         cp,
@@ -417,7 +453,7 @@ defmodule MingaEditor.PickerUI do
 
   # Printable characters → filter (with mode-switch detection)
   def handle_key(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}} = state,
+        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}}} = state,
         codepoint,
         0
       )
@@ -606,11 +642,17 @@ defmodule MingaEditor.PickerUI do
   to update item status after an action.
   """
   @spec refresh_items(state()) :: state()
-  def refresh_items(%{shell_state: %{modal: {:picker, %{picker_ui: %{picker: nil}}}}} = state),
-    do: state
+  def refresh_items(
+        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{picker: nil}}}}}} = state
+      ),
+      do: state
 
   def refresh_items(
-        %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}
+          }
+        } =
           state
       ) do
     ctx = Context.from_editor_state(state)
@@ -635,7 +677,7 @@ defmodule MingaEditor.PickerUI do
   """
   @spec update_picker(state(), (PickerState.t() -> PickerState.t())) :: state()
   def update_picker(state, fun) do
-    {:picker, payload} = state.shell_state.modal
+    {:picker, payload} = state.shell_runtime.state.modal
     new_pui = fun.(payload.picker_ui)
     ModalOverlay.transition(state, :picker, PickerPayload.put_picker_ui(payload, new_pui))
   end
@@ -647,7 +689,7 @@ defmodule MingaEditor.PickerUI do
   @spec maybe_switch_mode(state(), String.t(), String.t()) ::
           {:switched, state()} | :no_switch
   defp maybe_switch_mode(
-         %{shell_state: %{modal: {:picker, %{picker_ui: %{source: source}}}}} = state,
+         %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{source: source}}}}}} = state,
          char,
          query
        ) do
@@ -665,8 +707,11 @@ defmodule MingaEditor.PickerUI do
   @spec switch_to_source(state(), module(), String.t()) :: state()
   defp switch_to_source(
          %{
-           shell_state: %{
-             modal: {:picker, %{picker_ui: %{source: current_source, original_source: orig_src}}}
+           shell_runtime: %{
+             state: %{
+               modal:
+                 {:picker, %{picker_ui: %{source: current_source, original_source: orig_src}}}
+             }
            }
          } = state,
          new_source,
@@ -695,7 +740,8 @@ defmodule MingaEditor.PickerUI do
   # Switch back to the original source after the prefix is deleted.
   @spec switch_back_to_original(state()) :: state()
   defp switch_back_to_original(
-         %{shell_state: %{modal: {:picker, %{picker_ui: %{original_source: orig}}}}} = state
+         %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{original_source: orig}}}}}} =
+           state
        ) do
     ctx = Context.from_editor_state(state)
     items = orig.candidates(ctx)
@@ -723,7 +769,7 @@ defmodule MingaEditor.PickerUI do
   # the original buffer, not the preview buffer currently shown in the window.
   @spec restore_picker_origin(state()) :: state()
   defp restore_picker_origin(
-         %{shell_state: %{modal: {:picker, %{picker_ui: %{restore: idx}}}}} = state
+         %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{restore: idx}}}}}} = state
        )
        when is_integer(idx) do
     EditorState.switch_buffer(state, idx)
@@ -735,7 +781,7 @@ defmodule MingaEditor.PickerUI do
   # what it was when the picker opened (stored in the picker payload's `restore` field).
   @spec previewed?(state()) :: boolean()
   defp previewed?(%{
-         shell_state: %{modal: {:picker, %{picker_ui: %{restore: restore}}}},
+         shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{restore: restore}}}}},
          workspace: %{buffers: bs}
        })
        when is_integer(restore) do
@@ -749,7 +795,11 @@ defmodule MingaEditor.PickerUI do
   # the current tab in-place instead of creating a new tab.
   @spec maybe_preview_selection(state()) :: state()
   defp maybe_preview_selection(
-         %{shell_state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}} =
+         %{
+           shell_runtime: %{
+             state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}
+           }
+         } =
            state
        ) do
     if Picker.Source.live_preview?(source) do

--- a/lib/minga_editor/prompt_ui.ex
+++ b/lib/minga_editor/prompt_ui.ex
@@ -84,7 +84,7 @@ defmodule MingaEditor.PromptUI do
   Returns true if a prompt is currently open.
   """
   @spec open?(state()) :: boolean()
-  def open?(state), do: ModalOverlay.match(state.shell_state.modal, :prompt)
+  def open?(state), do: ModalOverlay.match(state.shell_runtime.state.modal, :prompt)
 
   @doc """
   Handles a key event while the prompt is active.
@@ -94,7 +94,7 @@ defmodule MingaEditor.PromptUI do
   """
   @spec handle_key(state(), non_neg_integer(), non_neg_integer()) :: {state(), action()}
   def handle_key(state, key, _mods) do
-    {:prompt, %{prompt_ui: prompt}} = state.shell_state.modal
+    {:prompt, %{prompt_ui: prompt}} = state.shell_runtime.state.modal
 
     case key do
       @escape ->
@@ -147,7 +147,7 @@ defmodule MingaEditor.PromptUI do
   """
   @spec update_prompt(state(), (PromptState.t() -> PromptState.t())) :: state()
   def update_prompt(state, fun) do
-    {:prompt, payload} = state.shell_state.modal
+    {:prompt, payload} = state.shell_runtime.state.modal
     new_pui = fun.(payload.prompt_ui)
     ModalOverlay.transition(state, :prompt, PromptPayload.put_prompt_ui(payload, new_pui))
   end
@@ -156,7 +156,7 @@ defmodule MingaEditor.PromptUI do
 
   @spec current_prompt(state()) :: PromptState.t()
   defp current_prompt(state) do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       {:prompt, %{prompt_ui: prompt}} -> prompt
       _ -> %PromptState{}
     end

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -39,7 +39,7 @@ defmodule MingaEditor.RenderPipeline.Input do
   `test/minga_editor/render_pipeline/input_launchpad_test.exs` — a field in
   neither silently disappears on the async render path (#2689).
 
-  Note: completion lives on `state.shell_state.modal` after #1426; the
+  Note: completion lives on `state.shell_runtime.state.modal` after #1426; the
   fingerprint includes the modal sum type, so completion changes are
   picked up there.
   """
@@ -60,6 +60,7 @@ defmodule MingaEditor.RenderPipeline.Input do
   alias MingaEditor.State.LSP, as: LSPState
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Renderer.Caches
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.UI.FontRegistry
   alias MingaEditor.UI.NotificationCenter
   alias MingaEditor.UI.Panel.MessageStore
@@ -146,7 +147,7 @@ defmodule MingaEditor.RenderPipeline.Input do
           port_manager: GenServer.server() | nil,
           theme: Theme.t(),
           capabilities: Capabilities.t(),
-          shell_id: EditorState.shell_id(),
+          shell_id: atom(),
           shell: module(),
           shell_identity: MingaEditor.Shell.Identity.t() | nil,
           shell_state: term(),
@@ -189,10 +190,10 @@ defmodule MingaEditor.RenderPipeline.Input do
       port_manager: state.port_manager,
       theme: state.theme,
       capabilities: state.capabilities,
-      shell_id: state.shell_id,
-      shell: EditorState.active_shell_module(state),
-      shell_identity: state.shell_identity,
-      shell_state: state.shell_state,
+      shell_id: Runtime.id(state.shell_runtime),
+      shell: Runtime.module(state.shell_runtime),
+      shell_identity: Runtime.identity(state.shell_runtime),
+      shell_state: Runtime.state(state.shell_runtime),
       message_store: state.message_store,
       notifications: state.notifications,
       sidebar_registry: state.sidebar_registry,

--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -38,8 +38,8 @@ defmodule MingaEditor.Renderer do
   def render(%EditorState{rendering: :disabled} = state), do: state
 
   def render(state) do
-    state = EditorState.ensure_shell_available(state)
-    EditorState.active_shell_module(state).render(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
+    MingaEditor.Shell.Runtime.module(state.shell_runtime).render(state)
   end
 
   @doc """
@@ -52,7 +52,7 @@ defmodule MingaEditor.Renderer do
   def render_or_async(%{backend: :headless} = state), do: render(state)
 
   def render_or_async(%{renderer: pid} = state) when is_pid(pid) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     if async_render?(state) do
       {state, revision} = EditorState.submit_render_intent(state)
@@ -90,7 +90,7 @@ defmodule MingaEditor.Renderer do
   end
 
   def reset_connection(%{renderer: pid} = state) when is_pid(pid) do
-    state = EditorState.ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     if async_render?(state) do
       {state, revision} = EditorState.submit_render_intent(state)
@@ -106,7 +106,8 @@ defmodule MingaEditor.Renderer do
   def reset_connection(state), do: render(state)
 
   @spec async_render?(state()) :: boolean()
-  defp async_render?(state), do: EditorState.active_shell_module(state).async_render?(state)
+  defp async_render?(state),
+    do: MingaEditor.Shell.Runtime.module(state.shell_runtime).async_render?(state)
 
   @doc """
   Runs the full render pipeline (content, chrome, compose, emit).

--- a/lib/minga_editor/session/chrome_state.ex
+++ b/lib/minga_editor/session/chrome_state.ex
@@ -79,7 +79,7 @@ defmodule MingaEditor.Session.ChromeState do
   def visible_tabs(%__MODULE__{visible_tabs: tabs}), do: tabs
 
   @spec tab_bar(map()) :: TabBar.t() | nil
-  defp tab_bar(%{shell_state: %{tab_bar: %TabBar{} = tb}}), do: tb
+  defp tab_bar(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}}), do: tb
   defp tab_bar(%{tab_bar: %TabBar{} = tb}), do: tb
   defp tab_bar(_state), do: nil
 

--- a/lib/minga_editor/shell.ex
+++ b/lib/minga_editor/shell.ex
@@ -78,6 +78,13 @@ defmodule MingaEditor.Shell do
   @callback on_agent_event(shell_state(), workspace(), session_pid :: pid(), event :: term()) ::
               {shell_state(), workspace(), [MingaEditor.effect()]}
 
+  @doc "Returns whether shell state owns an agent session pid."
+  @callback owns_agent_session?(shell_state(), session_pid :: pid()) :: boolean()
+
+  @doc "Handles an agent session going down and reports whether the shell owned it."
+  @callback handle_agent_session_down(shell_state(), session_pid :: pid(), reason :: term()) ::
+              {shell_state(), boolean()}
+
   @doc "A managed agent session restarted and the shell should refresh pid references."
   @callback handle_agent_session_restarted(
               shell_state(),
@@ -85,6 +92,21 @@ defmodule MingaEditor.Shell do
               new_session_pid :: pid(),
               reason :: term()
             ) :: {shell_state(), boolean()}
+
+  @doc "Handles a remote session disconnect and reports whether the shell owned it."
+  @callback handle_remote_session_disconnected(shell_state(), session_pid :: pid()) ::
+              {shell_state(), boolean()}
+
+  @doc "Persists shell state outside the pure Runtime transition boundary."
+  @callback persist_shell_state(shell_state()) :: shell_state()
+
+  @doc "Synchronizes optional agent status held by a shell."
+  @callback sync_agent_status(shell_state(), session_pid :: pid(), status :: term()) ::
+              shell_state()
+
+  @doc "Tracks an agent-touched file in optional shell state."
+  @callback track_agent_file(shell_state(), session_pid :: pid(), path :: String.t()) ::
+              shell_state()
 
   @doc "Returns the currently active tab, or nil if the shell has no tabs."
   @callback active_tab(shell_state()) :: MingaEditor.State.Tab.t() | nil
@@ -101,5 +123,12 @@ defmodule MingaEditor.Shell do
   @doc "Returns the agent session pid for the user's current view."
   @callback active_session(shell_state()) :: pid() | nil
 
-  @optional_callbacks after_gui_action: 2
+  @optional_callbacks after_gui_action: 2,
+                      owns_agent_session?: 2,
+                      handle_agent_session_down: 3,
+                      handle_agent_session_restarted: 4,
+                      handle_remote_session_disconnected: 2,
+                      persist_shell_state: 1,
+                      sync_agent_status: 3,
+                      track_agent_file: 3
 end

--- a/lib/minga_editor/shell/runtime.ex
+++ b/lib/minga_editor/shell/runtime.ex
@@ -1,0 +1,650 @@
+defmodule MingaEditor.Shell.Runtime do
+  @moduledoc """
+  Immutable owner of the editor's active shell runtime value.
+
+  A runtime contains one resolved registry entry, the state produced by that shell, and stashed states tied to exact registry identities. Registry lookup and every effectful policy decision stay outside this module. Callers resolve entries and initialize replacement states before invoking a transition.
+  """
+
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Identity
+  alias MingaEditor.Shell.StateStash
+
+  @type shell_state :: MingaEditor.Shell.shell_state()
+  @type stash :: %{atom() => StateStash.t()}
+  @type persistence_change :: {Entry.t(), shell_state(), shell_state()}
+
+  @enforce_keys [:entry, :state]
+  defstruct [:entry, :state, stash: %{}]
+
+  @type t :: %__MODULE__{entry: Entry.t(), state: shell_state(), stash: stash()}
+
+  @doc "Returns the deterministic built-in entry used by raw Editor state construction."
+  @spec default_entry() :: Entry.t()
+  def default_entry do
+    %Entry{
+      id: :traditional,
+      source: :builtin,
+      module: MingaEditor.Shell.Traditional,
+      display_name: "Traditional",
+      description: "Traditional editor shell",
+      capabilities: [:gui, :tui],
+      default?: true,
+      generation: 1
+    }
+  end
+
+  @doc "Builds a runtime from an already-resolved entry and initialized shell state."
+  @spec new(Entry.t(), shell_state()) :: t()
+  def new(%Entry{} = entry, state), do: %__MODULE__{entry: entry, state: state}
+
+  @doc "Returns the resolved active entry."
+  @spec entry(t()) :: Entry.t()
+  def entry(%__MODULE__{entry: entry}), do: entry
+
+  @doc "Returns the active shell id."
+  @spec id(t()) :: atom()
+  def id(%__MODULE__{entry: %Entry{id: id}}), do: id
+
+  @doc "Returns the active shell contract module."
+  @spec module(t()) :: module()
+  def module(%__MODULE__{entry: %Entry{module: module}}), do: module
+
+  @doc "Returns the active shell state."
+  @spec state(t()) :: shell_state()
+  def state(%__MODULE__{state: state}), do: state
+
+  @doc "Returns the identity-keyed shell-state stash."
+  @spec stash(t()) :: stash()
+  def stash(%__MODULE__{stash: stash}), do: stash
+
+  @doc "Returns the exact identity of the active resolved entry."
+  @spec identity(t()) :: Identity.t()
+  def identity(%__MODULE__{entry: entry}), do: Identity.new(entry)
+
+  @doc "Returns true when an asynchronous identity belongs to the active entry."
+  @spec matches_identity?(t(), Identity.t()) :: boolean()
+  def matches_identity?(%__MODULE__{entry: entry}, %Identity{} = identity),
+    do: Identity.matches?(identity, entry)
+
+  @doc "Returns true when a resolved entry is exactly the active registration."
+  @spec active_entry?(t(), Entry.t()) :: boolean()
+  def active_entry?(%__MODULE__{entry: active}, %Entry{} = entry), do: same_entry?(active, entry)
+
+  @doc "Returns whether an exact-identity stashed value can restore the resolved entry."
+  @spec restorable?(t(), Entry.t()) :: boolean()
+  def restorable?(%__MODULE__{} = runtime, %Entry{} = entry) do
+    case Map.get(runtime.stash, entry.id) do
+      %StateStash{} = stashed -> StateStash.matches?(stashed, entry)
+      nil -> false
+    end
+  end
+
+  @doc "Activates a resolved entry, stashing the outgoing state and restoring only an exact identity match."
+  @spec activate(t(), Entry.t(), shell_state()) :: t()
+  def activate(%__MODULE__{} = runtime, %Entry{} = target, initialized_state) do
+    if same_entry?(runtime.entry, target) do
+      runtime
+    else
+      stash =
+        Map.put(runtime.stash, runtime.entry.id, StateStash.new(runtime.entry, runtime.state))
+
+      {target_state, stash} = restore_target(stash, target, initialized_state)
+      %__MODULE__{entry: target, state: target_state, stash: stash}
+    end
+  end
+
+  @doc "Accepts the currently resolved active entry or resets state when its registry identity changed."
+  @spec validate_registration(t(), Entry.t(), shell_state()) :: {t(), :current | :reset}
+  def validate_registration(%__MODULE__{} = runtime, %Entry{} = resolved, initialized_state) do
+    if same_entry?(runtime.entry, resolved) do
+      {runtime, :current}
+    else
+      {%__MODULE__{
+         runtime
+         | entry: resolved,
+           state: initialized_state,
+           stash: Map.delete(runtime.stash, resolved.id)
+       }, :reset}
+    end
+  end
+
+  @doc "Falls back from a removed active registration without stashing its now-unresolvable value."
+  @spec fallback_from_removed(t(), Entry.t(), shell_state()) :: t()
+  def fallback_from_removed(%__MODULE__{} = runtime, %Entry{} = default_entry, initialized_state) do
+    {target_state, stash} = restore_target(runtime.stash, default_entry, initialized_state)
+    %__MODULE__{entry: default_entry, state: target_state, stash: stash}
+  end
+
+  @doc "Updates Traditional presentation state and leaves extension runtimes untouched."
+  @spec update_traditional_state(t(), (shell_state() -> shell_state())) :: t()
+  def update_traditional_state(
+        %__MODULE__{entry: %Entry{module: MingaEditor.Shell.Traditional}} = runtime,
+        fun
+      )
+      when is_function(fun, 1) do
+    %__MODULE__{runtime | state: fun.(runtime.state)}
+  end
+
+  def update_traditional_state(%__MODULE__{} = runtime, fun) when is_function(fun, 1), do: runtime
+
+  @doc "Installs shell state returned by a render for the exact active identity."
+  @spec accept_rendered_state(t(), atom(), Identity.t(), shell_state()) :: t()
+  def accept_rendered_state(
+        %__MODULE__{} = runtime,
+        shell_id,
+        %Identity{} = identity,
+        rendered_state
+      ) do
+    if runtime.entry.id == shell_id and Identity.matches?(identity, runtime.entry),
+      do: %__MODULE__{runtime | state: rendered_state},
+      else: runtime
+  end
+
+  @doc "Merges renderer-owned click regions into a matching active shell state."
+  @spec merge_renderer_observation(t(), atom(), Identity.t(), map()) :: t()
+  def merge_renderer_observation(
+        %__MODULE__{} = runtime,
+        shell_id,
+        %Identity{} = identity,
+        fields
+      ) do
+    if runtime.entry.id == shell_id and Identity.matches?(identity, runtime.entry) do
+      state = Enum.reduce(fields, runtime.state, &merge_renderer_field/2)
+      %__MODULE__{runtime | state: state}
+    else
+      runtime
+    end
+  end
+
+  @spec merge_renderer_field({atom(), term()}, shell_state()) :: shell_state()
+  defp merge_renderer_field({field, value}, shell_state) when is_map(shell_state) do
+    case Map.fetch(shell_state, field) do
+      {:ok, _current} -> Map.put(shell_state, field, value)
+      :error -> shell_state
+    end
+  end
+
+  defp merge_renderer_field({_field, _value}, shell_state), do: shell_state
+
+  @doc "Installs state returned by persistence for the exact active or stashed registration."
+  @spec accept_persisted_state(t(), Entry.t(), shell_state()) :: t()
+  def accept_persisted_state(%__MODULE__{} = runtime, %Entry{} = entry, persisted_state) do
+    if same_entry?(runtime.entry, entry) do
+      %__MODULE__{runtime | state: persisted_state}
+    else
+      accept_stashed_persisted_state(runtime, entry, persisted_state)
+    end
+  end
+
+  @doc "Routes a shell event through the active entry's contract."
+  @spec route_event(t(), MingaEditor.Shell.workspace(), term()) ::
+          {t(), MingaEditor.Shell.workspace()}
+  def route_event(%__MODULE__{} = runtime, workspace, event) do
+    {shell_state, workspace} = runtime.entry.module.handle_event(runtime.state, workspace, event)
+    {%__MODULE__{runtime | state: shell_state}, workspace}
+  end
+
+  @doc "Routes a shell GUI action through the active entry's contract."
+  @spec route_gui_action(t(), MingaEditor.Shell.workspace(), term()) ::
+          {t(), MingaEditor.Shell.workspace()}
+  def route_gui_action(%__MODULE__{} = runtime, workspace, action) do
+    {shell_state, workspace} =
+      runtime.entry.module.handle_gui_action(runtime.state, workspace, action)
+
+    {%__MODULE__{runtime | state: shell_state}, workspace}
+  end
+
+  @doc "Routes an agent event through the active entry and returns effects as data."
+  @spec route_agent_event(t(), MingaEditor.Shell.workspace(), pid(), term()) ::
+          {t(), MingaEditor.Shell.workspace(), [MingaEditor.effect()], persistence_change() | nil}
+  def route_agent_event(%__MODULE__{} = runtime, workspace, session_pid, event) do
+    old_state = runtime.state
+
+    {shell_state, workspace, effects} =
+      runtime.entry.module.on_agent_event(old_state, workspace, session_pid, event)
+
+    change = persistence_change(runtime.entry, old_state, shell_state)
+    {%__MODULE__{runtime | state: shell_state}, workspace, effects, change}
+  end
+
+  @doc "Routes an agent event through exact-identity stashes using caller-resolved entries."
+  @spec route_stashed_agent_event(t(), [Entry.t()], MingaEditor.Shell.workspace(), pid(), term()) ::
+          {t(), MingaEditor.Shell.workspace(), [MingaEditor.effect()], [persistence_change()]}
+  def route_stashed_agent_event(%__MODULE__{} = runtime, entries, workspace, session_pid, event) do
+    entries_by_id = Map.new(entries, &{&1.id, &1})
+
+    {stash, workspace, effects, changes} =
+      Enum.reduce(runtime.stash, {%{}, workspace, [], []}, fn {id, stashed},
+                                                              {stash_acc, workspace_acc,
+                                                               effects_acc, changes_acc} ->
+        case Map.get(entries_by_id, id) do
+          %Entry{} = entry ->
+            route_stashed_agent_value(
+              stash_acc,
+              effects_acc,
+              changes_acc,
+              stashed,
+              entry,
+              workspace_acc,
+              session_pid,
+              event
+            )
+
+          nil ->
+            {Map.put(stash_acc, id, stashed), workspace_acc, effects_acc, changes_acc}
+        end
+      end)
+
+    {%__MODULE__{runtime | stash: stash}, workspace, effects, changes}
+  end
+
+  @doc "Routes buffer-added lifecycle through the active shell and returns effects as data."
+  @spec route_buffer_added(
+          t(),
+          MingaEditor.Shell.workspace(),
+          MingaEditor.Shell.workspace(),
+          pid(),
+          MingaEditor.Shell.buffer_add_context()
+        ) :: {t(), MingaEditor.Shell.workspace(), [MingaEditor.effect()]}
+  def route_buffer_added(
+        %__MODULE__{} = runtime,
+        previous_workspace,
+        workspace,
+        buffer_pid,
+        context
+      ) do
+    {shell_state, workspace, effects} =
+      runtime.entry.module.on_buffer_added(
+        runtime.state,
+        previous_workspace,
+        workspace,
+        buffer_pid,
+        context
+      )
+
+    {%__MODULE__{runtime | state: shell_state}, workspace, effects}
+  end
+
+  @doc "Routes buffer-switch lifecycle through the active shell and returns effects as data."
+  @spec route_buffer_switched(t(), MingaEditor.Shell.workspace()) ::
+          {t(), MingaEditor.Shell.workspace(), [MingaEditor.effect()]}
+  def route_buffer_switched(%__MODULE__{} = runtime, workspace) do
+    {shell_state, workspace, effects} =
+      runtime.entry.module.on_buffer_switched(runtime.state, workspace)
+
+    {%__MODULE__{runtime | state: shell_state}, workspace, effects}
+  end
+
+  @doc "Routes buffer-removal lifecycle through the active shell and returns effects as data."
+  @spec route_buffer_died(t(), MingaEditor.Shell.workspace(), pid()) ::
+          {t(), MingaEditor.Shell.workspace(), [MingaEditor.effect()]}
+  def route_buffer_died(%__MODULE__{} = runtime, workspace, dead_pid) do
+    {shell_state, workspace, effects} =
+      runtime.entry.module.on_buffer_died(runtime.state, workspace, dead_pid)
+
+    {%__MODULE__{runtime | state: shell_state}, workspace, effects}
+  end
+
+  @doc "Routes an optional active session-down transition through the active entry."
+  @spec route_session_down(t(), pid(), term()) :: {t(), boolean(), persistence_change() | nil}
+  def route_session_down(%__MODULE__{} = runtime, session_pid, reason) do
+    route_active_boolean_callback(runtime, :handle_agent_session_down, [session_pid, reason])
+  end
+
+  @doc "Returns whether the active or an exact-identity stashed entry owns a session."
+  @spec owns_agent_session?(t(), [Entry.t()], pid()) :: boolean()
+  def owns_agent_session?(%__MODULE__{} = runtime, entries, session_pid) do
+    active_owns_agent_session?(runtime, session_pid) or
+      Enum.any?(entries, &stashed_entry_owns_agent_session?(runtime, &1, session_pid))
+  end
+
+  @doc "Routes session-down through the first exact-identity stash that owns it."
+  @spec route_stashed_session_down(t(), [Entry.t()], pid(), term()) ::
+          {t(), boolean(), [persistence_change()]}
+  def route_stashed_session_down(%__MODULE__{} = runtime, entries, session_pid, reason) do
+    route_first_stashed_boolean_callback(
+      runtime,
+      entries,
+      :handle_agent_session_down,
+      [session_pid, reason]
+    )
+  end
+
+  @doc "Routes a session restart through the active and exact-identity stashed entries."
+  @spec route_session_restarted(t(), [Entry.t()], pid(), pid(), term()) ::
+          {t(), boolean(), [persistence_change()]}
+  def route_session_restarted(%__MODULE__{} = runtime, entries, old_pid, new_pid, reason) do
+    {runtime, active_handled?, active_change} =
+      route_active_boolean_callback(runtime, :handle_agent_session_restarted, [
+        old_pid,
+        new_pid,
+        reason
+      ])
+
+    {runtime, stashed_handled?, stash_changes} =
+      route_all_stashed_boolean_callbacks(
+        runtime,
+        entries,
+        :handle_agent_session_restarted,
+        [old_pid, new_pid, reason]
+      )
+
+    changes = prepend_change(active_change, stash_changes)
+    {runtime, active_handled? or stashed_handled?, changes}
+  end
+
+  @doc "Routes a remote disconnect through the active entry."
+  @spec route_remote_session_disconnected(t(), pid()) ::
+          {t(), boolean(), persistence_change() | nil}
+  def route_remote_session_disconnected(%__MODULE__{} = runtime, session_pid) do
+    route_active_boolean_callback(runtime, :handle_remote_session_disconnected, [session_pid])
+  end
+
+  @doc "Routes a remote disconnect through the first exact-identity stash that owns it."
+  @spec route_stashed_remote_session_disconnected(t(), [Entry.t()], pid()) ::
+          {t(), boolean(), [persistence_change()]}
+  def route_stashed_remote_session_disconnected(
+        %__MODULE__{} = runtime,
+        entries,
+        session_pid
+      ) do
+    route_first_stashed_boolean_callback(
+      runtime,
+      entries,
+      :handle_remote_session_disconnected,
+      [session_pid]
+    )
+  end
+
+  @doc "Routes an optional agent status update through active and stashed entries."
+  @spec sync_agent_status(t(), [Entry.t()], pid(), term()) :: t()
+  def sync_agent_status(%__MODULE__{} = runtime, entries, session_pid, status) do
+    route_optional_state_update(runtime, entries, :sync_agent_status, [session_pid, status])
+  end
+
+  @doc "Routes optional agent-file tracking through active and stashed entries."
+  @spec track_agent_file(t(), [Entry.t()], pid(), String.t()) :: t()
+  def track_agent_file(%__MODULE__{} = runtime, entries, session_pid, path) do
+    route_optional_state_update(runtime, entries, :track_agent_file, [session_pid, path])
+  end
+
+  @doc "Drops extension feature state through active and exact-identity stashed shell callbacks."
+  @spec drop_extension_feature_state_sources(t(), [Entry.t()]) :: t()
+  def drop_extension_feature_state_sources(%__MODULE__{} = runtime, entries) do
+    route_optional_state_update(runtime, entries, :drop_extension_feature_state_sources, [])
+  end
+
+  @doc "Drops one feature-state source through active and exact-identity stashed callbacks."
+  @spec drop_feature_state_source(t(), [Entry.t()], MingaEditor.FeatureState.source()) :: t()
+  def drop_feature_state_source(%__MODULE__{} = runtime, entries, source) do
+    route_optional_state_update(runtime, entries, :drop_feature_state_source, [source])
+  end
+
+  @doc "Returns the active tab through the active shell contract."
+  @spec active_tab(t()) :: MingaEditor.State.Tab.t() | nil
+  def active_tab(%__MODULE__{} = runtime), do: runtime.entry.module.active_tab(runtime.state)
+
+  @doc "Finds a tab through the active shell contract."
+  @spec find_tab_by_buffer(t(), pid()) :: MingaEditor.State.Tab.t() | nil
+  def find_tab_by_buffer(%__MODULE__{} = runtime, pid),
+    do: runtime.entry.module.find_tab_by_buffer(runtime.state, pid)
+
+  @doc "Returns the active tab kind through the active shell contract."
+  @spec active_tab_kind(t()) :: atom()
+  def active_tab_kind(%__MODULE__{} = runtime),
+    do: runtime.entry.module.active_tab_kind(runtime.state)
+
+  @doc "Associates a session with a shell tab through the active contract."
+  @spec set_tab_session(t(), term(), pid() | nil) :: t()
+  def set_tab_session(%__MODULE__{} = runtime, tab_id, session_pid) do
+    shell_state = runtime.entry.module.set_tab_session(runtime.state, tab_id, session_pid)
+    %__MODULE__{runtime | state: shell_state}
+  end
+
+  @doc "Returns the active session through the active shell contract."
+  @spec active_session(t()) :: pid() | nil
+  def active_session(%__MODULE__{} = runtime),
+    do: runtime.entry.module.active_session(runtime.state)
+
+  @spec restore_target(stash(), Entry.t(), shell_state()) :: {shell_state(), stash()}
+  defp restore_target(stash, %Entry{} = target, initialized_state) do
+    target_state =
+      case Map.get(stash, target.id) do
+        %StateStash{} = stashed ->
+          case StateStash.restore(stashed, target) do
+            {:ok, state} -> state
+            :mismatch -> initialized_state
+          end
+
+        nil ->
+          initialized_state
+      end
+
+    {target_state, Map.delete(stash, target.id)}
+  end
+
+  @spec route_stashed_agent_value(
+          stash(),
+          [MingaEditor.effect()],
+          [persistence_change()],
+          StateStash.t(),
+          Entry.t(),
+          MingaEditor.Shell.workspace(),
+          pid(),
+          term()
+        ) ::
+          {stash(), MingaEditor.Shell.workspace(), [MingaEditor.effect()], [persistence_change()]}
+  defp route_stashed_agent_value(
+         stash,
+         effects,
+         changes,
+         %StateStash{} = stashed,
+         %Entry{} = entry,
+         workspace,
+         session_pid,
+         event
+       ) do
+    case StateStash.restore(stashed, entry) do
+      {:ok, old_state} ->
+        {new_state, workspace, new_effects} =
+          entry.module.on_agent_event(old_state, workspace, session_pid, event)
+
+        updated = StateStash.new(entry, new_state)
+        change = persistence_change(entry, old_state, new_state)
+
+        {
+          Map.put(stash, entry.id, updated),
+          workspace,
+          effects ++ new_effects,
+          prepend_change(change, changes)
+        }
+
+      :mismatch ->
+        {Map.put(stash, entry.id, stashed), workspace, effects, changes}
+    end
+  end
+
+  @spec active_owns_agent_session?(t(), pid()) :: boolean()
+  defp active_owns_agent_session?(%__MODULE__{} = runtime, session_pid) do
+    module = runtime.entry.module
+
+    function_exported?(module, :owns_agent_session?, 2) and
+      module.owns_agent_session?(runtime.state, session_pid)
+  end
+
+  @spec stashed_entry_owns_agent_session?(t(), Entry.t(), pid()) :: boolean()
+  defp stashed_entry_owns_agent_session?(
+         %__MODULE__{} = runtime,
+         %Entry{} = entry,
+         session_pid
+       ) do
+    case Map.get(runtime.stash, entry.id) do
+      %StateStash{} = stashed ->
+        with {:ok, state} <- StateStash.restore(stashed, entry),
+             true <- function_exported?(entry.module, :owns_agent_session?, 2) do
+          entry.module.owns_agent_session?(state, session_pid)
+        else
+          _ -> false
+        end
+
+      nil ->
+        false
+    end
+  end
+
+  @spec route_active_boolean_callback(t(), atom(), [term()]) ::
+          {t(), boolean(), persistence_change() | nil}
+  defp route_active_boolean_callback(%__MODULE__{} = runtime, callback, args) do
+    module = runtime.entry.module
+
+    if function_exported?(module, callback, length(args) + 1) do
+      old_state = runtime.state
+      {new_state, handled?} = apply(module, callback, [old_state | args])
+      change = if handled?, do: persistence_change(runtime.entry, old_state, new_state), else: nil
+      {%__MODULE__{runtime | state: new_state}, handled?, change}
+    else
+      {runtime, false, nil}
+    end
+  end
+
+  @spec route_all_stashed_boolean_callbacks(t(), [Entry.t()], atom(), [term()]) ::
+          {t(), boolean(), [persistence_change()]}
+  defp route_all_stashed_boolean_callbacks(%__MODULE__{} = runtime, entries, callback, args) do
+    Enum.reduce(entries, {runtime, false, []}, fn entry, {runtime_acc, handled_acc, changes} ->
+      case route_one_stashed_boolean_callback(runtime_acc, entry, callback, args) do
+        {runtime_next, handled?, change} ->
+          {runtime_next, handled_acc or handled?, prepend_change(change, changes)}
+      end
+    end)
+  end
+
+  @spec route_first_stashed_boolean_callback(t(), [Entry.t()], atom(), [term()]) ::
+          {t(), boolean(), [persistence_change()]}
+  defp route_first_stashed_boolean_callback(
+         %__MODULE__{} = runtime,
+         entries,
+         callback,
+         args
+       ) do
+    Enum.reduce_while(entries, {runtime, false, []}, fn entry, {runtime_acc, false, changes} ->
+      case route_one_stashed_boolean_callback(runtime_acc, entry, callback, args) do
+        {runtime_next, true, change} ->
+          {:halt, {runtime_next, true, prepend_change(change, changes)}}
+
+        {runtime_next, false, _change} ->
+          {:cont, {runtime_next, false, changes}}
+      end
+    end)
+  end
+
+  @spec route_one_stashed_boolean_callback(t(), Entry.t(), atom(), [term()]) ::
+          {t(), boolean(), persistence_change() | nil}
+  defp route_one_stashed_boolean_callback(
+         %__MODULE__{} = runtime,
+         %Entry{} = entry,
+         callback,
+         args
+       ) do
+    case Map.get(runtime.stash, entry.id) do
+      %StateStash{} = stashed ->
+        route_matching_stashed_boolean_callback(runtime, stashed, entry, callback, args)
+
+      nil ->
+        {runtime, false, nil}
+    end
+  end
+
+  @spec route_matching_stashed_boolean_callback(t(), StateStash.t(), Entry.t(), atom(), [term()]) ::
+          {t(), boolean(), persistence_change() | nil}
+  defp route_matching_stashed_boolean_callback(
+         %__MODULE__{} = runtime,
+         %StateStash{} = stashed,
+         %Entry{} = entry,
+         callback,
+         args
+       ) do
+    with {:ok, old_state} <- StateStash.restore(stashed, entry),
+         true <- function_exported?(entry.module, callback, length(args) + 1) do
+      {new_state, handled?} = apply(entry.module, callback, [old_state | args])
+      updated = StateStash.new(entry, new_state)
+      runtime = %__MODULE__{runtime | stash: Map.put(runtime.stash, entry.id, updated)}
+      change = if handled?, do: persistence_change(entry, old_state, new_state), else: nil
+      {runtime, handled?, change}
+    else
+      _ -> {runtime, false, nil}
+    end
+  end
+
+  @spec route_optional_state_update(t(), [Entry.t()], atom(), [term()]) :: t()
+  defp route_optional_state_update(%__MODULE__{} = runtime, entries, callback, args) do
+    runtime = route_active_optional_state_update(runtime, callback, args)
+
+    Enum.reduce(entries, runtime, fn entry, runtime_acc ->
+      route_stashed_optional_state_update(runtime_acc, entry, callback, args)
+    end)
+  end
+
+  @spec route_active_optional_state_update(t(), atom(), [term()]) :: t()
+  defp route_active_optional_state_update(%__MODULE__{} = runtime, callback, args) do
+    if function_exported?(runtime.entry.module, callback, length(args) + 1) do
+      state = apply(runtime.entry.module, callback, [runtime.state | args])
+      %__MODULE__{runtime | state: state}
+    else
+      runtime
+    end
+  end
+
+  @spec route_stashed_optional_state_update(t(), Entry.t(), atom(), [term()]) :: t()
+  defp route_stashed_optional_state_update(
+         %__MODULE__{} = runtime,
+         %Entry{} = entry,
+         callback,
+         args
+       ) do
+    case Map.get(runtime.stash, entry.id) do
+      %StateStash{} = stashed ->
+        with {:ok, old_state} <- StateStash.restore(stashed, entry),
+             true <- function_exported?(entry.module, callback, length(args) + 1) do
+          new_state = apply(entry.module, callback, [old_state | args])
+          updated = StateStash.new(entry, new_state)
+          %__MODULE__{runtime | stash: Map.put(runtime.stash, entry.id, updated)}
+        else
+          _ -> runtime
+        end
+
+      nil ->
+        runtime
+    end
+  end
+
+  @spec accept_stashed_persisted_state(t(), Entry.t(), shell_state()) :: t()
+  defp accept_stashed_persisted_state(%__MODULE__{} = runtime, %Entry{} = entry, persisted_state) do
+    case Map.get(runtime.stash, entry.id) do
+      %StateStash{} = stashed ->
+        if StateStash.matches?(stashed, entry) do
+          stash = Map.put(runtime.stash, entry.id, StateStash.new(entry, persisted_state))
+          %__MODULE__{runtime | stash: stash}
+        else
+          runtime
+        end
+
+      nil ->
+        runtime
+    end
+  end
+
+  @spec persistence_change(Entry.t(), shell_state(), shell_state()) :: persistence_change() | nil
+  defp persistence_change(_entry, state, state), do: nil
+  defp persistence_change(entry, old_state, new_state), do: {entry, old_state, new_state}
+
+  @spec prepend_change(persistence_change() | nil, [persistence_change()]) ::
+          [persistence_change()]
+  defp prepend_change(nil, changes), do: changes
+  defp prepend_change(change, changes), do: [change | changes]
+
+  @spec same_entry?(Entry.t(), Entry.t()) :: boolean()
+  defp same_entry?(%Entry{} = left, %Entry{} = right) do
+    left.id == right.id and left.module == right.module and left.source == right.source and
+      left.generation == right.generation
+  end
+end

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -7,8 +7,7 @@ defmodule MingaEditor.Shell.Traditional do
   the UX that ships today.
 
   Presentation fields live in `MingaEditor.Shell.Traditional.State`. The
-  Editor GenServer stores this as `state.shell_state` and dispatches
-  presentation events through the `MingaEditor.Shell` behaviour callbacks.
+  Editor GenServer stores this inside `state.shell_runtime` and dispatches presentation events through the `MingaEditor.Shell` behaviour callbacks.
 
   ## Migration status
 
@@ -182,6 +181,18 @@ defmodule MingaEditor.Shell.Traditional do
 
   @impl true
   @spec async_render?(term()) :: boolean()
+  def async_render?(%{
+        shell_runtime: %MingaEditor.Shell.Runtime{entry: %{module: __MODULE__}},
+        workspace: %{buffers: %{active: active}}
+      })
+      when is_pid(active),
+      do: true
+
+  def async_render?(%{
+        shell_runtime: %MingaEditor.Shell.Runtime{entry: %{module: __MODULE__}}
+      }),
+      do: false
+
   def async_render?(%{shell: __MODULE__, workspace: %{buffers: %{active: active}}})
       when is_pid(active),
       do: true
@@ -419,6 +430,15 @@ defmodule MingaEditor.Shell.Traditional do
 
   def on_agent_event(shell_state, workspace, _session_pid, _event) do
     {shell_state, workspace, []}
+  end
+
+  @impl true
+  @spec owns_agent_session?(ShellState.t(), pid()) :: boolean()
+  def owns_agent_session?(%ShellState{tab_bar: nil}, _session_pid), do: false
+
+  def owns_agent_session?(%ShellState{tab_bar: %TabBar{} = tab_bar}, session_pid) do
+    not is_nil(TabBar.find_by_session(tab_bar, session_pid)) or
+      not is_nil(TabBar.find_workspace_by_session(tab_bar, session_pid))
   end
 
   @impl true

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -121,6 +121,12 @@ defmodule MingaEditor.Shell.Traditional.State do
     Map.put(ss, :status_msg, nil)
   end
 
+  @doc "Controls whether missing-tool prompts are suppressed."
+  @spec set_suppress_tool_prompts(t(), boolean()) :: t()
+  def set_suppress_tool_prompts(%{} = ss, suppress?) when is_boolean(suppress?) do
+    Map.put(ss, :suppress_tool_prompts, suppress?)
+  end
+
   # ── Nav flash ──────────────────────────────────────────────────────────────
 
   @doc "Returns the nav flash state, or nil when inactive."
@@ -429,6 +435,31 @@ defmodule MingaEditor.Shell.Traditional.State do
       ToolManager.installed?(tool_name) or
       MapSet.member?(ToolManager.installing(), tool_name) or
       tool_name in ss.tool_prompt_queue
+  end
+
+  @doc "Replaces signature-help presentation state."
+  @spec set_signature_help(t(), MingaEditor.SignatureHelp.t() | nil) :: t()
+  def set_signature_help(%__MODULE__{} = state, signature_help) do
+    %{state | signature_help: signature_help}
+  end
+
+  @doc "Replaces the delayed warning-popup timer."
+  @spec set_warning_popup_timer(t(), reference() | nil) :: t()
+  def set_warning_popup_timer(%__MODULE__{} = state, timer) do
+    %{state | warning_popup_timer: timer}
+  end
+
+  @doc "Replaces the pending tool-install prompt queue."
+  @spec set_tool_prompt_queue(t(), [atom()]) :: t()
+  def set_tool_prompt_queue(%__MODULE__{} = state, queue) when is_list(queue) do
+    %{state | tool_prompt_queue: queue}
+  end
+
+  @doc "Replaces tool-prompt decisions and the pending queue atomically."
+  @spec set_tool_prompt_state(t(), [atom()], MapSet.t(atom())) :: t()
+  def set_tool_prompt_state(%__MODULE__{} = state, queue, declined)
+      when is_list(queue) do
+    %{state | tool_prompt_queue: queue, tool_declined: declined}
   end
 
   @doc "Sets whether a CUA space leader sequence is pending."

--- a/lib/minga_editor/shell/workflow.ex
+++ b/lib/minga_editor/shell/workflow.ex
@@ -1,0 +1,133 @@
+defmodule MingaEditor.Shell.Workflow do
+  @moduledoc """
+  Effectful editor workflows around the pure shell runtime value.
+
+  This module resolves registry entries, initializes shell states, and owns user-visible logging and status policy. `MingaEditor.Shell.Runtime` receives only resolved values.
+  """
+
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State, as: EditorState
+
+  @doc "Ensures the runtime's active registration is still current."
+  @spec ensure_available(EditorState.t()) :: EditorState.t()
+  def ensure_available(%EditorState{shell_runtime: runtime} = state) do
+    case Registry.get(Runtime.id(runtime)) do
+      %Entry{} = resolved -> validate_resolved_entry(state, runtime, resolved)
+      nil -> fall_back_from_removed_entry(state, runtime, Registry.default())
+    end
+  end
+
+  @doc "Switches to a registry-resolved shell id, preserving exact-identity state restoration."
+  @spec switch(EditorState.t(), atom()) :: EditorState.t()
+  def switch(%EditorState{} = state, shell_id) when is_atom(shell_id) do
+    Registry.seed_builtin()
+    entries = Registry.list()
+    switch_resolved(state, shell_id, entries)
+  end
+
+  @doc "Returns current resolved registry entries for stashed event workflows."
+  @spec resolved_entries() :: [Entry.t()]
+  def resolved_entries, do: Registry.list()
+
+  @spec validate_resolved_entry(EditorState.t(), Runtime.t(), Entry.t()) :: EditorState.t()
+  defp validate_resolved_entry(state, runtime, resolved) do
+    if Runtime.active_entry?(runtime, resolved) do
+      state
+    else
+      initialized_state = initialize_shell_state(resolved.module, Runtime.state(runtime))
+      {runtime, :reset} = Runtime.validate_registration(runtime, resolved, initialized_state)
+      apply_registration_reset(state, runtime, resolved)
+    end
+  end
+
+  @spec apply_registration_reset(EditorState.t(), Runtime.t(), Entry.t()) :: EditorState.t()
+  defp apply_registration_reset(state, runtime, resolved) do
+    Minga.Log.warning(
+      :editor,
+      "Shell #{inspect(resolved.id)} registry identity changed; resetting shell state"
+    )
+
+    state
+    |> EditorState.apply_shell_runtime_transition(runtime)
+    |> EditorState.reset_shell_layout()
+    |> EditorState.set_status("Shell #{resolved.display_name} reloaded")
+  end
+
+  @spec fall_back_from_removed_entry(EditorState.t(), Runtime.t(), Entry.t()) :: EditorState.t()
+  defp fall_back_from_removed_entry(state, runtime, default) do
+    Minga.Log.warning(
+      :editor,
+      "Active shell #{inspect(Runtime.id(runtime))} (#{inspect(Runtime.module(runtime))}) is unavailable; switching to #{inspect(default.id)}"
+    )
+
+    initialized_state = initialize_shell_state(default.module, Runtime.state(runtime))
+    runtime = Runtime.fallback_from_removed(runtime, default, initialized_state)
+
+    state
+    |> EditorState.apply_shell_runtime_transition(runtime)
+    |> EditorState.reset_shell_layout()
+    |> EditorState.set_status("Shell unavailable, switched to #{default.display_name}")
+  end
+
+  @spec switch_resolved(EditorState.t(), atom(), [Entry.t()]) :: EditorState.t()
+  defp switch_resolved(
+         %EditorState{shell_runtime: %Runtime{entry: %Entry{id: current_id}}} = state,
+         shell_id,
+         [_only]
+       )
+       when shell_id != current_id do
+    EditorState.set_status(state, "Only one shell is available")
+  end
+
+  defp switch_resolved(
+         %EditorState{shell_runtime: %Runtime{entry: %Entry{id: shell_id}}} = state,
+         shell_id,
+         _entries
+       ) do
+    EditorState.set_status(state, "Already using #{display_name(shell_id)}")
+  end
+
+  defp switch_resolved(state, shell_id, _entries) do
+    case Registry.get(shell_id) do
+      %Entry{} = target -> activate_resolved(state, target)
+      nil -> EditorState.set_status(state, "Shell #{shell_id} is unavailable")
+    end
+  end
+
+  @spec activate_resolved(EditorState.t(), Entry.t()) :: EditorState.t()
+  defp activate_resolved(state, target) do
+    initialized_state = activation_default(state.shell_runtime, target)
+    runtime = Runtime.activate(state.shell_runtime, target, initialized_state)
+
+    state
+    |> EditorState.apply_shell_runtime_transition(runtime)
+    |> EditorState.reset_shell_layout()
+  end
+
+  @spec activation_default(Runtime.t(), Entry.t()) :: term()
+  defp activation_default(runtime, target) do
+    if Runtime.restorable?(runtime, target),
+      do: Runtime.state(runtime),
+      else: initialize_shell_state(target.module, Runtime.state(runtime))
+  end
+
+  @spec initialize_shell_state(module(), term()) :: term()
+  defp initialize_shell_state(MingaEditor.Shell.Traditional, previous_state) do
+    %TraditionalState{
+      suppress_tool_prompts: Map.get(previous_state, :suppress_tool_prompts, false)
+    }
+  end
+
+  defp initialize_shell_state(module, _previous_state), do: module.init([])
+
+  @spec display_name(atom()) :: String.t()
+  defp display_name(shell_id) do
+    case Registry.get(shell_id) do
+      %Entry{display_name: name} -> name
+      nil -> Atom.to_string(shell_id)
+    end
+  end
+end

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -18,7 +18,7 @@ defmodule MingaEditor.Startup do
   alias MingaEditor.Commands
   alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.FileWatcherHelpers
-  alias MingaEditor.Shell.Identity, as: ShellIdentity
+  alias MingaEditor.Shell.Runtime, as: ShellRuntime
   alias MingaEditor.Sidebar.BuiltinSurfaces
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Session, as: EditorSessionState
@@ -181,10 +181,7 @@ defmodule MingaEditor.Startup do
       effect_scheduler: Keyword.get(opts, :effect_scheduler),
       editing_model: editing_model,
       focus_stack: MingaEditor.Input.default_stack(),
-      shell_id: shell_entry.id,
-      shell: shell_entry.module,
-      shell_identity: ShellIdentity.new(shell_entry),
-      shell_state: init_shell_state(shell_entry.module, opts),
+      shell_runtime: ShellRuntime.new(shell_entry, init_shell_state(shell_entry.module, opts)),
       message_store: MessageStore.new(),
       session: EditorSessionState.new(Keyword.take(opts, [:swap_dir, :session_dir]))
     }

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -10,7 +10,7 @@ defmodule MingaEditor.State do
   and are saved/restored when switching tabs. Each tab carries a snapshot
   of the workspace so switching tabs restores the full editing context.
 
-  **Shell fields** live in `state.shell_state` and hold presentation concerns: chrome, overlays, transient UI state. The active shell id is `state.shell_id`; `state.shell` is the registered module cached for hot-path compatibility. See `MingaEditor.Shell` for the behaviour definition.
+  **Shell runtime** lives in `state.shell_runtime` and owns the resolved active entry, shell-specific presentation state, and exact-identity state stash. See `MingaEditor.Shell.Runtime`.
 
   **Global fields** are shared across all tabs and never snapshotted:
   `port_manager`, `parser_manager`, `highlighting`, `injection_ranges`, `theme`, `render_timer`, `focus_stack`, and `capabilities`.
@@ -39,7 +39,7 @@ defmodule MingaEditor.State do
   alias MingaEditor.State.Dired, as: DiredState
   alias MingaEditor.State.LSP, as: LSPState
   alias MingaEditor.Shell.Identity, as: ShellIdentity
-  alias MingaEditor.Shell.StateStash
+  alias MingaEditor.Shell.Runtime, as: ShellRuntime
   alias MingaEditor.State.Session, as: EditorSessionState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -117,10 +117,7 @@ defmodule MingaEditor.State do
             injection_ranges: %{},
             terminal_viewport: Viewport.new(24, 80),
             editing_model: :vim,
-            shell_id: :traditional,
-            shell: MingaEditor.Shell.Traditional,
-            shell_identity: nil,
-            shell_state: %ShellState{},
+            shell_runtime: ShellRuntime.new(ShellRuntime.default_entry(), %ShellState{}),
             theme: MingaEditor.UI.Theme.Fallback.theme(),
             render_timer: nil,
             message_store: %MessageStore{},
@@ -143,7 +140,6 @@ defmodule MingaEditor.State do
             buffer_add_context: :open,
             remote: %Remote{},
             resource_pressure: ResourcePressure.new(),
-            shell_state_stash: %{},
             keystroke_history: KeystrokeHistory.new(),
             git_commit_gen_ref: nil,
             font_size_override: nil,
@@ -173,10 +169,7 @@ defmodule MingaEditor.State do
   @type backend :: :tui | :gui | :native_gui | :headless
   @type rendering_policy :: :enabled | :disabled
 
-  @type shell_id :: atom()
-  @type shell_state :: term()
-  @type shell_identity :: ShellIdentity.t() | nil
-  @type shell_state_stash :: %{shell_id() => StateStash.t()}
+  @type shell_state :: MingaEditor.Shell.shell_state()
 
   @type t :: %__MODULE__{
           backend: backend(),
@@ -197,10 +190,7 @@ defmodule MingaEditor.State do
           injection_ranges: %{pid() => [Minga.Language.Highlight.InjectionRange.t()]},
           terminal_viewport: Viewport.t(),
           editing_model: :vim | :cua,
-          shell_id: shell_id(),
-          shell: module(),
-          shell_identity: shell_identity(),
-          shell_state: shell_state(),
+          shell_runtime: ShellRuntime.t(),
           theme: Theme.t(),
           render_timer: reference() | nil,
           message_store: MessageStore.t(),
@@ -223,7 +213,6 @@ defmodule MingaEditor.State do
           remote: Remote.t(),
           resource_pressure: ResourcePressure.t(),
           session: EditorSessionState.t(),
-          shell_state_stash: shell_state_stash(),
           keystroke_history: KeystrokeHistory.t(),
           git_commit_gen_ref: reference() | nil,
           font_size_override: pos_integer() | nil,
@@ -708,11 +697,18 @@ defmodule MingaEditor.State do
   def apply_render_output(%__MODULE__{workspace: ws} = state, render_output) do
     windows = apply_synchronous_window_observations(ws.windows, render_output.workspace.windows)
 
+    shell_runtime =
+      ShellRuntime.accept_rendered_state(
+        state.shell_runtime,
+        render_output.shell_id,
+        render_output.shell_identity,
+        render_output.shell_state
+      )
+
     %{
       state
       | workspace: %{ws | windows: windows},
-        shell_state: render_output.shell_state,
-        shell_identity: Map.get(render_output, :shell_identity, state.shell_identity),
+        shell_runtime: shell_runtime,
         layout: render_output.layout,
         focus_tree: render_output.focus_tree,
         message_store: state.message_store,
@@ -768,18 +764,14 @@ defmodule MingaEditor.State do
   @doc "Applies a synchronous focused renderer receipt without importing renderer state."
   @spec apply_synchronous_renderer_receipt(t(), MingaEditor.Renderer.RenderReceipt.t()) :: t()
   def apply_synchronous_renderer_receipt(%__MODULE__{} = state, receipt) do
-    shell_state =
-      state.shell_state
-      |> merge_renderer_shell_field(:modeline_click_regions, receipt.modeline_click_regions)
-      |> merge_renderer_shell_field(:tab_bar_click_regions, receipt.tab_bar_click_regions)
-
+    shell_runtime = merge_renderer_receipt(state.shell_runtime, receipt)
     workspace = apply_window_observations(state.workspace, receipt.window_observations)
 
     %{
       state
       | layout: receipt.layout,
         focus_tree: receipt.focus_tree,
-        shell_state: shell_state,
+        shell_runtime: shell_runtime,
         workspace: workspace,
         keyframe_pending?: clear_keyframe_pending_from_receipt?(state, receipt),
         last_render_receipt_revision:
@@ -814,18 +806,14 @@ defmodule MingaEditor.State do
 
   defp apply_renderer_receipt(state, receipt, true) do
     if renderer_receipt_shell_current?(state, receipt) do
-      shell_state =
-        state.shell_state
-        |> merge_renderer_shell_field(:modeline_click_regions, receipt.modeline_click_regions)
-        |> merge_renderer_shell_field(:tab_bar_click_regions, receipt.tab_bar_click_regions)
-
+      shell_runtime = merge_renderer_receipt(state.shell_runtime, receipt)
       workspace = apply_window_observations(state.workspace, receipt.window_observations)
 
       %{
         state
         | layout: receipt.layout,
           focus_tree: receipt.focus_tree,
-          shell_state: shell_state,
+          shell_runtime: shell_runtime,
           workspace: workspace,
           keyframe_pending?: clear_keyframe_pending_from_receipt?(state, receipt),
           last_render_receipt_revision: receipt.intent_revision,
@@ -877,468 +865,138 @@ defmodule MingaEditor.State do
   @spec renderer_receipt_shell_current?(t(), MingaEditor.Renderer.RenderReceipt.t()) :: boolean()
   defp renderer_receipt_shell_current?(%__MODULE__{} = state, receipt) do
     case receipt.shell_identity do
-      %ShellIdentity{} = identity -> renderer_identity_current?(state, identity)
-      _missing_or_invalid -> false
+      %ShellIdentity{} = identity ->
+        receipt.shell_id == ShellRuntime.id(state.shell_runtime) and
+          ShellRuntime.matches_identity?(state.shell_runtime, identity)
+
+      _missing_or_invalid ->
+        false
     end
   end
 
-  @spec renderer_identity_current?(t(), ShellIdentity.t()) :: boolean()
-  defp renderer_identity_current?(%__MODULE__{} = state, %ShellIdentity{} = identity) do
-    case MingaEditor.Shell.Registry.get(active_shell_id(state)) do
-      %MingaEditor.Shell.Entry{} = entry -> ShellIdentity.matches?(identity, entry)
-      nil -> false
+  @spec merge_renderer_receipt(ShellRuntime.t(), MingaEditor.Renderer.RenderReceipt.t()) ::
+          ShellRuntime.t()
+  defp merge_renderer_receipt(runtime, receipt) do
+    case receipt.shell_identity do
+      %ShellIdentity{} = identity ->
+        ShellRuntime.merge_renderer_observation(runtime, receipt.shell_id, identity, %{
+          modeline_click_regions: receipt.modeline_click_regions,
+          tab_bar_click_regions: receipt.tab_bar_click_regions
+        })
+
+      _missing_or_invalid ->
+        runtime
     end
   end
 
   @spec log_stale_renderer_receipt(t(), MingaEditor.Renderer.RenderReceipt.t()) :: :ok
   defp log_stale_renderer_receipt(%__MODULE__{} = state, receipt) do
     Log.debug(:render, fn ->
-      "Dropping stale renderer receipt frame=#{receipt.frame_seq} shell=#{inspect(receipt.shell_id)} identity=#{inspect(receipt.shell_identity)} active_shell=#{inspect(active_shell_id(state))}"
+      "Dropping stale renderer receipt frame=#{receipt.frame_seq} shell=#{inspect(receipt.shell_id)} identity=#{inspect(receipt.shell_identity)} active_shell=#{inspect(ShellRuntime.id(state.shell_runtime))}"
     end)
   end
 
-  @spec merge_renderer_shell_field(shell_state(), atom(), term()) :: shell_state()
-  defp merge_renderer_shell_field(live_shell_state, field, value) do
-    if Map.has_key?(live_shell_state, field),
-      do: Map.put(live_shell_state, field, value),
-      else: live_shell_state
+  @doc "Installs a pure shell Runtime transition into the Editor root."
+  @spec apply_shell_runtime_transition(t(), ShellRuntime.t()) :: t()
+  def apply_shell_runtime_transition(%__MODULE__{} = state, %ShellRuntime{} = runtime) do
+    %{state | shell_runtime: runtime}
   end
 
-  @doc "Applies a function to the shell state and returns the updated state."
-  @spec update_shell_state(t() | %{shell_state: shell_state()}, (shell_state() -> shell_state())) ::
-          t() | %{shell_state: shell_state()}
-  def update_shell_state(%{shell_state: ss} = state, fun) when is_function(fun, 1) do
-    %{state | shell_state: fun.(ss)}
+  @doc "Invalidates shell-owned layout values after an activation transition."
+  @spec reset_shell_layout(t()) :: t()
+  def reset_shell_layout(%__MODULE__{} = state), do: %{state | layout: nil, focus_tree: nil}
+
+  # ── Traditional shell forwarding helpers ────────────────────────────────
+  # These transitional helpers move in later shell-state work.
+  # The resolved Traditional entry guards extension state.
+
+  @spec update_traditional_shell_state(t(), (shell_state() -> shell_state())) :: t()
+  defp update_traditional_shell_state(%__MODULE__{} = state, fun) when is_function(fun, 1) do
+    runtime = ShellRuntime.update_traditional_state(state.shell_runtime, fun)
+    apply_shell_runtime_transition(state, runtime)
   end
-
-  @type stashed_shell_transform ::
-          (module(), shell_state(), t() -> {StateStash.transformation(), t()})
-
-  @doc "Transforms current stashed shell states and reports whether any matching value changed."
-  @spec transform_stashed_shell_states(t(), stashed_shell_transform()) :: {t(), boolean()}
-  def transform_stashed_shell_states(%__MODULE__{} = state, fun) when is_function(fun, 3) do
-    state.shell_state_stash
-    |> Map.keys()
-    |> Enum.reduce({state, false}, fn shell_id, {state_acc, changed?} ->
-      transform_stashed_shell_state(state_acc, changed?, shell_id, fun)
-    end)
-  end
-
-  @doc "Transforms the first matching stashed shell that accepts the change."
-  @spec transform_first_stashed_shell_state(t(), stashed_shell_transform()) :: {t(), boolean()}
-  def transform_first_stashed_shell_state(%__MODULE__{} = state, fun) when is_function(fun, 3) do
-    state.shell_state_stash
-    |> Map.keys()
-    |> Enum.reduce_while({state, false}, fn shell_id, {state_acc, false} ->
-      state_acc
-      |> transform_stashed_shell_state(false, shell_id, fun)
-      |> continue_stashed_shell_transform()
-    end)
-  end
-
-  @spec continue_stashed_shell_transform({t(), boolean()}) ::
-          {:cont, {t(), boolean()}} | {:halt, {t(), boolean()}}
-  defp continue_stashed_shell_transform({_state, true} = result), do: {:halt, result}
-  defp continue_stashed_shell_transform(result), do: {:cont, result}
-
-  @spec transform_stashed_shell_state(t(), boolean(), shell_id(), stashed_shell_transform()) ::
-          {t(), boolean()}
-  defp transform_stashed_shell_state(state, changed?, shell_id, fun) do
-    stashed = Map.get(state.shell_state_stash, shell_id)
-    entry = MingaEditor.Shell.Registry.get(shell_id)
-    transform_stashed_shell_state(state, changed?, shell_id, stashed, entry, fun)
-  end
-
-  @spec transform_stashed_shell_state(
-          t(),
-          boolean(),
-          shell_id(),
-          StateStash.t() | nil,
-          MingaEditor.Shell.Entry.t() | nil,
-          stashed_shell_transform()
-        ) :: {t(), boolean()}
-  defp transform_stashed_shell_state(state, changed?, _shell_id, _stashed, nil, _fun),
-    do: {state, changed?}
-
-  defp transform_stashed_shell_state(state, changed?, _shell_id, nil, _entry, _fun),
-    do: {state, changed?}
-
-  defp transform_stashed_shell_state(state, changed?, shell_id, stashed, entry, fun) do
-    stashed
-    |> StateStash.transform(entry, state, fn shell_state, state_acc ->
-      fun.(entry.module, shell_state, state_acc)
-    end)
-    |> merge_stashed_shell_transformation(shell_id, changed?)
-  end
-
-  @spec merge_stashed_shell_transformation(
-          StateStash.transform_result(t()),
-          shell_id(),
-          boolean()
-        ) :: {t(), boolean()}
-  defp merge_stashed_shell_transformation({:updated, updated, state}, shell_id, _changed?) do
-    stash = Map.put(state.shell_state_stash, shell_id, updated)
-    {%{state | shell_state_stash: stash}, true}
-  end
-
-  defp merge_stashed_shell_transformation(
-         {:unchanged, _unchanged, state},
-         _shell_id,
-         changed?
-       ),
-       do: {state, changed?}
-
-  defp merge_stashed_shell_transformation({:mismatch, state}, _shell_id, changed?),
-    do: {state, changed?}
-
-  @doc "Returns the active shell id, preserving compatibility with tests that still set only `:shell`."
-  @spec active_shell_id(t() | map()) :: shell_id()
-  def active_shell_id(%{shell_id: id, shell: shell}) do
-    case MingaEditor.Shell.Registry.get(id) do
-      %{module: ^shell} -> id
-      _other -> MingaEditor.Shell.Registry.id_for_module(shell) || id
-    end
-  end
-
-  def active_shell_id(%{shell: shell}) when is_atom(shell) do
-    MingaEditor.Shell.Registry.id_for_module(shell) || MingaEditor.Shell.Registry.default().id
-  end
-
-  def active_shell_id(_state), do: MingaEditor.Shell.Registry.default().id
-
-  @doc "Returns the active shell module, refreshing from the registry when possible."
-  @spec active_shell_module(t() | map()) :: module()
-  def active_shell_module(%__MODULE__{} = state) do
-    case MingaEditor.Shell.Registry.get(state.shell_id) do
-      %MingaEditor.Shell.Entry{} = entry -> active_shell_module_for_entry(state, entry)
-      nil -> active_shell_module_for_missing_entry(state)
-    end
-  end
-
-  def active_shell_module(%{
-        shell_id: id,
-        shell: fallback,
-        shell_identity: %ShellIdentity{} = identity
-      }) do
-    case MingaEditor.Shell.Registry.get(id) do
-      %MingaEditor.Shell.Entry{} = entry ->
-        if ShellIdentity.matches?(identity, entry), do: entry.module, else: fallback
-
-      nil ->
-        fallback
-    end
-  end
-
-  def active_shell_module(%{shell_id: id, shell: fallback}) do
-    entry = MingaEditor.Shell.Registry.get(id)
-    fallback_id = MingaEditor.Shell.Registry.id_for_module(fallback)
-    resolve_active_shell_module(entry, id, fallback, fallback_id)
-  end
-
-  def active_shell_module(%{shell: shell}) when is_atom(shell), do: shell
-  def active_shell_module(_state), do: MingaEditor.Shell.Registry.default().module
-
-  @spec active_shell_module_for_entry(t(), MingaEditor.Shell.Entry.t()) :: module()
-  defp active_shell_module_for_entry(%__MODULE__{} = state, %MingaEditor.Shell.Entry{} = entry) do
-    if active_shell_entry_matches?(state, entry), do: entry.module, else: state.shell
-  end
-
-  @spec active_shell_module_for_missing_entry(t()) :: module()
-  defp active_shell_module_for_missing_entry(%__MODULE__{} = state) do
-    (MingaEditor.Shell.Registry.id_for_module(state.shell) && state.shell) ||
-      MingaEditor.Shell.Registry.default().module
-  end
-
-  @spec resolve_active_shell_module(
-          MingaEditor.Shell.Entry.t() | nil,
-          shell_id(),
-          module(),
-          shell_id() | nil
-        ) :: module()
-  defp resolve_active_shell_module(%{module: module}, id, _fallback, id), do: module
-  defp resolve_active_shell_module(%{module: module}, _id, _fallback, nil), do: module
-  defp resolve_active_shell_module(%{}, _id, fallback, _fallback_id), do: fallback
-
-  defp resolve_active_shell_module(nil, _id, _fallback, nil),
-    do: MingaEditor.Shell.Registry.default().module
-
-  defp resolve_active_shell_module(nil, _id, fallback, _fallback_id), do: fallback
-
-  @doc "Ensures the active shell still exists, falling back to the registry default if it was unregistered."
-  @spec ensure_shell_available(t()) :: t()
-  def ensure_shell_available(%__MODULE__{} = state) do
-    shell_id = active_shell_id(state)
-
-    case MingaEditor.Shell.Registry.get(shell_id) do
-      %MingaEditor.Shell.Entry{} = entry -> ensure_registered_shell_identity(state, entry)
-      nil -> switch_to_default_shell(%{state | shell_id: shell_id})
-    end
-  end
-
-  @spec ensure_registered_shell_identity(t(), MingaEditor.Shell.Entry.t()) :: t()
-  defp ensure_registered_shell_identity(%__MODULE__{} = state, %MingaEditor.Shell.Entry{} = entry) do
-    if active_shell_entry_matches?(state, entry) do
-      refresh_active_shell_identity(state, entry)
-    else
-      reset_active_shell_identity(state, entry)
-    end
-  end
-
-  @spec refresh_active_shell_identity(t(), MingaEditor.Shell.Entry.t()) :: t()
-  defp refresh_active_shell_identity(
-         %__MODULE__{shell_identity: nil} = state,
-         %MingaEditor.Shell.Entry{source: :builtin} = entry
-       ) do
-    %{state | shell_id: entry.id, shell: entry.module}
-  end
-
-  defp refresh_active_shell_identity(%__MODULE__{} = state, %MingaEditor.Shell.Entry{} = entry) do
-    %{state | shell_id: entry.id, shell: entry.module, shell_identity: ShellIdentity.new(entry)}
-  end
-
-  @spec reset_active_shell_identity(t(), MingaEditor.Shell.Entry.t()) :: t()
-  defp reset_active_shell_identity(%__MODULE__{} = state, %MingaEditor.Shell.Entry{} = entry) do
-    Log.warning(
-      :editor,
-      "Shell #{inspect(entry.id)} registry identity changed; resetting shell state"
-    )
-
-    %{
-      state
-      | shell_id: entry.id,
-        shell: entry.module,
-        shell_identity: ShellIdentity.new(entry),
-        shell_state: init_shell_state(entry.module, state.shell_state),
-        shell_state_stash: Map.delete(state.shell_state_stash, entry.id),
-        layout: nil,
-        focus_tree: nil
-    }
-    |> set_status("Shell #{entry.display_name} reloaded")
-  end
-
-  @spec active_shell_entry_matches?(t(), MingaEditor.Shell.Entry.t()) :: boolean()
-  defp active_shell_entry_matches?(
-         %__MODULE__{shell: shell},
-         %MingaEditor.Shell.Entry{source: :builtin, module: shell}
-       ) do
-    true
-  end
-
-  defp active_shell_entry_matches?(
-         %__MODULE__{shell: shell, shell_identity: %ShellIdentity{} = identity},
-         %MingaEditor.Shell.Entry{} = entry
-       ) do
-    shell == entry.module and ShellIdentity.matches?(identity, entry)
-  end
-
-  defp active_shell_entry_matches?(
-         %__MODULE__{shell: shell, shell_identity: nil},
-         %MingaEditor.Shell.Entry{source: :builtin, module: shell}
-       ) do
-    true
-  end
-
-  defp active_shell_entry_matches?(%__MODULE__{shell_identity: nil}, %MingaEditor.Shell.Entry{}),
-    do: false
-
-  @doc "Switches to a registered shell by id, stashing the current shell state by shell id."
-  @spec switch_shell(t(), shell_id()) :: t()
-  def switch_shell(%__MODULE__{} = state, shell_id) when is_atom(shell_id) do
-    MingaEditor.Shell.Registry.seed_builtin()
-    do_switch_shell(state, shell_id, MingaEditor.Shell.Registry.list())
-  end
-
-  @spec do_switch_shell(t(), shell_id(), [MingaEditor.Shell.Entry.t()]) :: t()
-  defp do_switch_shell(%__MODULE__{} = state, shell_id, entries) do
-    current_id = active_shell_id(state)
-    route_shell_switch(state, current_id, shell_id, entries)
-  end
-
-  @spec route_shell_switch(t(), shell_id(), shell_id(), [MingaEditor.Shell.Entry.t()]) :: t()
-  defp route_shell_switch(%__MODULE__{} = state, current_id, shell_id, [_only])
-       when shell_id != current_id do
-    set_status(state, "Only one shell is available")
-  end
-
-  defp route_shell_switch(%__MODULE__{} = state, shell_id, shell_id, _entries) do
-    set_status(state, "Already using #{shell_display_name(shell_id)}")
-  end
-
-  defp route_shell_switch(%__MODULE__{} = state, _current_id, shell_id, _entries) do
-    case MingaEditor.Shell.Registry.get(shell_id) do
-      %{module: module} -> switch_to_registered_shell(state, shell_id, module)
-      nil -> set_status(state, "Shell #{shell_id} is unavailable")
-    end
-  end
-
-  @spec switch_to_default_shell(t()) :: t()
-  defp switch_to_default_shell(%__MODULE__{} = state) do
-    default = MingaEditor.Shell.Registry.default()
-
-    Log.warning(
-      :editor,
-      "Active shell #{inspect(active_shell_id(state))} (#{inspect(state.shell)}) is unavailable; switching to #{inspect(default.id)}"
-    )
-
-    state
-    |> switch_to_registered_shell(default.id, default.module)
-    |> set_status("Shell unavailable, switched to #{default.display_name}")
-  end
-
-  @spec switch_to_registered_shell(t(), shell_id(), module()) :: t()
-  defp switch_to_registered_shell(%__MODULE__{} = state, target_id, module) do
-    current_entry = current_shell_entry_for_stash(state)
-    target_entry = MingaEditor.Shell.Registry.get(target_id)
-
-    stash =
-      state.shell_state_stash
-      |> stash_current_shell(current_entry, state.shell_state)
-      |> Map.delete(target_id)
-
-    shell_state =
-      restore_shell_state(state.shell_state_stash, target_entry, module, state.shell_state)
-
-    %{
-      state
-      | shell_id: target_id,
-        shell: module,
-        shell_identity: shell_identity(target_entry),
-        shell_state: shell_state,
-        shell_state_stash: stash,
-        layout: nil,
-        focus_tree: nil
-    }
-  end
-
-  @spec current_shell_entry_for_stash(t()) :: MingaEditor.Shell.Entry.t() | nil
-  defp current_shell_entry_for_stash(%__MODULE__{} = state) do
-    case MingaEditor.Shell.Registry.get(state.shell_id) do
-      %MingaEditor.Shell.Entry{} = entry -> current_shell_entry_for_stash(state, entry)
-      nil -> nil
-    end
-  end
-
-  @spec current_shell_entry_for_stash(t(), MingaEditor.Shell.Entry.t()) ::
-          MingaEditor.Shell.Entry.t() | nil
-  defp current_shell_entry_for_stash(%__MODULE__{} = state, %MingaEditor.Shell.Entry{} = entry) do
-    if active_shell_entry_matches?(state, entry), do: entry, else: nil
-  end
-
-  @spec shell_identity(MingaEditor.Shell.Entry.t() | nil) :: ShellIdentity.t() | nil
-  defp shell_identity(%MingaEditor.Shell.Entry{} = entry), do: ShellIdentity.new(entry)
-  defp shell_identity(nil), do: nil
-
-  @spec stash_current_shell(shell_state_stash(), MingaEditor.Shell.Entry.t() | nil, shell_state()) ::
-          shell_state_stash()
-  defp stash_current_shell(stash, nil, _shell_state), do: stash
-
-  defp stash_current_shell(stash, current_entry, shell_state) do
-    Map.put(stash, current_entry.id, StateStash.new(current_entry, shell_state))
-  end
-
-  @spec restore_shell_state(
-          shell_state_stash(),
-          MingaEditor.Shell.Entry.t() | nil,
-          module(),
-          shell_state()
-        ) ::
-          shell_state()
-  defp restore_shell_state(
-         stash,
-         %MingaEditor.Shell.Entry{} = target_entry,
-         module,
-         previous_shell_state
-       ) do
-    case Map.get(stash, target_entry.id) do
-      %StateStash{} = stashed ->
-        case StateStash.restore(stashed, target_entry) do
-          {:ok, shell_state} -> shell_state
-          :mismatch -> init_shell_state(module, previous_shell_state)
-        end
-
-      _other ->
-        init_shell_state(module, previous_shell_state)
-    end
-  end
-
-  defp restore_shell_state(_stash, _target_entry, module, previous_shell_state) do
-    init_shell_state(module, previous_shell_state)
-  end
-
-  @spec init_shell_state(module(), shell_state()) :: shell_state()
-  defp init_shell_state(MingaEditor.Shell.Traditional, previous_shell_state) do
-    %ShellState{
-      suppress_tool_prompts: Map.get(previous_shell_state, :suppress_tool_prompts, false)
-    }
-  end
-
-  defp init_shell_state(module, _previous_shell_state), do: module.init([])
-
-  @spec shell_display_name(shell_id()) :: String.t()
-  defp shell_display_name(shell_id) do
-    case MingaEditor.Shell.Registry.get(shell_id) do
-      %{display_name: name} -> name
-      nil -> Atom.to_string(shell_id)
-    end
-  end
-
-  # ── Shell field delegates ────────────────────────────────────────────────
-  # Thin wrappers that delegate to `ShellState` through `update_shell_state/2`.
-  # Both `update_shell_state` and `ShellState` methods use bare-map patterns
-  # so they work with Traditional state, extension shell state, and test stubs alike.
-  # The canonical @doc lives in `MingaEditor.Shell.Traditional.State`.
 
   @spec status_msg(t()) :: String.t() | nil
-  def status_msg(%{shell_state: ss}), do: ShellState.status_msg(ss)
+  def status_msg(%{
+        shell_runtime: %ShellRuntime{
+          entry: %{module: MingaEditor.Shell.Traditional},
+          state: shell_state
+        }
+      }),
+      do: ShellState.status_msg(shell_state)
+
+  def status_msg(_state), do: nil
   @spec set_status(t(), String.t()) :: t()
-  def set_status(s, msg), do: update_shell_state(s, &ShellState.set_status(&1, msg))
+  def set_status(s, msg), do: update_traditional_shell_state(s, &ShellState.set_status(&1, msg))
   @spec clear_status(t()) :: t()
-  def clear_status(s), do: update_shell_state(s, &ShellState.clear_status/1)
+  def clear_status(s), do: update_traditional_shell_state(s, &ShellState.clear_status/1)
+
+  @spec set_suppress_tool_prompts(t(), boolean()) :: t()
+  def set_suppress_tool_prompts(s, suppress?) when is_boolean(suppress?) do
+    update_traditional_shell_state(s, &ShellState.set_suppress_tool_prompts(&1, suppress?))
+  end
 
   @spec nav_flash(t()) :: MingaEditor.NavFlash.t() | nil
-  def nav_flash(%{shell_state: ss}), do: ShellState.nav_flash(ss)
+  def nav_flash(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.nav_flash(ss)
   @spec set_nav_flash(t(), MingaEditor.NavFlash.t()) :: t()
-  def set_nav_flash(s, flash), do: update_shell_state(s, &ShellState.set_nav_flash(&1, flash))
+  def set_nav_flash(s, flash),
+    do: update_traditional_shell_state(s, &ShellState.set_nav_flash(&1, flash))
+
   @spec cancel_nav_flash(t()) :: t()
-  def cancel_nav_flash(s), do: update_shell_state(s, &ShellState.cancel_nav_flash/1)
+  def cancel_nav_flash(s), do: update_traditional_shell_state(s, &ShellState.cancel_nav_flash/1)
 
   @spec yank_flash(t()) :: MingaEditor.YankFlash.t() | nil
-  def yank_flash(%{shell_state: ss}), do: ShellState.yank_flash(ss)
+  def yank_flash(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.yank_flash(ss)
   @spec set_yank_flash(t(), MingaEditor.YankFlash.t()) :: t()
-  def set_yank_flash(s, flash), do: update_shell_state(s, &ShellState.set_yank_flash(&1, flash))
+  def set_yank_flash(s, flash),
+    do: update_traditional_shell_state(s, &ShellState.set_yank_flash(&1, flash))
+
   @spec cancel_yank_flash(t()) :: t()
-  def cancel_yank_flash(s), do: update_shell_state(s, &ShellState.cancel_yank_flash/1)
+  def cancel_yank_flash(s), do: update_traditional_shell_state(s, &ShellState.cancel_yank_flash/1)
 
   @spec hover_popup(t()) :: MingaEditor.HoverPopup.t() | nil
-  def hover_popup(%{shell_state: ss}), do: ShellState.hover_popup(ss)
+  def hover_popup(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.hover_popup(ss)
   @spec set_hover_popup(t(), MingaEditor.HoverPopup.t()) :: t()
-  def set_hover_popup(s, popup), do: update_shell_state(s, &ShellState.set_hover_popup(&1, popup))
+  def set_hover_popup(s, popup),
+    do: update_traditional_shell_state(s, &ShellState.set_hover_popup(&1, popup))
+
   @spec dismiss_hover_popup(t()) :: t()
-  def dismiss_hover_popup(s), do: update_shell_state(s, &ShellState.dismiss_hover_popup/1)
+  def dismiss_hover_popup(s),
+    do: update_traditional_shell_state(s, &ShellState.dismiss_hover_popup/1)
 
   @spec whichkey(t()) :: WhichKey.t()
-  def whichkey(%{shell_state: ss}), do: ShellState.whichkey(ss)
+  def whichkey(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.whichkey(ss)
   @spec set_whichkey(t(), WhichKey.t()) :: t()
-  def set_whichkey(s, wk), do: update_shell_state(s, &ShellState.set_whichkey(&1, wk))
+  def set_whichkey(s, wk), do: update_traditional_shell_state(s, &ShellState.set_whichkey(&1, wk))
 
   @spec bottom_panel(t()) :: BottomPanel.t()
-  def bottom_panel(%{shell_state: ss}), do: ShellState.bottom_panel(ss)
+  def bottom_panel(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.bottom_panel(ss)
   @spec set_bottom_panel(t(), BottomPanel.t()) :: t()
   def set_bottom_panel(s, panel),
-    do: update_shell_state(s, &ShellState.set_bottom_panel(&1, panel))
+    do: update_traditional_shell_state(s, &ShellState.set_bottom_panel(&1, panel))
 
   @spec git_status_panel(t()) :: ShellState.git_status_panel() | nil
-  def git_status_panel(%{shell_state: ss}), do: ShellState.git_status_panel(ss)
+  def git_status_panel(%{shell_runtime: %ShellRuntime{state: ss}}),
+    do: ShellState.git_status_panel(ss)
+
+  @spec set_git_status_tui_state(t(), term()) :: t()
+  def set_git_status_tui_state(state, tui_state) do
+    update_traditional_shell_state(
+      state,
+      &ShellState.set_git_status_tui_state(&1, tui_state)
+    )
+  end
+
   @spec set_git_status_panel(t(), ShellState.git_status_panel() | nil) :: t()
   def set_git_status_panel(s, nil) do
     sync_git_status_sidebar(s, nil)
-    update_shell_state(s, &ShellState.set_git_status_panel(&1, nil))
+    update_traditional_shell_state(s, &ShellState.set_git_status_panel(&1, nil))
   end
 
   def set_git_status_panel(s, data) do
     panel = GitStatusPanel.new(data)
     sync_git_status_sidebar(s, panel)
-    update_shell_state(s, &ShellState.set_git_status_panel(&1, panel))
+    update_traditional_shell_state(s, &ShellState.set_git_status_panel(&1, panel))
   end
 
   @spec sync_git_status_sidebar(t(), GitStatusPanel.t() | nil) :: :ok
@@ -1355,18 +1013,25 @@ defmodule MingaEditor.State do
   @spec close_git_status_panel(t()) :: t()
   def close_git_status_panel(s) do
     sync_git_status_sidebar(s, nil)
-    update_shell_state(s, &ShellState.close_git_status_panel/1)
+    update_traditional_shell_state(s, &ShellState.close_git_status_panel/1)
   end
 
   @spec sidebar_active_id(t()) :: String.t() | nil
-  def sidebar_active_id(%{shell_state: %{sidebar_active_id: id}}), do: id
+  def sidebar_active_id(%{
+        shell_runtime: %ShellRuntime{
+          entry: %{module: MingaEditor.Shell.Traditional},
+          state: %{sidebar_active_id: id}
+        }
+      }),
+      do: id
+
   def sidebar_active_id(_state), do: nil
 
   @spec set_sidebar_active_id(t(), String.t() | nil) :: t()
   def set_sidebar_active_id(s, id) when is_binary(id) or is_nil(id) do
     sync_active_sidebar(s, id)
 
-    update_shell_state(s, fn ss ->
+    update_traditional_shell_state(s, fn ss ->
       if Map.has_key?(ss, :sidebar_active_id),
         do: ShellState.set_sidebar_active_id(ss, id),
         else: ss
@@ -1382,18 +1047,19 @@ defmodule MingaEditor.State do
   end
 
   @spec observatory_visible?(t()) :: boolean()
-  def observatory_visible?(%{shell_state: ss}), do: ShellState.observatory_visible?(ss)
+  def observatory_visible?(%{shell_runtime: %ShellRuntime{state: ss}}),
+    do: ShellState.observatory_visible?(ss)
 
   @spec open_observatory(t(), {reference(), reference()} | nil) :: t()
   def open_observatory(s, timer) do
     sync_observatory_sidebar(s, true)
-    update_shell_state(s, &ShellState.open_observatory(&1, timer))
+    update_traditional_shell_state(s, &ShellState.open_observatory(&1, timer))
   end
 
   @spec close_observatory(t()) :: t()
   def close_observatory(s) do
     sync_observatory_sidebar(s, false)
-    update_shell_state(s, &ShellState.close_observatory/1)
+    update_traditional_shell_state(s, &ShellState.close_observatory/1)
   end
 
   @spec sync_observatory_sidebar(t(), boolean()) :: :ok
@@ -1409,34 +1075,35 @@ defmodule MingaEditor.State do
 
   @spec set_observatory_data(t(), Observatory.Data.t() | nil) :: t()
   def set_observatory_data(s, data),
-    do: update_shell_state(s, &ShellState.set_observatory_data(&1, data))
+    do: update_traditional_shell_state(s, &ShellState.set_observatory_data(&1, data))
 
   @spec set_observatory_timer(t(), {reference(), reference()} | nil) :: t()
   def set_observatory_timer(s, timer),
-    do: update_shell_state(s, &ShellState.set_observatory_timer(&1, timer))
+    do: update_traditional_shell_state(s, &ShellState.set_observatory_timer(&1, timer))
 
   @spec set_observatory_inspection(t(), Observatory.Inspection.t() | nil) :: t()
   def set_observatory_inspection(s, inspection),
-    do: update_shell_state(s, &ShellState.set_observatory_inspection(&1, inspection))
+    do: update_traditional_shell_state(s, &ShellState.set_observatory_inspection(&1, inspection))
 
   @spec set_git_toast(t(), ShellState.git_toast()) :: t()
-  def set_git_toast(s, toast), do: update_shell_state(s, &ShellState.set_git_toast(&1, toast))
+  def set_git_toast(s, toast),
+    do: update_traditional_shell_state(s, &ShellState.set_git_toast(&1, toast))
 
   @spec clear_git_toast(t()) :: t()
-  def clear_git_toast(s), do: update_shell_state(s, &ShellState.clear_git_toast/1)
+  def clear_git_toast(s), do: update_traditional_shell_state(s, &ShellState.clear_git_toast/1)
 
   @spec clear_git_toast(t(), reference()) :: t()
   def clear_git_toast(s, dismiss_ref),
-    do: update_shell_state(s, &ShellState.clear_git_toast(&1, dismiss_ref))
+    do: update_traditional_shell_state(s, &ShellState.clear_git_toast(&1, dismiss_ref))
 
   @spec tab_bar(t()) :: TabBar.t() | nil
-  def tab_bar(%{shell_state: ss}), do: ShellState.tab_bar(ss)
+  def tab_bar(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.tab_bar(ss)
   @spec set_tab_bar(t(), TabBar.t() | nil) :: t()
-  def set_tab_bar(s, tb), do: update_shell_state(s, &ShellState.set_tab_bar(&1, tb))
+  def set_tab_bar(s, tb), do: update_traditional_shell_state(s, &ShellState.set_tab_bar(&1, tb))
 
   @spec drop_tab_context_feature_state_source(t(), FeatureState.source()) :: t()
   defp drop_tab_context_feature_state_source(
-         %__MODULE__{shell_state: %ShellState{}} = state,
+         %__MODULE__{shell_runtime: %ShellRuntime{state: %ShellState{}}} = state,
          source
        ) do
     case tab_bar(state) do
@@ -1449,7 +1116,7 @@ defmodule MingaEditor.State do
 
   @spec drop_tab_context_extension_feature_state_sources(t()) :: t()
   defp drop_tab_context_extension_feature_state_sources(
-         %__MODULE__{shell_state: %ShellState{}} = state
+         %__MODULE__{shell_runtime: %ShellRuntime{state: %ShellState{}}} = state
        ) do
     case tab_bar(state) do
       %TabBar{} = tb -> set_tab_bar(state, TabBar.drop_extension_feature_state_sources(tb))
@@ -1461,82 +1128,87 @@ defmodule MingaEditor.State do
 
   @spec drop_shell_feature_state_source(t(), FeatureState.source()) :: t()
   defp drop_shell_feature_state_source(%__MODULE__{} = state, source) do
-    state
-    |> update_active_shell_feature_state(:drop_feature_state_source, [source])
-    |> update_stashed_shell_feature_state(:drop_feature_state_source, [source])
+    runtime =
+      ShellRuntime.drop_feature_state_source(
+        state.shell_runtime,
+        MingaEditor.Shell.Workflow.resolved_entries(),
+        source
+      )
+
+    apply_shell_runtime_transition(state, runtime)
   end
 
   @spec drop_shell_extension_feature_state_sources(t()) :: t()
   defp drop_shell_extension_feature_state_sources(%__MODULE__{} = state) do
-    state
-    |> update_active_shell_feature_state(:drop_extension_feature_state_sources, [])
-    |> update_stashed_shell_feature_state(:drop_extension_feature_state_sources, [])
-  end
+    runtime =
+      ShellRuntime.drop_extension_feature_state_sources(
+        state.shell_runtime,
+        MingaEditor.Shell.Workflow.resolved_entries()
+      )
 
-  @spec update_active_shell_feature_state(t(), atom(), [term()]) :: t()
-  defp update_active_shell_feature_state(%__MODULE__{} = state, callback, args) do
-    module = active_shell_module(state)
-
-    case apply_optional_shell_callback(module, state.shell_state, callback, args) do
-      {:ok, shell_state} -> update_shell_state(state, fn _shell_state -> shell_state end)
-      :missing -> state
-    end
-  end
-
-  @spec update_stashed_shell_feature_state(t(), atom(), [term()]) :: t()
-  defp update_stashed_shell_feature_state(%__MODULE__{} = state, callback, args) do
-    {state, _changed?} =
-      transform_stashed_shell_states(state, fn module, shell_state, state_acc ->
-        case apply_optional_shell_callback(module, shell_state, callback, args) do
-          {:ok, ^shell_state} -> {:unchanged, state_acc}
-          {:ok, cleaned_shell_state} -> {{:updated, cleaned_shell_state}, state_acc}
-          :missing -> {:unchanged, state_acc}
-        end
-      end)
-
-    state
-  end
-
-  @spec apply_optional_shell_callback(module() | nil, term(), atom(), [term()]) ::
-          {:ok, term()} | :missing
-  defp apply_optional_shell_callback(module, shell_state, callback, args)
-       when is_atom(module) and not is_nil(module) do
-    arity = Enum.count(args) + 1
-
-    if shell_callback_exported?(module, callback, arity) do
-      {:ok, apply(module, callback, [shell_state | args])}
-    else
-      :missing
-    end
-  end
-
-  defp apply_optional_shell_callback(_module, _shell_state, _callback, _args), do: :missing
-
-  @spec shell_callback_exported?(module(), atom(), arity()) :: boolean()
-  defp shell_callback_exported?(module, callback, arity) do
-    Code.ensure_loaded?(module) and Enum.member?(module.__info__(:functions), {callback, arity})
+    apply_shell_runtime_transition(state, runtime)
   end
 
   @spec agent(t()) :: AgentState.t()
-  def agent(%{shell_state: ss}), do: ShellState.agent(ss)
+  def agent(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.agent(ss)
   @spec set_agent(t(), AgentState.t()) :: t()
-  def set_agent(s, agent), do: update_shell_state(s, &ShellState.set_agent(&1, agent))
+  def set_agent(s, agent), do: update_traditional_shell_state(s, &ShellState.set_agent(&1, agent))
 
   @spec modal(t()) :: MingaEditor.State.ModalOverlay.t()
-  def modal(%{shell_state: ss}), do: ShellState.modal(ss)
+  def modal(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.modal(ss)
   @spec set_modal(t(), MingaEditor.State.ModalOverlay.t()) :: t()
-  def set_modal(s, modal), do: update_shell_state(s, &ShellState.set_modal(&1, modal))
+  def set_modal(s, modal), do: update_traditional_shell_state(s, &ShellState.set_modal(&1, modal))
 
   @spec inline_asks(t()) :: MingaEditor.State.InlineAsk.store()
-  def inline_asks(%{shell_state: ss}), do: ShellState.inline_asks(ss)
+  def inline_asks(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.inline_asks(ss)
   @spec set_inline_asks(t(), MingaEditor.State.InlineAsk.store()) :: t()
-  def set_inline_asks(s, asks), do: update_shell_state(s, &ShellState.set_inline_asks(&1, asks))
+  def set_inline_asks(s, asks),
+    do: update_traditional_shell_state(s, &ShellState.set_inline_asks(&1, asks))
 
   @spec inline_edits(t()) :: MingaEditor.State.InlineEdit.store()
-  def inline_edits(%{shell_state: ss}), do: ShellState.inline_edits(ss)
+  def inline_edits(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.inline_edits(ss)
   @spec set_inline_edits(t(), MingaEditor.State.InlineEdit.store()) :: t()
   def set_inline_edits(s, edits),
-    do: update_shell_state(s, &ShellState.set_inline_edits(&1, edits))
+    do: update_traditional_shell_state(s, &ShellState.set_inline_edits(&1, edits))
+
+  @doc "Replaces Traditional signature-help presentation state."
+  @spec set_signature_help(t(), MingaEditor.SignatureHelp.t() | nil) :: t()
+  def set_signature_help(state, signature_help) do
+    update_traditional_shell_state(state, &ShellState.set_signature_help(&1, signature_help))
+  end
+
+  @doc "Replaces the Traditional delayed warning-popup timer."
+  @spec set_warning_popup_timer(t(), reference() | nil) :: t()
+  def set_warning_popup_timer(state, timer) do
+    update_traditional_shell_state(state, &ShellState.set_warning_popup_timer(&1, timer))
+  end
+
+  @doc "Replaces the Traditional tool-install prompt queue."
+  @spec set_tool_prompt_queue(t(), [atom()]) :: t()
+  def set_tool_prompt_queue(state, queue) do
+    update_traditional_shell_state(state, &ShellState.set_tool_prompt_queue(&1, queue))
+  end
+
+  @doc "Replaces Traditional tool-prompt decisions and pending queue atomically."
+  @spec set_tool_prompt_state(t(), [atom()], MapSet.t(atom())) :: t()
+  def set_tool_prompt_state(state, queue, declined) do
+    update_traditional_shell_state(
+      state,
+      &ShellState.set_tool_prompt_state(&1, queue, declined)
+    )
+  end
+
+  @doc "Sets whether the Traditional CUA space-leader sequence is pending."
+  @spec set_space_leader_pending(t(), boolean()) :: t()
+  def set_space_leader_pending(state, value) do
+    update_traditional_shell_state(state, &ShellState.set_space_leader_pending(&1, value))
+  end
+
+  @doc "Replaces the Traditional CUA space-leader timer."
+  @spec set_space_leader_timer(t(), reference() | nil) :: t()
+  def set_space_leader_timer(state, timer) do
+    update_traditional_shell_state(state, &ShellState.set_space_leader_timer(&1, timer))
+  end
 
   # ── Global field accessors ─────────────────────────────────────────────────
 
@@ -1698,14 +1370,17 @@ defmodule MingaEditor.State do
   """
   @spec close_buffer_pure(t(), pid()) :: {t(), [MingaEditor.effect()]}
   def close_buffer_pure(%__MODULE__{} = state, pid) do
-    state = do_remove_dead_buffer(state, pid)
-    state = ensure_shell_available(state)
+    state = state |> do_remove_dead_buffer(pid) |> MingaEditor.Shell.Workflow.ensure_available()
 
-    # Dispatch to the shell for presentation cleanup (tab removal, card updates, etc.)
-    {shell_state, workspace, shell_effects} =
-      active_shell_module(state).on_buffer_died(state.shell_state, state.workspace, pid)
+    {runtime, workspace, shell_effects} =
+      ShellRuntime.route_buffer_died(state.shell_runtime, state.workspace, pid)
 
-    {%{state | shell_state: shell_state, workspace: workspace}, shell_effects}
+    state =
+      state
+      |> apply_shell_runtime_transition(runtime)
+      |> set_workspace(workspace)
+
+    {state, shell_effects}
   end
 
   @doc """
@@ -2036,7 +1711,7 @@ defmodule MingaEditor.State do
   @doc "Returns the set of buffer pids known to the live workspace and tab snapshots."
   @spec known_open_buffer_pids(t()) :: [pid()]
   def known_open_buffer_pids(%__MODULE__{} = state) do
-    (state.workspace.buffers.list ++ tab_context_buffer_pids(state.shell_state.tab_bar))
+    (state.workspace.buffers.list ++ tab_context_buffer_pids(tab_bar(state)))
     |> Enum.filter(&is_pid/1)
     |> Enum.uniq()
   end
@@ -2049,8 +1724,9 @@ defmodule MingaEditor.State do
   """
   @spec rebind_buffer_file_identity(t(), pid()) :: t()
   def rebind_buffer_file_identity(%__MODULE__{} = state, buffer_pid) when is_pid(buffer_pid) do
-    case {matching_file_tabs(state.shell_state.tab_bar, buffer_pid),
-          buffer_file_ref(buffer_pid, state.workspace)} do
+    tab_bar = tab_bar(state)
+
+    case {matching_file_tabs(tab_bar, buffer_pid), buffer_file_ref(buffer_pid, state.workspace)} do
       {[], _} ->
         state
 
@@ -2058,8 +1734,7 @@ defmodule MingaEditor.State do
         state
 
       {tabs, %FileRef{} = file_ref} ->
-        updated_tab_bar = rebind_tabs_to_file_ref(state.shell_state.tab_bar, tabs, file_ref)
-        %{state | shell_state: %{state.shell_state | tab_bar: updated_tab_bar}}
+        set_tab_bar(state, rebind_tabs_to_file_ref(tab_bar, tabs, file_ref))
     end
   end
 
@@ -2205,12 +1880,11 @@ defmodule MingaEditor.State do
     state =
       state
       |> update_workspace(&SessionState.set_buffers(&1, new_bs))
-      |> ensure_shell_available()
+      |> MingaEditor.Shell.Workflow.ensure_available()
 
-    # Dispatch to the active shell for presentation logic
-    {shell_state, workspace, shell_effects} =
-      active_shell_module(state).on_buffer_added(
-        state.shell_state,
+    {runtime, workspace, shell_effects} =
+      ShellRuntime.route_buffer_added(
+        state.shell_runtime,
         prev_workspace,
         state.workspace,
         pid,
@@ -2219,7 +1893,7 @@ defmodule MingaEditor.State do
 
     state =
       state
-      |> update_shell_state(fn _ -> shell_state end)
+      |> apply_shell_runtime_transition(runtime)
       |> set_workspace(workspace)
       |> Map.put(:buffer_add_context, :open)
 
@@ -2251,19 +1925,19 @@ defmodule MingaEditor.State do
     state =
       state
       |> update_workspace(&SessionState.switch_buffer(&1, idx))
-      |> ensure_shell_available()
+      |> MingaEditor.Shell.Workflow.ensure_available()
 
     case state.buffer_add_context do
       :preview ->
         %{state | buffer_add_context: :open}
 
       :open ->
-        {shell_state, workspace, shell_effects} =
-          active_shell_module(state).on_buffer_switched(state.shell_state, state.workspace)
+        {runtime, workspace, shell_effects} =
+          ShellRuntime.route_buffer_switched(state.shell_runtime, state.workspace)
 
         state =
           state
-          |> update_shell_state(fn _ -> shell_state end)
+          |> apply_shell_runtime_transition(runtime)
           |> set_workspace(workspace)
 
         apply_buffer_effects(state, shell_effects)
@@ -2288,7 +1962,14 @@ defmodule MingaEditor.State do
   end
 
   @spec clear_file_tabs(t()) :: t()
-  defp clear_file_tabs(%__MODULE__{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp clear_file_tabs(
+         %__MODULE__{
+           shell_runtime: %ShellRuntime{
+             entry: %{module: MingaEditor.Shell.Traditional},
+             state: %{tab_bar: %TabBar{} = tb}
+           }
+         } = state
+       ) do
     set_tab_bar(state, TabBar.remove_file_tabs(tb))
   end
 
@@ -2304,13 +1985,13 @@ defmodule MingaEditor.State do
   """
   @spec refresh_active_buffer_presentation(t()) :: t()
   def refresh_active_buffer_presentation(%__MODULE__{} = state) do
-    state = ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
-    {shell_state, workspace, shell_effects} =
-      active_shell_module(state).on_buffer_switched(state.shell_state, state.workspace)
+    {runtime, workspace, shell_effects} =
+      ShellRuntime.route_buffer_switched(state.shell_runtime, state.workspace)
 
     state
-    |> update_shell_state(fn _ -> shell_state end)
+    |> apply_shell_runtime_transition(runtime)
     |> set_workspace(workspace)
     |> apply_buffer_effects(shell_effects)
   end
@@ -2694,7 +2375,7 @@ defmodule MingaEditor.State do
   """
   @spec switch_tab_pure(t(), Tab.id()) :: {t(), [MingaEditor.effect()]}
   def switch_tab_pure(%__MODULE__{} = state, target_id) do
-    state = ensure_shell_available(state)
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     case tab_bar(state) do
       nil ->
@@ -2764,7 +2445,12 @@ defmodule MingaEditor.State do
   @doc "Syncs the live workspace agent UI mirror from the active workspace."
   @spec sync_agent_ui_from_active_workspace(t()) :: t()
   def sync_agent_ui_from_active_workspace(
-        %__MODULE__{shell_state: %{tab_bar: %TabBar{} = tab_bar}} = state
+        %__MODULE__{
+          shell_runtime: %ShellRuntime{
+            entry: %{module: MingaEditor.Shell.Traditional},
+            state: %{tab_bar: %TabBar{} = tab_bar}
+          }
+        } = state
       ) do
     agent_ui =
       case TabBar.active_workspace(tab_bar) do
@@ -2813,22 +2499,16 @@ defmodule MingaEditor.State do
   end
 
   @spec active_tab(t()) :: Tab.t() | nil
-  def active_tab(%__MODULE__{} = state) do
-    state = ensure_shell_available(state)
-    active_shell_module(state).active_tab(state.shell_state)
-  end
+  def active_tab(%__MODULE__{} = state), do: ShellRuntime.active_tab(state.shell_runtime)
 
   @spec find_tab_by_buffer(t(), pid()) :: Tab.t() | nil
   def find_tab_by_buffer(%__MODULE__{} = state, pid) do
-    state = ensure_shell_available(state)
-    active_shell_module(state).find_tab_by_buffer(state.shell_state, pid)
+    ShellRuntime.find_tab_by_buffer(state.shell_runtime, pid)
   end
 
   @spec active_tab_kind(t()) :: Tab.kind()
-  def active_tab_kind(%__MODULE__{} = state) do
-    state = ensure_shell_available(state)
-    active_shell_module(state).active_tab_kind(state.shell_state)
-  end
+  def active_tab_kind(%__MODULE__{} = state),
+    do: ShellRuntime.active_tab_kind(state.shell_runtime)
 
   # ── Spinner lifecycle for tab switching ──────────────────────────────────────
 
@@ -2850,19 +2530,15 @@ defmodule MingaEditor.State do
 
   @spec set_tab_session(t(), Tab.id(), pid() | nil) :: t()
   def set_tab_session(%__MODULE__{} = state, tab_id, session_pid) do
-    state = ensure_shell_available(state)
-
-    shell_state =
-      active_shell_module(state).set_tab_session(state.shell_state, tab_id, session_pid)
-
-    %{state | shell_state: shell_state}
+    runtime = ShellRuntime.set_tab_session(state.shell_runtime, tab_id, session_pid)
+    apply_shell_runtime_transition(state, runtime)
   end
 
   @doc """
   Rebuilds the agent rendering cache from the Session process when
   switching to an agent tab. The Session is the source of truth for
   status, pending approval, and error; the cache lives on
-  `state.shell_state.agent` and is repopulated from the Tab's session
+  `state.shell_runtime.state.agent` and is repopulated from the Tab's session
   pid on every tab switch.
 
   The session pid itself lives on `Tab.session` (see `set_tab_session/3`),
@@ -2930,9 +2606,19 @@ defmodule MingaEditor.State do
   installed, currently being installed, or already in the prompt queue.
   """
   @spec skip_tool_prompt?(t(), atom()) :: boolean()
-  def skip_tool_prompt?(%__MODULE__{shell_state: ss}, tool_name) do
+  def skip_tool_prompt?(
+        %__MODULE__{
+          shell_runtime: %ShellRuntime{
+            entry: %{module: MingaEditor.Shell.Traditional},
+            state: ss
+          }
+        },
+        tool_name
+      ) do
     ShellState.skip_tool_prompt?(ss, tool_name)
   end
+
+  def skip_tool_prompt?(%__MODULE__{}, _tool_name), do: true
 
   # ── Buffer lifecycle effect application ──────────────────────────────────────
   #

--- a/lib/minga_editor/state/agent_access.ex
+++ b/lib/minga_editor/state/agent_access.ex
@@ -14,15 +14,15 @@ defmodule MingaEditor.State.AgentAccess do
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace
-  alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Session.State, as: WorkspaceState
 
   # ── Readers ────────────────────────────────────────────────────────────────
 
   @doc "Returns the agent session lifecycle state."
   @spec agent(EditorState.t() | map()) :: AgentState.t()
-  def agent(%EditorState{shell_state: %{agent: a}}), do: a
-  def agent(%{shell_state: %{agent: a}}), do: a
+  def agent(%EditorState{shell_runtime: %Runtime{state: %{agent: a}}}), do: a
   def agent(%{agent: a}), do: a
   def agent(_), do: %AgentState{}
 
@@ -30,9 +30,6 @@ defmodule MingaEditor.State.AgentAccess do
   @spec agent_ui(EditorState.t() | map()) :: UIState.t()
   def agent_ui(%EditorState{} = state),
     do: active_workspace_agent_ui(state) || state.workspace.agent_ui
-
-  def agent_ui(%{shell_state: %{tab_bar: %TabBar{}}, workspace: %{agent_ui: agent_ui}} = state),
-    do: active_workspace_agent_ui(state) || agent_ui || UIState.new()
 
   def agent_ui(%{workspace: %{agent_ui: a}}), do: a || UIState.new()
   def agent_ui(%{agent_ui: a}), do: a || UIState.new()
@@ -52,23 +49,11 @@ defmodule MingaEditor.State.AgentAccess do
   Traditional reads the active workspace. Extension shells read through shell behaviours until they move onto the same workspace model.
   """
   @spec session(EditorState.t() | map()) :: pid() | nil
-  def session(%EditorState{} = state) do
-    state = EditorState.ensure_shell_available(state)
+  def session(%EditorState{shell_runtime: %Runtime{entry: %Entry{id: :traditional}}} = state),
+    do: active_workspace_session(state)
 
-    if EditorState.active_shell_id(state) == :traditional do
-      active_workspace_session(state)
-    else
-      EditorState.active_shell_module(state).active_session(state.shell_state)
-    end
-  end
-
-  def session(%{shell_state: shell_state} = state) do
-    if EditorState.active_shell_id(state) == :traditional do
-      active_workspace_session(state)
-    else
-      EditorState.active_shell_module(state).active_session(shell_state)
-    end
-  end
+  def session(%EditorState{shell_runtime: %Runtime{} = runtime}),
+    do: Runtime.active_session(runtime)
 
   def session(_), do: nil
 
@@ -85,12 +70,8 @@ defmodule MingaEditor.State.AgentAccess do
   @doc "Updates agent session lifecycle state via a transform function."
   @spec update_agent(EditorState.t() | map(), (AgentState.t() -> AgentState.t())) ::
           EditorState.t() | map()
-  def update_agent(%EditorState{shell_state: %{agent: a} = ss} = state, fun) do
-    %{state | shell_state: %{ss | agent: fun.(a)}}
-  end
-
-  def update_agent(%{shell_state: %{agent: a} = ss} = state, fun) do
-    %{state | shell_state: %{ss | agent: fun.(a)}}
+  def update_agent(%EditorState{} = state, fun) do
+    EditorState.set_agent(state, fun.(agent(state)))
   end
 
   def update_agent(%{agent: a} = state, fun) do
@@ -102,10 +83,6 @@ defmodule MingaEditor.State.AgentAccess do
   @spec update_agent_ui(EditorState.t() | map(), (UIState.t() -> UIState.t())) ::
           EditorState.t() | map()
   def update_agent_ui(%EditorState{} = state, fun) do
-    update_workspace_agent_ui(state, fun)
-  end
-
-  def update_agent_ui(%{shell_state: %{tab_bar: %TabBar{}}} = state, fun) do
     update_workspace_agent_ui(state, fun)
   end
 
@@ -140,7 +117,9 @@ defmodule MingaEditor.State.AgentAccess do
   end
 
   @spec active_workspace_agent_ui(EditorState.t() | map()) :: UIState.t() | nil
-  defp active_workspace_agent_ui(%{shell_state: %{tab_bar: %TabBar{} = tab_bar}}) do
+  defp active_workspace_agent_ui(%EditorState{
+         shell_runtime: %Runtime{state: %{tab_bar: %TabBar{} = tab_bar}}
+       }) do
     case TabBar.active_workspace(tab_bar) do
       %Workspace{agent_ui: %UIState{} = agent_ui} -> agent_ui
       _ -> nil
@@ -150,7 +129,9 @@ defmodule MingaEditor.State.AgentAccess do
   defp active_workspace_agent_ui(_state), do: nil
 
   @spec active_workspace_session(EditorState.t() | map()) :: pid() | nil
-  defp active_workspace_session(%{shell_state: %{tab_bar: %TabBar{} = tab_bar}}) do
+  defp active_workspace_session(%EditorState{
+         shell_runtime: %Runtime{state: %{tab_bar: %TabBar{} = tab_bar}}
+       }) do
     case TabBar.active_workspace(tab_bar) do
       %Workspace{session: session} when is_pid(session) -> session
       _ -> nil
@@ -162,7 +143,10 @@ defmodule MingaEditor.State.AgentAccess do
   @spec update_workspace_agent_ui(EditorState.t() | map(), (UIState.t() -> UIState.t())) ::
           EditorState.t() | map()
   defp update_workspace_agent_ui(
-         %{shell_state: %{tab_bar: %TabBar{} = tab_bar}, workspace: workspace} = state,
+         %EditorState{
+           shell_runtime: %Runtime{state: %{tab_bar: %TabBar{} = tab_bar}},
+           workspace: %WorkspaceState{} = workspace
+         } = state,
          fun
        ) do
     current_ui =
@@ -184,22 +168,6 @@ defmodule MingaEditor.State.AgentAccess do
     |> set_workspace(set_live_agent_ui(workspace, next_ui))
   end
 
-  defp update_workspace_agent_ui(%{shell_state: %{tab_bar: %TabBar{} = tab_bar}} = state, fun) do
-    current_ui = active_workspace_agent_ui(state) || UIState.new()
-    next_ui = fun.(current_ui)
-
-    tab_bar =
-      case TabBar.active_workspace(tab_bar) do
-        %Workspace{id: workspace_id} ->
-          TabBar.update_workspace(tab_bar, workspace_id, &Workspace.set_agent_ui(&1, next_ui))
-
-        _workspace ->
-          tab_bar
-      end
-
-    set_tab_bar(state, tab_bar)
-  end
-
   defp update_workspace_agent_ui(%{workspace: %{agent_ui: agent_ui} = workspace} = state, fun) do
     next_ui = fun.(agent_ui || UIState.new())
     %{state | workspace: set_live_agent_ui(workspace, next_ui)}
@@ -208,10 +176,6 @@ defmodule MingaEditor.State.AgentAccess do
   @spec set_tab_bar(EditorState.t() | map(), TabBar.t()) :: EditorState.t() | map()
   defp set_tab_bar(%EditorState{} = state, %TabBar{} = tab_bar) do
     EditorState.set_tab_bar(state, tab_bar)
-  end
-
-  defp set_tab_bar(%{shell_state: shell_state} = state, %TabBar{} = tab_bar) do
-    %{state | shell_state: ShellState.set_tab_bar(shell_state, tab_bar)}
   end
 
   @spec set_workspace(EditorState.t() | map(), WorkspaceState.t() | map()) ::

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -118,7 +118,7 @@ defmodule MingaEditor.State.ModalOverlay do
   """
   @spec open(EditorState.t(), variant(), payload()) :: EditorState.t()
   def open(%EditorState{} = state, variant, payload) do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       {:conflict, _} when variant != :conflict ->
         Minga.Log.info(
           :editor,
@@ -165,7 +165,7 @@ defmodule MingaEditor.State.ModalOverlay do
 
   @spec do_close(EditorState.t(), :close | :dismiss) :: EditorState.t()
   defp do_close(state, _kind) do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       :none -> state
       _ -> EditorState.set_modal(state, :none)
     end
@@ -182,6 +182,9 @@ defmodule MingaEditor.State.ModalOverlay do
   RenderPipeline.Input flavour of state works the same as EditorState.
   """
   @spec completion(map()) :: Completion.t() | nil
+  def completion(%{shell_runtime: %{state: %{modal: {:completion, %CompletionPayload{} = p}}}}),
+    do: p.completion
+
   def completion(%{shell_state: %{modal: {:completion, %CompletionPayload{} = p}}}),
     do: p.completion
 
@@ -194,6 +197,11 @@ defmodule MingaEditor.State.ModalOverlay do
   caring about completion state itself use this.
   """
   @spec completion_trigger(map()) :: CompletionTrigger.t()
+  def completion_trigger(%{
+        shell_runtime: %{state: %{modal: {:completion, %CompletionPayload{} = p}}}
+      }),
+      do: p.trigger || CompletionTrigger.new()
+
   def completion_trigger(%{shell_state: %{modal: {:completion, %CompletionPayload{} = p}}}),
     do: p.trigger || CompletionTrigger.new()
 
@@ -207,7 +215,7 @@ defmodule MingaEditor.State.ModalOverlay do
   """
   @spec update_completion(EditorState.t(), (Completion.t() -> Completion.t())) :: EditorState.t()
   def update_completion(%EditorState{} = state, fun) when is_function(fun, 1) do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       {:completion, %CompletionPayload{completion: comp} = payload} ->
         new_comp = fun.(comp)
         new_payload = CompletionPayload.put_completion(payload, new_comp)
@@ -233,7 +241,7 @@ defmodule MingaEditor.State.ModalOverlay do
   """
   @spec put_completion_trigger(EditorState.t(), CompletionTrigger.t()) :: EditorState.t()
   def put_completion_trigger(%EditorState{} = state, trigger) do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       {:completion, %CompletionPayload{} = payload} ->
         new_payload = CompletionPayload.put_trigger(payload, trigger)
         EditorState.set_modal(state, {:completion, new_payload})
@@ -270,6 +278,11 @@ defmodule MingaEditor.State.ModalOverlay do
   """
   @spec command_completion(map()) :: CommandCompletionPayload.t() | nil
   def command_completion(%{
+        shell_runtime: %{state: %{modal: {:command_completion, %CommandCompletionPayload{} = p}}}
+      }),
+      do: p
+
+  def command_completion(%{
         shell_state: %{modal: {:command_completion, %CommandCompletionPayload{} = p}}
       }),
       do: p
@@ -288,7 +301,7 @@ defmodule MingaEditor.State.ModalOverlay do
   """
   @spec dismiss_if_stale(EditorState.t()) :: EditorState.t()
   def dismiss_if_stale(%EditorState{} = state) do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       {:completion, %CompletionPayload{owner: owner}} ->
         if active_tab_id(state) == owner do
           state
@@ -302,6 +315,6 @@ defmodule MingaEditor.State.ModalOverlay do
   end
 
   @spec active_tab_id(EditorState.t()) :: term() | nil
-  defp active_tab_id(%EditorState{shell_state: %{tab_bar: %{active_id: id}}}), do: id
+  defp active_tab_id(%EditorState{shell_runtime: %{state: %{tab_bar: %{active_id: id}}}}), do: id
   defp active_tab_id(%EditorState{}), do: nil
 end

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -188,7 +188,7 @@ defmodule MingaEditor.StatusBar.Data do
     {indent_type, indent_size} = indent_info(state, buf, filetype)
     selection_info = selection_info(mode, mode_state, buf, {line, col})
 
-    agent = AgentAccess.agent(state)
+    agent = agent_state(state)
     background = background_subagent_summary(state)
     workspace = workspace_modeline_summary(state)
 
@@ -221,7 +221,7 @@ defmodule MingaEditor.StatusBar.Data do
       agent_theme_colors: if(agent.runtime.status, do: Theme.agent_theme(state.theme), else: nil),
       background_subagent_count: background.count,
       active_background_subagent_label: background.label,
-      status_msg: Map.get(state.shell_state, :status_msg),
+      status_msg: status_message(state),
       pending_keys: pending_keys(state, mode, mode_state),
       workspace_label: workspace.label,
       workspace_draft_count: workspace.draft_count,
@@ -247,12 +247,33 @@ defmodule MingaEditor.StatusBar.Data do
   end
 
   @spec whichkey_showing?(EditorState.t() | map()) :: boolean()
+  defp whichkey_showing?(%EditorState{shell_runtime: %{state: %{whichkey: %{show: true}}}}),
+    do: true
+
   defp whichkey_showing?(%{shell_state: %{whichkey: %{show: true}}}), do: true
   defp whichkey_showing?(_state), do: false
 
   @spec active_register_name(EditorState.t() | map()) :: String.t()
   defp active_register_name(%EditorState{} = state), do: Editing.active_register(state)
   defp active_register_name(_state), do: ""
+
+  @spec agent_state(EditorState.t() | map()) :: AgentState.t()
+  defp agent_state(%EditorState{} = state), do: AgentAccess.agent(state)
+  defp agent_state(%{shell_state: %{agent: %AgentState{} = agent}}), do: agent
+  defp agent_state(_state), do: %AgentState{}
+
+  @spec status_message(EditorState.t() | map()) :: String.t() | nil
+  defp status_message(%EditorState{} = state), do: EditorState.status_msg(state)
+  defp status_message(%{shell_state: %{status_msg: status_msg}}), do: status_msg
+  defp status_message(_state), do: nil
+
+  @spec agent_session(EditorState.t() | map()) :: pid() | nil
+  defp agent_session(%EditorState{} = state), do: AgentAccess.session(state)
+
+  defp agent_session(%{shell: shell, shell_state: shell_state}) when is_atom(shell),
+    do: shell.active_session(shell_state)
+
+  defp agent_session(_state), do: nil
 
   @spec register_prefix(String.t()) :: String.t()
   defp register_prefix(""), do: ""
@@ -352,9 +373,9 @@ defmodule MingaEditor.StatusBar.Data do
 
   @spec build_agent_data(EditorState.t() | map()) :: agent_data()
   defp build_agent_data(state) do
-    agent = AgentAccess.agent(state)
+    agent = agent_state(state)
     panel = AgentAccess.panel(state)
-    session = AgentAccess.session(state)
+    session = agent_session(state)
 
     message_count = agent_message_count(session)
 
@@ -413,7 +434,7 @@ defmodule MingaEditor.StatusBar.Data do
       buf_count: Enum.count(state.workspace.buffers.list),
       background_subagent_count: background.count,
       active_background_subagent_label: background.label,
-      status_msg: Map.get(state.shell_state, :status_msg),
+      status_msg: status_message(state),
       pending_keys: pending_keys(state, mode, mode_state),
       workspace_label: workspace.label,
       workspace_draft_count: workspace.draft_count,
@@ -691,7 +712,19 @@ defmodule MingaEditor.StatusBar.Data do
           count: non_neg_integer(),
           label: String.t() | nil
         }
-  defp background_subagent_summary(%{shell_state: %{tab_bar: %MingaEditor.State.TabBar{} = tb}}) do
+  defp background_subagent_summary(%EditorState{shell_runtime: %{state: %{tab_bar: tb}}}) do
+    background_subagent_summary(tb)
+  end
+
+  defp background_subagent_summary(%{shell_state: %{tab_bar: tb}}) do
+    background_subagent_summary(tb)
+  end
+
+  @spec background_subagent_summary(MingaEditor.State.TabBar.t()) :: %{
+          count: non_neg_integer(),
+          label: String.t() | nil
+        }
+  defp background_subagent_summary(%MingaEditor.State.TabBar{} = tb) do
     tabs = Enum.filter(tb.tabs, &MingaEditor.State.Tab.background_subagent?/1)
     running = Enum.filter(tabs, &(&1.agent_status in [:thinking, :tool_executing]))
     active = Enum.find(tabs, &(&1.id == tb.active_id))

--- a/lib/minga_editor/ui/picker/context.ex
+++ b/lib/minga_editor/ui/picker/context.ex
@@ -95,7 +95,7 @@ defmodule MingaEditor.UI.Picker.Context do
       file_tree: State.file_tree_state(state),
       search: state.workspace.search,
       viewport: state.terminal_viewport,
-      tab_bar: state.shell_state.tab_bar,
+      tab_bar: state.shell_runtime.state.tab_bar,
       agent_session: agent_session,
       picker_ui: picker_ui,
       document_symbols: active_document_symbols(state),
@@ -123,7 +123,7 @@ defmodule MingaEditor.UI.Picker.Context do
   @spec picker_ui_from_modal(State.t(), map() | nil) :: PickerState.t()
   defp picker_ui_from_modal(state, extra_context) do
     base =
-      case state.shell_state.modal do
+      case state.shell_runtime.state.modal do
         {:picker, %{picker_ui: pui}} -> pui
         _ -> %PickerState{}
       end

--- a/lib/minga_editor/ui/picker/pending_reviews_source.ex
+++ b/lib/minga_editor/ui/picker/pending_reviews_source.ex
@@ -40,7 +40,7 @@ defmodule MingaEditor.UI.Picker.PendingReviewsSource do
 
   def on_select(
         %Item{id: workspace_id},
-        %{shell_state: %{tab_bar: %TabBar{} = tab_bar}} = state
+        %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tab_bar}}} = state
       )
       when is_integer(workspace_id) do
     switch_to_workspace(state, tab_bar, workspace_id)

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -53,9 +53,9 @@ defmodule MingaEditor.UI.Picker.Source do
   Called when the user selects an item. Returns the new editor state.
 
   Important: this callback runs *after* the picker has been closed
-  (`state.shell_state.modal` has been reset to `:none`). Any context the
+  (`state.shell_runtime.state.modal` has been reset to `:none`). Any context the
   callback needs must travel with the `Picker.item()` (typically embedded
-  in `Item.id`). Reading `state.shell_state.modal` here will see `:none`.
+  in `Item.id`). Reading `state.shell_runtime.state.modal` here will see `:none`.
   """
   @callback on_select(Picker.item(), state :: term()) :: term()
 
@@ -103,7 +103,7 @@ defmodule MingaEditor.UI.Picker.Source do
 
   Like `on_select/2`, this runs *after* the picker has been closed. Any
   context required must travel with the `Picker.item()`; do not read
-  `state.shell_state.modal` here.
+  `state.shell_runtime.state.modal` here.
   """
   @callback on_action(term(), Picker.item(), state :: term()) :: term()
 
@@ -196,7 +196,7 @@ defmodule MingaEditor.UI.Picker.Source do
   """
   @spec restore_or_keep(term()) :: term()
   def restore_or_keep(state) do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       {:picker, %{picker_ui: %{restore: idx}}} when is_integer(idx) ->
         EditorState.switch_buffer(state, idx)
 

--- a/lib/minga_editor/ui/picker/theme_source.ex
+++ b/lib/minga_editor/ui/picker/theme_source.ex
@@ -42,7 +42,7 @@ defmodule MingaEditor.UI.Picker.ThemeSource do
   @impl true
   @spec on_cancel(term()) :: term()
   def on_cancel(state) do
-    case state.shell_state.modal do
+    case state.shell_runtime.state.modal do
       {:picker, %{picker_ui: %{restore_theme: %Theme{} = theme}}} ->
         put_theme(state, theme)
 

--- a/lib/minga_editor/ui/picker/workspace_icon_source.ex
+++ b/lib/minga_editor/ui/picker/workspace_icon_source.ex
@@ -95,7 +95,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceIconSource do
   @spec on_select(Item.t(), term()) :: term()
   def on_select(
         %Item{id: icon_name},
-        %{shell_state: %{tab_bar: %TabBar{} = tb}} = state
+        %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state
       ) do
     ws_id = TabBar.active_workspace_id(tb)
     tb = TabBar.update_workspace(tb, ws_id, &Workspace.set_icon(&1, icon_name))

--- a/lib/minga_editor/ui/picker/workspace_source.ex
+++ b/lib/minga_editor/ui/picker/workspace_source.ex
@@ -65,7 +65,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceSource do
   @spec on_select(Item.t(), term()) :: term()
   def on_select(
         %Item{id: workspace_id},
-        %{shell_state: %{tab_bar: %TabBar{} = tb}} = state
+        %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state
       ) do
     target_id = TabBar.switch_to_workspace(tb, workspace_id).active_id
     EditorState.switch_tab(state, target_id)

--- a/lib/minga_editor/ui/picker/workspace_target_source.ex
+++ b/lib/minga_editor/ui/picker/workspace_target_source.ex
@@ -379,7 +379,10 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSource do
 
   @spec fetch_transfer_workspaces(term(), map()) ::
           {:ok, TabBar.t(), Workspace.t(), Workspace.t()} | {:error, String.t()}
-  defp fetch_transfer_workspaces(%{shell_state: %{tab_bar: %TabBar{} = tab_bar}}, context) do
+  defp fetch_transfer_workspaces(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tab_bar}}},
+         context
+       ) do
     source_id = Map.fetch!(context, :source_workspace_id)
     destination_id = Map.fetch!(context, :destination_workspace_id)
 

--- a/lib/minga_editor/ui/prompt/project_remove_confirm.ex
+++ b/lib/minga_editor/ui/prompt/project_remove_confirm.ex
@@ -35,7 +35,9 @@ defmodule MingaEditor.UI.Prompt.ProjectRemoveConfirm do
   def on_cancel(state), do: EditorState.set_status(state, "Project removal cancelled")
 
   @spec project_path(EditorState.t()) :: String.t() | nil
-  defp project_path(%{shell_state: %{modal: {:prompt, %{prompt_ui: %{context: %{path: path}}}}}})
+  defp project_path(%{
+         shell_runtime: %{state: %{modal: {:prompt, %{prompt_ui: %{context: %{path: path}}}}}}
+       })
        when is_binary(path),
        do: path
 

--- a/lib/minga_editor/ui/prompt/workspace_rename.ex
+++ b/lib/minga_editor/ui/prompt/workspace_rename.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.UI.Prompt.WorkspaceRename do
 
   @behaviour MingaEditor.UI.Prompt.Handler
 
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Workspace
   alias MingaEditor.State.TabBar
 
@@ -17,17 +18,18 @@ defmodule MingaEditor.UI.Prompt.WorkspaceRename do
 
   @impl true
   @spec on_submit(String.t(), map()) :: map()
-  def on_submit(text, %{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  def on_submit(text, %{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     trimmed = String.trim(text)
 
     if trimmed == "" do
-      ss = state.shell_state
-      %{state | shell_state: %{ss | status_msg: "Workspace name cannot be empty"}}
+      EditorState.set_status(state, "Workspace name cannot be empty")
     else
       ws_id = TabBar.active_workspace_id(tb)
       tb = TabBar.update_workspace(tb, ws_id, &Workspace.rename(&1, trimmed))
-      ss = state.shell_state
-      %{state | shell_state: %{ss | tab_bar: tb, status_msg: "Renamed: #{trimmed}"}}
+
+      state
+      |> EditorState.set_tab_bar(tb)
+      |> EditorState.set_status("Renamed: #{trimmed}")
     end
   end
 

--- a/test/minga/credo/no_direct_modal_overlay_write_check_test.exs
+++ b/test/minga/credo/no_direct_modal_overlay_write_check_test.exs
@@ -51,7 +51,7 @@ defmodule Minga.Credo.NoDirectModalOverlayWriteCheckTest do
     """
     defmodule MingaEditor.State.ModalOverlay do
       def close(state) do
-        %{state.shell_state | modal: :none}
+        %{state.shell_runtime.state | modal: :none}
       end
     end
     """

--- a/test/minga_editor/agent/concurrent_sessions_test.exs
+++ b/test/minga_editor/agent/concurrent_sessions_test.exs
@@ -4,7 +4,7 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
   switching tabs while one session is mid-stream does not interrupt
   it or route its events to the wrong tab.
 
-  These tests exercise per-workspace session ownership: workspaces are the source of truth, while legacy tab session fields remain only as locators for event routing and migration paths. The editor's `state.shell_state.agent` struct holds rendering caches only.
+  These tests exercise per-workspace session ownership: workspaces are the source of truth, while legacy tab session fields remain only as locators for event routing and migration paths. The active Traditional runtime state holds rendering caches only.
   """
 
   use ExUnit.Case, async: true
@@ -12,6 +12,8 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.AgentLifecycle
+  alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -30,17 +32,20 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
 
     %EditorState{
       port_manager: self(),
-      shell: MingaEditor.Shell.Traditional,
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80),
         editing: VimState.new(),
         keymap_scope: :editor,
         agent_ui: UIState.new()
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{
-        agent: %AgentState{},
-        tab_bar: tb
-      }
+      shell_runtime:
+        Runtime.new(
+          Registry.get(:traditional),
+          %MingaEditor.Shell.Traditional.State{
+            agent: %AgentState{},
+            tab_bar: tb
+          }
+        )
     }
   end
 
@@ -123,7 +128,7 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
       # Switching tabs only repoints the active_id; it does not stop or
       # restart either session process.
       switched =
-        EditorState.set_tab_bar(state, %{state.shell_state.tab_bar | active_id: 2})
+        EditorState.set_tab_bar(state, %{state.shell_runtime.state.tab_bar | active_id: 2})
 
       assert AgentAccess.session(switched) == session_b
       assert GenServer.call(session_a, :status) == :idle
@@ -165,7 +170,7 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
       assert AgentAccess.session(switched) == idle
       assert GenServer.call(streaming, :status) == :idle
 
-      tab_one = Enum.find(switched.shell_state.tab_bar.tabs, &(&1.id == 1))
+      tab_one = Enum.find(switched.shell_runtime.state.tab_bar.tabs, &(&1.id == 1))
       assert tab_one.session == streaming
 
       # Switching back restores the streaming session as the active one.

--- a/test/minga_editor/agent/diff_review_authoritative_store_test.exs
+++ b/test/minga_editor/agent/diff_review_authoritative_store_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.Agent.DiffReviewAuthoritativeStoreTest do
   alias MingaEditor.Agent.View.Preview
   alias MingaEditor.Commands.AgentSubStates
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Tab
@@ -109,7 +110,7 @@ defmodule MingaEditor.Agent.DiffReviewAuthoritativeStoreTest do
     %EditorState{
       port_manager: self(),
       workspace: %SessionState{agent_ui: agent_ui, viewport: Viewport.new(24, 80)},
-      shell_state: %TraditionalState{tab_bar: tab_bar}
+      shell_runtime: Runtime.new(Runtime.default_entry(), %TraditionalState{tab_bar: tab_bar})
     }
   end
 end

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -20,6 +20,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
   alias MingaEditor.Agent.UIState
   alias MingaAgent.Event
   alias MingaAgent.Session
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
@@ -172,10 +173,14 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       tab_bar = TabBar.move_tab_to_workspace(tab_bar, 1, workspace.id)
 
-      state = %{
-        agent: %AgentState{},
-        shell: Traditional,
-        shell_state: %{tab_bar: tab_bar}
+      state = %EditorState{
+        port_manager: nil,
+        workspace: workspace(),
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %TraditionalState{agent: %AgentState{}, tab_bar: tab_bar}
+          )
       }
 
       send(
@@ -185,7 +190,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       :sys.get_state(session)
       {state, effects} = Events.handle(state, {:tool_started, "alpha", %{}})
-      assert AgentState.active_tool_name(state.agent) == "alpha"
+      assert AgentState.active_tool_name(AgentAccess.agent(state)) == "alpha"
       assert effects == [{:render, 16}]
 
       send(
@@ -195,7 +200,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       :sys.get_state(session)
       {state, effects} = Events.handle(state, {:tool_started, "beta", %{}})
-      assert AgentState.active_tool_name(state.agent) == "beta"
+      assert AgentState.active_tool_name(AgentAccess.agent(state)) == "beta"
       assert effects == [{:render, 16}]
 
       send(
@@ -206,7 +211,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       :sys.get_state(session)
       {state, effects} = Events.handle(state, {:tool_ended, "alpha", "contents", :done})
-      assert AgentState.active_tool_name(state.agent) == "beta"
+      assert AgentState.active_tool_name(AgentAccess.agent(state)) == "beta"
       assert effects == [{:render, 16}]
 
       send(
@@ -217,7 +222,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       :sys.get_state(session)
       {state, effects} = Events.handle(state, {:tool_ended, "beta", "output", :done})
-      assert AgentState.active_tool_name(state.agent) == nil
+      assert AgentState.active_tool_name(AgentAccess.agent(state)) == nil
       assert effects == [{:render, 16}]
     end
 
@@ -255,9 +260,9 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       state = %EditorState{
         port_manager: self(),
-        shell: Traditional,
         workspace: %SessionState{viewport: Viewport.new(24, 80), agent_ui: UIState.new()},
-        shell_state: %TraditionalState{agent: agent, tab_bar: tab_bar}
+        shell_runtime:
+          Runtime.new(Runtime.default_entry(), %TraditionalState{agent: agent, tab_bar: tab_bar})
       }
 
       {state, effects} = Events.handle(state, {:context_usage, 95, 100})
@@ -293,11 +298,14 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       state = %EditorState{
         port_manager: self(),
-        shell: Traditional,
         workspace:
           %SessionState{viewport: Viewport.new(24, 80)}
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
-        shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+          )
       }
 
       {state, _effects} =
@@ -306,7 +314,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
           {:file_changed, test_path, "before", "after", "tc_test", "edit_file"}
         )
 
-      tb = state.shell_state.tab_bar
+      tb = state.shell_runtime.state.tab_bar
       assert TabBar.get(tb, tab1.id).group_id == 0
       assert TabBar.get(tb, tab2.id).group_id == workspace.id
       assert Workspace.has_file?(TabBar.get_workspace(tb, workspace.id), test_ref)
@@ -341,11 +349,14 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       state = %EditorState{
         port_manager: self(),
-        shell: Traditional,
         workspace:
           %SessionState{viewport: Viewport.new(24, 80)}
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
-        shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+          )
       }
 
       {state, _effects} =
@@ -354,7 +365,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
           {:file_changed, test_path, "before", "after", "tc_test", "edit_file"}
         )
 
-      tb = state.shell_state.tab_bar
+      tb = state.shell_runtime.state.tab_bar
       agent_workspace = TabBar.get_workspace(tb, workspace.id)
       assert TabBar.get(tb, tab2.id).group_id == workspace.id
       assert Workspace.has_file?(agent_workspace, test_ref)
@@ -385,17 +396,20 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       state = %EditorState{
         port_manager: self(),
-        shell: Traditional,
         workspace:
           %SessionState{viewport: Viewport.new(24, 80)}
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
-        shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+          )
       }
 
       {state, _effects} =
         Events.handle(state, {:file_changed, path, "before", "after", "tc_test", "edit_file"})
 
-      tb = state.shell_state.tab_bar
+      tb = state.shell_runtime.state.tab_bar
       assert TabBar.get(tb, file_tab.id).group_id == workspace.id
       assert Workspace.has_file?(TabBar.get_workspace(tb, workspace.id), expected_ref)
     end
@@ -415,17 +429,20 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       state = %EditorState{
         port_manager: self(),
-        shell: Traditional,
         workspace:
           %SessionState{viewport: Viewport.new(24, 80)}
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
-        shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+          )
       }
 
       {state, _effects} =
         Events.handle(state, {:file_changed, path, "before", "after", "tc_test", "edit_file"})
 
-      tb = state.shell_state.tab_bar
+      tb = state.shell_runtime.state.tab_bar
       assert TabBar.get(tb, file_tab.id).group_id == 0
       assert TabBar.get(tb, agent_tab.id).group_id == workspace.id
       assert TabBar.get_workspace(tb, workspace.id).files == []

--- a/test/minga_editor/agent/ingest_approval_regression_test.exs
+++ b/test/minga_editor/agent/ingest_approval_regression_test.exs
@@ -30,6 +30,7 @@ defmodule MingaEditor.Agent.IngestApprovalRegressionTest do
   alias MingaEditor.Agent.Ingest
   alias MingaEditor.Commands.AgentSession
   alias MingaEditor.Commands.AgentSubStates
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -165,14 +166,17 @@ defmodule MingaEditor.Agent.IngestApprovalRegressionTest do
 
     %EditorState{
       port_manager: self(),
-      shell: MingaEditor.Shell.Traditional,
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80)
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{
-        tab_bar: tb,
-        agent: agent
-      }
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{
+            tab_bar: tb,
+            agent: agent
+          }
+        )
     }
   end
 end

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
   alias MingaAgent.TurnUsage
   alias MingaEditor.Agent.SlashCommand
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaAgent.RuntimeState
   alias MingaEditor.State.Agent, as: AgentState
@@ -226,21 +227,24 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
       %EditorState{
         port_manager: nil,
-        shell: MingaEditor.Shell.Traditional,
         workspace: %MingaEditor.Session.State{
           viewport: Viewport.new(24, 80),
           editing: VimState.new(),
           agent_ui: UIState.new()
         },
-        shell_state: %MingaEditor.Shell.Traditional.State{
-          status_msg: nil,
-          tab_bar: tab_bar,
-          agent: %AgentState{
-            runtime: %RuntimeState{status: :idle},
-            error: nil,
-            spinner_timer: nil
-          }
-        }
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %MingaEditor.Shell.Traditional.State{
+              status_msg: nil,
+              tab_bar: tab_bar,
+              agent: %AgentState{
+                runtime: %RuntimeState{status: :idle},
+                error: nil,
+                spinner_timer: nil
+              }
+            }
+          )
       }
     end
 
@@ -254,7 +258,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
     test "/help returns ok and sets status message" do
       {:ok, state} = SlashCommand.execute(mock_state(), "/help")
-      assert state.shell_state.status_msg == "Commands listed in chat"
+      assert state.shell_runtime.state.status_msg == "Commands listed in chat"
     end
 
     test "/stop aborts agent (no-op without session)" do
@@ -273,17 +277,17 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
     test "/thinking without args cycles level (no session = status msg)" do
       {:ok, state} = SlashCommand.execute(mock_state(), "/thinking")
-      assert state.shell_state.status_msg != nil
+      assert state.shell_runtime.state.status_msg != nil
     end
 
     test "/thinking with arg sets level (no session = status msg)" do
       {:ok, state} = SlashCommand.execute(mock_state(), "/thinking high")
-      assert state.shell_state.status_msg == "No agent session"
+      assert state.shell_runtime.state.status_msg == "No agent session"
     end
 
     test "/model without name opens the model picker" do
       {:ok, state} = SlashCommand.execute(mock_state(session: start_session()), "/model")
-      assert {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+      assert {:picker, %{picker_ui: picker_ui}} = state.shell_runtime.state.modal
       assert picker_ui.source == MingaEditor.UI.Picker.AgentModelSource
     end
 
@@ -294,12 +298,12 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
     test "command parsing is case-insensitive" do
       {:ok, state} = SlashCommand.execute(mock_state(), "/HELP")
-      assert state.shell_state.status_msg == "Commands listed in chat"
+      assert state.shell_runtime.state.status_msg == "Commands listed in chat"
     end
 
     test "command parsing trims whitespace" do
       {:ok, state} = SlashCommand.execute(mock_state(), "/help  ")
-      assert state.shell_state.status_msg == "Commands listed in chat"
+      assert state.shell_runtime.state.status_msg == "Commands listed in chat"
     end
 
     test "/resume opens the persisted agent session picker", %{tmp_dir: dir} do
@@ -320,7 +324,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       session = start_session()
       {:ok, state} = SlashCommand.execute(mock_state(session: session), "/resume", dir)
 
-      assert {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+      assert {:picker, %{picker_ui: picker_ui}} = state.shell_runtime.state.modal
       assert picker_ui.source == MingaEditor.UI.Picker.AgentSessionSource
       assert picker_ui.context.persisted_only == true
     end
@@ -329,7 +333,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       session = start_session()
       {:ok, state} = SlashCommand.execute(mock_state(session: session), "/sessions")
 
-      assert {:picker, %{picker_ui: picker_ui}} = state.shell_state.modal
+      assert {:picker, %{picker_ui: picker_ui}} = state.shell_runtime.state.modal
       assert picker_ui.source == MingaEditor.UI.Picker.AgentSessionSource
     end
 
@@ -338,8 +342,8 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       {:ok, state} = SlashCommand.execute(mock_state(session: session), "/plan")
 
       assert Session.status(session) == :plan
-      assert state.shell_state.status_msg == "Plan mode enabled"
-      assert state.shell_state.agent.runtime.status == :plan
+      assert state.shell_runtime.state.status_msg == "Plan mode enabled"
+      assert state.shell_runtime.state.agent.runtime.status == :plan
 
       assert Enum.any?(Session.messages(session), fn
                {:system, text, :info} -> text =~ "Plan mode" and text =~ "/exec"
@@ -353,8 +357,8 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       {:ok, state} = SlashCommand.execute(mock_state(session: session), "/exec")
 
       assert Session.status(session) == :idle
-      assert state.shell_state.status_msg == "Execution mode enabled"
-      assert state.shell_state.agent.runtime.status == :idle
+      assert state.shell_runtime.state.status_msg == "Execution mode enabled"
+      assert state.shell_runtime.state.agent.runtime.status == :idle
 
       assert Enum.any?(Session.messages(session), fn
                {:system, text, :info} -> text =~ "Execution mode" and text =~ "/plan"
@@ -382,7 +386,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
       {:ok, state} = SlashCommand.execute(mock_state(session: session), "/trust list")
 
-      assert state.shell_state.status_msg =~ "Trusted tools:"
+      assert state.shell_runtime.state.status_msg =~ "Trusted tools:"
       messages = Session.messages(session)
       assert Enum.any?(messages, &match?({:system, "Trusted tools:" <> _, :info}, &1))
     end
@@ -394,7 +398,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
       {:ok, state} = SlashCommand.execute(mock_state(session: session), "/trust revoke shell")
 
-      assert state.shell_state.status_msg == "Trust cleared for shell"
+      assert state.shell_runtime.state.status_msg == "Trust cleared for shell"
       assert Session.list_tool_trust(session) == %{"write_file" => :turn}
     end
 
@@ -405,7 +409,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
       {:ok, state} = SlashCommand.execute(mock_state(session: session), "/trust clear")
 
-      assert state.shell_state.status_msg == "All tool trust cleared"
+      assert state.shell_runtime.state.status_msg == "All tool trust cleared"
       assert Session.list_tool_trust(session) == %{}
     end
 
@@ -421,17 +425,17 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
     test "/memory add and clear replace /remember and /forget", %{tmp_dir: dir} do
       {:ok, state} = SlashCommand.execute(mock_state(), "/memory add prefer small diffs", dir)
-      assert state.shell_state.status_msg == "Saved to memory: prefer small diffs"
+      assert state.shell_runtime.state.status_msg == "Saved to memory: prefer small diffs"
       assert Memory.read(dir) =~ "prefer small diffs"
 
       {:ok, state} = SlashCommand.execute(mock_state(), "/memory clear", dir)
-      assert state.shell_state.status_msg == "Memory cleared."
+      assert state.shell_runtime.state.status_msg == "Memory cleared."
       assert Memory.read(dir) == nil
     end
 
     test "/memory shows memory usage", %{tmp_dir: dir} do
       {:ok, state} = SlashCommand.execute(mock_state(), "/memory", dir)
-      assert state.shell_state.status_msg =~ "No memory file found"
+      assert state.shell_runtime.state.status_msg =~ "No memory file found"
     end
 
     test "/memory rejects unknown subcommands" do

--- a/test/minga_editor/agent/view/prompt_renderer_test.exs
+++ b/test/minga_editor/agent/view/prompt_renderer_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.Agent.View.PromptRendererTest do
   alias MingaEditor.Agent.View.PromptRenderer
   alias MingaEditor.Agent.ViewContext
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaAgent.RuntimeState
   alias MingaEditor.State.Agent, as: AgentState
@@ -57,7 +58,11 @@ defmodule MingaEditor.Agent.View.PromptRendererTest do
         agent_ui: agentic
       },
       focus_stack: Input.default_stack(),
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: agent},
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: agent}
+        ),
       theme: Theme.get!(:doom_one)
     }
   end

--- a/test/minga_editor/commands/agent_code_block_test.exs
+++ b/test/minga_editor/commands/agent_code_block_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.Commands.AgentCodeBlockTest do
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.Commands.Agent, as: AgentCommands
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.Buffers
@@ -19,7 +20,11 @@ defmodule MingaEditor.Commands.AgentCodeBlockTest do
         buffers: %Buffers{},
         agent_ui: %UIState{}
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: %AgentState{}}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: %AgentState{}}
+        )
     }
   end
 

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -22,8 +22,8 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
   alias Minga.Project.FileRef
   alias MingaEditor.Commands.Agent, as: AgentCommands
   alias MingaEditor.Commands.AgentSession
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
-  alias MingaAgent.RuntimeState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
@@ -100,7 +100,6 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
     %EditorState{
       port_manager: nil,
-      shell: MingaEditor.Shell.Traditional,
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80),
         editing: VimState.new(),
@@ -113,7 +112,11 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
         },
         agent_ui: agentic
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb},
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb}
+        ),
       focus_stack: Input.default_stack()
     }
   end
@@ -136,13 +139,13 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
         |> WorkspaceModel.set_active_file(source_ref)
       end)
 
-    %{state | shell_state: %{state.shell_state | tab_bar: tab_bar}}
+    EditorState.set_tab_bar(state, tab_bar)
   end
 
   defp source_workspace_with_background_agent_tab do
     state = source_workspace_state()
-    {tab_bar, _agent_tab} = TabBar.insert(state.shell_state.tab_bar, :agent, "Agent")
-    %{state | shell_state: %{state.shell_state | tab_bar: tab_bar}}
+    {tab_bar, _agent_tab} = TabBar.insert(state.shell_runtime.state.tab_bar, :agent, "Agent")
+    EditorState.set_tab_bar(state, tab_bar)
   end
 
   defp active_agent_workspace_state do
@@ -277,7 +280,9 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       new_state = AgentCommands.submit_prompt(state)
 
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == "/modle"
-      assert new_state.shell_state.status_msg == "Unknown command: /modle. Did you mean /model?"
+
+      assert new_state.shell_runtime.state.status_msg ==
+               "Unknown command: /modle. Did you mean /model?"
 
       assert_receive {:stub_system_message, "Unknown command: /modle. Did you mean /model?",
                       :error}
@@ -300,7 +305,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       new_state = AgentCommands.submit_prompt(state)
 
-      assert new_state.shell_state.status_msg =~ "No model configured"
+      assert new_state.shell_runtime.state.status_msg =~ "No model configured"
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == "hello agent"
     end
 
@@ -323,7 +328,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       new_state = AgentCommands.submit_prompt(state)
 
-      assert new_state.shell_state.status_msg =~ "No agent session"
+      assert new_state.shell_runtime.state.status_msg =~ "No agent session"
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == "hello agent"
     end
 
@@ -346,7 +351,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       new_state = AgentCommands.submit_prompt(state)
 
-      assert new_state.shell_state.status_msg =~
+      assert new_state.shell_runtime.state.status_msg =~
                "No provider credentials are configured for this model"
 
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == "draft prompt"
@@ -371,7 +376,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       new_state = AgentCommands.submit_prompt(state)
 
-      assert new_state.shell_state.status_msg =~ "Agent provider still starting"
+      assert new_state.shell_runtime.state.status_msg =~ "Agent provider still starting"
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == "draft prompt"
     end
 
@@ -394,7 +399,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       new_state = AgentCommands.submit_prompt(state)
 
-      assert new_state.shell_state.status_msg ==
+      assert new_state.shell_runtime.state.status_msg ==
                "Failed to start agent: boom. Your prompt was preserved."
 
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == "draft prompt"
@@ -438,7 +443,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       new_state = AgentCommands.submit_prompt(state)
 
-      assert new_state.shell_state.status_msg =~ "Cannot resolve file mentions"
+      assert new_state.shell_runtime.state.status_msg =~ "Cannot resolve file mentions"
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == "@missing.ex explain"
       refute_receive {:readiness_session_prompt, _prompt}
     end
@@ -468,7 +473,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       new_state = AgentCommands.submit_prompt(state)
 
       assert_receive {:readiness_session_prompt, "stale panel prompt"}
-      assert is_nil(new_state.shell_state.status_msg)
+      assert is_nil(new_state.shell_runtime.state.status_msg)
       assert UIState.prompt_text(AgentAccess.panel(new_state)) == ""
     end
 
@@ -503,7 +508,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
         new_state = AgentCommands.submit_prompt(state)
 
-        assert new_state.shell_state.status_msg =~ expected_message
+        assert new_state.shell_runtime.state.status_msg =~ expected_message
         assert UIState.prompt_text(AgentAccess.panel(new_state)) == "draft prompt"
       end
     end
@@ -514,13 +519,8 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       state = base_state()
 
       state =
-        %{
-          state
-          | shell_state: %{
-              state.shell_state
-              | agent: %{state.shell_state.agent | runtime: %RuntimeState{status: :thinking}}
-            }
-        }
+        state
+        |> AgentAccess.update_agent(&AgentState.set_status(&1, :thinking))
         |> AgentAccess.update_agent_ui(
           &UIState.set_prompt_text(&1, "/login openai --complete ref code")
         )
@@ -684,7 +684,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       new_state = AgentCommands.scope_ctrl_c(state)
 
       assert_receive :restart_provider_called
-      assert new_state.shell_state.status_msg == "Agent provider restarted"
+      assert new_state.shell_runtime.state.status_msg == "Agent provider restarted"
     end
   end
 
@@ -705,7 +705,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       state = base_state(session: nil)
       new_state = AgentCommands.cycle_thinking_level(state)
 
-      assert new_state.shell_state.status_msg =~ "No agent session"
+      assert new_state.shell_runtime.state.status_msg =~ "No agent session"
     end
   end
 
@@ -715,14 +715,14 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       new_state = AgentCommands.set_thinking_level(state, "high")
 
       assert AgentAccess.panel(new_state).thinking_level == "high"
-      assert new_state.shell_state.status_msg == "Thinking: high"
+      assert new_state.shell_runtime.state.status_msg == "Thinking: high"
     end
 
     test "sets status message when no session exists" do
       state = base_state(session: nil)
       new_state = AgentCommands.set_thinking_level(state, "high")
 
-      assert new_state.shell_state.status_msg =~ "No agent session"
+      assert new_state.shell_runtime.state.status_msg =~ "No agent session"
     end
   end
 
@@ -734,7 +734,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       new_state = command.execute.(state)
 
-      assert {:picker, %{picker_ui: picker_ui}} = new_state.shell_state.modal
+      assert {:picker, %{picker_ui: picker_ui}} = new_state.shell_runtime.state.modal
       assert picker_ui.source == MingaEditor.UI.Picker.ThinkingLevelSource
       assert picker_ui.context == %{current_level: "low"}
     end
@@ -745,7 +745,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       new_state = command.execute.(state)
 
-      assert new_state.shell_state.status_msg =~ "No agent session"
+      assert new_state.shell_runtime.state.status_msg =~ "No agent session"
     end
 
     test "agent_thinking_* commands set fixed levels" do
@@ -758,7 +758,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
         new_state = command!(command_name).execute.(base_state())
 
         assert AgentAccess.panel(new_state).thinking_level == expected_level
-        assert new_state.shell_state.status_msg == "Thinking: #{expected_level}"
+        assert new_state.shell_runtime.state.status_msg == "Thinking: #{expected_level}"
       end
     end
   end
@@ -784,7 +784,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       assert AgentAccess.panel(new_state).model_name == "openai:o4-mini"
       assert AgentAccess.panel(new_state).thinking_level == "high"
-      assert new_state.shell_state.status_msg == "Model: openai:o4-mini [2/3]"
+      assert new_state.shell_runtime.state.status_msg == "Model: openai:o4-mini [2/3]"
     end
   end
 
@@ -866,10 +866,10 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
     test "creates an active agent workspace with no file context" do
       state = source_workspace_state()
-      source_workspace = TabBar.get_workspace(state.shell_state.tab_bar, 0)
+      source_workspace = TabBar.get_workspace(state.shell_runtime.state.tab_bar, 0)
 
       new_state = AgentCommands.new_agent_session(state)
-      tab_bar = new_state.shell_state.tab_bar
+      tab_bar = new_state.shell_runtime.state.tab_bar
       active_workspace = TabBar.active_workspace(tab_bar)
 
       assert active_workspace.kind == :agent
@@ -887,7 +887,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
     test "switching back to the source file tab restores file content" do
       state = source_workspace_state()
-      file_tab_id = state.shell_state.tab_bar.active_id
+      file_tab_id = state.shell_runtime.state.tab_bar.active_id
 
       new_state = AgentCommands.new_agent_session(state)
       switched = EditorState.switch_tab(new_state, file_tab_id)
@@ -900,14 +900,14 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
     test "switching to a file tab inside an agent workspace restores file content" do
       state = source_workspace_state()
-      file_tab_id = state.shell_state.tab_bar.active_id
-      file_tab = TabBar.get(state.shell_state.tab_bar, file_tab_id)
+      file_tab_id = state.shell_runtime.state.tab_bar.active_id
+      file_tab = TabBar.get(state.shell_runtime.state.tab_bar, file_tab_id)
 
       new_state = AgentCommands.new_agent_session(state)
-      agent_workspace_id = TabBar.active_workspace_id(new_state.shell_state.tab_bar)
+      agent_workspace_id = TabBar.active_workspace_id(new_state.shell_runtime.state.tab_bar)
 
       tab_bar =
-        new_state.shell_state.tab_bar
+        new_state.shell_runtime.state.tab_bar
         |> TabBar.move_tab_to_workspace(file_tab_id, agent_workspace_id)
         |> TabBar.update_context(file_tab_id, file_tab.context)
 
@@ -918,7 +918,9 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
       active_window = switched.workspace.windows.map[switched.workspace.windows.active]
 
-      assert TabBar.active_workspace_id(switched.shell_state.tab_bar) == agent_workspace_id
+      assert TabBar.active_workspace_id(switched.shell_runtime.state.tab_bar) ==
+               agent_workspace_id
+
       assert EditorState.active_tab_kind(switched) == :file
       assert active_window.content == {:buffer, switched.workspace.buffers.active}
       refute MingaEditor.Window.Content.agent_chat?(active_window.content)
@@ -926,11 +928,11 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
     test "creating from an existing agent workspace preserves the source tab context" do
       state = active_agent_workspace_state()
-      old_tab = TabBar.active(state.shell_state.tab_bar)
+      old_tab = TabBar.active(state.shell_runtime.state.tab_bar)
       old_session = old_tab.session
 
       new_state = AgentCommands.new_agent_session(state)
-      tab_bar = new_state.shell_state.tab_bar
+      tab_bar = new_state.shell_runtime.state.tab_bar
       updated_old_tab = TabBar.get(tab_bar, old_tab.id)
       old_context = TabContext.to_workspace_map(updated_old_tab.context)
       new_session = TabBar.active(tab_bar).session
@@ -945,11 +947,11 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
     test "background agent session creation does not switch active workspace" do
       state = source_workspace_with_background_agent_tab()
-      source_active_id = state.shell_state.tab_bar.active_id
-      source_workspace = TabBar.get_workspace(state.shell_state.tab_bar, 0)
+      source_active_id = state.shell_runtime.state.tab_bar.active_id
+      source_workspace = TabBar.get_workspace(state.shell_runtime.state.tab_bar, 0)
 
       new_state = AgentSession.start_agent_session(state)
-      tab_bar = new_state.shell_state.tab_bar
+      tab_bar = new_state.shell_runtime.state.tab_bar
       agent_workspaces = Enum.filter(tab_bar.workspaces, &(&1.kind == :agent))
 
       assert tab_bar.active_id == source_active_id
@@ -970,7 +972,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       state = base_state()
       new_state = AgentCommands.cycle_agent_tabs(state)
 
-      agent_tabs = TabBar.filter_by_kind(new_state.shell_state.tab_bar, :agent)
+      agent_tabs = TabBar.filter_by_kind(new_state.shell_runtime.state.tab_bar, :agent)
       assert agent_tabs != []
     end
   end

--- a/test/minga_editor/commands/agent_session_down_test.exs
+++ b/test/minga_editor/commands/agent_session_down_test.exs
@@ -80,10 +80,10 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
 
       result = BufferManagement.handle_agent_session_down(state, foreign_pid, :killed)
 
-      assert result.shell_state.status_msg == "original message",
+      assert EditorState.status_msg(result) == "original message",
              "status_msg must not be overwritten by crashes from other editors' sessions"
 
-      assert result.shell_state.tab_bar == state.shell_state.tab_bar,
+      assert EditorState.tab_bar(result) == EditorState.tab_bar(state),
              "tab_bar must be untouched when no tab references the crashed session"
     end
 
@@ -96,7 +96,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
 
       result = BufferManagement.handle_agent_session_down(state, foreign_pid, :normal)
 
-      assert result.shell_state.status_msg == "original message"
+      assert EditorState.status_msg(result) == "original message"
     end
 
     test "sets crash status when a tab references the crashed session" do
@@ -105,7 +105,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
 
       result = BufferManagement.handle_agent_session_down(state, session_pid, :killed)
 
-      assert result.shell_state.status_msg == "Agent session crashed (SPC a n to restart)"
+      assert EditorState.status_msg(result) == "Agent session crashed (SPC a n to restart)"
     end
 
     test "sets ended status when an owned session exits normally" do
@@ -114,7 +114,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
 
       result = BufferManagement.handle_agent_session_down(state, session_pid, :normal)
 
-      assert result.shell_state.status_msg == "Agent session ended"
+      assert EditorState.status_msg(result) == "Agent session ended"
     end
 
     test "treats workspaces membership as ownership" do
@@ -124,7 +124,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
 
       result = BufferManagement.handle_agent_session_down(state, session_pid, :killed)
 
-      assert result.shell_state.status_msg == "Agent session crashed (SPC a n to restart)"
+      assert EditorState.status_msg(result) == "Agent session crashed (SPC a n to restart)"
     end
 
     test "removes a clean project view workspace on normal session end", %{tmp_dir: dir} do
@@ -139,9 +139,9 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
 
       assert_receive {:DOWN, ^changeset_ref, :process, _, _}
       assert_receive {:DOWN, ^fork_store_ref, :process, _, _}
-      assert TabBar.get_workspace(result.shell_state.tab_bar, workspace_id) == nil
-      assert TabBar.find_workspace_by_session(result.shell_state.tab_bar, session_pid) == nil
-      assert result.shell_state.status_msg == "Agent session ended"
+      assert TabBar.get_workspace(EditorState.tab_bar(result), workspace_id) == nil
+      assert TabBar.find_workspace_by_session(EditorState.tab_bar(result), session_pid) == nil
+      assert EditorState.status_msg(result) == "Agent session ended"
     end
 
     test "keeps a dirty project view workspace and marks review attention", %{tmp_dir: dir} do
@@ -157,13 +157,13 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
       {state, workspace_id} = workspace_state_with_project_view(session_pid, project_view)
 
       result = BufferManagement.handle_agent_session_down(state, session_pid, :normal)
-      workspace = TabBar.get_workspace(result.shell_state.tab_bar, workspace_id)
+      workspace = TabBar.get_workspace(EditorState.tab_bar(result), workspace_id)
 
       assert workspace.session == nil
       assert workspace.agent_status == :error
       assert workspace.review.state == :needs_review
       assert WorkspaceReview.pending?(workspace.review)
-      assert result.shell_state.status_msg == "Agent session ended, workspace drafts need review"
+      assert EditorState.status_msg(result) == "Agent session ended, workspace drafts need review"
       assert Minga.Buffer.content(buffer) == "one\n"
     end
 
@@ -176,7 +176,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
       {state, workspace_id} = workspace_state_with_project_view(session_pid, project_view)
 
       result = BufferManagement.handle_agent_session_down(state, session_pid, :normal)
-      workspace = TabBar.get_workspace(result.shell_state.tab_bar, workspace_id)
+      workspace = TabBar.get_workspace(EditorState.tab_bar(result), workspace_id)
 
       assert_receive {:project_view_close_called, ^dir}
       assert workspace.session == nil
@@ -185,7 +185,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
       assert workspace.review.last_error == :close_failed
       assert WorkspaceReview.pending?(workspace.review)
 
-      assert result.shell_state.status_msg ==
+      assert EditorState.status_msg(result) ==
                "Agent session ended, workspace review needs attention"
     end
 
@@ -200,7 +200,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
       {state, workspace_id} = workspace_state_with_project_view(session_pid, project_view)
 
       result = BufferManagement.handle_agent_session_down(state, session_pid, :killed)
-      workspace = TabBar.get_workspace(result.shell_state.tab_bar, workspace_id)
+      workspace = TabBar.get_workspace(EditorState.tab_bar(result), workspace_id)
 
       assert workspace.session == nil
       assert workspace.agent_status == :error
@@ -208,7 +208,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
       assert workspace.review.last_error == :diff_failed
       assert WorkspaceReview.pending?(workspace.review)
 
-      assert result.shell_state.status_msg ==
+      assert EditorState.status_msg(result) ==
                "Agent session crashed, workspace review needs attention"
     end
 
@@ -217,10 +217,10 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
       state = build_state(tab_bar_with_remote_session(session_pid))
 
       result = BufferManagement.handle_agent_session_down(state, session_pid, :noconnection)
-      remote_tab = Enum.find(result.shell_state.tab_bar.tabs, &(&1.session == session_pid))
+      remote_tab = Enum.find(EditorState.tab_bar(result).tabs, &(&1.session == session_pid))
 
       assert remote_tab.connection_status == :disconnected
-      assert result.shell_state.status_msg == "[home] disconnected, reconnecting..."
+      assert EditorState.status_msg(result) == "[home] disconnected, reconnecting..."
     end
   end
 end

--- a/test/minga_editor/commands/agent_split_test.exs
+++ b/test/minga_editor/commands/agent_split_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.Commands.Agent, as: AgentCommands
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.Buffers
@@ -65,7 +66,6 @@ defmodule MingaEditor.Commands.AgentSplitTest do
 
     %EditorState{
       port_manager: self(),
-      shell: MingaEditor.Shell.Traditional,
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80),
         buffers: %Buffers{active: buf, list: [buf]},
@@ -76,7 +76,11 @@ defmodule MingaEditor.Commands.AgentSplitTest do
           next_id: 2
         }
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb}
+        )
     }
   end
 
@@ -88,7 +92,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
       new_state = AgentCommands.toggle_agent_split(state)
 
       assert EditorState.active_tab_kind(new_state) == :agent
-      assert new_state.shell_state.tab_bar.active_id == 2
+      assert EditorState.tab_bar(new_state).active_id == 2
     end
 
     test "switches back to file tab when on agent tab" do
@@ -101,7 +105,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
       # Toggle off (switch to file)
       state = AgentCommands.toggle_agent_split(state)
       assert EditorState.active_tab_kind(state) == :file
-      assert state.shell_state.tab_bar.active_id == 1
+      assert EditorState.tab_bar(state).active_id == 1
     end
 
     test "agent tab has agent_chat window in context" do
@@ -118,12 +122,12 @@ defmodule MingaEditor.Commands.AgentSplitTest do
     test "round-trip toggle restores file state" do
       state = make_state()
       original_buf = state.workspace.buffers.active
-      original_active = state.shell_state.tab_bar.active_id
+      original_active = EditorState.tab_bar(state).active_id
 
       state = AgentCommands.toggle_agent_split(state)
       state = AgentCommands.toggle_agent_split(state)
 
-      assert state.shell_state.tab_bar.active_id == original_active
+      assert EditorState.tab_bar(state).active_id == original_active
       assert state.workspace.buffers.active == original_buf
     end
   end

--- a/test/minga_editor/commands/agent_split_toggle_test.exs
+++ b/test/minga_editor/commands/agent_split_toggle_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
   alias MingaEditor.Agent.View.Preview
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.Commands.Agent, as: AgentCommands
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -59,7 +60,6 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
 
     state = %EditorState{
       port_manager: self(),
-      shell: MingaEditor.Shell.Traditional,
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80),
         editing: VimState.new(),
@@ -73,7 +73,11 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
         }
       },
       focus_stack: Input.default_stack(),
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb}
+        )
     }
 
     if active do
@@ -182,7 +186,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
 
       new_state = AgentCommands.toggle_agentic_view(state)
 
-      agent_tab_after = TabBar.find_by_kind(new_state.shell_state.tab_bar, :agent)
+      agent_tab_after = TabBar.find_by_kind(new_state.shell_runtime.state.tab_bar, :agent)
       assert agent_tab_after != nil
       assert agent_tab_after.id == agent_tab_before.id
     end
@@ -215,7 +219,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       assert EditorState.active_tab_kind(without_agent) == :file
       assert without_agent.workspace.keymap_scope == :editor
       refute_process_down(session)
-      assert TabBar.find_by_session(without_agent.shell_state.tab_bar, session) != nil
+      assert TabBar.find_by_session(without_agent.shell_runtime.state.tab_bar, session) != nil
     end
 
     test "agent ESC behavior returns to file without stopping the session" do
@@ -227,7 +231,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       assert EditorState.active_tab_kind(without_agent) == :file
       assert without_agent.workspace.keymap_scope == :editor
       refute_process_down(session)
-      assert TabBar.find_by_session(without_agent.shell_state.tab_bar, session) != nil
+      assert TabBar.find_by_session(without_agent.shell_runtime.state.tab_bar, session) != nil
     end
   end
 
@@ -255,7 +259,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       assert Enum.count(TabBar.filter_by_kind(MingaEditor.State.tab_bar(state), :agent)) == 1
 
       new_state = BufferManagement.execute(state, :kill_buffer)
-      assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :agent) == []
+      assert TabBar.filter_by_kind(new_state.shell_runtime.state.tab_bar, :agent) == []
     end
   end
 
@@ -378,13 +382,13 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       agent_tab_id = TabBar.find_by_kind(MingaEditor.State.tab_bar(state), :agent).id
 
       first = AgentCommands.toggle_agentic_view(state)
-      assert TabBar.get(first.shell_state.tab_bar, agent_tab_id) != nil
+      assert TabBar.get(first.shell_runtime.state.tab_bar, agent_tab_id) != nil
 
       second = AgentCommands.toggle_agentic_view(first)
-      assert TabBar.get(second.shell_state.tab_bar, agent_tab_id) != nil
+      assert TabBar.get(second.shell_runtime.state.tab_bar, agent_tab_id) != nil
 
       third = AgentCommands.toggle_agentic_view(second)
-      assert TabBar.get(third.shell_state.tab_bar, agent_tab_id) != nil
+      assert TabBar.get(third.shell_runtime.state.tab_bar, agent_tab_id) != nil
     end
   end
 end

--- a/test/minga_editor/commands/buffer_management_frontend_test.exs
+++ b/test/minga_editor/commands/buffer_management_frontend_test.exs
@@ -31,17 +31,17 @@ defmodule MingaEditor.Commands.BufferManagement.FrontendTest do
     for {label, caps} <- [{"GUI", @gui}, {"Go TUI", @go_tui}] do
       test "#{label} opens bottom panel on messages tab without stealing focus" do
         state = BufferManagement.execute(base_state(unquote(Macro.escape(caps))), :view_messages)
-        assert state.shell_state.bottom_panel.visible == true
-        assert state.shell_state.bottom_panel.active_tab == :messages
-        assert state.shell_state.bottom_panel.filter == nil
-        assert state.shell_state.bottom_panel.focused == false
+        assert EditorState.bottom_panel(state).visible == true
+        assert EditorState.bottom_panel(state).active_tab == :messages
+        assert EditorState.bottom_panel(state).filter == nil
+        assert EditorState.bottom_panel(state).focused == false
       end
     end
 
     test "clears dismissed state" do
       state = MingaEditor.State.set_bottom_panel(base_state(@gui), %BottomPanel{dismissed: true})
       state = BufferManagement.execute(state, :view_messages)
-      assert state.shell_state.bottom_panel.dismissed == false
+      assert EditorState.bottom_panel(state).dismissed == false
     end
   end
 
@@ -49,10 +49,10 @@ defmodule MingaEditor.Commands.BufferManagement.FrontendTest do
     for {label, caps} <- [{"GUI", @gui}, {"Go TUI", @go_tui}] do
       test "#{label} opens bottom panel with warnings filter without stealing focus" do
         state = BufferManagement.execute(base_state(unquote(Macro.escape(caps))), :view_warnings)
-        assert state.shell_state.bottom_panel.visible == true
-        assert state.shell_state.bottom_panel.active_tab == :messages
-        assert state.shell_state.bottom_panel.filter == :warnings
-        assert state.shell_state.bottom_panel.focused == false
+        assert EditorState.bottom_panel(state).visible == true
+        assert EditorState.bottom_panel(state).active_tab == :messages
+        assert EditorState.bottom_panel(state).filter == :warnings
+        assert EditorState.bottom_panel(state).focused == false
       end
     end
   end

--- a/test/minga_editor/commands/eval_test.exs
+++ b/test/minga_editor/commands/eval_test.exs
@@ -32,19 +32,19 @@ defmodule MingaEditor.Commands.EvalTest do
     test "evaluates arithmetic and shows result on status line" do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, "1 + 1"})
-      assert result.shell_state.status_msg == "2"
+      assert EditorState.status_msg(result) == "2"
     end
 
     test "evaluates string expressions" do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, ~s("hello" <> " world")})
-      assert result.shell_state.status_msg == ~s("hello world")
+      assert EditorState.status_msg(result) == ~s("hello world")
     end
 
     test "evaluates list expressions" do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, "Enum.map([1,2,3], & &1 * 2)"})
-      assert result.shell_state.status_msg == "[2, 4, 6]"
+      assert EditorState.status_msg(result) == "[2, 4, 6]"
     end
   end
 
@@ -52,7 +52,7 @@ defmodule MingaEditor.Commands.EvalTest do
     test "editor binding contains the current process PID" do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, "editor"})
-      assert result.shell_state.status_msg == inspect(self())
+      assert EditorState.status_msg(result) == inspect(self())
     end
   end
 
@@ -61,13 +61,13 @@ defmodule MingaEditor.Commands.EvalTest do
     test "syntax error returns formatted error on status line" do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, "1 +"})
-      assert result.shell_state.status_msg =~ "**"
+      assert EditorState.status_msg(result) =~ "**"
     end
 
     test "runtime error returns formatted error without crashing" do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, "1 / 0"})
-      assert result.shell_state.status_msg =~ "ArithmeticError"
+      assert EditorState.status_msg(result) =~ "ArithmeticError"
     end
 
     @tag capture_log: true
@@ -75,13 +75,13 @@ defmodule MingaEditor.Commands.EvalTest do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, "undefined_var"})
 
-      assert result.shell_state.status_msg =~ "undefined variable"
+      assert EditorState.status_msg(result) =~ "undefined variable"
     end
 
     test "throw is caught and displayed" do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, "throw(:oops)"})
-      assert result.shell_state.status_msg =~ "**"
+      assert EditorState.status_msg(result) =~ "**"
     end
   end
 
@@ -89,7 +89,7 @@ defmodule MingaEditor.Commands.EvalTest do
     test "long-running eval times out gracefully" do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, ":timer.sleep(10_000)"}, timeout: 100)
-      assert result.shell_state.status_msg == "Eval timed out (0s)"
+      assert EditorState.status_msg(result) == "Eval timed out (0s)"
     end
   end
 
@@ -115,7 +115,7 @@ defmodule MingaEditor.Commands.EvalTest do
     test "works without messages buffer singleton" do
       state = build_state()
       result = Eval.execute(state, {:eval_expression, "1 + 1"})
-      assert result.shell_state.status_msg == "2"
+      assert EditorState.status_msg(result) == "2"
     end
   end
 end

--- a/test/minga_editor/commands/file_tree_editing_test.exs
+++ b/test/minga_editor/commands/file_tree_editing_test.exs
@@ -13,6 +13,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
   alias Minga.Project.FileTree
   alias MingaEditor.Commands
   alias MingaEditor.Input.FileTreeHandler
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -188,10 +189,18 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
       assert Buffer.dirty?(buffer)
       assert File.read!(renamed) == "content"
       refute File.exists?(file)
-      assert TabBar.active(state.shell_state.tab_bar).file_ref == new_ref
-      assert TabBar.get_workspace(state.shell_state.tab_bar, 0).active_file == new_ref
-      assert WorkspaceModel.has_file?(TabBar.get_workspace(state.shell_state.tab_bar, 0), new_ref)
-      refute WorkspaceModel.has_file?(TabBar.get_workspace(state.shell_state.tab_bar, 0), old_ref)
+      assert TabBar.active(state.shell_runtime.state.tab_bar).file_ref == new_ref
+      assert TabBar.get_workspace(state.shell_runtime.state.tab_bar, 0).active_file == new_ref
+
+      assert WorkspaceModel.has_file?(
+               TabBar.get_workspace(state.shell_runtime.state.tab_bar, 0),
+               new_ref
+             )
+
+      refute WorkspaceModel.has_file?(
+               TabBar.get_workspace(state.shell_runtime.state.tab_bar, 0),
+               old_ref
+             )
 
       assert :ok = Buffer.save(buffer)
       assert File.read!(renamed) == "!content"
@@ -260,7 +269,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
           |> SessionState.set_file_tree(
             FileTreeState.open(%FileTreeState{}, FileTree.new(dir) |> FileTree.refresh(), nil)
           ),
-        shell_state: %ShellState{tab_bar: tab_bar},
+        shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{tab_bar: tab_bar}),
         focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
       }
 
@@ -274,11 +283,19 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
 
       assert ft(state).editing == nil
       assert Buffer.file_path(target_buffer) == renamed
-      assert TabBar.active(state.shell_state.tab_bar).id == active_tab.id
-      assert TabBar.get(state.shell_state.tab_bar, inactive_tab.id).file_ref == new_ref
-      assert TabBar.get_workspace(state.shell_state.tab_bar, 0).active_file == active_ref
-      assert WorkspaceModel.has_file?(TabBar.get_workspace(state.shell_state.tab_bar, 0), new_ref)
-      refute WorkspaceModel.has_file?(TabBar.get_workspace(state.shell_state.tab_bar, 0), old_ref)
+      assert TabBar.active(state.shell_runtime.state.tab_bar).id == active_tab.id
+      assert TabBar.get(state.shell_runtime.state.tab_bar, inactive_tab.id).file_ref == new_ref
+      assert TabBar.get_workspace(state.shell_runtime.state.tab_bar, 0).active_file == active_ref
+
+      assert WorkspaceModel.has_file?(
+               TabBar.get_workspace(state.shell_runtime.state.tab_bar, 0),
+               new_ref
+             )
+
+      refute WorkspaceModel.has_file?(
+               TabBar.get_workspace(state.shell_runtime.state.tab_bar, 0),
+               old_ref
+             )
     end
 
     test "rename reports a dead buffer retarget as an error instead of crashing", %{
@@ -436,7 +453,7 @@ defmodule MingaEditor.Commands.FileTreeEditingTest do
       port_manager: self(),
       events_registry: events_registry,
       workspace: workspace,
-      shell_state: shell_state,
+      shell_runtime: Runtime.new(Runtime.default_entry(), shell_state),
       focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
     }
   end

--- a/test/minga_editor/commands/file_tree_neo_bindings_test.exs
+++ b/test/minga_editor/commands/file_tree_neo_bindings_test.exs
@@ -10,7 +10,6 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
   alias Minga.Project.FileRef
   alias Minga.Project.FileTree
   alias MingaEditor.Commands.FileTree, as: FileTreeCommands
-  alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -169,7 +168,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
       state =
         tmp_dir
         |> build_state(Buffers.add(%Buffers{}, active_buffer))
-        |> EditorState.update_shell_state(fn _ -> %ShellState{tab_bar: tab_bar} end)
+        |> EditorState.set_tab_bar(tab_bar)
         |> select_entry("alpha.txt")
         |> FileTreeCommands.mark_move()
 
@@ -178,11 +177,19 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
       assert BufferProcess.file_path(target_buffer) == target
       assert File.read!(target) == "source"
       assert {:ok, ^target_buffer} = BufferProcess.pid_for_path(target)
-      assert TabBar.active(state.shell_state.tab_bar).id == active_tab.id
-      assert TabBar.get(state.shell_state.tab_bar, inactive_tab.id).file_ref == new_ref
-      assert TabBar.get_workspace(state.shell_state.tab_bar, 0).active_file == active_ref
-      assert WorkspaceModel.has_file?(TabBar.get_workspace(state.shell_state.tab_bar, 0), new_ref)
-      refute WorkspaceModel.has_file?(TabBar.get_workspace(state.shell_state.tab_bar, 0), old_ref)
+      assert TabBar.active(EditorState.tab_bar(state)).id == active_tab.id
+      assert TabBar.get(EditorState.tab_bar(state), inactive_tab.id).file_ref == new_ref
+      assert TabBar.get_workspace(EditorState.tab_bar(state), 0).active_file == active_ref
+
+      assert WorkspaceModel.has_file?(
+               TabBar.get_workspace(EditorState.tab_bar(state), 0),
+               new_ref
+             )
+
+      refute WorkspaceModel.has_file?(
+               TabBar.get_workspace(EditorState.tab_bar(state), 0),
+               old_ref
+             )
     end
 
     @tag :tmp_dir
@@ -252,10 +259,18 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
       assert BufferProcess.file_path(buffer) == target
       assert File.read!(target) == "source"
-      assert TabBar.active(state.shell_state.tab_bar).file_ref == new_ref
-      assert TabBar.get_workspace(state.shell_state.tab_bar, 0).active_file == new_ref
-      assert WorkspaceModel.has_file?(TabBar.get_workspace(state.shell_state.tab_bar, 0), new_ref)
-      refute WorkspaceModel.has_file?(TabBar.get_workspace(state.shell_state.tab_bar, 0), old_ref)
+      assert TabBar.active(EditorState.tab_bar(state)).file_ref == new_ref
+      assert TabBar.get_workspace(EditorState.tab_bar(state), 0).active_file == new_ref
+
+      assert WorkspaceModel.has_file?(
+               TabBar.get_workspace(EditorState.tab_bar(state), 0),
+               new_ref
+             )
+
+      refute WorkspaceModel.has_file?(
+               TabBar.get_workspace(EditorState.tab_bar(state), 0),
+               old_ref
+             )
 
       BufferProcess.replace_content(buffer, "updated", :user)
       assert :ok = BufferProcess.save(buffer)
@@ -452,7 +467,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
       TabBar.new(tab, root)
       |> TabBar.update_workspace(0, fn ws -> WorkspaceModel.set_active_file(ws, file_ref) end)
 
-    EditorState.update_shell_state(state, fn _ -> %ShellState{tab_bar: tab_bar} end)
+    EditorState.set_tab_bar(state, tab_bar)
   end
 
   defp build_state(root, buffers \\ %Buffers{}) do

--- a/test/minga_editor/commands/help_test.exs
+++ b/test/minga_editor/commands/help_test.exs
@@ -49,7 +49,7 @@ defmodule MingaEditor.Commands.HelpTest do
 
       assert is_pid(help)
       assert result.workspace.buffers.active == help
-      assert result.shell_state.status_msg == nil
+      assert EditorState.status_msg(result) == nil
       assert BufferProcess.read_only?(help)
       assert BufferProcess.get_option(help, :autopair_block) == false
 

--- a/test/minga_editor/commands/inline_ask_test.exs
+++ b/test/minga_editor/commands/inline_ask_test.exs
@@ -9,6 +9,8 @@ defmodule MingaEditor.Commands.InlineAskTest do
   alias MingaEditor.InlineAsk.Events, as: InlineAskEvents
   alias MingaEditor.Input.InlineAsk, as: InlineAskInput
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -37,7 +39,7 @@ defmodule MingaEditor.Commands.InlineAskTest do
     state = InlineAskCommand.open(state)
 
     original_content = Buffer.content(buffer)
-    original_workspace_count = Enum.count(state.shell_state.tab_bar.workspaces)
+    original_workspace_count = Enum.count(state.shell_runtime.state.tab_bar.workspaces)
 
     assert {:handled, state} = InlineAskInput.handle_key(state, ?w, 0)
     assert {:handled, state} = InlineAskInput.handle_key(state, ?h, 0)
@@ -49,7 +51,7 @@ defmodule MingaEditor.Commands.InlineAskTest do
     assert {:handled, state} = InlineAskInput.handle_key(state, 27, 0)
     assert active_ask(state, buffer) == nil
     assert Buffer.content(buffer) == original_content
-    assert Enum.count(state.shell_state.tab_bar.workspaces) == original_workspace_count
+    assert Enum.count(state.shell_runtime.state.tab_bar.workspaces) == original_workspace_count
   end
 
   test "prompt send failure marks ask failed and clears session", %{tmp_dir: root} do
@@ -167,7 +169,7 @@ defmodule MingaEditor.Commands.InlineAskTest do
 
     assert_receive {:seeded, "What is this?", "It authenticates users."}
     assert active_ask(state, buffer) == nil
-    assert %{shell_state: %{tab_bar: tb}} = state
+    assert %EditorState{shell_runtime: %Runtime{state: %{tab_bar: tb}}} = state
     assert %{kind: :agent} = TabBar.active(tb)
     assert workspace = TabBar.active_workspace(tb)
     assert Enum.any?(workspace.files, &(&1.display_name == "auth.ex"))
@@ -196,9 +198,13 @@ defmodule MingaEditor.Commands.InlineAskTest do
           }
         }
         |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
-      shell_state: %TraditionalState{
-        tab_bar: TabBar.new(Tab.new_file(1, Path.basename(rel_path)), root)
-      }
+      shell_runtime:
+        Runtime.new(
+          Registry.get(:traditional),
+          %TraditionalState{
+            tab_bar: TabBar.new(Tab.new_file(1, Path.basename(rel_path)), root)
+          }
+        )
     }
 
     {state, buffer}
@@ -219,7 +225,9 @@ defmodule MingaEditor.Commands.InlineAskTest do
     %{state | workspace: workspace}
   end
 
-  defp fake_start_agent_session(%{shell_state: %{tab_bar: %TabBar{} = tb}} = state) do
+  defp fake_start_agent_session(
+         %EditorState{shell_runtime: %Runtime{state: %{tab_bar: %TabBar{} = tb}}} = state
+       ) do
     session_pid = self()
     active_tab = TabBar.active(tb)
     {tb, workspace} = TabBar.add_workspace(tb, "Inline Ask", session_pid)

--- a/test/minga_editor/commands/inline_edit_test.exs
+++ b/test/minga_editor/commands/inline_edit_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
   alias MingaEditor.InlineEdit.Events, as: InlineEditEvents
   alias MingaEditor.Input.InlineEdit, as: InlineEditInput
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -193,9 +194,13 @@ defmodule MingaEditor.Commands.InlineEditTest do
           }
         }
         |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
-      shell_state: %TraditionalState{
-        tab_bar: TabBar.new(Tab.new_file(1, Path.basename(rel_path)), root)
-      }
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %TraditionalState{
+            tab_bar: TabBar.new(Tab.new_file(1, Path.basename(rel_path)), root)
+          }
+        )
     }
 
     {state, buffer}

--- a/test/minga_editor/commands/lsp_test.exs
+++ b/test/minga_editor/commands/lsp_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Commands.LspTest do
   use ExUnit.Case, async: false
 
   alias Minga.Test.LspIsolation
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.Commands.Lsp, as: LspCommands
 
   import MingaEditor.RenderPipeline.TestHelpers
@@ -17,7 +18,7 @@ defmodule MingaEditor.Commands.LspTest do
     test "shows 'no language servers running' when none active" do
       state = base_state()
       result = LspCommands.execute(state, :lsp_info)
-      assert result.shell_state.status_msg == "No language servers running"
+      assert EditorState.status_msg(result) == "No language servers running"
     end
   end
 
@@ -31,13 +32,13 @@ defmodule MingaEditor.Commands.LspTest do
       }
 
       result = LspCommands.execute(state, :lsp_restart)
-      assert result.shell_state.status_msg == "No active buffer"
+      assert EditorState.status_msg(result) == "No active buffer"
     end
 
     test "shows 'no LSP server' when no clients attached" do
       state = base_state()
       result = LspCommands.execute(state, :lsp_restart)
-      assert result.shell_state.status_msg == "No LSP server for this buffer"
+      assert EditorState.status_msg(result) == "No LSP server for this buffer"
     end
   end
 
@@ -51,13 +52,13 @@ defmodule MingaEditor.Commands.LspTest do
       }
 
       result = LspCommands.execute(state, :lsp_stop)
-      assert result.shell_state.status_msg == "No active buffer"
+      assert EditorState.status_msg(result) == "No active buffer"
     end
 
     test "shows 'no LSP server' when no clients attached" do
       state = base_state()
       result = LspCommands.execute(state, :lsp_stop)
-      assert result.shell_state.status_msg == "No LSP server for this buffer"
+      assert EditorState.status_msg(result) == "No LSP server for this buffer"
     end
   end
 
@@ -71,14 +72,14 @@ defmodule MingaEditor.Commands.LspTest do
       }
 
       result = LspCommands.execute(state, :lsp_start)
-      assert result.shell_state.status_msg == "No active buffer"
+      assert EditorState.status_msg(result) == "No active buffer"
     end
 
     test "shows 'no LSP server available' for unsupported filetype" do
       state = base_state(filetype: :unknown)
       result = LspCommands.execute(state, :lsp_start)
       # The test buffer has an unsupported filetype with no configured LSP server
-      assert String.contains?(result.shell_state.status_msg, "No LSP server available")
+      assert String.contains?(EditorState.status_msg(result), "No LSP server available")
     end
   end
 end

--- a/test/minga_editor/commands/search_async_test.exs
+++ b/test/minga_editor/commands/search_async_test.exs
@@ -29,8 +29,8 @@ defmodule MingaEditor.Commands.SearchAsyncTest do
       # already hold results (or the call would hang on a large repo).
       new_state = Search.execute(state, :confirm_project_search)
 
-      assert ModalOverlay.match(new_state.shell_state.modal, :picker)
-      {:picker, %{picker_ui: picker_ui}} = new_state.shell_state.modal
+      assert ModalOverlay.match(EditorState.modal(new_state), :picker)
+      {:picker, %{picker_ui: picker_ui}} = EditorState.modal(new_state)
       assert picker_ui.load_status == :loading
       assert picker_ui.source == MingaEditor.UI.Picker.ProjectSearchSource
 
@@ -70,7 +70,7 @@ defmodule MingaEditor.Commands.SearchAsyncTest do
         |> with_search_prompt("")
 
       new_state = Search.execute(state, :confirm_project_search)
-      refute ModalOverlay.match(new_state.shell_state.modal, :picker)
+      refute ModalOverlay.match(EditorState.modal(new_state), :picker)
     end
   end
 end

--- a/test/minga_editor/commands/tutor_test.exs
+++ b/test/minga_editor/commands/tutor_test.exs
@@ -109,7 +109,7 @@ defmodule MingaEditor.Commands.TutorTest do
       state = build_state()
       result = Tutor.execute(state, :tutor)
 
-      assert result.shell_state.status_msg =~ "Tutorial"
+      assert EditorState.status_msg(result) =~ "Tutorial"
     end
 
     test "includes Minga-specific lessons" do

--- a/test/minga_editor/commands/ui_frontend_test.exs
+++ b/test/minga_editor/commands/ui_frontend_test.exs
@@ -6,7 +6,8 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Observatory
   alias MingaEditor.Session.State, as: SessionState
-  alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
 
@@ -23,7 +24,11 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       port_manager: self(),
       capabilities: caps,
       workspace: %SessionState{viewport: Viewport.new(24, 80)},
-      shell_state: %MingaEditor.Shell.Traditional.State{bottom_panel: %BottomPanel{}}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{bottom_panel: %BottomPanel{}}
+        )
     }
   end
 
@@ -31,7 +36,7 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
     for {label, caps} <- [{"GUI", @gui}, {"Go TUI", @go_tui}] do
       test "#{label} toggle_bottom_panel opens panel when hidden" do
         state = Commands.execute(base_state(unquote(Macro.escape(caps))), :toggle_bottom_panel)
-        assert state.shell_state.bottom_panel.visible == true
+        assert state.shell_runtime.state.bottom_panel.visible == true
       end
 
       test "#{label} toggle_bottom_panel closes panel when visible" do
@@ -42,7 +47,7 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
           )
 
         state = Commands.execute(state, :toggle_bottom_panel)
-        assert state.shell_state.bottom_panel.visible == false
+        assert state.shell_runtime.state.bottom_panel.visible == false
       end
 
       test "#{label} bottom_panel_next_tab cycles to next tab" do
@@ -53,7 +58,7 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
           )
 
         state = Commands.execute(state, :bottom_panel_next_tab)
-        assert state.shell_state.bottom_panel.active_tab == :diagnostics
+        assert state.shell_runtime.state.bottom_panel.active_tab == :diagnostics
       end
 
       test "#{label} bottom_panel_prev_tab cycles to previous tab" do
@@ -64,7 +69,7 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
           )
 
         state = Commands.execute(state, :bottom_panel_prev_tab)
-        assert state.shell_state.bottom_panel.active_tab == :messages
+        assert state.shell_runtime.state.bottom_panel.active_tab == :messages
       end
     end
   end
@@ -75,8 +80,8 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
         state =
           Commands.execute(base_state(unquote(Macro.escape(caps))), :toggle_beam_observatory)
 
-        assert state.shell_state.observatory_visible == true
-        assert {timer, _token} = state.shell_state.observatory_timer
+        assert state.shell_runtime.state.observatory_visible == true
+        assert {timer, _token} = state.shell_runtime.state.observatory_timer
 
         Process.cancel_timer(timer)
       end
@@ -86,21 +91,14 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       token = make_ref()
       timer = Process.send_after(self(), {:observatory_tick, token}, 60_000)
 
-      state = %{
-        base_state(@gui)
-        | shell_state:
-            MingaEditor.Shell.Traditional.State.open_observatory(
-              base_state(@gui).shell_state,
-              {timer, token}
-            )
-      }
+      state = MingaEditor.State.open_observatory(base_state(@gui), {timer, token})
 
       state = MingaEditor.State.set_observatory_data(state, %{tree: :placeholder})
       state = Commands.execute(state, :toggle_beam_observatory)
 
-      assert state.shell_state.observatory_visible == false
-      assert state.shell_state.observatory_timer == nil
-      assert state.shell_state.observatory_data == nil
+      assert state.shell_runtime.state.observatory_visible == false
+      assert state.shell_runtime.state.observatory_timer == nil
+      assert state.shell_runtime.state.observatory_data == nil
     end
 
     test "is a no-op for the legacy Zig cell-grid frontend (no semantic_ui)" do
@@ -110,14 +108,25 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
     end
 
     test "is a no-op when the active shell has no observatory fields" do
-      state = %{base_state(@gui) | shell_state: %{}}
+      entry = %Entry{
+        id: :fake,
+        source: {:extension, :test},
+        module: MingaEditor.Test.FakeShell,
+        display_name: "Fake",
+        description: "Shell without observatory fields",
+        capabilities: [:gui],
+        default?: false,
+        generation: 1
+      }
+
+      state = %{base_state(@gui) | shell_runtime: Runtime.new(entry, %{})}
 
       assert Commands.execute(state, :toggle_beam_observatory) == state
     end
 
     test "ignores stale refresh ticks" do
       state = Commands.execute(base_state(@gui), :toggle_beam_observatory)
-      assert {timer, _token} = state.shell_state.observatory_timer
+      assert {timer, _token} = state.shell_runtime.state.observatory_timer
 
       assert {:noreply, ^state} = MingaEditor.handle_info({:observatory_tick, make_ref()}, state)
 
@@ -133,7 +142,7 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       # The tick handler returns the *unchanged* state: collection does not run
       # inline (no data set) and no next tick is scheduled here.
       assert {:noreply, ^state} = MingaEditor.handle_info({:observatory_tick, token}, state)
-      assert state.shell_state.observatory_data == nil
+      assert state.shell_runtime.state.observatory_data == nil
 
       # The collection ran in a supervised Task and reported back as a message,
       # exactly like a picker/async-action result.
@@ -157,9 +166,9 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       assert {:noreply, new_state} =
                MingaEditor.handle_info({:observatory_data_result, token, data}, state)
 
-      assert new_state.shell_state.observatory_data == data
+      assert new_state.shell_runtime.state.observatory_data == data
 
-      assert {next_timer, next_token} = new_state.shell_state.observatory_timer
+      assert {next_timer, next_token} = new_state.shell_runtime.state.observatory_timer
       assert is_reference(next_timer)
       # A fresh token gates the next cycle; the prior token is now stale.
       assert next_token != token
@@ -178,15 +187,13 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       assert {:noreply, ^state} =
                MingaEditor.handle_info({:observatory_data_result, make_ref(), data}, state)
 
-      assert state.shell_state.observatory_data == nil
+      assert state.shell_runtime.state.observatory_data == nil
     end
   end
 
   # Builds editor state with the observatory open and a known refresh token, so
   # current_observatory_token?/2 matches without scheduling a real timer.
   defp observatory_state(caps, token) do
-    base = base_state(caps)
-    shell = ShellState.open_observatory(base.shell_state, {make_ref(), token})
-    %{base | shell_state: shell}
+    MingaEditor.State.open_observatory(base_state(caps), {make_ref(), token})
   end
 end

--- a/test/minga_editor/commands/use_selection_for_find_test.exs
+++ b/test/minga_editor/commands/use_selection_for_find_test.exs
@@ -7,6 +7,8 @@ defmodule MingaEditor.Commands.UseSelectionForFindTest do
 
   use ExUnit.Case, async: true
 
+  alias MingaEditor.State, as: EditorState
+
   import MingaEditor.CommandStateHelpers
 
   describe "Layer 0/1 command state: use_selection_for_find" do
@@ -16,7 +18,7 @@ defmodule MingaEditor.Commands.UseSelectionForFindTest do
       state = MingaEditor.Commands.execute(state, :use_selection_for_find)
 
       assert state.workspace.search.last_pattern == "hello"
-      assert state.shell_state.status_msg =~ "hello"
+      assert EditorState.status_msg(state) =~ "hello"
     end
 
     test "sets forward search direction" do

--- a/test/minga_editor/commands/workspace_test.exs
+++ b/test/minga_editor/commands/workspace_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
   alias MingaAgent.ProjectView
   alias MingaAgent.Test.ProjectView.CloseFailingBackend
   alias MingaEditor.Commands.Workspace
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
@@ -64,7 +65,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
           next_id: 2
         }
       },
-      shell_state: %TraditionalState{tab_bar: tb}
+      shell_runtime: Runtime.new(Runtime.default_entry(), %TraditionalState{tab_bar: tb})
     }
   end
 
@@ -99,7 +100,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
   end
 
   defp put_active_workspace_project_view(state, project_view) do
-    tb = state.shell_state.tab_bar
+    tb = state.shell_runtime.state.tab_bar
     workspace_id = TabBar.active_workspace_id(tb)
 
     EditorState.set_tab_bar(
@@ -113,7 +114,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
   end
 
   defp put_active_workspace_session(state, session_pid) do
-    tb = state.shell_state.tab_bar
+    tb = state.shell_runtime.state.tab_bar
     workspace_id = TabBar.active_workspace_id(tb)
 
     EditorState.set_tab_bar(
@@ -123,7 +124,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
   end
 
   defp put_active_workspace_review(state, review) do
-    tb = state.shell_state.tab_bar
+    tb = state.shell_runtime.state.tab_bar
     workspace_id = TabBar.active_workspace_id(tb)
 
     EditorState.set_tab_bar(
@@ -174,7 +175,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
     state = %EditorState{
       port_manager: self(),
       workspace: manual_workspace_state(manual_live_buf, :insert),
-      shell_state: %TraditionalState{tab_bar: tb}
+      shell_runtime: Runtime.new(Runtime.default_entry(), %TraditionalState{tab_bar: tb})
     }
 
     {state, manual_live_buf}
@@ -227,7 +228,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
       result = Workspace.workspace_next(state)
 
       assert %EditorState{} = result
-      assert result.shell_state.tab_bar.active_id == 2
+      assert result.shell_runtime.state.tab_bar.active_id == 2
     end
   end
 
@@ -237,7 +238,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
       result = Workspace.workspace_prev(state)
 
       assert %EditorState{} = result
-      assert result.shell_state.tab_bar.active_id == 3
+      assert result.shell_runtime.state.tab_bar.active_id == 3
     end
   end
 
@@ -247,11 +248,11 @@ defmodule MingaEditor.Commands.WorkspaceTest do
       result = Workspace.workspace_toggle(state)
 
       assert %EditorState{} = result
-      assert result.shell_state.tab_bar.active_id == 2
+      assert result.shell_runtime.state.tab_bar.active_id == 2
       assert result.workspace.buffers.active == nil
       assert result.workspace.editing.mode == :normal
 
-      manual_tab = TabBar.get(result.shell_state.tab_bar, 1)
+      manual_tab = TabBar.get(result.shell_runtime.state.tab_bar, 1)
       assert manual_tab.context.buffers.active == manual_live_buf
       assert manual_tab.context.editing.mode == :insert
     end
@@ -263,7 +264,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
       result = Workspace.workspace_close(state)
 
       assert %EditorState{} = result
-      tab_bar = result.shell_state.tab_bar
+      tab_bar = result.shell_runtime.state.tab_bar
       assert TabBar.active_workspace_id(tab_bar) == 0
       assert TabBar.get_workspace(tab_bar, 1) == nil
       assert Enum.map(TabBar.tabs_in_workspace(tab_bar, 0), & &1.id) == [1, 2]
@@ -286,7 +287,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       result = Workspace.workspace_close(state)
 
-      assert result.shell_state.tab_bar == state.shell_state.tab_bar
+      assert result.shell_runtime.state.tab_bar == state.shell_runtime.state.tab_bar
 
       assert EditorState.status_msg(result) =~
                "Actions: Keep workspace, Review drafts, Discard drafts and close"
@@ -305,8 +306,8 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       result = Workspace.workspace_discard_and_close(state)
 
-      assert TabBar.get_workspace(result.shell_state.tab_bar, 1) == nil
-      assert TabBar.active_workspace_id(result.shell_state.tab_bar) == 0
+      assert TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1) == nil
+      assert TabBar.active_workspace_id(result.shell_runtime.state.tab_bar) == 0
     end
 
     test "workspace_discard_and_close refuses while the agent session is alive and keeps ProjectView drafts intact",
@@ -335,7 +336,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
         })
 
       result = Workspace.workspace_discard_and_close(state)
-      workspace = TabBar.get_workspace(result.shell_state.tab_bar, 1)
+      workspace = TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1)
 
       assert workspace != nil
       assert workspace.session == session_pid
@@ -375,8 +376,8 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       result = Workspace.workspace_discard_and_close(state)
 
-      assert TabBar.get_workspace(result.shell_state.tab_bar, 1) == nil
-      assert TabBar.active_workspace_id(result.shell_state.tab_bar) == 0
+      assert TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1) == nil
+      assert TabBar.active_workspace_id(result.shell_runtime.state.tab_bar) == 0
       assert File.read!(path) == "one\n"
       assert_receive {:DOWN, ^changeset_ref, :process, _, _}
       assert_receive {:DOWN, ^fork_store_ref, :process, _, _}
@@ -397,14 +398,14 @@ defmodule MingaEditor.Commands.WorkspaceTest do
         |> put_active_workspace_session(session_pid)
 
       result = Workspace.workspace_close(state)
-      workspace = TabBar.get_workspace(result.shell_state.tab_bar, 1)
+      workspace = TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1)
 
       assert workspace != nil
 
       assert EditorState.status_msg(result) ==
                "Stop the agent session before closing this workspace"
 
-      assert result.shell_state.tab_bar == state.shell_state.tab_bar
+      assert result.shell_runtime.state.tab_bar == state.shell_runtime.state.tab_bar
       assert :ok = ProjectView.write_file(project_view, "lib/a.ex", "still alive\n")
       assert {:ok, "still alive\n"} = ProjectView.read_file(project_view, "lib/a.ex")
       refute_receive {:DOWN, ^changeset_ref, :process, _, _}
@@ -425,8 +426,8 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       result = Workspace.workspace_close(state)
 
-      assert TabBar.get_workspace(result.shell_state.tab_bar, 1) == nil
-      assert TabBar.active_workspace_id(result.shell_state.tab_bar) == 0
+      assert TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1) == nil
+      assert TabBar.active_workspace_id(result.shell_runtime.state.tab_bar) == 0
       assert_receive {:DOWN, ^changeset_ref, :process, _, _}
       assert_receive {:DOWN, ^fork_store_ref, :process, _, _}
     end
@@ -442,7 +443,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
         |> put_active_workspace_project_view(view)
 
       result = Workspace.workspace_close(state)
-      workspace = TabBar.get_workspace(result.shell_state.tab_bar, 1)
+      workspace = TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1)
 
       assert workspace != nil
       assert workspace.review.state == :needs_review
@@ -471,7 +472,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
         })
 
       result = Workspace.workspace_resolve_conflicts(state)
-      review = TabBar.get_workspace(result.shell_state.tab_bar, 1).review
+      review = TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1).review
 
       assert review.state == :conflict
       assert review.conflict_files != []
@@ -485,7 +486,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       assert {:picker,
               %{picker_ui: %{source: WorkspaceSource, picker: %{title: "Switch Workspace"}}}} =
-               result.shell_state.modal
+               result.shell_runtime.state.modal
 
       active_item =
         result
@@ -511,7 +512,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       assert {:picker,
               %{picker_ui: %{source: PendingReviewsSource, picker: %{title: "Pending reviews"}}}} =
-               result.shell_state.modal
+               result.shell_runtime.state.modal
     end
   end
 
@@ -533,7 +534,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
         })
 
       result = Workspace.workspace_review_drafts(state)
-      review = TabBar.get_workspace(result.shell_state.tab_bar, 1).review
+      review = TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1).review
 
       assert review.state == :needs_review
       assert review.changed_files == [file_ref()]
@@ -559,7 +560,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
         })
 
       result = Workspace.workspace_promote(state)
-      review = TabBar.get_workspace(result.shell_state.tab_bar, 1).review
+      review = TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1).review
 
       assert review.state == :needs_review
       assert review.changed_files == [file_ref()]
@@ -585,7 +586,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
         })
 
       result = Workspace.workspace_discard(state)
-      review = TabBar.get_workspace(result.shell_state.tab_bar, 1).review
+      review = TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1).review
 
       assert review.state == :needs_review
       assert review.changed_files == [file_ref()]
@@ -612,8 +613,8 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       result = Workspace.workspace_discard_and_close(state)
 
-      assert TabBar.get_workspace(result.shell_state.tab_bar, 1) != nil
-      assert TabBar.active_workspace_id(result.shell_state.tab_bar) == 1
+      assert TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1) != nil
+      assert TabBar.active_workspace_id(result.shell_runtime.state.tab_bar) == 1
       assert EditorState.status_msg(result) =~ "Workspace review transition failed"
     end
 
@@ -632,7 +633,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
         })
 
       result = Workspace.workspace_discard(state)
-      review = TabBar.get_workspace(result.shell_state.tab_bar, 1).review
+      review = TabBar.get_workspace(result.shell_runtime.state.tab_bar, 1).review
 
       assert review.state == :needs_review
       assert review.changed_files == [file_ref()]
@@ -648,7 +649,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       assert {:picker,
               %{picker_ui: %{source: WorkspaceTargetSource, context: %{operation: :move}}}} =
-               result.shell_state.modal
+               result.shell_runtime.state.modal
     end
 
     test "workspace_copy_file opens the target workspace picker" do
@@ -658,7 +659,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       assert {:picker,
               %{picker_ui: %{source: WorkspaceTargetSource, context: %{operation: :copy}}}} =
-               result.shell_state.modal
+               result.shell_runtime.state.modal
     end
 
     test "workspace_move_file reports when no other workspaces exist" do
@@ -668,7 +669,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
       state = %EditorState{
         port_manager: self(),
         workspace: %SessionState{viewport: Viewport.new(24, 80)},
-        shell_state: %TraditionalState{tab_bar: tb}
+        shell_runtime: Runtime.new(Runtime.default_entry(), %TraditionalState{tab_bar: tb})
       }
 
       result = Workspace.workspace_move_file(state)
@@ -684,7 +685,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
       assert {:picker,
               %{picker_ui: %{source: WorkspaceIconSource, picker: %{title: "Set Workspace Icon"}}}} =
-               result.shell_state.modal
+               result.shell_runtime.state.modal
 
       current_icon =
         result
@@ -710,7 +711,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
                   cursor: 7
                 }
               }} =
-               result.shell_state.modal
+               result.shell_runtime.state.modal
     end
   end
 
@@ -720,7 +721,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
       result = Workspace.switch_to_manual_workspace(state)
 
       assert %EditorState{} = result
-      assert result.shell_state.tab_bar.active_id == 1
+      assert result.shell_runtime.state.tab_bar.active_id == 1
     end
   end
 
@@ -730,14 +731,14 @@ defmodule MingaEditor.Commands.WorkspaceTest do
       result = Workspace.workspace_goto(state, 0)
 
       assert %EditorState{} = result
-      assert result.shell_state.tab_bar.active_id == 1
+      assert result.shell_runtime.state.tab_bar.active_id == 1
     end
 
     test "workspace numbers are one-based" do
       state = make_state()
 
-      assert Workspace.workspace_goto(state, 1).shell_state.tab_bar.active_id == 2
-      assert Workspace.workspace_goto(state, 2).shell_state.tab_bar.active_id == 3
+      assert Workspace.workspace_goto(state, 1).shell_runtime.state.tab_bar.active_id == 2
+      assert Workspace.workspace_goto(state, 2).shell_runtime.state.tab_bar.active_id == 3
     end
   end
 end

--- a/test/minga_editor/completion_async_test.exs
+++ b/test/minga_editor/completion_async_test.exs
@@ -25,6 +25,7 @@ defmodule MingaEditor.CompletionAsyncTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Editing.Completion
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.CompletionHandling
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.State.ModalOverlay
@@ -42,7 +43,7 @@ defmodule MingaEditor.CompletionAsyncTest do
   end
 
   defp open_completion_modal(state, completion, gen) do
-    owner = state.shell_state.tab_bar.active_id
+    owner = EditorState.tab_bar(state).active_id
     trigger = %{CompletionTrigger.new() | gen: gen}
     payload = CompletionPayload.new(owner, completion: completion, trigger: trigger)
     ModalOverlay.open(state, :completion, payload)
@@ -188,7 +189,7 @@ defmodule MingaEditor.CompletionAsyncTest do
     # {:completion_processed, ...} -> the Editor's handle_info apply clause.
     defp inject_pending_completion(ctx, ref) do
       :sys.replace_state(ctx.editor, fn state ->
-        owner = state.shell_state.tab_bar.active_id
+        owner = EditorState.tab_bar(state).active_id
 
         trigger = %{
           CompletionTrigger.new()
@@ -250,14 +251,14 @@ defmodule MingaEditor.CompletionAsyncTest do
       _ =
         wait_until(
           ctx,
-          fn state -> not ModalOverlay.match(state.shell_state.modal, :completion) end,
+          fn state -> not ModalOverlay.match(EditorState.modal(state), :completion) end,
           max_attempts: 200,
           interval_ms: 10,
           message: "pending completion modal was left stuck after a Task crash"
         )
 
       final = editor_state(ctx)
-      refute ModalOverlay.match(final.shell_state.modal, :completion)
+      refute ModalOverlay.match(EditorState.modal(final), :completion)
       assert ModalOverlay.completion(final) == nil
     end
   end

--- a/test/minga_editor/completion_doc_preview_test.exs
+++ b/test/minga_editor/completion_doc_preview_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.CompletionDocPreviewTest do
   alias Minga.Editing.Completion
   alias MingaEditor.CompletionHandling
   alias MingaEditor.CompletionUI
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
@@ -27,7 +28,8 @@ defmodule MingaEditor.CompletionDocPreviewTest do
     %EditorState{
       port_manager: self(),
       workspace: ws,
-      shell_state: %MingaEditor.Shell.Traditional.State{modal: modal}
+      shell_runtime:
+        Runtime.new(Runtime.default_entry(), %MingaEditor.Shell.Traditional.State{modal: modal})
     }
   end
 

--- a/test/minga_editor/feature_state_shell_cleanup_test.exs
+++ b/test/minga_editor/feature_state_shell_cleanup_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.FeatureStateShellCleanupTest do
   alias MingaEditor.FeatureState
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.StateStash
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
@@ -27,6 +28,16 @@ defmodule MingaEditor.FeatureStateShellCleanupTest do
         capabilities: []
       })
 
+    :ok =
+      Registry.register({:extension, :fake_shell_alt}, %{
+        id: :fake_shell_alt,
+        module: MingaEditor.Test.FakeShellAlt,
+        display_name: "Fake Shell Alt",
+        description: "Alternate test shell",
+        default?: false,
+        capabilities: []
+      })
+
     on_exit(fn ->
       Registry.reset_for_test()
       Registry.seed_builtin()
@@ -40,22 +51,24 @@ defmodule MingaEditor.FeatureStateShellCleanupTest do
     stashed_context = context_with_feature_state(:stashed_owned, :stashed_other)
 
     entry = Registry.get(:fake_shell)
+    stashed_entry = Registry.get(:fake_shell_alt)
+
+    runtime =
+      Runtime.new(stashed_entry, %{contexts: [stashed_context]})
+      |> Runtime.activate(entry, %{contexts: [active_context]})
 
     state = %EditorState{
       port_manager: self(),
       workspace: workspace(),
-      shell_id: :fake_shell,
-      shell: MingaEditor.Test.FakeShell,
-      shell_state: %{contexts: [active_context]},
-      shell_state_stash: %{fake_shell: StateStash.new(entry, %{contexts: [stashed_context]})}
+      shell_runtime: runtime
     }
 
     cleaned = EditorState.drop_feature_state_source(state, @source)
 
-    [cleaned_context] = cleaned.shell_state.contexts
+    [cleaned_context] = Runtime.state(cleaned.shell_runtime).contexts
 
-    assert %StateStash{module: MingaEditor.Test.FakeShell, state: stashed_shell_state} =
-             cleaned.shell_state_stash.fake_shell
+    assert %StateStash{module: MingaEditor.Test.FakeShellAlt, state: stashed_shell_state} =
+             Runtime.stash(cleaned.shell_runtime).fake_shell_alt
 
     [cleaned_stashed_context] = stashed_shell_state.contexts
     restored = SessionState.restore_tab_context(workspace(), cleaned_context)
@@ -73,12 +86,14 @@ defmodule MingaEditor.FeatureStateShellCleanupTest do
     stashed_context = context_with_feature_state(:stashed_owned, :stashed_other)
     stale_entry = Registry.get(:fake_shell)
 
+    runtime =
+      Runtime.new(stale_entry, %{contexts: [stashed_context]})
+      |> Runtime.activate(Runtime.default_entry(), %MingaEditor.Shell.Traditional.State{})
+
     state = %EditorState{
       port_manager: self(),
       workspace: workspace(),
-      shell_state_stash: %{
-        fake_shell: StateStash.new(stale_entry, %{contexts: [stashed_context]})
-      }
+      shell_runtime: runtime
     }
 
     assert :ok = Registry.unregister_source({:extension, :fake_shell})
@@ -94,7 +109,10 @@ defmodule MingaEditor.FeatureStateShellCleanupTest do
              })
 
     cleaned = EditorState.drop_feature_state_source(state, @source)
-    %StateStash{state: %{contexts: [unchanged_context]}} = cleaned.shell_state_stash.fake_shell
+
+    %StateStash{state: %{contexts: [unchanged_context]}} =
+      Runtime.stash(cleaned.shell_runtime).fake_shell
+
     restored = SessionState.restore_tab_context(workspace(), unchanged_context)
 
     assert SessionState.get_feature_state(restored, @source, @feature) == :stashed_owned

--- a/test/minga_editor/feature_state_test.exs
+++ b/test/minga_editor/feature_state_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.FeatureStateTest do
   alias MingaEditor.Commands.BufferManagement
   alias MingaEditor.FeatureState
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Tab
@@ -109,7 +110,7 @@ defmodule MingaEditor.FeatureStateTest do
     state = %EditorState{
       port_manager: self(),
       workspace: live_workspace,
-      shell_state: shell_state
+      shell_runtime: Runtime.new(Runtime.default_entry(), shell_state)
     }
 
     cleaned = EditorState.drop_feature_state_source(state, @source)
@@ -144,7 +145,7 @@ defmodule MingaEditor.FeatureStateTest do
     state = %EditorState{
       port_manager: self(),
       workspace: live_workspace,
-      shell_state: %ShellState{tab_bar: TabBar.new(tab)}
+      shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{tab_bar: TabBar.new(tab)})
     }
 
     reloaded =
@@ -154,7 +155,7 @@ defmodule MingaEditor.FeatureStateTest do
         assert EditorState.get_feature_state(cleaned_state, @other_source, @feature) == nil
         assert EditorState.get_feature_state(cleaned_state, :builtin, @feature) == :builtin
 
-        cleaned_tab = TabBar.get(cleaned_state.shell_state.tab_bar, 1)
+        cleaned_tab = TabBar.get(cleaned_state.shell_runtime.state.tab_bar, 1)
 
         assert_snapshot_feature_state(cleaned_tab.context,
           config: nil,
@@ -173,7 +174,7 @@ defmodule MingaEditor.FeatureStateTest do
     assert EditorState.get_feature_state(reloaded, @other_source, @feature) == nil
     assert EditorState.get_feature_state(reloaded, :builtin, @feature) == :builtin
 
-    reloaded_tab = TabBar.get(reloaded.shell_state.tab_bar, 1)
+    reloaded_tab = TabBar.get(reloaded.shell_runtime.state.tab_bar, 1)
 
     assert_snapshot_feature_state(reloaded_tab.context,
       config: nil,
@@ -190,7 +191,7 @@ defmodule MingaEditor.FeatureStateTest do
     state = %EditorState{
       port_manager: self(),
       workspace: live_workspace,
-      shell_state: shell_state
+      shell_runtime: Runtime.new(Runtime.default_entry(), shell_state)
     }
 
     restored = EditorState.restore_tab_context(state, TabContext.empty())
@@ -206,7 +207,7 @@ defmodule MingaEditor.FeatureStateTest do
     state = %EditorState{
       port_manager: self(),
       workspace: live_workspace,
-      shell_state: shell_state
+      shell_runtime: Runtime.new(Runtime.default_entry(), shell_state)
     }
 
     context = EditorState.build_agent_tab_defaults(state, %MingaEditor.State.Windows{})

--- a/test/minga_editor/focus_tree_test.exs
+++ b/test/minga_editor/focus_tree_test.exs
@@ -14,6 +14,8 @@ defmodule MingaEditor.FocusTreeTest do
   alias MingaEditor.FocusTree.Node, as: TreeNode
   alias MingaEditor.Layout
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
@@ -181,7 +183,11 @@ defmodule MingaEditor.FocusTreeTest do
         port_manager: self(),
         workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()},
         layout: single_window_layout(),
-        shell_state: %ShellState{bottom_panel: %BottomPanel{visible: true, height_percent: 25}}
+        shell_runtime:
+          Runtime.new(
+            Registry.get(:traditional),
+            %ShellState{bottom_panel: %BottomPanel{visible: true, height_percent: 25}}
+          )
       }
 
       tree = FocusTree.from_state(state)

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -12,6 +12,8 @@ defmodule MingaEditor.Frontend.Emit.AdapterGUIChromeCacheTest do
   alias Minga.Frontend.Adapter.GUI.Caches, as: AdapterCaches
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.RenderModel.UI.Builder
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.StatusBar.Data, as: StatusBarData
@@ -88,7 +90,7 @@ defmodule MingaEditor.Frontend.Emit.AdapterGUIChromeCacheTest do
     end
 
     test "tab bar is emitted through adapter" do
-      state = put_in(gui_state().shell_state.tab_bar, TabBar.new(Tab.new_file(1, "test.ex")))
+      state = EditorState.set_tab_bar(gui_state(), TabBar.new(Tab.new_file(1, "test.ex")))
       {_ctx, _caches, cmds} = encode_via_adapter(state)
 
       assert opcode_count(cmds, 0x71) == 1,
@@ -96,7 +98,13 @@ defmodule MingaEditor.Frontend.Emit.AdapterGUIChromeCacheTest do
     end
 
     test "unsupported shell GUI payload logs and keeps standard chrome" do
-      unsupported_state = %{gui_state() | shell: UnknownGuiPayloadShell}
+      state = gui_state()
+      entry = %{Runtime.entry(state.shell_runtime) | module: UnknownGuiPayloadShell}
+
+      unsupported_state = %{
+        state
+        | shell_runtime: Runtime.new(entry, Runtime.state(state.shell_runtime))
+      }
 
       {{_ctx, _caches, cmds}, log} =
         with_log(fn -> encode_via_adapter(unsupported_state) end)
@@ -108,7 +116,7 @@ defmodule MingaEditor.Frontend.Emit.AdapterGUIChromeCacheTest do
     test "workspaces are emitted through adapter" do
       state = gui_state()
       tab_bar = tab_bar_with_two_workspaces()
-      state_with_agents = put_in(state.shell_state.tab_bar, tab_bar)
+      state_with_agents = EditorState.set_tab_bar(state, tab_bar)
       {_ctx, _caches, first_cmds} = encode_via_adapter(state_with_agents)
 
       assert opcode_count(first_cmds, 0x98) == 1,

--- a/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
+++ b/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
@@ -20,7 +20,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
   alias MingaEditor.Layout.SurfaceRegistry
   alias MingaEditor.Layout.SurfaceRegistry.Placement
   alias MingaEditor.SignatureHelp
-  alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.State, as: EditorState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -43,12 +43,9 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
       anchor_col: 3
     }
 
-    shell_state =
-      state.shell_state
-      |> ShellState.set_hover_popup(hover)
-      |> Map.put(:signature_help, signature)
-
-    %{state | shell_state: shell_state}
+    state
+    |> EditorState.set_hover_popup(hover)
+    |> EditorState.set_signature_help(signature)
   end
 
   defp emit_commands(state) do

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -15,6 +15,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
   alias Minga.Project.FileRef
   alias Minga.Project.FileTree
   alias MingaEditor.Handlers.FileEventHandler
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -87,7 +88,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
 
       panel = EditorState.git_status_panel(new_state)
       refute Map.has_key?(panel, :tui_state)
-      assert ShellState.git_status_tui_state(new_state.shell_state) == nil
+      assert ShellState.git_status_tui_state(Runtime.state(new_state.shell_runtime)) == nil
     end
 
     test "without git panel or file tree open is a no-op" do
@@ -318,7 +319,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
         |> TabBar.update_workspace(0, fn ws -> WorkspaceModel.set_active_file(ws, old_ref) end)
 
       state = %EditorState{port_manager: self(), workspace: workspace}
-      state = EditorState.update_shell_state(state, fn _ -> %ShellState{tab_bar: tab_bar} end)
+      state = EditorState.set_tab_bar(state, tab_bar)
 
       :ok = BufferProcess.save_as(buffer, path)
 
@@ -327,16 +328,16 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
 
       {new_state, effects} = FileEventHandler.handle(state, event)
 
-      assert TabBar.active(new_state.shell_state.tab_bar).file_ref == new_ref
-      assert TabBar.get_workspace(new_state.shell_state.tab_bar, 0).active_file == new_ref
+      assert TabBar.active(EditorState.tab_bar(new_state)).file_ref == new_ref
+      assert TabBar.get_workspace(EditorState.tab_bar(new_state), 0).active_file == new_ref
 
       assert WorkspaceModel.has_file?(
-               TabBar.get_workspace(new_state.shell_state.tab_bar, 0),
+               TabBar.get_workspace(EditorState.tab_bar(new_state), 0),
                new_ref
              )
 
       refute WorkspaceModel.has_file?(
-               TabBar.get_workspace(new_state.shell_state.tab_bar, 0),
+               TabBar.get_workspace(EditorState.tab_bar(new_state), 0),
                old_ref
              )
 
@@ -405,7 +406,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
           |> SessionState.set_file_tree(%FileTreeState{project_root: root})
       }
 
-      state = EditorState.update_shell_state(state, fn _ -> %ShellState{tab_bar: tab_bar} end)
+      state = EditorState.set_tab_bar(state, tab_bar)
 
       :ok = BufferProcess.save_as(target_buffer, path)
 
@@ -414,7 +415,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
          %Minga.Events.BufferEvent{buffer: target_buffer, path: path}}
 
       {new_state, _effects} = FileEventHandler.handle(state, event)
-      updated_tb = new_state.shell_state.tab_bar
+      updated_tb = EditorState.tab_bar(new_state)
 
       assert TabBar.get(updated_tb, inactive_tab.id).file_ref == new_ref
       assert TabBar.get_workspace(updated_tb, 0).active_file == active_ref

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -17,6 +17,8 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Handlers.GuiActionHandler
   alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Window
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -356,7 +358,17 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
   test "observatory inspect is a no-op when the active shell has no observatory state", %{
     sidebar_registry: table
   } do
-    state = %{base_state(table) | shell_state: %{}}
+    entry = %Entry{
+      id: :fake,
+      source: :config,
+      module: MingaEditor.Test.FakeShell,
+      display_name: "Fake",
+      description: "Fake shell",
+      capabilities: [:gui],
+      generation: 1
+    }
+
+    state = %{base_state(table) | shell_runtime: Runtime.new(entry, %{})}
 
     assert GuiActionHandler.dispatch(state, {:observatory_inspect, "<0.1.0>"}) == state
   end
@@ -375,11 +387,11 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
       height: 10
     }
 
-    state = %{base_state(table) | shell_state: %{observatory_inspection: inspection}}
+    state = base_state(table) |> EditorState.set_observatory_inspection(inspection)
 
     new_state = GuiActionHandler.dispatch(state, :float_popup_dismiss)
 
-    assert new_state.shell_state.observatory_inspection == nil
+    assert Runtime.state(new_state.shell_runtime).observatory_inspection == nil
   end
 
   test "float_popup_dismiss closes the open :float popup window (#2338)", %{

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -11,6 +11,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
   alias MingaEditor.CompletionHandling
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.Handlers.LspEventHandler
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.SignatureHelp
@@ -141,7 +142,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       assert effects == [:render_now]
 
       assert %SignatureHelp{signatures: [%{label: "foo(arg)"}]} =
-               new_state.shell_state.signature_help
+               Runtime.state(new_state.shell_runtime).signature_help
     end
 
     test "tracked semantic token response updates highlights and returns render_now" do
@@ -265,7 +266,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       assert effects == [:render_now]
       assert Minga.Buffer.content(buf) == "modified content\n"
-      assert new_state.shell_state.status_msg =~ "Buffer changed"
+      assert EditorState.status_msg(new_state) =~ "Buffer changed"
     end
 
     test "a mutation queued after the LSP content read makes the commit stale" do
@@ -314,7 +315,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       assert effects == [:render_now]
       assert Minga.Buffer.content(buf) =~ "!line one"
-      assert new_state.shell_state.status_msg =~ "Buffer changed"
+      assert EditorState.status_msg(new_state) =~ "Buffer changed"
     end
 
     test "does not apply edits to a read-only buffer" do
@@ -340,7 +341,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       assert effects == [:render_now]
       assert Minga.Buffer.content(buf) =~ "line one"
-      assert new_state.shell_state.status_msg =~ "read-only"
+      assert EditorState.status_msg(new_state) =~ "read-only"
     end
 
     test "drops edits when the target buffer exited" do
@@ -367,7 +368,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
         LspEventHandler.handle(state, {:lsp_response, ref, {:ok, edits}})
 
       assert effects == [:render_now]
-      assert new_state.shell_state.status_msg =~ "closed"
+      assert EditorState.status_msg(new_state) =~ "closed"
     end
 
     test "handles nil response (no formatting changes)" do
@@ -380,7 +381,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
         LspEventHandler.handle(state, {:lsp_response, ref, {:ok, nil}})
 
       assert effects == [:render_now]
-      assert new_state.shell_state.status_msg =~ "No formatting changes"
+      assert EditorState.status_msg(new_state) =~ "No formatting changes"
     end
 
     test "handles error response" do
@@ -393,7 +394,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
         LspEventHandler.handle(state, {:lsp_response, ref, {:error, :timeout}})
 
       assert effects == [:render_now]
-      assert new_state.shell_state.status_msg =~ "Format error"
+      assert EditorState.status_msg(new_state) =~ "Format error"
     end
   end
 
@@ -407,7 +408,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       {new_state, effects} = LspEventHandler.handle(state, {:lsp_format_spinner, ref})
 
       assert effects == [:render_now]
-      assert new_state.shell_state.status_msg =~ "Formatting"
+      assert EditorState.status_msg(new_state) =~ "Formatting"
     end
 
     test "spinner is no-op when format already completed" do
@@ -429,7 +430,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       {new_state, effects} = LspEventHandler.handle(state, {:lsp_format_cancellable, ref})
 
       assert effects == [:render_now]
-      assert new_state.shell_state.status_msg =~ "Esc to cancel"
+      assert EditorState.status_msg(new_state) =~ "Esc to cancel"
     end
 
     test "timeout drops pending and sets timeout status" do
@@ -442,7 +443,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       assert effects == [:render_now]
       assert new_state.workspace.lsp_pending == %{}
-      assert new_state.shell_state.status_msg =~ "timed out"
+      assert EditorState.status_msg(new_state) =~ "timed out"
     end
 
     test "timeout is no-op when format already completed" do

--- a/test/minga_editor/handlers/session_restore_test.exs
+++ b/test/minga_editor/handlers/session_restore_test.exs
@@ -30,11 +30,11 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
     assert :ok = Session.save(snapshot, session_dir: dir)
 
     restored = dir |> initial_state() |> SessionRestore.restore_session()
-    assert [_, _] = TabBar.visible_file_tabs(restored.shell_state.tab_bar)
+    assert [_, _] = TabBar.visible_file_tabs(EditorState.tab_bar(restored))
     assert Minga.Buffer.file_path(restored.workspace.buffers.active) == first_path
 
     second_tab =
-      Enum.find(TabBar.visible_file_tabs(restored.shell_state.tab_bar), fn tab ->
+      Enum.find(TabBar.visible_file_tabs(EditorState.tab_bar(restored)), fn tab ->
         tab.label == "second.ex"
       end)
 
@@ -81,7 +81,7 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
 
     restored = dir |> initial_state() |> SessionRestore.restore_session()
 
-    assert [_] = TabBar.visible_file_tabs(restored.shell_state.tab_bar)
+    assert [_] = TabBar.visible_file_tabs(EditorState.tab_bar(restored))
     assert Minga.Buffer.file_path(restored.workspace.buffers.active) == existing_path
     refute File.exists?(missing_path)
   end

--- a/test/minga_editor/handlers/tool_handler_test.exs
+++ b/test/minga_editor/handlers/tool_handler_test.exs
@@ -138,7 +138,7 @@ defmodule MingaEditor.Handlers.ToolHandlerTest do
   describe "tool_missing (suppressed)" do
     test "returns log effect when prompts are suppressed" do
       state = base_state()
-      state = EditorState.update_shell_state(state, &%{&1 | suppress_tool_prompts: true})
+      state = EditorState.set_suppress_tool_prompts(state, true)
 
       event = {:minga_event, :tool_missing, %Minga.Events.ToolMissingEvent{command: "rg"}}
       {new_state, effects} = ToolHandler.handle(state, event)

--- a/test/minga_editor/inline_ask/events_test.exs
+++ b/test/minga_editor/inline_ask/events_test.exs
@@ -6,9 +6,12 @@ defmodule MingaEditor.InlineAsk.EventsTest do
   alias MingaAgent.Session
   alias MingaAgent.SessionManager
   alias MingaEditor.InlineAsk.Events
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.InlineAsk
+  alias MingaEditor.Viewport
 
   test "text deltas append to the matching inline ask" do
     session = self()
@@ -97,7 +100,16 @@ defmodule MingaEditor.InlineAsk.EventsTest do
       )
       |> InlineAsk.thinking(session_pid)
 
-    state = %{shell_state: %TraditionalState{inline_asks: %{buffer_pid => ask}}}
+    state = %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{viewport: Viewport.new(24, 80)},
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %TraditionalState{inline_asks: %{buffer_pid => ask}}
+        )
+    }
+
     {state, buffer_pid}
   end
 

--- a/test/minga_editor/inline_ask/render_test.exs
+++ b/test/minga_editor/inline_ask/render_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.InlineAsk.RenderTest do
   alias Minga.Core.Decorations
   alias Minga.Project.FileRef
   alias MingaEditor.InlineAsk.Render
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State.InlineAsk
 
@@ -23,7 +24,11 @@ defmodule MingaEditor.InlineAsk.RenderTest do
     ask = InlineAsk.append_input(ask, "why?")
 
     state = %{
-      shell_state: %TraditionalState{inline_asks: %{buffer_pid => ask}}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %TraditionalState{inline_asks: %{buffer_pid => ask}}
+        )
     }
 
     decorations = Render.merge_decorations(Decorations.new(), state, buffer_pid)
@@ -46,6 +51,23 @@ defmodule MingaEditor.InlineAsk.RenderTest do
     assert text =~ "why?"
   end
 
+  test "merge_decorations reads flattened render-pipeline shell state" do
+    buffer_pid = self()
+
+    ask =
+      InlineAsk.new(
+        buffer_pid,
+        %FileRef{kind: :buffer, display_name: "scratch.ex", buffer_pid: buffer_pid},
+        "scratch.ex",
+        0
+      )
+
+    state = %{shell_state: %TraditionalState{inline_asks: %{buffer_pid => ask}}}
+    decorations = Render.merge_decorations(Decorations.new(), state, buffer_pid)
+
+    assert Decorations.has_block_decorations?(decorations)
+  end
+
   test "merge_decorations leaves other buffers unchanged" do
     active_buffer = self()
 
@@ -60,7 +82,13 @@ defmodule MingaEditor.InlineAsk.RenderTest do
         0
       )
 
-    state = %{shell_state: %TraditionalState{inline_asks: %{active_buffer => ask}}}
+    state = %{
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %TraditionalState{inline_asks: %{active_buffer => ask}}
+        )
+    }
 
     decorations = Render.merge_decorations(Decorations.new(), state, other_buffer)
 

--- a/test/minga_editor/inline_edit/render_test.exs
+++ b/test/minga_editor/inline_edit/render_test.exs
@@ -1,0 +1,27 @@
+defmodule MingaEditor.InlineEdit.RenderTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Core.Decorations
+  alias Minga.Project.FileRef
+  alias MingaEditor.InlineEdit.Render
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State.InlineEdit
+
+  test "merge_decorations reads flattened render-pipeline shell state" do
+    buffer_pid = self()
+
+    edit =
+      InlineEdit.new(
+        buffer_pid,
+        %FileRef{kind: :buffer, display_name: "scratch.ex", buffer_pid: buffer_pid},
+        "scratch.ex",
+        {1, 2},
+        "old text"
+      )
+
+    state = %{shell_state: %TraditionalState{inline_edits: %{buffer_pid => edit}}}
+    decorations = Render.merge_decorations(Decorations.new(), state, buffer_pid)
+
+    assert Decorations.has_block_decorations?(decorations)
+  end
+end

--- a/test/minga_editor/input/agent_mouse_test.exs
+++ b/test/minga_editor/input/agent_mouse_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.Input.AgentMouseTest do
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Layout
   alias MingaEditor.LayoutPreset
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -59,7 +60,11 @@ defmodule MingaEditor.Input.AgentMouseTest do
         }
       },
       focus_stack: [],
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tab_bar}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tab_bar}
+        )
     }
   end
 

--- a/test/minga_editor/input/agent_nav_test.exs
+++ b/test/minga_editor/input/agent_nav_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.Input.AgentNavTest do
   alias Minga.Editing.Scroll
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Input.AgentNav
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -52,7 +53,11 @@ defmodule MingaEditor.Input.AgentNavTest do
           next_id: 2
         }
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: %AgentState{}}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: %AgentState{}}
+        )
     }
   end
 

--- a/test/minga_editor/input/agent_panel_nav_test.exs
+++ b/test/minga_editor/input/agent_panel_nav_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.Input.AgentPanelNavTest do
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Input.AgentPanel
   alias MingaEditor.Input.Scoped
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -48,7 +49,11 @@ defmodule MingaEditor.Input.AgentPanelNavTest do
         viewport: Viewport.new(24, 80),
         agent_ui: agent_ui
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: %AgentState{}},
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: %AgentState{}}
+        ),
       focus_stack: [Scoped, MingaEditor.Input.ModeFSM]
     }
   end

--- a/test/minga_editor/input/completion_key_test.exs
+++ b/test/minga_editor/input/completion_key_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.Input.CompletionKeyTest do
   alias Minga.Editing.Completion
   alias Minga.Mode
   alias MingaEditor.Input.Completion, as: CompletionInput
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
@@ -26,10 +27,14 @@ defmodule MingaEditor.Input.CompletionKeyTest do
     %EditorState{
       port_manager: nil,
       backend: :headless,
-      shell_state: %MingaEditor.Shell.Traditional.State{
-        modal: {:completion, payload},
-        whichkey: %WhichKey{}
-      },
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{
+            modal: {:completion, payload},
+            whichkey: %WhichKey{}
+          }
+        ),
       workspace: %MingaEditor.Session.State{
         editing: %VimState{mode: :insert, mode_state: Mode.initial_state()},
         viewport: Viewport.new(30, 80)

--- a/test/minga_editor/input/completion_mouse_test.exs
+++ b/test/minga_editor/input/completion_mouse_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Input.CompletionMouseTest do
   use ExUnit.Case, async: true
 
   alias Minga.Editing.Completion
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
@@ -19,10 +20,14 @@ defmodule MingaEditor.Input.CompletionMouseTest do
 
     %EditorState{
       port_manager: nil,
-      shell_state: %MingaEditor.Shell.Traditional.State{
-        modal: {:completion, payload},
-        whichkey: %WhichKey{}
-      },
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{
+            modal: {:completion, payload},
+            whichkey: %WhichKey{}
+          }
+        ),
       workspace: %MingaEditor.Session.State{
         editing: %VimState{mode: mode, mode_state: Mode.initial_state()},
         viewport: Viewport.new(30, 80)
@@ -60,7 +65,11 @@ defmodule MingaEditor.Input.CompletionMouseTest do
     test "passes through when no completion is active" do
       state = %EditorState{
         port_manager: nil,
-        shell_state: %MingaEditor.Shell.Traditional.State{whichkey: %WhichKey{}},
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %MingaEditor.Shell.Traditional.State{whichkey: %WhichKey{}}
+          ),
         workspace: %MingaEditor.Session.State{
           editing: %VimState{mode: :normal, mode_state: Mode.initial_state()},
           viewport: Viewport.new(30, 80)

--- a/test/minga_editor/input/handler_test.exs
+++ b/test/minga_editor/input/handler_test.exs
@@ -49,8 +49,8 @@ defmodule MingaEditor.Input.HandlerTest do
       state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
 
       assert {:handled, new_state} = ConflictPrompt.handle_key(state, ?r, 0)
-      refute ModalOverlay.match(new_state.shell_state.modal, :conflict)
-      assert new_state.shell_state.status_msg =~ "reloaded"
+      refute ModalOverlay.match(EditorState.modal(new_state), :conflict)
+      assert EditorState.status_msg(new_state) =~ "reloaded"
     end
 
     test "handles 'k' key during conflict by keeping local", %{tmp_dir: tmp_dir} do
@@ -61,7 +61,7 @@ defmodule MingaEditor.Input.HandlerTest do
       state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, path))
 
       assert {:handled, new_state} = ConflictPrompt.handle_key(state, ?k, 0)
-      refute ModalOverlay.match(new_state.shell_state.modal, :conflict)
+      refute ModalOverlay.match(EditorState.modal(new_state), :conflict)
     end
 
     test "swallows unrecognized keys during conflict" do
@@ -71,7 +71,7 @@ defmodule MingaEditor.Input.HandlerTest do
 
       assert {:handled, new_state} = ConflictPrompt.handle_key(state, ?x, 0)
       # State unchanged except for swallowing the key
-      assert new_state.shell_state.modal == state.shell_state.modal
+      assert EditorState.modal(new_state) == EditorState.modal(state)
     end
   end
 

--- a/test/minga_editor/input/hover_test.exs
+++ b/test/minga_editor/input/hover_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaEditor.Input.HoverTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.HoverPopup
   alias MingaEditor.Input.Hover
 
@@ -39,13 +40,13 @@ defmodule MingaEditor.Input.HoverTest do
     test "K focuses into the hover" do
       state = state_with_hover()
       assert {:handled, new_state} = Hover.handle_key(state, @key_upper_k, @none)
-      assert new_state.shell_state.hover_popup.focused == true
+      assert EditorState.hover_popup(new_state).focused == true
     end
 
     test "any other key dismisses hover and passes through" do
       state = state_with_hover()
       assert {:passthrough, new_state} = Hover.handle_key(state, @key_h, @none)
-      assert new_state.shell_state.hover_popup == nil
+      assert EditorState.hover_popup(new_state) == nil
     end
   end
 
@@ -53,7 +54,7 @@ defmodule MingaEditor.Input.HoverTest do
     test "j scrolls down" do
       state = state_with_hover(focused: true)
       assert {:handled, new_state} = Hover.handle_key(state, @key_j, @none)
-      assert new_state.shell_state.hover_popup.scroll_offset > 0
+      assert EditorState.hover_popup(new_state).scroll_offset > 0
     end
 
     test "k scrolls up" do
@@ -62,29 +63,29 @@ defmodule MingaEditor.Input.HoverTest do
       state =
         MingaEditor.State.set_hover_popup(
           state,
-          HoverPopup.scroll_down(state.shell_state.hover_popup)
+          HoverPopup.scroll_down(EditorState.hover_popup(state))
         )
 
       assert {:handled, new_state} = Hover.handle_key(state, @key_k, @none)
-      assert new_state.shell_state.hover_popup.scroll_offset == 0
+      assert EditorState.hover_popup(new_state).scroll_offset == 0
     end
 
     test "q dismisses" do
       state = state_with_hover(focused: true)
       assert {:handled, new_state} = Hover.handle_key(state, @key_q, @none)
-      assert new_state.shell_state.hover_popup == nil
+      assert EditorState.hover_popup(new_state) == nil
     end
 
     test "Escape dismisses" do
       state = state_with_hover(focused: true)
       assert {:handled, new_state} = Hover.handle_key(state, @key_escape, @none)
-      assert new_state.shell_state.hover_popup == nil
+      assert EditorState.hover_popup(new_state) == nil
     end
 
     test "other keys dismiss and pass through" do
       state = state_with_hover(focused: true)
       assert {:passthrough, new_state} = Hover.handle_key(state, @key_h, @none)
-      assert new_state.shell_state.hover_popup == nil
+      assert EditorState.hover_popup(new_state) == nil
     end
   end
 
@@ -95,7 +96,7 @@ defmodule MingaEditor.Input.HoverTest do
       # rect, so this handler keeps the popup for any motion that reaches it; the
       # coordinate-gated routing is tested in MingaEditor.MouseTest.
       assert {:handled, new_state} = Hover.handle_mouse(state, 0, 0, :none, @none, :motion, 1)
-      assert %HoverPopup{} = new_state.shell_state.hover_popup
+      assert %HoverPopup{} = EditorState.hover_popup(new_state)
     end
 
     test "wheel scrolls the popup even when not focused" do
@@ -104,13 +105,13 @@ defmodule MingaEditor.Input.HoverTest do
       assert {:handled, new_state} =
                Hover.handle_mouse(state, 0, 0, :wheel_down, @none, :press, 1)
 
-      assert new_state.shell_state.hover_popup.scroll_offset > 0
+      assert EditorState.hover_popup(new_state).scroll_offset > 0
     end
 
     test "clicking inside the popup focuses it instead of dismissing" do
       state = state_with_hover()
       assert {:handled, new_state} = Hover.handle_mouse(state, 0, 0, :left, @none, :press, 1)
-      assert %HoverPopup{focused: true} = new_state.shell_state.hover_popup
+      assert %HoverPopup{focused: true} = EditorState.hover_popup(new_state)
     end
   end
 
@@ -129,7 +130,7 @@ defmodule MingaEditor.Input.HoverTest do
     test "o toggles an expandable popup without dismissing it" do
       state = state_with_expandable_hover()
       assert {:handled, new_state} = Hover.handle_key(state, @key_o, @none)
-      popup = new_state.shell_state.hover_popup
+      popup = EditorState.hover_popup(new_state)
       assert popup != nil
       assert popup.expanded?
     end
@@ -137,7 +138,7 @@ defmodule MingaEditor.Input.HoverTest do
     test "o dismisses a non-expandable popup (no special behavior)" do
       state = state_with_hover(focused: true)
       assert {:passthrough, new_state} = Hover.handle_key(state, @key_o, @none)
-      assert new_state.shell_state.hover_popup == nil
+      assert EditorState.hover_popup(new_state) == nil
     end
   end
 end

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -102,12 +102,12 @@ defmodule MingaEditor.Input.InterruptTest do
     assert state.workspace.keymap_scope == :editor
     assert state.workspace.editing.mode == :normal
     assert state.workspace.editing.mode_state == Mode.initial_state()
-    assert state.shell_state.modal == :none
-    assert state.shell_state.whichkey.node == nil
-    assert state.shell_state.whichkey.show == false
+    assert EditorState.modal(state) == :none
+    assert EditorState.whichkey(state).node == nil
+    assert EditorState.whichkey(state).show == false
     assert AgentAccess.view(state).pending_prefix == nil
-    assert state.shell_state.status_msg == nil
-    assert state.shell_state.hover_popup == hover
+    assert EditorState.status_msg(state) == nil
+    assert EditorState.hover_popup(state) == hover
   end
 
   describe "Ctrl-G basics" do
@@ -131,8 +131,8 @@ defmodule MingaEditor.Input.InterruptTest do
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
       assert new_state.workspace.keymap_scope == :editor
       assert new_state.workspace.editing.mode == :normal
-      assert new_state.shell_state.modal == :none
-      assert new_state.shell_state.whichkey.node == nil
+      assert EditorState.modal(new_state) == :none
+      assert EditorState.whichkey(new_state).node == nil
     end
   end
 
@@ -252,7 +252,7 @@ defmodule MingaEditor.Input.InterruptTest do
         ModalOverlay.open(state, :picker, PickerPayload.new(%Picker{picker: picker, source: nil}))
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      assert new_state.shell_state.modal == :none
+      assert EditorState.modal(new_state) == :none
     end
 
     test "dismisses which-key popup" do
@@ -260,8 +260,8 @@ defmodule MingaEditor.Input.InterruptTest do
       state = MingaEditor.State.set_whichkey(state, %WhichKey{node: %{}, show: true})
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      assert new_state.shell_state.whichkey.node == nil
-      assert new_state.shell_state.whichkey.show == false
+      assert EditorState.whichkey(new_state).node == nil
+      assert EditorState.whichkey(new_state).show == false
     end
 
     test "dismisses conflict prompt" do
@@ -270,7 +270,7 @@ defmodule MingaEditor.Input.InterruptTest do
       state = ModalOverlay.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      refute ModalOverlay.match(new_state.shell_state.modal, :conflict)
+      refute ModalOverlay.match(EditorState.modal(new_state), :conflict)
     end
 
     test "closes completion menu" do
@@ -284,14 +284,14 @@ defmodule MingaEditor.Input.InterruptTest do
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
       assert MingaEditor.State.ModalOverlay.completion(new_state) == nil
-      refute ModalOverlay.match(new_state.shell_state.modal, :completion)
+      refute ModalOverlay.match(EditorState.modal(new_state), :completion)
     end
 
     test "clears status message" do
       state = MingaEditor.State.set_status(base_state(), "some message")
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
-      assert new_state.shell_state.status_msg == nil
+      assert EditorState.status_msg(new_state) == nil
     end
   end
 

--- a/test/minga_editor/input/observatory_test.exs
+++ b/test/minga_editor/input/observatory_test.exs
@@ -4,7 +4,11 @@ defmodule MingaEditor.Input.ObservatoryTest do
   alias Minga.SystemObserver.ProcessSnapshot
   alias Minga.SystemObserver.TreeNode
   alias MingaEditor.Input.Observatory
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Viewport
 
   describe "inspect_process/2" do
     test "formats GenServer state for a selected process" do
@@ -15,7 +19,7 @@ defmodule MingaEditor.Input.ObservatoryTest do
       state = Observatory.inspect_process(state, pid_string)
 
       assert %{visible: true, title: title, lines: lines} =
-               state.shell_state.observatory_inspection
+               state.shell_runtime.state.observatory_inspection
 
       assert title == "Process #{pid_string}"
       assert "Class: agent session" in lines
@@ -26,14 +30,14 @@ defmodule MingaEditor.Input.ObservatoryTest do
       state = Observatory.inspect_process(base_state(), "not-a-pid")
 
       assert %{visible: true, title: "Process not-a-pid", lines: ["Invalid BEAM PID"]} =
-               state.shell_state.observatory_inspection
+               state.shell_runtime.state.observatory_inspection
     end
 
     test "empty PID dismisses the inspection popup" do
       state = Observatory.inspect_process(base_state(), "not-a-pid")
       state = Observatory.inspect_process(state, "")
 
-      assert state.shell_state.observatory_inspection == nil
+      assert state.shell_runtime.state.observatory_inspection == nil
     end
 
     test "falls back to process info when GenServer state is unavailable" do
@@ -43,19 +47,23 @@ defmodule MingaEditor.Input.ObservatoryTest do
 
       state = Observatory.inspect_process(base_state(), :erlang.pid_to_list(pid) |> to_string())
 
-      assert %{visible: true, lines: lines} = state.shell_state.observatory_inspection
+      assert %{visible: true, lines: lines} = state.shell_runtime.state.observatory_inspection
       assert Enum.any?(lines, &String.starts_with?(&1, "GenServer state unavailable:"))
       assert "Process info:" in lines
     end
   end
 
   defp base_state do
-    %{shell_state: %ShellState{}}
+    %EditorState{
+      port_manager: self(),
+      workspace: %SessionState{viewport: Viewport.new(24, 80)},
+      shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{})
+    }
   end
 
   defp state_with_tree(pid, process_class) do
     tree = %TreeNode{pid: pid, snapshot: snapshot(process_class), children: [], depth: 0}
-    %{shell_state: %ShellState{observatory_data: %{tree: tree}}}
+    EditorState.set_observatory_data(base_state(), %{tree: tree})
   end
 
   defp snapshot(process_class) do

--- a/test/minga_editor/input/picker_mouse_test.exs
+++ b/test/minga_editor/input/picker_mouse_test.exs
@@ -2,6 +2,8 @@ defmodule MingaEditor.Input.PickerMouseTest do
   @moduledoc "Tests for mouse interaction with the picker overlay."
   use ExUnit.Case, async: true
 
+  alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
@@ -38,11 +40,15 @@ defmodule MingaEditor.Input.PickerMouseTest do
         editing: VimState.new(),
         viewport: vp
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{
-        modal:
-          {:picker,
-           PickerPayload.new(%MingaEditor.State.Picker{picker: picker, source: TestSource})}
-      }
+      shell_runtime:
+        Runtime.new(
+          Registry.get(:traditional),
+          %MingaEditor.Shell.Traditional.State{
+            modal:
+              {:picker,
+               PickerPayload.new(%MingaEditor.State.Picker{picker: picker, source: TestSource})}
+          }
+        )
     }
   end
 
@@ -50,7 +56,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
     test "wheel_down moves picker selection down" do
       state = picker_state([%Item{id: 1, label: "one"}, %Item{id: 2, label: "two"}])
       {:handled, new_state} = PickerInput.handle_mouse(state, 10, 10, :wheel_down, 0, :press, 1)
-      {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_state.modal
+      {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_runtime.state.modal
       assert pui.selected == 1
     end
 
@@ -59,7 +65,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       # Move down first, then up
       {:handled, state} = PickerInput.handle_mouse(state, 10, 10, :wheel_down, 0, :press, 1)
       {:handled, new_state} = PickerInput.handle_mouse(state, 10, 10, :wheel_up, 0, :press, 1)
-      {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_state.modal
+      {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_runtime.state.modal
       assert pui.selected == 0
     end
   end
@@ -79,7 +85,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       {:handled, new_state} = PickerInput.handle_mouse(state, 26, 10, :left, 0, :press, 1)
 
       # Picker should be closed
-      assert new_state.shell_state.modal == :none
+      assert new_state.shell_runtime.state.modal == :none
       # Source's on_select should have been called
       assert new_state.selected_item.id == 1
     end
@@ -89,7 +95,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
 
       {:handled, new_state} = PickerInput.handle_mouse(state, 28, 10, :left, 0, :press, 1)
 
-      assert new_state.shell_state.modal == :none
+      assert new_state.shell_runtime.state.modal == :none
       assert new_state.selected_item.id == 1
     end
 
@@ -100,7 +106,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       # 30 rows leave 27 item rows, plus separator and prompt. The last rendered item is item 27.
       {:handled, new_state} = PickerInput.handle_mouse(state, 28, 10, :left, 0, :press, 1)
 
-      assert new_state.shell_state.modal == :none
+      assert new_state.shell_runtime.state.modal == :none
       assert new_state.selected_item.id == 27
     end
 
@@ -110,7 +116,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
 
       {:handled, new_state} = PickerInput.handle_mouse(state, 1, 10, :left, 0, :press, 1)
 
-      assert ModalOverlay.match(new_state.shell_state.modal, :picker)
+      assert ModalOverlay.match(new_state.shell_runtime.state.modal, :picker)
       refute Map.has_key?(new_state, :selected_item)
     end
 
@@ -121,7 +127,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       # Click on row 0 (well above the picker)
       {:handled, new_state} = PickerInput.handle_mouse(state, 0, 10, :left, 0, :press, 1)
       # Picker should still be open
-      assert ModalOverlay.match(new_state.shell_state.modal, :picker)
+      assert ModalOverlay.match(new_state.shell_runtime.state.modal, :picker)
     end
   end
 
@@ -136,15 +142,19 @@ defmodule MingaEditor.Input.PickerMouseTest do
           editing: VimState.new(),
           viewport: Viewport.new(24, 80)
         },
-        shell_state: %MingaEditor.Shell.Traditional.State{
-          modal:
-            {:picker,
-             PickerPayload.new(%MingaEditor.State.Picker{
-               picker: picker,
-               source: TestSource,
-               layout: :centered
-             })}
-        }
+        shell_runtime:
+          Runtime.new(
+            Registry.get(:traditional),
+            %MingaEditor.Shell.Traditional.State{
+              modal:
+                {:picker,
+                 PickerPayload.new(%MingaEditor.State.Picker{
+                   picker: picker,
+                   source: TestSource,
+                   layout: :centered
+                 })}
+            }
+          )
       }
     end
 
@@ -157,7 +167,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       # First item is at interior row 0 = screen row 10.
       {:handled, new_state} = PickerInput.handle_mouse(state, 10, 20, :left, 0, :press, 1)
 
-      assert new_state.shell_state.modal == :none
+      assert new_state.shell_runtime.state.modal == :none
       assert Map.has_key?(new_state, :selected_item)
     end
 
@@ -173,7 +183,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       # The prompt row is still inside the hit-test rect; it must not map to a hidden item.
       {:handled, new_state} = PickerInput.handle_mouse(state, prompt_row, 20, :left, 0, :press, 1)
 
-      assert ModalOverlay.match(new_state.shell_state.modal, :picker)
+      assert ModalOverlay.match(new_state.shell_runtime.state.modal, :picker)
       refute Map.has_key?(new_state, :selected_item)
     end
 
@@ -198,7 +208,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       {:handled, new_state} =
         PickerInput.handle_mouse(state, last_item_row, 20, :left, 0, :press, 1)
 
-      assert new_state.shell_state.modal == :none
+      assert new_state.shell_runtime.state.modal == :none
       assert new_state.selected_item.id == 20
     end
 
@@ -211,7 +221,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       {:handled, new_state} = PickerInput.handle_mouse(state, 5, 20, :left, 0, :press, 1)
 
       # Picker should be closed (dismissed), no item selected
-      assert new_state.shell_state.modal == :none
+      assert new_state.shell_runtime.state.modal == :none
       refute Map.has_key?(new_state, :selected_item)
     end
 
@@ -222,7 +232,7 @@ defmodule MingaEditor.Input.PickerMouseTest do
       {:handled, new_state} =
         PickerInput.handle_mouse(state, 10, 20, :wheel_down, 0, :press, 1)
 
-      {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_state.modal
+      {:picker, %{picker_ui: %{picker: pui}}} = new_state.shell_runtime.state.modal
       assert pui.selected == 1
     end
   end

--- a/test/minga_editor/input/prompt_test.exs
+++ b/test/minga_editor/input/prompt_test.exs
@@ -37,7 +37,7 @@ defmodule MingaEditor.Input.PromptTest do
       state = PromptUI.open(base_state(), TestHandler)
       assert {:handled, new_state} = InputPrompt.handle_key(state, ?a, 0)
 
-      {:prompt, %{prompt_ui: pui}} = new_state.shell_state.modal
+      {:prompt, %{prompt_ui: pui}} = EditorState.modal(new_state)
       assert pui.text == "a"
     end
 

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -203,7 +203,7 @@ defmodule MingaEditor.Input.RouterTest do
 
       new_state = Router.dispatch(state, ?q, 0)
 
-      refute new_state.shell_state.bottom_panel.visible
+      refute EditorState.bottom_panel(new_state).visible
     end
 
     test "focused bottom panel handles CUA Escape" do
@@ -214,7 +214,7 @@ defmodule MingaEditor.Input.RouterTest do
 
       new_state = Router.dispatch(state, 27, 0)
 
-      refute new_state.shell_state.bottom_panel.visible
+      refute EditorState.bottom_panel(new_state).visible
     end
 
     test "focused bottom panel consumes CUA q without closing or editing the buffer" do
@@ -226,7 +226,7 @@ defmodule MingaEditor.Input.RouterTest do
       before_content = BufferProcess.content(state.workspace.buffers.active)
       new_state = Router.dispatch(state, ?q, 0)
 
-      assert new_state.shell_state.bottom_panel.visible
+      assert EditorState.bottom_panel(new_state).visible
       assert BufferProcess.content(new_state.workspace.buffers.active) == before_content
     end
   end
@@ -339,7 +339,7 @@ defmodule MingaEditor.Input.RouterTest do
 
       new_state = Router.dispatch_mouse(state, 8, 10, :left, 0, :press, 1)
 
-      assert BottomPanel.focused?(new_state.shell_state.bottom_panel)
+      assert BottomPanel.focused?(EditorState.bottom_panel(new_state))
       refute_receive {:mouse_probe, :buffer_content, :editor}, 20
     end
 

--- a/test/minga_editor/input/scoped_editor_agent_test.exs
+++ b/test/minga_editor/input/scoped_editor_agent_test.exs
@@ -129,11 +129,11 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
 
       {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
       assert new_state.workspace.keymap_scope == :editor
-      assert new_state.shell_state.tab_bar.active_id == 1
-      assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :agent) != []
+      assert EditorState.tab_bar(new_state).active_id == 1
+      assert TabBar.filter_by_kind(EditorState.tab_bar(new_state), :agent) != []
 
       assert Enum.any?(
-               new_state.shell_state.tab_bar.tabs,
+               EditorState.tab_bar(new_state).tabs,
                &(&1.kind == :agent and &1.session == session)
              )
     end
@@ -144,35 +144,35 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
 
       {:handled, new_state} = Scoped.handle_key(state, 27, 0)
       assert new_state.workspace.keymap_scope == :editor
-      assert new_state.shell_state.tab_bar.active_id == 1
-      assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :agent) != []
+      assert EditorState.tab_bar(new_state).active_id == 1
+      assert TabBar.filter_by_kind(EditorState.tab_bar(new_state), :agent) != []
     end
 
     test "return falls back to the most recent remaining file tab when the target closed", %{
       state: state
     } do
-      {tb, fallback_tab} = TabBar.insert(state.shell_state.tab_bar, :file, "fallback.ex")
+      {tb, fallback_tab} = TabBar.insert(EditorState.tab_bar(state), :file, "fallback.ex")
       {:ok, tb} = TabBar.remove(tb, 1)
-      state = put_in(state.shell_state.tab_bar, tb)
+      state = EditorState.set_tab_bar(state, tb)
 
       {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
       assert new_state.workspace.keymap_scope == :editor
-      assert new_state.shell_state.tab_bar.active_id == fallback_tab.id
+      assert EditorState.tab_bar(new_state).active_id == fallback_tab.id
     end
 
     test "return without file tabs does not create an untitled fallback", %{
       state: state,
       file_buffer: file_buffer
     } do
-      {:ok, tb} = TabBar.remove(state.shell_state.tab_bar, 1)
-      state = put_in(state.shell_state.tab_bar, tb)
+      {:ok, tb} = TabBar.remove(EditorState.tab_bar(state), 1)
+      state = EditorState.set_tab_bar(state, tb)
 
       {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
       assert new_state.workspace.keymap_scope == :editor
-      assert TabBar.filter_by_kind(new_state.shell_state.tab_bar, :file) == []
+      assert TabBar.filter_by_kind(EditorState.tab_bar(new_state), :file) == []
       assert new_state.workspace.buffers.active == file_buffer
       assert hd(new_state.workspace.buffers.list) == file_buffer
-      assert new_state.shell_state.status_msg == "No file tabs in this workspace"
+      assert EditorState.status_msg(new_state) == "No file tabs in this workspace"
     end
 
     test "? toggles help", %{state: state} do
@@ -228,12 +228,12 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
       {:handled, new_state} = Scoped.handle_key(state, 27, 0)
       refute AgentAccess.view(new_state).help_visible
       assert new_state.workspace.keymap_scope == :agent
-      assert new_state.shell_state.tab_bar.active_id == state.shell_state.tab_bar.active_id
+      assert EditorState.tab_bar(new_state).active_id == EditorState.tab_bar(state).active_id
     end
 
     test "ESC leaves prompt focus without clearing prompt text before returning", %{state: state} do
       state = focus_prompt(state, "keep this")
-      agent_tab_id = TabBar.find_by_kind(state.shell_state.tab_bar, :agent).id
+      agent_tab_id = TabBar.find_by_kind(EditorState.tab_bar(state), :agent).id
 
       {:handled, unfocused_state} = Scoped.handle_key(state, 27, 0)
       refute AgentAccess.input_focused?(unfocused_state)
@@ -242,7 +242,7 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
 
       {:handled, returned_state} = Scoped.handle_key(unfocused_state, 27, 0)
       assert returned_state.workspace.keymap_scope == :editor
-      assert returned_state.shell_state.tab_bar.active_id == 1
+      assert EditorState.tab_bar(returned_state).active_id == 1
 
       reopened_state = EditorState.switch_tab(returned_state, agent_tab_id)
       assert UIState.prompt_text(AgentAccess.agent_ui(reopened_state)) == "keep this"

--- a/test/minga_editor/input/signature_help_test.exs
+++ b/test/minga_editor/input/signature_help_test.exs
@@ -21,7 +21,7 @@ defmodule MingaEditor.Input.SignatureHelpTest do
   defp state_with_sig_help do
     state = base_state()
     sh = SigHelp.from_response(@sample_response, 10, 20)
-    MingaEditor.State.update_shell_state(state, &%{&1 | signature_help: sh})
+    MingaEditor.State.set_signature_help(state, sh)
   end
 
   describe "handle_key/3 with no signature help" do
@@ -35,7 +35,7 @@ defmodule MingaEditor.Input.SignatureHelpTest do
     test "C-j cycles to next signature" do
       state = state_with_sig_help()
       assert {:handled, new_state} = SigHelpInput.handle_key(state, ?j, @ctrl)
-      assert new_state.shell_state.signature_help.active_signature == 1
+      assert new_state.shell_runtime.state.signature_help.active_signature == 1
     end
 
     test "C-k cycles to previous signature" do
@@ -43,19 +43,19 @@ defmodule MingaEditor.Input.SignatureHelpTest do
       # Go to signature 1 first
       {:handled, state} = SigHelpInput.handle_key(state, ?j, @ctrl)
       assert {:handled, new_state} = SigHelpInput.handle_key(state, ?k, @ctrl)
-      assert new_state.shell_state.signature_help.active_signature == 0
+      assert new_state.shell_runtime.state.signature_help.active_signature == 0
     end
 
     test "Escape dismisses" do
       state = state_with_sig_help()
       assert {:handled, new_state} = SigHelpInput.handle_key(state, @escape, 0)
-      assert new_state.shell_state.signature_help == nil
+      assert new_state.shell_runtime.state.signature_help == nil
     end
 
     test "regular keys pass through (signature stays visible)" do
       state = state_with_sig_help()
       assert {:passthrough, new_state} = SigHelpInput.handle_key(state, ?a, 0)
-      assert new_state.shell_state.signature_help != nil
+      assert new_state.shell_runtime.state.signature_help != nil
     end
   end
 end

--- a/test/minga_editor/input/sub_state_handlers_test.exs
+++ b/test/minga_editor/input/sub_state_handlers_test.exs
@@ -17,6 +17,7 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
   alias MingaEditor.Agent.View.Preview
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Editing.Scroll
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -71,7 +72,11 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
         agent_ui: agentic
       },
       focus_stack: [],
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tab_bar}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tab_bar}
+        )
     }
   end
 

--- a/test/minga_editor/layout/footer_band_overlays_test.exs
+++ b/test/minga_editor/layout/footer_band_overlays_test.exs
@@ -29,6 +29,7 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
   alias MingaEditor.Layout
   alias MingaEditor.Layout.OverlayBand
   alias MingaEditor.Layout.SurfaceRegistry
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.UI.Notification
@@ -47,21 +48,14 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
     %{state | notifications: center}
   end
 
-  defp with_observatory(state) do
-    put_in(state.shell_state.observatory_visible, true)
-  end
+  defp with_observatory(state), do: EditorState.open_observatory(state, nil)
 
   defp with_agent_context(state) do
     approval = %{tool_call_id: "tc1", name: "shell", args: %{}}
 
     state =
-      %{
-        state
-        | shell_state: %{
-            state.shell_state
-            | agent: AgentState.set_pending_approval(state.shell_state.agent, approval)
-          }
-      }
+      state
+      |> AgentAccess.update_agent(&AgentState.set_pending_approval(&1, approval))
       |> AgentAccess.update_agent_ui(fn ui ->
         UIState.update_activity(ui, fn _ -> Activity.new() end)
       end)
@@ -83,9 +77,9 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
 
     tree = %TreeNode{pid: spawn(fn -> :ok end), snapshot: snapshot, children: children, depth: 0}
 
-    state = with_observatory(state)
-    shell_state = %{state.shell_state | observatory_data: %{tree: tree}}
-    %{state | shell_state: shell_state}
+    state
+    |> with_observatory()
+    |> EditorState.set_observatory_data(%{tree: tree})
   end
 
   # Records `count` agent edits for the active buffer's path and wires the
@@ -192,6 +186,15 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
 
       assert height == 4
       assert row + height == 24
+
+      transfer_state =
+        state
+        |> Map.from_struct()
+        |> Map.delete(:shell_runtime)
+        |> Map.put(:shell, state.shell_runtime.entry.module)
+        |> Map.put(:shell_state, state.shell_runtime.state)
+
+      assert SurfaceRegistry.rect_for(transfer_state, :observatory) == {row, 0, 80, height}
     end
 
     test "the edit timeline band height is one header plus one row per entry" do

--- a/test/minga_editor/layout/surface_registry_test.exs
+++ b/test/minga_editor/layout/surface_registry_test.exs
@@ -17,6 +17,7 @@ defmodule MingaEditor.Layout.SurfaceRegistryTest do
   alias MingaEditor.Layout.SurfaceRegistry
   alias MingaEditor.Layout.SurfaceRegistry.Placement
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
@@ -231,7 +232,11 @@ defmodule MingaEditor.Layout.SurfaceRegistryTest do
         port_manager: self(),
         workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()},
         layout: single_window_layout(),
-        shell_state: %ShellState{bottom_panel: %BottomPanel{visible: true, height_percent: 25}}
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %ShellState{bottom_panel: %BottomPanel{visible: true, height_percent: 25}}
+          )
       }
 
       placements = SurfaceRegistry.placements(state)

--- a/test/minga_editor/layout_test.exs
+++ b/test/minga_editor/layout_test.exs
@@ -88,9 +88,10 @@ defmodule MingaEditor.LayoutTest do
     tb = TabBar.update_context(tb, agent_tab.id, agent_ctx)
     tb = TabBar.switch_to(tb, file_tab.id)
 
-    state = put_in(state.workspace.agent_ui, agentic)
-    ss = state.shell_state
-    %{state | shell_state: %{ss | tab_bar: tb, agent: agent}}
+    state
+    |> EditorState.set_agent_ui(agentic)
+    |> EditorState.set_tab_bar(tb)
+    |> EditorState.set_agent(agent)
   end
 
   defp with_vsplit(state) do

--- a/test/minga_editor/lsp_actions/code_action_test.exs
+++ b/test/minga_editor/lsp_actions/code_action_test.exs
@@ -17,17 +17,17 @@ defmodule MingaEditor.LspActions.CodeActionTest do
   describe "handle_code_action_response/2" do
     test "error sets status message" do
       state = LspActions.handle_code_action_response(stub_state(), {:error, "timeout"})
-      assert state.shell_state.status_msg == "Code action request failed"
+      assert EditorState.status_msg(state) == "Code action request failed"
     end
 
     test "nil result sets status message" do
       state = LspActions.handle_code_action_response(stub_state(), {:ok, nil})
-      assert state.shell_state.status_msg == "No code actions available"
+      assert EditorState.status_msg(state) == "No code actions available"
     end
 
     test "empty list sets status message" do
       state = LspActions.handle_code_action_response(stub_state(), {:ok, []})
-      assert state.shell_state.status_msg == "No code actions available"
+      assert EditorState.status_msg(state) == "No code actions available"
     end
 
     test "actions with non-empty list opens picker" do
@@ -41,7 +41,7 @@ defmodule MingaEditor.LspActions.CodeActionTest do
       result = LspActions.handle_code_action_response(stub_state(), {:ok, actions})
 
       # When PickerUI.open succeeds, the picker is active in the modal.
-      {:picker, %{picker_ui: picker_ui}} = result.shell_state.modal
+      {:picker, %{picker_ui: picker_ui}} = EditorState.modal(result)
       assert picker_ui.source == MingaEditor.UI.Picker.CodeActionSource
     end
   end

--- a/test/minga_editor/lsp_actions/navigation_test.exs
+++ b/test/minga_editor/lsp_actions/navigation_test.exs
@@ -23,34 +23,34 @@ defmodule MingaEditor.LspActions.NavigationTest do
   describe "handle_type_definition_response/2" do
     test "error sets status message" do
       state = LspActions.handle_type_definition_response(stub_state(), {:error, "timeout"})
-      assert state.shell_state.status_msg == "Type definition request failed"
+      assert EditorState.status_msg(state) == "Type definition request failed"
     end
 
     test "nil result sets status message" do
       state = LspActions.handle_type_definition_response(stub_state(), {:ok, nil})
-      assert state.shell_state.status_msg == "No type definition found"
+      assert EditorState.status_msg(state) == "No type definition found"
     end
 
     test "empty list sets status message" do
       state = LspActions.handle_type_definition_response(stub_state(), {:ok, []})
-      assert state.shell_state.status_msg == "No type definition found"
+      assert EditorState.status_msg(state) == "No type definition found"
     end
   end
 
   describe "handle_implementation_response/2" do
     test "error sets status message" do
       state = LspActions.handle_implementation_response(stub_state(), {:error, "timeout"})
-      assert state.shell_state.status_msg == "Implementation request failed"
+      assert EditorState.status_msg(state) == "Implementation request failed"
     end
 
     test "nil result sets status message" do
       state = LspActions.handle_implementation_response(stub_state(), {:ok, nil})
-      assert state.shell_state.status_msg == "No implementation found"
+      assert EditorState.status_msg(state) == "No implementation found"
     end
 
     test "empty list sets status message" do
       state = LspActions.handle_implementation_response(stub_state(), {:ok, []})
-      assert state.shell_state.status_msg == "No implementation found"
+      assert EditorState.status_msg(state) == "No implementation found"
     end
   end
 end

--- a/test/minga_editor/lsp_actions/references_test.exs
+++ b/test/minga_editor/lsp_actions/references_test.exs
@@ -22,17 +22,17 @@ defmodule MingaEditor.LspActions.ReferencesTest do
   describe "handle_references_response/2" do
     test "error result sets status message" do
       state = LspActions.handle_references_response(stub_state(), {:error, "timeout"})
-      assert state.shell_state.status_msg == "References request failed"
+      assert EditorState.status_msg(state) == "References request failed"
     end
 
     test "nil result sets status message" do
       state = LspActions.handle_references_response(stub_state(), {:ok, nil})
-      assert state.shell_state.status_msg == "No references found"
+      assert EditorState.status_msg(state) == "No references found"
     end
 
     test "empty list sets status message" do
       state = LspActions.handle_references_response(stub_state(), {:ok, []})
-      assert state.shell_state.status_msg == "No references found"
+      assert EditorState.status_msg(state) == "No references found"
     end
   end
 end

--- a/test/minga_editor/lsp_actions/rename_test.exs
+++ b/test/minga_editor/lsp_actions/rename_test.exs
@@ -18,12 +18,12 @@ defmodule MingaEditor.LspActions.RenameTest do
   describe "handle_prepare_rename_response/2" do
     test "error sets status message" do
       state = LspActions.handle_prepare_rename_response(stub_state(), {:error, "invalid"})
-      assert state.shell_state.status_msg == "Cannot rename at this position"
+      assert EditorState.status_msg(state) == "Cannot rename at this position"
     end
 
     test "nil result sets status message" do
       state = LspActions.handle_prepare_rename_response(stub_state(), {:ok, nil})
-      assert state.shell_state.status_msg == "Cannot rename at this position"
+      assert EditorState.status_msg(state) == "Cannot rename at this position"
     end
 
     test "successful prepare enters command mode with rename prompt" do
@@ -55,17 +55,17 @@ defmodule MingaEditor.LspActions.RenameTest do
   describe "handle_rename_response/2" do
     test "error sets status message" do
       state = LspActions.handle_rename_response(stub_state(), {:error, "failed"})
-      assert state.shell_state.status_msg == "Rename failed"
+      assert EditorState.status_msg(state) == "Rename failed"
     end
 
     test "nil result sets status message" do
       state = LspActions.handle_rename_response(stub_state(), {:ok, nil})
-      assert state.shell_state.status_msg == "Rename returned no edits"
+      assert EditorState.status_msg(state) == "Rename returned no edits"
     end
 
     test "empty workspace edit sets status message" do
       state = LspActions.handle_rename_response(stub_state(), {:ok, %{}})
-      assert state.shell_state.status_msg =~ "no edits to apply"
+      assert EditorState.status_msg(state) =~ "no edits to apply"
     end
   end
 

--- a/test/minga_editor/lsp_actions_test.exs
+++ b/test/minga_editor/lsp_actions_test.exs
@@ -79,7 +79,7 @@ defmodule MingaEditor.LspActionsTest do
 
       for {response, expected_status} <- cases do
         result = LspActions.handle_definition_response(fake_state(), response)
-        assert result.shell_state.status_msg == expected_status
+        assert EditorState.status_msg(result) == expected_status
       end
     end
 
@@ -99,7 +99,7 @@ defmodule MingaEditor.LspActionsTest do
         )
 
       assert %HoverPopup{focused: true, open_action: {:goto_location, ^uri, 1, 6}} =
-               result.shell_state.hover_popup
+               EditorState.hover_popup(result)
     end
 
     test "hover response reports empty results or creates an unfocused popup" do
@@ -110,8 +110,9 @@ defmodule MingaEditor.LspActionsTest do
       ]
 
       for {response, expected_status} <- empty_cases do
-        assert LspActions.handle_hover_response(fake_state(), response).shell_state.status_msg ==
-                 expected_status
+        assert fake_state()
+               |> LspActions.handle_hover_response(response)
+               |> EditorState.status_msg() == expected_status
       end
 
       for hover <- [
@@ -124,8 +125,8 @@ defmodule MingaEditor.LspActionsTest do
             }
           ] do
         result = LspActions.handle_hover_response(fake_state(), {:ok, hover})
-        assert %HoverPopup{focused: false} = result.shell_state.hover_popup
-        assert result.shell_state.hover_popup.content_lines != []
+        assert %HoverPopup{focused: false} = EditorState.hover_popup(result)
+        assert EditorState.hover_popup(result).content_lines != []
       end
     end
 
@@ -145,8 +146,8 @@ defmodule MingaEditor.LspActionsTest do
             20
           )
 
-        assert %HoverPopup{} = result.shell_state.hover_popup
-        assert result.shell_state.hover_popup.content_lines != []
+        assert %HoverPopup{} = EditorState.hover_popup(result)
+        assert EditorState.hover_popup(result).content_lines != []
       end
 
       for response <- [
@@ -169,10 +170,11 @@ defmodule MingaEditor.LspActionsTest do
 
   describe "code lens responses" do
     test "code_lens reports missing buffers and no-ops when no client is registered" do
-      assert LspActions.code_lens(fake_state()).shell_state.status_msg == "No active buffer"
+      assert fake_state() |> LspActions.code_lens() |> EditorState.status_msg() ==
+               "No active buffer"
 
       state = fake_state_with_buffer(start_buffer!("hello"))
-      assert LspActions.code_lens(state).shell_state.status_msg == nil
+      assert state |> LspActions.code_lens() |> EditorState.status_msg() == nil
     end
 
     test "stores resolved lenses with commands directly" do
@@ -318,7 +320,7 @@ defmodule MingaEditor.LspActionsTest do
     test "reports cannot-rename for failed responses" do
       for response <- [{:error, "not renameable"}, {:ok, nil}] do
         result = LspActions.handle_prepare_rename_response(fake_state_with_vim(), response)
-        assert result.shell_state.status_msg == "Cannot rename at this position"
+        assert EditorState.status_msg(result) == "Cannot rename at this position"
       end
     end
   end

--- a/test/minga_editor/merge_conflict/render_test.exs
+++ b/test/minga_editor/merge_conflict/render_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.MergeConflict.RenderTest do
   alias MingaEditor.Mouse
   alias MingaEditor.Mouse.HitTest
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -106,7 +107,7 @@ defmodule MingaEditor.MergeConflict.RenderTest do
     state = Mouse.handle(state, row, col + gutter_width + 1, :left, 0, :press, 1)
 
     assert BufferProcess.content(buffer) == before_content
-    assert state.shell_state.status_msg == nil
+    assert EditorState.status_msg(state) == nil
   end
 
   test "mouse click on action block separators is a no-op", %{
@@ -135,7 +136,7 @@ defmodule MingaEditor.MergeConflict.RenderTest do
 
     assert BufferProcess.content(buffer) == before_content
     assert BufferProcess.cursor(buffer) == before_cursor
-    assert state.shell_state.status_msg == nil
+    assert EditorState.status_msg(state) == nil
   end
 
   defp start_conflict_buffer(events_registry, options_server) do
@@ -168,7 +169,7 @@ defmodule MingaEditor.MergeConflict.RenderTest do
           next_id: 2
         }
       },
-      shell_state: %ShellState{}
+      shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{})
     }
   end
 

--- a/test/minga_editor/minibuffer_data_test.exs
+++ b/test/minga_editor/minibuffer_data_test.exs
@@ -12,6 +12,7 @@ defmodule MingaEditor.MinibufferDataTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.MinibufferData
+  alias MingaEditor.State.ModalOverlay.CommandCompletion
   alias MingaEditor.State.Prompt, as: PromptState
 
   describe "clamp_index/2" do
@@ -108,6 +109,29 @@ defmodule MingaEditor.MinibufferDataTest do
 
       # candidate_index 1 should be clamped and set as selected_index
       assert result.selected_index == 1
+    end
+
+    test "reuses command candidates from flattened render-pipeline shell state" do
+      candidate = %{
+        label: "write",
+        description: "cached",
+        match_score: 1,
+        match_positions: [0],
+        annotation: ""
+      }
+
+      state = %{
+        shell_state: %{
+          modal:
+            {:command_completion,
+             CommandCompletion.new(filter_text: "wri", candidates: [candidate], total: 1)}
+        },
+        workspace: %{editing: %{mode: :command, mode_state: %{input: "wri", candidate_index: 0}}}
+      }
+
+      result = MinibufferData.from_state(state)
+      assert result.candidates == [candidate]
+      assert result.total_candidates == 1
     end
 
     test "generates completion candidates for non-empty input" do

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -611,7 +611,7 @@ defmodule MingaEditor.MouseTest do
 
     test "switching tabs clears a standing link preview" do
       {state, _buf1, _buf2} = start_two_tab_state()
-      [first_tab_id | _] = Enum.map(state.shell_state.tab_bar.tabs, & &1.id)
+      [first_tab_id | _] = Enum.map(EditorState.tab_bar(state).tabs, & &1.id)
       {row, col} = buffer_screen_pos(state, 0, 2)
 
       state = mouse(state, row, col, :none, :motion, @super)

--- a/test/minga_editor/picker_async_stale_test.exs
+++ b/test/minga_editor/picker_async_stale_test.exs
@@ -14,6 +14,7 @@ defmodule MingaEditor.PickerAsyncStaleTest do
 
   use Minga.Test.EditorCase, async: true, rendering: :disabled
 
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Picker.Candidate
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.TodoSearchSource
@@ -30,7 +31,9 @@ defmodule MingaEditor.PickerAsyncStaleTest do
   end
 
   defp picker_payload(ctx) do
-    case :sys.get_state(ctx.editor, @sync_timeout).shell_state.modal do
+    state = :sys.get_state(ctx.editor, @sync_timeout)
+
+    case EditorState.modal(state) do
       {:picker, payload} -> payload
       _ -> nil
     end

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.PickerUITest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.PickerUI
   alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.ModalOverlay
@@ -96,7 +97,11 @@ defmodule MingaEditor.PickerUITest do
     state = %EditorState{
       port_manager: self(),
       workspace: preview_workspace,
-      shell_state: %ShellState{tab_bar: tb, modal: {:picker, PickerPayload.new(picker_state)}}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %ShellState{tab_bar: tb, modal: {:picker, PickerPayload.new(picker_state)}}
+        )
     }
 
     {state, original_buf, preview_buf}
@@ -181,7 +186,7 @@ defmodule MingaEditor.PickerUITest do
       state = picker_state_with_buffers(["alpha", "beta", "gamma"])
 
       new_state = PickerUI.handle_key(state, ?o, MingaEditor.Input.mod_ctrl())
-      {:picker, %{picker_ui: %{action_menu: {actions, 0}}}} = new_state.shell_state.modal
+      {:picker, %{picker_ui: %{action_menu: {actions, 0}}}} = new_state.shell_runtime.state.modal
 
       assert actions == [
                {"Kill all marked",
@@ -194,7 +199,7 @@ defmodule MingaEditor.PickerUITest do
 
       new_state = PickerUI.handle_key(state, 13, 0)
 
-      assert new_state.shell_state.modal == :none
+      assert new_state.shell_runtime.state.modal == :none
       assert Enum.count(new_state.workspace.buffers.list) == 1
       assert Minga.Buffer.content(new_state.workspace.buffers.active) == "alpha"
     end
@@ -214,14 +219,18 @@ defmodule MingaEditor.PickerUITest do
       state = %EditorState{
         port_manager: nil,
         workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()},
-        shell_state: %ShellState{modal: {:picker, PickerPayload.new(picker_state)}}
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %ShellState{modal: {:picker, PickerPayload.new(picker_state)}}
+          )
       }
 
       result = PickerUI.handle_key(state, ?d, 0)
-      {:picker, %{picker_ui: picker_ui}} = result.shell_state.modal
+      {:picker, %{picker_ui: picker_ui}} = result.shell_runtime.state.modal
 
       assert picker_ui.picker.query == "d"
-      assert result.shell_state.status_msg == nil
+      assert result.shell_runtime.state.status_msg == nil
       assert result.workspace.editing.mode == :normal
     end
   end
@@ -238,7 +247,7 @@ defmodule MingaEditor.PickerUITest do
 
       new_state = PickerUI.handle_key(picker_state, 13, 0)
 
-      assert new_state.shell_state.modal == :none
+      assert new_state.shell_runtime.state.modal == :none
       assert Map.get(new_state, :selected_item_id) == :first
       refute Map.has_key?(new_state, :bulk_selected)
     end
@@ -254,12 +263,14 @@ defmodule MingaEditor.PickerUITest do
 
       menu_state = PickerUI.handle_key(picker_state, ?o, MingaEditor.Input.mod_ctrl())
 
-      assert {:picker, %{picker_ui: %{action_menu: {actions, 0}}}} = menu_state.shell_state.modal
+      assert {:picker, %{picker_ui: %{action_menu: {actions, 0}}}} =
+               menu_state.shell_runtime.state.modal
+
       assert Enum.map(actions, &elem(&1, 0)) == ["Open", "Delete"]
 
       new_state = PickerUI.handle_key(menu_state, 13, 0)
 
-      assert new_state.shell_state.modal == :none
+      assert new_state.shell_runtime.state.modal == :none
       assert Map.get(new_state, :action_item_id) == :first
       refute Map.has_key?(new_state, :bulk_selected)
     end
@@ -271,8 +282,8 @@ defmodule MingaEditor.PickerUITest do
 
       new_state = PickerUI.handle_key(state, 13, 0)
 
-      tb = new_state.shell_state.tab_bar
-      assert new_state.shell_state.modal == :none
+      tb = new_state.shell_runtime.state.tab_bar
+      assert new_state.shell_runtime.state.modal == :none
       assert TabBar.count(tb) == 2
       assert %Buffers{active: ^original_buf} = TabBar.get(tb, 1).context.buffers
       assert %Buffers{active: ^preview_buf} = TabBar.get(tb, 2).context.buffers
@@ -283,13 +294,13 @@ defmodule MingaEditor.PickerUITest do
       {state, _original_buf, _preview_buf} = preview_promotion_state()
 
       switched_state = PickerUI.handle_key(state, ?>, 0)
-      {:picker, %{picker_ui: switched_pui}} = switched_state.shell_state.modal
+      {:picker, %{picker_ui: switched_pui}} = switched_state.shell_runtime.state.modal
       assert switched_pui.source == MingaEditor.UI.Picker.CommandSource
       assert switched_pui.original_source == MingaEditor.UI.Picker.FileSource
       assert switched_pui.mode_prefix == ">"
 
       reverted_state = PickerUI.handle_key(switched_state, 127, 0)
-      {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_state.modal
+      {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_runtime.state.modal
       assert reverted_pui.source == MingaEditor.UI.Picker.FileSource
       assert reverted_pui.original_source == nil
       assert reverted_pui.mode_prefix == ""
@@ -299,13 +310,13 @@ defmodule MingaEditor.PickerUITest do
       {state, _original_buf, _preview_buf} = preview_promotion_state()
 
       switched_state = PickerUI.handle_key(state, ?#, 0)
-      {:picker, %{picker_ui: switched_pui}} = switched_state.shell_state.modal
+      {:picker, %{picker_ui: switched_pui}} = switched_state.shell_runtime.state.modal
       assert switched_pui.source == MingaEditor.UI.Picker.ProjectSearchSource
       assert switched_pui.original_source == MingaEditor.UI.Picker.FileSource
       assert switched_pui.mode_prefix == "#"
 
       reverted_state = PickerUI.handle_key(switched_state, 127, 0)
-      {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_state.modal
+      {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_runtime.state.modal
       assert reverted_pui.source == MingaEditor.UI.Picker.FileSource
       assert reverted_pui.original_source == nil
       assert reverted_pui.mode_prefix == ""
@@ -317,10 +328,10 @@ defmodule MingaEditor.PickerUITest do
       source = :"Elixir.MingaEditor.PickerUITest.GitLogSource"
       picker = Picker.new([%Item{id: "abc123", label: "abc123"}], title: "Git Log")
       picker_state = %PickerState{picker: picker, source: source}
-      state = put_in(state.shell_state.modal, {:picker, PickerPayload.new(picker_state)})
+      state = ModalOverlay.open(state, :picker, PickerPayload.new(picker_state))
 
       state = Enum.reduce(~c"fix", state, fn cp, acc -> PickerUI.handle_key(acc, cp, 0) end)
-      {:picker, %{picker_ui: pui}} = state.shell_state.modal
+      {:picker, %{picker_ui: pui}} = state.shell_runtime.state.modal
 
       assert pui.source == source
       assert pui.picker.query == "fix"
@@ -364,7 +375,7 @@ defmodule MingaEditor.PickerUITest do
       final =
         Enum.reduce(["c", "co", "con", "conf", "config"], state, fn query, _acc ->
           typed = type_string(state, query)
-          {:picker, %{picker_ui: %{picker: picker}}} = typed.shell_state.modal
+          {:picker, %{picker_ui: %{picker: picker}}} = typed.shell_runtime.state.modal
 
           assert picker.query == query
           assert Picker.count(picker) == @result_limit
@@ -372,7 +383,7 @@ defmodule MingaEditor.PickerUITest do
           typed
         end)
 
-      {:picker, %{picker_ui: %{picker: picker}}} = final.shell_state.modal
+      {:picker, %{picker_ui: %{picker: picker}}} = final.shell_runtime.state.modal
       assert Picker.count(picker) == @result_limit
     end
 
@@ -382,7 +393,7 @@ defmodule MingaEditor.PickerUITest do
       # path quietly diverging from Picker.refilter (e.g. an unbounded code path
       # sneaking back in).
       typed = type_string(large_picker_state(NoBulkActionsSource, 10_000), "config")
-      {:picker, %{picker_ui: %{picker: picker}}} = typed.shell_state.modal
+      {:picker, %{picker_ui: %{picker: picker}}} = typed.shell_runtime.state.modal
 
       reference =
         for(i <- 1..10_000, do: %Item{id: i, label: "config_module_#{i}.ex"})
@@ -399,8 +410,8 @@ defmodule MingaEditor.PickerUITest do
       small = type_string(large_picker_state(NoBulkActionsSource, 1_000), "config")
       large = type_string(large_picker_state(NoBulkActionsSource, 50_000), "config")
 
-      {:picker, %{picker_ui: %{picker: small_picker}}} = small.shell_state.modal
-      {:picker, %{picker_ui: %{picker: large_picker}}} = large.shell_state.modal
+      {:picker, %{picker_ui: %{picker: small_picker}}} = small.shell_runtime.state.modal
+      {:picker, %{picker_ui: %{picker: large_picker}}} = large.shell_runtime.state.modal
 
       assert Picker.count(small_picker) == @result_limit
       assert Picker.count(large_picker) == @result_limit
@@ -420,7 +431,7 @@ defmodule MingaEditor.PickerUITest do
           Enum.reduce(keystrokes, state, fn cp, acc -> PickerUI.handle_key(acc, cp, 0) end)
         end)
 
-      {:picker, %{picker_ui: %{picker: picker}}} = final.shell_state.modal
+      {:picker, %{picker_ui: %{picker: picker}}} = final.shell_runtime.state.modal
       assert picker.query == "config"
       assert Picker.count(picker) == @result_limit
 
@@ -434,7 +445,7 @@ defmodule MingaEditor.PickerUITest do
       state = large_picker_state(LargePreviewSource, 10_000)
 
       typed = type_string(state, "config_module_1.ex")
-      {:picker, %{picker_ui: %{picker: picker}}} = typed.shell_state.modal
+      {:picker, %{picker_ui: %{picker: picker}}} = typed.shell_runtime.state.modal
 
       # Selection landed on a real match and preview applied on_select for it.
       assert Picker.selected_item(picker) != nil
@@ -448,7 +459,7 @@ defmodule MingaEditor.PickerUITest do
       state = large_file_picker_state(50_000)
 
       switched = PickerUI.handle_key(state, ?>, 0)
-      {:picker, %{picker_ui: pui}} = switched.shell_state.modal
+      {:picker, %{picker_ui: pui}} = switched.shell_runtime.state.modal
 
       assert pui.source == MingaEditor.UI.Picker.CommandSource
       assert pui.original_source == MingaEditor.UI.Picker.FileSource

--- a/test/minga_editor/prompt_ui_test.exs
+++ b/test/minga_editor/prompt_ui_test.exs
@@ -58,7 +58,7 @@ defmodule MingaEditor.PromptUITest do
   end
 
   defp prompt_state(state) do
-    case state.shell_state.modal do
+    case EditorState.modal(state) do
       {:prompt, %{prompt_ui: pui}} -> pui
       _ -> %PromptState{}
     end
@@ -113,7 +113,7 @@ defmodule MingaEditor.PromptUITest do
         |> PromptUI.open(TestHandler)
 
       assert prompt_state(state).handler == TestHandler
-      refute ModalOverlay.match(state.shell_state.modal, :picker)
+      refute ModalOverlay.match(EditorState.modal(state), :picker)
     end
   end
 
@@ -267,7 +267,7 @@ defmodule MingaEditor.PromptUITest do
         |> PromptUI.close()
 
       refute PromptUI.open?(state)
-      assert state.shell_state.modal == :none
+      assert EditorState.modal(state) == :none
     end
   end
 

--- a/test/minga_editor/render_model/ui/agent_context_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_context_builder_test.exs
@@ -57,7 +57,7 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
 
       state =
         %{
-          shell_state: %{agent: AgentState.set_pending_approval(%AgentState{}, approval)},
+          agent: AgentState.set_pending_approval(%AgentState{}, approval),
           workspace: %{agent_ui: UIState.new()}
         }
         |> then(fn state -> elem(AgentEvents.handle(state, {:approval_pending, approval}), 0) end)
@@ -73,7 +73,7 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
         windows: nil,
         layout: nil,
         shell: MingaEditor.Shell.Traditional,
-        shell_state: state.shell_state,
+        shell_state: %{agent: AgentAccess.agent(state)},
         agent_ui: AgentAccess.agent_ui(state)
       }
 

--- a/test/minga_editor/render_pipeline/chrome_dirty_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_dirty_test.exs
@@ -6,7 +6,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Session.State, as: SessionState
-  alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.State, as: EditorState
 
   setup do
     table = Module.concat(__MODULE__, "Sidebar#{System.unique_integer([:positive])}")
@@ -169,8 +169,8 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
       input = Input.from_editor_state(state)
       fp1 = Input.chrome_fingerprint(input)
 
-      shell_state =
-        ShellState.set_git_status_panel(state.shell_state, %{
+      state =
+        EditorState.set_git_status_panel(state, %{
           repo_state: :normal,
           branch: "main",
           ahead: 0,
@@ -178,7 +178,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
           entries: []
         })
 
-      input2 = Input.from_editor_state(%{state | shell_state: shell_state})
+      input2 = Input.from_editor_state(state)
       fp2 = Input.chrome_fingerprint(input2)
 
       assert fp1 != fp2

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -5,6 +5,8 @@ defmodule MingaEditor.RenderPipeline.InputTest do
   alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.RenderPipeline.WindowIntent
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Runtime
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -37,9 +39,10 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       assert input.port_manager == state.port_manager
       assert input.theme == state.theme
       assert input.capabilities == state.capabilities
-      assert input.shell_id == state.shell_id
-      assert input.shell == state.shell
-      assert input.shell_state == state.shell_state
+      assert input.shell_id == Runtime.id(state.shell_runtime)
+      assert input.shell == Runtime.module(state.shell_runtime)
+      assert input.shell_identity == Runtime.identity(state.shell_runtime)
+      assert input.shell_state == Runtime.state(state.shell_runtime)
       assert input.font_registry == MingaEditor.UI.FontRegistry.new()
       assert input.message_store == state.message_store
       assert input.editing_model == state.editing_model
@@ -63,7 +66,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
         :git_remote_op,
         :last_cursor_line,
         :buffer_add_context,
-        :shell_state_stash
+        :shell_runtime
       ]
 
       for field <- excluded do
@@ -201,8 +204,8 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       assert result.layout == :rendered_layout
       assert result.workspace.windows == windows
       refute Map.has_key?(Map.from_struct(result), :caches)
-      assert result.shell_state.modeline_click_regions == [{:modeline, 1}]
-      assert result.shell_state.tab_bar_click_regions == [{:tab, 2}]
+      assert Runtime.state(result.shell_runtime).modeline_click_regions == [{:modeline, 1}]
+      assert Runtime.state(result.shell_runtime).tab_bar_click_regions == [{:tab, 2}]
     end
 
     test "fresh receipt commits renderer-computed viewport observations", %{state: state} do
@@ -264,11 +267,24 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       input = Input.from_editor_state(state)
       stale = receipt(input, 10, false, layout: :rendered_layout)
 
+      fake_entry = %Entry{
+        id: :fake,
+        source: :config,
+        module: MingaEditor.Test.FakeShell,
+        display_name: "Fake",
+        description: "Fake shell",
+        capabilities: [:gui],
+        generation: 1
+      }
+
       switched = %{
         state
-        | shell_id: :fake,
-          shell: MingaEditor.Test.FakeShell,
-          shell_state: %{modeline_click_regions: [], tab_bar_click_regions: []}
+        | shell_runtime:
+            Runtime.activate(
+              state.shell_runtime,
+              fake_entry,
+              %{modeline_click_regions: [], tab_bar_click_regions: []}
+            )
       }
 
       assert EditorState.apply_renderer_writeback(switched, stale) == switched

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -1160,15 +1160,9 @@ defmodule MingaEditor.Renderer.ServerTest do
   end
 
   defp build_sync_shell_state(renderer_pid) do
-    state = build_editor_state(:tui, renderer_pid)
-
-    %{
-      state
-      | shell_id: :fake,
-        shell: MingaEditor.Test.FakeShell,
-        shell_identity: MingaEditor.Shell.Identity.new(MingaEditor.Shell.Registry.get(:fake)),
-        shell_state: MingaEditor.Test.FakeShell.init([])
-    }
+    :tui
+    |> build_editor_state(renderer_pid)
+    |> MingaEditor.Shell.Workflow.switch(:fake)
   end
 
   defp build_editor_state(backend, renderer_pid, content \\ "test") do
@@ -1198,9 +1192,11 @@ defmodule MingaEditor.Renderer.ServerTest do
       port_manager: port,
       workspace: workspace,
       renderer: renderer_pid,
-      shell_id: :traditional,
-      shell: MingaEditor.Shell.Traditional,
-      shell_state: %MingaEditor.Shell.Traditional.State{}
+      shell_runtime:
+        MingaEditor.Shell.Runtime.new(
+          MingaEditor.Shell.Registry.get(:traditional),
+          %MingaEditor.Shell.Traditional.State{}
+        )
     }
   end
 end

--- a/test/minga_editor/session/chrome_state_review_test.exs
+++ b/test/minga_editor/session/chrome_state_review_test.exs
@@ -21,7 +21,7 @@ defmodule MingaEditor.Session.ChromeStateReviewTest do
     }
 
     tb = TabBar.update_workspace(tb, workspace.id, &WorkspaceModel.set_review(&1, review))
-    chrome = ChromeState.from_editor_state(%{shell_state: %{tab_bar: tb}})
+    chrome = ChromeState.from_editor_state(%{tab_bar: tb})
     agent_summary = Enum.find(chrome.workspaces, &(&1.id == workspace.id))
 
     assert agent_summary.draft_count == 1

--- a/test/minga_editor/session/chrome_state_test.exs
+++ b/test/minga_editor/session/chrome_state_test.exs
@@ -37,7 +37,7 @@ defmodule MingaEditor.Session.ChromeStateTest do
       chrome =
         ChromeState.from_editor_state(%{
           workspace: %{custom_name: "Client App", file_tree: %FileTreeState{}},
-          shell_state: %{tab_bar: nil}
+          tab_bar: nil
         })
 
       assert hd(chrome.workspaces).label == "Client App"
@@ -230,7 +230,7 @@ defmodule MingaEditor.Session.ChromeStateTest do
           buffers: %Buffers{active: active_buffer, list: List.wrap(active_buffer)}
         }
         |> SessionState.set_file_tree(%FileTreeState{project_root: project_root}),
-      shell_state: %{tab_bar: tb}
+      tab_bar: tb
     }
   end
 

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -14,7 +14,8 @@ defmodule MingaEditor.Shell.RegistryTest do
   alias MingaEditor.Shell.Identity
   alias MingaEditor.Input.Router
   alias MingaEditor.Shell.Registry
-  alias MingaEditor.Shell.StateStash
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Workflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.Test.FakeShell
@@ -48,6 +49,18 @@ defmodule MingaEditor.Shell.RegistryTest do
     snapshot = Registry.snapshot()
     assert Registry.resolve(:fake) == snapshot.entries.fake
     assert Registry.resolve(FakeShell) == snapshot.entries.fake
+  end
+
+  test "input dispatch uses the active extension shell contract" do
+    Registry.seed_builtin()
+    assert :ok = Registry.register({:extension, :fake}, shell_attrs(:fake, FakeShell, "Fake"))
+
+    state = TestHelpers.base_state() |> Workflow.switch(:fake)
+    assert Runtime.id(state.shell_runtime) == :fake
+
+    state = Router.dispatch(state, ?x, 0)
+    assert Runtime.id(state.shell_runtime) == :fake
+    assert Runtime.state(state.shell_runtime).events == [:input_probe]
   end
 
   test "register rejects duplicate shell ids" do
@@ -258,10 +271,10 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     state =
       TestHelpers.base_state()
-      |> EditorState.switch_shell(:fake)
-      |> EditorState.switch_shell(:traditional)
+      |> Workflow.switch(:fake)
+      |> Workflow.switch(:traditional)
 
-    assert state.shell_state_stash.fake.state == %{name: :fake, events: []}
+    assert Runtime.stash(state.shell_runtime).fake.state == %{name: :fake, events: []}
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -274,10 +287,10 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
-    switched = EditorState.switch_shell(state, :fake)
+    switched = Workflow.switch(state, :fake)
 
-    assert switched.shell == FakeShellAlt
-    assert switched.shell_state == %{name: :fake_alt, events: []}
+    assert Runtime.module(switched.shell_runtime) == FakeShellAlt
+    assert switched.shell_runtime.state == %{name: :fake_alt, events: []}
   end
 
   test "switching back restores state for the matching registration" do
@@ -294,12 +307,32 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     state =
       TestHelpers.base_state()
-      |> EditorState.switch_shell(:fake)
-      |> EditorState.update_shell_state(&Map.put(&1, :marker, :preserved))
-      |> EditorState.switch_shell(:traditional)
-      |> EditorState.switch_shell(:fake)
+      |> Workflow.switch(:fake)
+      |> put_active_shell_fields(%{marker: :preserved})
+      |> Workflow.switch(:traditional)
+      |> Workflow.switch(:fake)
 
-    assert state.shell_state.marker == :preserved
+    assert state.shell_runtime.state.marker == :preserved
+  end
+
+  test "current and exactly stashed registrations do not rerun shell initialization" do
+    Registry.seed_builtin()
+
+    assert :ok =
+             Registry.register(
+               {:extension, :fake_alt},
+               shell_attrs(:fake_alt, FakeShellAlt, "Fake Alt")
+             )
+
+    state = TestHelpers.base_state() |> Workflow.switch(:fake_alt)
+    assert_receive {:fake_shell_alt_initialized, _pid}
+
+    state = Workflow.ensure_available(state)
+    refute_receive {:fake_shell_alt_initialized, _pid}
+
+    state = Workflow.switch(state, :traditional)
+    _state = Workflow.switch(state, :fake_alt)
+    refute_receive {:fake_shell_alt_initialized, _pid}
   end
 
   test "switch invalidates layout and focus while active-shell selection remains a no-op" do
@@ -316,14 +349,14 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     switched =
       %{TestHelpers.base_state() | layout: :layout, focus_tree: :focus}
-      |> EditorState.switch_shell(:fake)
+      |> Workflow.switch(:fake)
 
     assert switched.layout == nil
     assert switched.focus_tree == nil
 
     unchanged =
       %{TestHelpers.base_state() | layout: :layout, focus_tree: :focus}
-      |> EditorState.switch_shell(:traditional)
+      |> Workflow.switch(:traditional)
 
     assert unchanged.layout == :layout
     assert unchanged.focus_tree == :focus
@@ -344,19 +377,19 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     state =
       TestHelpers.base_state()
-      |> EditorState.switch_shell(:fake)
-      |> EditorState.update_shell_state(&Map.put(&1, :obsolete, true))
+      |> Workflow.switch(:fake)
+      |> put_active_shell_fields(%{obsolete: true})
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
-    result = EditorState.ensure_shell_available(state)
+    result = Workflow.ensure_available(state)
     default = Registry.default()
 
-    assert result.shell_id == default.id
-    assert result.shell == default.module
-    assert Identity.matches?(result.shell_identity, default)
-    refute Map.has_key?(result.shell_state, :obsolete)
-    refute Map.has_key?(result.shell_state_stash, :fake)
+    assert Runtime.id(result.shell_runtime) == default.id
+    assert Runtime.module(result.shell_runtime) == default.module
+    assert Runtime.identity(result.shell_runtime) == Identity.new(default)
+    refute Map.has_key?(result.shell_runtime.state, :obsolete)
+    refute Map.has_key?(Runtime.stash(result.shell_runtime), :fake)
     assert result.layout == nil
     assert result.focus_tree == nil
   end
@@ -384,14 +417,14 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     state =
       TestHelpers.base_state()
-      |> EditorState.switch_shell(:fake)
-      |> EditorState.update_shell_state(&Map.put(&1, :record_agent_events?, true))
-      |> EditorState.switch_shell(:fake_alt)
+      |> Workflow.switch(:fake)
+      |> put_active_shell_fields(%{record_agent_events?: true})
+      |> Workflow.switch(:fake_alt)
       |> Map.put(:backend, :gui)
 
     event = {:status_changed, :error}
     {:noreply, matching} = MingaEditor.handle_info({:agent_event, self(), event}, state)
-    assert matching.shell_state_stash.fake.state.events == [event]
+    assert Runtime.stash(matching.shell_runtime).fake.state.events == [event]
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -407,8 +440,30 @@ defmodule MingaEditor.Shell.RegistryTest do
     {:noreply, stale} =
       MingaEditor.handle_info({:agent_event, self(), {:status_changed, :idle}}, matching)
 
-    assert stale.shell_state_stash.fake.state.events == [event]
+    assert Runtime.stash(stale.shell_runtime).fake.state.events == [event]
     Process.cancel_timer(stale.render_timer)
+  end
+
+  test "active agent event retains state returned by shell persistence" do
+    Registry.seed_builtin()
+    assert :ok = Registry.register({:extension, :fake}, shell_attrs(:fake, FakeShell, "Fake"))
+
+    persisted_state = %{events: [:persisted]}
+
+    state =
+      TestHelpers.base_state()
+      |> Workflow.switch(:fake)
+      |> put_active_shell_fields(%{
+        record_agent_events?: true,
+        persist_as: persisted_state
+      })
+      |> Map.put(:backend, :gui)
+
+    {:noreply, updated} =
+      MingaEditor.handle_info({:agent_event, self(), {:status_changed, :error}}, state)
+
+    assert Runtime.state(updated.shell_runtime) == persisted_state
+    Process.cancel_timer(updated.render_timer)
   end
 
   test "Agent.Events updates matching stashes but skips a replaced registration" do
@@ -437,16 +492,12 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     state =
       TestHelpers.base_state()
-      |> EditorState.switch_shell(:fake_alt)
-      |> EditorState.update_shell_state(fn shell_state ->
-        Map.merge(shell_state, %{agent: %AgentState{}, session: session, tab_bar: nil})
-      end)
-      |> Map.put(:shell_state_stash, %{
-        fake: StateStash.new(fake_entry, %{session: session})
-      })
+      |> Workflow.switch(:fake_alt)
+      |> put_active_shell_fields(%{agent: %AgentState{}, session: session, tab_bar: nil})
+      |> stash_shell_state(fake_entry, %{session: session})
 
     {matching, _effects} = Events.handle(state, {:status_changed, :thinking})
-    assert matching.shell_state_stash.fake.state.synced_agent_status == :thinking
+    assert Runtime.stash(matching.shell_runtime).fake.state.synced_agent_status == :thinking
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -460,7 +511,7 @@ defmodule MingaEditor.Shell.RegistryTest do
              })
 
     {stale, _effects} = Events.handle(matching, {:status_changed, :idle})
-    assert stale.shell_state_stash.fake.state.synced_agent_status == :thinking
+    assert Runtime.stash(stale.shell_runtime).fake.state.synced_agent_status == :thinking
   end
 
   test "buffer session restart updates a matching stash but not a replaced registration" do
@@ -480,10 +531,9 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     entry = Registry.get(:fake)
 
-    state = %{
+    state =
       TestHelpers.base_state()
-      | shell_state_stash: %{fake: StateStash.new(entry, %{session: old_pid})}
-    }
+      |> stash_shell_state(entry, %{session: old_pid})
 
     matching =
       BufferManagement.handle_agent_session_restarted(
@@ -494,12 +544,9 @@ defmodule MingaEditor.Shell.RegistryTest do
         :restarted
       )
 
-    assert matching.shell_state_stash.fake.state.session == new_pid
+    assert Runtime.stash(matching.shell_runtime).fake.state.session == new_pid
 
-    stale_state = %{
-      state
-      | shell_state_stash: %{fake: StateStash.new(entry, %{session: old_pid})}
-    }
+    stale_state = state
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -521,7 +568,7 @@ defmodule MingaEditor.Shell.RegistryTest do
         :restarted
       )
 
-    assert stale.shell_state_stash.fake.state.session == old_pid
+    assert Runtime.stash(stale.shell_runtime).fake.state.session == old_pid
     assert {:stale, _normalized} = BufferManagement.prepare_agent_session_restart(stale, old_pid)
   end
 
@@ -542,8 +589,8 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     state =
       TestHelpers.base_state()
-      |> EditorState.switch_shell(:fake)
-      |> EditorState.update_shell_state(&Map.put(&1, :session, old_pid))
+      |> Workflow.switch(:fake)
+      |> put_active_shell_fields(%{session: old_pid})
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -567,13 +614,13 @@ defmodule MingaEditor.Shell.RegistryTest do
         :restarted
       )
 
-    assert Map.take(restarted.shell_state, [:name, :events]) == %{name: :fake, events: []}
-    refute Map.has_key?(restarted.shell_state, :session)
-    assert Identity.matches?(restarted.shell_identity, current_entry)
+    assert Map.take(restarted.shell_runtime.state, [:name, :events]) == %{name: :fake, events: []}
+    refute Map.has_key?(restarted.shell_runtime.state, :session)
+    assert Runtime.identity(restarted.shell_runtime) == Identity.new(current_entry)
 
     assert {:stale, normalized} = BufferManagement.prepare_agent_session_restart(state, old_pid)
-    assert Identity.matches?(normalized.shell_identity, current_entry)
-    refute Map.has_key?(normalized.shell_state, :session)
+    assert Runtime.identity(normalized.shell_runtime) == Identity.new(current_entry)
+    refute Map.has_key?(normalized.shell_runtime.state, :session)
   end
 
   test "restart dispatch retains normalized state when subscription is stale" do
@@ -609,12 +656,10 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     state =
       TestHelpers.base_state()
-      |> EditorState.switch_shell(:fake)
-      |> EditorState.update_shell_state(&Map.put(&1, :session, old_pid))
+      |> Workflow.switch(:fake)
+      |> put_active_shell_fields(%{session: old_pid})
       |> Map.put(:agent_ingest, dead_ingest)
-      |> Map.put(:shell_state_stash, %{
-        valid: StateStash.new(valid_entry, %{session: old_pid})
-      })
+      |> stash_shell_state(valid_entry, %{session: old_pid})
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -642,9 +687,9 @@ defmodule MingaEditor.Shell.RegistryTest do
         nil
       )
 
-    assert Identity.matches?(normalized.shell_identity, current_entry)
-    refute Map.has_key?(normalized.shell_state, :session)
-    assert normalized.shell_state_stash.valid.state.session == old_pid
+    assert Runtime.identity(normalized.shell_runtime) == Identity.new(current_entry)
+    refute Map.has_key?(normalized.shell_runtime.state, :session)
+    assert Runtime.stash(normalized.shell_runtime).valid.state.session == old_pid
   end
 
   test "session down and disconnect reset obsolete active shell state before callbacks" do
@@ -662,8 +707,8 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     state =
       TestHelpers.base_state()
-      |> EditorState.switch_shell(:fake)
-      |> EditorState.update_shell_state(&Map.put(&1, :session, session))
+      |> Workflow.switch(:fake)
+      |> put_active_shell_fields(%{session: session})
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -681,14 +726,14 @@ defmodule MingaEditor.Shell.RegistryTest do
     disconnected = BufferManagement.handle_agent_session_down(state, session, :noconnection)
 
     for normalized <- [normal, disconnected] do
-      assert Identity.matches?(normalized.shell_identity, current_entry)
-      refute Map.has_key?(normalized.shell_state, :session)
-      refute Map.has_key?(normalized.shell_state, :session_down?)
-      refute Map.has_key?(normalized.shell_state, :remote_disconnected?)
+      assert Runtime.identity(normalized.shell_runtime) == Identity.new(current_entry)
+      refute Map.has_key?(normalized.shell_runtime.state, :session)
+      refute Map.has_key?(normalized.shell_runtime.state, :session_down?)
+      refute Map.has_key?(normalized.shell_runtime.state, :remote_disconnected?)
     end
   end
 
-  test "buffer lifecycle stops after the first stashed shell handles a restart" do
+  test "buffer lifecycle updates every stashed shell that owns a restarted session" do
     Registry.seed_builtin()
     old_pid = self()
     new_pid = spawn(fn -> receive do: (:stop -> :ok) end)
@@ -712,13 +757,12 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
-    state = %{
+    state =
       TestHelpers.base_state()
-      | shell_state_stash: %{
-          fake: StateStash.new(Registry.get(:fake), %{session: old_pid}),
-          fake_alt: StateStash.new(Registry.get(:fake_alt), %{session: old_pid})
-        }
-    }
+      |> stash_shell_states([
+        {Registry.get(:fake), %{session: old_pid}},
+        {Registry.get(:fake_alt), %{session: old_pid}}
+      ])
 
     restarted =
       BufferManagement.handle_agent_session_restarted(
@@ -729,9 +773,11 @@ defmodule MingaEditor.Shell.RegistryTest do
         :restarted
       )
 
-    sessions = Enum.map(restarted.shell_state_stash, fn {_id, stash} -> stash.state.session end)
-    assert Enum.count(sessions, &(&1 == new_pid)) == 1
-    assert Enum.count(sessions, &(&1 == old_pid)) == 1
+    sessions =
+      Enum.map(Runtime.stash(restarted.shell_runtime), fn {_id, stash} -> stash.state.session end)
+
+    assert Enum.sort(sessions) == [new_pid, new_pid]
+    refute Enum.any?(sessions, &(&1 == old_pid))
   end
 
   test "buffer lifecycle skips a stale stash before the matching owner" do
@@ -771,13 +817,12 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
-    state = %{
+    state =
       TestHelpers.base_state()
-      | shell_state_stash: %{
-          a_stale: StateStash.new(stale_entry, %{session: old_pid}),
-          z_valid: StateStash.new(valid_entry, %{session: old_pid})
-        }
-    }
+      |> stash_shell_states([
+        {stale_entry, %{session: old_pid}},
+        {valid_entry, %{session: old_pid}}
+      ])
 
     restarted =
       BufferManagement.handle_agent_session_restarted(
@@ -788,12 +833,13 @@ defmodule MingaEditor.Shell.RegistryTest do
         :restarted
       )
 
-    assert restarted.shell_state_stash.a_stale.state.session == old_pid
-    assert restarted.shell_state_stash.z_valid.state.session == new_pid
+    assert Runtime.stash(restarted.shell_runtime).a_stale.state.session == old_pid
+    assert Runtime.stash(restarted.shell_runtime).z_valid.state.session == new_pid
   end
 
-  test "stash transformations thread the current aggregate into later callbacks" do
+  test "agent status synchronization updates every exact-identity stash" do
     Registry.seed_builtin()
+    session = self()
 
     assert :ok =
              Registry.register({:extension, :first}, %{
@@ -813,29 +859,18 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
-    state = %{
+    state =
       TestHelpers.base_state()
-      | shell_state_stash: %{
-          first: StateStash.new(Registry.get(:first), %{}),
-          second: StateStash.new(Registry.get(:second), %{})
-        }
-    }
+      |> stash_shell_states([
+        {Registry.get(:first), %{session: session}},
+        {Registry.get(:second), %{session: session}}
+      ])
 
-    {transformed, true} =
-      EditorState.transform_stashed_shell_states(state, fn _module, shell_state, state_acc ->
-        transformed_count =
-          Enum.count(state_acc.shell_state_stash, fn {_id, stash} ->
-            Map.get(stash.state, :transformed?, false)
-          end)
+    runtime = Runtime.sync_agent_status(state.shell_runtime, Registry.list(), session, :thinking)
+    stash = Runtime.stash(runtime)
 
-        send(self(), {:transformed_count, transformed_count})
-        {{:updated, Map.put(shell_state, :transformed?, true)}, state_acc}
-      end)
-
-    assert_receive {:transformed_count, 0}
-    assert_receive {:transformed_count, 1}
-    assert transformed.shell_state_stash.first.state.transformed?
-    assert transformed.shell_state_stash.second.state.transformed?
+    assert stash.first.state.synced_agent_status == :thinking
+    assert stash.second.state.synced_agent_status == :thinking
   end
 
   test "renderer writeback drops stale output after a shell id is re-registered" do
@@ -850,7 +885,7 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
-    state = TestHelpers.base_state() |> EditorState.switch_shell(:fake)
+    state = TestHelpers.base_state() |> Workflow.switch(:fake)
     input = Input.from_editor_state(state)
 
     assert :ok = Registry.unregister_source({:extension, :fake})
@@ -876,12 +911,15 @@ defmodule MingaEditor.Shell.RegistryTest do
       render_sent_at: 0
     }
 
-    result = EditorState.apply_renderer_writeback(state, writeback)
+    result =
+      state
+      |> Workflow.ensure_available()
+      |> EditorState.apply_renderer_writeback(writeback)
 
     assert result.layout == nil
     assert result.focus_tree == nil
-    assert result.shell_id == :fake
-    refute Map.has_key?(result.shell_state, :modeline_click_regions)
+    assert Runtime.id(result.shell_runtime) == :fake
+    refute Map.has_key?(result.shell_runtime.state, :modeline_click_regions)
   end
 
   test "input dispatch falls back when the active shell has been unregistered" do
@@ -896,13 +934,49 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
-    state = TestHelpers.base_state() |> EditorState.switch_shell(:fake)
+    state = TestHelpers.base_state() |> Workflow.switch(:fake)
     assert :ok = Registry.unregister_source({:extension, :fake})
 
     result = Router.dispatch(state, ?j, 0)
 
-    assert result.shell_id == :traditional
-    assert result.shell == MingaEditor.Shell.Traditional
+    assert Runtime.id(result.shell_runtime) == :traditional
+    assert Runtime.module(result.shell_runtime) == MingaEditor.Shell.Traditional
+  end
+
+  @spec put_active_shell_fields(EditorState.t(), map()) :: EditorState.t()
+  defp put_active_shell_fields(%EditorState{} = state, fields) when is_map(fields) do
+    replacement = Map.merge(Runtime.state(state.shell_runtime), fields)
+
+    {runtime, workspace} =
+      Runtime.route_event(
+        state.shell_runtime,
+        state.workspace,
+        {:replace_test_state, replacement}
+      )
+
+    state
+    |> EditorState.apply_shell_runtime_transition(runtime)
+    |> EditorState.set_workspace(workspace)
+  end
+
+  @spec stash_shell_states(EditorState.t(), [{Entry.t(), term()}]) :: EditorState.t()
+  defp stash_shell_states(%EditorState{} = state, entries_and_states) do
+    Enum.reduce(entries_and_states, state, fn {entry, shell_state}, state_acc ->
+      stash_shell_state(state_acc, entry, shell_state)
+    end)
+  end
+
+  @spec stash_shell_state(EditorState.t(), Entry.t(), term()) :: EditorState.t()
+  defp stash_shell_state(%EditorState{} = state, %Entry{} = entry, shell_state) do
+    active_entry = Runtime.entry(state.shell_runtime)
+    active_state = Runtime.state(state.shell_runtime)
+
+    runtime =
+      state.shell_runtime
+      |> Runtime.activate(entry, shell_state)
+      |> Runtime.activate(active_entry, active_state)
+
+    EditorState.apply_shell_runtime_transition(state, runtime)
   end
 
   defp shell_attrs(id, module, label) do

--- a/test/minga_editor/shell/runtime_test.exs
+++ b/test/minga_editor/shell/runtime_test.exs
@@ -1,0 +1,222 @@
+defmodule MingaEditor.Shell.RuntimeTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Test.FakeShell
+  alias MingaEditor.Test.FakeShellAlt
+  alias MingaEditor.Viewport
+
+  @workspace %SessionState{viewport: Viewport.new(24, 80)}
+
+  setup_all do
+    {:module, FakeShell} = Code.ensure_loaded(FakeShell)
+    {:module, FakeShellAlt} = Code.ensure_loaded(FakeShellAlt)
+    :ok
+  end
+
+  test "construction exposes one resolved active shell value" do
+    entry = entry(:fake, FakeShell, 7)
+    runtime = Runtime.new(entry, %{marker: :active})
+
+    assert Runtime.entry(runtime) == entry
+    assert Runtime.id(runtime) == :fake
+    assert Runtime.module(runtime) == FakeShell
+    assert Runtime.state(runtime) == %{marker: :active}
+    assert Runtime.stash(runtime) == %{}
+    assert Runtime.matches_identity?(runtime, Runtime.identity(runtime))
+  end
+
+  test "activation stashes outgoing state and restores only the exact registration" do
+    fake = entry(:fake, FakeShell, 1)
+    alternate = entry(:alternate, FakeShellAlt, 2)
+
+    runtime =
+      fake
+      |> Runtime.new(%{marker: :fake})
+      |> Runtime.activate(alternate, %{marker: :alternate})
+
+    assert Runtime.state(runtime) == %{marker: :alternate}
+    assert Runtime.stash(runtime).fake.state == %{marker: :fake}
+
+    restored = Runtime.activate(runtime, fake, %{marker: :new_default})
+    assert Runtime.state(restored) == %{marker: :fake}
+    refute Map.has_key?(Runtime.stash(restored), :fake)
+    assert Runtime.stash(restored).alternate.state == %{marker: :alternate}
+  end
+
+  test "reused ids with stale module, source, or generation never restore old state" do
+    original = entry(:fake, FakeShell, 1)
+    alternate = entry(:alternate, FakeShellAlt, 2)
+
+    for replacement <- [
+          entry(:fake, FakeShell, 9),
+          entry(:fake, FakeShellAlt, 1),
+          %Entry{entry(:fake, FakeShell, 1) | source: {:extension, :replacement}}
+        ] do
+      runtime =
+        original
+        |> Runtime.new(%{marker: :stale})
+        |> Runtime.activate(alternate, %{})
+        |> Runtime.activate(replacement, %{marker: :fresh})
+
+      assert Runtime.state(runtime) == %{marker: :fresh}
+      refute Map.has_key?(Runtime.stash(runtime), :fake)
+    end
+  end
+
+  test "registration validation preserves exact identity and resets changed identity" do
+    original = entry(:fake, FakeShell, 1)
+    runtime = Runtime.new(original, %{marker: :active})
+
+    assert {^runtime, :current} =
+             Runtime.validate_registration(runtime, original, %{marker: :unused})
+
+    replacement = entry(:fake, FakeShellAlt, 2)
+
+    assert {reset, :reset} =
+             Runtime.validate_registration(runtime, replacement, %{marker: :reset})
+
+    assert Runtime.entry(reset) == replacement
+    assert Runtime.state(reset) == %{marker: :reset}
+    assert Runtime.stash(reset) == %{}
+  end
+
+  test "fallback after active registration removal restores an exact default stash" do
+    default = entry(:traditional, FakeShell, 1, :builtin)
+    extension = entry(:fake, FakeShellAlt, 2)
+
+    runtime =
+      default
+      |> Runtime.new(%{marker: :default})
+      |> Runtime.activate(extension, %{marker: :extension})
+
+    fallback = Runtime.fallback_from_removed(runtime, default, %{marker: :new_default})
+    assert Runtime.entry(fallback) == default
+    assert Runtime.state(fallback) == %{marker: :default}
+    refute Map.has_key?(Runtime.stash(fallback), :traditional)
+    refute Map.has_key?(Runtime.stash(fallback), :fake)
+  end
+
+  test "active events route through the active entry contract" do
+    runtime = Runtime.new(entry(:fake, FakeShell, 1), %{events: []})
+
+    assert {updated, @workspace} = Runtime.route_event(runtime, @workspace, :refresh)
+    assert Runtime.state(updated).events == [:refresh]
+  end
+
+  test "active agent events preserve identity and return effects and persistence as data" do
+    entry = entry(:fake, FakeShell, 1)
+    old_state = %{events: [], record_agent_events?: true}
+    runtime = Runtime.new(entry, old_state)
+
+    assert {updated, @workspace, [], {%Entry{} = changed_entry, ^old_state, new_state}} =
+             Runtime.route_agent_event(runtime, @workspace, self(), :background)
+
+    assert changed_entry == entry
+    assert Runtime.entry(updated) == entry
+    assert Runtime.state(updated) == new_state
+    assert new_state.events == [:background]
+  end
+
+  test "stashed agent events use each stashed entry and skip removed registrations" do
+    fake = entry(:fake, FakeShell, 1)
+    alternate = entry(:alternate, FakeShellAlt, 2)
+
+    runtime =
+      fake
+      |> Runtime.new(%{events: [], record_agent_events?: true})
+      |> Runtime.activate(alternate, %{events: []})
+
+    {updated, @workspace, [], changes} =
+      Runtime.route_stashed_agent_event(runtime, [fake], @workspace, self(), :background)
+
+    assert Runtime.entry(updated) == alternate
+    assert Runtime.state(updated) == %{events: []}
+    assert Runtime.stash(updated).fake.state.events == [:background]
+    assert [{%Entry{module: FakeShell}, _old_state, _new_state}] = changes
+
+    {unchanged, @workspace, [], []} =
+      Runtime.route_stashed_agent_event(runtime, [], @workspace, self(), :ignored)
+
+    assert Runtime.stash(unchanged) == Runtime.stash(runtime)
+  end
+
+  test "persisted state is accepted only for the exact active or stashed registration" do
+    fake = entry(:fake, FakeShell, 1)
+    alternate = entry(:alternate, FakeShellAlt, 2)
+
+    active = Runtime.new(fake, %{marker: :before})
+    persisted = Runtime.accept_persisted_state(active, fake, %{marker: :persisted})
+    assert Runtime.state(persisted) == %{marker: :persisted}
+
+    stale = entry(:fake, FakeShell, 9)
+    assert Runtime.accept_persisted_state(active, stale, %{marker: :stale}) == active
+
+    stashed = Runtime.activate(active, alternate, %{marker: :alternate})
+    stashed = Runtime.accept_persisted_state(stashed, fake, %{marker: :persisted_stash})
+    assert Runtime.state(stashed) == %{marker: :alternate}
+    assert Runtime.stash(stashed).fake.state == %{marker: :persisted_stash}
+  end
+
+  test "active and stashed session lifecycle routes through exact entry contracts" do
+    old_pid = self()
+
+    new_pid =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> if Process.alive?(new_pid), do: send(new_pid, :stop) end)
+
+    fake = entry(:fake, FakeShell, 1)
+    alternate = entry(:alternate, FakeShellAlt, 2)
+
+    active = Runtime.new(fake, %{session: old_pid})
+
+    assert {down, true, {%Entry{module: FakeShell}, _old, _new}} =
+             Runtime.route_session_down(active, old_pid, :boom)
+
+    assert Runtime.state(down).session_down?
+
+    runtime = Runtime.activate(active, alternate, %{session: old_pid})
+
+    assert {restarted, true, changes} =
+             Runtime.route_session_restarted(runtime, [fake], old_pid, new_pid, :restart)
+
+    assert Runtime.state(restarted).session == new_pid
+    assert Runtime.stash(restarted).fake.state.session == new_pid
+    assert [_, _] = changes
+
+    stashed_runtime =
+      fake
+      |> Runtime.new(%{session: old_pid})
+      |> Runtime.activate(alternate, %{session: new_pid})
+
+    assert {stashed_down, true, [_change]} =
+             Runtime.route_stashed_session_down(stashed_runtime, [fake], old_pid, :boom)
+
+    assert Runtime.stash(stashed_down).fake.state.session_down?
+
+    assert {disconnected, true, [_change]} =
+             Runtime.route_stashed_remote_session_disconnected(stashed_runtime, [fake], old_pid)
+
+    assert Runtime.stash(disconnected).fake.state.remote_disconnected?
+  end
+
+  defp entry(id, module, generation, source \\ {:extension, :runtime_test}) do
+    %Entry{
+      id: id,
+      source: source,
+      module: module,
+      display_name: Atom.to_string(id),
+      description: "Runtime test shell",
+      capabilities: [:gui, :tui],
+      default?: source == :builtin,
+      generation: generation
+    }
+  end
+end

--- a/test/minga_editor/state/agent_workspace_lifecycle_test.exs
+++ b/test/minga_editor/state/agent_workspace_lifecycle_test.exs
@@ -12,6 +12,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Commands.AgentSession
   alias MingaEditor.Commands.BufferManagement
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -30,13 +31,15 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     state = EditorState.switch_tab(state, 2)
 
     assert prompt_text(state.workspace.agent_ui) == "draft one"
-    assert prompt_text(TabBar.active_workspace(state.shell_state.tab_bar).agent_ui) == "draft one"
+
+    assert prompt_text(TabBar.active_workspace(state.shell_runtime.state.tab_bar).agent_ui) ==
+             "draft one"
   end
 
   test "switching to a workspace without agent UI clears the live mirror" do
     state = state_with_tabs()
     ui_two = put_prompt(UIState.new(), "workspace two")
-    {tab_bar, workspace_two} = TabBar.add_workspace(state.shell_state.tab_bar, "Agent")
+    {tab_bar, workspace_two} = TabBar.add_workspace(state.shell_runtime.state.tab_bar, "Agent")
 
     tab_bar =
       tab_bar
@@ -57,7 +60,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
   test "closing a workspace clears stale agent UI after tabs migrate to manual" do
     state = state_with_tabs()
     ui_two = put_prompt(UIState.new(), "workspace two")
-    {tab_bar, workspace_two} = TabBar.add_workspace(state.shell_state.tab_bar, "Agent")
+    {tab_bar, workspace_two} = TabBar.add_workspace(state.shell_runtime.state.tab_bar, "Agent")
 
     tab_bar =
       tab_bar
@@ -72,16 +75,16 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
 
     state = MingaEditor.Commands.Workspace.workspace_close(state)
 
-    assert TabBar.active_workspace_id(state.shell_state.tab_bar) == 0
+    assert TabBar.active_workspace_id(state.shell_runtime.state.tab_bar) == 0
     assert prompt_text(state.workspace.agent_ui) == ""
   end
 
   test "switching to inactive remote workspace drains queued catch-up once" do
     state = state_with_agent_workspace_tabs()
-    initial_tab_id = TabBar.active(state.shell_state.tab_bar).id
+    initial_tab_id = TabBar.active(state.shell_runtime.state.tab_bar).id
     catchup = [EventRecord.new("remote-session", :message_changed, %{})]
 
-    {tab_bar, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Remote Agent")
+    {tab_bar, agent_tab} = TabBar.add(state.shell_runtime.state.tab_bar, :agent, "Remote Agent")
     {tab_bar, remote_workspace} = TabBar.add_workspace(tab_bar, "Remote Agent")
 
     tab_bar =
@@ -98,7 +101,10 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     initial_version = panel_message_version(state)
 
     {state, _effects} = EditorState.switch_tab_pure(state, agent_tab.id)
-    drained_workspace = TabBar.get_workspace(state.shell_state.tab_bar, remote_workspace.id)
+
+    drained_workspace =
+      TabBar.get_workspace(state.shell_runtime.state.tab_bar, remote_workspace.id)
+
     first_version = panel_message_version(state)
 
     assert first_version == initial_version + 1
@@ -109,7 +115,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
 
     assert panel_message_version(state) == first_version
 
-    assert TabBar.get_workspace(state.shell_state.tab_bar, remote_workspace.id).pending_catchup_events ==
+    assert TabBar.get_workspace(state.shell_runtime.state.tab_bar, remote_workspace.id).pending_catchup_events ==
              []
   end
 
@@ -134,7 +140,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     ui_two = put_prompt(UIState.new(), "workspace two")
 
     {tab_bar, workspace_two} =
-      TabBar.add_workspace(state.shell_state.tab_bar, "Agent", session_two)
+      TabBar.add_workspace(state.shell_runtime.state.tab_bar, "Agent", session_two)
 
     workspace_one_id = TabBar.active_workspace_id(tab_bar)
 
@@ -173,7 +179,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     assert is_pid(new_session)
     refute new_session == old_session
 
-    tab_bar = state.shell_state.tab_bar
+    tab_bar = state.shell_runtime.state.tab_bar
     assert TabBar.active_workspace_id(tab_bar) == workspace_id
     workspace = TabBar.get_workspace(tab_bar, workspace_id)
     assert workspace.session == new_session
@@ -189,11 +195,11 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     on_exit(fn -> stop_session(old_session) end)
     old_ref = Process.monitor(old_session)
     {state, workspace_id, file_ref} = state_with_active_agent_workspace(old_session)
-    agent_tab_id = TabBar.active(state.shell_state.tab_bar).id
+    agent_tab_id = TabBar.active(state.shell_runtime.state.tab_bar).id
 
     state = EditorState.switch_tab(state, 1)
-    assert TabBar.active(state.shell_state.tab_bar).kind == :file
-    assert TabBar.active_workspace_id(state.shell_state.tab_bar) == workspace_id
+    assert TabBar.active(state.shell_runtime.state.tab_bar).kind == :file
+    assert TabBar.active_workspace_id(state.shell_runtime.state.tab_bar) == workspace_id
 
     state = AgentSession.restart_session(state, "Restarting agent")
     new_session = MingaEditor.State.AgentAccess.session(state)
@@ -203,7 +209,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     assert is_pid(new_session)
     refute new_session == old_session
 
-    tab_bar = state.shell_state.tab_bar
+    tab_bar = state.shell_runtime.state.tab_bar
     workspace = TabBar.get_workspace(tab_bar, workspace_id)
     agent_tab = TabBar.get(tab_bar, agent_tab_id)
 
@@ -227,7 +233,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
 
     {shell_state, workspace} =
       Traditional.handle_gui_action(
-        state.shell_state,
+        state.shell_runtime.state,
         state.workspace,
         {:workspace_close, workspace_id}
       )
@@ -244,7 +250,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     {state, workspace_id, file_ref} = state_with_active_agent_workspace(session)
 
     state = BufferManagement.handle_agent_session_down(state, session, :shutdown)
-    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+    workspace = TabBar.get_workspace(state.shell_runtime.state.tab_bar, workspace_id)
 
     assert workspace.session == nil
     assert workspace.agent_status == :idle
@@ -266,18 +272,20 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     state = EditorState.switch_tab(state, 1)
 
     state = BufferManagement.execute(state, :force_quit)
-    tab_bar = state.shell_state.tab_bar
+    tab_bar = state.shell_runtime.state.tab_bar
     workspace = TabBar.get_workspace(tab_bar, workspace_id)
 
     assert TabBar.get(tab_bar, 1) == nil
     assert workspace.files == [file_ref]
 
     state = MingaEditor.Commands.Workspace.workspace_close(state)
-    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+    workspace = TabBar.get_workspace(state.shell_runtime.state.tab_bar, workspace_id)
 
     assert workspace.session == session
     assert workspace.files == [file_ref]
-    assert state.shell_state.status_msg == "Stop the agent session before closing this workspace"
+
+    assert state.shell_runtime.state.status_msg ==
+             "Stop the agent session before closing this workspace"
   end
 
   test "closing a remote agent workspace stops the session and scrubs migrated tab projections" do
@@ -290,7 +298,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     state = MingaEditor.Commands.Workspace.workspace_close(state)
     assert_receive {:DOWN, ^ref, :process, ^session, _reason}
 
-    tab_bar = state.shell_state.tab_bar
+    tab_bar = state.shell_runtime.state.tab_bar
     agent_tab = TabBar.get(tab_bar, agent_tab_id)
 
     assert TabBar.get_workspace(tab_bar, workspace_id) == nil
@@ -311,7 +319,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
       state_with_active_remote_agent_workspace(session)
 
     state = BufferManagement.execute(state, :force_quit)
-    tab_bar = state.shell_state.tab_bar
+    tab_bar = state.shell_runtime.state.tab_bar
     workspace = TabBar.get_workspace(tab_bar, workspace_id)
 
     assert TabBar.get(tab_bar, agent_tab_id) == nil
@@ -336,7 +344,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
       |> BufferManagement.execute(:force_quit)
       |> EditorState.switch_tab(1)
 
-    tab_bar = state.shell_state.tab_bar
+    tab_bar = state.shell_runtime.state.tab_bar
     workspace = TabBar.get_workspace(tab_bar, workspace_id)
 
     assert TabBar.get(tab_bar, agent_tab_id) == nil
@@ -349,7 +357,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     assert_receive {:DOWN, ^ref, :process, ^session, _reason}
 
     state = BufferManagement.handle_agent_session_down(state, session, :normal)
-    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+    workspace = TabBar.get_workspace(state.shell_runtime.state.tab_bar, workspace_id)
 
     assert workspace.session == nil
     assert workspace.agent_status == :idle
@@ -358,7 +366,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     assert workspace.remote_session.server_name == "home"
     assert workspace.remote_session.session_id == session_id
     assert workspace.remote_session.connection_status == :connected
-    refute Enum.any?(state.shell_state.tab_bar.tabs, &(&1.kind == :agent))
+    refute Enum.any?(state.shell_runtime.state.tab_bar.tabs, &(&1.kind == :agent))
   end
 
   test "stop_current_session from file tab stops workspace session and preserves files and draft after cleanup" do
@@ -371,7 +379,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     assert_receive {:DOWN, ^ref, :process, ^session, _reason}
 
     state = BufferManagement.handle_agent_session_down(state, session, :shutdown)
-    workspace = TabBar.get_workspace(state.shell_state.tab_bar, workspace_id)
+    workspace = TabBar.get_workspace(state.shell_runtime.state.tab_bar, workspace_id)
 
     assert workspace.session == nil
     assert workspace.files == [file_ref]
@@ -380,7 +388,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
 
   defp state_with_agent_workspace_tabs do
     state = state_with_tabs()
-    {tab_bar, workspace} = TabBar.add_workspace(state.shell_state.tab_bar, "Agent")
+    {tab_bar, workspace} = TabBar.add_workspace(state.shell_runtime.state.tab_bar, "Agent")
 
     tab_bar =
       tab_bar
@@ -396,7 +404,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     file_ref = FileRef.from_buffer(state.workspace.buffers.active)
     ui = UIState.new() |> put_prompt("restart draft") |> show_panel()
 
-    {tab_bar, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Agent")
+    {tab_bar, agent_tab} = TabBar.add(state.shell_runtime.state.tab_bar, :agent, "Agent")
     {tab_bar, workspace} = TabBar.add_workspace(tab_bar, "Agent", session)
 
     tab_bar =
@@ -422,10 +430,10 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
   defp state_with_active_remote_agent_workspace(session, remote_session_id \\ "session-1")
        when is_pid(session) and is_binary(remote_session_id) do
     {state, workspace_id, file_ref} = state_with_active_agent_workspace(session)
-    agent_tab_id = TabBar.active(state.shell_state.tab_bar).id
+    agent_tab_id = TabBar.active(state.shell_runtime.state.tab_bar).id
 
     tab_bar =
-      state.shell_state.tab_bar
+      state.shell_runtime.state.tab_bar
       |> TabBar.update_workspace(workspace_id, fn workspace ->
         Workspace.put_remote_session(workspace, "home", remote_session_id, :connected)
       end)
@@ -452,7 +460,6 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
 
     %EditorState{
       port_manager: nil,
-      shell: MingaEditor.Shell.Traditional,
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80),
         editing: VimState.new(),
@@ -465,7 +472,11 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
         },
         agent_ui: UIState.new()
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tab_bar}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{tab_bar: tab_bar}
+        )
     }
   end
 

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -8,6 +8,9 @@ defmodule MingaEditor.State.BufferLifecycleTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Events
   alias MingaEditor.BufferLifecycle
+  alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
@@ -45,6 +48,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
 
     state = %EditorState{
       port_manager: self(),
+      shell_runtime: resolved_traditional_runtime(),
       workspace: %SessionState{
         viewport: Viewport.new(24, 80),
         editing: VimState.new(),
@@ -92,7 +96,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
       original_buf = state.workspace.buffers.active
       opened_buf = start_buffer("opened")
       {opened, effects} = EditorState.add_buffer_pure(state, opened_buf, context: :open)
-      tb = opened.shell_state.tab_bar
+      tb = EditorState.tab_bar(opened)
       assert {:monitor, opened_buf} in effects
       assert TabBar.count(tb) == 2
       assert tb.active_id == 2
@@ -102,11 +106,11 @@ defmodule MingaEditor.State.BufferLifecycleTest do
 
       preview_buf = start_buffer("preview")
       {previewed, _effects} = EditorState.add_buffer_pure(state, preview_buf, context: :preview)
-      assert TabBar.count(previewed.shell_state.tab_bar) == 1
+      assert TabBar.count(EditorState.tab_bar(previewed)) == 1
       assert previewed.workspace.buffers.active == preview_buf
 
       assert %Buffers{active: ^original_buf} =
-               TabBar.get(previewed.shell_state.tab_bar, 1).context.buffers
+               TabBar.get(EditorState.tab_bar(previewed), 1).context.buffers
 
       assert previewed.buffer_add_context == :open
 
@@ -121,7 +125,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
       file_buf = start_buffer("file content")
 
       {new_state, effects} = EditorState.add_buffer_pure(state, file_buf, context: :open)
-      tb = new_state.shell_state.tab_bar
+      tb = EditorState.tab_bar(new_state)
       agent_tab = TabBar.get(tb, 1)
       file_tab = TabBar.active(tb)
       window = active_window(new_state)
@@ -151,14 +155,14 @@ defmodule MingaEditor.State.BufferLifecycleTest do
       {state, _effects} = EditorState.add_buffer_pure(state, buf2, context: :open)
       {reactivated, effects} = EditorState.add_buffer_pure(state, buf1, context: :open)
       assert effects == []
-      assert reactivated.shell_state.tab_bar.active_id == 1
+      assert EditorState.tab_bar(reactivated).active_id == 1
       assert reactivated.workspace.buffers.active == buf1
 
       assert %Buffers{active: ^buf1} =
-               TabBar.get(reactivated.shell_state.tab_bar, 1).context.buffers
+               TabBar.get(EditorState.tab_bar(reactivated), 1).context.buffers
 
       assert %Buffers{active: ^buf2} =
-               TabBar.get(reactivated.shell_state.tab_bar, 2).context.buffers
+               TabBar.get(EditorState.tab_bar(reactivated), 2).context.buffers
 
       dir1 = Path.join(tmp_dir, "one")
       dir2 = Path.join(tmp_dir, "two")
@@ -171,15 +175,15 @@ defmodule MingaEditor.State.BufferLifecycleTest do
 
       {distinct, effects} = EditorState.add_buffer_pure(state, same_buf2, context: :open)
       assert {:monitor, same_buf2} in effects
-      assert TabBar.count(distinct.shell_state.tab_bar) == 2
-      assert TabBar.get(distinct.shell_state.tab_bar, 1).label == "same.ex"
-      assert TabBar.get(distinct.shell_state.tab_bar, 2).label == "same.ex"
+      assert TabBar.count(EditorState.tab_bar(distinct)) == 2
+      assert TabBar.get(EditorState.tab_bar(distinct), 1).label == "same.ex"
+      assert TabBar.get(EditorState.tab_bar(distinct), 2).label == "same.ex"
 
       assert %Buffers{active: ^same_buf1} =
-               TabBar.get(distinct.shell_state.tab_bar, 1).context.buffers
+               TabBar.get(EditorState.tab_bar(distinct), 1).context.buffers
 
       assert %Buffers{active: ^same_buf2} =
-               TabBar.get(distinct.shell_state.tab_bar, 2).context.buffers
+               TabBar.get(EditorState.tab_bar(distinct), 2).context.buffers
     end
 
     test "agent chat windows without tab bars keep their content when a file buffer is added" do
@@ -223,7 +227,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
       assert opened.workspace.buffers.active == other_buf
 
       assert %Buffers{active: ^other_buf} =
-               TabBar.active(opened.shell_state.tab_bar).context.buffers
+               TabBar.active(EditorState.tab_bar(opened)).context.buffers
 
       preview_buf = start_buffer("preview")
 
@@ -237,7 +241,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
       assert previewed.buffer_add_context == :open
 
       assert %Buffers{active: ^original_buf} =
-               TabBar.active(previewed.shell_state.tab_bar).context.buffers
+               TabBar.active(EditorState.tab_bar(previewed)).context.buffers
     end
   end
 
@@ -343,6 +347,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
 
     %EditorState{
       port_manager: self(),
+      shell_runtime: resolved_traditional_runtime(),
       workspace: %SessionState{
         viewport: Viewport.new(24, 80),
         editing: VimState.new(),
@@ -355,6 +360,10 @@ defmodule MingaEditor.State.BufferLifecycleTest do
         }
       }
     }
+  end
+
+  defp resolved_traditional_runtime do
+    Runtime.new(Registry.get(:traditional), %TraditionalState{})
   end
 
   defp with_buffer_pool(state, buffers) do

--- a/test/minga_editor/state/event_routing_test.exs
+++ b/test/minga_editor/state/event_routing_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.State.EventRoutingTest do
 
   alias MingaEditor.Agent.Events, as: AgentEvents
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaAgent.RuntimeState
   alias MingaEditor.State.Agent, as: AgentState
@@ -19,14 +20,17 @@ defmodule MingaEditor.State.EventRoutingTest do
 
     state = %EditorState{
       port_manager: self(),
-      shell: MingaEditor.Shell.Traditional,
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80)
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{
-        tab_bar: tb,
-        agent: %AgentState{runtime: %RuntimeState{status: :idle}}
-      }
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{
+            tab_bar: tb,
+            agent: %AgentState{runtime: %RuntimeState{status: :idle}}
+          }
+        )
     }
 
     %{state: state, session: session}
@@ -253,13 +257,13 @@ defmodule MingaEditor.State.EventRoutingTest do
   describe "set_tab_session/3" do
     test "sets the session pid on a tab for event routing" do
       %{state: state} = make_state()
-      tab = TabBar.active(state.shell_state.tab_bar)
+      tab = TabBar.active(state.shell_runtime.state.tab_bar)
       new_session = spawn(fn -> :timer.sleep(:infinity) end)
 
       state = EditorState.set_tab_session(state, tab.id, new_session)
 
-      tab = TabBar.get(state.shell_state.tab_bar, tab.id)
-      workspace = TabBar.active_workspace(state.shell_state.tab_bar)
+      tab = TabBar.get(state.shell_runtime.state.tab_bar, tab.id)
+      workspace = TabBar.active_workspace(state.shell_runtime.state.tab_bar)
       assert tab.session == new_session
       assert workspace.session == new_session
     end
@@ -283,7 +287,7 @@ defmodule MingaEditor.State.EventRoutingTest do
     test "status_changed syncs agent_status on the agent tab" do
       %{state: state, session: session} = make_state()
 
-      {tb, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Agent")
+      {tb, agent_tab} = TabBar.add(state.shell_runtime.state.tab_bar, :agent, "Agent")
 
       tb =
         tb
@@ -294,14 +298,14 @@ defmodule MingaEditor.State.EventRoutingTest do
 
       {new_state, _effects} = AgentEvents.handle(state, {:status_changed, :thinking})
 
-      agent_tab = TabBar.get(new_state.shell_state.tab_bar, agent_tab.id)
+      agent_tab = TabBar.get(new_state.shell_runtime.state.tab_bar, agent_tab.id)
       assert agent_tab.agent_status == :thinking
     end
 
     test "status_changed to :idle updates tab status" do
       %{state: state, session: session} = make_state()
 
-      {tb, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Agent")
+      {tb, agent_tab} = TabBar.add(state.shell_runtime.state.tab_bar, :agent, "Agent")
 
       tb =
         tb
@@ -313,7 +317,7 @@ defmodule MingaEditor.State.EventRoutingTest do
       {state, _} = AgentEvents.handle(state, {:status_changed, :thinking})
       {new_state, _} = AgentEvents.handle(state, {:status_changed, :idle})
 
-      agent_tab = TabBar.get(new_state.shell_state.tab_bar, agent_tab.id)
+      agent_tab = TabBar.get(new_state.shell_runtime.state.tab_bar, agent_tab.id)
       assert agent_tab.agent_status == :idle
     end
   end

--- a/test/minga_editor/state/modal_overlay_test.exs
+++ b/test/minga_editor/state/modal_overlay_test.exs
@@ -2,9 +2,12 @@ defmodule MingaEditor.State.ModalOverlayTest do
   use ExUnit.Case, async: true
 
   alias Minga.Editing.Completion
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.CompletionTrigger
+  alias MingaEditor.State.ModalOverlay.CommandCompletion, as: CommandCompletionPayload
   alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
   alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
@@ -21,7 +24,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       workspace: %SessionState{
         viewport: %Viewport{top: 0, left: 0, rows: 10, cols: 40}
       },
-      shell_state: %ShellState{}
+      shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{})
     }
   end
 
@@ -95,7 +98,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       result = ModalOverlay.open(state, :picker, payload)
 
-      assert result.shell_state.modal == {:picker, payload}
+      assert result.shell_runtime.state.modal == {:picker, payload}
     end
 
     test "writes the prompt variant" do
@@ -104,7 +107,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       result = ModalOverlay.open(state, :prompt, payload)
 
-      assert result.shell_state.modal == {:prompt, payload}
+      assert result.shell_runtime.state.modal == {:prompt, payload}
     end
 
     test "writes the completion modal payload" do
@@ -113,8 +116,23 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       result = ModalOverlay.open(state, :completion, payload)
 
-      assert result.shell_state.modal == {:completion, payload}
+      assert result.shell_runtime.state.modal == {:completion, payload}
       assert ModalOverlay.completion(result) == payload.completion
+    end
+
+    test "accessors read flattened render-pipeline shell state" do
+      completion_payload = completion_payload(7)
+      transfer = %{shell_state: %{modal: {:completion, completion_payload}}}
+
+      assert ModalOverlay.completion(transfer) == completion_payload.completion
+      assert ModalOverlay.completion_trigger(transfer) == completion_payload.trigger
+
+      command_payload = CommandCompletionPayload.new(filter_text: "w")
+      transfer = %{shell_state: %{modal: {:command_completion, command_payload}}}
+      assert ModalOverlay.command_completion(transfer) == command_payload
+
+      assert ModalOverlay.completion_trigger(%{shell_state: %{modal: :none}}) ==
+               CompletionTrigger.new()
     end
 
     test "writes the conflict variant" do
@@ -124,7 +142,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       result = ModalOverlay.open(state, :conflict, payload)
 
-      assert result.shell_state.modal == {:conflict, payload}
+      assert result.shell_runtime.state.modal == {:conflict, payload}
     end
   end
 
@@ -137,7 +155,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       prompt = prompt_payload("hello")
       result = ModalOverlay.open(state, :prompt, prompt)
 
-      assert result.shell_state.modal == {:prompt, prompt}
+      assert result.shell_runtime.state.modal == {:prompt, prompt}
     end
 
     test "replacing completion with picker clears the completion accessor" do
@@ -148,7 +166,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       picker = picker_payload()
       result = ModalOverlay.open(state, :picker, picker)
 
-      assert result.shell_state.modal == {:picker, picker}
+      assert result.shell_runtime.state.modal == {:picker, picker}
       assert ModalOverlay.completion(result) == nil
     end
   end
@@ -182,7 +200,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       next = ConflictPayload.new(self(), "different message", opened_at: 2_000)
       result = ModalOverlay.open(state, :conflict, next)
 
-      assert result.shell_state.modal == {:conflict, next}
+      assert result.shell_runtime.state.modal == {:conflict, next}
     end
   end
 
@@ -195,7 +213,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
       picker = picker_payload()
       result = ModalOverlay.transition(state, :picker, picker)
 
-      assert result.shell_state.modal == {:picker, picker}
+      assert result.shell_runtime.state.modal == {:picker, picker}
     end
   end
 
@@ -207,7 +225,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       result = ModalOverlay.close(state)
 
-      assert result.shell_state.modal == :none
+      assert result.shell_runtime.state.modal == :none
     end
 
     test "dismiss clears the active prompt" do
@@ -217,7 +235,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       result = ModalOverlay.dismiss(state)
 
-      assert result.shell_state.modal == :none
+      assert result.shell_runtime.state.modal == :none
     end
 
     test "dismiss clears an active conflict" do
@@ -227,7 +245,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       result = ModalOverlay.dismiss(state)
 
-      assert result.shell_state.modal == :none
+      assert result.shell_runtime.state.modal == :none
     end
 
     test "close clears the completion accessor when a completion is active" do
@@ -237,7 +255,7 @@ defmodule MingaEditor.State.ModalOverlayTest do
 
       result = ModalOverlay.close(state)
 
-      assert result.shell_state.modal == :none
+      assert result.shell_runtime.state.modal == :none
       assert ModalOverlay.completion(result) == nil
     end
 
@@ -252,32 +270,34 @@ defmodule MingaEditor.State.ModalOverlayTest do
     test "dismisses a completion modal whose owner doesn't match the active tab" do
       state = %{
         base_state()
-        | shell_state: %ShellState{
-            modal: :none,
-            tab_bar: tab_bar_with_active(99)
-          }
+        | shell_runtime:
+            Runtime.new(
+              Runtime.default_entry(),
+              %ShellState{modal: :none, tab_bar: tab_bar_with_active(99)}
+            )
       }
 
       state = ModalOverlay.open(state, :completion, completion_payload(1))
-      assert ModalOverlay.match(state.shell_state.modal, :completion)
+      assert ModalOverlay.match(state.shell_runtime.state.modal, :completion)
 
       result = ModalOverlay.dismiss_if_stale(state)
-      assert result.shell_state.modal == :none
+      assert result.shell_runtime.state.modal == :none
     end
 
     test "leaves completion alone when its owner matches the active tab" do
       state = %{
         base_state()
-        | shell_state: %ShellState{
-            modal: :none,
-            tab_bar: tab_bar_with_active(7)
-          }
+        | shell_runtime:
+            Runtime.new(
+              Runtime.default_entry(),
+              %ShellState{modal: :none, tab_bar: tab_bar_with_active(7)}
+            )
       }
 
       state = ModalOverlay.open(state, :completion, completion_payload(7))
       result = ModalOverlay.dismiss_if_stale(state)
 
-      assert ModalOverlay.match(result.shell_state.modal, :completion)
+      assert ModalOverlay.match(result.shell_runtime.state.modal, :completion)
     end
 
     test "no-op for non-completion modals" do

--- a/test/minga_editor/state/shell_callbacks_test.exs
+++ b/test/minga_editor/state/shell_callbacks_test.exs
@@ -13,6 +13,9 @@ defmodule MingaEditor.State.ShellCallbacksTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
@@ -52,6 +55,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
 
     state = %EditorState{
       port_manager: self(),
+      shell_runtime: Runtime.new(Registry.get(:traditional), %TraditionalState{}),
       workspace: %SessionState{
         viewport: Viewport.new(24, 80),
         editing: VimState.new(),
@@ -76,6 +80,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
 
     state = %EditorState{
       port_manager: self(),
+      shell_runtime: Runtime.new(Registry.get(:traditional), %TraditionalState{}),
       workspace: %SessionState{
         viewport: Viewport.new(24, 80),
         editing: VimState.new(),
@@ -111,7 +116,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
 
       assert new_state.workspace.buffers.active == buf2
 
-      active_tab = TabBar.active(new_state.shell_state.tab_bar)
+      active_tab = TabBar.active(EditorState.tab_bar(new_state))
       assert active_tab.context.buffers.active == buf2
       assert active_tab.context.buffers.active == new_state.workspace.buffers.active
     end
@@ -132,7 +137,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
 
       assert new_state.workspace.buffers.active == buf2
 
-      active_tab = TabBar.active(new_state.shell_state.tab_bar)
+      active_tab = TabBar.active(EditorState.tab_bar(new_state))
       assert active_tab.kind == :agent
       assert active_tab.context.buffers.active == buf2
       assert active_tab.context.buffers.active == new_state.workspace.buffers.active
@@ -147,7 +152,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
 
       tab = EditorState.find_tab_by_buffer(new_state, buf2)
       assert %Tab{kind: :file} = tab
-      assert tab.id == new_state.shell_state.tab_bar.active_id
+      assert tab.id == EditorState.tab_bar(new_state).active_id
     end
 
     test "Traditional: dirty marker queries correct buffer after switch" do
@@ -162,7 +167,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
 
       new_state = EditorState.switch_buffer(state, 1)
 
-      active_tab = TabBar.active(new_state.shell_state.tab_bar)
+      active_tab = TabBar.active(EditorState.tab_bar(new_state))
       tab_buf = active_tab.context.buffers.active
       assert tab_buf == buf2
       refute BufferProcess.dirty?(tab_buf)
@@ -176,14 +181,14 @@ defmodule MingaEditor.State.ShellCallbacksTest do
       state = EditorState.add_buffer(state, buf3)
 
       state = EditorState.switch_buffer(state, 1)
-      assert TabBar.active(state.shell_state.tab_bar).context.buffers.active == buf2
+      assert TabBar.active(EditorState.tab_bar(state)).context.buffers.active == buf2
 
       state = EditorState.switch_buffer(state, 2)
-      assert TabBar.active(state.shell_state.tab_bar).context.buffers.active == buf3
+      assert TabBar.active(EditorState.tab_bar(state)).context.buffers.active == buf3
 
       state = EditorState.switch_buffer(state, 0)
       buf1 = state.workspace.buffers.active
-      assert TabBar.active(state.shell_state.tab_bar).context.buffers.active == buf1
+      assert TabBar.active(EditorState.tab_bar(state)).context.buffers.active == buf1
 
       assert EditorState.find_tab_by_buffer(state, buf1) != nil
     end
@@ -336,7 +341,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
 
       # Should not crash
       new_state = EditorState.set_tab_session(state, 1, session_pid)
-      assert new_state.shell_state == state.shell_state
+      assert new_state.shell_runtime == state.shell_runtime
     end
   end
 
@@ -352,7 +357,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
 
     test "no-op when switching to already active tab" do
       state = state_with_file_tab()
-      tb = state.shell_state.tab_bar
+      tb = EditorState.tab_bar(state)
       active_id = tb.active_id
 
       {new_state, effects} = EditorState.switch_tab_pure(state, active_id)

--- a/test/minga_editor/state/snapshot_test.exs
+++ b/test/minga_editor/state/snapshot_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.State.SnapshotTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.FeatureState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -30,7 +31,11 @@ defmodule MingaEditor.State.SnapshotTest do
         },
         keymap_scope: Keyword.get(opts, :keymap_scope, :editor)
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: Keyword.get(opts, :tab_bar)}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{tab_bar: Keyword.get(opts, :tab_bar)}
+        )
     }
   end
 
@@ -190,7 +195,7 @@ defmodule MingaEditor.State.SnapshotTest do
         |> EditorState.update_workspace(&MingaEditor.Session.State.set_file_tree(&1, file_tree))
 
       file_restored = EditorState.restore_tab_context(file_state, %{})
-      file_ctx = TabBar.active(file_restored.shell_state.tab_bar).context
+      file_ctx = TabBar.active(EditorState.tab_bar(file_restored)).context
 
       assert file_ctx.file_tree.project_root == file_tree.project_root
       assert file_ctx.file_tree.tree == nil
@@ -202,7 +207,7 @@ defmodule MingaEditor.State.SnapshotTest do
         |> EditorState.update_workspace(&MingaEditor.Session.State.set_file_tree(&1, file_tree))
 
       agent_restored = EditorState.restore_tab_context(agent_state, %{})
-      agent_ctx = TabBar.active(agent_restored.shell_state.tab_bar).context
+      agent_ctx = TabBar.active(EditorState.tab_bar(agent_restored)).context
 
       assert agent_ctx.file_tree.project_root == file_tree.project_root
       assert agent_ctx.file_tree.tree == nil
@@ -221,7 +226,7 @@ defmodule MingaEditor.State.SnapshotTest do
 
       restored = EditorState.restore_tab_context(state, %{})
 
-      updated_tb = restored.shell_state.tab_bar
+      updated_tb = EditorState.tab_bar(restored)
       stored_ctx = TabBar.get(updated_tb, tab.id).context
 
       refute Context.empty?(stored_ctx)
@@ -341,10 +346,10 @@ defmodule MingaEditor.State.SnapshotTest do
       # Should have restored tab b's context
       assert switched.workspace.editing.mode == :insert
       assert switched.workspace.buffers.active == buf_b
-      assert switched.shell_state.tab_bar.active_id == tab_b.id
+      assert EditorState.tab_bar(switched).active_id == tab_b.id
 
       # Tab a should have been snapshotted with flat context
-      saved_a = TabBar.get(switched.shell_state.tab_bar, tab_a.id)
+      saved_a = TabBar.get(EditorState.tab_bar(switched), tab_a.id)
       assert saved_a.context.keymap_scope == :editor
       assert saved_a.context.editing.mode == :normal
       assert saved_a.context.buffers.active == buf_a
@@ -369,7 +374,7 @@ defmodule MingaEditor.State.SnapshotTest do
       state = make_state(buffer: buf, tab_bar: tb, mode: :normal, keymap_scope: :editor)
       switched = EditorState.switch_tab(state, tab_b.id)
 
-      stored_ctx = TabBar.get(switched.shell_state.tab_bar, tab_b.id).context
+      stored_ctx = TabBar.get(EditorState.tab_bar(switched), tab_b.id).context
       refute Context.empty?(stored_ctx)
       assert stored_ctx.keymap_scope == :editor
       assert stored_ctx.buffers.active == buf

--- a/test/minga_editor/state/tab_switch_test.exs
+++ b/test/minga_editor/state/tab_switch_test.exs
@@ -159,7 +159,7 @@ defmodule MingaEditor.State.TabSwitchTest do
   describe "switch_tab_pure/2" do
     test "no-op when tab bar is nil" do
       state = base_state()
-      assert state.shell_state.tab_bar == nil
+      assert EditorState.tab_bar(state) == nil
 
       {new_state, effects} = EditorState.switch_tab_pure(state, 42)
 
@@ -169,7 +169,7 @@ defmodule MingaEditor.State.TabSwitchTest do
 
     test "no-op when switching to already active tab" do
       {state, _buf1, _buf2} = state_with_two_file_tabs()
-      tb = state.shell_state.tab_bar
+      tb = EditorState.tab_bar(state)
       active_id = tb.active_id
 
       {new_state, effects} = EditorState.switch_tab_pure(state, active_id)
@@ -180,7 +180,7 @@ defmodule MingaEditor.State.TabSwitchTest do
 
     test "file-to-file preserves both tab contexts" do
       {state, buf1, buf2} = state_with_two_file_tabs()
-      tb = state.shell_state.tab_bar
+      tb = EditorState.tab_bar(state)
       tab2_id = Enum.find(tb.tabs, &(&1.id != tb.active_id)).id
 
       # Confirm starting state
@@ -199,7 +199,7 @@ defmodule MingaEditor.State.TabSwitchTest do
       assert :start_spinner in effects
 
       # Tab 1's context should be snapshotted (preserved for later restore)
-      tb = new_state.shell_state.tab_bar
+      tb = EditorState.tab_bar(new_state)
       tab1 = TabBar.get(tb, 1)
       assert tab1.context.buffers.active == buf1
     end
@@ -218,7 +218,7 @@ defmodule MingaEditor.State.TabSwitchTest do
       assert new_state.workspace.keymap_scope == :agent
 
       # The tab bar should show the agent tab as active
-      tb = new_state.shell_state.tab_bar
+      tb = EditorState.tab_bar(new_state)
       assert tb.active_id == agent_tab_id
       active_tab = TabBar.active(tb)
       assert active_tab.kind == :agent
@@ -243,14 +243,14 @@ defmodule MingaEditor.State.TabSwitchTest do
       assert new_state.workspace.keymap_scope == :editor
 
       # The agent tab's context should be preserved
-      tb = new_state.shell_state.tab_bar
+      tb = EditorState.tab_bar(new_state)
       agent_tab = TabBar.get(tb, agent_tab_id)
       assert agent_tab.context.keymap_scope == :agent
     end
 
     test "round-trip invariant: switch away and back restores equivalent state" do
       {state, _buf1, buf2} = state_with_two_file_tabs()
-      tb = state.shell_state.tab_bar
+      tb = EditorState.tab_bar(state)
       tab2_id = Enum.find(tb.tabs, &(&1.id != tb.active_id)).id
 
       # Capture the workspace state before any switch
@@ -294,7 +294,7 @@ defmodule MingaEditor.State.TabSwitchTest do
 
     test "invalidates layout after switch" do
       {state, _buf1, _buf2} = state_with_two_file_tabs()
-      tb = state.shell_state.tab_bar
+      tb = EditorState.tab_bar(state)
       tab2_id = Enum.find(tb.tabs, &(&1.id != tb.active_id)).id
 
       {new_state, _effects} = EditorState.switch_tab_pure(state, tab2_id)
@@ -305,7 +305,7 @@ defmodule MingaEditor.State.TabSwitchTest do
 
     test "tab switch restores the target tab's pending LSP refs" do
       {state, _buf1, buf2} = state_with_two_file_tabs()
-      tb = state.shell_state.tab_bar
+      tb = EditorState.tab_bar(state)
       current_id = tb.active_id
       target_id = Enum.find(tb.tabs, &(&1.id != tb.active_id)).id
 
@@ -321,20 +321,20 @@ defmodule MingaEditor.State.TabSwitchTest do
 
       assert switched.workspace.lsp_pending == pending_target
 
-      assert TabBar.get(switched.shell_state.tab_bar, current_id).context.lsp_pending ==
+      assert TabBar.get(EditorState.tab_bar(switched), current_id).context.lsp_pending ==
                pending_current
 
       {switched_back, _effects} = EditorState.switch_tab_pure(switched, current_id)
 
       assert switched_back.workspace.lsp_pending == pending_current
 
-      assert TabBar.get(switched_back.shell_state.tab_bar, target_id).context.lsp_pending ==
+      assert TabBar.get(EditorState.tab_bar(switched_back), target_id).context.lsp_pending ==
                pending_target
     end
 
     test "tab switch preserves live highlighting and ignores stale target parser state" do
       {state, buf1, buf2} = state_with_two_file_tabs()
-      tb = state.shell_state.tab_bar
+      tb = EditorState.tab_bar(state)
       current_id = tb.active_id
       target_id = Enum.find(tb.tabs, &(&1.id != tb.active_id)).id
 
@@ -360,7 +360,7 @@ defmodule MingaEditor.State.TabSwitchTest do
 
       assert switched.highlighting == live_highlight
 
-      refute :highlight in TabBar.get(switched.shell_state.tab_bar, current_id).context.present_fields
+      refute :highlight in TabBar.get(EditorState.tab_bar(switched), current_id).context.present_fields
 
       {switched_back, _effects} = EditorState.switch_tab_pure(switched, current_id)
 
@@ -369,7 +369,7 @@ defmodule MingaEditor.State.TabSwitchTest do
 
     test "tab switch preserves live injection ranges and ignores stale target ranges" do
       {state, buf1, buf2} = state_with_two_file_tabs()
-      tb = state.shell_state.tab_bar
+      tb = EditorState.tab_bar(state)
       current_id = tb.active_id
       target_id = Enum.find(tb.tabs, &(&1.id != tb.active_id)).id
 
@@ -390,7 +390,7 @@ defmodule MingaEditor.State.TabSwitchTest do
 
       assert switched.injection_ranges == live_ranges
 
-      refute :injection_ranges in TabBar.get(switched.shell_state.tab_bar, current_id).context.present_fields
+      refute :injection_ranges in TabBar.get(EditorState.tab_bar(switched), current_id).context.present_fields
 
       {switched_back, _effects} = EditorState.switch_tab_pure(switched, current_id)
 

--- a/test/minga_editor/state_test.exs
+++ b/test/minga_editor/state_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.StateTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Project.FileRef
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -177,7 +178,7 @@ defmodule MingaEditor.StateTest do
       state = state_with_agent_tab()
       file_buf = start_buffer("file content")
       new_state = EditorState.add_buffer(state, file_buf)
-      active_tab = TabBar.active(new_state.shell_state.tab_bar)
+      active_tab = TabBar.active(new_state.shell_runtime.state.tab_bar)
       active_window = active_window(new_state)
       tab_window = active_tab.context.windows.map[active_tab.context.windows.active]
 
@@ -278,11 +279,11 @@ defmodule MingaEditor.StateTest do
         workspace:
           %SessionState{viewport: Viewport.new(24, 80)}
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
-        shell_state: %ShellState{tab_bar: tab_bar}
+        shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{tab_bar: tab_bar})
       }
 
       updated_state = EditorState.rebind_buffer_file_identity(state, target_buffer)
-      updated_tb = updated_state.shell_state.tab_bar
+      updated_tb = updated_state.shell_runtime.state.tab_bar
 
       assert TabBar.get(updated_tb, matching_tab.id).file_ref == target_ref
       assert TabBar.get(updated_tb, list_only_tab.id).file_ref == old_list_ref
@@ -367,11 +368,11 @@ defmodule MingaEditor.StateTest do
             buffers: %Buffers{active: active_buffer, list: [active_buffer], active_index: 0}
           }
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
-        shell_state: %ShellState{tab_bar: tab_bar}
+        shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{tab_bar: tab_bar})
       }
 
       updated_state = EditorState.rebind_buffer_file_identity(state, target_buffer)
-      updated_tb = updated_state.shell_state.tab_bar
+      updated_tb = updated_state.shell_runtime.state.tab_bar
 
       assert TabBar.get(updated_tb, inactive_tab.id).file_ref == new_ref
       assert TabBar.get(updated_tb, active_tab.id).file_ref == active_ref

--- a/test/minga_editor/status_bar/data_safe_mode_test.exs
+++ b/test/minga_editor/status_bar/data_safe_mode_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.StatusBar.DataSafeModeTest do
 
   alias Minga.Config.Options
   alias MingaEditor.StatusBar.Data
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Viewport
@@ -20,7 +21,7 @@ defmodule MingaEditor.StatusBar.DataSafeModeTest do
       port_manager: self(),
       options_server: options,
       workspace: %SessionState{viewport: Viewport.new(24, 80)},
-      shell_state: %MingaEditor.Shell.Traditional.State{}
+      shell_runtime: Runtime.new(Runtime.default_entry(), %MingaEditor.Shell.Traditional.State{})
     }
 
     {:buffer, buffer_data} = Data.from_state(state)

--- a/test/minga_editor/status_bar/data_test.exs
+++ b/test/minga_editor/status_bar/data_test.exs
@@ -10,6 +10,8 @@ defmodule MingaEditor.StatusBar.DataTest do
   alias MingaAgent.SessionMetadata
   alias MingaAgent.Subagent.Handle
   alias MingaEditor.StatusBar.Data
+  alias MingaEditor.Shell.Registry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -234,7 +236,8 @@ defmodule MingaEditor.StatusBar.DataTest do
       port_manager: self(),
       options_server: options,
       workspace: %SessionState{viewport: Viewport.new(24, 80)},
-      shell_state: %MingaEditor.Shell.Traditional.State{}
+      shell_runtime:
+        Runtime.new(Registry.get(:traditional), %MingaEditor.Shell.Traditional.State{})
     }
 
     {:buffer, data} = Data.from_state(state)
@@ -322,7 +325,11 @@ defmodule MingaEditor.StatusBar.DataTest do
     %EditorState{
       port_manager: self(),
       workspace: %SessionState{viewport: Viewport.new(24, 80)},
-      shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tab_bar}
+      shell_runtime:
+        Runtime.new(
+          Registry.get(:traditional),
+          %MingaEditor.Shell.Traditional.State{tab_bar: tab_bar}
+        )
     }
   end
 
@@ -339,7 +346,11 @@ defmodule MingaEditor.StatusBar.DataTest do
           next_id: 2
         }
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tab_bar}
+      shell_runtime:
+        Runtime.new(
+          Registry.get(:traditional),
+          %MingaEditor.Shell.Traditional.State{tab_bar: tab_bar}
+        )
     }
   end
 
@@ -353,7 +364,8 @@ defmodule MingaEditor.StatusBar.DataTest do
         port_manager: self(),
         options_server: options_server,
         workspace: workspace,
-        shell_state: %MingaEditor.Shell.Traditional.State{}
+        shell_runtime:
+          Runtime.new(Registry.get(:traditional), %MingaEditor.Shell.Traditional.State{})
       }
 
     {state, buf}

--- a/test/minga_editor/ui/picker/command_source_test.exs
+++ b/test/minga_editor/ui/picker/command_source_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.UI.Picker.CommandSourceTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Command
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.Viewport
@@ -36,7 +37,8 @@ defmodule MingaEditor.UI.Picker.CommandSourceTest do
           buffers: %Buffers{active: buf, list: [buf], active_index: 0},
           editing: VimState.new()
         },
-        shell_state: %MingaEditor.Shell.Traditional.State{}
+        shell_runtime:
+          Runtime.new(Runtime.default_entry(), %MingaEditor.Shell.Traditional.State{})
       }
 
       result =
@@ -48,7 +50,7 @@ defmodule MingaEditor.UI.Picker.CommandSourceTest do
       # Should have opened the scope picker, not set pending_command
       assert is_nil(Map.get(result, :pending_command))
       # The scope picker should be open
-      {:picker, %{picker_ui: picker_ui}} = result.shell_state.modal
+      {:picker, %{picker_ui: picker_ui}} = Runtime.state(result.shell_runtime).modal
       assert picker_ui.picker != nil
       assert picker_ui.source == MingaEditor.UI.Picker.OptionScopeSource
       # Context should carry the option info

--- a/test/minga_editor/ui/picker/language_source_test.exs
+++ b/test/minga_editor/ui/picker/language_source_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.UI.Picker.LanguageSourceTest do
   @moduledoc "Tests for the language picker source."
   use ExUnit.Case, async: true
 
+  alias MingaEditor.State, as: EditorState
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Search
@@ -86,17 +87,20 @@ defmodule MingaEditor.UI.Picker.LanguageSourceTest do
 
       new_state = BufferManagement.apply_filetype_change(state, :python)
       assert BufferProcess.filetype(buf) == :python
-      assert new_state.shell_state.status_msg =~ "python"
+      assert EditorState.status_msg(new_state) =~ "python"
     end
 
     test "returns error message when no active buffer" do
-      state = %{
-        workspace: %{buffers: %{active: nil}},
-        shell_state: %MingaEditor.Shell.Traditional.State{status_msg: nil}
+      state = %EditorState{
+        port_manager: nil,
+        workspace: %MingaEditor.Session.State{
+          viewport: Viewport.new(80, 24),
+          buffers: %Buffers{}
+        }
       }
 
       new_state = BufferManagement.apply_filetype_change(state, :python)
-      assert new_state.shell_state.status_msg =~ "No active buffer"
+      assert EditorState.status_msg(new_state) =~ "No active buffer"
     end
   end
 
@@ -122,9 +126,12 @@ defmodule MingaEditor.UI.Picker.LanguageSourceTest do
   defp state_with_buffer(content, filetype) do
     {:ok, buf} = BufferProcess.start_link(content: content, filetype: filetype)
 
-    %{
-      workspace: %{buffers: %{active: buf, list: [buf], active_index: 0}},
-      shell_state: %MingaEditor.Shell.Traditional.State{status_msg: nil}
+    %EditorState{
+      port_manager: nil,
+      workspace: %MingaEditor.Session.State{
+        viewport: Viewport.new(80, 24),
+        buffers: %Buffers{active: buf, list: [buf], active_index: 0}
+      }
     }
   end
 end

--- a/test/minga_editor/ui/picker/option_scope_source_test.exs
+++ b/test/minga_editor/ui/picker/option_scope_source_test.exs
@@ -7,6 +7,10 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Config.Options
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Search
   alias MingaEditor.VimState
@@ -46,10 +50,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
       {:ok, buf} = BufferProcess.start_link(content: "hello", filetype: :elixir)
       assert BufferProcess.get_option(buf, :wrap) == false
 
-      state = %{
-        workspace: %{buffers: %{active: buf}},
-        shell_state: %MingaEditor.Shell.Traditional.State{status_msg: nil}
-      }
+      state = state_with_buffer(buf)
 
       result =
         OptionScopeSource.on_select(
@@ -58,7 +59,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
         )
 
       assert BufferProcess.get_option(buf, :wrap) == true
-      assert result.shell_state.status_msg =~ "this buffer"
+      assert result.shell_runtime.state.status_msg =~ "this buffer"
     end
   end
 
@@ -68,10 +69,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
       original = Options.get(:wrap)
       ctx = %{option_name: :wrap, new_value: !original}
 
-      state = %{
-        workspace: %{buffers: %{active: buf}},
-        shell_state: %MingaEditor.Shell.Traditional.State{status_msg: nil}
-      }
+      state = state_with_buffer(buf)
 
       result =
         OptionScopeSource.on_select(
@@ -80,7 +78,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
         )
 
       assert Options.get(:wrap) == !original
-      assert result.shell_state.status_msg =~ "all buffers"
+      assert result.shell_runtime.state.status_msg =~ "all buffers"
 
       Options.set(:wrap, original)
     end
@@ -95,7 +93,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
   describe "on_select after picker close (regression for context-in-id fix)" do
     # `PickerUI.run_select_and_close/3` resets the modal to `:none` before
     # invoking `on_select`. Previously this source read the picker context
-    # from `state.shell_state.picker_ui.context`, which had been cleared by
+    # from the active shell runtime's picker context, which had been cleared by
     # the close, so the option was never applied. The fix carries the
     # context inside `Item.id`. This test pins that contract by passing a
     # state with `modal: :none` (matching what `on_select` actually sees in
@@ -105,13 +103,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
       {:ok, buf} = BufferProcess.start_link(content: "hello", filetype: :elixir)
       assert BufferProcess.get_option(buf, :wrap) == false
 
-      state = %{
-        workspace: %{buffers: %{active: buf}},
-        shell_state: %MingaEditor.Shell.Traditional.State{
-          status_msg: nil,
-          modal: :none
-        }
-      }
+      state = state_with_buffer(buf)
 
       result =
         OptionScopeSource.on_select(
@@ -120,7 +112,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
         )
 
       assert BufferProcess.get_option(buf, :wrap) == true
-      assert result.shell_state.status_msg =~ "this buffer"
+      assert result.shell_runtime.state.status_msg =~ "this buffer"
     end
 
     test "applies global-scoped option when modal is already :none" do
@@ -128,13 +120,7 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
       original = Options.get(:wrap)
       ctx = %{option_name: :wrap, new_value: !original}
 
-      state = %{
-        workspace: %{buffers: %{active: buf}},
-        shell_state: %MingaEditor.Shell.Traditional.State{
-          status_msg: nil,
-          modal: :none
-        }
-      }
+      state = state_with_buffer(buf)
 
       result =
         OptionScopeSource.on_select(
@@ -143,9 +129,20 @@ defmodule MingaEditor.UI.Picker.OptionScopeSourceTest do
         )
 
       assert Options.get(:wrap) == !original
-      assert result.shell_state.status_msg =~ "all buffers"
+      assert result.shell_runtime.state.status_msg =~ "all buffers"
 
       Options.set(:wrap, original)
     end
+  end
+
+  defp state_with_buffer(buffer) do
+    %EditorState{
+      port_manager: self(),
+      workspace: %SessionState{
+        buffers: %Buffers{active: buffer, list: [buffer], active_index: 0},
+        viewport: Viewport.new(24, 80)
+      },
+      shell_runtime: Runtime.new(Runtime.default_entry(), %TraditionalState{})
+    }
   end
 end

--- a/test/minga_editor/ui/picker/pending_reviews_source_test.exs
+++ b/test/minga_editor/ui/picker/pending_reviews_source_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.UI.Picker.PendingReviewsSourceTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Search
@@ -51,7 +52,7 @@ defmodule MingaEditor.UI.Picker.PendingReviewsSourceTest do
         buffers: %Buffers{list: [buffer], active: buffer, active_index: 0},
         keymap_scope: :editor
       },
-      shell_state: %ShellState{tab_bar: tab_bar}
+      shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{tab_bar: tab_bar})
     }
   end
 
@@ -152,8 +153,8 @@ defmodule MingaEditor.UI.Picker.PendingReviewsSourceTest do
           state
         )
 
-      assert TabBar.active_workspace_id(switched.shell_state.tab_bar) == workspace.id
-      assert [tab] = TabBar.tabs_in_workspace(switched.shell_state.tab_bar, workspace.id)
+      assert TabBar.active_workspace_id(EditorState.tab_bar(switched)) == workspace.id
+      assert [tab] = TabBar.tabs_in_workspace(EditorState.tab_bar(switched), workspace.id)
       assert tab.kind == :agent
     end
 
@@ -181,7 +182,7 @@ defmodule MingaEditor.UI.Picker.PendingReviewsSourceTest do
       switched =
         PendingReviewsSource.on_select(%Item{id: workspace.id, label: "Needs review"}, state)
 
-      assert switched.shell_state.tab_bar.active_id == tab2.id
+      assert EditorState.tab_bar(switched).active_id == tab2.id
       assert switched.workspace.buffers.active == buf_b
     end
   end

--- a/test/minga_editor/ui/picker/theme_source_test.exs
+++ b/test/minga_editor/ui/picker/theme_source_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaEditor.UI.Picker.ThemeSourceTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.Picker, as: PickerState
@@ -83,10 +84,13 @@ defmodule MingaEditor.UI.Picker.ThemeSourceTest do
     test "restores the original theme from picker state" do
       original = Theme.get!(:doom_one)
 
-      state = %{
-        theme: Theme.get!(:one_dark),
-        shell_state: %{modal: {:picker, %{picker_ui: %{restore_theme: original}}}}
-      }
+      state =
+        base_state()
+        |> EditorState.apply_theme(Theme.get!(:one_dark))
+        |> ModalOverlay.open(
+          :picker,
+          PickerPayload.new(%PickerState{restore_theme: original})
+        )
 
       restored = ThemeSource.on_cancel(state)
       assert restored.theme.name == :doom_one
@@ -116,10 +120,7 @@ defmodule MingaEditor.UI.Picker.ThemeSourceTest do
     end
 
     test "returns state unchanged when no restore_theme" do
-      state = %{
-        theme: Theme.get!(:one_dark),
-        shell_state: %{modal: :none}
-      }
+      state = base_state() |> EditorState.apply_theme(Theme.get!(:one_dark))
 
       assert ThemeSource.on_cancel(state) == state
     end

--- a/test/minga_editor/ui/picker/workspace_icon_source_test.exs
+++ b/test/minga_editor/ui/picker/workspace_icon_source_test.exs
@@ -1,6 +1,10 @@
 defmodule MingaEditor.UI.Picker.WorkspaceIconSourceTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Search
   alias MingaEditor.State.Tab
@@ -89,18 +93,26 @@ defmodule MingaEditor.UI.Picker.WorkspaceIconSourceTest do
       tb = TabBar.move_tab_to_workspace(tb, 2, group.id)
       tb = TabBar.switch_to_workspace(tb, group.id)
 
-      state = %{shell_state: %{tab_bar: tb}}
+      state = state_with_tab_bar(tb)
       item = %Item{id: "brain", label: "brain"}
       new_state = WorkspaceIconSource.on_select(item, state)
-      g = TabBar.active_workspace(new_state.shell_state.tab_bar)
+      g = TabBar.active_workspace(new_state.shell_runtime.state.tab_bar)
       assert g.icon == "brain"
     end
   end
 
   describe "on_cancel/1" do
     test "returns state unchanged" do
-      state = %{shell_state: %{tab_bar: TabBar.new(Tab.new_file(1, "a.ex"))}}
+      state = state_with_tab_bar(TabBar.new(Tab.new_file(1, "a.ex")))
       assert WorkspaceIconSource.on_cancel(state) == state
     end
+  end
+
+  defp state_with_tab_bar(tab_bar) do
+    %EditorState{
+      port_manager: self(),
+      workspace: %SessionState{viewport: Viewport.new(24, 80)},
+      shell_runtime: Runtime.new(Runtime.default_entry(), %TraditionalState{tab_bar: tab_bar})
+    }
   end
 end

--- a/test/minga_editor/ui/picker/workspace_source_test.exs
+++ b/test/minga_editor/ui/picker/workspace_source_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceSourceTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Mode
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Search
@@ -40,7 +41,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceSourceTest do
         buffers: %Buffers{list: [buffer], active: buffer, active_index: 0},
         keymap_scope: :editor
       },
-      shell_state: %ShellState{tab_bar: tab_bar}
+      shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{tab_bar: tab_bar})
     }
   end
 
@@ -121,10 +122,10 @@ defmodule MingaEditor.UI.Picker.WorkspaceSourceTest do
 
       assert switched.workspace.buffers.active == buf_b
       assert switched.workspace.editing.mode == :insert
-      assert switched.shell_state.tab_bar.active_id == tab2.id
+      assert EditorState.tab_bar(switched).active_id == tab2.id
       assert EditorState.active_tab(switched).id == tab2.id
-      assert TabBar.get(switched.shell_state.tab_bar, 1).context.buffers.active == buf_a
-      assert TabBar.get(switched.shell_state.tab_bar, tab2.id).context.buffers.active == buf_b
+      assert TabBar.get(EditorState.tab_bar(switched), 1).context.buffers.active == buf_a
+      assert TabBar.get(EditorState.tab_bar(switched), tab2.id).context.buffers.active == buf_b
     end
   end
 

--- a/test/minga_editor/ui/picker/workspace_target_source_test.exs
+++ b/test/minga_editor/ui/picker/workspace_target_source_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
   alias MingaAgent.ProjectView
   alias MingaAgent.Test.ProjectView.FailingBackend
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
@@ -47,7 +48,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
     {%EditorState{
        port_manager: self(),
        workspace: %SessionState{viewport: Viewport.new(24, 80)},
-       shell_state: %ShellState{tab_bar: tb}
+       shell_runtime: Runtime.new(Runtime.default_entry(), %ShellState{tab_bar: tb})
      }, ref, agent_a, agent_b}
   end
 
@@ -78,7 +79,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
     }
   end
 
-  defp workspace(state, id), do: TabBar.get_workspace(state.shell_state.tab_bar, id)
+  defp workspace(state, id), do: TabBar.get_workspace(state.shell_runtime.state.tab_bar, id)
 
   defp review(state, files) do
     %WorkspaceReview{state: state, changed_files: files}
@@ -87,7 +88,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
   describe "candidates/1" do
     test "excludes the current workspace", %{tmp_dir: root} do
       {state, ref, _agent_a, _agent_b} = state_with_workspaces(root)
-      tb = state.shell_state.tab_bar
+      tb = state.shell_runtime.state.tab_bar
 
       items =
         WorkspaceTargetSource.candidates(
@@ -124,7 +125,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
         EditorState.set_tab_bar(
           state,
           TabBar.update_workspace(
-            state.shell_state.tab_bar,
+            state.shell_runtime.state.tab_bar,
             agent_a.id,
             &Workspace.remove_file(&1, ref)
           )
@@ -156,7 +157,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
         EditorState.set_tab_bar(
           state,
           TabBar.update_workspace(
-            state.shell_state.tab_bar,
+            state.shell_runtime.state.tab_bar,
             agent_a.id,
             &Workspace.remove_file(&1, ref)
           )
@@ -204,7 +205,9 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
 
       assert Workspace.has_file?(workspace(result, agent_a.id), ref)
       assert workspace(result, agent_a.id).review.changed_files == [ref]
-      assert {:picker, %{picker_ui: %{source: WorkspaceTargetSource}}} = result.shell_state.modal
+
+      assert {:picker, %{picker_ui: %{source: WorkspaceTargetSource}}} =
+               result.shell_runtime.state.modal
 
       assert EditorState.status_msg(result) ==
                "Drafts for auth.ex will be discarded. Continue / Promote first / Cancel."
@@ -260,7 +263,9 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
       result = WorkspaceTargetSource.on_select(transfer_item(:move, agent_a.id, 0, ref), state)
 
       assert Workspace.has_file?(workspace(result, agent_a.id), ref)
-      assert {:picker, %{picker_ui: %{source: WorkspaceTargetSource}}} = result.shell_state.modal
+
+      assert {:picker, %{picker_ui: %{source: WorkspaceTargetSource}}} =
+               result.shell_runtime.state.modal
 
       assert EditorState.status_msg(result) ==
                "Drafts for auth.ex will be discarded. Continue / Promote first / Cancel."
@@ -554,7 +559,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
 
   defp activate_workspace(state, workspace_id, file_ref) do
     tb =
-      state.shell_state.tab_bar
+      state.shell_runtime.state.tab_bar
       |> TabBar.update_tab(1, fn tab ->
         tab
         |> Tab.set_group(workspace_id)
@@ -567,7 +572,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
   defp update_workspace(state, workspace_id, fun) do
     EditorState.set_tab_bar(
       state,
-      TabBar.update_workspace(state.shell_state.tab_bar, workspace_id, fun)
+      TabBar.update_workspace(state.shell_runtime.state.tab_bar, workspace_id, fun)
     )
   end
 end

--- a/test/minga_editor/ui/prompt/workspace_rename_test.exs
+++ b/test/minga_editor/ui/prompt/workspace_rename_test.exs
@@ -1,9 +1,14 @@
 defmodule MingaEditor.UI.Prompt.WorkspaceRenameTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.UI.Prompt.WorkspaceRename
+  alias MingaEditor.Viewport
 
   describe "label/0" do
     test "returns the prompt label" do
@@ -18,12 +23,17 @@ defmodule MingaEditor.UI.Prompt.WorkspaceRenameTest do
       {tb, group} = TabBar.add_workspace(tb, "Agent")
       tb = TabBar.move_tab_to_workspace(tb, 2, group.id)
       tb = TabBar.switch_to_workspace(tb, group.id)
-      state = %{shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tb, status_msg: ""}}
+      state = state_with_tab_bar(tb)
 
       new_state = WorkspaceRename.on_submit("Research Bot", state)
-      assert TabBar.active_workspace(new_state.shell_state.tab_bar).label == "Research Bot"
-      assert TabBar.active_workspace(new_state.shell_state.tab_bar).custom_name == "Research Bot"
-      assert new_state.shell_state.status_msg =~ "Renamed"
+
+      assert TabBar.active_workspace(new_state.shell_runtime.state.tab_bar).label ==
+               "Research Bot"
+
+      assert TabBar.active_workspace(new_state.shell_runtime.state.tab_bar).custom_name ==
+               "Research Bot"
+
+      assert new_state.shell_runtime.state.status_msg =~ "Renamed"
     end
 
     test "trims whitespace from name" do
@@ -32,41 +42,41 @@ defmodule MingaEditor.UI.Prompt.WorkspaceRenameTest do
       {tb, group} = TabBar.add_workspace(tb, "Agent")
       tb = TabBar.move_tab_to_workspace(tb, 2, group.id)
       tb = TabBar.switch_to_workspace(tb, group.id)
-      state = %{shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tb, status_msg: ""}}
+      state = state_with_tab_bar(tb)
 
       new_state = WorkspaceRename.on_submit("  My Space  ", state)
-      assert TabBar.active_workspace(new_state.shell_state.tab_bar).label == "My Space"
+      assert TabBar.active_workspace(new_state.shell_runtime.state.tab_bar).label == "My Space"
     end
 
     test "rejects empty name with error message" do
       tb = TabBar.new(Tab.new_file(1, "a.ex"))
-      state = %{shell_state: %MingaEditor.Shell.Traditional.State{tab_bar: tb, status_msg: ""}}
+      state = state_with_tab_bar(tb)
       new_state = WorkspaceRename.on_submit("", state)
-      assert new_state.shell_state.status_msg =~ "cannot be empty"
+      assert new_state.shell_runtime.state.status_msg =~ "cannot be empty"
     end
 
     test "rejects whitespace-only name" do
-      state = %{
-        shell_state: %MingaEditor.Shell.Traditional.State{
-          tab_bar: TabBar.new(Tab.new_file(1, "a.ex")),
-          status_msg: ""
-        }
-      }
+      state = state_with_tab_bar(TabBar.new(Tab.new_file(1, "a.ex")))
 
       new_state = WorkspaceRename.on_submit("   ", state)
-      assert new_state.shell_state.status_msg =~ "cannot be empty"
+      assert new_state.shell_runtime.state.status_msg =~ "cannot be empty"
     end
   end
 
   describe "on_cancel/1" do
     test "returns state unchanged" do
-      state = %{
-        shell_state: %MingaEditor.Shell.Traditional.State{
-          tab_bar: TabBar.new(Tab.new_file(1, "a.ex"))
-        }
-      }
+      state = state_with_tab_bar(TabBar.new(Tab.new_file(1, "a.ex")))
 
       assert WorkspaceRename.on_cancel(state) == state
     end
+  end
+
+  defp state_with_tab_bar(tab_bar) do
+    %EditorState{
+      port_manager: self(),
+      workspace: %SessionState{viewport: Viewport.new(24, 80)},
+      shell_runtime:
+        Runtime.new(Runtime.default_entry(), %TraditionalState{tab_bar: tab_bar, status_msg: ""})
+    }
   end
 end

--- a/test/perf/keystroke_latency_test.exs
+++ b/test/perf/keystroke_latency_test.exs
@@ -202,9 +202,11 @@ defmodule Minga.Perf.KeystrokeLatencyTest do
       port_manager: port,
       workspace: workspace,
       renderer: renderer_pid,
-      shell_id: :traditional,
-      shell: MingaEditor.Shell.Traditional,
-      shell_state: %MingaEditor.Shell.Traditional.State{}
+      shell_runtime:
+        MingaEditor.Shell.Runtime.new(
+          MingaEditor.Shell.Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{}
+        )
     }
 
     {state, port}

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -669,13 +669,16 @@ defmodule Minga.Test.EditorCase do
   @doc "Returns true if a picker is currently open."
   @spec picker_open?(editor_ctx()) :: boolean()
   def picker_open?(%{editor: editor}) do
-    MingaEditor.State.ModalOverlay.match(get_editor_state(editor).shell_state.modal, :picker)
+    MingaEditor.State.ModalOverlay.match(
+      MingaEditor.State.modal(get_editor_state(editor)),
+      :picker
+    )
   end
 
   @doc "Returns the active picker state, or nil."
   @spec picker_state(editor_ctx()) :: MingaEditor.UI.Picker.t() | nil
   def picker_state(%{editor: editor}) do
-    case get_editor_state(editor).shell_state.modal do
+    case MingaEditor.State.modal(get_editor_state(editor)) do
       {:picker, %{picker_ui: %{picker: picker}}} -> picker
       _ -> nil
     end
@@ -706,13 +709,19 @@ defmodule Minga.Test.EditorCase do
   @doc "Returns true if the completion menu is visible."
   @spec completion_visible?(editor_ctx()) :: boolean()
   def completion_visible?(%{editor: editor}) do
-    MingaEditor.State.ModalOverlay.match(get_editor_state(editor).shell_state.modal, :completion)
+    MingaEditor.State.ModalOverlay.match(
+      MingaEditor.State.modal(get_editor_state(editor)),
+      :completion
+    )
   end
 
   @doc "Returns true if a file conflict prompt is open."
   @spec conflict_open?(editor_ctx()) :: boolean()
   def conflict_open?(%{editor: editor}) do
-    MingaEditor.State.ModalOverlay.match(get_editor_state(editor).shell_state.modal, :conflict)
+    MingaEditor.State.ModalOverlay.match(
+      MingaEditor.State.modal(get_editor_state(editor)),
+      :conflict
+    )
   end
 
   @doc "Returns the pending quit mode (:quit | :quit_all | nil)."
@@ -730,20 +739,22 @@ defmodule Minga.Test.EditorCase do
   @doc "Returns the tab bar labels."
   @spec tab_labels(editor_ctx()) :: [String.t()]
   def tab_labels(%{editor: editor}) do
-    Enum.map(get_editor_state(editor).shell_state.tab_bar.tabs, & &1.label)
+    Enum.map(MingaEditor.State.tab_bar(get_editor_state(editor)).tabs, & &1.label)
   end
 
   @doc "Returns the active workspace ID."
   @spec active_workspace_id(editor_ctx()) :: non_neg_integer()
   def active_workspace_id(%{editor: editor}) do
-    MingaEditor.State.TabBar.active_workspace_id(get_editor_state(editor).shell_state.tab_bar)
+    MingaEditor.State.TabBar.active_workspace_id(
+      MingaEditor.State.tab_bar(get_editor_state(editor))
+    )
   end
 
   @doc "Returns visible file tabs for the given workspace ID."
   @spec visible_file_tabs(editor_ctx(), non_neg_integer()) :: [map()]
   def visible_file_tabs(%{editor: editor}, workspace_id) do
     MingaEditor.State.TabBar.visible_file_tabs(
-      get_editor_state(editor).shell_state.tab_bar,
+      MingaEditor.State.tab_bar(get_editor_state(editor)),
       workspace_id
     )
   end
@@ -751,7 +762,7 @@ defmodule Minga.Test.EditorCase do
   @doc "Returns the picker payload (ModalOverlay.Picker) when a picker is open, or nil."
   @spec modal_picker(editor_ctx()) :: MingaEditor.State.ModalOverlay.Picker.t() | nil
   def modal_picker(%{editor: editor}) do
-    case get_editor_state(editor).shell_state.modal do
+    case MingaEditor.State.modal(get_editor_state(editor)) do
       {:picker, payload} -> payload
       _ -> nil
     end
@@ -766,7 +777,7 @@ defmodule Minga.Test.EditorCase do
   def modal_picker!(ctx) do
     case modal_picker(ctx) do
       nil ->
-        modal = get_editor_state(ctx.editor).shell_state.modal
+        modal = MingaEditor.State.modal(get_editor_state(ctx.editor))
         raise "expected picker payload, but modal was: #{inspect(modal)}"
 
       payload ->

--- a/test/support/fake_shell.ex
+++ b/test/support/fake_shell.ex
@@ -42,11 +42,16 @@ defmodule MingaEditor.Test.FakeShell do
 
   @impl true
   @spec input_handlers(term()) :: %{overlay: [module()], surface: [module()]}
-  def input_handlers(_editor_state), do: %{overlay: [], surface: []}
+  def input_handlers(_editor_state),
+    do: %{overlay: [], surface: [MingaEditor.Test.FakeShellInput]}
 
   @impl true
   @spec handle_event(map(), MingaEditor.Session.State.t(), term()) ::
           {map(), MingaEditor.Session.State.t()}
+  def handle_event(_shell_state, workspace, {:replace_test_state, replacement})
+      when is_map(replacement),
+      do: {replacement, workspace}
+
   def handle_event(shell_state, workspace, event) do
     {%{shell_state | events: [event | Map.get(shell_state, :events, [])]}, workspace}
   end
@@ -95,6 +100,11 @@ defmodule MingaEditor.Test.FakeShell do
   def on_agent_event(shell_state, workspace, _session, _event), do: {shell_state, workspace, []}
 
   @impl true
+  @spec owns_agent_session?(map(), pid()) :: boolean()
+  def owns_agent_session?(%{session: session}, session), do: true
+  def owns_agent_session?(_shell_state, _session), do: false
+
+  @impl true
   @spec handle_agent_session_restarted(map(), pid(), pid(), term()) :: {map(), boolean()}
   def handle_agent_session_restarted(%{session: old_pid} = shell_state, old_pid, new_pid, _reason) do
     {Map.put(shell_state, :session, new_pid), true}
@@ -103,23 +113,31 @@ defmodule MingaEditor.Test.FakeShell do
   def handle_agent_session_restarted(shell_state, _old_pid, _new_pid, _reason),
     do: {shell_state, false}
 
+  @impl true
   @spec handle_agent_session_down(map(), pid(), term()) :: {map(), boolean()}
   def handle_agent_session_down(%{session: session} = shell_state, session, _reason),
     do: {Map.put(shell_state, :session_down?, true), true}
 
   def handle_agent_session_down(shell_state, _session, _reason), do: {shell_state, false}
 
+  @impl true
   @spec handle_remote_session_disconnected(map(), pid()) :: {map(), boolean()}
   def handle_remote_session_disconnected(%{session: session} = shell_state, session),
     do: {Map.put(shell_state, :remote_disconnected?, true), true}
 
   def handle_remote_session_disconnected(shell_state, _session), do: {shell_state, false}
 
+  @impl true
   @spec sync_agent_status(map(), pid(), atom()) :: map()
   def sync_agent_status(%{session: session} = shell_state, session, status),
     do: Map.put(shell_state, :synced_agent_status, status)
 
   def sync_agent_status(shell_state, _session, _status), do: shell_state
+
+  @impl true
+  @spec persist_shell_state(map()) :: map()
+  def persist_shell_state(%{persist_as: persisted_state}), do: persisted_state
+  def persist_shell_state(shell_state), do: shell_state
 
   @impl true
   @spec active_tab(map()) :: nil

--- a/test/support/fake_shell_alt.ex
+++ b/test/support/fake_shell_alt.ex
@@ -5,7 +5,10 @@ defmodule MingaEditor.Test.FakeShellAlt do
 
   @impl true
   @spec init(keyword()) :: map()
-  def init(opts), do: %{name: Keyword.get(opts, :name, :fake_alt), events: []}
+  def init(opts) do
+    send(self(), {:fake_shell_alt_initialized, self()})
+    %{name: Keyword.get(opts, :name, :fake_alt), events: []}
+  end
 
   @impl true
   @spec compute_layout(map()) :: MingaEditor.Layout.t()
@@ -46,6 +49,10 @@ defmodule MingaEditor.Test.FakeShellAlt do
   @impl true
   @spec handle_event(map(), MingaEditor.Session.State.t(), term()) ::
           {map(), MingaEditor.Session.State.t()}
+  def handle_event(_shell_state, workspace, {:replace_test_state, replacement})
+      when is_map(replacement),
+      do: {replacement, workspace}
+
   def handle_event(shell_state, workspace, event),
     do: {%{shell_state | events: [event | Map.get(shell_state, :events, [])]}, workspace}
 
@@ -82,6 +89,11 @@ defmodule MingaEditor.Test.FakeShellAlt do
   def on_agent_event(shell_state, workspace, _session, _event), do: {shell_state, workspace, []}
 
   @impl true
+  @spec owns_agent_session?(map(), pid()) :: boolean()
+  def owns_agent_session?(%{session: session}, session), do: true
+  def owns_agent_session?(_shell_state, _session), do: false
+
+  @impl true
   @spec handle_agent_session_restarted(map(), pid(), pid(), term()) :: {map(), boolean()}
   def handle_agent_session_restarted(%{session: old_pid} = shell_state, old_pid, new_pid, _reason) do
     {Map.put(shell_state, :session, new_pid), true}
@@ -90,11 +102,35 @@ defmodule MingaEditor.Test.FakeShellAlt do
   def handle_agent_session_restarted(shell_state, _old_pid, _new_pid, _reason),
     do: {shell_state, false}
 
+  @impl true
+  @spec handle_agent_session_down(map(), pid(), term()) :: {map(), boolean()}
+  def handle_agent_session_down(%{session: session} = shell_state, session, _reason),
+    do: {Map.put(shell_state, :session_down?, true), true}
+
+  def handle_agent_session_down(shell_state, _session, _reason), do: {shell_state, false}
+
+  @impl true
+  @spec handle_remote_session_disconnected(map(), pid()) :: {map(), boolean()}
+  def handle_remote_session_disconnected(%{session: session} = shell_state, session),
+    do: {Map.put(shell_state, :remote_disconnected?, true), true}
+
+  def handle_remote_session_disconnected(shell_state, _session), do: {shell_state, false}
+
+  @impl true
   @spec sync_agent_status(map(), pid(), atom()) :: map()
   def sync_agent_status(%{session: session} = shell_state, session, status),
     do: Map.put(shell_state, :synced_agent_status, status)
 
   def sync_agent_status(shell_state, _session, _status), do: shell_state
+
+  @spec drop_feature_state_source(map(), MingaEditor.FeatureState.source()) :: map()
+  def drop_feature_state_source(%{contexts: contexts} = shell_state, source)
+      when is_list(contexts) do
+    contexts = Enum.map(contexts, &drop_context_feature_source(&1, source))
+    %{shell_state | contexts: contexts}
+  end
+
+  def drop_feature_state_source(shell_state, _source), do: shell_state
 
   @impl true
   @spec active_tab(map()) :: nil
@@ -116,4 +152,15 @@ defmodule MingaEditor.Test.FakeShellAlt do
   @spec active_session(map()) :: pid() | nil
   def active_session(%{session: session}) when is_pid(session), do: session
   def active_session(_shell_state), do: nil
+
+  @spec drop_context_feature_source(
+          MingaEditor.State.Tab.Context.t(),
+          MingaEditor.FeatureState.source()
+        ) :: MingaEditor.State.Tab.Context.t()
+  defp drop_context_feature_source(context, source) do
+    %MingaEditor.Session.State{viewport: MingaEditor.Viewport.new(1, 1)}
+    |> MingaEditor.Session.State.restore_tab_context(context)
+    |> MingaEditor.Session.State.drop_feature_state_source(source)
+    |> MingaEditor.Session.State.to_tab_context()
+  end
 end

--- a/test/support/fake_shell_input.ex
+++ b/test/support/fake_shell_input.ex
@@ -1,0 +1,41 @@
+defmodule MingaEditor.Test.FakeShellInput do
+  @moduledoc "Test-only input handler proving extension shell dispatch uses the active Runtime entry."
+
+  @behaviour MingaEditor.Input.Handler
+
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.State, as: EditorState
+
+  @impl true
+  @spec handle_key(
+          MingaEditor.Input.Handler.handler_state(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: MingaEditor.Input.Handler.result()
+  def handle_key(%EditorState{} = state, ?x, 0) do
+    {runtime, workspace} = Runtime.route_event(state.shell_runtime, state.workspace, :input_probe)
+
+    state =
+      state
+      |> EditorState.apply_shell_runtime_transition(runtime)
+      |> EditorState.set_workspace(workspace)
+
+    {:handled, state}
+  end
+
+  def handle_key(state, _codepoint, _modifiers), do: {:passthrough, state}
+
+  @impl true
+  @spec handle_mouse_at_node(
+          MingaEditor.Input.Handler.handler_state(),
+          MingaEditor.FocusTree.Node.t(),
+          integer(),
+          integer(),
+          atom(),
+          non_neg_integer(),
+          atom(),
+          pos_integer()
+        ) :: MingaEditor.Input.Handler.result()
+  def handle_mouse_at_node(state, _node, _row, _col, _button, _mods, _event_type, _click_count),
+    do: {:passthrough, state}
+end

--- a/test/support/render_pipeline_test_helpers.ex
+++ b/test/support/render_pipeline_test_helpers.ex
@@ -13,8 +13,9 @@ defmodule MingaEditor.RenderPipeline.TestHelpers do
   alias MingaEditor.RenderPipeline.ComposedFrame
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Scroll
-  alias MingaEditor.Shell.Identity, as: ShellIdentity
   alias MingaEditor.Shell.Registry, as: ShellRegistry
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.{Buffers, Highlighting, Windows}
   alias MingaEditor.Viewport
@@ -71,7 +72,7 @@ defmodule MingaEditor.RenderPipeline.TestHelpers do
         }
       },
       focus_stack: Input.default_stack(),
-      shell_identity: ShellIdentity.new(shell_entry),
+      shell_runtime: Runtime.new(shell_entry, %ShellState{}),
       theme: Theme.get!(:doom_one)
     }
   end

--- a/test/support/scoped_input_helpers.ex
+++ b/test/support/scoped_input_helpers.ex
@@ -5,6 +5,7 @@ defmodule Minga.Test.ScopedInputHelpers do
 
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -65,7 +66,11 @@ defmodule Minga.Test.ScopedInputHelpers do
         keymap_scope: Keyword.get(opts, :keymap_scope, :editor),
         agent_ui: agentic
       },
-      shell_state: %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tab_bar}
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tab_bar}
+        )
     }
   end
 
@@ -93,7 +98,7 @@ defmodule Minga.Test.ScopedInputHelpers do
         return_target
       )
 
-    {tab_bar, agent_tab} = TabBar.add(state.shell_state.tab_bar, :agent, "Agent")
+    {tab_bar, agent_tab} = TabBar.add(state.shell_runtime.state.tab_bar, :agent, "Agent")
     {tab_bar, workspace} = TabBar.add_workspace(tab_bar, "Agent", session)
     workspace = Workspace.set_agent_ui(workspace, agent_ui)
 
@@ -104,13 +109,12 @@ defmodule Minga.Test.ScopedInputHelpers do
         tab |> Tab.set_session(session) |> Tab.set_group(workspace.id)
       end)
 
-    shell_state = %{
-      state.shell_state
-      | tab_bar: tab_bar
-    }
-
     workspace_state = %{state.workspace | agent_ui: agent_ui, keymap_scope: :agent}
-    state = %{state | shell_state: shell_state, workspace: workspace_state}
+
+    state =
+      state
+      |> EditorState.set_tab_bar(tab_bar)
+      |> EditorState.set_workspace(workspace_state)
 
     {state, session, file_buffer}
   end


### PR DESCRIPTION
# TL;DR
Shell lifecycle state now lives in one immutable `MingaEditor.Shell.Runtime` value, so active identity, implementation, current state, and exact-identity stashes cannot drift across parallel Editor fields. Registry resolution and external effects remain outside the runtime owner, while built-in and extension callbacks dispatch through their resolved shell entries.

Closes #2863

## Context
This is the next state-ownership slice in #2861. It builds on the coherent shell registry publication from #2837 and gives later Editor decomposition work one explicit owner for shell lifecycle transitions.

## Changes
- Added `MingaEditor.Shell.Runtime` for active entry, current shell state, exact-identity stashes, activation, fallback, callback routing, renderer writeback, and persistence normalization.
- Added `MingaEditor.Shell.Workflow` as the effect boundary for registry resolution, shell initialization, logging, layout invalidation, and extension fallback.
- Replaced the parallel root `shell_id`, `shell`, `shell_identity`, `shell_state`, and `shell_state_stash` fields with `shell_runtime`, then removed the old root mapper and forwarding APIs.
- Routed active and stashed agent, buffer, session, GUI, input, renderer, and extension events through each resolved entry's shell contract without passing extension maps through Traditional-state transitions.
- Preserved the flattened `shell`, `shell_id`, and `shell_state` transfer fields on `RenderPipeline.Input`, including modal, inline overlay, footer overlay, and command-completion consumers.
- Added pure runtime transition coverage plus registry, extension input, active and stashed event, persistence, stale render, initialization, transfer-value, and fallback regressions.

## Verification
- `make lint`
- `mix test.llm` (9,251 tests, 97 properties, 58 doctests, zero failures)
- Focused runtime, registry, modal overlay, inline ask/edit rendering, footer overlay, minibuffer, and extension input suites
- Final commit review: PASS

## Acceptance Criteria Addressed
- Active shell identity, implementation, current value, and stashed values are represented by one owned runtime value. ✅
- Shell selection, switching, stashing, restoration, removal, and identity validation flow through intent-named runtime transitions. ✅
- The runtime receives resolved entries and performs no registry, process, logging, rendering, timer, or persistence effects. ✅
- Active and stashed callbacks dispatch through each shell contract without applying Traditional-state functions to extension maps. ✅
- Built-in and extension activation, restoration, routing, and fallback behavior remain compatible. ✅
- Parallel root fields, old generic shell mappers, bare-map compatibility clauses, and forwarding delegates are removed. ✅
- Pure transition tests cover activation, switching, stale identity, removed registrations, stash restoration, and fallback. ✅
