### PR TITLE
fix(editor): address post-merge review findings

### DIFF
--- a/bench/gui_key_latency_bench.exs
+++ b/bench/gui_key_latency_bench.exs
@@ -67,7 +67,7 @@ defmodule Minga.Bench.GUIKeyLatency do
         theme_change: measure_theme_change(ctx)
       }
     after
-      stop_if_alive(ctx.editor)
+      stop_if_alive(ctx.generation)
       stop_if_alive(ctx.buffer)
       stop_if_alive(ctx.port)
       stop_if_alive(ctx.sidebar)
@@ -102,8 +102,8 @@ defmodule Minga.Bench.GUIKeyLatency do
 
     {:ok, buffer} = BufferProcess.start_link(buffer_opts)
 
-    {:ok, editor} =
-      MingaEditor.start_link(
+    {:ok, generation} =
+      MingaEditor.GenerationSupervisor.start_editor_generation_link(
         name: :"gui_bench_editor_#{id}",
         backend: :headless,
         port_manager: port,
@@ -116,13 +116,22 @@ defmodule Minga.Bench.GUIKeyLatency do
         suppress_tool_prompts: true
       )
 
+    {:ok, editor} = MingaEditor.GenerationSupervisor.editor_owner(generation)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:ready, width, height}})
     {:ok, _snapshot} = HeadlessPort.collect_frame(ref, 15_000)
     _ = :sys.get_state(editor)
     _ = HeadlessPort.get_screen(port)
 
-    %{editor: editor, buffer: buffer, port: port, sidebar: sidebar, width: width, height: height}
+    %{
+      generation: generation,
+      editor: editor,
+      buffer: buffer,
+      port: port,
+      sidebar: sidebar,
+      width: width,
+      height: height
+    }
   end
 
   defp measure_cursor_move(ctx), do: measure_key(ctx, ?j)

--- a/bench/keystroke_latency_baseline.exs
+++ b/bench/keystroke_latency_baseline.exs
@@ -294,7 +294,7 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
     try do
       fun.(ctx)
     after
-      stop_if_alive(ctx.editor)
+      stop_if_alive(ctx.generation)
       stop_if_alive(ctx.buffer)
       stop_if_alive(ctx.port)
       stop_if_alive(ctx.sidebar)
@@ -317,8 +317,8 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
 
     {:ok, buffer} = BufferProcess.start_link(content: document(), file_path: "bench_elixir.ex")
 
-    {:ok, editor} =
-      MingaEditor.start_link(
+    {:ok, generation} =
+      MingaEditor.GenerationSupervisor.start_editor_generation_link(
         name: :"kl_bench_editor_#{id}",
         backend: :headless,
         port_manager: port,
@@ -330,12 +330,21 @@ defmodule Minga.Bench.KeystrokeLatencyBaseline do
         suppress_tool_prompts: true
       )
 
+    {:ok, editor} = MingaEditor.GenerationSupervisor.editor_owner(generation)
     ref = HeadlessPort.prepare_await(port)
     send(editor, {:minga_input, {:ready, width, height}})
     {:ok, _snapshot} = HeadlessPort.collect_frame(ref, 15_000)
     _ = :sys.get_state(editor)
 
-    %{editor: editor, buffer: buffer, port: port, sidebar: sidebar, width: width, height: height}
+    %{
+      generation: generation,
+      editor: editor,
+      buffer: buffer,
+      port: port,
+      sidebar: sidebar,
+      width: width,
+      height: height
+    }
   end
 
   # Opens the file tree sidebar so the large-frame scenario renders it. Falls

--- a/extensions/git_porcelain/test/minga_git_porcelain/commands/remote_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/commands/remote_test.exs
@@ -159,16 +159,21 @@ defmodule MingaGitPorcelain.CommandsRemoteTest do
   defp start_editor(content \\ "") do
     {:ok, buffer} = BufferProcess.start_link(content: content)
 
-    {:ok, editor} =
-      MingaEditor.start_link(
-        name: :"editor_#{:erlang.unique_integer([:positive])}",
-        port_manager: nil,
-        buffer: buffer,
-        width: 40,
-        height: 10,
-        editing_model: :vim
+    generation =
+      start_supervised!(
+        Supervisor.child_spec(
+          {MingaEditor,
+           name: :"editor_#{:erlang.unique_integer([:positive])}",
+           port_manager: nil,
+           buffer: buffer,
+           width: 40,
+           height: 10,
+           editing_model: :vim},
+          id: make_ref()
+        )
       )
 
+    {:ok, editor} = MingaEditor.GenerationSupervisor.editor_owner(generation)
     {editor, buffer}
   end
 

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -97,9 +97,26 @@ defmodule MingaEditor do
 
   # ── Client API ──────────────────────────────────────────────────────────────
 
-  @doc "Starts the editor."
+  @doc false
+  @spec child_spec([start_opt()]) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {MingaEditor.GenerationSupervisor, :start_editor_generation_link, [opts]},
+      restart: :permanent,
+      shutdown: :infinity,
+      type: :supervisor,
+      modules: [MingaEditor.GenerationSupervisor]
+    }
+  end
+
+  @doc "Starts an Editor owner with an existing generation-owned effect scheduler."
   @spec start_link([start_opt()]) :: GenServer.on_start()
-  def start_link(opts \\ []) do
+  def start_link(opts \\ []), do: start_owner_link(opts)
+
+  @doc "OTP child start for the Editor owner inside a generation boundary."
+  @spec start_owner_link([start_opt()]) :: GenServer.on_start()
+  def start_owner_link(opts) do
     {name, opts} = Keyword.pop(opts, :name, __MODULE__)
     GenServer.start_link(__MODULE__, opts, name: name)
   end
@@ -278,7 +295,8 @@ defmodule MingaEditor do
   end
 
   @spec attach_effect_scheduler(GenServer.server() | nil) :: :ok
-  defp attach_effect_scheduler(nil), do: :ok
+  defp attach_effect_scheduler(nil),
+    do: raise(ArgumentError, "an Editor effect scheduler is required")
 
   defp attach_effect_scheduler(scheduler) do
     :ok = EffectScheduler.attach(scheduler, self())

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -29,6 +29,8 @@ defmodule MingaEditor.Agent.Events do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Workflow
 
   @type effect ::
           :render
@@ -697,26 +699,33 @@ defmodule MingaEditor.Agent.Events do
   end
 
   @spec sync_active_shell_agent_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
-  defp sync_active_shell_agent_status(state, status) do
-    session = AgentAccess.session(state)
-    update_shell_for_session(state, :sync_agent_status, [session, status])
-  end
+  defp sync_active_shell_agent_status(state, status),
+    do: update_shell_for_active_session(state, :sync_agent_status, [status])
 
   @spec track_active_shell_agent_file(EditorState.t(), String.t()) :: EditorState.t()
-  defp track_active_shell_agent_file(state, path) do
-    session = AgentAccess.session(state)
-    update_shell_for_session(state, :track_agent_file, [session, path])
+  defp track_active_shell_agent_file(state, path),
+    do: update_shell_for_active_session(state, :track_agent_file, [path])
+
+  @spec update_shell_for_active_session(EditorState.t() | map(), atom(), [term()]) ::
+          EditorState.t() | map()
+  defp update_shell_for_active_session(%EditorState{} = state, callback, args) do
+    state = Workflow.ensure_available(state)
+    session = Runtime.active_session(state.shell_runtime)
+    update_shell_for_session(state, callback, session, args)
   end
 
-  @spec update_shell_for_session(EditorState.t(), atom(), [term()]) :: EditorState.t()
-  defp update_shell_for_session(state, _callback, [session | _args]) when not is_pid(session),
+  defp update_shell_for_active_session(state, _callback, _args), do: state
+
+  @spec update_shell_for_session(EditorState.t(), atom(), pid() | nil, [term()]) ::
+          EditorState.t()
+  defp update_shell_for_session(state, _callback, session, _args) when not is_pid(session),
     do: state
 
-  defp update_shell_for_session(state, :sync_agent_status, [session, status]) do
+  defp update_shell_for_session(state, :sync_agent_status, session, [status]) do
     runtime =
-      MingaEditor.Shell.Runtime.sync_agent_status(
+      Runtime.sync_agent_status(
         state.shell_runtime,
-        MingaEditor.Shell.Workflow.resolved_entries(),
+        Workflow.resolved_entries(),
         session,
         status
       )
@@ -724,11 +733,11 @@ defmodule MingaEditor.Agent.Events do
     EditorState.apply_shell_runtime_transition(state, runtime)
   end
 
-  defp update_shell_for_session(state, :track_agent_file, [session, path]) do
+  defp update_shell_for_session(state, :track_agent_file, session, [path]) do
     runtime =
-      MingaEditor.Shell.Runtime.track_agent_file(
+      Runtime.track_agent_file(
         state.shell_runtime,
-        MingaEditor.Shell.Workflow.resolved_entries(),
+        Workflow.resolved_entries(),
         session,
         path
       )

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -20,6 +20,9 @@ defmodule MingaEditor.FileTree.Freshness do
 
   @type state :: EditorState.t()
 
+  @refresh_retry_base_ms 25
+  @refresh_retry_max_ms 1_000
+
   @doc "Returns true when the file tree is open."
   @spec open?(state()) :: boolean()
   def open?(state), do: match?(%FileTreeState{tree: %FileTree{}}, file_tree_state(state))
@@ -145,8 +148,22 @@ defmodule MingaEditor.FileTree.Freshness do
 
       {:error, reason} ->
         Minga.Log.warning(:editor, "File tree refresh not scheduled: #{inspect(reason)}")
-        state
+        schedule_refresh_retry(state)
     end
+  end
+
+  @spec schedule_refresh_retry(state()) :: state()
+  defp schedule_refresh_retry(state) do
+    token = make_ref()
+    {attempt, file_tree} = FileTreeState.track_refresh_retry(file_tree_state(state), token)
+    Process.send_after(self(), {:file_tree_refresh_timer, token}, refresh_retry_delay(attempt))
+    set_file_tree(state, file_tree)
+  end
+
+  @spec refresh_retry_delay(pos_integer()) :: pos_integer()
+  defp refresh_retry_delay(attempt) do
+    exponent = min(attempt - 1, 6)
+    min(@refresh_retry_base_ms * Integer.pow(2, exponent), @refresh_retry_max_ms)
   end
 
   @spec apply_completed_refresh(state(), Refresh.t(), FileTree.t(), Outcome.t()) ::
@@ -213,7 +230,7 @@ defmodule MingaEditor.FileTree.Freshness do
       %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
         status = GitStatus.from_entries(entries, entry_base_path || git_root, tree.root)
         updated_tree = FileTree.replace_git_status(tree, status)
-        file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
+        file_tree = FileTreeState.replace_tree_metadata(file_tree, updated_tree)
 
         state
         |> set_file_tree(file_tree)
@@ -231,7 +248,7 @@ defmodule MingaEditor.FileTree.Freshness do
       %FileTreeState{tree: %FileTree{} = tree} = file_tree ->
         updated_tree = Refresh.with_cached_git_status(tree, EditorState.events_registry(state))
 
-        file_tree = FileTreeState.replace_tree(file_tree, updated_tree)
+        file_tree = FileTreeState.replace_tree_metadata(file_tree, updated_tree)
 
         state
         |> set_file_tree(file_tree)

--- a/lib/minga_editor/frontend/manager/output_handler.ex
+++ b/lib/minga_editor/frontend/manager/output_handler.ex
@@ -1,6 +1,7 @@
 defmodule MingaEditor.Frontend.Manager.OutputHandler do
   @moduledoc "Owns non-suspending Port admission, bounded frame retention, and recovery correlation."
 
+  alias Minga.Protocol.Opcodes
   alias Minga.Telemetry
   alias MingaEditor.Frontend.FrameTransaction
   alias MingaEditor.Frontend.Manager
@@ -8,6 +9,8 @@ defmodule MingaEditor.Frontend.Manager.OutputHandler do
   alias MingaEditor.Frontend.Manager.PendingFrame
   alias MingaEditor.Frontend.Manager.State
   alias MingaEditor.Frontend.Protocol
+
+  @clipboard_write Opcodes.clipboard_write()
 
   @doc "Attempts one command batch without suspending the Port owner."
   @spec admit_commands(State.t(), [binary()]) :: {Manager.admission(), State.t()}
@@ -78,9 +81,19 @@ defmodule MingaEditor.Frontend.Manager.OutputHandler do
 
   @spec attempt_output(State.t()) :: {Manager.admission(), State.t()}
   defp attempt_output(state) do
+    now = System.monotonic_time(:millisecond)
+
+    case expired_current(state, now) do
+      nil -> attempt_next_output(state)
+      failed -> {:unwritable, require_keyframe_recovery(state, failed)}
+    end
+  end
+
+  @spec attempt_next_output(State.t()) :: {Manager.admission(), State.t()}
+  defp attempt_next_output(state) do
     case OutputPressure.next_control(state.output_pressure) do
       nil -> attempt_current(state)
-      {opcode, batch} -> attempt_control(state, opcode, batch)
+      {key, batch} -> attempt_control(state, key, batch)
     end
   end
 
@@ -123,15 +136,30 @@ defmodule MingaEditor.Frontend.Manager.OutputHandler do
   end
 
   @spec current_unwritable(State.t(), PendingFrame.t()) :: {Manager.admission(), State.t()}
-  defp current_unwritable(state, current) do
+  defp current_unwritable(state, _current) do
     now = System.monotonic_time(:millisecond)
+    retry_or_recover_current(state, now)
+  end
 
-    if OutputPressure.expired?(state.output_pressure, now, state.output_failure_ms) do
-      {:unwritable, require_keyframe_recovery(state, current)}
-    else
-      {:unwritable, ensure_retry(state, now)}
+  @spec retry_or_recover_current(State.t(), integer()) :: {Manager.admission(), State.t()}
+  defp retry_or_recover_current(state, now) do
+    case expired_current(state, now) do
+      nil -> {:unwritable, ensure_retry(state, now)}
+      failed -> {:unwritable, require_keyframe_recovery(state, failed)}
     end
   end
+
+  @spec expired_current(State.t(), integer()) :: PendingFrame.t() | nil
+  defp expired_current(
+         %{output_pressure: %OutputPressure{current: %PendingFrame{} = current}} = state,
+         now
+       ) do
+    if OutputPressure.expired?(state.output_pressure, now, state.output_failure_ms),
+      do: current,
+      else: nil
+  end
+
+  defp expired_current(%{output_pressure: %OutputPressure{current: nil}}, _now), do: nil
 
   @spec ensure_retry(State.t(), integer()) :: State.t()
   defp ensure_retry(state, now) do
@@ -160,11 +188,7 @@ defmodule MingaEditor.Frontend.Manager.OutputHandler do
       {:minga_input, {:request_keyframe, stats.last_applied_frame_seq, failed.generation}}
     )
 
-    state = %{state | output_pressure: output_pressure}
-
-    if OutputPressure.controls_pending?(output_pressure),
-      do: ensure_retry(state, System.monotonic_time(:millisecond)),
-      else: state
+    %{state | output_pressure: output_pressure}
   end
 
   @spec admit_control(State.t(), [binary()]) :: {Manager.admission(), State.t()}
@@ -186,23 +210,24 @@ defmodule MingaEditor.Frontend.Manager.OutputHandler do
     end
   end
 
-  @spec attempt_control(State.t(), non_neg_integer(), binary()) ::
+  @spec attempt_control(State.t(), OutputPressure.control_key(), binary()) ::
           {Manager.admission(), State.t()}
-  defp attempt_control(state, opcode, batch) do
+  defp attempt_control(state, key, batch) do
     case write_batch(state, batch) do
       :accepted ->
-        output_pressure = OutputPressure.control_admitted(state.output_pressure, opcode)
+        output_pressure = OutputPressure.control_admitted(state.output_pressure, key)
         attempt_output(%{state | output_pressure: output_pressure})
 
       :unwritable ->
-        {:unwritable, ensure_retry(state, System.monotonic_time(:millisecond))}
+        retry_or_recover_current(state, System.monotonic_time(:millisecond))
     end
   end
 
   @spec retain_control(State.t(), non_neg_integer(), binary()) ::
           {Manager.admission(), State.t()}
   defp retain_control(state, opcode, batch) do
-    output_pressure = OutputPressure.retain_control(state.output_pressure, opcode, batch)
+    key = control_key(opcode, batch)
+    output_pressure = OutputPressure.retain_control(state.output_pressure, key, batch)
     state = %{state | output_pressure: output_pressure}
     {:unwritable, ensure_retry(state, System.monotonic_time(:millisecond))}
   end
@@ -210,6 +235,15 @@ defmodule MingaEditor.Frontend.Manager.OutputHandler do
   @spec output_pending?(OutputPressure.t()) :: boolean()
   defp output_pending?(%OutputPressure{current: current} = pressure),
     do: current != nil or OutputPressure.controls_pending?(pressure)
+
+  @spec control_key(non_neg_integer(), binary()) :: OutputPressure.control_key()
+  defp control_key(
+         @clipboard_write,
+         <<@clipboard_write, _payload_length::32, target::8, _payload::binary>>
+       ),
+       do: {@clipboard_write, target}
+
+  defp control_key(opcode, _batch), do: opcode
 
   @spec first_opcode(binary()) :: non_neg_integer()
   defp first_opcode(<<opcode, _::binary>>), do: opcode

--- a/lib/minga_editor/frontend/manager/output_pressure.ex
+++ b/lib/minga_editor/frontend/manager/output_pressure.ex
@@ -9,16 +9,22 @@ defmodule MingaEditor.Frontend.Manager.OutputPressure do
             unwritable_since: nil,
             retry_token: nil,
             minimum_ack_generation: 0,
+            last_admitted_generation: 0,
+            last_admitted_frame_seq: 0,
             last_applied_generation: 0,
             last_applied_frame_seq: 0
+
+  @type control_key :: non_neg_integer() | {non_neg_integer(), non_neg_integer()}
 
   @type t :: %__MODULE__{
           current: PendingFrame.t() | nil,
           replacement: PendingFrame.t() | nil,
-          controls: %{non_neg_integer() => binary()},
+          controls: %{control_key() => binary()},
           unwritable_since: integer() | nil,
           retry_token: reference() | nil,
           minimum_ack_generation: non_neg_integer(),
+          last_admitted_generation: non_neg_integer(),
+          last_admitted_frame_seq: non_neg_integer(),
           last_applied_generation: non_neg_integer(),
           last_applied_frame_seq: non_neg_integer()
         }
@@ -33,6 +39,8 @@ defmodule MingaEditor.Frontend.Manager.OutputPressure do
           control_bytes: non_neg_integer(),
           total_retained_bytes: non_neg_integer(),
           minimum_ack_generation: non_neg_integer(),
+          last_admitted_generation: non_neg_integer(),
+          last_admitted_frame_seq: non_neg_integer(),
           last_applied_generation: non_neg_integer(),
           last_applied_frame_seq: non_neg_integer()
         }
@@ -49,25 +57,30 @@ defmodule MingaEditor.Frontend.Manager.OutputPressure do
   def enqueue(%__MODULE__{} = pressure, %PendingFrame{} = frame),
     do: {:coalesced, %{pressure | replacement: frame}}
 
-  @doc "Coalesces the latest unwritable out-of-band control batch by opcode."
-  @spec retain_control(t(), non_neg_integer(), binary()) :: t()
-  def retain_control(%__MODULE__{} = pressure, opcode, batch)
-      when is_integer(opcode) and opcode >= 0 and is_binary(batch),
-      do: %{pressure | controls: Map.put(pressure.controls, opcode, batch)}
+  @doc "Coalesces the latest unwritable out-of-band control batch by resource key."
+  @spec retain_control(t(), control_key(), binary()) :: t()
+  def retain_control(%__MODULE__{} = pressure, key, batch)
+      when is_integer(key) and key >= 0 and is_binary(batch),
+      do: put_control(pressure, key, batch)
 
-  @doc "Returns the next retained control batch in deterministic opcode order."
-  @spec next_control(t()) :: {non_neg_integer(), binary()} | nil
+  def retain_control(%__MODULE__{} = pressure, {opcode, resource} = key, batch)
+      when is_integer(opcode) and opcode >= 0 and is_integer(resource) and resource >= 0 and
+             is_binary(batch),
+      do: put_control(pressure, key, batch)
+
+  @doc "Returns the next retained control batch in deterministic resource-key order."
+  @spec next_control(t()) :: {control_key(), binary()} | nil
   def next_control(%__MODULE__{controls: controls}) when map_size(controls) == 0, do: nil
 
   def next_control(%__MODULE__{controls: controls}) do
-    opcode = controls |> Map.keys() |> Enum.min()
-    {opcode, Map.fetch!(controls, opcode)}
+    key = controls |> Map.keys() |> Enum.min()
+    {key, Map.fetch!(controls, key)}
   end
 
   @doc "Drops one admitted control batch."
-  @spec control_admitted(t(), non_neg_integer()) :: t()
-  def control_admitted(%__MODULE__{} = pressure, opcode),
-    do: %{pressure | controls: Map.delete(pressure.controls, opcode)}
+  @spec control_admitted(t(), control_key()) :: t()
+  def control_admitted(%__MODULE__{} = pressure, key),
+    do: %{pressure | controls: Map.delete(pressure.controls, key)}
 
   @doc "Clears the unwritable interval after every retained batch drains."
   @spec settled(t()) :: t()
@@ -111,13 +124,15 @@ defmodule MingaEditor.Frontend.Manager.OutputPressure do
   @doc "Advances after the current frame is admitted and returns the admitted frame."
   @spec admitted(t()) :: {PendingFrame.t(), t()}
   def admitted(%__MODULE__{current: %PendingFrame{} = current} = pressure) do
+    {generation, frame_seq} = admission_watermark(pressure, current)
+
     {current,
      %{
        pressure
        | current: pressure.replacement,
          replacement: nil,
-         unwritable_since: nil,
-         retry_token: nil
+         last_admitted_generation: generation,
+         last_admitted_frame_seq: frame_seq
      }}
   end
 
@@ -128,6 +143,7 @@ defmodule MingaEditor.Frontend.Manager.OutputPressure do
       pressure
       | current: nil,
         replacement: nil,
+        controls: %{},
         unwritable_since: nil,
         retry_token: nil,
         minimum_ack_generation: max(pressure.minimum_ack_generation, failed.generation + 1)
@@ -171,6 +187,8 @@ defmodule MingaEditor.Frontend.Manager.OutputPressure do
       control_bytes: control_bytes,
       total_retained_bytes: current_bytes + replacement_bytes + control_bytes,
       minimum_ack_generation: pressure.minimum_ack_generation,
+      last_admitted_generation: pressure.last_admitted_generation,
+      last_admitted_frame_seq: pressure.last_admitted_frame_seq,
       last_applied_generation: pressure.last_applied_generation,
       last_applied_frame_seq: pressure.last_applied_frame_seq
     }
