### PR TITLE
refactor(editor): own render correlation state

### DIFF
--- a/docs/adr/0002-editor-state-transitions-have-explicit-owners.md
+++ b/docs/adr/0002-editor-state-transitions-have-explicit-owners.md
@@ -33,6 +33,8 @@ Scheduler lifecycle state is not copied into Editor values. A domain value may r
 
 File-tree refresh is the first application of this rule. `MingaEditor.State.FileTree.Refresh` owns debounce and current-result correlation, `MingaEditor.State.FileTree` owns tree/root acceptance, `MingaEditor.FileTree.Freshness` owns the workflow and external ordering, and `MingaEditor.FileTree.Refresh` owns typed scan execution and outcome application. The scheduler owns the running scan and at most one coalesced follow-up.
 
+Render correlation follows the same boundary. `MingaEditor.State.RenderCorrelation` owns the render timer token, semantic intent revisions, receipt ordering, and pending keyframe request. `MingaEditor.State` retains one atomic receipt integration transition because shell identity, workspace observations, layout, focus, and click regions must agree. Timer creation, renderer submission, frontend communication, and stale-receipt logging stay in Editor workflows. `MingaEditor.Renderer.Server` remains authoritative for resident rows, render caches, acknowledgement credit, and renderer-private state.
+
 ## Migration ledger
 
 The epic assigns every broad ownership area to a committed convergence slice:

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -551,7 +551,7 @@ defmodule MingaEditor do
   end
 
   def handle_info({:minga_input, {:request_keyframe, _last_good, _generation}}, state) do
-    new_state = %{state | keyframe_pending?: true}
+    new_state = EditorState.request_render_keyframe(state)
     {:noreply, Renderer.render_or_async(new_state)}
   end
 
@@ -1357,7 +1357,7 @@ defmodule MingaEditor do
   # The first call renders immediately (delay_ms == 0 path) or schedules
   # at the given delay. Subsequent calls during an active window are
   # coalesced: the pending timer already covers them. The `:debounced_render`
-  # handler clears `render_timer` so the next event after the window can
+  # handler clears the correlation owner's timer so the next event after the window can
   # schedule again.
   #
   # For streaming agent responses, this ensures new text is visible within
@@ -1375,21 +1375,25 @@ defmodule MingaEditor do
   end
 
   @spec schedule_render(state(), non_neg_integer()) :: state()
-  def schedule_render(%{render_timer: ref} = state, _delay_ms) when is_reference(ref), do: state
+  def schedule_render(%EditorState{} = state, delay_ms)
+      when is_integer(delay_ms) and delay_ms >= 0 do
+    if EditorState.render_scheduled?(state), do: state, else: schedule_new_render(state, delay_ms)
+  end
 
   # In test mode (headless backend), render synchronously to eliminate timer
   # races that cause CI flakiness. No debounce needed when there's no real
   # display to coalesce frames for.
-  def schedule_render(%{backend: :headless} = state, _delay_ms) do
+  @spec schedule_new_render(state(), non_neg_integer()) :: state()
+  defp schedule_new_render(%{backend: :headless} = state, _delay_ms) do
     state = RenderHandler.maybe_trigger_nav_flash(state)
     state = Renderer.render_or_async(state)
-    %{state | render_timer: nil}
+    EditorState.clear_render_timer(state)
   end
 
-  def schedule_render(state, delay_ms) do
+  defp schedule_new_render(state, delay_ms) do
     effective_delay_ms = schedule_render_delay_ms(state, delay_ms)
     ref = Process.send_after(self(), :debounced_render, effective_delay_ms)
-    %{state | render_timer: ref}
+    EditorState.schedule_render_timer(state, ref)
   end
 
   # LSP status aggregation moved to MingaEditor.State.LSP

--- a/lib/minga_editor/handlers/render_handler.ex
+++ b/lib/minga_editor/handlers/render_handler.ex
@@ -39,7 +39,7 @@ defmodule MingaEditor.Handlers.RenderHandler do
   def handle_debounced_render(state) do
     state = maybe_trigger_nav_flash(state)
     state = Renderer.render_or_async(state)
-    %{state | render_timer: nil}
+    EditorState.clear_render_timer(state)
   end
 
   @doc """
@@ -47,13 +47,26 @@ defmodule MingaEditor.Handlers.RenderHandler do
 
   Narrows the merge to renderer-owned fields only.
   """
-  @spec handle_render_done(state(), map()) :: state()
-  def handle_render_done(state, writeback) do
-    emit_render_done_hop(writeback)
-
+  @spec handle_render_done(state(), MingaEditor.Renderer.RenderReceipt.t()) :: state()
+  def handle_render_done(state, receipt) do
+    emit_render_done_hop(receipt)
+    state = Workflow.ensure_available(state)
+    {state, result} = EditorState.integrate_renderer_receipt(state, receipt)
+    log_receipt_result(result, state, receipt)
     state
-    |> Workflow.ensure_available()
-    |> EditorState.apply_renderer_writeback(writeback)
+  end
+
+  @spec log_receipt_result(
+          EditorState.render_receipt_result(),
+          state(),
+          MingaEditor.Renderer.RenderReceipt.t()
+        ) :: :ok
+  defp log_receipt_result(:applied, _state, _receipt), do: :ok
+
+  defp log_receipt_result({:stale, reason}, state, receipt) do
+    Minga.Log.debug(:render, fn ->
+      "Dropping stale renderer receipt reason=#{reason} frame=#{receipt.frame_seq} shell=#{inspect(receipt.shell_id)} identity=#{inspect(receipt.shell_identity)} active_shell=#{inspect(MingaEditor.Shell.Runtime.id(state.shell_runtime))}"
+    end)
   end
 
   # Measures the Renderer.Server → Editor writeback scheduling delay using the

--- a/lib/minga_editor/render_pipeline.ex
+++ b/lib/minga_editor/render_pipeline.ex
@@ -57,9 +57,7 @@ defmodule MingaEditor.RenderPipeline do
   @doc """
   Runs the full render pipeline for the given Input.
 
-  Returns updated Input with per-window render caches populated.
-  The caller applies mutations back to EditorState via
-  `EditorState.apply_render_output/2`.
+  Returns updated Input with per-window render caches populated. `Renderer.Server` retains renderer-private state and returns a focused receipt for atomic Editor integration.
   """
   @spec run(input()) :: input()
   def run(input) do

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -3,12 +3,10 @@ defmodule MingaEditor.RenderPipeline.Input do
   Narrow rendering contract between the Editor GenServer and the render pipeline.
 
   Bundles exactly the fields that the pipeline stages read from EditorState,
