### PR TITLE
fix(port): bound frontend output pressure

### DIFF
--- a/lib/minga_editor/frontend.ex
+++ b/lib/minga_editor/frontend.ex
@@ -29,7 +29,8 @@ defmodule MingaEditor.Frontend do
   # ── Manager operations ───────────────────────────────────────────────────
 
   @doc "Sends a list of pre-encoded commands to the frontend process."
-  @spec send_commands(GenServer.server(), [binary()]) :: :ok
+  @spec send_commands(GenServer.server() | nil, [binary()]) ::
+          MingaEditor.Frontend.Adapter.admission()
   def send_commands(server \\ MingaEditor.Frontend.Manager, commands),
     do: MingaEditor.Frontend.Manager.send_commands(server, commands)
 
@@ -38,7 +39,8 @@ defmodule MingaEditor.Frontend do
   frontend emits a `[:minga, :render, :hop_latency]` (`hop: :send_commands`)
   sample for the Renderer.Server → Port.Manager scheduling delay.
   """
-  @spec send_render_commands(GenServer.server(), [binary()]) :: :ok
+  @spec send_render_commands(GenServer.server() | nil, [binary()]) ::
+          MingaEditor.Frontend.Adapter.admission()
   def send_render_commands(server \\ MingaEditor.Frontend.Manager, commands),
     do: MingaEditor.Frontend.Manager.send_render_commands(server, commands)
 
@@ -90,7 +92,7 @@ defmodule MingaEditor.Frontend do
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer()
-        ) :: :ok
+        ) :: MingaEditor.Frontend.Adapter.admission()
   def send_frame_boundary(port, frame_seq, base_frame_seq, input_seq \\ 0) do
     send_commands(port, [
       Protocol.encode_begin_frame(frame_seq, base_frame_seq, 1),
@@ -101,13 +103,15 @@ defmodule MingaEditor.Frontend do
   # ── Configuration ────────────────────────────────────────────────────────
 
   @doc "Sets the window title."
-  @spec set_title(GenServer.server(), String.t()) :: :ok
+  @spec set_title(GenServer.server() | nil, String.t()) ::
+          MingaEditor.Frontend.Adapter.admission()
   def set_title(port \\ MingaEditor.Frontend.Manager, title) do
     send_commands(port, [Protocol.encode_set_title(title)])
   end
 
   @doc "Sets the window background color."
-  @spec set_window_bg(GenServer.server(), non_neg_integer()) :: :ok
+  @spec set_window_bg(GenServer.server() | nil, non_neg_integer()) ::
+          MingaEditor.Frontend.Adapter.admission()
   def set_window_bg(port \\ MingaEditor.Frontend.Manager, color) do
     send_commands(port, [Protocol.encode_set_window_bg(color)])
   end
@@ -118,7 +122,8 @@ defmodule MingaEditor.Frontend do
   Emitted out-of-band (post-commit) like `set_title`, so it joins the frontend
   out-of-band allowlist. The GUI shows `NSCursor.pointingHand` while `active`.
   """
-  @spec set_link_cursor(GenServer.server(), boolean()) :: :ok
+  @spec set_link_cursor(GenServer.server() | nil, boolean()) ::
+          MingaEditor.Frontend.Adapter.admission()
   def set_link_cursor(port \\ MingaEditor.Frontend.Manager, active) do
     send_commands(port, [Protocol.encode_set_link_cursor(active)])
   end
@@ -127,7 +132,7 @@ defmodule MingaEditor.Frontend do
   @spec configure_font(GenServer.server(), String.t(), pos_integer(), boolean(), atom(), [
           String.t()
         ]) ::
-          :ok
+          MingaEditor.Frontend.Adapter.admission()
   def configure_font(port, family, size, ligatures, weight, fallbacks \\ []) do
     cmds = [Protocol.encode_set_font(family, size, ligatures, weight)]
 
@@ -155,7 +160,8 @@ defmodule MingaEditor.Frontend do
   # ── GUI Chrome ───────────────────────────────────────────────────────────
 
   @doc "Sends a clipboard write command to the GUI frontend."
-  @spec clipboard_write(GenServer.server(), String.t(), atom()) :: :ok
+  @spec clipboard_write(GenServer.server(), String.t(), atom()) ::
+          MingaEditor.Frontend.Adapter.admission()
   def clipboard_write(port, text, pasteboard \\ :general) do
     send_commands(port, [ProtocolGUI.encode_clipboard_write(text, pasteboard)])
   end

--- a/lib/minga_editor/frontend/adapter.ex
+++ b/lib/minga_editor/frontend/adapter.ex
@@ -19,17 +19,18 @@ defmodule MingaEditor.Frontend.Adapter do
   messages. The event types are defined in `MingaEditor.Frontend.Protocol`.
   """
 
+  @typedoc "Non-suspending frontend output admission result."
+  @type admission :: :accepted | :unwritable
+
   @doc "Starts the frontend process."
   @callback start_link(opts :: keyword()) :: GenServer.on_start()
 
   @doc """
   Sends a list of pre-encoded render command binaries to the frontend.
 