@@ -179,10 +197,31 @@ defmodule MingaEditor.Frontend.Manager.OutputPressure do
   @spec stale_ack?(t(), non_neg_integer(), non_neg_integer()) :: boolean()
   defp stale_ack?(pressure, generation, frame_seq) do
     generation < pressure.minimum_ack_generation or
+      generation > pressure.last_admitted_generation or
+      (generation == pressure.last_admitted_generation and
+         frame_seq > pressure.last_admitted_frame_seq) or
       generation < pressure.last_applied_generation or
       (generation == pressure.last_applied_generation and
          frame_seq <= pressure.last_applied_frame_seq)
   end
+
+  @spec admission_watermark(t(), PendingFrame.t()) ::
+          {non_neg_integer(), non_neg_integer()}
+  defp admission_watermark(pressure, %PendingFrame{generation: generation, frame_seq: frame_seq})
+       when generation > pressure.last_admitted_generation,
+       do: {generation, frame_seq}
+
+  defp admission_watermark(pressure, %PendingFrame{generation: generation, frame_seq: frame_seq})
+       when generation == pressure.last_admitted_generation and
+              frame_seq > pressure.last_admitted_frame_seq,
+       do: {generation, frame_seq}
+
+  defp admission_watermark(pressure, %PendingFrame{}),
+    do: {pressure.last_admitted_generation, pressure.last_admitted_frame_seq}
+
+  @spec put_control(t(), control_key(), binary()) :: t()
+  defp put_control(pressure, key, batch),
+    do: %{pressure | controls: Map.put(pressure.controls, key, batch)}
 
   @spec frame_bytes(PendingFrame.t() | nil) :: non_neg_integer()
   defp frame_bytes(nil), do: 0

--- a/lib/minga_editor/generation_supervisor.ex
+++ b/lib/minga_editor/generation_supervisor.ex
@@ -12,7 +12,7 @@ defmodule MingaEditor.GenerationSupervisor do
 
   @typedoc "Options for the generation-owned process names and Editor child."
   @type start_opt ::
-          {:name, GenServer.name()}
+          {:name, GenServer.name() | nil}
           | {:task_supervisor_name, GenServer.name()}
           | {:scheduler_name, GenServer.name()}
           | {:max_admitted, pos_integer()}
@@ -21,8 +21,23 @@ defmodule MingaEditor.GenerationSupervisor do
 
   @spec start_link([start_opt()]) :: Supervisor.on_start()
   def start_link(opts) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    Supervisor.start_link(__MODULE__, opts, name: name)