-  excluding ~15 fields the pipeline never touches (render_timer, buffer_monitors,
-  focus_stack, lsp, parser_status, pending_quit, session, git_remote_op, etc.).
+  excluding Editor-owned process and correlation fields the pipeline never touches (`render_correlation`, buffer monitors, focus stack, session lifecycle, and similar state).
 
   The Editor builds this before calling `RenderPipeline.run/1`. Pipeline stages
-  read from Input and never reach back into EditorState. After the pipeline
-  completes, the caller writes mutations back via `EditorState.apply_render_output/2`.
+  read from Input and never reach back into EditorState. `Renderer.Server` returns a focused receipt that the Editor integrates atomically.
 
   ## Structural compatibility
 
@@ -58,6 +56,7 @@ defmodule MingaEditor.RenderPipeline.Input do
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.LSP, as: LSPState
+  alias MingaEditor.State.RenderCorrelation
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Shell.Runtime
@@ -180,9 +179,7 @@ defmodule MingaEditor.RenderPipeline.Input do
   @doc """
   Builds a render pipeline Input from the full editor state.
 
-  Extracts exactly the fields that the pipeline's seven stages read,
-  leaving GenServer-only fields (render_timer, buffer_monitors,
-  focus_stack, session, pending_quit, etc.) behind.
+  Extracts exactly the fields that the pipeline's seven stages read, leaving Editor process and correlation state behind.
   """
   @spec from_editor_state(EditorState.t()) :: t()
   def from_editor_state(%EditorState{workspace: ws} = state) do
@@ -209,7 +206,7 @@ defmodule MingaEditor.RenderPipeline.Input do
       highlighting: state.highlighting,
       terminal_viewport: state.terminal_viewport,
       last_input_seq: state.last_input_seq,
-      force_keyframe?: Map.get(state, :keyframe_pending?, false),
+      force_keyframe?: RenderCorrelation.force_keyframe?(state.render_correlation),
       line_spacing: Minga.Config.Options.get(state.options_server, :line_spacing) || 1.0,
       cursor_animate: Minga.Config.Options.get(state.options_server, :cursor_animate),
       gui_config_state: state.gui_config_state,

--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -84,7 +84,7 @@ defmodule MingaEditor.Renderer do
     seq = System.unique_integer([:positive, :monotonic])
 
     case RendererServer.reset_sync(renderer, intent, seq) do
-      {:ok, receipt} -> EditorState.apply_synchronous_renderer_receipt(state, receipt)
+      {:ok, receipt} -> EditorState.integrate_synchronous_renderer_receipt(state, receipt)
       {:error, error} -> log_synchronous_error(state, seq, error)
     end
   end
@@ -121,7 +121,7 @@ defmodule MingaEditor.Renderer do
     intent = Intent.from_editor_state(state)
 
     case RendererServer.render_sync(renderer, intent, seq) do
-      {:ok, receipt} -> EditorState.apply_synchronous_renderer_receipt(state, receipt)
+      {:ok, receipt} -> EditorState.integrate_synchronous_renderer_receipt(state, receipt)
       {:error, error} -> log_synchronous_error(state, seq, error)
     end
   end

--- a/lib/minga_editor/renderer/caches.ex
+++ b/lib/minga_editor/renderer/caches.ex
@@ -3,9 +3,7 @@ defmodule MingaEditor.Renderer.Caches do
   Explicit render-pipeline cache state, replacing process-dictionary entries.
 
   Each field corresponds to a former `Process.put/get` key used across the
-  render pipeline stages. The struct is carried on `EditorState` and on
-  `RenderPipeline.Input`, survives across frames, and is written back via
-  `EditorState.apply_render_output/2` after each pipeline run.
+  render pipeline stages. `Renderer.Server` retains the struct across frames and injects it into `RenderPipeline.Input`; it never crosses back into Editor state.
 
   ## Ownership by stage
 
@@ -61,9 +59,8 @@ defmodule MingaEditor.Renderer.Caches do
     recovery_generation: 1,
 
     # Whether the most recently emitted frame was a keyframe (base_frame_seq 0,
-    # full window snapshots). The Editor reads this to clear `keyframe_pending?`
-    # only when a frame that actually honored the request reaches emit, so a
-    # concurrent delta writeback can't silently swallow a pending keyframe (#2219).
+    # full window snapshots). Renderer receipts carry this correlation fact so the
+    # Editor can fulfill a pending keyframe request only after actual emission.
     last_frame_keyframe?: false,
 
     # ── Core adapter caches (render-model migration) ─────────────────────────

--- a/lib/minga_editor/renderer/render_receipt.ex
+++ b/lib/minga_editor/renderer/render_receipt.ex
@@ -69,6 +69,12 @@ defmodule MingaEditor.Renderer.RenderReceipt do
     }
   end
 
+  @doc "Returns the receipt correlated to the normalized Editor intent revision."
+  @spec correlate(t(), non_neg_integer()) :: t()
+  def correlate(%__MODULE__{} = receipt, revision)
+      when is_integer(revision) and revision >= 0,
+      do: %{receipt | intent_revision: revision}
+
   @spec window_observations(Input.t()) :: %{
           optional(MingaEditor.Window.id()) => WindowObservation.t()
         }

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -13,7 +13,7 @@ defmodule MingaEditor.State do
   **Shell runtime** lives in `state.shell_runtime` and owns the resolved active entry, shell-specific presentation state, and exact-identity state stash. See `MingaEditor.Shell.Runtime`.
 
   **Global fields** are shared across all tabs and never snapshotted:
-  `port_manager`, `parser_manager`, `highlighting`, `injection_ranges`, `theme`, `render_timer`, `focus_stack`, and `capabilities`.
+  `port_manager`, `parser_manager`, `highlighting`, `injection_ranges`, `theme`, `render_correlation`, `focus_stack`, and `capabilities`.
 
   ## Composed sub-structs
 
@@ -46,6 +46,7 @@ defmodule MingaEditor.State do
   alias MingaEditor.State.Highlighting
   alias MingaEditor.State.Mouse
   alias MingaEditor.State.Remote
+  alias MingaEditor.State.RenderCorrelation
   alias MingaEditor.State.ResourcePressure
   alias MingaEditor.State.Search
   alias MingaEditor.State.Tab
@@ -53,7 +54,6 @@ defmodule MingaEditor.State do
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.WhichKey
   alias MingaEditor.State.Windows
-  alias MingaEditor.Renderer.RenderWindow
   alias MingaEditor.Renderer.WindowObservation
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
@@ -119,7 +119,7 @@ defmodule MingaEditor.State do
             editing_model: :vim,
             shell_runtime: ShellRuntime.new(ShellRuntime.default_entry(), %ShellState{}),
             theme: MingaEditor.UI.Theme.Fallback.theme(),
-            render_timer: nil,
+            render_correlation: RenderCorrelation.new(),
             message_store: %MessageStore{},
             notifications: NotificationCenter.new(),
             git_remote_op: nil,