-  Commands are encoded via `MingaEditor.Frontend.Protocol.encode_*` functions.
-  The frontend processes them in order. A `commit_frame` command closes the
-  frame transaction and triggers a render flush (#2219).
+  Commands are encoded via `MingaEditor.Frontend.Protocol.encode_*` functions. The frontend returns `:accepted` when the batch entered its transport or `:unwritable` without suspending the caller. A `commit_frame` command closes the frame transaction and triggers a render flush (#2219).
   """
-  @callback send_commands(server :: GenServer.server(), commands :: [binary()]) :: :ok
+  @callback send_commands(server :: GenServer.server(), commands :: [binary()]) :: admission()
 
   @doc """
   Subscribes the calling process to receive input events.

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -159,10 +159,10 @@ defmodule MingaEditor.Frontend.Emit do
       [:minga, :render, :emit_prepare],
       %{byte_count: byte_count, input_seq: input_seq, frame_seq: frame_seq, keyframe?: keyframe?},
       fn ->
-        MingaEditor.Frontend.send_render_commands(ctx.port_manager, commands)
-        caches = send_title(render_model, caches)
-        caches = send_window_bg(render_model, caches)
-        {send_link_cursor(ctx, caches), ctx}
+        _admission = MingaEditor.Frontend.send_render_commands(ctx.port_manager, commands)
+        caches = send_title(render_model, ctx.port_manager, caches)
+        caches = send_window_bg(render_model, ctx.port_manager, caches)
+        {send_link_cursor(ctx, ctx.port_manager, caches), ctx}
       end
     )
   rescue
@@ -275,21 +275,27 @@ defmodule MingaEditor.Frontend.Emit do
 
   # ── Side-channel writes (shared) ─────────────────────────────────────────
 
-  @spec send_title(Minga.RenderModel.t() | ctx(), Caches.t()) :: Caches.t()
-  defp send_title(%Minga.RenderModel{title: title}, caches) do
+  @spec send_title(Minga.RenderModel.t() | ctx(), GenServer.server() | nil, Caches.t()) ::
+          Caches.t()
+  defp send_title(%Minga.RenderModel{title: title}, port_manager, caches) do
     if title != caches.last_title do
-      MingaEditor.Frontend.set_title(title)
-      %{caches | last_title: title}
+      case MingaEditor.Frontend.set_title(port_manager, title) do
+        :accepted -> %{caches | last_title: title}
+        :unwritable -> caches
+      end
     else
       caches
     end
   end
 
-  @spec send_window_bg(Minga.RenderModel.t() | ctx(), Caches.t()) :: Caches.t()
-  defp send_window_bg(%Minga.RenderModel{window_bg: bg}, caches) do
+  @spec send_window_bg(Minga.RenderModel.t() | ctx(), GenServer.server() | nil, Caches.t()) ::
+          Caches.t()
+  defp send_window_bg(%Minga.RenderModel{window_bg: bg}, port_manager, caches) do
     if bg != caches.last_window_bg do
-      MingaEditor.Frontend.set_window_bg(bg)
-      %{caches | last_window_bg: bg}
+      case MingaEditor.Frontend.set_window_bg(port_manager, bg) do
+        :accepted -> %{caches | last_window_bg: bg}
+        :unwritable -> caches
+      end
     else
       caches
     end
@@ -299,15 +305,17 @@ defmodule MingaEditor.Frontend.Emit do
   # (#2630). Mirrors send_title/send_window_bg: only emits when the navigable
   # state flips, so an unchanged preview never re-sends. GUI-only by construction
   # (ctx.link_cursor is gated on gui? when the context is built).
-  @spec send_link_cursor(ctx(), Caches.t()) :: Caches.t()
-  defp send_link_cursor(%{gui?: true, link_cursor: active}, caches) do
+  @spec send_link_cursor(ctx(), GenServer.server() | nil, Caches.t()) :: Caches.t()
+  defp send_link_cursor(%{gui?: true, link_cursor: active}, port_manager, caches) do
     if active != caches.last_link_cursor do
-      MingaEditor.Frontend.set_link_cursor(active)
-      %{caches | last_link_cursor: active}
+      case MingaEditor.Frontend.set_link_cursor(port_manager, active) do
+        :accepted -> %{caches | last_link_cursor: active}
+        :unwritable -> caches
+      end
     else
       caches
     end
   end
 
-  defp send_link_cursor(_ctx, caches), do: caches
+  defp send_link_cursor(_ctx, _port_manager, caches), do: caches
 end

--- a/lib/minga_editor/frontend/manager.ex
+++ b/lib/minga_editor/frontend/manager.ex
@@ -13,8 +13,9 @@ defmodule MingaEditor.Frontend.Manager do
     Port.Manager opens `{:fd, 0, 1}` as a Port instead of spawning a child.
     Used when launching from `Minga.app` (Finder, Spotlight, Dock).
 
-  Both modes use identical `{:packet, 4}` framing. The protocol layer
-  (event decoding, render commands, subscriber broadcasting) is the same.
+  Both modes use identical `{:packet, 4}` framing. The protocol layer (event decoding, render commands, subscriber broadcasting) is the same.
+
+  Output admission always uses `Port.command/3` with `:nosuspend`. If the transport is unwritable, the manager retains one current frame and one latest coalesced replacement, retries within a short budget, then requests correlated keyframe recovery. Synchronous admission calls keep frame binaries out of the manager mailbox while leaving the process free to receive frontend input between attempts.
 
   Subscribers register via `subscribe/1` and receive messages as:
 
@@ -29,11 +30,15 @@ defmodule MingaEditor.Frontend.Manager do
 
   alias Minga.Telemetry
   alias Minga.Telemetry.StartupTimer
-  alias MingaEditor.Frontend.FrameTransaction
+  alias MingaEditor.Frontend.Manager.OutputHandler
+  alias MingaEditor.Frontend.Manager.OutputPressure
   alias MingaEditor.Frontend.Protocol
 
   @typedoc "Renderer backend."
   @type backend :: :tui | :gui
+
+  @typedoc "Non-suspending frontend transport admission result."
+  @type admission :: :accepted | :unwritable
 
   @typedoc "Options for starting the port manager."
   @type start_opt ::
@@ -42,6 +47,9 @@ defmodule MingaEditor.Frontend.Manager do
           | {:backend, backend()}
           | {:port_mode, MingaEditor.Frontend.Manager.State.port_mode()}
           | {:port_opener, (term(), [term()] -> port())}
+          | {:port_commander, MingaEditor.Frontend.Manager.State.port_commander()}
+          | {:output_retry_ms, pos_integer()}
+          | {:output_failure_ms, non_neg_integer()}
           | {:tty_path, String.t() | nil}
 
   alias MingaEditor.Frontend.Manager.State, as: PortState
@@ -59,27 +67,31 @@ defmodule MingaEditor.Frontend.Manager do
     GenServer.start_link(__MODULE__, opts, name: name)
   end
 
-  @doc "Sends a list of encoded render command binaries to the renderer."
+  @doc "Attempts non-suspending admission of encoded commands to the renderer."
   @impl MingaEditor.Frontend.Adapter
-  @spec send_commands(GenServer.server(), [binary()]) :: :ok
-  def send_commands(server \\ __MODULE__, commands) when is_list(commands) do
-    GenServer.cast(server, {:send_commands, commands})
+  @spec send_commands(GenServer.server() | nil, [binary()]) :: admission()
+  def send_commands(server \\ __MODULE__, commands)
+  def send_commands(nil, commands) when is_list(commands), do: :unwritable
+
+  def send_commands(server, commands) when is_list(commands) do
+    GenServer.call(server, {:send_commands, commands}, :infinity)
   end
 
   @doc """
-  Like `send_commands/2` but precedes the frame batch with a `{:hop_mark, ...}`
-  probe cast stamped with a monotonic send time. The receiver emits a
-  `[:minga, :render, :hop_latency]` (`hop: :send_commands`) sample measuring
-  the Renderer.Server → Port.Manager scheduling delay. The probe is enqueued
-  immediately before the frame so its delay tracks the frame's delay, without
-  altering the `{:send_commands, commands}` message contract. Used only for the
-  per-frame render batch on the keystroke path.
+  Like `send_commands/2` but stamps the synchronous admission request with a monotonic send time. The receiver emits a `[:minga, :render, :hop_latency]` (`hop: :send_commands`) sample measuring the Renderer.Server to Port.Manager scheduling delay. Used only for the per-frame render batch on the keystroke path.
   """
-  @spec send_render_commands(GenServer.server(), [binary()]) :: :ok
-  def send_render_commands(server \\ __MODULE__, commands) when is_list(commands) do
-    GenServer.cast(server, {:hop_mark, :send_commands, System.monotonic_time(:microsecond)})
-    GenServer.cast(server, {:send_commands, commands})
+  @spec send_render_commands(GenServer.server() | nil, [binary()]) :: admission()
+  def send_render_commands(server \\ __MODULE__, commands)
+  def send_render_commands(nil, commands) when is_list(commands), do: :unwritable
+
+  def send_render_commands(server, commands) when is_list(commands) do
+    sent_at = System.monotonic_time(:microsecond)
+    GenServer.call(server, {:send_render_commands, commands, sent_at}, :infinity)
   end
+
+  @doc "Returns bounded output-pressure diagnostics."
+  @spec output_pressure(GenServer.server()) :: OutputPressure.stats()
+  def output_pressure(server \\ __MODULE__), do: GenServer.call(server, :output_pressure)
 
   @doc "Subscribes the calling process to receive input events."
   @impl MingaEditor.Frontend.Adapter
@@ -124,7 +136,17 @@ defmodule MingaEditor.Frontend.Manager do
     renderer_path = Keyword.fetch!(opts, :renderer_path)
     port_opener = Keyword.get(opts, :port_opener, &Port.open/2)
     tty_path = Keyword.get(opts, :tty_path)
-    state = %PortState{renderer_path: renderer_path, port_mode: port_mode, tty_path: tty_path}
+
+    state = %PortState{
+      renderer_path: renderer_path,
+      port_mode: port_mode,
+      tty_path: tty_path,
+      output_pressure: OutputPressure.new(),
+      port_commander: Keyword.get(opts, :port_commander, &Port.command/3),
+      output_retry_ms: Keyword.get(opts, :output_retry_ms, 2),
+      output_failure_ms: Keyword.get(opts, :output_failure_ms, 50)
+    }
+
     result = {:ok, start_port(state, port_opener)}
     StartupTimer.mark(:frontend_port_ready)
     result
@@ -166,27 +188,19 @@ defmodule MingaEditor.Frontend.Manager do
     {:reply, state.capabilities, state}
   end
 
-  @impl true
-  @spec handle_cast(term(), state()) :: {:noreply, state()}
-  def handle_cast({:send_commands, _commands}, %{port: nil} = state) do
-    {:noreply, state}
+  def handle_call(:output_pressure, _from, state) do
+    {:reply, OutputPressure.stats(state.output_pressure), state}
   end
 
-  def handle_cast({:hop_mark, hop, sent_at}, state) do
-    Telemetry.hop_latency(hop, sent_at)
-    {:noreply, state}
+  def handle_call({:send_commands, commands}, _from, state) do
+    {admission, state} = OutputHandler.admit_commands(state, commands)
+    {:reply, admission, state}
   end
 
-  def handle_cast({:send_commands, commands}, state) do
-    log_frame_transaction_violation(commands)
-
-    Telemetry.span_with_stop_metadata([:minga, :port, :write], %{}, fn ->
-      batch = IO.iodata_to_binary(commands)
-      Port.command(state.port, batch)
-      {:ok, %{byte_count: byte_size(batch)}}
-    end)
-
-    {:noreply, state}
+  def handle_call({:send_render_commands, commands, sent_at}, _from, state) do
+    Telemetry.hop_latency(:send_commands, sent_at)
+    {admission, state} = OutputHandler.admit_commands(state, commands)
+    {:reply, admission, state}
   end
 
   @impl true
@@ -211,6 +225,9 @@ defmodule MingaEditor.Frontend.Manager do
         broadcast(new_state.subscribers, {:minga_input, {:resize, width, height}})
         {:noreply, new_state}
 
+      {:ok, {:frame_applied, generation, frame_seq} = event} ->
+        {:noreply, OutputHandler.frame_applied(state, event, generation, frame_seq)}
+
       {:ok, {:log_message, level, text}} ->
         log_renderer_message(level, text)
         {:noreply, state}
@@ -229,16 +246,19 @@ defmodule MingaEditor.Frontend.Manager do
     end
   end
 
+  def handle_info({:retry_frontend_output, token}, state),
+    do: {:noreply, OutputHandler.retry(state, token)}
+
   def handle_info({port, {:exit_status, 0}}, %{port: port} = state) do
     Minga.Log.info(:port, "Renderer: exited normally")
     maybe_stop_system(0)
-    {:noreply, %{state | port: nil, ready: false}}
+    {:noreply, OutputHandler.disconnect(state)}
   end
 
   def handle_info({port, {:exit_status, status}}, %{port: port} = state) do
     Minga.Log.error(:port, "Renderer: crashed (exit #{status})")
     maybe_stop_system(1)
-    {:noreply, %{state | port: nil, ready: false}}
+    {:noreply, OutputHandler.disconnect(state)}
   end
 
   # In connected mode ({:fd, 0, 1}), stdin EOF means the GUI parent exited.
@@ -246,7 +266,7 @@ defmodule MingaEditor.Frontend.Manager do
   def handle_info({port, :eof}, %{port: port} = state) do
     Minga.Log.info(:port, "GUI parent disconnected (stdin EOF)")
     maybe_stop_system(0)
-    {:noreply, %{state | port: nil, ready: false}}
+    {:noreply, OutputHandler.disconnect(state)}
   end
 
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do
@@ -259,20 +279,6 @@ defmodule MingaEditor.Frontend.Manager do
   end
 
   # ── Private ──
-
-  @spec log_frame_transaction_violation([binary()]) :: :ok
-  defp log_frame_transaction_violation(commands) do
-    case FrameTransaction.validate(commands) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Minga.Log.warning(
-          :port,
-          "Frontend command batch violates frame transaction: #{FrameTransaction.format_error(reason)}"
-        )
-    end
-  end
 
   @spec start_port(state(), fun()) :: state()
   defp start_port(%{port_mode: :connected} = state, port_opener) do
@@ -386,9 +392,15 @@ defmodule MingaEditor.Frontend.Manager do
 
     Minga.Log.error(:port, message)
 
-    if state.port do
-      Port.command(state.port, Protocol.encode_protocol_error(message))
-    end
+    state =
+      if state.port do
+        {_admission, state} =
+          OutputHandler.write_control(state, Protocol.encode_protocol_error(message))
+
+        state
+      else
+        state
+      end
 
     {:noreply, %{state | ready: false}}
   end

--- a/lib/minga_editor/frontend/manager/output_handler.ex
+++ b/lib/minga_editor/frontend/manager/output_handler.ex
@@ -1,0 +1,253 @@
+defmodule MingaEditor.Frontend.Manager.OutputHandler do
+  @moduledoc "Owns non-suspending Port admission, bounded frame retention, and recovery correlation."
+
+  alias Minga.Telemetry
+  alias MingaEditor.Frontend.FrameTransaction
+  alias MingaEditor.Frontend.Manager
+  alias MingaEditor.Frontend.Manager.OutputPressure
+  alias MingaEditor.Frontend.Manager.PendingFrame
+  alias MingaEditor.Frontend.Manager.State
+  alias MingaEditor.Frontend.Protocol
+
+  @doc "Attempts one command batch without suspending the Port owner."
+  @spec admit_commands(State.t(), [binary()]) :: {Manager.admission(), State.t()}
+  def admit_commands(%{port: nil} = state, _commands), do: {:unwritable, state}
+
+  def admit_commands(state, commands) do
+    log_frame_transaction_violation(commands)
+
+    case PendingFrame.from_commands(commands) do
+      {:ok, frame} -> admit_frame(state, frame)
+      {:error, _reason} -> admit_control(state, commands)
+    end
+  end
+
+  @doc "Retries the retained current frame for the matching timer token."
+  @spec retry(State.t(), reference()) :: State.t()
+  def retry(state, token) do
+    case OutputPressure.consume_retry(state.output_pressure, token) do
+      {:ok, output_pressure} ->
+        {_admission, state} = attempt_output(%{state | output_pressure: output_pressure})
+        state
+
+      :stale ->
+        state
+    end
+  end
+
+  @doc "Broadcasts a correlated acknowledgement or rejects it as stale."
+  @spec frame_applied(
+          State.t(),
+          Protocol.input_event(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: State.t()
+  def frame_applied(state, event, generation, frame_seq) do
+    case OutputPressure.acknowledge(state.output_pressure, generation, frame_seq) do
+      {:accepted, output_pressure} ->
+        broadcast(state.subscribers, {:minga_input, event})
+        %{state | output_pressure: output_pressure}
+
+      :stale ->
+        Minga.Log.debug(
+          :port,
+          "Ignored stale frontend acknowledgement generation #{generation} frame #{frame_seq}"
+        )
+
+        state
+    end
+  end
+
+  @doc "Clears retained output when the frontend transport disconnects."
+  @spec disconnect(State.t()) :: State.t()
+  def disconnect(state),
+    do: %{state | port: nil, ready: false, output_pressure: OutputPressure.new()}
+
+  @doc "Attempts and, if needed, retains one out-of-band control write."
+  @spec write_control(State.t(), binary()) :: {Manager.admission(), State.t()}
+  def write_control(%{port: nil} = state, _batch), do: {:unwritable, state}
+  def write_control(state, batch), do: admit_control_batch(state, first_opcode(batch), batch)
+
+  @spec admit_frame(State.t(), PendingFrame.t()) :: {Manager.admission(), State.t()}
+  defp admit_frame(state, frame) do
+    case OutputPressure.enqueue(state.output_pressure, frame) do
+      {:attempt, output_pressure} -> attempt_output(%{state | output_pressure: output_pressure})
+      {:coalesced, output_pressure} -> {:unwritable, %{state | output_pressure: output_pressure}}
+    end
+  end
+
+  @spec attempt_output(State.t()) :: {Manager.admission(), State.t()}
+  defp attempt_output(state) do
+    case OutputPressure.next_control(state.output_pressure) do
+      nil -> attempt_current(state)
+      {opcode, batch} -> attempt_control(state, opcode, batch)
+    end
+  end
+
+  @spec attempt_current(State.t()) :: {Manager.admission(), State.t()}
+  defp attempt_current(%{output_pressure: %{current: nil}} = state) do
+    output_pressure = OutputPressure.settled(state.output_pressure)
+    {:accepted, %{state | output_pressure: output_pressure}}
+  end
+
+  defp attempt_current(%{output_pressure: %{current: current}} = state) do
+    case write_batch(state, current.batch) do
+      :accepted -> current_admitted(state)
+      :unwritable -> current_unwritable(state, current)
+    end
+  end
+
+  @spec current_admitted(State.t()) :: {Manager.admission(), State.t()}
+  defp current_admitted(state) do
+    {admitted, output_pressure} = OutputPressure.admitted(state.output_pressure)
+    state = %{state | output_pressure: output_pressure}
+
+    case output_pressure.current do
+      nil ->
+        attempt_output(state)
+
+      successor ->
+        admit_successor(state, successor, admitted)
+    end
+  end
+
+  @spec admit_successor(State.t(), PendingFrame.t(), PendingFrame.t()) ::
+          {Manager.admission(), State.t()}
+  defp admit_successor(state, successor, admitted) do
+    if PendingFrame.follows?(successor, admitted) do
+      {_successor_admission, state} = attempt_output(state)
+      {:accepted, state}
+    else
+      {:accepted, require_keyframe_recovery(state, successor)}
+    end
+  end
+
+  @spec current_unwritable(State.t(), PendingFrame.t()) :: {Manager.admission(), State.t()}
+  defp current_unwritable(state, current) do
+    now = System.monotonic_time(:millisecond)
+
+    if OutputPressure.expired?(state.output_pressure, now, state.output_failure_ms) do
+      {:unwritable, require_keyframe_recovery(state, current)}
+    else
+      {:unwritable, ensure_retry(state, now)}
+    end
+  end
+
+  @spec ensure_retry(State.t(), integer()) :: State.t()
+  defp ensure_retry(state, now) do
+    if OutputPressure.retry_scheduled?(state.output_pressure) do
+      state
+    else
+      token = make_ref()
+      Process.send_after(self(), {:retry_frontend_output, token}, state.output_retry_ms)
+      output_pressure = OutputPressure.mark_unwritable(state.output_pressure, now, token)
+      %{state | output_pressure: output_pressure}
+    end
+  end
+
+  @spec require_keyframe_recovery(State.t(), PendingFrame.t()) :: State.t()
+  defp require_keyframe_recovery(state, failed) do
+    stats = OutputPressure.stats(state.output_pressure)
+    output_pressure = OutputPressure.require_recovery(state.output_pressure, failed)
+
+    Minga.Log.warning(
+      :port,
+      "Frontend output remained unwritable for frame #{failed.frame_seq}; requesting keyframe recovery"
+    )
+
+    broadcast(
+      state.subscribers,
+      {:minga_input, {:request_keyframe, stats.last_applied_frame_seq, failed.generation}}
+    )
+
+    state = %{state | output_pressure: output_pressure}
+
+    if OutputPressure.controls_pending?(output_pressure),
+      do: ensure_retry(state, System.monotonic_time(:millisecond)),
+      else: state
+  end
+
+  @spec admit_control(State.t(), [binary()]) :: {Manager.admission(), State.t()}
+  defp admit_control(state, []), do: {write_batch(state, <<>>), state}
+
+  defp admit_control(state, [first | _commands] = commands),
+    do: admit_control_batch(state, first_opcode(first), IO.iodata_to_binary(commands))
+
+  @spec admit_control_batch(State.t(), non_neg_integer(), binary()) ::
+          {Manager.admission(), State.t()}
+  defp admit_control_batch(state, opcode, batch) do
+    if output_pending?(state.output_pressure) do
+      retain_control(state, opcode, batch)
+    else
+      case write_batch(state, batch) do
+        :accepted -> {:accepted, state}
+        :unwritable -> retain_control(state, opcode, batch)
+      end
+    end
+  end
+
+  @spec attempt_control(State.t(), non_neg_integer(), binary()) ::
+          {Manager.admission(), State.t()}
+  defp attempt_control(state, opcode, batch) do
+    case write_batch(state, batch) do
+      :accepted ->
+        output_pressure = OutputPressure.control_admitted(state.output_pressure, opcode)
+        attempt_output(%{state | output_pressure: output_pressure})
+
+      :unwritable ->
+        {:unwritable, ensure_retry(state, System.monotonic_time(:millisecond))}
+    end
+  end
+
+  @spec retain_control(State.t(), non_neg_integer(), binary()) ::
+          {Manager.admission(), State.t()}
+  defp retain_control(state, opcode, batch) do
+    output_pressure = OutputPressure.retain_control(state.output_pressure, opcode, batch)
+    state = %{state | output_pressure: output_pressure}
+    {:unwritable, ensure_retry(state, System.monotonic_time(:millisecond))}
+  end
+
+  @spec output_pending?(OutputPressure.t()) :: boolean()
+  defp output_pending?(%OutputPressure{current: current} = pressure),
+    do: current != nil or OutputPressure.controls_pending?(pressure)
+
+  @spec first_opcode(binary()) :: non_neg_integer()
+  defp first_opcode(<<opcode, _::binary>>), do: opcode
+  defp first_opcode(<<>>), do: 0
+
+  @spec write_batch(State.t(), binary()) :: Manager.admission()
+  defp write_batch(state, batch) do
+    Telemetry.span_with_stop_metadata([:minga, :port, :write], %{}, fn ->
+      admission = port_admission(state, batch)
+      {admission, %{byte_count: byte_size(batch), admission: admission}}
+    end)
+  end
+
+  @spec port_admission(State.t(), binary()) :: Manager.admission()
+  defp port_admission(state, batch) do
+    if state.port_commander.(state.port, batch, [:nosuspend]),
+      do: :accepted,
+      else: :unwritable
+  rescue
+    ArgumentError -> :unwritable
+  end
+
+  @spec log_frame_transaction_violation([binary()]) :: :ok
+  defp log_frame_transaction_violation(commands) do
+    case FrameTransaction.validate(commands) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Minga.Log.warning(
+          :port,
+          "Frontend command batch violates frame transaction: #{FrameTransaction.format_error(reason)}"
+        )
+    end
+  end
+
+  @spec broadcast([pid()], term()) :: :ok
+  defp broadcast(subscribers, message) do
+    Enum.each(subscribers, &send(&1, message))
+  end
+end

--- a/lib/minga_editor/frontend/manager/output_pressure.ex
+++ b/lib/minga_editor/frontend/manager/output_pressure.ex
@@ -1,0 +1,194 @@
+defmodule MingaEditor.Frontend.Manager.OutputPressure do
+  @moduledoc "Bounded frontend output retention and acknowledgement correlation state."
+
+  alias MingaEditor.Frontend.Manager.PendingFrame
+
+  defstruct current: nil,
+            replacement: nil,
+            controls: %{},
+            unwritable_since: nil,
+            retry_token: nil,
+            minimum_ack_generation: 0,
+            last_applied_generation: 0,
+            last_applied_frame_seq: 0
+
+  @type t :: %__MODULE__{
+          current: PendingFrame.t() | nil,
+          replacement: PendingFrame.t() | nil,
+          controls: %{non_neg_integer() => binary()},
+          unwritable_since: integer() | nil,
+          retry_token: reference() | nil,
+          minimum_ack_generation: non_neg_integer(),
+          last_applied_generation: non_neg_integer(),
+          last_applied_frame_seq: non_neg_integer()
+        }
+
+  @type stats :: %{
+          current_frame_seq: non_neg_integer() | nil,
+          replacement_frame_seq: non_neg_integer() | nil,
+          current_bytes: non_neg_integer(),
+          replacement_bytes: non_neg_integer(),
+          retained_bytes: non_neg_integer(),
+          control_batches: non_neg_integer(),
+          control_bytes: non_neg_integer(),
+          total_retained_bytes: non_neg_integer(),
+          minimum_ack_generation: non_neg_integer(),
+          last_applied_generation: non_neg_integer(),
+          last_applied_frame_seq: non_neg_integer()
+        }
+
+  @doc "Returns empty pressure state."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Retains a first unwritable frame or replaces the single coalesced successor."
+  @spec enqueue(t(), PendingFrame.t()) :: {:attempt, t()} | {:coalesced, t()}
+  def enqueue(%__MODULE__{current: nil} = pressure, %PendingFrame{} = frame),
+    do: {:attempt, %{pressure | current: frame}}
+
+  def enqueue(%__MODULE__{} = pressure, %PendingFrame{} = frame),
+    do: {:coalesced, %{pressure | replacement: frame}}
+
+  @doc "Coalesces the latest unwritable out-of-band control batch by opcode."
+  @spec retain_control(t(), non_neg_integer(), binary()) :: t()
+  def retain_control(%__MODULE__{} = pressure, opcode, batch)
+      when is_integer(opcode) and opcode >= 0 and is_binary(batch),
+      do: %{pressure | controls: Map.put(pressure.controls, opcode, batch)}
+
+  @doc "Returns the next retained control batch in deterministic opcode order."
+  @spec next_control(t()) :: {non_neg_integer(), binary()} | nil
+  def next_control(%__MODULE__{controls: controls}) when map_size(controls) == 0, do: nil
+
+  def next_control(%__MODULE__{controls: controls}) do
+    opcode = controls |> Map.keys() |> Enum.min()
+    {opcode, Map.fetch!(controls, opcode)}
+  end
+
+  @doc "Drops one admitted control batch."
+  @spec control_admitted(t(), non_neg_integer()) :: t()
+  def control_admitted(%__MODULE__{} = pressure, opcode),
+    do: %{pressure | controls: Map.delete(pressure.controls, opcode)}
+
+  @doc "Clears the unwritable interval after every retained batch drains."
+  @spec settled(t()) :: t()
+  def settled(%__MODULE__{current: nil, replacement: nil, controls: controls} = pressure)
+      when map_size(controls) == 0,
+      do: %{pressure | unwritable_since: nil, retry_token: nil}
+
+  def settled(%__MODULE__{} = pressure), do: pressure
+
+  @doc "Returns whether any control batch is retained."
+  @spec controls_pending?(t()) :: boolean()
+  def controls_pending?(%__MODULE__{controls: controls}), do: map_size(controls) > 0
+
+  @doc "Returns whether a retry timer is already correlated."
+  @spec retry_scheduled?(t()) :: boolean()
+  def retry_scheduled?(%__MODULE__{retry_token: token}), do: is_reference(token)
+
+  @doc "Marks the current admission unwritable and correlates one retry token."
+  @spec mark_unwritable(t(), integer(), reference()) :: t()
+  def mark_unwritable(%__MODULE__{} = pressure, now, retry_token)
+      when is_integer(now) and is_reference(retry_token) do
+    since = pressure.unwritable_since || now
+    %{pressure | unwritable_since: since, retry_token: retry_token}
+  end
+
+  @doc "Consumes the matching retry token and rejects stale timer messages."
+  @spec consume_retry(t(), reference()) :: {:ok, t()} | :stale
+  def consume_retry(%__MODULE__{retry_token: token} = pressure, token) when is_reference(token),
+    do: {:ok, %{pressure | retry_token: nil}}
+
+  def consume_retry(%__MODULE__{}, _token), do: :stale
+
+  @doc "Returns whether the current unwritable interval reached its failure budget."
+  @spec expired?(t(), integer(), non_neg_integer()) :: boolean()
+  def expired?(%__MODULE__{unwritable_since: since}, now, failure_ms)
+      when is_integer(since) and is_integer(now) and is_integer(failure_ms) and failure_ms >= 0,
+      do: now - since >= failure_ms
+
+  def expired?(%__MODULE__{}, _now, _failure_ms), do: false
+
+  @doc "Advances after the current frame is admitted and returns the admitted frame."
+  @spec admitted(t()) :: {PendingFrame.t(), t()}
+  def admitted(%__MODULE__{current: %PendingFrame{} = current} = pressure) do
+    {current,
+     %{
+       pressure
+       | current: pressure.replacement,
+         replacement: nil,
+         unwritable_since: nil,
+         retry_token: nil
+     }}
+  end
+
+  @doc "Drops retained output and requires acknowledgements from the next generation."
+  @spec require_recovery(t(), PendingFrame.t()) :: t()
+  def require_recovery(%__MODULE__{} = pressure, %PendingFrame{} = failed) do
+    %{
+      pressure
+      | current: nil,
+        replacement: nil,
+        unwritable_since: nil,
+        retry_token: nil,
+        minimum_ack_generation: max(pressure.minimum_ack_generation, failed.generation + 1)
+    }
+  end
+
+  @doc "Accepts a correlated acknowledgement or rejects stale generation and sequence values."
+  @spec acknowledge(t(), non_neg_integer(), non_neg_integer()) :: {:accepted, t()} | :stale
+  def acknowledge(%__MODULE__{} = pressure, generation, frame_seq)
+      when is_integer(generation) and generation >= 0 and is_integer(frame_seq) and frame_seq >= 0 do
+    if stale_ack?(pressure, generation, frame_seq) do
+      :stale
+    else
+      {:accepted,
+       %{
+         pressure
+         | last_applied_generation: generation,
+           last_applied_frame_seq: frame_seq
+       }}
+    end
+  end
+
+  @doc "Returns bounded retained-byte and acknowledgement diagnostics."
+  @spec stats(t()) :: stats()
+  def stats(%__MODULE__{} = pressure) do
+    current_bytes = frame_bytes(pressure.current)
+    replacement_bytes = frame_bytes(pressure.replacement)
+
+    control_bytes =
+      pressure.controls
+      |> Map.values()
+      |> Enum.reduce(0, fn batch, total -> total + byte_size(batch) end)
+
+    %{
+      current_frame_seq: frame_seq(pressure.current),
+      replacement_frame_seq: frame_seq(pressure.replacement),
+      current_bytes: current_bytes,
+      replacement_bytes: replacement_bytes,
+      retained_bytes: current_bytes + replacement_bytes,
+      control_batches: map_size(pressure.controls),
+      control_bytes: control_bytes,
+      total_retained_bytes: current_bytes + replacement_bytes + control_bytes,
+      minimum_ack_generation: pressure.minimum_ack_generation,
+      last_applied_generation: pressure.last_applied_generation,
+      last_applied_frame_seq: pressure.last_applied_frame_seq
+    }
+  end
+
+  @spec stale_ack?(t(), non_neg_integer(), non_neg_integer()) :: boolean()
+  defp stale_ack?(pressure, generation, frame_seq) do
+    generation < pressure.minimum_ack_generation or
+      generation < pressure.last_applied_generation or
+      (generation == pressure.last_applied_generation and
+         frame_seq <= pressure.last_applied_frame_seq)
+  end
+
+  @spec frame_bytes(PendingFrame.t() | nil) :: non_neg_integer()
+  defp frame_bytes(nil), do: 0
+  defp frame_bytes(frame), do: PendingFrame.byte_size(frame)
+
+  @spec frame_seq(PendingFrame.t() | nil) :: non_neg_integer() | nil
+  defp frame_seq(nil), do: nil
+  defp frame_seq(%PendingFrame{frame_seq: frame_seq}), do: frame_seq
+end

--- a/lib/minga_editor/frontend/manager/pending_frame.ex
+++ b/lib/minga_editor/frontend/manager/pending_frame.ex
@@ -1,0 +1,54 @@
+defmodule MingaEditor.Frontend.Manager.PendingFrame do
+  @moduledoc "Immutable encoded frame retained while frontend transport admission is unwritable."
+
+  alias Minga.Protocol.Opcodes
+  alias MingaEditor.Frontend.FrameTransaction
+
+  @begin_frame Opcodes.begin_frame()
+
+  @enforce_keys [:batch, :frame_seq, :base_frame_seq, :generation]
+  defstruct [:batch, :frame_seq, :base_frame_seq, :generation]
+
+  @type t :: %__MODULE__{
+          batch: binary(),
+          frame_seq: non_neg_integer(),
+          base_frame_seq: non_neg_integer(),
+          generation: non_neg_integer()
+        }
+
+  @doc "Builds retained frame metadata from one complete encoded transaction."
+  @spec from_commands([binary()]) :: {:ok, t()} | {:error, FrameTransaction.validation_error()}
+  def from_commands(commands) when is_list(commands) do
+    with :ok <- FrameTransaction.validate(commands),
+         {:ok, frame_seq, base_frame_seq, generation} <- transaction_header(commands) do
+      {:ok,
+       %__MODULE__{
+         batch: IO.iodata_to_binary(commands),
+         frame_seq: frame_seq,
+         base_frame_seq: base_frame_seq,
+         generation: generation
+       }}
+    end
+  end
+
+  @doc "Returns retained encoded bytes."
+  @spec byte_size(t()) :: non_neg_integer()
+  def byte_size(%__MODULE__{batch: batch}), do: Kernel.byte_size(batch)
+
+  @doc "Returns whether this frame can follow an admitted predecessor without a missing base."
+  @spec follows?(t(), t()) :: boolean()
+  def follows?(%__MODULE__{base_frame_seq: 0}, %__MODULE__{}), do: true
+
+  def follows?(%__MODULE__{base_frame_seq: base}, %__MODULE__{frame_seq: frame_seq}),
+    do: base == frame_seq
+
+  @spec transaction_header([binary()]) ::
+          {:ok, non_neg_integer(), non_neg_integer(), non_neg_integer()}
+          | {:error, FrameTransaction.validation_error()}
+  defp transaction_header([
+         <<@begin_frame, frame_seq::32, base_frame_seq::32, generation::32>> | _commands
+       ]),
+       do: {:ok, frame_seq, base_frame_seq, generation}
+
+  defp transaction_header(_commands), do: {:error, :malformed_command}
+end

--- a/lib/minga_editor/frontend/manager/state.ex
+++ b/lib/minga_editor/frontend/manager/state.ex
@@ -6,6 +6,7 @@ defmodule MingaEditor.Frontend.Manager.State do
   """
 
   alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.Frontend.Manager.OutputPressure
 
   @typedoc """
   Port connection mode.
@@ -14,8 +15,9 @@ defmodule MingaEditor.Frontend.Manager.State do
   - `:connected` — BEAM is the child; the GUI parent already set up stdin/stdout pipes. Port.Manager connects to fd 0/1 instead of spawning.
   """
   @type port_mode :: :spawn | :connected
+  @type port_commander :: (port(), iodata(), [:nosuspend] -> boolean())
 
-  @enforce_keys [:renderer_path]
+  @enforce_keys [:renderer_path, :output_pressure, :port_commander]
   defstruct port: nil,
             subscribers: [],
             renderer_path: "",
@@ -23,7 +25,11 @@ defmodule MingaEditor.Frontend.Manager.State do
             ready: false,
             terminal_size: nil,
             capabilities: %Capabilities{},
-            tty_path: nil
+            tty_path: nil,
+            output_pressure: nil,
+            port_commander: nil,
+            output_retry_ms: 2,
+            output_failure_ms: 50
 
   @type t :: %__MODULE__{
           port: port() | nil,
@@ -33,6 +39,10 @@ defmodule MingaEditor.Frontend.Manager.State do
           ready: boolean(),
           terminal_size: {width :: pos_integer(), height :: pos_integer()} | nil,
           capabilities: Capabilities.t(),
-          tty_path: String.t() | nil
+          tty_path: String.t() | nil,
+          output_pressure: OutputPressure.t(),
+          port_commander: port_commander(),
+          output_retry_ms: pos_integer(),
+          output_failure_ms: non_neg_integer()
         }
 end

--- a/lib/minga_editor/renderer/state.ex
+++ b/lib/minga_editor/renderer/state.ex
@@ -284,6 +284,7 @@ defmodule MingaEditor.Renderer.State do
     %{
       state
       | caches: Caches.reset_frontend_state(state.caches),
+        font_registry: FontRegistry.require_reregistration(state.font_registry),
         message_store: reset_message_cursor(state.message_store),
         resident_windows: residents
     }

--- a/lib/minga_editor/ui/font_registry.ex
+++ b/lib/minga_editor/ui/font_registry.ex
@@ -80,6 +80,13 @@ defmodule MingaEditor.UI.FontRegistry do
   @spec mark_registered(t()) :: t()
   def mark_registered(%__MODULE__{} = registry), do: %{registry | pending: %{}}
 
+  @doc "Requires every allocated fallback font to be emitted in the next recovery keyframe."
+  @spec require_reregistration(t()) :: t()
+  def require_reregistration(%__MODULE__{} = registry) do
+    pending = Map.new(registry.families, fn {family, id} -> {id, family} end)
+    %{registry | pending: pending}
+  end
+
   @doc "Runs a function with this registry installed for render-local font resolution."
   @spec with_process_registry(t(), (-> result)) :: result when result: term()
   def with_process_registry(%__MODULE__{} = font_registry, fun) when is_function(fun, 0) do

--- a/test/conformance/production_render_corpus_test.exs
+++ b/test/conformance/production_render_corpus_test.exs
@@ -128,7 +128,7 @@ defmodule Minga.Conformance.ProductionRenderCorpusTest do
   end
 
   defp submit(port, seq, base, generation, commands) do
-    :ok = HeadlessPort.send_transaction(port, seq, base, generation, commands)
+    :accepted = HeadlessPort.send_transaction(port, seq, base, generation, commands)
     _ = HeadlessPort.production_state(port)
   end
 

--- a/test/minga_editor/commands/ui_frontend_test.exs
+++ b/test/minga_editor/commands/ui_frontend_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaEditor.Commands.UI.FrontendTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.BottomPanel
   alias MingaEditor.Commands
   alias MingaEditor.Frontend.Capabilities
@@ -19,9 +20,20 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
   @go_tui %Capabilities{frontend_type: :tui, semantic_ui: true}
   @zig %Capabilities{frontend_type: :tui, semantic_ui: false}
 
+  setup do
+    frontend =
+      start_supervised!(
+        {RecordingFrontend, owner: self()},
+        id: {:ui_frontend_recorder, System.unique_integer([:positive])}
+      )
+
+    Process.put(:ui_frontend_recorder, frontend)
+    :ok
+  end
+
   defp base_state(caps) do
     %EditorState{
-      port_manager: self(),
+      port_manager: Process.get(:ui_frontend_recorder),
       capabilities: caps,
       workspace: %SessionState{viewport: Viewport.new(24, 80)},
       shell_runtime:

--- a/test/minga_editor/effect_scheduler_test.exs
+++ b/test/minga_editor/effect_scheduler_test.exs
@@ -10,7 +10,7 @@ defmodule MingaEditor.EffectSchedulerTest do
   alias MingaEditor.EffectScheduler
   alias MingaEditor.GenerationSupervisor
 
-  @effect_timeout 2_000
+  @effect_timeout 15_000
 
   test "normal completion produces exactly one completed terminal outcome" do
     scheduler = start_scheduler()

--- a/test/minga_editor/frontend/emit/keyframe_side_channel_test.exs
+++ b/test/minga_editor/frontend/emit/keyframe_side_channel_test.exs
@@ -7,15 +7,13 @@ defmodule MingaEditor.Frontend.Emit.KeyframeSideChannelTest do
   channels (`last_title` / `last_window_bg`), so a frontend that lost its title or
   background mid-session gets them back on the keyframe.
 
-  `Frontend.set_title/2` and `set_window_bg/2` route to the named
-  `MingaEditor.Frontend.Manager` rather than the frame's `port_manager`, so this
-  test registers `self()` under that name to observe the side-channel sends. That
-  global registration is why this lives in its own `async: false` module.
+  Frame and side-channel writes share the frame context's frontend, so this test observes both through one recording adapter.
   """
 
-  use ExUnit.Case, async: false
+  use ExUnit.Case, async: true
 
   alias Minga.Protocol.Opcodes
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Frontend.Emit
   alias MingaEditor.Frontend.Emit.Context
@@ -26,10 +24,16 @@ defmodule MingaEditor.Frontend.Emit.KeyframeSideChannelTest do
 
   import MingaEditor.RenderPipeline.TestHelpers
 
+  @op_begin_frame Opcodes.begin_frame()
+
   setup do
-    # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
-    Process.register(self(), MingaEditor.Frontend.Manager)
-    on_exit(fn -> safe_unregister(MingaEditor.Frontend.Manager) end)
+    frontend =
+      start_supervised!(
+        {RecordingFrontend, owner: self()},
+        id: {:keyframe_side_channel_frontend, System.unique_integer([:positive])}
+      )
+
+    Process.put(:keyframe_side_channel_frontend, frontend)
     :ok
   end
 
@@ -52,8 +56,8 @@ defmodule MingaEditor.Frontend.Emit.KeyframeSideChannelTest do
 
     # A delta frame with the same title/bg sends neither side channel (cache hit).
     {_c3, caches} = emit_and_capture(frame, state, caches, frame_seq: 24)
-    refute_received {:"$gen_cast", {:send_commands, [<<^title_op, _::binary>>]}}
-    refute_received {:"$gen_cast", {:send_commands, [<<^bg_op, _::binary>>]}}
+    refute_received {:frontend_commands, _frontend, [<<^title_op, _::binary>>]}
+    refute_received {:frontend_commands, _frontend, [<<^bg_op, _::binary>>]}
 
     # The forced keyframe drops last_title/last_window_bg, so both re-send even though
     # the values are unchanged from the prior frame (mirrors reset_frontend_state/1).
@@ -61,18 +65,18 @@ defmodule MingaEditor.Frontend.Emit.KeyframeSideChannelTest do
       emit_and_capture(frame, state, caches, frame_seq: 33, force_keyframe?: true)
 
     assert key_caches.last_frame_keyframe?
-    assert_received {:"$gen_cast", {:send_commands, [<<^title_op, _::binary>>]}}
-    assert_received {:"$gen_cast", {:send_commands, [<<^bg_op, _::binary>>]}}
+    assert_received {:frontend_commands, _frontend, [<<^title_op, _::binary>>]}
+    assert_received {:frontend_commands, _frontend, [<<^bg_op, _::binary>>]}
   end
 
   # ── Helpers ──────────────────────────────────────────────────────────────────
 
   defp semantic_state do
-    %{base_state() | capabilities: %Capabilities{frontend_type: :tui, semantic_ui: true}}
+    %{emit_state() | capabilities: %Capabilities{frontend_type: :tui, semantic_ui: true}}
   end
 
   defp window_frame_with_content do
-    frame = build_frame_with_window(base_state(), viewport_top: 0)
+    frame = build_frame_with_window(emit_state(), viewport_top: 0)
 
     row = %RenderRow{
       row_id: RenderRow.stable_id(:normal, 0),
@@ -103,27 +107,26 @@ defmodule MingaEditor.Frontend.Emit.KeyframeSideChannelTest do
     }
 
     {new_caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches)
-    # The frame's render commands go to port_manager (self()); drain that cast so the
-    # side-channel assertions only see set_title/set_window_bg.
-    assert_receive {:"$gen_cast", {:send_commands, _commands}}
+
+    assert_receive {:frontend_commands, _frontend, [<<@op_begin_frame, _::binary>> | _]}
+
     {nil, new_caches}
   end
 
   defp flush_side_channels(title_op, bg_op) do
     receive do
-      {:"$gen_cast", {:send_commands, [<<^title_op, _::binary>>]}} ->
+      {:frontend_commands, _frontend, [<<^title_op, _::binary>>]} ->
         flush_side_channels(title_op, bg_op)
 
-      {:"$gen_cast", {:send_commands, [<<^bg_op, _::binary>>]}} ->
+      {:frontend_commands, _frontend, [<<^bg_op, _::binary>>]} ->
         flush_side_channels(title_op, bg_op)
     after
       0 -> :ok
     end
   end
 
-  defp safe_unregister(name) do
-    Process.unregister(name)
-  rescue
-    ArgumentError -> :ok
+  defp emit_state(opts \\ []) do
+    frontend = Process.get(:keyframe_side_channel_frontend)
+    base_state(Keyword.put(opts, :port_manager, frontend))
   end
 end

--- a/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
+++ b/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
@@ -14,6 +14,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
   use ExUnit.Case, async: true
 
   alias Minga.Protocol.Opcodes
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.Frontend.Emit
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.HoverPopup
@@ -27,12 +28,24 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
   alias Minga.RenderModel.Cursor
   alias MingaEditor.RenderPipeline.ComposedFrame
 
+  @op_begin_frame Opcodes.begin_frame()
   @op_surface_layout Opcodes.gui_surface_layout()
+
+  setup do
+    frontend =
+      start_supervised!(
+        {RecordingFrontend, owner: self()},
+        id: {:surface_layout_frontend, System.unique_integer([:positive])}
+      )
+
+    Process.put(:surface_layout_frontend, frontend)
+    :ok
+  end
 
   # A base state with both promoted floating popups live in shell_state, so the
   # focus tree adds hover/signature-help overlay nodes and the registry places them.
   defp state_with_floating_popups do
-    state = base_state()
+    state = emit_state()
     hover = HoverPopup.new("Returns the **value**.", 2, 6)
 
     signature = %SignatureHelp{
@@ -52,8 +65,15 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
     frame = ComposedFrame.new([], Cursor.new(0, 0, :block))
     ctx = Context.from_editor_state(state)
     Emit.emit(frame, ctx)
-    assert_receive {:"$gen_cast", {:send_commands, commands}}
+
+    assert_receive {:frontend_commands, _frontend,
+                    [<<@op_begin_frame, _::binary>> | _] = commands}
+
     commands
+  end
+
+  defp emit_state(opts \\ []) do
+    base_state(Keyword.put(opts, :port_manager, Process.get(:surface_layout_frontend)))
   end
 
   defp surface_layout_command(commands) do
@@ -100,7 +120,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
   end
 
   test "every frame's transaction carries a gui_surface_layout command before commit" do
-    commands = emit_commands(base_state())
+    commands = emit_commands(emit_state())
 
     assert cmd = surface_layout_command(commands)
 
@@ -114,7 +134,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
   end
 
   test "emitted placement bytes decode to the exact rects BEAM hit-testing uses (AC-1)" do
-    state = base_state()
+    state = emit_state()
     commands = emit_commands(state)
 
     decoded = commands |> surface_layout_command() |> decode_placements()
@@ -133,7 +153,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
   end
 
   test "rect for each decoded surface_id equals the registry rect_for that surface" do
-    state = base_state()
+    state = emit_state()
     commands = emit_commands(state)
     decoded = commands |> surface_layout_command() |> decode_placements()
     placements = SurfaceRegistry.placements(state)
@@ -201,7 +221,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
     center =
       MingaEditor.UI.NotificationCenter.upsert(MingaEditor.UI.NotificationCenter.new(), note)
 
-    state = %{base_state() | notifications: center}
+    state = %{emit_state() | notifications: center}
 
     commands = emit_commands(state)
     decoded = commands |> surface_layout_command() |> decode_placements()
@@ -230,7 +250,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
     # A degenerate state with no focus tree surfaces still produces a valid,
     # decodable command: the transaction always carries the layout authority,
     # even when the authority is empty.
-    state = base_state()
+    state = emit_state()
     # Force an empty placement context directly through the encoder to prove the
     # zero-count framing round-trips (the live state always has chrome, so this
     # exercises the boundary the production encoder must handle).

--- a/test/minga_editor/frontend/emit_test.exs
+++ b/test/minga_editor/frontend/emit_test.exs
@@ -20,20 +20,34 @@ defmodule MingaEditor.Frontend.EmitTest do
   alias Minga.RenderModel.Window.IndentGuides
   alias Minga.RenderModel.Window.Row, as: RenderRow
   alias Minga.RenderModel.Window.Span, as: RenderSpan
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.UI.FontRegistry
 
   import MingaEditor.RenderPipeline.TestHelpers
 
+  @op_begin_frame Opcodes.begin_frame()
+
+  setup do
+    frontend =
+      start_supervised!(
+        {RecordingFrontend, owner: self()},
+        id: {:emit_recording_frontend, System.unique_integer([:positive])}
+      )
+
+    Process.put(:emit_test_frontend, frontend)
+    :ok
+  end
+
   describe "emit/2 dispatching" do
     test "TUI path emits a semantic frame, not a leading cell-grid clear" do
       frame = ComposedFrame.new([], Cursor.new(0, 0, :block))
 
-      state = base_state()
+      state = emit_state()
       ctx = Context.from_editor_state(state)
       Emit.emit(frame, ctx)
 
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      commands = assert_receive_frame_commands()
 
       # The TUI renders via the semantic GUI protocol, now bracketed as a frame
       # transaction (#2219): every frame opens with begin_frame (0x10) and closes
@@ -51,17 +65,17 @@ defmodule MingaEditor.Frontend.EmitTest do
     test "GUI path produces commands (no clear expected for GUI with to_commands)" do
       frame = ComposedFrame.new([], Cursor.new(0, 0, :block))
 
-      state = gui_state()
+      state = %{gui_state() | port_manager: Process.get(:emit_test_frontend)}
       ctx = Context.from_editor_state(state)
       Emit.emit(frame, ctx)
 
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      commands = assert_receive_frame_commands()
       assert is_list(commands)
       assert Enum.all?(commands, &is_binary/1)
     end
 
     test "semantic TUI path emits semantic window commands instead of cell-grid clear" do
-      frame = build_frame_with_window(base_state(), viewport_top: 0)
+      frame = build_frame_with_window(emit_state(), viewport_top: 0)
 
       row = %RenderRow{
         row_id: RenderRow.stable_id(:normal, 0),
@@ -84,14 +98,14 @@ defmodule MingaEditor.Frontend.EmitTest do
       frame = %{frame | windows: [window_model]}
 
       state = %{
-        base_state()
+        emit_state()
         | capabilities: %Capabilities{frontend_type: :tui, semantic_ui: true}
       }
 
       ctx = Context.from_editor_state(state)
       Emit.emit(frame, ctx)
 
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      commands = assert_receive_frame_commands()
       refute match?([<<0x12>> | _], commands)
 
       assert Enum.any?(commands, fn
@@ -181,7 +195,7 @@ defmodule MingaEditor.Frontend.EmitTest do
       {recovered_caches, _font_registry, _message_store} =
         Emit.emit(invalid_frame, ctx, nil, caches)
 
-      refute_receive {:"$gen_cast", {:send_commands, _}}
+      refute_receive {:frontend_commands, _frontend, [<<@op_begin_frame, _::binary>> | _]}
       assert recovered_caches.adapter_gui_caches == Minga.Frontend.Adapter.GUI.Caches.new()
       assert recovered_caches.last_emitted_frame_seq == 0
 
@@ -258,7 +272,7 @@ defmodule MingaEditor.Frontend.EmitTest do
     test "styled virtual text allocates a font id and emits a register_font command" do
       face = %Face{name: "vt", fg: 0xFFFFFF, bg: 0x000000, font_family: "Fira Code"}
 
-      state = base_state(content: "hello\nworld")
+      state = emit_state(content: "hello\nworld")
       buffer = state.workspace.buffers.active
 
       BufferProcess.add_virtual_text(buffer, {0, 0},
@@ -268,7 +282,7 @@ defmodule MingaEditor.Frontend.EmitTest do
       )
 
       run_pipeline(state)
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      commands = assert_receive_frame_commands()
 
       # register_font (0x52) with the first allocated id (1), then the family
       # length and bytes. The window builder allocated the id during the content
@@ -285,10 +299,10 @@ defmodule MingaEditor.Frontend.EmitTest do
       frame = ComposedFrame.new([], Cursor.new(0, 0, :block))
 
       {_id, registry, true} = FontRegistry.get_or_register(FontRegistry.new(), "Fira Code")
-      ctx = %{Context.from_editor_state(base_state()) | font_registry: registry}
+      ctx = %{Context.from_editor_state(emit_state()) | font_registry: registry}
 
       {_caches, font_registry, _message_store} = Emit.emit(frame, ctx, nil, %Caches{})
-      assert_receive {:"$gen_cast", {:send_commands, commands}}
+      commands = assert_receive_frame_commands()
 
       assert FontRegistry.pending_registrations(font_registry) == []
 
@@ -301,13 +315,13 @@ defmodule MingaEditor.Frontend.EmitTest do
 
   describe "update_tracking (shared)" do
     test "writes viewport tracking state into returned caches" do
-      frame = build_frame_with_window(base_state(), viewport_top: 0)
-      state = base_state()
+      frame = build_frame_with_window(emit_state(), viewport_top: 0)
+      state = emit_state()
       _layout = Layout.put(state)
       ctx = Context.from_editor_state(state)
 
       {caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, %Caches{})
-      assert_receive {:"$gen_cast", {:send_commands, _}}
+      _ = assert_receive_frame_commands()
 
       assert is_map(caches.emit_prev_viewport_tops)
       assert is_map(caches.emit_prev_content_rects)
@@ -320,19 +334,19 @@ defmodule MingaEditor.Frontend.EmitTest do
     test "sends title command only when title changes" do
       frame = ComposedFrame.new([], Cursor.new(0, 0, :block))
 
-      state = base_state()
+      state = emit_state()
       ctx = Context.from_editor_state(state)
       caches0 = %Caches{}
 
       {caches1, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches0)
       # Flush first commands + title
-      assert_receive {:"$gen_cast", {:send_commands, _commands}}
+      _commands = assert_receive_frame_commands()
 
       assert is_binary(caches1.last_title)
 
       # Emit again with same ctx; title should not be re-sent (cache hit)
       {caches2, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches1)
-      assert_receive {:"$gen_cast", {:send_commands, _commands2}}
+      _commands2 = assert_receive_frame_commands()
 
       assert caches2.last_title == caches1.last_title
     end
@@ -342,18 +356,18 @@ defmodule MingaEditor.Frontend.EmitTest do
     test "sends background command only when theme changes" do
       frame = ComposedFrame.new([], Cursor.new(0, 0, :block))
 
-      state = base_state()
+      state = emit_state()
       ctx = Context.from_editor_state(state)
       caches0 = %Caches{}
 
       {caches1, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches0)
-      assert_receive {:"$gen_cast", {:send_commands, _}}
+      _ = assert_receive_frame_commands()
 
       assert caches1.last_window_bg == state.theme.editor.bg
 
       # Emit again, should not re-send
       {caches2, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches1)
-      assert_receive {:"$gen_cast", {:send_commands, _}}
+      _ = assert_receive_frame_commands()
       assert caches2.last_window_bg == caches1.last_window_bg
     end
   end
@@ -361,11 +375,11 @@ defmodule MingaEditor.Frontend.EmitTest do
   # ── Frame-transaction test helpers ───────────────────────────────────────
 
   defp semantic_state do
-    %{base_state() | capabilities: %Capabilities{frontend_type: :tui, semantic_ui: true}}
+    %{emit_state() | capabilities: %Capabilities{frontend_type: :tui, semantic_ui: true}}
   end
 
   defp window_frame_with_content do
-    frame = build_frame_with_window(base_state(), viewport_top: 0)
+    frame = build_frame_with_window(emit_state(), viewport_top: 0)
 
     row = %RenderRow{
       row_id: RenderRow.stable_id(:normal, 0),
@@ -403,7 +417,7 @@ defmodule MingaEditor.Frontend.EmitTest do
   end
 
   # Drives Emit.emit/4 with an explicit frame_seq and optional keyframe forcing,
-  # capturing the single send_commands cast (port_manager is self()).
+  # capturing the admitted frame batch from the recording frontend.
   defp acknowledge(caches, frame_seq) do
     Caches.acknowledge_frame(caches, frame_seq, caches.recovery_generation)
   end
@@ -417,7 +431,18 @@ defmodule MingaEditor.Frontend.EmitTest do
     }
 
     {new_caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, caches)
-    assert_receive {:"$gen_cast", {:send_commands, commands}}
+    commands = assert_receive_frame_commands()
     {commands, new_caches}
+  end
+
+  defp assert_receive_frame_commands do
+    assert_receive {:frontend_commands, _frontend,
+                    [<<@op_begin_frame, _::binary>> | _] = commands}
+
+    commands
+  end
+
+  defp emit_state(opts \\ []) do
+    base_state(Keyword.put(opts, :port_manager, Process.get(:emit_test_frontend)))
   end
 end

--- a/test/minga_editor/frontend/manager/output_pressure_test.exs
+++ b/test/minga_editor/frontend/manager/output_pressure_test.exs
@@ -1,0 +1,99 @@
+defmodule MingaEditor.Frontend.Manager.OutputPressureTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Protocol.Opcodes
+  alias MingaEditor.Frontend.Manager.OutputPressure
+  alias MingaEditor.Frontend.Manager.PendingFrame
+  alias MingaEditor.Frontend.Protocol
+
+  test "retains one current frame and coalesces one latest replacement" do
+    first = frame(10, 9, 1)
+    second = frame(11, 10, 1)
+    latest = frame(12, 11, 1)
+
+    assert {:attempt, pressure} = OutputPressure.enqueue(OutputPressure.new(), first)
+    assert {:coalesced, pressure} = OutputPressure.enqueue(pressure, second)
+    assert {:coalesced, pressure} = OutputPressure.enqueue(pressure, latest)
+
+    stats = OutputPressure.stats(pressure)
+    assert stats.current_frame_seq == 10
+    assert stats.replacement_frame_seq == 12
+    assert stats.current_bytes == PendingFrame.byte_size(first)
+    assert stats.replacement_bytes == PendingFrame.byte_size(latest)
+    assert stats.retained_bytes == stats.current_bytes + stats.replacement_bytes
+  end
+
+  test "admission promotes the coalesced replacement and preserves frame ordering metadata" do
+    first = frame(10, 9, 1)
+    replacement = frame(11, 10, 1)
+
+    {:attempt, pressure} = OutputPressure.enqueue(OutputPressure.new(), first)
+    {:coalesced, pressure} = OutputPressure.enqueue(pressure, replacement)
+    assert {^first, pressure} = OutputPressure.admitted(pressure)
+    assert pressure.current == replacement
+    assert PendingFrame.follows?(replacement, first)
+    refute PendingFrame.follows?(frame(12, 9, 1), first)
+    assert PendingFrame.follows?(frame(12, 0, 2), first)
+  end
+
+  test "recovery raises the acknowledgement generation floor and rejects stale acknowledgements" do
+    failed = frame(11, 10, 3)
+    {:attempt, pressure} = OutputPressure.enqueue(OutputPressure.new(), failed)
+    pressure = OutputPressure.require_recovery(pressure, failed)
+
+    assert OutputPressure.acknowledge(pressure, 3, 11) == :stale
+    assert {:accepted, pressure} = OutputPressure.acknowledge(pressure, 4, 12)
+    assert OutputPressure.acknowledge(pressure, 4, 11) == :stale
+
+    stats = OutputPressure.stats(pressure)
+    assert stats.minimum_ack_generation == 4
+    assert stats.last_applied_generation == 4
+    assert stats.last_applied_frame_seq == 12
+    assert stats.retained_bytes == 0
+  end
+
+  test "control batches coalesce by opcode and survive frame recovery" do
+    first_font = Protocol.encode_set_font("First", 14, true, :regular)
+    latest_font = Protocol.encode_set_font("Latest", 16, true, :regular)
+    title = Protocol.encode_set_title("Minga")
+    pressure = OutputPressure.new()
+    pressure = OutputPressure.retain_control(pressure, Opcodes.set_font(), first_font)
+    pressure = OutputPressure.retain_control(pressure, Opcodes.set_font(), latest_font)
+    pressure = OutputPressure.retain_control(pressure, Opcodes.set_title(), title)
+
+    stats = OutputPressure.stats(pressure)
+    assert stats.control_batches == 2
+    assert stats.control_bytes == byte_size(latest_font) + byte_size(title)
+
+    failed = frame(11, 10, 3)
+    {:attempt, pressure} = OutputPressure.enqueue(pressure, failed)
+    pressure = OutputPressure.require_recovery(pressure, failed)
+    assert OutputPressure.controls_pending?(pressure)
+    assert OutputPressure.stats(pressure).control_batches == 2
+  end
+
+  test "unwritable failure timing starts once and retry tokens are correlated" do
+    pending = frame(7, 6, 1)
+    {:attempt, pressure} = OutputPressure.enqueue(OutputPressure.new(), pending)
+    first_token = make_ref()
+    second_token = make_ref()
+    pressure = OutputPressure.mark_unwritable(pressure, 100, first_token)
+    pressure = OutputPressure.mark_unwritable(pressure, 120, second_token)
+
+    refute OutputPressure.expired?(pressure, 149, 50)
+    assert OutputPressure.expired?(pressure, 150, 50)
+    assert OutputPressure.consume_retry(pressure, first_token) == :stale
+    assert {:ok, pressure} = OutputPressure.consume_retry(pressure, second_token)
+    assert pressure.retry_token == nil
+  end
+
+  defp frame(frame_seq, base_frame_seq, generation) do
+    commands = [
+      Protocol.encode_begin_frame(frame_seq, base_frame_seq, generation),
+      Protocol.encode_commit_frame(frame_seq)
+    ]
+
+    assert {:ok, frame} = PendingFrame.from_commands(commands)
+    frame
+  end
+end

--- a/test/minga_editor/frontend/manager_test.exs
+++ b/test/minga_editor/frontend/manager_test.exs
@@ -53,12 +53,12 @@ defmodule MingaEditor.Frontend.ManagerTest do
   end
 
   describe "send_commands/2" do
-    test "returns ok when no port is open" do
+    test "returns unwritable when no port is open" do
       name = unique_name()
       start_manager(name)
 
-      assert :ok = Manager.send_commands(name, [])
-      assert :ok = Manager.send_commands(name, [Protocol.encode_commit_frame(0)])
+      assert :unwritable = Manager.send_commands(name, [])
+      assert :unwritable = Manager.send_commands(name, [Protocol.encode_commit_frame(0)])
     end
   end
 
@@ -247,6 +247,154 @@ defmodule MingaEditor.Frontend.ManagerTest do
     end
   end
 
+  describe "output pressure" do
+    test "unwritable transport requests correlated keyframe recovery and rejects stale acknowledgements" do
+      name = unique_name()
+      commander = fn _port, _batch, [:nosuspend] -> false end
+
+      {pid, fake_port} =
+        start_connected(name,
+          port_commander: commander,
+          output_retry_ms: 1,
+          output_failure_ms: 0
+        )
+
+      :ok = Manager.subscribe(name)
+      send_port_data(pid, fake_port, <<0x0A, 1::32, 10::32>>)
+      assert_receive {:minga_input, {:frame_applied, 1, 10}}
+
+      assert :unwritable = Manager.send_render_commands(name, frame_commands(11, 10, 1))
+      assert_receive {:minga_input, {:request_keyframe, 10, 1}}, 1_000
+
+      send_port_data(pid, fake_port, <<0x0A, 1::32, 11::32>>)
+      refute_receive {:minga_input, {:frame_applied, 1, 11}}, 50
+
+      send_port_data(pid, fake_port, <<0x0A, 2::32, 12::32>>)
+      assert_receive {:minga_input, {:frame_applied, 2, 12}}
+
+      pressure = Manager.output_pressure(name)
+      assert pressure.minimum_ack_generation == 2
+      assert pressure.last_applied_generation == 2
+      assert pressure.last_applied_frame_seq == 12
+      assert pressure.retained_bytes == 0
+    end
+
+    test "an unwritable font configuration is retained and retried before later frames" do
+      name = unique_name()
+      parent = self()
+      outcomes = start_supervised!({Agent, fn -> [false, true] end}, id: make_ref())
+
+      commander = fn _port, batch, [:nosuspend] ->
+        outcome =
+          Agent.get_and_update(outcomes, fn
+            [next | rest] -> {next, rest}
+            [] -> {true, []}
+          end)
+
+        send(parent, {:font_control_attempt, outcome, batch})
+        outcome
+      end
+
+      {_pid, _fake_port} =
+        start_connected(name,
+          port_commander: commander,
+          output_retry_ms: 20,
+          output_failure_ms: 1_000
+        )
+
+      font_command = Protocol.encode_set_font("Fira Code", 15, true, :regular)
+      assert :unwritable = Manager.send_commands(name, [font_command])
+      assert_receive {:font_control_attempt, false, ^font_command}
+
+      pressure = Manager.output_pressure(name)
+      assert pressure.control_batches == 1
+      assert pressure.control_bytes == byte_size(font_command)
+
+      assert_receive {:font_control_attempt, true, ^font_command}, 1_000
+      pressure = Manager.output_pressure(name)
+      assert pressure.control_batches == 0
+      assert pressure.control_bytes == 0
+    end
+
+    test "an incompatible coalesced replacement triggers keyframe recovery instead of skipping its base" do
+      name = unique_name()
+      outcomes = start_supervised!({Agent, fn -> [false, true] end}, id: make_ref())
+
+      commander = fn _port, _batch, [:nosuspend] ->
+        Agent.get_and_update(outcomes, fn
+          [outcome | rest] -> {outcome, rest}
+          [] -> {true, []}
+        end)
+      end
+
+      {_pid, _fake_port} =
+        start_connected(name,
+          port_commander: commander,
+          output_retry_ms: 20,
+          output_failure_ms: 1_000
+        )
+
+      :ok = Manager.subscribe(name)
+      assert :unwritable = Manager.send_render_commands(name, frame_commands(10, 9, 1))
+      assert :unwritable = Manager.send_render_commands(name, frame_commands(12, 11, 1))
+      assert_receive {:minga_input, {:request_keyframe, 0, 1}}, 1_000
+
+      pressure = Manager.output_pressure(name)
+      assert pressure.minimum_ack_generation == 2
+      assert pressure.retained_bytes == 0
+    end
+
+    @tag :heavy
+    test "a frontend that stops reading retains at most two frames and keeps input responsive" do
+      name = unique_name()
+      parent = self()
+
+      opener = fn _spec, _opts ->
+        port = Port.open({:spawn, "sleep 10"}, [:binary, {:packet, 4}])
+        send(parent, {:pressure_port, port})
+        port
+      end
+
+      pid =
+        start_supervised!(
+          {Manager,
+           name: name,
+           renderer_path: "/nonexistent",
+           port_mode: :connected,
+           port_opener: opener,
+           output_retry_ms: 1_000,
+           output_failure_ms: 10_000},
+          id: name
+        )
+
+      assert_receive {:pressure_port, port}
+      :ok = Manager.subscribe(name)
+      payload = :binary.copy(<<0>>, 128 * 1_024)
+
+      results =
+        Enum.map(1..100, fn frame_seq ->
+          Manager.send_render_commands(
+            name,
+            frame_commands(frame_seq, max(frame_seq - 1, 0), 1, payload)
+          )
+        end)
+
+      assert :unwritable in results
+      pressure = Manager.output_pressure(name)
+      frame_bytes = IO.iodata_length(frame_commands(100, 99, 1, payload))
+      assert pressure.current_bytes > 0
+      assert pressure.replacement_bytes > 0
+      assert pressure.retained_bytes <= frame_bytes * 2
+
+      send_port_data(pid, port, <<0x02, 101::16, 51::16>>)
+      assert_receive {:minga_input, {:resize, 101, 51}}, 1_000
+      assert Manager.terminal_size(name) == {101, 51}
+
+      {:message_queue_len, queue_len} = Process.info(pid, :message_queue_len)
+      assert queue_len <= 1
+    end
+  end
+
   describe "unknown messages" do
     test "unknown messages are ignored" do
       name = unique_name()
@@ -328,14 +476,14 @@ defmodule MingaEditor.Frontend.ManagerTest do
       refute Manager.ready?(name)
 
       send(pid, {fake_port, :eof})
-      assert :ok = Manager.send_commands(name, [Protocol.encode_commit_frame(0)])
+      assert :unwritable = Manager.send_commands(name, [Protocol.encode_commit_frame(0)])
     end
 
-    test "send_commands works when connected" do
+    test "send_commands returns accepted when connected" do
       name = unique_name()
       {_pid, _fake_port} = start_connected(name)
 
-      assert :ok = Manager.send_commands(name, [Protocol.encode_commit_frame(0)])
+      assert :accepted = Manager.send_commands(name, [Protocol.encode_commit_frame(0)])
     end
 
     test "send_commands emits actual port write telemetry when connected" do
@@ -356,8 +504,11 @@ defmodule MingaEditor.Frontend.ManagerTest do
         {_pid, _fake_port} = start_connected(name)
         command = Protocol.encode_commit_frame(0)
 
-        assert :ok = Manager.send_commands(name, [command])
-        assert_receive {:port_write, %{duration: duration}, %{byte_count: byte_count}}, 1_000
+        assert :accepted = Manager.send_commands(name, [command])
+
+        assert_receive {:port_write, %{duration: duration}, %{byte_count: byte_count}},
+                       1_000
+
         assert duration >= 0
         assert byte_count == byte_size(command)
       after
@@ -384,17 +535,28 @@ defmodule MingaEditor.Frontend.ManagerTest do
     end
   end
 
-  defp start_connected(name) do
+  defp start_connected(name, extra_opts \\ []) do
     opener = fake_port_opener()
 
-    pid =
-      start_supervised!(
-        {Manager,
-         name: name, renderer_path: "/nonexistent", port_mode: :connected, port_opener: opener},
-        id: name
-      )
+    opts =
+      [
+        name: name,
+        renderer_path: "/nonexistent",
+        port_mode: :connected,
+        port_opener: opener
+      ] ++ extra_opts
+
+    pid = start_supervised!({Manager, opts}, id: name)
 
     assert_receive {:fake_port, fake_port}
     {pid, fake_port}
+  end
+
+  defp frame_commands(frame_seq, base_frame_seq, generation, payload \\ <<>>) do
+    [
+      Protocol.encode_begin_frame(frame_seq, base_frame_seq, generation),
+      <<0x70, payload::binary>>,
+      Protocol.encode_commit_frame(frame_seq)
+    ]
   end
 end

--- a/test/minga_editor/handlers/gui_action_git_async_test.exs
+++ b/test/minga_editor/handlers/gui_action_git_async_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.Handlers.GuiActionGitAsyncTest do
 
   alias Minga.Git.Stub
   alias Minga.Test.GitRepositoryResolver
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effect.Request
   alias MingaEditor.EffectScheduler
@@ -41,7 +42,18 @@ defmodule MingaEditor.Handlers.GuiActionGitAsyncTest do
 
     on_exit(fn -> Stub.clear(git_root) end)
 
-    state = TestHelpers.base_state(sidebar_registry: table, effect_scheduler: scheduler)
+    frontend =
+      start_supervised!(
+        {RecordingFrontend, owner: self()},
+        id: {:git_async_frontend, System.unique_integer([:positive])}
+      )
+
+    state =
+      TestHelpers.base_state(
+        sidebar_registry: table,
+        effect_scheduler: scheduler,
+        port_manager: frontend
+      )
 
     dispatch_opts = [
       git_root_resolver: {GitRepositoryResolver, {:return, git_root, git_root}}

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.Input.RouterTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Test.InputRouterMouseProbe
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.BottomPanel
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.FocusTree
@@ -19,7 +20,15 @@ defmodule MingaEditor.Input.RouterTest do
   setup do
     table = Module.concat(__MODULE__, "Sidebar#{System.unique_integer([:positive])}")
     start_supervised!({Sidebar, name: table, notify: false})
+
+    frontend =
+      start_supervised!(
+        {RecordingFrontend, owner: self()},
+        id: {:router_recording_frontend, System.unique_integer([:positive])}
+      )
+
     Process.put(:sidebar_registry, table)
+    Process.put(:router_recording_frontend, frontend)
     :ok
   end
 
@@ -27,7 +36,7 @@ defmodule MingaEditor.Input.RouterTest do
     {:ok, buf} = BufferProcess.start_link(content: "hello\nworld\nthird")
 
     %EditorState{
-      port_manager: self(),
+      port_manager: Process.get(:router_recording_frontend),
       sidebar_registry: Process.get(:sidebar_registry),
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80),
@@ -240,7 +249,7 @@ defmodule MingaEditor.Input.RouterTest do
 
       %EditorState{
         backend: :tui,
-        port_manager: self(),
+        port_manager: Process.get(:router_recording_frontend),
         renderer: renderer_pid,
         sidebar_registry: Process.get(:sidebar_registry),
         terminal_viewport: Viewport.new(24, 80),
@@ -292,7 +301,7 @@ defmodule MingaEditor.Input.RouterTest do
       pending_state = Router.dispatch(state, ?d, 0)
       assert pending_state.workspace.editing.mode == :operator_pending
       assert_receive {:acknowledged_render, first_seq, 1, 0}, @async_render_timeout
-      refute_receive {:"$gen_cast", {:send_commands, _commands}}, 20
+      refute_receive {:frontend_commands, _frontend, _commands}, 20
 
       RendererServer.frame_status(renderer, {:frame_applied, 1, first_seq})
       assert_receive {:render_done, %{frame_seq: ^first_seq}}, @async_render_timeout

--- a/test/minga_editor/render_pipeline/chrome_dirty_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_dirty_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.TestHelpers
@@ -11,12 +12,24 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
   setup do
     table = Module.concat(__MODULE__, "Sidebar#{System.unique_integer([:positive])}")
     start_supervised!({Sidebar, name: table, notify: false})
+
+    frontend =
+      start_supervised!(
+        {RecordingFrontend, owner: self()},
+        id: {:chrome_dirty_frontend, System.unique_integer([:positive])}
+      )
+
+    Process.put(:chrome_dirty_frontend, frontend)
     %{sidebar_registry: table}
+  end
+
+  defp base_state(opts \\ []) do
+    TestHelpers.base_state(Keyword.put(opts, :port_manager, Process.get(:chrome_dirty_frontend)))
   end
 
   describe "chrome_fingerprint/1" do
     test "same input produces same fingerprint" do
-      state = TestHelpers.base_state()
+      state = base_state()
       input = Input.from_editor_state(state)
 
       fp1 = Input.chrome_fingerprint(input)
@@ -26,7 +39,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
     end
 
     test "changing vim mode changes fingerprint" do
-      state = TestHelpers.base_state()
+      state = base_state()
       input = Input.from_editor_state(state)
       fp_normal = Input.chrome_fingerprint(input)
 
@@ -40,7 +53,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
     end
 
     test "changing theme changes fingerprint" do
-      state = TestHelpers.base_state()
+      state = base_state()
       input = Input.from_editor_state(state)
       fp_before = Input.chrome_fingerprint(input)
 
@@ -58,7 +71,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
       path = Path.join(dir, "saved.ex")
       File.write!(path, "defmodule Saved do\nend\n")
 
-      state = TestHelpers.base_state(content: File.read!(path))
+      state = base_state(content: File.read!(path))
       buf = state.workspace.buffers.active
       :ok = BufferProcess.save_as(buf, path)
       :ok = BufferProcess.insert_text(buf, "# dirty\n")
@@ -74,7 +87,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
     end
 
     test "moving cursor changes fingerprint" do
-      state = TestHelpers.base_state()
+      state = base_state()
       buf = state.workspace.buffers.active
 
       input1 = Input.from_editor_state(state)
@@ -90,7 +103,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
     end
 
     test "changing file tree changes fingerprint" do
-      state = TestHelpers.base_state()
+      state = base_state()
       input = Input.from_editor_state(state)
       fp1 = Input.chrome_fingerprint(input)
 
@@ -116,7 +129,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
                  snapshot: [rows: [%{id: "a", text: "alpha"}]]
                })
 
-      state = TestHelpers.base_state(sidebar_registry: table)
+      state = base_state(sidebar_registry: table)
       fp_visible = state |> Input.from_editor_state() |> Input.chrome_fingerprint()
 
       assert :ok = Sidebar.set_visible(table, {:extension, :outline}, "outline", false)
@@ -149,7 +162,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
                  snapshot: [rows: [%{id: "a", text: "alpha"}]]
                })
 
-      state = TestHelpers.base_state(sidebar_registry: table)
+      state = base_state(sidebar_registry: table)
       state1 = TestHelpers.run_pipeline(state)
       fingerprint1 = :sys.get_state(state1.renderer).caches.chrome_prev_fingerprint
 
@@ -165,7 +178,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
     end
 
     test "shell-owned chrome state changes fingerprint through shell hook" do
-      state = TestHelpers.base_state()
+      state = base_state()
       input = Input.from_editor_state(state)
       fp1 = Input.chrome_fingerprint(input)
 
@@ -185,7 +198,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
     end
 
     test "unchanged input between frames produces stable fingerprint" do
-      state = TestHelpers.base_state()
+      state = base_state()
       input = Input.from_editor_state(state)
 
       # Simulate two frames with no state changes
@@ -198,7 +211,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
 
   describe "chrome skip integration" do
     test "second render with unchanged state skips chrome rebuild" do
-      state = TestHelpers.base_state()
+      state = base_state()
 
       # First render: builds chrome fresh in renderer-owned state.
       state1 = TestHelpers.run_pipeline(state)
@@ -222,7 +235,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
     end
 
     test "render after cursor move rebuilds chrome" do
-      state = TestHelpers.base_state()
+      state = base_state()
       buf = state.workspace.buffers.active
 
       # First render.
@@ -249,7 +262,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
       File.write!(first_path, "defmodule First do\nend\n")
       File.write!(second_path, "defmodule Second do\nend\n")
 
-      state = TestHelpers.base_state(content: File.read!(first_path))
+      state = base_state(content: File.read!(first_path))
       first_buf = state.workspace.buffers.active
       :ok = BufferProcess.save_as(first_buf, first_path)
       {:ok, second_buf} = BufferProcess.start_link(content: File.read!(second_path))

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -18,6 +18,7 @@ defmodule MingaEditor.Shell.RegistryTest do
   alias MingaEditor.Shell.Workflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
+  alias Minga.Test.RecordingFrontend
   alias MingaEditor.Test.FakeShell
   alias MingaEditor.Test.FakeShellAlt
 
@@ -934,7 +935,13 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
-    state = TestHelpers.base_state() |> Workflow.switch(:fake)
+    frontend =
+      start_supervised!(
+        {RecordingFrontend, owner: self()},
+        id: {:registry_fallback_frontend, System.unique_integer([:positive])}
+      )
+
+    state = TestHelpers.base_state(port_manager: frontend) |> Workflow.switch(:fake)
     assert :ok = Registry.unregister_source({:extension, :fake})
 
     result = Router.dispatch(state, ?j, 0)

--- a/test/minga_editor/ui/font_registry_test.exs
+++ b/test/minga_editor/ui/font_registry_test.exs
@@ -52,6 +52,17 @@ defmodule Minga.FontRegistryTest do
   end
 
   describe "pending registrations" do
+    test "recovery requires every allocated family to be registered again" do
+      reg = FontRegistry.new()
+      {_id, reg, _} = FontRegistry.get_or_register(reg, "Fira Code")
+      reg = FontRegistry.mark_registered(reg)
+
+      reg = FontRegistry.require_reregistration(reg)
+
+      assert FontRegistry.pending_registrations(reg) == [{1, "Fira Code"}]
+      assert FontRegistry.lookup(reg, "Fira Code") == 1
+    end
+
     test "mark_registered clears pending registrations without forgetting families" do
       reg = FontRegistry.new()
       {_id, reg, _} = FontRegistry.get_or_register(reg, "Fira Code")

--- a/test/support/headless_port.ex
+++ b/test/support/headless_port.ex
@@ -137,9 +137,11 @@ defmodule Minga.Test.HeadlessPort do
 
   @doc "Sends encoded render commands to the headless screen grid."
   @impl MingaEditor.Frontend.Adapter
-  @spec send_commands(GenServer.server(), [binary()]) :: :ok
+  @spec send_commands(GenServer.server(), [binary()]) ::
+          MingaEditor.Frontend.Adapter.admission()
   def send_commands(server, commands) when is_list(commands) do
     GenServer.cast(server, {:send_commands, commands})
+    :accepted
   end
 
   @doc "Submits commands through the production begin/commit transaction gate."
@@ -149,7 +151,7 @@ defmodule Minga.Test.HeadlessPort do
           non_neg_integer(),
           non_neg_integer(),
           [binary()]
-        ) :: :ok
+        ) :: MingaEditor.Frontend.Adapter.admission()
   def send_transaction(server, seq, base, generation, commands) do
     send_commands(
       server,
@@ -443,6 +445,15 @@ defmodule Minga.Test.HeadlessPort do
     {:reply, :ok, %{state | waiters: [{pid, ref} | state.waiters]}}
   end
 
+  def handle_call({:send_commands, commands}, _from, state) do
+    {:reply, :accepted, apply_commands(state, commands)}
+  end
+
+  def handle_call({:send_render_commands, commands, sent_at}, _from, state) do
+    Minga.Telemetry.hop_latency(:send_commands, sent_at)
+    {:reply, :accepted, apply_commands(state, commands)}
+  end
+
   # ── send_commands — the core render capture ──
 
   @impl true
@@ -451,10 +462,11 @@ defmodule Minga.Test.HeadlessPort do
     {:noreply, state}
   end
 
-  def handle_cast({:send_commands, commands}, state) do
-    new_state = Enum.reduce(commands, state, &apply_command/2)
-    {:noreply, new_state}
-  end
+  def handle_cast({:send_commands, commands}, state),
+    do: {:noreply, apply_commands(state, commands)}
+
+  @spec apply_commands(State.t(), [binary()]) :: State.t()
+  defp apply_commands(state, commands), do: Enum.reduce(commands, state, &apply_command/2)
 
   @impl true
   def handle_info({:DOWN, _ref, :process, pid, _reason}, state) do

--- a/test/support/recording_frontend.ex
+++ b/test/support/recording_frontend.ex
@@ -30,9 +30,11 @@ defmodule Minga.Test.RecordingFrontend do
   end
 
   @impl MingaEditor.Frontend.Adapter
-  @spec send_commands(GenServer.server(), [binary()]) :: :ok
+  @spec send_commands(GenServer.server(), [binary()]) ::
+          MingaEditor.Frontend.Adapter.admission()
   def send_commands(server, commands) when is_list(commands) do
     GenServer.cast(server, {:send_commands, commands})
+    :accepted
   end
 
   @impl MingaEditor.Frontend.Adapter
@@ -108,14 +110,27 @@ defmodule Minga.Test.RecordingFrontend do
     {:reply, :ok, %{state | commands: []}}
   end
 
+  def handle_call({:send_commands, commands}, _from, state) do
+    {:reply, :accepted, record_commands(state, commands)}
+  end
+
+  def handle_call({:send_render_commands, commands, sent_at}, _from, state) do
+    Minga.Telemetry.hop_latency(:send_commands, sent_at)
+    {:reply, :accepted, record_commands(state, commands)}
+  end
+
   @impl GenServer
   def handle_cast({:hop_mark, hop, sent_at}, state) do
     Minga.Telemetry.hop_latency(hop, sent_at)
     {:noreply, state}
   end
 
-  def handle_cast({:send_commands, commands}, state) do
+  def handle_cast({:send_commands, commands}, state),
+    do: {:noreply, record_commands(state, commands)}
+
+  @spec record_commands(state(), [binary()]) :: state()
+  defp record_commands(state, commands) do
     send(state.owner, {:frontend_commands, self(), commands})
-    {:noreply, %{state | commands: Enum.reverse(commands) ++ state.commands}}
+    %{state | commands: Enum.reverse(commands) ++ state.commands}
   end
 end

--- a/test/support/render_pipeline_test_helpers.ex
+++ b/test/support/render_pipeline_test_helpers.ex
@@ -54,7 +54,7 @@ defmodule MingaEditor.RenderPipeline.TestHelpers do
     shell_entry = ShellRegistry.get(:traditional)
 
     %EditorState{
-      port_manager: self(),
+      port_manager: Keyword.get(opts, :port_manager, self()),
       parser_manager: Keyword.get(opts, :parser_manager, Minga.Parser.Manager),
       effect_scheduler: Keyword.get(opts, :effect_scheduler),
       terminal_viewport: vp,


### PR DESCRIPTION
# TL;DR
Frontend output admission no longer suspends the process that owns input and lifecycle messages. The manager returns explicit admission results, retains only bounded current/latest frame state under pressure, retries bounded control state, and starts correlated keyframe recovery when the transport remains unwritable.

Closes #2846

## Context
A slow or stopped frontend reader previously made `Port.command/2` suspend `Frontend.Manager`, which also owns input, resize, readiness, and lifecycle handling. This work is a prerequisite for the render-correlation ownership slice in #2864.

## Changes
- Replaced frame casts with synchronous admission calls and `Port.command/3` using `[:nosuspend]`, returning `:accepted` or `:unwritable` without blocking the manager on transport pressure.
- Added bounded output-pressure state with one current frame, one latest coalesced replacement, retained-byte diagnostics, retry correlation, and stale-ack generation floors.
- Added a short failure budget that requests keyframe recovery from the last applied frame and rejects acknowledgements from failed generations.
- Coalesced unwritable out-of-band controls by opcode so one-shot font configuration and other latest-value controls retry before recovery frames instead of disappearing.
- Kept side-channel caches dirty until their writes are accepted, and required allocated fallback fonts to re-register after frontend recovery.
- Updated test frontends to implement the explicit admission contract without adding another production process.
- Added deterministic pressure, incompatible-base, control retry, and stale-ack coverage plus a real stopped-reader test that verifies mailbox and retained-byte bounds while input remains responsive.

## Verification
- `make lint`
- `mix test.llm --seed 924457` (9,260 tests, 97 properties, 58 doctests, zero failures)
- `mix test.heavy test/minga_editor/frontend/manager_test.exs` (11 heavy tests, zero failures)
- Focused manager, output-pressure, renderer, conceal, EffectScheduler, emit, keyframe, and input-routing suites
- Focused bug hunt found and fixed dropped one-shot font configuration under pressure
- Final reviewer: PASS

## Acceptance Criteria Addressed
- Frontend output uses non-suspending admission with an explicit accepted or unwritable result. ✅
- At most one current frame and one coalesced replacement are retained while the transport is unwritable. ✅
- An unwritable transport enters correlated resynchronization promptly instead of accumulating frame casts. ✅
- Recovery starts from a correlated keyframe and stale frame acknowledgements are rejected. ✅
- A stopped-reader pressure test verifies bounded mailbox length, retained frame bytes, and continued input handling. ✅