+    case Keyword.get(opts, :name, __MODULE__) do
+      nil -> Supervisor.start_link(__MODULE__, opts)
+      name -> Supervisor.start_link(__MODULE__, opts, name: name)
+    end
+  end
+
+  @doc "Starts an Editor generation for an enclosing supervisor to own."
+  @spec start_editor_generation_link(keyword()) :: Supervisor.on_start()
+  def start_editor_generation_link(editor_opts) do
+    generation_id = make_ref()
+
+    start_link(
+      name: nil,
+      task_supervisor_name: {:global, {__MODULE__, generation_id, :tasks}},
+      scheduler_name: {:global, {__MODULE__, generation_id, :scheduler}},
+      editor: {MingaEditor, editor_opts}
+    )
   end
 
   @impl true
@@ -45,10 +60,36 @@ defmodule MingaEditor.GenerationSupervisor do
     children = [
       Supervisor.child_spec({Task.Supervisor, name: task_name}, id: :effect_task_supervisor),
       Supervisor.child_spec({MingaEditor.EffectScheduler, scheduler_opts}, id: :effect_scheduler),
-      Supervisor.child_spec({editor_module, owner_opts}, id: :editor_owner)
+      editor_child_spec(editor_module, owner_opts)
     ]
 
     Supervisor.init(children, strategy: :one_for_all)
+  end
+
+  @doc "Returns the Editor endpoint owned by a running generation."
+  @spec editor_owner(Supervisor.supervisor()) ::
+          {:ok, pid()} | {:error, :editor_owner_not_started}
+  def editor_owner(generation) do
+    case List.keyfind(Supervisor.which_children(generation), :editor_owner, 0) do
+      {:editor_owner, editor, :worker, _modules} when is_pid(editor) -> {:ok, editor}
+      _missing -> {:error, :editor_owner_not_started}
+    end
+  end
+
+  @spec editor_child_spec(module(), keyword()) :: Supervisor.child_spec()
+  defp editor_child_spec(MingaEditor, owner_opts) do
+    %{
+      id: :editor_owner,
+      start: {MingaEditor, :start_owner_link, [owner_opts]},
+      restart: :permanent,
+      shutdown: 5_000,
+      type: :worker,
+      modules: [MingaEditor]
+    }
+  end
+
+  defp editor_child_spec(editor_module, owner_opts) do
+    Supervisor.child_spec({editor_module, owner_opts}, id: :editor_owner)
   end
 
   @spec maybe_put_observer(keyword(), keyword()) :: keyword()

--- a/lib/minga_editor/shell/runtime.ex
+++ b/lib/minga_editor/shell/runtime.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.Shell.Runtime do
   alias MingaEditor.Shell.Entry
   alias MingaEditor.Shell.Identity
   alias MingaEditor.Shell.StateStash
+  alias MingaEditor.State.TabBar
 
   @type shell_state :: MingaEditor.Shell.shell_state()
   @type stash :: %{atom() => StateStash.t()}
@@ -466,10 +467,7 @@ defmodule MingaEditor.Shell.Runtime do
 
   @spec active_owns_agent_session?(t(), pid()) :: boolean()
   defp active_owns_agent_session?(%__MODULE__{} = runtime, session_pid) do
-    module = runtime.entry.module
-
-    function_exported?(module, :owns_agent_session?, 2) and
-      module.owns_agent_session?(runtime.state, session_pid)
+    shell_state_owns_agent_session?(runtime.entry.module, runtime.state, session_pid)
   end
 
   @spec stashed_entry_owns_agent_session?(t(), Entry.t(), pid()) :: boolean()
@@ -480,17 +478,43 @@ defmodule MingaEditor.Shell.Runtime do
        ) do
     case Map.get(runtime.stash, entry.id) do
       %StateStash{} = stashed ->
-        with {:ok, state} <- StateStash.restore(stashed, entry),
-             true <- function_exported?(entry.module, :owns_agent_session?, 2) do
-          entry.module.owns_agent_session?(state, session_pid)
-        else
-          _ -> false
+        case StateStash.restore(stashed, entry) do
+          {:ok, state} -> shell_state_owns_agent_session?(entry.module, state, session_pid)
+          :mismatch -> false
         end
 
       nil ->
         false
     end
   end
+
+  @spec shell_state_owns_agent_session?(module(), shell_state(), pid()) :: boolean()
+  defp shell_state_owns_agent_session?(module, shell_state, session_pid) do
+    if function_exported?(module, :owns_agent_session?, 2) do
+      module.owns_agent_session?(shell_state, session_pid)
+    else
+      module.active_session(shell_state) == session_pid or
+        legacy_shell_state_owns_agent_session?(shell_state, session_pid)
+    end
+  end
+
+  @spec legacy_shell_state_owns_agent_session?(shell_state(), pid()) :: boolean()
+  defp legacy_shell_state_owns_agent_session?(%{cards: cards} = shell_state, session_pid)
+       when is_map(cards) do
+    Enum.any?(cards, fn {_card_id, card} -> Map.get(card, :session) == session_pid end) or
+      legacy_tab_bar_owns_agent_session?(shell_state, session_pid)
+  end
+
+  defp legacy_shell_state_owns_agent_session?(shell_state, session_pid),
+    do: legacy_tab_bar_owns_agent_session?(shell_state, session_pid)
+
+  @spec legacy_tab_bar_owns_agent_session?(shell_state(), pid()) :: boolean()
+  defp legacy_tab_bar_owns_agent_session?(%{tab_bar: %TabBar{} = tab_bar}, session_pid) do
+    not is_nil(TabBar.find_by_session(tab_bar, session_pid)) or
+      not is_nil(TabBar.find_workspace_by_session(tab_bar, session_pid))
+  end
+
+  defp legacy_tab_bar_owns_agent_session?(_shell_state, _session_pid), do: false
 
   @spec route_active_boolean_callback(t(), atom(), [term()]) ::
           {t(), boolean(), persistence_change() | nil}
@@ -565,11 +589,16 @@ defmodule MingaEditor.Shell.Runtime do
        ) do
     with {:ok, old_state} <- StateStash.restore(stashed, entry),
          true <- function_exported?(entry.module, callback, length(args) + 1) do
-      {new_state, handled?} = apply(entry.module, callback, [old_state | args])
-      updated = StateStash.new(entry, new_state)
-      runtime = %__MODULE__{runtime | stash: Map.put(runtime.stash, entry.id, updated)}
-      change = if handled?, do: persistence_change(entry, old_state, new_state), else: nil
-      {runtime, handled?, change}
+      case apply(entry.module, callback, [old_state | args]) do
+        {new_state, true} ->
+          updated = StateStash.new(entry, new_state)
+          runtime = %__MODULE__{runtime | stash: Map.put(runtime.stash, entry.id, updated)}
+          change = persistence_change(entry, old_state, new_state)
+          {runtime, true, change}
+
+        {_new_state, false} ->
+          {runtime, false, nil}
+      end
     else
       _ -> {runtime, false, nil}
     end

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -40,6 +40,7 @@ defmodule MingaEditor.State do
   alias MingaEditor.State.LSP, as: LSPState
   alias MingaEditor.Shell.Identity, as: ShellIdentity
   alias MingaEditor.Shell.Runtime, as: ShellRuntime
+  alias MingaEditor.Shell.Workflow, as: ShellWorkflow
   alias MingaEditor.State.Session, as: EditorSessionState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -2449,16 +2450,22 @@ defmodule MingaEditor.State do
   end
 
   @spec active_tab(t()) :: Tab.t() | nil
-  def active_tab(%__MODULE__{} = state), do: ShellRuntime.active_tab(state.shell_runtime)
+  def active_tab(%__MODULE__{} = state) do
+    state = ShellWorkflow.ensure_available(state)
+    ShellRuntime.active_tab(state.shell_runtime)
+  end
 
   @spec find_tab_by_buffer(t(), pid()) :: Tab.t() | nil
   def find_tab_by_buffer(%__MODULE__{} = state, pid) do
+    state = ShellWorkflow.ensure_available(state)
     ShellRuntime.find_tab_by_buffer(state.shell_runtime, pid)
   end
 
   @spec active_tab_kind(t()) :: Tab.kind()
-  def active_tab_kind(%__MODULE__{} = state),
-    do: ShellRuntime.active_tab_kind(state.shell_runtime)
+  def active_tab_kind(%__MODULE__{} = state) do
+    state = ShellWorkflow.ensure_available(state)
+    ShellRuntime.active_tab_kind(state.shell_runtime)
+  end
 
   # ── Spinner lifecycle for tab switching ──────────────────────────────────────
 
@@ -2480,6 +2487,7 @@ defmodule MingaEditor.State do
 
   @spec set_tab_session(t(), Tab.id(), pid() | nil) :: t()
   def set_tab_session(%__MODULE__{} = state, tab_id, session_pid) do
+    state = ShellWorkflow.ensure_available(state)
     runtime = ShellRuntime.set_tab_session(state.shell_runtime, tab_id, session_pid)
     apply_shell_runtime_transition(state, runtime)
   end

--- a/lib/minga_editor/state/agent_access.ex
+++ b/lib/minga_editor/state/agent_access.ex
@@ -16,6 +16,7 @@ defmodule MingaEditor.State.AgentAccess do
   alias MingaEditor.State.Workspace
   alias MingaEditor.Shell.Entry
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Workflow
   alias MingaEditor.Session.State, as: WorkspaceState
 
   # ── Readers ────────────────────────────────────────────────────────────────