@@ -147,15 +147,6 @@ defmodule MingaEditor.State do
             # Echoed back on commit_frame so the frontend can resolve a
             # keystroke-to-write latency sample. 0 means "no correlation".
             last_input_seq: 0,
-            # Set when the frontend sends request_keyframe (#2219). The next emitted
-            # frame is forced to a keyframe (base_frame_seq 0, full snapshots) and the
-            # flag is cleared once that frame goes out.
-            keyframe_pending?: false,
-            # Editor-owned render correlation. Submission advances independently
-            # of acknowledgement so an older pending receipt is already stale.
-            latest_render_intent_revision: 0,
-            last_render_receipt_revision: 0,
-            last_render_receipt_seq: 0,
             # Cached native settings snapshot emitted in-frame as the config_state
             # semantic model (#2119). Rebuilt only when a settings option changes
             # (see MingaEditor.refresh_gui_config_state/1), so the render pipeline
@@ -192,7 +183,7 @@ defmodule MingaEditor.State do
           editing_model: :vim | :cua,
           shell_runtime: ShellRuntime.t(),
           theme: Theme.t(),
-          render_timer: reference() | nil,
+          render_correlation: RenderCorrelation.t(),
           message_store: MessageStore.t(),
           notifications: NotificationCenter.t(),
           git_remote_op: git_remote_op(),
@@ -217,10 +208,6 @@ defmodule MingaEditor.State do
           git_commit_gen_ref: reference() | nil,
           font_size_override: pos_integer() | nil,
           last_input_seq: non_neg_integer(),
-          keyframe_pending?: boolean(),
-          latest_render_intent_revision: non_neg_integer(),
-          last_render_receipt_revision: non_neg_integer(),
-          last_render_receipt_seq: non_neg_integer(),
           gui_config_state: Minga.RenderModel.UI.ConfigState.t() | nil,
           session_started?: boolean()
         }
@@ -688,82 +675,108 @@ defmodule MingaEditor.State do
 
   # ── Render pipeline write-back ─────────────────────────────────────────────
 
-  @doc """
-  Applies render pipeline mutations back to the editor state.
+  @type render_receipt_result ::
+          :applied | {:stale, RenderCorrelation.freshness_reason() | :shell_identity}
 
-  This compatibility path applies only editor-owned observations from a synchronous pipeline output: window viewport observations, shell state, layout, focus, and click regions. Renderer caches, resident content, font state, and acknowledgement state remain owned by `Renderer.Server` and are never copied into Editor state.
-  """
-  @spec apply_render_output(t(), MingaEditor.RenderPipeline.Input.t()) :: t()
-  def apply_render_output(%__MODULE__{workspace: ws} = state, render_output) do
-    windows = apply_synchronous_window_observations(ws.windows, render_output.workspace.windows)
+  @doc "Returns whether the Editor already owns a scheduled render timer."
+  @spec render_scheduled?(t()) :: boolean()
+  def render_scheduled?(%__MODULE__{render_correlation: correlation}),
+    do: RenderCorrelation.scheduled?(correlation)
 