@@ -49,11 +50,14 @@ defmodule MingaEditor.State.AgentAccess do
   Traditional reads the active workspace. Extension shells read through shell behaviours until they move onto the same workspace model.
   """
   @spec session(EditorState.t() | map()) :: pid() | nil
-  def session(%EditorState{shell_runtime: %Runtime{entry: %Entry{id: :traditional}}} = state),
-    do: active_workspace_session(state)
+  def session(%EditorState{} = state) do
+    state = Workflow.ensure_available(state)
 
-  def session(%EditorState{shell_runtime: %Runtime{} = runtime}),
-    do: Runtime.active_session(runtime)
+    case state.shell_runtime do
+      %Runtime{entry: %Entry{id: :traditional}} -> active_workspace_session(state)
+      %Runtime{} = runtime -> Runtime.active_session(runtime)
+    end
+  end
 
   def session(_), do: nil
 

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -176,6 +176,10 @@ defmodule MingaEditor.State.FileTree do
     }
   end
 
+  @doc "Replaces metadata on the current tree without changing topology status or refresh correlation."
+  @spec replace_tree_metadata(t(), FileTree.t()) :: t()
+  def replace_tree_metadata(%__MODULE__{} = ft, %FileTree{} = tree), do: %{ft | tree: tree}
+
   @doc "Marks the sidebar as loading."
   @spec loading(t()) :: t()
   def loading(%__MODULE__{} = ft) do
@@ -224,6 +228,13 @@ defmodule MingaEditor.State.FileTree do
   def track_refresh_request(%__MODULE__{} = ft, root, token)
       when is_binary(root) and is_reference(token) do
     %{ft | refresh: Refresh.request_admitted(ft.refresh, root, token)}
+  end
+
+  @doc "Re-arms one pending refresh intent after scheduler admission pressure."
+  @spec track_refresh_retry(t(), Refresh.debounce_token()) :: {pos_integer(), t()}
+  def track_refresh_retry(%__MODULE__{} = ft, token) when is_reference(token) do
+    {attempt, refresh} = Refresh.retry_debounce(ft.refresh, token)
+    {attempt, %{ft | refresh: refresh}}
   end
 
   @doc "Atomically accepts a current refresh result or identifies why it cannot apply."

--- a/lib/minga_editor/state/file_tree/refresh.ex
+++ b/lib/minga_editor/state/file_tree/refresh.ex
@@ -18,19 +18,27 @@ defmodule MingaEditor.State.FileTree.Refresh do
 
   @type t :: %__MODULE__{
           debounce: debounce_token() | nil,
-          current: current_request() | nil
+          current: current_request() | nil,
+          retry_attempt: non_neg_integer()
         }
 
-  defstruct debounce: nil, current: nil
+  defstruct debounce: nil, current: nil, retry_attempt: 0
 
-  @doc "Records one debounce intent, leaving an existing timer authoritative."
+  @doc "Records one debounce intent, leaving an existing timer authoritative and invalidating older result authority."
   @spec request_debounce(t(), debounce_token()) :: {:scheduled | :already_scheduled, t()}
   def request_debounce(%__MODULE__{debounce: nil} = refresh, token) when is_reference(token) do
-    {:scheduled, %{refresh | debounce: token}}
+    {:scheduled, %{refresh | debounce: token, current: nil, retry_attempt: 0}}
   end
 
   def request_debounce(%__MODULE__{} = refresh, token) when is_reference(token) do
-    {:already_scheduled, refresh}
+    {:already_scheduled, %{refresh | current: nil, retry_attempt: 0}}
+  end
+
+  @doc "Re-arms one correlated debounce after scheduler admission pressure."
+  @spec retry_debounce(t(), debounce_token()) :: {pos_integer(), t()}
+  def retry_debounce(%__MODULE__{debounce: nil} = refresh, token) when is_reference(token) do
+    attempt = refresh.retry_attempt + 1
+    {attempt, %{refresh | debounce: token, current: nil, retry_attempt: attempt}}
   end
 
   @doc "Consumes only the currently correlated debounce timer message."
@@ -47,7 +55,7 @@ defmodule MingaEditor.State.FileTree.Refresh do
   @spec request_admitted(t(), String.t(), request_token()) :: t()
   def request_admitted(%__MODULE__{} = refresh, root, token)
       when is_binary(root) and is_reference(token) do
-    %{refresh | current: %{root: Path.expand(root), token: token}}
+    %{refresh | current: %{root: Path.expand(root), token: token}, retry_attempt: 0}
   end
 
   @doc "Classifies and consumes a terminal result for the semantic current request."
@@ -69,5 +77,6 @@ defmodule MingaEditor.State.FileTree.Refresh do
 
   @doc "Invalidates every timer and result correlation when the tree lifecycle changes."
   @spec invalidate(t()) :: t()
-  def invalidate(%__MODULE__{} = refresh), do: %{refresh | debounce: nil, current: nil}
+  def invalidate(%__MODULE__{} = refresh),
+    do: %{refresh | debounce: nil, current: nil, retry_attempt: 0}
 end

--- a/macos/Tests/MingaTests/RenderPerformanceGateTests.swift
+++ b/macos/Tests/MingaTests/RenderPerformanceGateTests.swift
@@ -30,7 +30,7 @@ struct RenderPerformanceGateTests {
         let tinyBaseline = RenderPerformanceBaseline(
             version: 1, fixtureVersion: "resident-ordinary-edit-v2", decodeApplyP95Ms: 0.03,
             commandPreparationP95Ms: 0.35, combinedP95Ms: 0.39, provenance: provenance)
-        let boundary = 0.03 + RenderPerformanceGate.minimumRegressionAllowanceMs
+        let boundary = 0.08
         let pass = RenderPerformanceMeasurement(
             decodeApplyP50Ms: 0.01, decodeApplyP95Ms: boundary,
             commandPreparationP50Ms: 0.13, commandPreparationP95Ms: 0.35,

--- a/test/minga/architecture_test.exs
+++ b/test/minga/architecture_test.exs
@@ -10,12 +10,62 @@ defmodule Minga.ArchitectureTest do
   # Serial because this inspects the process-global application supervision tree.
   use ExUnit.Case, async: false
 
+  @supervision_timeout 5_000
+
   test "Shell.Registry is a top-level serialized publisher" do
     top_children = Supervisor.which_children(Minga.Supervisor)
     top_ids = Enum.map(top_children, &elem(&1, 0))
 
     assert MingaEditor.Shell.Registry in top_ids
     assert Process.whereis(MingaEditor.Shell.Registry) != nil
+  end
+
+  test "Shell.Registry crash reseeds Traditional and restarts downstream supervisors" do
+    :ok = MingaEditor.Shell.Registry.reset_for_test()
+    assert MingaEditor.Shell.Registry.resolve(:traditional) == nil
+
+    registry = Process.whereis(MingaEditor.Shell.Registry)
+    foundation = Process.whereis(Minga.Foundation.Supervisor)
+    services = Process.whereis(Minga.Services.Supervisor)
+
+    registry_ref = Process.monitor(registry)
+    foundation_ref = Process.monitor(foundation)
+    services_ref = Process.monitor(services)
+
+    Process.exit(registry, :kill)
+
+    assert_receive {:DOWN, ^registry_ref, :process, ^registry, :killed}, @supervision_timeout
+
+    assert_receive {:DOWN, ^foundation_ref, :process, ^foundation, _foundation_reason},
+                   @supervision_timeout
+
+    assert_receive {:DOWN, ^services_ref, :process, ^services, _services_reason},
+                   @supervision_timeout
+
+    children =
+      Minga.Supervisor
+      |> Supervisor.which_children()
+      |> Map.new(fn {id, pid, _type, _modules} -> {id, pid} end)
+
+    new_registry = children[MingaEditor.Shell.Registry]
+    new_foundation = children[Minga.Foundation.Supervisor]
+    new_services = children[Minga.Services.Supervisor]
+
+    assert is_pid(new_registry)
+    assert is_pid(new_foundation)
+    assert is_pid(new_services)
+    refute new_registry == registry
+    refute new_foundation == foundation
+    refute new_services == services
+
+    assert %MingaEditor.Shell.Entry{
+             id: :traditional,
+             source: :builtin,
+             module: MingaEditor.Shell.Traditional,
+             generation: generation
+           } = MingaEditor.Shell.Registry.default()
+
+    assert generation > 0
   end
 
   test "MingaAgent.Supervisor is a top-level peer, not nested under Services" do

--- a/test/minga/chaos/editor_fuzzer_test.exs
+++ b/test/minga/chaos/editor_fuzzer_test.exs
@@ -89,8 +89,8 @@ defmodule Minga.Chaos.EditorFuzzerTest do
       end
     end)
 
-    {:ok, editor} =
-      MingaEditor.start_link(
+    {:ok, generation} =
+      MingaEditor.GenerationSupervisor.start_editor_generation_link(
         name: :"chaos_editor_#{id}",
         port_manager: port,
         buffer: buffer,
@@ -98,6 +98,8 @@ defmodule Minga.Chaos.EditorFuzzerTest do
         height: height,
         editing_model: :vim
       )
+
+    {:ok, editor} = MingaEditor.GenerationSupervisor.editor_owner(generation)
 
     # Allow the editor process to use our Mox stubs
     Mox.allow(Minga.Clipboard.Mock, self(), editor)
@@ -116,6 +118,7 @@ defmodule Minga.Chaos.EditorFuzzerTest do
     {:ok, _snapshot} = HeadlessPort.collect_frame(ref)
 
     %{
+      generation: generation,
       editor: editor,
       buffer: buffer,
       port: port,
@@ -401,12 +404,12 @@ defmodule Minga.Chaos.EditorFuzzerTest do
   end
 
   defp cleanup_ctx(%{
-         editor: editor,
+         generation: generation,
          buffer: buffer,
          port: port,
          clipboard_table: clipboard_table
        }) do
-    stop_process(editor)
+    stop_process(generation)
     stop_process(port)
     stop_process(buffer)
     delete_table(clipboard_table)

--- a/test/minga_agent/tools/shell_test.exs
+++ b/test/minga_agent/tools/shell_test.exs
@@ -9,6 +9,8 @@ defmodule MingaAgent.Tools.ShellTest do
   # Excluded from test.llm; runs in test.heavy and full suite.
   @moduletag :heavy
 
+  @external_command_timeout_seconds 15
+
   # Drains all shell chunks from the mailbox. Uses a short timeout since
   # Shell.execute blocks until the command completes, so by the time we
   # call this the chunks are already in the mailbox.
@@ -34,7 +36,12 @@ defmodule MingaAgent.Tools.ShellTest do
       end
 
       assert {:ok, output} =
-               Shell.execute("echo line1; echo line2; echo line3", dir, 5, on_output: on_output)
+               Shell.execute(
+                 "echo line1; echo line2; echo line3",
+                 dir,
+                 @external_command_timeout_seconds,
+                 on_output: on_output
+               )
 
       # Should have received at least one chunk
       chunks = collect_shell_chunks()
@@ -64,7 +71,7 @@ defmodule MingaAgent.Tools.ShellTest do
                Shell.execute(
                  "for i in $(seq 1 20); do echo \"line $i\"; done",
                  dir,
-                 5,
+                 @external_command_timeout_seconds,
                  on_output: on_output
                )
 
@@ -95,7 +102,10 @@ defmodule MingaAgent.Tools.ShellTest do
 
       task =
         Task.async(fn ->
-          Shell.execute("cat #{inspect(fifo)} >/dev/null && echo done", dir, 5,
+          Shell.execute(
+            "cat #{inspect(fifo)} >/dev/null && echo done",
+            dir,
+            @external_command_timeout_seconds,
             on_output: on_output,
             running_indicator_ms: 250
           )
@@ -118,7 +128,10 @@ defmodule MingaAgent.Tools.ShellTest do
       end
 
       assert {:ok, _output} =
-               Shell.execute("elixir -e 'IO.write(String.duplicate(\"x\", 70000))'", dir, 5,
+               Shell.execute(
+                 "elixir -e 'IO.write(String.duplicate(\"x\", 70000))'",
+                 dir,
+                 @external_command_timeout_seconds,
                  on_output: on_output
                )
 
@@ -139,7 +152,10 @@ defmodule MingaAgent.Tools.ShellTest do
       end
 
       assert {:ok, _output} =
-               Shell.execute("elixir -e 'IO.write(String.duplicate(\"€\", 30000))'", dir, 5,
+               Shell.execute(
+                 "elixir -e 'IO.write(String.duplicate(\"€\", 30000))'",
+                 dir,
+                 @external_command_timeout_seconds,
                  on_output: on_output
                )
 
@@ -164,7 +180,10 @@ defmodule MingaAgent.Tools.ShellTest do
       command =
         "elixir -e 'IO.write(String.duplicate(\"x\", 51199)); IO.binwrite(:stdio, <<226>>); Process.sleep(50); IO.binwrite(:stdio, <<130, 172>>)'"
 
-      assert {:ok, _output} = Shell.execute(command, dir, 5, on_output: on_output)
+      assert {:ok, _output} =
+               Shell.execute(command, dir, @external_command_timeout_seconds,
+                 on_output: on_output
+               )
 
       combined = collect_shell_chunks() |> IO.iodata_to_binary()
 
@@ -174,7 +193,9 @@ defmodule MingaAgent.Tools.ShellTest do
     end
 
     test "works without on_output callback", %{tmp_dir: dir} do
-      assert {:ok, output} = Shell.execute("echo hello", dir, 5, [])
+      assert {:ok, output} =
+               Shell.execute("echo hello", dir, @external_command_timeout_seconds, [])
+
       assert output == "hello"
     end
   end

--- a/test/minga_editor/commands/structural_navigation_test.exs
+++ b/test/minga_editor/commands/structural_navigation_test.exs
@@ -80,19 +80,24 @@ defmodule MingaEditor.Commands.StructuralNavigationTest do
         filetype: :javascript
       )
 
-    {:ok, editor} =
-      MingaEditor.start_link(
-        name: :"structural_nav_editor_#{id}",
-        port_manager: nil,
-        buffer: buffer,
-        width: 40,
-        height: 10,
-        editing_model: :vim,
-        events_registry: events_registry,
-        project_root: project_root,
-        suppress_tool_prompts: true
+    generation =
+      start_supervised!(
+        Supervisor.child_spec(
+          {MingaEditor,
+           name: :"structural_nav_editor_#{id}",
+           port_manager: nil,
+           buffer: buffer,
+           width: 40,
+           height: 10,
+           editing_model: :vim,
+           events_registry: events_registry,
+           project_root: project_root,
+           suppress_tool_prompts: true},
+          id: make_ref()
+        )
       )
 
+    {:ok, editor} = MingaEditor.GenerationSupervisor.editor_owner(generation)
     editor_state = :sys.get_state(editor, @sync_timeout)
     _state_with_presentation = HighlightSync.setup_for_buffer(editor_state)
 

--- a/test/minga_editor/effect_scheduler_test.exs
+++ b/test/minga_editor/effect_scheduler_test.exs
@@ -403,6 +403,71 @@ defmodule MingaEditor.EffectSchedulerTest do
     refute_received {:effect_terminal, %Outcome{request: %{id: ^queued_id}}}
   end
 
+  test "manual headless Editor generation provisions a generation-owned scheduler" do
+    editor_name = {:global, {__MODULE__, make_ref(), :editor}}
+
+    assert {:ok, generation} =
+             GenerationSupervisor.start_editor_generation_link(
+               name: editor_name,
+               backend: :headless,
+               rendering: :disabled,
+               port_manager: nil,
+               suppress_tool_prompts: true
+             )
+
+    assert {:ok, editor} = GenerationSupervisor.editor_owner(generation)
+    assert GenServer.whereis(editor_name) == editor
+    scheduler = :sys.get_state(editor).effect_scheduler
+    assert is_pid(GenServer.whereis(scheduler))
+    assert EffectScheduler.stats(scheduler).capacity == 64
+    assert :ok = Supervisor.stop(generation)
+  end
+
+  test "supervised Editor tracks and tears down the whole generation" do
+    editor_name = {:global, {__MODULE__, make_ref(), :supervised_editor}}
+
+    generation =
+      start_supervised!(
+        {MingaEditor,
+         name: editor_name,
+         backend: :headless,
+         rendering: :disabled,
+         port_manager: nil,
+         suppress_tool_prompts: true},
+        restart: :temporary
+      )
+
+    assert {:ok, editor} = GenerationSupervisor.editor_owner(generation)
+    refute editor == generation
+    assert GenServer.whereis(editor_name) == editor
+
+    task_supervisor = generation_child!(generation, :effect_task_supervisor)
+    scheduler = generation_child!(generation, :effect_scheduler)
+    generation_monitor = Process.monitor(generation)
+    editor_monitor = Process.monitor(editor)
+    scheduler_monitor = Process.monitor(scheduler)
+    task_supervisor_monitor = Process.monitor(task_supervisor)
+
+    request = EffectProbe.request(self(), :supervised_generation, :resource, Policy.fifo(0))
+    assert EffectScheduler.schedule(scheduler, request) == {:ok, request.id, :running}
+
+    assert_receive {:effect_started, :supervised_generation, worker, [:supervised_generation]},
+                   @effect_timeout
+
+    worker_monitor = Process.monitor(worker)
+
+    assert :ok = stop_supervised(MingaEditor)
+    assert_receive {:DOWN, ^generation_monitor, :process, ^generation, :shutdown}, @effect_timeout
+    assert_receive {:DOWN, ^editor_monitor, :process, ^editor, :shutdown}, @effect_timeout
+    assert_receive {:DOWN, ^scheduler_monitor, :process, ^scheduler, :shutdown}, @effect_timeout
+
+    assert_receive {:DOWN, ^task_supervisor_monitor, :process, ^task_supervisor, :shutdown},
+                   @effect_timeout
+
+    assert_receive {:DOWN, ^worker_monitor, :process, ^worker, _reason}, @effect_timeout
+    assert GenServer.whereis(editor_name) == nil
+  end
+
   test "generation restart kills old work before a replacement owner attaches" do
     generation_name = {:global, {__MODULE__, make_ref(), :generation}}
     task_name = {:global, {__MODULE__, make_ref(), :tasks}}
@@ -462,6 +527,14 @@ defmodule MingaEditor.EffectSchedulerTest do
 
     assert Supervisor.count_children(generation).active == 3
     refute_received {:effect_terminal, %Outcome{request: %{id: ^request_id}}}
+  end
+
+  @spec generation_child!(Supervisor.supervisor(), term()) :: pid()
+  defp generation_child!(generation, child_id) do
+    case List.keyfind(Supervisor.which_children(generation), child_id, 0) do
+      {^child_id, child, _type, _modules} when is_pid(child) -> child
+      _missing -> raise "missing generation child #{inspect(child_id)}"
+    end
   end
 
   @spec start_scheduler(keyword()) :: pid()

--- a/test/minga_editor/file_tree/freshness_test.exs
+++ b/test/minga_editor/file_tree/freshness_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
   alias Minga.Git.Stub, as: GitStub
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
+  alias Minga.Test.FileTreeRefreshScanner
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.EffectScheduler
   alias MingaEditor.FileTree.Freshness
@@ -55,6 +56,55 @@ defmodule MingaEditor.FileTree.FreshnessTest do
 
     assert is_reference(current.token)
     assert current.root == Path.expand(root)
+    assert EffectScheduler.active?(scheduler, Refresh)
+  end
+
+  test "scheduler pressure preserves one pending intent and retries admission", %{tmp_dir: root} do
+    blocker_root = Path.join(root, "blocker")
+    File.mkdir_p!(blocker_root)
+    scheduler = start_scheduler(max_admitted: 1)
+
+    blocker =
+      Refresh.request(tree(blocker_root, []), Minga.Events.default_registry(),
+        scanner: FileTreeRefreshScanner,
+        scanner_context: {self(), :blocker, :wait}
+      )
+
+    assert EffectScheduler.schedule(scheduler, blocker) == {:ok, blocker.id, :running}
+    assert EffectScheduler.stats(scheduler).admitted == 1
+
+    old_request = Refresh.request(tree(root, []), Minga.Events.default_registry())
+
+    state =
+      root
+      |> state_with_tree(scheduler)
+      |> track(old_request)
+      |> Freshness.request_refresh(60_000)
+
+    assert file_tree(state).refresh.current == nil
+    timer_token = file_tree(state).refresh.debounce
+    retrying = Freshness.begin_refresh(state, timer_token)
+    retry_token = file_tree(retrying).refresh.debounce
+
+    assert is_reference(retry_token)
+    assert retry_token != timer_token
+    assert file_tree(retrying).refresh.retry_attempt == 1
+    assert EffectScheduler.stats(scheduler).admitted == 1
+
+    assert :ok = EffectScheduler.cancel(scheduler, blocker.id)
+
+    assert_receive {:effect_result, ^scheduler,
+                    %Outcome{request: %{id: blocker_id}, status: :canceled} = blocker_outcome}
+
+    assert blocker_id == blocker.id
+    assert :ok = EffectScheduler.claim(scheduler, blocker_outcome)
+    EffectScheduler.finalize(scheduler, blocker_outcome)
+
+    assert_receive {:file_tree_refresh_timer, ^retry_token}
+    admitted = Freshness.begin_refresh(retrying, retry_token)
+
+    assert is_reference(file_tree(admitted).refresh.current.token)
+    assert file_tree(admitted).refresh.retry_attempt == 0
     assert EffectScheduler.active?(scheduler, Refresh)
   end
 
@@ -141,6 +191,27 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     assert reason != ""
   end
 
+  test "git metadata updates preserve an unavailable-root error", %{tmp_dir: root} do
+    state =
+      root
+      |> state_with_tree()
+      |> EditorState.update_file_tree(&FileTreeState.refresh_failed(&1, :enoent))
+
+    event = %Events.GitStatusEvent{
+      git_root: root,
+      entries: [],
+      branch: nil,
+      ahead: 0,
+      behind: 0
+    }
+
+    from_event = Freshness.refresh_git_status(state, event)
+    assert {:error, _reason} = FileTreeState.status(file_tree(from_event))
+
+    from_cache = Freshness.refresh_git_status_from_cache(from_event)
+    assert {:error, _reason} = FileTreeState.status(file_tree(from_cache))
+  end
+
   test "current root failures preserve the tree and expose an error state", %{tmp_dir: root} do
     state = %{state_with_tree(root) | backend: :tui}
     request = Refresh.request(file_tree(state).tree, EditorState.events_registry(state))
@@ -186,13 +257,17 @@ defmodule MingaEditor.FileTree.FreshnessTest do
   defp close_tree(state), do: EditorState.update_file_tree(state, &FileTreeState.close/1)
   defp file_tree(state), do: EditorState.file_tree_state(state)
 
-  defp start_scheduler do
+  defp start_scheduler(opts \\ []) do
     task_supervisor =
       start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
 
     scheduler =
       start_supervised!(
-        Supervisor.child_spec({EffectScheduler, task_supervisor: task_supervisor}, id: make_ref())
+        Supervisor.child_spec(
+          {EffectScheduler,
+           task_supervisor: task_supervisor, max_admitted: Keyword.get(opts, :max_admitted, 64)},
+          id: make_ref()
+        )
       )
 
     :ok = EffectScheduler.attach(scheduler, self())

--- a/test/minga_editor/file_tree/refresh_test.exs
+++ b/test/minga_editor/file_tree/refresh_test.exs
@@ -7,7 +7,12 @@ defmodule MingaEditor.FileTree.RefreshTest do
   alias Minga.Test.FileTreeRefreshScanner
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.EffectScheduler
+  alias MingaEditor.FileTree.Freshness
   alias MingaEditor.FileTree.Refresh
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  import MingaEditor.RenderPipeline.TestHelpers
 
   @moduletag :tmp_dir
   @timeout 2_000
@@ -78,6 +83,72 @@ defmodule MingaEditor.FileTree.RefreshTest do
     assert_terminal(third.id, :completed)
   end
 
+  test "composed workflow rejects the first completion and applies only the coalesced latest tree",
+       %{
+         tmp_dir: root
+       } do
+    scheduler = start_scheduler()
+    original = tree(root)
+    first_tree = tree(root, ["first.ex"])
+    second_tree = tree(root, ["second.ex"])
+    latest_tree = tree(root, ["latest.ex"])
+    first = request(original, :first_composed, :wait)
+    second = request(original, :second_composed, :wait)
+    latest = request(original, :latest_composed, :wait)
+    state = state_with_tree(original, scheduler)
+
+    assert EffectScheduler.schedule(scheduler, first) == {:ok, first.id, :running}
+
+    {state, %Outcome{status: :running}} =
+      Refresh.apply(state, receive_lifecycle(first.id, :running))
+
+    assert_receive {:file_tree_scan_started, :first_composed, first_worker}, @timeout
+    state = track(state, first)
+    send(first_worker, {:release_file_tree_scan, :first_composed, {:return, first_tree}})
+    first_outcome = receive_outcome(scheduler, first.id, :completed)
+
+    state = invalidate_current(state)
+    assert EffectScheduler.schedule(scheduler, second) == {:ok, second.id, :queued}
+
+    {state, %Outcome{status: :queued}} =
+      Refresh.apply(state, receive_lifecycle(second.id, :queued))
+
+    state = track(state, second)
+
+    state = invalidate_current(state)
+    assert EffectScheduler.schedule(scheduler, latest) == {:ok, latest.id, :queued}
+    state = track(state, latest)
+
+    {state, %Outcome{status: :stale}} =
+      Refresh.apply(state, receive_lifecycle(second.id, :stale))
+
+    {state, %Outcome{status: :queued}} =
+      Refresh.apply(state, receive_lifecycle(latest.id, :queued))
+
+    assert :ok = EffectScheduler.claim(scheduler, first_outcome)
+
+    assert {state, %Outcome{status: :stale} = stale_first} =
+             Refresh.apply(state, first_outcome)
+
+    assert state |> file_tree() |> then(& &1.tree) == original
+    EffectScheduler.finalize(scheduler, stale_first)
+
+    assert_receive {:file_tree_scan_started, :latest_composed, latest_worker}, @timeout
+    send(latest_worker, {:release_file_tree_scan, :latest_composed, {:return, latest_tree}})
+    latest_outcome = receive_outcome(scheduler, latest.id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, latest_outcome)
+
+    assert {state, %Outcome{status: :completed} = accepted_latest} =
+             Refresh.apply(state, latest_outcome)
+
+    EffectScheduler.finalize(scheduler, accepted_latest)
+    Process.cancel_timer(state.render_correlation.timer)
+    assert state |> file_tree() |> then(& &1.tree) == latest_tree
+    refute state |> file_tree() |> then(& &1.tree) == second_tree
+    assert EffectScheduler.stats(scheduler).admitted == 0
+    refute EffectScheduler.active?(scheduler, Refresh)
+  end
+
   test "failed work terminalizes and leaves the root schedulable", %{tmp_dir: root} do
     scheduler = start_scheduler()
     failed = request(tree(root), :failed_work, {:error, :gone})
@@ -123,7 +194,23 @@ defmodule MingaEditor.FileTree.RefreshTest do
     assert_receive {:file_tree_scan_started, :after_cancel, _worker}, @timeout
   end
 
-  defp tree(root), do: root |> FileTree.new() |> FileTree.put_entries([])
+  defp tree(root), do: tree(root, [])
+
+  defp tree(root, names) do
+    entries =
+      Enum.map(names, fn name ->
+        %{
+          name: name,
+          path: Path.join(root, name),
+          dir?: false,
+          depth: 0,
+          last_child?: true,
+          guides: []
+        }
+      end)
+
+    root |> FileTree.new() |> FileTree.put_entries(entries)
+  end
 
   defp request(tree, label, action) do
     Refresh.request(tree, Minga.Events.default_registry(),
@@ -148,9 +235,43 @@ defmodule MingaEditor.FileTree.RefreshTest do
     scheduler
   end
 
+  defp state_with_tree(tree, scheduler) do
+    file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
+
+    state = base_state()
+    state = %{state | backend: :tui, effect_scheduler: scheduler}
+    EditorState.set_file_tree(state, file_tree)
+  end
+
+  defp track(state, request) do
+    EditorState.update_file_tree(
+      state,
+      &FileTreeState.track_refresh_request(&1, request.effect.root, request.id)
+    )
+  end
+
+  defp invalidate_current(state) do
+    state = Freshness.request_refresh(state, 60_000)
+    token = file_tree(state).refresh.debounce
+
+    EditorState.update_file_tree(state, fn file_tree ->
+      {:ready, _tree, elapsed} = FileTreeState.refresh_debounce_elapsed(file_tree, token)
+      elapsed
+    end)
+  end
+
+  defp file_tree(state), do: EditorState.file_tree_state(state)
+
   defp assert_lifecycle(request_id, status) do
-    assert_receive {:effect_lifecycle, %Outcome{request: %{id: ^request_id}, status: ^status}},
+    assert %Outcome{} = receive_lifecycle(request_id, status)
+  end
+
+  defp receive_lifecycle(request_id, status) do
+    assert_receive {:effect_lifecycle,
+                    %Outcome{request: %{id: ^request_id}, status: ^status} = outcome},
                    @timeout
+
+    outcome
   end
 
   defp receive_outcome(scheduler, request_id, status) do

--- a/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
+++ b/test/minga_editor/frontend/emit/surface_layout_emit_test.exs
@@ -15,6 +15,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
 
   alias Minga.Protocol.Opcodes
   alias Minga.Test.RecordingFrontend
+  alias MingaEditor.FocusTree
   alias MingaEditor.Frontend.Emit
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.HoverPopup
@@ -59,6 +60,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
     state
     |> EditorState.set_hover_popup(hover)
     |> EditorState.set_signature_help(signature)
+    |> freeze_focus_tree()
   end
 
   defp emit_commands(state) do
@@ -73,8 +75,13 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
   end
 
   defp emit_state(opts \\ []) do
-    base_state(Keyword.put(opts, :port_manager, Process.get(:surface_layout_frontend)))
+    opts
+    |> Keyword.put(:port_manager, Process.get(:surface_layout_frontend))
+    |> base_state()
+    |> freeze_focus_tree()
   end
+
+  defp freeze_focus_tree(state), do: %{state | focus_tree: FocusTree.from_state(state)}
 
   defp surface_layout_command(commands) do
     Enum.find(commands, &match?(<<@op_surface_layout, _::binary>>, &1))
@@ -221,7 +228,7 @@ defmodule MingaEditor.Frontend.Emit.SurfaceLayoutEmitTest do
     center =
       MingaEditor.UI.NotificationCenter.upsert(MingaEditor.UI.NotificationCenter.new(), note)
 
-    state = %{emit_state() | notifications: center}
+    state = emit_state() |> Map.put(:notifications, center) |> freeze_focus_tree()
 
     commands = emit_commands(state)
     decoded = commands |> surface_layout_command() |> decode_placements()

--- a/test/minga_editor/frontend/manager/output_pressure_test.exs
+++ b/test/minga_editor/frontend/manager/output_pressure_test.exs
@@ -36,23 +36,46 @@ defmodule MingaEditor.Frontend.Manager.OutputPressureTest do
     assert PendingFrame.follows?(frame(12, 0, 2), first)
   end
 
-  test "recovery raises the acknowledgement generation floor and rejects stale acknowledgements" do
+  test "recovery raises the acknowledgement floor and only admitted frames can acknowledge" do
     failed = frame(11, 10, 3)
     {:attempt, pressure} = OutputPressure.enqueue(OutputPressure.new(), failed)
     pressure = OutputPressure.require_recovery(pressure, failed)
 
     assert OutputPressure.acknowledge(pressure, 3, 11) == :stale
+    assert OutputPressure.acknowledge(pressure, 4, 12) == :stale
+
+    recovery = frame(12, 0, 4)
+    {:attempt, pressure} = OutputPressure.enqueue(pressure, recovery)
+    assert {^recovery, pressure} = OutputPressure.admitted(pressure)
     assert {:accepted, pressure} = OutputPressure.acknowledge(pressure, 4, 12)
     assert OutputPressure.acknowledge(pressure, 4, 11) == :stale
 
     stats = OutputPressure.stats(pressure)
     assert stats.minimum_ack_generation == 4
+    assert stats.last_admitted_generation == 4
+    assert stats.last_admitted_frame_seq == 12
     assert stats.last_applied_generation == 4
     assert stats.last_applied_frame_seq == 12
     assert stats.retained_bytes == 0
   end
 
-  test "control batches coalesce by opcode and survive frame recovery" do
+  test "frame admission bounds acknowledgements without future acknowledgements moving diagnostics" do
+    first = frame(10, 9, 1)
+    {:attempt, pressure} = OutputPressure.enqueue(OutputPressure.new(), first)
+    assert {^first, pressure} = OutputPressure.admitted(pressure)
+    assert {:accepted, pressure} = OutputPressure.acknowledge(pressure, 1, 10)
+
+    assert OutputPressure.acknowledge(pressure, 1, 11) == :stale
+    assert OutputPressure.acknowledge(pressure, 0xFFFFFFFF, 1) == :stale
+
+    stats = OutputPressure.stats(pressure)
+    assert stats.last_admitted_generation == 1
+    assert stats.last_admitted_frame_seq == 10
+    assert stats.last_applied_generation == 1
+    assert stats.last_applied_frame_seq == 10
+  end
+
+  test "control batches coalesce by opcode and are cleared with failed output" do
     first_font = Protocol.encode_set_font("First", 14, true, :regular)
     latest_font = Protocol.encode_set_font("Latest", 16, true, :regular)
     title = Protocol.encode_set_title("Minga")
@@ -68,8 +91,8 @@ defmodule MingaEditor.Frontend.Manager.OutputPressureTest do
     failed = frame(11, 10, 3)
     {:attempt, pressure} = OutputPressure.enqueue(pressure, failed)
     pressure = OutputPressure.require_recovery(pressure, failed)
-    assert OutputPressure.controls_pending?(pressure)
-    assert OutputPressure.stats(pressure).control_batches == 2
+    refute OutputPressure.controls_pending?(pressure)
+    assert OutputPressure.stats(pressure).control_batches == 0
   end
 
   test "unwritable failure timing starts once and retry tokens are correlated" do

--- a/test/minga_editor/frontend/manager_test.exs
+++ b/test/minga_editor/frontend/manager_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.Frontend.ManagerTest do
 
   alias MingaEditor.Frontend.Manager
   alias MingaEditor.Frontend.Protocol
+  alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
 
   defp unique_name, do: :"port_mgr_#{:erlang.unique_integer([:positive])}"
 
@@ -248,35 +249,83 @@ defmodule MingaEditor.Frontend.ManagerTest do
   end
 
   describe "output pressure" do
-    test "unwritable transport requests correlated keyframe recovery and rejects stale acknowledgements" do
+    test "the output failure budget clears retained controls and stops retries per generation" do
       name = unique_name()
-      commander = fn _port, _batch, [:nosuspend] -> false end
+      transport = start_supervised!({Agent, fn -> %{attempts: 0, writable: false} end})
+
+      commander = fn _port, _batch, [:nosuspend] ->
+        Agent.get_and_update(transport, fn state ->
+          {state.writable, %{state | attempts: state.attempts + 1}}
+        end)
+      end
 
       {pid, fake_port} =
         start_connected(name,
           port_commander: commander,
           output_retry_ms: 1,
-          output_failure_ms: 0
+          output_failure_ms: 5
         )
 
       :ok = Manager.subscribe(name)
+      title = Protocol.encode_set_title("Retained title")
+
+      assert :unwritable = Manager.send_render_commands(name, frame_commands(11, 0, 1))
+      assert :unwritable = Manager.send_commands(name, [title])
+      assert_receive {:minga_input, {:request_keyframe, 0, 1}}, 100
+
+      pressure = Manager.output_pressure(name)
+      assert pressure.current_bytes == 0
+      assert pressure.replacement_bytes == 0
+      assert pressure.control_batches == 0
+      assert pressure.total_retained_bytes == 0
+
+      attempts_after_recovery = Agent.get(transport, & &1.attempts)
+      refute_receive {:minga_input, {:request_keyframe, 0, 1}}, 30
+      assert Agent.get(transport, & &1.attempts) == attempts_after_recovery
+
+      assert :unwritable = Manager.send_render_commands(name, frame_commands(12, 0, 2))
+      assert_receive {:minga_input, {:request_keyframe, 0, 2}}, 100
+
+      Agent.update(transport, &%{&1 | writable: true})
+      assert :accepted = Manager.send_render_commands(name, frame_commands(13, 0, 3))
+
+      send_port_data(pid, fake_port, <<0x0A, 1::32, 11::32>>)
+      send_port_data(pid, fake_port, <<0x0A, 2::32, 12::32>>)
+      refute_receive {:minga_input, {:frame_applied, _, _}}, 30
+
+      send_port_data(pid, fake_port, <<0x0A, 3::32, 13::32>>)
+      assert_receive {:minga_input, {:frame_applied, 3, 13}}
+
+      pressure = Manager.output_pressure(name)
+      assert pressure.minimum_ack_generation == 3
+      assert pressure.last_admitted_generation == 3
+      assert pressure.last_admitted_frame_seq == 13
+      assert pressure.last_applied_generation == 3
+      assert pressure.last_applied_frame_seq == 13
+    end
+
+    test "future acknowledgements do not poison correlation for later admitted frames" do
+      name = unique_name()
+      {pid, fake_port} = start_connected(name)
+      :ok = Manager.subscribe(name)
+
+      assert :accepted = Manager.send_render_commands(name, frame_commands(10, 0, 1))
       send_port_data(pid, fake_port, <<0x0A, 1::32, 10::32>>)
       assert_receive {:minga_input, {:frame_applied, 1, 10}}
 
-      assert :unwritable = Manager.send_render_commands(name, frame_commands(11, 10, 1))
-      assert_receive {:minga_input, {:request_keyframe, 10, 1}}, 1_000
-
       send_port_data(pid, fake_port, <<0x0A, 1::32, 11::32>>)
-      refute_receive {:minga_input, {:frame_applied, 1, 11}}, 50
-
-      send_port_data(pid, fake_port, <<0x0A, 2::32, 12::32>>)
-      assert_receive {:minga_input, {:frame_applied, 2, 12}}
+      send_port_data(pid, fake_port, <<0x0A, 0xFFFFFFFF::32, 1::32>>)
+      refute_receive {:minga_input, {:frame_applied, _, _}}, 30
 
       pressure = Manager.output_pressure(name)
-      assert pressure.minimum_ack_generation == 2
-      assert pressure.last_applied_generation == 2
-      assert pressure.last_applied_frame_seq == 12
-      assert pressure.retained_bytes == 0
+      assert pressure.last_admitted_generation == 1
+      assert pressure.last_admitted_frame_seq == 10
+      assert pressure.last_applied_generation == 1
+      assert pressure.last_applied_frame_seq == 10
+
+      assert :accepted = Manager.send_render_commands(name, frame_commands(11, 10, 1))
+      send_port_data(pid, fake_port, <<0x0A, 1::32, 11::32>>)
+      assert_receive {:minga_input, {:frame_applied, 1, 11}}
     end
 
     test "an unwritable font configuration is retained and retried before later frames" do
@@ -314,6 +363,73 @@ defmodule MingaEditor.Frontend.ManagerTest do
       pressure = Manager.output_pressure(name)
       assert pressure.control_batches == 0
       assert pressure.control_bytes == 0
+    end
+
+    test "clipboard writes for distinct pasteboards are both retained and admitted" do
+      name = unique_name()
+      parent = self()
+      writable = start_supervised!({Agent, fn -> false end}, id: make_ref())
+
+      commander = fn _port, batch, [:nosuspend] ->
+        admitted? = Agent.get(writable, & &1)
+        send(parent, {:clipboard_attempt, admitted?, batch})
+        admitted?
+      end
+
+      {_pid, _fake_port} =
+        start_connected(name,
+          port_commander: commander,
+          output_retry_ms: 20,
+          output_failure_ms: 1_000
+        )
+
+      general = ProtocolGUI.encode_clipboard_write("general", :general)
+      find = ProtocolGUI.encode_clipboard_write("find", :find)
+
+      assert :unwritable = Manager.send_commands(name, [general])
+      assert_receive {:clipboard_attempt, false, ^general}
+      assert :unwritable = Manager.send_commands(name, [find])
+      assert Manager.output_pressure(name).control_batches == 2
+
+      Agent.update(writable, fn _ -> true end)
+      assert_receive {:clipboard_attempt, true, ^general}, 1_000
+      assert_receive {:clipboard_attempt, true, ^find}, 1_000
+      assert Manager.output_pressure(name).control_batches == 0
+    end
+
+    test "clipboard writes coalesce only within the same pasteboard" do
+      name = unique_name()
+      parent = self()
+      writable = start_supervised!({Agent, fn -> false end}, id: make_ref())
+
+      commander = fn _port, batch, [:nosuspend] ->
+        admitted? = Agent.get(writable, & &1)
+        send(parent, {:clipboard_attempt, admitted?, batch})
+        admitted?
+      end
+
+      {_pid, _fake_port} =
+        start_connected(name,
+          port_commander: commander,
+          output_retry_ms: 20,
+          output_failure_ms: 1_000
+        )
+
+      old_general = ProtocolGUI.encode_clipboard_write("old", :general)
+      latest_general = ProtocolGUI.encode_clipboard_write("latest", :general)
+      find = ProtocolGUI.encode_clipboard_write("find", :find)
+
+      assert :unwritable = Manager.send_commands(name, [old_general])
+      assert_receive {:clipboard_attempt, false, ^old_general}
+      assert :unwritable = Manager.send_commands(name, [find])
+      assert :unwritable = Manager.send_commands(name, [latest_general])
+      assert Manager.output_pressure(name).control_batches == 2
+
+      Agent.update(writable, fn _ -> true end)
+      assert_receive {:clipboard_attempt, true, ^latest_general}, 1_000
+      assert_receive {:clipboard_attempt, true, ^find}, 1_000
+      refute_receive {:clipboard_attempt, true, ^old_general}, 30
+      assert Manager.output_pressure(name).control_batches == 0
     end
 
     test "an incompatible coalesced replacement triggers keyframe recovery instead of skipping its base" do

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -18,6 +18,7 @@ defmodule MingaEditor.Shell.RegistryTest do
   alias MingaEditor.Shell.Workflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.AgentAccess
   alias Minga.Test.RecordingFrontend
   alias MingaEditor.Test.FakeShell
   alias MingaEditor.Test.FakeShellAlt
@@ -211,6 +212,162 @@ defmodule MingaEditor.Shell.RegistryTest do
     assert after_cleanup.default_id == :traditional
   end
 
+  test "queued source cleanup preserves another source and a later unrelated registration" do
+    Registry.seed_builtin()
+    parent = self()
+    registry = Process.whereis(Registry)
+    source_a = {:extension, :source_a}
+    source_b = {:extension, :source_b}
+    unrelated_source = {:extension, :unrelated}
+
+    assert :ok = Registry.register(source_a, shell_attrs(:remove_me, FakeShell, "Remove Me"))
+    assert :ok = Registry.register(source_b, shell_attrs(:keep_me, FakeShellAlt, "Keep Me"))
+
+    before = Registry.snapshot()
+    traditional = before.entries.traditional
+    source_b_entry = before.entries.keep_me
+
+    cleanup =
+      Task.async(fn ->
+        send(parent, {:cleanup_ready, self()})
+        receive do: (:call_registry -> Registry.unregister_source(source_a))
+      end)
+
+    registration =
+      Task.async(fn ->
+        send(parent, {:registration_ready, self()})
+
+        receive do: (:call_registry ->
+                       Registry.register(
+                         unrelated_source,
+                         shell_attrs(:unrelated, FakeShell, "Unrelated")
+                       ))
+      end)
+
+    assert_receive {:cleanup_ready, cleanup_pid}
+    assert_receive {:registration_ready, registration_pid}
+    :ok = :sys.suspend(registry)
+
+    try do
+      1 = :erlang.trace(cleanup_pid, true, [:send])
+      send(cleanup_pid, :call_registry)
+
+      assert_receive {:trace, ^cleanup_pid, :send,
+                      {:"$gen_call", {_from, _tag}, {:unregister_source, ^source_a}}, ^registry}
+
+      1 = :erlang.trace(registration_pid, true, [:send])
+      send(registration_pid, :call_registry)
+
+      assert_receive {:trace, ^registration_pid, :send,
+                      {:"$gen_call", {_from, _tag}, {:register, %Entry{id: :unrelated}}},
+                      ^registry}
+
+      assert Registry.snapshot() == before
+    after
+      :ok = :sys.resume(registry)
+    end
+
+    assert Task.await(cleanup) == :ok
+    assert Task.await(registration) == :ok
+
+    after_calls = Registry.snapshot()
+    refute Map.has_key?(after_calls.entries, :remove_me)
+    refute Enum.any?(after_calls.entries, fn {_id, entry} -> entry.source == source_a end)
+    assert after_calls.entries.keep_me == source_b_entry
+    assert after_calls.entries.unrelated.source == unrelated_source
+    assert after_calls.entries.unrelated.module == FakeShell
+    assert after_calls.entries.traditional == traditional
+    assert after_calls.default_id == :traditional
+  end
+
+  test "reader resolves only complete old, absent, and new entries across queued reload calls" do
+    Registry.seed_builtin()
+    parent = self()
+    registry = Process.whereis(Registry)
+    old_source = {:extension, :old}
+    new_source = {:extension, :new}
+    assert :ok = Registry.register(old_source, shell_attrs(:reload, FakeShell, "Old"))
+    old_entry = Registry.get(:reload)
+
+    reader =
+      Task.async(fn ->
+        Enum.each([:old, :absent, :new], fn phase ->
+          receive do
+            {:observe, ^phase} ->
+              observation = {
+                Registry.resolve(:reload),
+                Registry.resolve(FakeShell),
+                Registry.resolve(FakeShellAlt)
+              }
+
+              send(parent, {:observation, phase, observation})
+          end
+        end)
+      end)
+
+    unregister =
+      Task.async(fn ->
+        send(parent, {:unregister_ready, self()})
+        receive do: (:call_registry -> Registry.unregister(old_source, :reload))
+      end)
+
+    assert_receive {:unregister_ready, unregister_pid}
+    :ok = :sys.suspend(registry)
+
+    try do
+      1 = :erlang.trace(unregister_pid, true, [:send])
+      send(unregister_pid, :call_registry)
+
+      assert_receive {:trace, ^unregister_pid, :send,
+                      {:"$gen_call", {_from, _tag}, {:unregister, ^old_source, :reload}},
+                      ^registry}
+
+      send(reader.pid, {:observe, :old})
+      assert_receive {:observation, :old, old_observation}
+      assert old_observation == {old_entry, old_entry, nil}
+    after
+      :ok = :sys.resume(registry)
+    end
+
+    assert Task.await(unregister) == :ok
+
+    registration =
+      Task.async(fn ->
+        send(parent, {:reload_ready, self()})
+
+        receive do: (:call_registry ->
+                       Registry.register(
+                         new_source,
+                         shell_attrs(:reload, FakeShellAlt, "New")
+                       ))
+      end)
+
+    assert_receive {:reload_ready, registration_pid}
+    :ok = :sys.suspend(registry)
+
+    try do
+      1 = :erlang.trace(registration_pid, true, [:send])
+      send(registration_pid, :call_registry)
+
+      assert_receive {:trace, ^registration_pid, :send,
+                      {:"$gen_call", {_from, _tag}, {:register, %Entry{id: :reload}}}, ^registry}
+
+      send(reader.pid, {:observe, :absent})
+      assert_receive {:observation, :absent, absent_observation}
+      assert absent_observation == {nil, nil, nil}
+    after
+      :ok = :sys.resume(registry)
+    end
+
+    assert Task.await(registration) == :ok
+    new_entry = Registry.get(:reload)
+
+    send(reader.pid, {:observe, :new})
+    assert_receive {:observation, :new, new_observation}
+    assert new_observation == {new_entry, nil, new_entry}
+    assert Task.await(reader) == :ok
+  end
+
   test "readers observe coherent cleanup and reload publication boundaries" do
     Registry.seed_builtin()
     parent = self()
@@ -291,7 +448,7 @@ defmodule MingaEditor.Shell.RegistryTest do
     switched = Workflow.switch(state, :fake)
 
     assert Runtime.module(switched.shell_runtime) == FakeShellAlt
-    assert switched.shell_runtime.state == %{name: :fake_alt, events: []}
+    assert switched.shell_runtime.state == %{name: :fake_alt, events: [], tab_bar: nil}
   end
 
   test "switching back restores state for the matching registration" do
@@ -874,31 +1031,79 @@ defmodule MingaEditor.Shell.RegistryTest do
     assert stash.second.state.synced_agent_status == :thinking
   end
 
-  test "renderer writeback drops stale output after a shell id is re-registered" do
+  test "active shell callbacks normalize a stale registration before dispatch" do
     Registry.seed_builtin()
+    source = {:extension, :fake}
+    assert :ok = Registry.register(source, shell_attrs(:fake, FakeShell, "Fake"))
+
+    state = TestHelpers.base_state() |> Workflow.switch(:fake)
+
+    {runtime, workspace} =
+      Runtime.route_event(
+        state.shell_runtime,
+        state.workspace,
+        {:replace_test_state, %{callback_owner: self(), session: self()}}
+      )
+
+    state =
+      state
+      |> EditorState.set_workspace(workspace)
+      |> EditorState.apply_shell_runtime_transition(runtime)
+
+    assert :ok = Registry.unregister_source(source)
 
     assert :ok =
-             Registry.register({:extension, :fake}, %{
-               id: :fake,
-               module: FakeShell,
-               display_name: "Fake",
-               description: "Fake shell",
-               capabilities: [:tui]
-             })
+             Registry.register(
+               source,
+               shell_attrs(:fake, FakeShellAlt, "Replacement")
+             )
+
+    replacement = Registry.get(:fake)
+    refute Runtime.active_entry?(state.shell_runtime, replacement)
+
+    assert AgentAccess.session(state) == nil
+    assert EditorState.active_tab(state) == nil
+    assert EditorState.find_tab_by_buffer(state, self()) == nil
+    assert EditorState.active_tab_kind(state) == :none
+
+    updated = EditorState.set_tab_session(state, 1, self())
+    assert Runtime.active_entry?(updated.shell_runtime, replacement)
+
+    {event_state, _effects} = Events.handle(state, {:status_changed, :thinking})
+    assert Runtime.active_entry?(event_state.shell_runtime, replacement)
+
+    refute_received :fake_shell_active_session
+    refute_received :fake_shell_active_tab
+    refute_received {:fake_shell_find_tab_by_buffer, _pid}
+    refute_received :fake_shell_active_tab_kind
+    refute_received {:fake_shell_set_tab_session, _tab_id, _session_pid}
+    refute_received {:fake_shell_sync_agent_status, _session, _status}
+  end
+
+  test "renderer writeback drops stale output after the same shell is re-registered" do
+    Registry.seed_builtin()
+    source = {:extension, :fake}
+
+    attrs = %{
+      id: :fake,
+      module: FakeShell,
+      display_name: "Fake",
+      description: "Fake shell",
+      capabilities: [:tui]
+    }
+
+    assert :ok = Registry.register(source, attrs)
+    old_entry = Registry.get(:fake)
 
     state = TestHelpers.base_state() |> Workflow.switch(:fake)
     input = Input.from_editor_state(state)
 
-    assert :ok = Registry.unregister_source({:extension, :fake})
+    assert :ok = Registry.unregister_source(source)
+    assert :ok = Registry.register(source, attrs)
 
-    assert :ok =
-             Registry.register({:extension, :fake_alt}, %{
-               id: :fake,
-               module: FakeShellAlt,
-               display_name: "Fake Alt",
-               description: "Fake shell alt",
-               capabilities: [:tui]
-             })
+    new_entry = Registry.get(:fake)
+    assert new_entry.generation > old_entry.generation
+    refute Identity.matches?(input.shell_identity, new_entry)
 
     writeback = %MingaEditor.Renderer.RenderReceipt{
       layout: :rendered_layout,

--- a/test/minga_editor/shell/runtime_test.exs
+++ b/test/minga_editor/shell/runtime_test.exs
@@ -4,6 +4,8 @@ defmodule MingaEditor.Shell.RuntimeTest do
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Entry
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
   alias MingaEditor.Test.FakeShell
   alias MingaEditor.Test.FakeShellAlt
   alias MingaEditor.Viewport
@@ -158,6 +160,43 @@ defmodule MingaEditor.Shell.RuntimeTest do
     stashed = Runtime.accept_persisted_state(stashed, fake, %{marker: :persisted_stash})
     assert Runtime.state(stashed) == %{marker: :alternate}
     assert Runtime.stash(stashed).fake.state == %{marker: :persisted_stash}
+  end
+
+  test "legacy shells without an ownership callback retain restart ownership" do
+    session = self()
+    legacy = entry(:legacy, FakeShellAlt, 1)
+
+    tab_bar =
+      1
+      |> Tab.new_agent("Agent")
+      |> Tab.set_session(session)
+      |> TabBar.new()
+
+    for shell_state <- [
+          %{session: session},
+          %{cards: %{one: %{session: session}}},
+          %{tab_bar: tab_bar}
+        ] do
+      runtime = Runtime.new(legacy, shell_state)
+      assert Runtime.owns_agent_session?(runtime, [legacy], session)
+
+      stashed = Runtime.activate(runtime, entry(:active, FakeShell, 2), %{})
+      assert Runtime.owns_agent_session?(stashed, [legacy], session)
+    end
+  end
+
+  test "rejected stashed callbacks leave runtime state unchanged" do
+    stashed_entry = entry(:fake, FakeShell, 1)
+
+    runtime =
+      stashed_entry
+      |> Runtime.new(%{mutate_rejected_callback?: true})
+      |> Runtime.activate(entry(:active, FakeShellAlt, 2), %{})
+
+    assert {^runtime, false, []} =
+             Runtime.route_stashed_session_down(runtime, [stashed_entry], self(), :foreign)
+
+    refute Map.has_key?(Runtime.stash(runtime).fake.state, :foreign_mutation)
   end
 
   test "active and stashed session lifecycle routes through exact entry contracts" do

--- a/test/minga_editor/state/file_tree_refresh_test.exs
+++ b/test/minga_editor/state/file_tree_refresh_test.exs
@@ -23,6 +23,36 @@ defmodule MingaEditor.State.FileTree.RefreshTest do
     assert {:stale, ^elapsed} = FileTreeState.refresh_debounce_elapsed(elapsed, timer)
   end
 
+  test "a newer debounce intent immediately invalidates older result authority" do
+    root = "/tmp/minga-refresh-newer-intent"
+    request = make_ref()
+    timer = make_ref()
+
+    tracked = open_tree(root) |> FileTreeState.track_refresh_request(root, request)
+    assert tracked.refresh.current.token == request
+
+    assert {:scheduled, pending} = FileTreeState.request_refresh_debounce(tracked, timer)
+    assert pending.refresh.current == nil
+    assert pending.refresh.debounce == timer
+  end
+
+  test "an admission retry keeps one correlated pending intent and advances backoff" do
+    file_tree = open_tree("/tmp/minga-refresh-retry")
+    first_timer = make_ref()
+    second_timer = make_ref()
+
+    assert {1, first} = FileTreeState.track_refresh_retry(file_tree, first_timer)
+    assert first.refresh.debounce == first_timer
+    assert first.refresh.retry_attempt == 1
+
+    assert {:ready, _tree, elapsed} =
+             FileTreeState.refresh_debounce_elapsed(first, first_timer)
+
+    assert {2, second} = FileTreeState.track_refresh_retry(elapsed, second_timer)
+    assert second.refresh.debounce == second_timer
+    assert second.refresh.retry_attempt == 2
+  end
+
   test "a current request atomically replaces the tree and clears correlation" do
     root = "/tmp/minga-refresh-current"
     original = open_tree(root)
@@ -103,6 +133,24 @@ defmodule MingaEditor.State.FileTree.RefreshTest do
              )
 
     assert Enum.map(current.tree.entries, & &1.name) == ["current.ex"]
+  end
+
+  test "metadata replacement preserves root errors and refresh correlation" do
+    root = "/tmp/minga-refresh-metadata"
+    request = make_ref()
+
+    file_tree =
+      root
+      |> open_tree()
+      |> FileTreeState.track_refresh_request(root, request)
+      |> FileTreeState.refresh_failed(:enoent)
+
+    metadata_tree = tree(root, [entry(root, "badged.ex")])
+    replaced = FileTreeState.replace_tree_metadata(file_tree, metadata_tree)
+
+    assert replaced.tree == metadata_tree
+    assert FileTreeState.status(replaced) == FileTreeState.status(file_tree)
+    assert replaced.refresh == file_tree.refresh
   end
 
   test "failed and canceled terminals clear only the matching request" do

--- a/test/minga_editor/system_wake_test.exs
+++ b/test/minga_editor/system_wake_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.SystemWakeTest do
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.LSP.SyncServer
+  alias MingaEditor.GenerationSupervisor
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab
@@ -20,7 +21,7 @@ defmodule MingaEditor.SystemWakeTest do
         id: :wake_inactive_buffer
       )
 
-    editor =
+    generation =
       start_supervised!(
         {MingaEditor,
          name: :"editor_#{System.unique_integer([:positive])}",
@@ -31,6 +32,8 @@ defmodule MingaEditor.SystemWakeTest do
          height: 10,
          editing_model: :vim}
       )
+
+    assert {:ok, editor} = GenerationSupervisor.editor_owner(generation)
 
     stale_client = spawn(fn -> receive do: (_ -> :ok) end)
     on_exit(fn -> Process.exit(stale_client, :kill) end)

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -18,6 +18,7 @@ defmodule Minga.Test.EditorCase do
   alias Minga.Test.HeadlessPort
   alias Minga.Test.Snapshot
   alias MingaEditor.Extension.Sidebar
+  alias MingaEditor.GenerationSupervisor
   alias MingaEditor.MinibufferData
   alias MingaEditor.Shell.Traditional.Modeline
   alias MingaEditor.StatusBar.Data, as: StatusBarData
@@ -48,6 +49,7 @@ defmodule Minga.Test.EditorCase do
   @typedoc "Test context with editor processes."
   @type editor_ctx :: %{
           optional(:rendering) => MingaEditor.State.rendering_policy(),
+          generation: pid(),
           editor: pid(),
           buffer: pid(),
           port: pid(),
@@ -179,11 +181,14 @@ defmodule Minga.Test.EditorCase do
     editor_opts =
       if project_root, do: [{:project_root, project_root} | editor_opts], else: editor_opts
 
-    {:ok, editor} = MingaEditor.start_link(editor_opts)
+    generation =
+      start_supervised!(Supervisor.child_spec({MingaEditor, editor_opts}, id: make_ref()))
 
+    {:ok, editor} = GenerationSupervisor.editor_owner(generation)
     synchronize_ready(editor, port, width, height, rendering)
 
     Map.merge(ctx, %{
+      generation: generation,
       editor: editor,
       buffer: buffer,
       port: port,
@@ -249,11 +254,14 @@ defmodule Minga.Test.EditorCase do
     editor_opts =
       if project_root, do: [{:project_root, project_root} | editor_opts], else: editor_opts
 
-    {:ok, editor} = MingaEditor.start_link(editor_opts)
+    generation =
+      start_supervised!(Supervisor.child_spec({MingaEditor, editor_opts}, id: make_ref()))
 
+    {:ok, editor} = GenerationSupervisor.editor_owner(generation)
     synchronize_ready(editor, port, width, height, rendering)
 
     %{
+      generation: generation,
       editor: editor,
       buffer: buffer,
       port: port,

--- a/test/support/fake_shell.ex
+++ b/test/support/fake_shell.ex
@@ -118,6 +118,13 @@ defmodule MingaEditor.Test.FakeShell do
   def handle_agent_session_down(%{session: session} = shell_state, session, _reason),
     do: {Map.put(shell_state, :session_down?, true), true}
 
+  def handle_agent_session_down(
+        %{mutate_rejected_callback?: true} = shell_state,
+        _session,
+        _reason
+      ),
+      do: {Map.put(shell_state, :foreign_mutation, true), false}
+
   def handle_agent_session_down(shell_state, _session, _reason), do: {shell_state, false}
 
   @impl true
@@ -129,6 +136,11 @@ defmodule MingaEditor.Test.FakeShell do
 
   @impl true
   @spec sync_agent_status(map(), pid(), atom()) :: map()
+  def sync_agent_status(%{callback_owner: owner} = shell_state, session, status) do
+    send(owner, {:fake_shell_sync_agent_status, session, status})
+    sync_agent_status(Map.delete(shell_state, :callback_owner), session, status)
+  end
+
   def sync_agent_status(%{session: session} = shell_state, session, status),
     do: Map.put(shell_state, :synced_agent_status, status)
 
@@ -141,22 +153,47 @@ defmodule MingaEditor.Test.FakeShell do
 
   @impl true
   @spec active_tab(map()) :: nil
+  def active_tab(%{callback_owner: owner}) do
+    send(owner, :fake_shell_active_tab)
+    nil
+  end
+
   def active_tab(_shell_state), do: nil
 
   @impl true
   @spec find_tab_by_buffer(map(), pid()) :: nil
+  def find_tab_by_buffer(%{callback_owner: owner}, pid) do
+    send(owner, {:fake_shell_find_tab_by_buffer, pid})
+    nil
+  end
+
   def find_tab_by_buffer(_shell_state, _pid), do: nil
 
   @impl true
   @spec active_tab_kind(map()) :: :none
+  def active_tab_kind(%{callback_owner: owner}) do
+    send(owner, :fake_shell_active_tab_kind)
+    :none
+  end
+
   def active_tab_kind(_shell_state), do: :none
 
   @impl true
   @spec set_tab_session(map(), term(), pid() | nil) :: map()
+  def set_tab_session(%{callback_owner: owner} = shell_state, tab_id, session_pid) do
+    send(owner, {:fake_shell_set_tab_session, tab_id, session_pid})
+    shell_state
+  end
+
   def set_tab_session(shell_state, _tab_id, _session_pid), do: shell_state
 
   @impl true
   @spec active_session(map()) :: pid() | nil
+  def active_session(%{callback_owner: owner} = shell_state) do
+    send(owner, :fake_shell_active_session)
+    Map.get(shell_state, :session)
+  end
+
   def active_session(%{session: session}) when is_pid(session), do: session
   def active_session(_shell_state), do: nil
 

--- a/test/support/fake_shell_alt.ex
+++ b/test/support/fake_shell_alt.ex
@@ -7,7 +7,7 @@ defmodule MingaEditor.Test.FakeShellAlt do
   @spec init(keyword()) :: map()
   def init(opts) do
     send(self(), {:fake_shell_alt_initialized, self()})
-    %{name: Keyword.get(opts, :name, :fake_alt), events: []}
+    %{name: Keyword.get(opts, :name, :fake_alt), events: [], tab_bar: nil}
   end
 
   @impl true
@@ -87,11 +87,6 @@ defmodule MingaEditor.Test.FakeShellAlt do
   @spec on_agent_event(map(), MingaEditor.Session.State.t(), pid(), term()) ::
           {map(), MingaEditor.Session.State.t(), [MingaEditor.effect()]}
   def on_agent_event(shell_state, workspace, _session, _event), do: {shell_state, workspace, []}
-
-  @impl true
-  @spec owns_agent_session?(map(), pid()) :: boolean()
-  def owns_agent_session?(%{session: session}, session), do: true
-  def owns_agent_session?(_shell_state, _session), do: false
 
   @impl true
   @spec handle_agent_session_restarted(map(), pid(), pid(), term()) :: {map(), boolean()}


### PR DESCRIPTION
# TL;DR
Post-merge review found correctness and coverage gaps across the five recent editor, frontend-pressure, registry, shell-runtime, and macOS benchmark changes. This follow-up fixes the production regressions, makes lifecycle tests deterministic, and preserves the intended ownership and bounded-resource contracts.

Follow-up to #2876, #2877, #2879, #2882, and #2883.

## Context
Each original PR passed its pre-merge checks, but reviewing the merged diffs together exposed interactions and edge cases that isolated review missed. The most important problems were dropped file-tree refresh intent under scheduler pressure, stale extension-shell callbacks, frontend recovery starvation, uncorrelated future acknowledgements, and incorrect OTP ownership when a directly started editor was placed under another supervisor.

## Changes
- Make every live Editor use a generation-owned effect scheduler, preserve file-tree refresh intent with bounded correlated retries, and keep unavailable-root errors intact during Git metadata updates.
- Make the generation supervisor the lifecycle handle for both supervised and manual Editor startup, while treating the Editor PID only as the operational endpoint; migrate tests and benchmarks to retain and stop the generation explicitly.
- Add deterministic shell-registry publication, reload-generation, cleanup-race, and supervision-restart coverage.
- Pin the macOS render benchmark test to the literal `0.08 ms` boundary so changing the production allowance cannot silently move the expected value.
- Preserve legacy shell restart ownership when the optional callback is absent, reject state mutations from unhandled stashed callbacks, and normalize stale shell registrations before callback dispatch.
- Apply the frontend output-pressure deadline across retained controls and frames, reject acknowledgements beyond admitted frame watermarks, and coalesce clipboard controls independently per pasteboard target.

## Compatibility
OTP child-spec and manual generation startup now return the generation supervisor PID; callers resolve the operational endpoint with `MingaEditor.GenerationSupervisor.editor_owner/1` and stop the generation for teardown. `MingaEditor.start_link/1` is now the internal owner start and requires an existing generation-owned scheduler. Existing extension shells without `owns_agent_session?/2` keep their previous restart behavior.

## Verification
- `make lint` (Credo clean, compilation clean, Dialyzer 0 errors)
- `mix test.llm` (9,320 tests, 97 properties, 58 doctests, 0 failures)
- CI-parity Elixir suite (9,821 checks: 9,665 tests, 98 properties, 58 doctests, 0 failures)
- Focused scheduler, file-tree freshness, and system-wake suite (30 tests, 0 failures)
- Focused frontend manager suites (28 tests, 0 failures)
- `mix test.heavy test/minga_editor/frontend/manager_test.exs` (11 tests, 0 failures)
- `mix swift.build`
- `mix swift.build -- -project macos/Minga.xcodeproj -scheme Minga test`
- Surface-layout snapshot test repeated 50 times (300 tests, 0 failures)
- Keystroke baseline completed small-frame, large-frame, and agent-stream scenarios
- `git diff --check`
- Targeted final blocker review: PASS

## Acceptance Criteria Addressed
- File-tree refreshes remain live and correlated when scheduler admission is unavailable or full. ✅
- Metadata-only updates cannot clear filesystem topology errors. ✅
- The generation supervisor is the OTP-owned lifecycle boundary for supervised Editor startup. ✅
- Shell registry lifecycle and generation guarantees have deterministic concurrency and restart coverage. ✅
- The macOS benchmark test independently enforces the documented 0.05 ms allowance. ✅
- Legacy and reloaded extension shells preserve correct callback and restart behavior. ✅
- Frontend pressure recovery remains bounded, correlated, and pasteboard-safe. ✅