-    shell_runtime =
-      ShellRuntime.accept_rendered_state(
-        state.shell_runtime,
-        render_output.shell_id,
-        render_output.shell_identity,
-        render_output.shell_state
+  @doc "Stores one externally created render timer in the correlation owner."
+  @spec schedule_render_timer(t(), reference()) :: t()
+  def schedule_render_timer(%__MODULE__{} = state, timer) when is_reference(timer) do
+    {:scheduled, correlation} = RenderCorrelation.schedule(state.render_correlation, timer)
+    %{state | render_correlation: correlation}
+  end
+
+  @doc "Clears the active render timer after delivery or synchronous rendering."
+  @spec clear_render_timer(t()) :: t()
+  def clear_render_timer(%__MODULE__{} = state) do
+    %{state | render_correlation: RenderCorrelation.clear_timer(state.render_correlation)}
+  end
+
+  @doc "Marks the next completed frame as a required keyframe."
+  @spec request_render_keyframe(t()) :: t()
+  def request_render_keyframe(%__MODULE__{} = state) do
+    %{state | render_correlation: RenderCorrelation.request_keyframe(state.render_correlation)}
+  end
+
+  @doc "Marks a newly ready frontend for correlated keyframe recovery."
+  @spec frontend_render_ready(t()) :: t()
+  def frontend_render_ready(%__MODULE__{} = state) do
+    %{state | render_correlation: RenderCorrelation.frontend_ready(state.render_correlation)}
+  end
+
+  @doc "Advances editor-owned correlation before submitting a render intent."
+  @spec submit_render_intent(t()) :: {t(), pos_integer()}
+  def submit_render_intent(%__MODULE__{} = state) do
+    {correlation, revision} = RenderCorrelation.submit(state.render_correlation)
+    {%{state | render_correlation: correlation}, revision}
+  end
+
+  @doc "Atomically integrates a synchronous focused renderer receipt."
+  @spec integrate_synchronous_renderer_receipt(t(), MingaEditor.Renderer.RenderReceipt.t()) :: t()
+  def integrate_synchronous_renderer_receipt(
+        %__MODULE__{} = state,
+        %MingaEditor.Renderer.RenderReceipt{} = receipt
+      ) do
+    correlation =
+      RenderCorrelation.accept_synchronous_receipt(
+        state.render_correlation,
+        receipt.intent_revision,
+        receipt.frame_seq,
+        receipt.keyframe?
       )
 
-    %{
-      state
-      | workspace: %{ws | windows: windows},
-        shell_runtime: shell_runtime,
-        layout: render_output.layout,
-        focus_tree: render_output.focus_tree,
-        message_store: state.message_store,
-        # Clear keyframe_pending? only when the frame that just emitted actually
-        # carried the keyframe. A render that started before the request (or one
-        # that the request didn't force) must not swallow the still-pending flag (#2219).
-        keyframe_pending?: clear_keyframe_pending?(state, render_output.caches)
-    }
+    commit_renderer_receipt(state, receipt, correlation)
   end
 
-  @spec apply_synchronous_window_observations(Windows.t(), Windows.t()) :: Windows.t()
-  defp apply_synchronous_window_observations(editor_windows, rendered_windows) do
-    Enum.reduce(rendered_windows.map, editor_windows, fn rendered, windows ->
-      apply_synchronous_window_observation(windows, rendered)
-    end)
-  end
+  @doc "Atomically integrates a fresh asynchronous receipt or returns its stale reason."
+  @spec integrate_renderer_receipt(t(), MingaEditor.Renderer.RenderReceipt.t()) ::
+          {t(), render_receipt_result()}
+  def integrate_renderer_receipt(
+        %__MODULE__{} = state,
+        %MingaEditor.Renderer.RenderReceipt{} = receipt
+      ) do
+    case RenderCorrelation.classify_receipt(
+           state.render_correlation,
+           receipt.intent_revision,
+           receipt.frame_seq
+         ) do
+      {:stale, reason} ->
+        {state, {:stale, reason}}
 
-  @spec apply_synchronous_window_observation(Windows.t(), {Window.id(), term()}) :: Windows.t()
-  defp apply_synchronous_window_observation(windows, {id, %RenderWindow{} = rendered}) do
-    case Windows.fetch(windows, id) do
-      {:ok, %Window{} = editor_window} ->
-        version = max(rendered.render_cache.last_buf_version, 0)
-
-        Windows.update(windows, id, fn _window ->
-          Window.observe_render(editor_window, rendered.viewport, version)
-        end)
-
-      :error ->
-        windows
+      {:fresh, revision} ->
+        receipt = MingaEditor.Renderer.RenderReceipt.correlate(receipt, revision)
+        integrate_fresh_renderer_receipt(state, receipt)
     end
   end
 
-  defp apply_synchronous_window_observation(windows, {id, %Window{} = editor_window}) do
-    Windows.update(windows, id, fn _window -> editor_window end)
+  @spec integrate_fresh_renderer_receipt(t(), MingaEditor.Renderer.RenderReceipt.t()) ::
+          {t(), render_receipt_result()}
+  defp integrate_fresh_renderer_receipt(state, receipt) do
+    if renderer_receipt_shell_current?(state, receipt) do
+      correlation =
+        RenderCorrelation.accept_receipt(
+          state.render_correlation,
+          receipt.intent_revision,
+          receipt.frame_seq,
+          receipt.keyframe?
+        )
+
+      {commit_renderer_receipt(state, receipt, correlation), :applied}
+    else
+      {state, {:stale, :shell_identity}}
+    end
   end
 
-  # The flag stays set until a frame that genuinely honored force_keyframe? reaches
-  # emit. last_frame_keyframe? is stamped by the Emit stage on the caches it returns.
-  @spec clear_keyframe_pending?(t(), map()) :: boolean()
-  defp clear_keyframe_pending?(%__MODULE__{keyframe_pending?: false}, _caches), do: false
-
-  defp clear_keyframe_pending?(%__MODULE__{keyframe_pending?: true}, caches) do
-    not Map.get(caches, :last_frame_keyframe?, false)
-  end
-
-  @doc "Advances editor-owned correlation before submitting an async intent."
-  @spec submit_render_intent(t()) :: {t(), pos_integer()}
-  def submit_render_intent(%__MODULE__{} = state) do
-    revision = state.latest_render_intent_revision + 1
-    {%{state | latest_render_intent_revision: revision}, revision}
-  end
-
-  @doc "Applies a synchronous focused renderer receipt without importing renderer state."
-  @spec apply_synchronous_renderer_receipt(t(), MingaEditor.Renderer.RenderReceipt.t()) :: t()
-  def apply_synchronous_renderer_receipt(%__MODULE__{} = state, receipt) do
+  @spec commit_renderer_receipt(
+          t(),
+          MingaEditor.Renderer.RenderReceipt.t(),
+          RenderCorrelation.t()
+        ) :: t()
+  defp commit_renderer_receipt(state, receipt, correlation) do
     shell_runtime = merge_renderer_receipt(state.shell_runtime, receipt)
     workspace = apply_window_observations(state.workspace, receipt.window_observations)
 
@@ -773,56 +786,8 @@ defmodule MingaEditor.State do
         focus_tree: receipt.focus_tree,
         shell_runtime: shell_runtime,
         workspace: workspace,
-        keyframe_pending?: clear_keyframe_pending_from_receipt?(state, receipt),
-        last_render_receipt_revision:
-          max(state.last_render_receipt_revision, receipt.intent_revision),
-        last_render_receipt_seq: max(state.last_render_receipt_seq, receipt.frame_seq)
+        render_correlation: correlation
     }
-  end
-
-  @doc "Applies a correlation-protected focused renderer receipt."
-  @spec apply_renderer_writeback(t(), MingaEditor.Renderer.RenderReceipt.t()) :: t()
-  def apply_renderer_writeback(
-        %__MODULE__{} = state,
-        %MingaEditor.Renderer.RenderReceipt{} = receipt
-      ) do
-    revision =
-      if receipt.intent_revision == 0 and state.latest_render_intent_revision == 0,
-        do: receipt.frame_seq,
-        else: receipt.intent_revision
-
-    receipt = %{receipt | intent_revision: revision}
-
-    fresh? =
-      revision >= state.latest_render_intent_revision and
-        revision > state.last_render_receipt_revision and
-        receipt.frame_seq > state.last_render_receipt_seq
-
-    apply_renderer_receipt(state, receipt, fresh?)
-  end
-
-  @spec apply_renderer_receipt(t(), MingaEditor.Renderer.RenderReceipt.t(), boolean()) :: t()
-  defp apply_renderer_receipt(state, _receipt, false), do: state
-
-  defp apply_renderer_receipt(state, receipt, true) do
-    if renderer_receipt_shell_current?(state, receipt) do
-      shell_runtime = merge_renderer_receipt(state.shell_runtime, receipt)
-      workspace = apply_window_observations(state.workspace, receipt.window_observations)
-
-      %{
-        state
-        | layout: receipt.layout,
-          focus_tree: receipt.focus_tree,
-          shell_runtime: shell_runtime,
-          workspace: workspace,
-          keyframe_pending?: clear_keyframe_pending_from_receipt?(state, receipt),
-          last_render_receipt_revision: receipt.intent_revision,
-          last_render_receipt_seq: receipt.frame_seq
-      }
-    else
-      log_stale_renderer_receipt(state, receipt)
-      state
-    end
   end
 
   @spec apply_window_observations(SessionState.t(), map()) :: SessionState.t()
@@ -853,15 +818,6 @@ defmodule MingaEditor.State do
 
   defp observe_renderer_window(window, _buffer, _viewport, _version), do: window
 
-  @spec clear_keyframe_pending_from_receipt?(t(), MingaEditor.Renderer.RenderReceipt.t()) ::
-          boolean()
-  defp clear_keyframe_pending_from_receipt?(%__MODULE__{keyframe_pending?: false}, _receipt),
-    do: false
-
-  defp clear_keyframe_pending_from_receipt?(%__MODULE__{keyframe_pending?: true}, receipt) do
-    not receipt.keyframe?
-  end
-
   @spec renderer_receipt_shell_current?(t(), MingaEditor.Renderer.RenderReceipt.t()) :: boolean()
   defp renderer_receipt_shell_current?(%__MODULE__{} = state, receipt) do
     case receipt.shell_identity do
@@ -887,13 +843,6 @@ defmodule MingaEditor.State do
       _missing_or_invalid ->
         runtime
     end
-  end
-
-  @spec log_stale_renderer_receipt(t(), MingaEditor.Renderer.RenderReceipt.t()) :: :ok
-  defp log_stale_renderer_receipt(%__MODULE__{} = state, receipt) do
-    Log.debug(:render, fn ->
-      "Dropping stale renderer receipt frame=#{receipt.frame_seq} shell=#{inspect(receipt.shell_id)} identity=#{inspect(receipt.shell_identity)} active_shell=#{inspect(ShellRuntime.id(state.shell_runtime))}"
-    end)
   end
 
   @doc "Installs a pure shell Runtime transition into the Editor root."
@@ -1556,6 +1505,7 @@ defmodule MingaEditor.State do
     |> then(fn state ->
       %{state | message_store: MessageStore.reset_sent_cursor(state.message_store)}
     end)
+    |> frontend_render_ready()
   end
 
   @doc """

--- a/lib/minga_editor/state/render_correlation.ex
+++ b/lib/minga_editor/state/render_correlation.ex
@@ -1,0 +1,122 @@
+defmodule MingaEditor.State.RenderCorrelation do
+  @moduledoc "Immutable Editor-owned render scheduling, keyframe, and receipt-ordering state."
+
+  defstruct timer: nil,
+            keyframe_pending?: false,
+            latest_intent_revision: 0,
+            last_receipt_revision: 0,
+            last_receipt_seq: 0
+
+  @type t :: %__MODULE__{
+          timer: reference() | nil,
+          keyframe_pending?: boolean(),
+          latest_intent_revision: non_neg_integer(),
+          last_receipt_revision: non_neg_integer(),
+          last_receipt_seq: non_neg_integer()
+        }
+
+  @type freshness_reason :: :superseded_intent | :stale_receipt_revision | :stale_sequence
+  @type freshness :: {:fresh, non_neg_integer()} | {:stale, freshness_reason()}
+
+  @doc "Returns initial render correlation state."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Admits one render timer or coalesces into the already scheduled timer."
+  @spec schedule(t(), reference()) :: {:scheduled | :coalesced, t()}
+  def schedule(%__MODULE__{timer: nil} = correlation, timer) when is_reference(timer),
+    do: {:scheduled, %{correlation | timer: timer}}
+
+  def schedule(%__MODULE__{} = correlation, timer) when is_reference(timer),
+    do: {:coalesced, correlation}
+
+  @doc "Returns whether a render timer currently owns the throttle window."
+  @spec scheduled?(t()) :: boolean()
+  def scheduled?(%__MODULE__{timer: timer}), do: is_reference(timer)
+
+  @doc "Clears the render timer after synchronous rendering or timer delivery."
+  @spec clear_timer(t()) :: t()
+  def clear_timer(%__MODULE__{} = correlation), do: %{correlation | timer: nil}
+
+  @doc "Marks the next completed render as requiring a keyframe."
+  @spec request_keyframe(t()) :: t()
+  def request_keyframe(%__MODULE__{} = correlation),
+    do: %{correlation | keyframe_pending?: true}
+
+  @doc "Resets frontend correlation without making an older receipt fresh again."
+  @spec reset(t()) :: t()
+  def reset(%__MODULE__{} = correlation), do: request_keyframe(correlation)
+
+  @doc "Marks a newly ready frontend as requiring a correlated keyframe."
+  @spec frontend_ready(t()) :: t()
+  def frontend_ready(%__MODULE__{} = correlation), do: reset(correlation)
+
+  @doc "Returns whether render intent construction must force a keyframe."
+  @spec force_keyframe?(t()) :: boolean()
+  def force_keyframe?(%__MODULE__{keyframe_pending?: pending?}), do: pending?
+
+  @doc "Advances the Editor-owned semantic intent revision."
+  @spec submit(t()) :: {t(), pos_integer()}
+  def submit(%__MODULE__{} = correlation) do
+    revision = correlation.latest_intent_revision + 1
+    {%{correlation | latest_intent_revision: revision}, revision}
+  end
+
+  @doc "Classifies asynchronous receipt ordering and normalizes legacy revision zero."
+  @spec classify_receipt(t(), non_neg_integer(), non_neg_integer()) :: freshness()
+  def classify_receipt(%__MODULE__{} = correlation, intent_revision, frame_seq)
+      when is_integer(intent_revision) and intent_revision >= 0 and is_integer(frame_seq) and
+             frame_seq >= 0 do
+    revision = normalize_revision(correlation, intent_revision, frame_seq)
+    classify_normalized(correlation, revision, frame_seq)
+  end
+
+  @doc "Records one accepted asynchronous receipt and clears a fulfilled keyframe request."
+  @spec accept_receipt(t(), non_neg_integer(), non_neg_integer(), boolean()) :: t()
+  def accept_receipt(%__MODULE__{} = correlation, revision, frame_seq, keyframe?)
+      when is_integer(revision) and revision >= 0 and is_integer(frame_seq) and frame_seq >= 0 and
+             is_boolean(keyframe?) do
+    %{
+      correlation
+      | keyframe_pending?: pending_after_receipt?(correlation, keyframe?),
+        last_receipt_revision: revision,
+        last_receipt_seq: frame_seq
+    }
+  end
+
+  @doc "Records a synchronous receipt while preserving monotonic ordering evidence."
+  @spec accept_synchronous_receipt(t(), non_neg_integer(), non_neg_integer(), boolean()) :: t()
+  def accept_synchronous_receipt(%__MODULE__{} = correlation, revision, frame_seq, keyframe?)
+      when is_integer(revision) and revision >= 0 and is_integer(frame_seq) and frame_seq >= 0 and
+             is_boolean(keyframe?) do
+    %{
+      correlation
+      | keyframe_pending?: pending_after_receipt?(correlation, keyframe?),
+        last_receipt_revision: max(correlation.last_receipt_revision, revision),
+        last_receipt_seq: max(correlation.last_receipt_seq, frame_seq)
+    }
+  end
+
+  @spec normalize_revision(t(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
+  defp normalize_revision(%__MODULE__{latest_intent_revision: 0}, 0, frame_seq), do: frame_seq
+  defp normalize_revision(%__MODULE__{}, intent_revision, _frame_seq), do: intent_revision
+
+  @spec classify_normalized(t(), non_neg_integer(), non_neg_integer()) :: freshness()
+  defp classify_normalized(correlation, revision, _frame_seq)
+       when revision < correlation.latest_intent_revision,
+       do: {:stale, :superseded_intent}
+
+  defp classify_normalized(correlation, revision, _frame_seq)
+       when revision <= correlation.last_receipt_revision,
+       do: {:stale, :stale_receipt_revision}
+
+  defp classify_normalized(correlation, _revision, frame_seq)
+       when frame_seq <= correlation.last_receipt_seq,
+       do: {:stale, :stale_sequence}
+
+  defp classify_normalized(_correlation, revision, _frame_seq), do: {:fresh, revision}
+
+  @spec pending_after_receipt?(t(), boolean()) :: boolean()
+  defp pending_after_receipt?(%__MODULE__{keyframe_pending?: false}, _keyframe?), do: false
+  defp pending_after_receipt?(%__MODULE__{keyframe_pending?: true}, keyframe?), do: not keyframe?
+end

--- a/test/minga_editor/file_tree/freshness_test.exs
+++ b/test/minga_editor/file_tree/freshness_test.exs
@@ -75,8 +75,8 @@ defmodule MingaEditor.FileTree.FreshnessTest do
 
     assert file_tree(accepted).tree == refreshed
     assert Minga.Buffer.content(buffer) =~ "fresh.ex"
-    assert is_reference(accepted.render_timer)
-    Process.cancel_timer(accepted.render_timer)
+    assert is_reference(accepted.render_correlation.timer)
+    Process.cancel_timer(accepted.render_correlation.timer)
   end
 
   test "failed and canceled outcomes clear current correlation without requesting rendering", %{
@@ -90,7 +90,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     assert {failed, %Outcome{status: :failed}} =
              Refresh.apply(tracked, Outcome.failed(request, :unreadable))
 
-    assert failed.render_timer == nil
+    assert failed.render_correlation.timer == nil
     assert failed |> file_tree() |> then(& &1.refresh.current) == nil
 
     retry = Refresh.request(file_tree(failed).tree, EditorState.events_registry(failed))
@@ -99,7 +99,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     assert {canceled, %Outcome{status: :canceled}} =
              Refresh.apply(retracked, Outcome.canceled(retry, :requested))
 
-    assert canceled.render_timer == nil
+    assert canceled.render_correlation.timer == nil
     assert canceled |> file_tree() |> then(& &1.refresh.current) == nil
   end
 
@@ -115,7 +115,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
              Refresh.apply(closed, Outcome.completed(request, refreshed))
 
     assert file_tree(closed_state).tree == nil
-    assert closed_state.render_timer == nil
+    assert closed_state.render_correlation.timer == nil
 
     rerooted =
       state_with_tree(old_root)
@@ -126,7 +126,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
              Refresh.apply(rerooted, Outcome.completed(request, refreshed))
 
     assert file_tree(rerooted_state).tree.root == Path.expand(new_root)
-    assert rerooted_state.render_timer == nil
+    assert rerooted_state.render_correlation.timer == nil
   end
 
   test "project-root replacement exposes unavailable roots as errors", %{tmp_dir: root} do
@@ -153,8 +153,8 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     assert {:error, reason} = FileTreeState.status(file_tree(failed))
     assert reason != ""
     assert file_tree(failed).refresh.current == nil
-    assert is_reference(failed.render_timer)
-    Process.cancel_timer(failed.render_timer)
+    assert is_reference(failed.render_correlation.timer)
+    Process.cancel_timer(failed.render_correlation.timer)
   end
 
   defp state_with_tree(root, scheduler \\ nil, buffer \\ nil) do

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaEditor.RenderPipeline.InputTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.RenderPipeline.TestHelpers
@@ -57,7 +58,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
 
       # These GenServer-only or Editor-owned fields must NOT be in Input
       excluded = [
-        :render_timer,
+        :render_correlation,
         :buffer_monitors,
         :focus_stack,
         :pending_quit,
@@ -99,19 +100,24 @@ defmodule MingaEditor.RenderPipeline.InputTest do
   end
 
   describe "EditorState.reset_frontend_render_state/1" do
-    test "resets frontend caches and message send cursor", %{state: state} do
+    test "resets frontend cursors and requests a keyframe without resetting receipt ordering", %{
+      state: state
+    } do
       message_store =
         state.message_store
         |> MessageStore.append("first", :info, :editor)
         |> MessageStore.mark_sent(1)
 
       state = %{state | message_store: message_store}
+      {state, revision} = EditorState.submit_render_intent(state)
 
       result = EditorState.reset_frontend_render_state(state)
 
       assert result.message_store.last_sent_id == 0
       assert result.message_store.stream_instance == message_store.stream_instance
       assert Enum.map(result.message_store.entries, & &1.text) == ["first"]
+      assert result.render_correlation.keyframe_pending?
+      assert result.render_correlation.latest_intent_revision == revision
     end
   end
 
@@ -132,76 +138,25 @@ defmodule MingaEditor.RenderPipeline.InputTest do
     end
   end
 
-  describe "EditorState.apply_render_output/2" do
-    test "writes back bounded editor window observations", %{state: state} do
-      input = Input.from_editor_state(state)
-      win_id = input.workspace.windows.active
-      window = Map.fetch!(input.workspace.windows.map, win_id)
-
-      mutated_cache = %{window.render_cache | viewport_top: 42}
-      mutated_window = %{window | render_cache: mutated_cache}
-      mutated_map = Map.put(input.workspace.windows.map, win_id, mutated_window)
-      ws = input.workspace
-      mutated_input = %{input | workspace: %{ws | windows: %{ws.windows | map: mutated_map}}}
-
-      result = EditorState.apply_render_output(state, mutated_input)
-
-      assert result.workspace.windows.map[win_id].render_cache.viewport_top == 42
-    end
-
-    test "preserves fields not in Input", %{state: state} do
-      state = %{state | focus_stack: [:test_handler]}
-      input = Input.from_editor_state(state)
-
-      result = EditorState.apply_render_output(state, input)
-
-      assert result.focus_stack == [:test_handler]
-      assert result.render_timer == state.render_timer
-      assert result.buffer_monitors == state.buffer_monitors
-    end
-
-    test "writes back layout", %{state: state} do
-      input = Input.from_editor_state(state)
-
-      layout = MingaEditor.Layout.compute(state)
-      mutated_input = %{input | layout: layout}
-
-      result = EditorState.apply_render_output(state, mutated_input)
-
-      assert result.layout == layout
-    end
-
-    test "does not write renderer-owned message cursor back to Editor", %{state: state} do
-      input = Input.from_editor_state(state)
-
-      message_store =
-        state.message_store
-        |> MessageStore.append("first", :info, :editor)
-        |> MessageStore.append("second", :info, :editor)
-        |> MessageStore.mark_sent(2)
-
-      result = EditorState.apply_render_output(state, %{input | message_store: message_store})
-
-      assert result.message_store == state.message_store
-    end
-  end
-
-  describe "EditorState.apply_renderer_writeback/2" do
+  describe "EditorState.integrate_renderer_receipt/2" do
     test "applies only editor-owned receipt fields and Editor has no renderer caches",
          %{state: state} do
       input = Input.from_editor_state(state)
       windows = state.workspace.windows
+      focus_tree = FocusNode.new(:editor_area, {0, 0, 80, 24})
 
       receipt =
         receipt(input, 10, false,
           layout: :rendered_layout,
+          focus_tree: focus_tree,
           modeline_click_regions: [{:modeline, 1}],
           tab_bar_click_regions: [{:tab, 2}]
         )
 
-      result = EditorState.apply_renderer_writeback(state, receipt)
+      result = integrate_receipt(state, receipt)
 
       assert result.layout == :rendered_layout
+      assert result.focus_tree == focus_tree
       assert result.workspace.windows == windows
       refute Map.has_key?(Map.from_struct(result), :caches)
       assert Runtime.state(result.shell_runtime).modeline_click_regions == [{:modeline, 1}]
@@ -229,7 +184,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       assert %MingaEditor.Renderer.WindowObservation{viewport: ^viewport} =
                receipt.window_observations[id]
 
-      result = EditorState.apply_renderer_writeback(state, receipt)
+      result = integrate_receipt(state, receipt)
       observed = Map.fetch!(result.workspace.windows.map, id)
 
       assert observed.viewport.top == 12
@@ -243,11 +198,11 @@ defmodule MingaEditor.RenderPipeline.InputTest do
 
       result =
         state
-        |> EditorState.apply_renderer_writeback(newer)
-        |> EditorState.apply_renderer_writeback(older)
+        |> integrate_receipt(newer)
+        |> integrate_receipt(older)
 
       assert result.layout == :newer
-      assert result.last_render_receipt_seq == 20
+      assert result.render_correlation.last_receipt_seq == 20
     end
 
     test "pending acknowledgement is stale after a newer resize/focus/shell intent", %{
@@ -260,7 +215,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       changed = %{state | layout: :resized_layout, focus_tree: :new_focus}
 
       assert new_revision == old_revision + 1
-      assert EditorState.apply_renderer_writeback(changed, pending) == changed
+      assert integrate_receipt(changed, pending) == changed
     end
 
     test "receipt from a replaced shell identity is side-effect free", %{state: state} do
@@ -287,18 +242,18 @@ defmodule MingaEditor.RenderPipeline.InputTest do
             )
       }
 
-      assert EditorState.apply_renderer_writeback(switched, stale) == switched
+      assert integrate_receipt(switched, stale) == switched
     end
 
     test "only an applied keyframe receipt clears a pending keyframe request", %{state: state} do
       input = Input.from_editor_state(state)
-      state = %{state | keyframe_pending?: true}
+      state = EditorState.request_render_keyframe(state)
 
-      state = EditorState.apply_renderer_writeback(state, receipt(input, 10, false))
-      assert state.keyframe_pending?
+      state = integrate_receipt(state, receipt(input, 10, false))
+      assert state.render_correlation.keyframe_pending?
 
-      state = EditorState.apply_renderer_writeback(state, receipt(input, 11, true))
-      refute state.keyframe_pending?
+      state = integrate_receipt(state, receipt(input, 11, true))
+      refute state.render_correlation.keyframe_pending?
     end
   end
 
@@ -340,6 +295,11 @@ defmodule MingaEditor.RenderPipeline.InputTest do
 
       assert Input.sync_active_window_cursor(input) == input
     end
+  end
+
+  defp integrate_receipt(state, receipt) do
+    {state, _result} = EditorState.integrate_renderer_receipt(state, receipt)
+    state
   end
 
   defp receipt(input, frame_seq, keyframe?, overrides \\ []) do

--- a/test/minga_editor/render_pipeline/resident_incremental_test.exs
+++ b/test/minga_editor/render_pipeline/resident_incremental_test.exs
@@ -11,6 +11,7 @@ defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
   alias MingaEditor.RenderPipeline.Scroll
   alias MingaEditor.Renderer.BufferChanges
   alias MingaEditor.Renderer.ProductionGate
+  alias MingaEditor.Renderer.RenderReceipt
   alias MingaEditor.Renderer.State, as: RendererState
   alias MingaEditor.State, as: EditorState
 
@@ -37,7 +38,8 @@ defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
     {scrolls, input} = Scroll.scroll_windows(input, layout)
     {contents, _cursor, output} = Content.build_content(input, scrolls)
     renderer = BufferChanges.commit(renderer, output, intent)
-    editor = EditorState.apply_render_output(editor, output)
+    receipt = RenderReceipt.from_output(output, 0, 0, 0)
+    editor = EditorState.integrate_synchronous_renderer_receipt(editor, receipt)
     model = contents |> List.first() |> Map.fetch!(:models) |> List.first()
     {model, %{editor: editor, renderer: renderer, output: output}}
   end

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -741,10 +741,10 @@ defmodule MingaEditor.Renderer.ServerTest do
 
       result = MingaEditor.Renderer.render_or_async(state)
 
-      assert result.latest_render_intent_revision == state.latest_render_intent_revision + 1
+      assert result.render_correlation.latest_intent_revision ==
+               state.render_correlation.latest_intent_revision + 1
 
-      assert %{result | latest_render_intent_revision: state.latest_render_intent_revision} ==
-               state
+      assert %{result | render_correlation: state.render_correlation} == state
 
       assert_receive {:render_done, %RenderReceipt{}},
                      @async_render_timeout

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -442,7 +442,7 @@ defmodule MingaEditor.Shell.RegistryTest do
       MingaEditor.handle_info({:agent_event, self(), {:status_changed, :idle}}, matching)
 
     assert Runtime.stash(stale.shell_runtime).fake.state.events == [event]
-    Process.cancel_timer(stale.render_timer)
+    Process.cancel_timer(stale.render_correlation.timer)
   end
 
   test "active agent event retains state returned by shell persistence" do
@@ -464,7 +464,7 @@ defmodule MingaEditor.Shell.RegistryTest do
       MingaEditor.handle_info({:agent_event, self(), {:status_changed, :error}}, state)
 
     assert Runtime.state(updated.shell_runtime) == persisted_state
-    Process.cancel_timer(updated.render_timer)
+    Process.cancel_timer(updated.render_correlation.timer)
   end
 
   test "Agent.Events updates matching stashes but skips a replaced registration" do
@@ -912,10 +912,8 @@ defmodule MingaEditor.Shell.RegistryTest do
       render_sent_at: 0
     }
 
-    result =
-      state
-      |> Workflow.ensure_available()
-      |> EditorState.apply_renderer_writeback(writeback)
+    available = Workflow.ensure_available(state)
+    {result, _receipt_result} = EditorState.integrate_renderer_receipt(available, writeback)
 
     assert result.layout == nil
     assert result.focus_tree == nil

--- a/test/minga_editor/state/render_correlation_test.exs
+++ b/test/minga_editor/state/render_correlation_test.exs
@@ -1,0 +1,100 @@
+defmodule MingaEditor.State.RenderCorrelationTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.State.RenderCorrelation
+
+  test "render timer admission coalesces until the timer is cleared" do
+    first = make_ref()
+    second = make_ref()
+
+    assert {:scheduled, correlation} = RenderCorrelation.schedule(RenderCorrelation.new(), first)
+    assert RenderCorrelation.scheduled?(correlation)
+    assert correlation.timer == first
+    assert {:coalesced, unchanged} = RenderCorrelation.schedule(correlation, second)
+    assert unchanged == correlation
+
+    cleared = RenderCorrelation.clear_timer(correlation)
+    refute RenderCorrelation.scheduled?(cleared)
+    assert cleared.timer == nil
+  end
+
+  test "frontend readiness and reset require a keyframe without resetting ordering evidence" do
+    correlation = %RenderCorrelation{
+      latest_intent_revision: 8,
+      last_receipt_revision: 7,
+      last_receipt_seq: 41
+    }
+
+    ready = RenderCorrelation.frontend_ready(correlation)
+    assert RenderCorrelation.force_keyframe?(ready)
+    assert ready.latest_intent_revision == 8
+    assert ready.last_receipt_revision == 7
+    assert ready.last_receipt_seq == 41
+
+    reset = RenderCorrelation.reset(correlation)
+    assert reset == ready
+  end
+
+  test "intent submissions advance independently of receipt acknowledgement" do
+    {correlation, first} = RenderCorrelation.submit(RenderCorrelation.new())
+    {correlation, second} = RenderCorrelation.submit(correlation)
+
+    assert first == 1
+    assert second == 2
+    assert correlation.latest_intent_revision == 2
+    assert correlation.last_receipt_revision == 0
+  end
+
+  test "receipt freshness rejects superseded, duplicate, and out-of-order evidence" do
+    correlation = %RenderCorrelation{
+      latest_intent_revision: 3,
+      last_receipt_revision: 2,
+      last_receipt_seq: 20
+    }
+
+    assert RenderCorrelation.classify_receipt(correlation, 2, 21) ==
+             {:stale, :superseded_intent}
+
+    assert RenderCorrelation.classify_receipt(correlation, 3, 20) ==
+             {:stale, :stale_sequence}
+
+    accepted = RenderCorrelation.accept_receipt(correlation, 3, 21, false)
+
+    assert RenderCorrelation.classify_receipt(accepted, 3, 22) ==
+             {:stale, :stale_receipt_revision}
+
+    assert RenderCorrelation.classify_receipt(accepted, 4, 21) ==
+             {:stale, :stale_sequence}
+
+    assert RenderCorrelation.classify_receipt(accepted, 4, 22) == {:fresh, 4}
+  end
+
+  test "legacy revision zero normalizes to frame sequence before any submitted intent" do
+    correlation = RenderCorrelation.new()
+    assert RenderCorrelation.classify_receipt(correlation, 0, 12) == {:fresh, 12}
+
+    correlation = RenderCorrelation.accept_receipt(correlation, 12, 12, false)
+
+    assert RenderCorrelation.classify_receipt(correlation, 0, 12) ==
+             {:stale, :stale_receipt_revision}
+  end
+
+  test "only an accepted keyframe fulfills a pending keyframe request" do
+    correlation = RenderCorrelation.request_keyframe(RenderCorrelation.new())
+    assert RenderCorrelation.force_keyframe?(correlation)
+
+    delta = RenderCorrelation.accept_receipt(correlation, 1, 1, false)
+    assert RenderCorrelation.force_keyframe?(delta)
+
+    keyframe = RenderCorrelation.accept_receipt(delta, 2, 2, true)
+    refute RenderCorrelation.force_keyframe?(keyframe)
+  end
+
+  test "synchronous receipts preserve monotonic revision and sequence evidence" do
+    correlation = %RenderCorrelation{last_receipt_revision: 10, last_receipt_seq: 20}
+    correlation = RenderCorrelation.accept_synchronous_receipt(correlation, 8, 19, false)
+
+    assert correlation.last_receipt_revision == 10
+    assert correlation.last_receipt_seq == 20
+  end
+end


### PR DESCRIPTION
# TL;DR

Editor render scheduling, keyframe recovery, intent revisions, and receipt ordering now live in one immutable correlation value. Renderer feedback still integrates atomically at the Editor root, while `Renderer.Server` remains authoritative for resident content, caches, and acknowledgements.

Closes #2864

## Context

This is the render-correlation ownership slice of #2861. It removes parallel root fields and compatibility writeback paths without changing the single-Editor-process or Renderer process boundaries.

## Changes

- Add `MingaEditor.State.RenderCorrelation` with pure timer, keyframe, frontend-reset, submission, freshness, and receipt transitions.
- Route synchronous and asynchronous renderer feedback through one focused receipt and one atomic root integration path for shell identity, workspace observations, layout, focus, and click regions.
- Keep timer creation, stale-receipt logging, render submission, and frontend communication in Editor workflows outside the pure owner.
- Remove the old root correlation fields and broad `apply_render_output/2` compatibility path, and document the resulting ownership boundary in ADR-0002.

## Verification

- `mix test.debug test/minga_editor/state/render_correlation_test.exs test/minga_editor/render_pipeline/input_test.exs test/minga_editor/render_pipeline/resident_incremental_test.exs test/minga_editor/renderer/server_test.exs test/minga_editor/file_tree/freshness_test.exs test/minga_editor/shell/registry_test.exs` (96 passed, 4 excluded)
- `mix test.quick` (9,263 tests, 97 properties, 58 doctests, 0 failures)
- `make lint` (format, Credo, compile, and incremental Dialyzer passed)
- `mix test.llm` (9,263 tests, 97 properties, 58 doctests, 0 failures)
- Focused render-correlation bug hunt found no high-confidence issues.
- Final acceptance review passed after adding explicit non-nil focus-tree writeback coverage.

## Acceptance Criteria Addressed

- One Editor-owned render scheduling and correlation value with explicit transitions ✅
- Atomic root receipt integration across freshness, shell, workspace, layout, focus, and click-region observations ✅
- Preserved stale, duplicate, keyframe, reconnect, synchronous, and asynchronous behavior ✅
- External actions remain outside pure calculations ✅
- `Renderer.Server` retains renderer-private authority ✅
- Old fields, duplicate merge paths, and migration delegates removed ✅
- Focused ordering, reset, identity, layout, and focus tests added ✅
