### PR TITLE
refactor(editor): centralize buffer activation and focus

### DIFF
--- a/bench/resident_frame_bench.exs
+++ b/bench/resident_frame_bench.exs
@@ -74,7 +74,7 @@ defmodule Minga.Bench.ResidentFrame do
 
   defp timed_frame(state) do
     state = Content.reset_rows_rasterized(state)
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, state} = Scroll.scroll_windows(state, layout)

--- a/docs/adr/0002-editor-state-transitions-have-explicit-owners.md
+++ b/docs/adr/0002-editor-state-transitions-have-explicit-owners.md
@@ -35,6 +35,8 @@ File-tree refresh is the first application of this rule. `MingaEditor.State.File
 
 Render correlation follows the same boundary. `MingaEditor.State.RenderCorrelation` owns the render timer token, semantic intent revisions, receipt ordering, and pending keyframe request. `MingaEditor.State` retains one atomic receipt integration transition because shell identity, workspace observations, layout, focus, and click regions must agree. Timer creation, renderer submission, frontend communication, and stale-receipt logging stay in Editor workflows. `MingaEditor.Renderer.Server` remains authoritative for resident rows, render caches, acknowledgement credit, and renderer-private state.
 
+Buffer activation and window focus use a session aggregate plus focused workflows. `MingaEditor.Session.State.activate_buffer/3` coordinates the leaf-owned buffer selection with the active window, keymap scope, launchpad, and hover observations. `MingaEditor.Session.State.focus_window/3` commits focus only after `MingaEditor.WindowFocus` successfully saves and restores process-owned cursors; the workflow then composes Traditional bottom-panel presentation through its shell owners. `MingaEditor.BufferActivation` coordinates shell callbacks and their external effects. No buffer call, monitor, log, render request, or shell presentation effect runs inside the pure session transitions.
+
 ## Migration ledger
 
 The epic assigns every broad ownership area to a committed convergence slice:

--- a/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
@@ -363,7 +363,7 @@ defmodule MingaGitPorcelain.Input.GitStatus do
         end
 
       i ->
-        EditorState.switch_buffer(state, i)
+        MingaEditor.BufferActivation.activate(state, i)
     end
   end
 

--- a/extensions/git_porcelain/lib/minga_git_porcelain/ui/picker/git_changed_source.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/ui/picker/git_changed_source.ex
@@ -68,7 +68,7 @@ defmodule MingaGitPorcelain.UI.Picker.GitChangedSource do
         if tab do
           EditorState.switch_tab(state, tab.id)
         else
-          EditorState.switch_buffer(state, idx)
+          MingaEditor.BufferActivation.activate(state, idx)
         end
     end
   end

--- a/lib/minga_editor/buffer_activation.ex
+++ b/lib/minga_editor/buffer_activation.ex
@@ -1,0 +1,53 @@
+defmodule MingaEditor.BufferActivation do
+  @moduledoc "Focused workflow for activating a buffer and synchronizing shell presentation."
+
+  alias MingaEditor.Handlers.EffectHandler
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Workflow, as: ShellWorkflow
+  alias MingaEditor.State, as: EditorState
+
+  @type state :: EditorState.t()
+  @type option :: {:notify_shell?, boolean()} | {:replace_window_content?, boolean()}
+
+  @doc "Activates a session buffer selection and optionally synchronizes shell presentation."
+  @spec activate(state(), SessionState.buffer_activation()) :: state()
+  @spec activate(state(), SessionState.buffer_activation(), [option()]) :: state()
+  def activate(%EditorState{} = state, activation, opts \\ []) when is_list(opts) do
+    workspace =
+      SessionState.activate_buffer(state.workspace, activation,
+        replace_window_content?: Keyword.get(opts, :replace_window_content?, false)
+      )
+
+    state = EditorState.set_workspace(state, workspace)
+
+    if Keyword.get(opts, :notify_shell?, true) do
+      synchronize_shell(state)
+    else
+      state
+    end
+  end
+
+  @doc "Refreshes shell presentation after the active buffer changes identity in place."
+  @spec refresh_presentation(state()) :: state()
+  def refresh_presentation(%EditorState{} = state), do: synchronize_shell(state)
+
+  @spec synchronize_shell(state()) :: state()
+  defp synchronize_shell(%EditorState{} = state) do
+    state = ShellWorkflow.ensure_available(state)
+
+    case state.buffer_add_context do
+      :preview ->
+        EditorState.set_buffer_add_context(state, :open)
+
+      :open ->
+        {runtime, workspace, effects} =
+          Runtime.route_buffer_switched(state.shell_runtime, state.workspace)
+
+        state
+        |> EditorState.apply_shell_runtime_transition(runtime)
+        |> EditorState.set_workspace(workspace)
+        |> EffectHandler.apply_buffer_activation_effects(effects)
+    end
+  end
+end

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -371,9 +371,7 @@ defmodule MingaEditor.Commands.Agent do
         Buffers.replace_list(buffers, [active_buffer | buffers.list], 0)
       end
 
-    workspace
-    |> SessionState.set_buffers(buffers)
-    |> SessionState.sync_active_window_buffer()
+    SessionState.activate_buffer(workspace, buffers)
   end
 
   defp restore_return_target_buffer(workspace, _active_buffer), do: workspace
@@ -1542,7 +1540,7 @@ defmodule MingaEditor.Commands.Agent do
         end
 
       idx ->
-        state = EditorState.switch_buffer(state, idx)
+        state = MingaEditor.BufferActivation.activate(state, idx)
         safe_move_to(state.workspace.buffers.active, {line, 0})
         state
     end

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -28,7 +28,6 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
-  alias MingaEditor.State.Windows
   alias MingaEditor.State.Tab
   alias MingaEditor.State.Tab.Context, as: TabContext
   alias MingaEditor.State.TabBar
@@ -774,13 +773,13 @@ defmodule MingaEditor.Commands.BufferManagement do
     target_buf = Enum.at(buffers, idx)
 
     case find_tab_for_buffer(tb, target_buf) do
-      nil -> EditorState.switch_buffer(state, idx)
-      tab_id when tab_id == tb.active_id -> EditorState.switch_buffer(state, idx)
+      nil -> MingaEditor.BufferActivation.activate(state, idx)
+      tab_id when tab_id == tb.active_id -> MingaEditor.BufferActivation.activate(state, idx)
       tab_id -> EditorState.switch_tab(state, tab_id)
     end
   end
 
-  defp switch_to_buffer(state, idx), do: EditorState.switch_buffer(state, idx)
+  defp switch_to_buffer(state, idx), do: MingaEditor.BufferActivation.activate(state, idx)
 
   @spec next_buffer(state()) :: state()
   defp next_buffer(%{workspace: %{buffers: %{active: active, list: buffers}}} = state) do
@@ -849,7 +848,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp switch_to_buffer_pid(%{workspace: %{buffers: %{list: buffers}}} = state, target_buf) do
     case Enum.find_index(buffers, &(&1 == target_buf)) do
       nil -> state
-      idx -> EditorState.switch_buffer(state, idx)
+      idx -> MingaEditor.BufferActivation.activate(state, idx)
     end
   end
 
@@ -1025,9 +1024,7 @@ defmodule MingaEditor.Commands.BufferManagement do
           new_idx = min(idx, Enum.count(new_buffers) - 1)
           new_bs = Buffers.replace_list(bs, new_buffers, new_idx)
 
-          state
-          |> EditorState.set_buffers(new_bs)
-          |> EditorState.sync_active_window_buffer()
+          MingaEditor.BufferActivation.activate(state, new_bs, notify_shell?: false)
       end
     end
   end
@@ -1973,7 +1970,7 @@ defmodule MingaEditor.Commands.BufferManagement do
     state = restore_active_tab_context(state)
 
     if state.workspace.buffers.active do
-      EditorState.sync_active_window_buffer(state)
+      MingaEditor.BufferActivation.activate(state, state.workspace.buffers, notify_shell?: false)
     else
       EditorState.enter_empty_state(state)
     end
@@ -2118,7 +2115,7 @@ defmodule MingaEditor.Commands.BufferManagement do
     case Buffer.save_as(buf, target) do
       :ok ->
         state
-        |> EditorState.refresh_active_buffer_presentation()
+        |> MingaEditor.BufferActivation.refresh_presentation()
         |> setup_highlight_or_defer()
         |> EditorState.set_status("Wrote #{Path.basename(target)}")
 
@@ -2404,7 +2401,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp focus_popup_window(state, buffer_pid) do
     case find_popup_for_buffer(state, buffer_pid) do
       {:ok, popup_window_id} ->
-        EditorState.update_windows(state, &Windows.set_active(&1, popup_window_id))
+        MingaEditor.WindowFocus.focus(state, popup_window_id)
 
       :none ->
         state

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -92,7 +92,8 @@ defmodule MingaEditor.Commands.FileTree do
   end
 
   @spec restore_scope(state()) :: atom()
-  defp restore_scope(state), do: EditorState.scope_for_active_window(state)
+  defp restore_scope(state),
+    do: MingaEditor.Session.State.scope_for_active_window(state.workspace)
 
   @spec file_tree_state(state()) :: FileTreeState.t()
   defp file_tree_state(state), do: EditorState.file_tree_state(state)
@@ -959,7 +960,7 @@ defmodule MingaEditor.Commands.FileTree do
           if tab do
             EditorState.switch_tab(state, tab.id)
           else
-            EditorState.switch_buffer(state, idx)
+            MingaEditor.BufferActivation.activate(state, idx)
           end
 
         update_file_tree(state, &FileTreeState.set_tree(&1, FileTree.reveal(tree, path)))

--- a/lib/minga_editor/commands/help.ex
+++ b/lib/minga_editor/commands/help.ex
@@ -927,7 +927,7 @@ defmodule MingaEditor.Commands.Help do
 
     state =
       if idx do
-        EditorState.switch_buffer(state, idx)
+        MingaEditor.BufferActivation.activate(state, idx)
       else
         Commands.add_buffer(state, buffer)
       end

--- a/lib/minga_editor/commands/launchpad.ex
+++ b/lib/minga_editor/commands/launchpad.ex
@@ -41,7 +41,7 @@ defmodule MingaEditor.Commands.Launchpad do
 
   The one-keystroke vim materialization (`i`/`a`/`o`/`O`) from the empty
   state: buffer creation flips the window back to buffer content and clears
-  the launchpad via `sync_active_window_buffer/1`.
+  the launchpad through `MingaEditor.Session.State.activate_buffer/2`.
   """
   @spec materialize_and_insert(state()) :: state()
   def materialize_and_insert(state) do

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -21,7 +21,6 @@ defmodule MingaEditor.Commands.Movement do
   alias MingaEditor.FoldMap
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
@@ -596,7 +595,9 @@ defmodule MingaEditor.Commands.Movement do
 
       state
       |> EditorState.set_bottom_panel(panel)
-      |> EditorState.set_keymap_scope(EditorState.scope_for_active_window(state))
+      |> EditorState.set_keymap_scope(
+        MingaEditor.Session.State.scope_for_active_window(state.workspace)
+      )
     else
       navigate_window_to_neighbor(state, :up)
     end
@@ -607,7 +608,7 @@ defmodule MingaEditor.Commands.Movement do
   defp navigate_window(state, :right) do
     if EditorState.file_tree_state(state).focused do
       state = update_file_tree(state, &FileTreeState.unfocus/1)
-      scope = EditorState.scope_for_active_window(state)
+      scope = MingaEditor.Session.State.scope_for_active_window(state.workspace)
       EditorState.set_keymap_scope(state, scope)
     else
       navigate_window_to_neighbor(state, :right)
@@ -629,7 +630,7 @@ defmodule MingaEditor.Commands.Movement do
            screen
          ) do
       {:ok, neighbor_id} ->
-        EditorState.focus_window(state, neighbor_id)
+        MingaEditor.WindowFocus.focus(state, neighbor_id)
 
       :error ->
         # No neighbor in that direction; check if an edge panel is there.
@@ -645,7 +646,9 @@ defmodule MingaEditor.Commands.Movement do
       state
       |> EditorState.set_bottom_panel(BottomPanel.focus(panel))
       |> update_file_tree(&FileTreeState.unfocus/1)
-      |> EditorState.set_keymap_scope(EditorState.scope_for_active_window(state))
+      |> EditorState.set_keymap_scope(
+        MingaEditor.Session.State.scope_for_active_window(state.workspace)
+      )
     else
       state
     end
@@ -682,29 +685,8 @@ defmodule MingaEditor.Commands.Movement do
 
   @spec focus_remaining_window(state(), Windows.t()) :: state()
   defp focus_remaining_window(state, removed_windows) do
-    remaining = WindowTree.leaves(removed_windows.tree)
-    new_active = hd(remaining)
-
-    case Windows.fetch(removed_windows, new_active) do
-      {:ok, new_active_window} ->
-        apply_remaining_window_focus(state, removed_windows, new_active, new_active_window)
-
-      :error ->
-        state
-    end
-  end
-
-  @spec apply_remaining_window_focus(state(), Windows.t(), Window.id(), Window.t()) :: state()
-  defp apply_remaining_window_focus(state, removed_windows, new_active, new_active_window) do
-    # Restore the surviving window's cursor into the buffer
-    Buffer.move_to(new_active_window.buffer, new_active_window.cursor)
-
-    new_windows = Windows.set_active(removed_windows, new_active)
-    new_buffers = Buffers.set_active_override(state.workspace.buffers, new_active_window.buffer)
-
-    state
-    |> EditorState.set_windows(new_windows)
-    |> EditorState.set_buffers(new_buffers)
+    new_active = removed_windows.tree |> WindowTree.leaves() |> hd()
+    MingaEditor.WindowFocus.focus_surviving_window(state, removed_windows, new_active)
   end
 
   # ── Private helpers ──────────────────────────────────────────────────────

--- a/lib/minga_editor/commands/tutor.ex
+++ b/lib/minga_editor/commands/tutor.ex
@@ -10,7 +10,6 @@ defmodule MingaEditor.Commands.Tutor do
   alias Minga.Buffer.Document
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.State.Buffers
 
   @type state :: EditorState.t()
 
@@ -83,7 +82,7 @@ defmodule MingaEditor.Commands.Tutor do
 
     state =
       if idx do
-        EditorState.update_buffers(state, &Buffers.switch_to(&1, idx))
+        MingaEditor.BufferActivation.activate(state, idx)
       else
         Commands.add_buffer(state, buffer)
       end

--- a/lib/minga_editor/extension/editor_api.ex
+++ b/lib/minga_editor/extension/editor_api.ex
@@ -48,7 +48,7 @@ defmodule MingaEditor.Extension.EditorAPI do
   @spec focus_buffer(state(), pid()) :: state()
   def focus_buffer(state, buffer_pid) when is_pid(buffer_pid) do
     case Windows.find_by_content(state.workspace.windows, &(&1.buffer == buffer_pid)) do
-      {window_id, _window} -> EditorState.focus_window(state, window_id)
+      {window_id, _window} -> MingaEditor.WindowFocus.focus(state, window_id)
       nil -> state
     end
   end

--- a/lib/minga_editor/handlers/effect_handler.ex
+++ b/lib/minga_editor/handlers/effect_handler.ex
@@ -114,6 +114,30 @@ defmodule MingaEditor.Handlers.EffectHandler do
     apply_effects(state, rest)
   end
 
+  @doc "Applies effects returned by a shell buffer-activation callback without recursively notifying that callback."
+  @spec apply_buffer_activation_effects(EditorState.t(), [effect()]) :: EditorState.t()
+  def apply_buffer_activation_effects(state, []), do: state
+
+  def apply_buffer_activation_effects(state, [effect | rest]) do
+    state = apply_buffer_activation_effect(state, effect)
+    apply_buffer_activation_effects(state, rest)
+  end
+
+  @spec apply_buffer_activation_effect(EditorState.t(), effect()) :: EditorState.t()
+  defp apply_buffer_activation_effect(state, {:switch_buffer, pid}) when is_pid(pid) do
+    case Enum.find_index(state.workspace.buffers.list, &(&1 == pid)) do
+      nil ->
+        state
+
+      idx ->
+        state
+        |> MingaEditor.BufferActivation.activate(idx, notify_shell?: false)
+        |> MingaEditor.reset_nav_flash_tracking()
+    end
+  end
+
+  defp apply_buffer_activation_effect(state, effect), do: apply_effect(state, effect)
+
   @spec compact_session_safely(pid()) :: {:ok, String.t()} | {:error, term()}
   defp compact_session_safely(session_pid) do
     MingaAgent.Session.compact(session_pid)
@@ -134,8 +158,12 @@ defmodule MingaEditor.Handlers.EffectHandler do
 
   defp apply_effect(state, {:switch_buffer, pid}) when is_pid(pid) do
     case Enum.find_index(state.workspace.buffers.list, &(&1 == pid)) do
-      nil -> state
-      idx -> EditorState.switch_buffer(state, idx) |> MingaEditor.reset_nav_flash_tracking()
+      nil ->
+        state
+
+      idx ->
+        MingaEditor.BufferActivation.activate(state, idx)
+        |> MingaEditor.reset_nav_flash_tracking()
     end
   end
 

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -1661,14 +1661,13 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec show_buffer_in_active_window(state(), pid()) :: state()
   defp show_buffer_in_active_window(state, pid) when is_pid(pid) do
-    state
-    |> EditorState.update_buffers(fn buffers ->
-      case Enum.find_index(buffers.list, &(&1 == pid)) do
-        nil -> Buffers.add(buffers, pid)
-        idx -> Buffers.switch_to(buffers, idx)
+    buffers =
+      case Enum.find_index(state.workspace.buffers.list, &(&1 == pid)) do
+        nil -> Buffers.add(state.workspace.buffers, pid)
+        idx -> Buffers.switch_to(state.workspace.buffers, idx)
       end
-    end)
-    |> EditorState.sync_active_window_buffer()
+
+    MingaEditor.BufferActivation.activate(state, buffers, notify_shell?: false)
   end
 
   @spec tab_active_buffer(Tab.t()) :: pid() | nil
@@ -1681,10 +1680,11 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec register_buffer_in_active_window(state(), pid(), String.t()) :: state()
   defp register_buffer_in_active_window(state, buffer_pid, file_path) do
+    buffers = Buffers.add(state.workspace.buffers, buffer_pid)
+
     state =
       state
-      |> EditorState.update_buffers(&Buffers.add(&1, buffer_pid))
-      |> EditorState.sync_active_window_buffer()
+      |> MingaEditor.BufferActivation.activate(buffers, notify_shell?: false)
       |> EditorState.monitor_buffer(buffer_pid)
 
     Minga.Log.info(:editor, "Opened: #{file_path}")

--- a/lib/minga_editor/input/agent_mouse.ex
+++ b/lib/minga_editor/input/agent_mouse.ex
@@ -238,7 +238,7 @@ defmodule MingaEditor.Input.AgentMouse do
   @spec maybe_focus_window(EditorState.t(), pos_integer()) :: EditorState.t()
   defp maybe_focus_window(state, win_id) do
     if state.workspace.windows.active != win_id do
-      EditorState.focus_window(state, win_id)
+      MingaEditor.WindowFocus.focus(state, win_id)
     else
       state
     end

--- a/lib/minga_editor/input/bottom_panel.ex
+++ b/lib/minga_editor/input/bottom_panel.ex
@@ -65,7 +65,9 @@ defmodule MingaEditor.Input.BottomPanel do
   defp close_panel(state, panel) do
     state
     |> EditorState.set_bottom_panel(BottomPanel.hide(panel))
-    |> EditorState.set_keymap_scope(EditorState.scope_for_active_window(state))
+    |> EditorState.set_keymap_scope(
+      MingaEditor.Session.State.scope_for_active_window(state.workspace)
+    )
   end
 
   @impl true
@@ -95,7 +97,9 @@ defmodule MingaEditor.Input.BottomPanel do
       state
       |> EditorState.set_bottom_panel(panel)
       |> EditorState.update_file_tree(&FileTreeState.unfocus/1)
-      |> EditorState.set_keymap_scope(EditorState.scope_for_active_window(state))
+      |> EditorState.set_keymap_scope(
+        MingaEditor.Session.State.scope_for_active_window(state.workspace)
+      )
 
     {:handled, state}
   end

--- a/lib/minga_editor/layout_preset.ex
+++ b/lib/minga_editor/layout_preset.ex
@@ -64,8 +64,20 @@ defmodule MingaEditor.LayoutPreset do
 
   @spec remove_agent_window(EditorState.t(), Window.id()) :: EditorState.t()
   defp remove_agent_window(state, agent_win_id) do
-    state = maybe_switch_focus_away(state, agent_win_id)
+    state
+    |> maybe_switch_focus_away(agent_win_id)
+    |> remove_inactive_agent_window(agent_win_id)
+  end
 
+  @spec remove_inactive_agent_window(EditorState.t(), Window.id()) :: EditorState.t()
+  defp remove_inactive_agent_window(
+         %{workspace: %{windows: %{active: active}}} = state,
+         agent_win_id
+       )
+       when active == agent_win_id,
+       do: state
+
+  defp remove_inactive_agent_window(state, agent_win_id) do
     case Windows.remove_window(state.workspace.windows, agent_win_id) do
       {:ok, windows} ->
         state = EditorState.set_windows(state, windows)
@@ -91,7 +103,7 @@ defmodule MingaEditor.LayoutPreset do
   defp maybe_switch_focus_away(state, _closing_id) do
     case find_non_agent_window(state) do
       {buf_win_id, _window} ->
-        EditorState.focus_window(state, buf_win_id)
+        MingaEditor.WindowFocus.focus(state, buf_win_id)
 
       nil ->
         state

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -1635,7 +1635,7 @@ defmodule MingaEditor.LspActions do
         end
 
       i ->
-        EditorState.switch_buffer(state, i)
+        MingaEditor.BufferActivation.activate(state, i)
     end
   end
 

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -1439,7 +1439,7 @@ defmodule MingaEditor.Mouse do
     screen = Layout.get(state).editor_area
 
     case WindowTree.window_at(state.workspace.windows.tree, screen, row, col) do
-      {:ok, id, _rect} -> EditorState.focus_window(state, id)
+      {:ok, id, _rect} -> MingaEditor.WindowFocus.focus(state, id)
       :error -> state
     end
   end

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -772,7 +772,7 @@ defmodule MingaEditor.PickerUI do
          %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{restore: idx}}}}}} = state
        )
        when is_integer(idx) do
-    EditorState.switch_buffer(state, idx)
+    MingaEditor.BufferActivation.activate(state, idx)
   end
 
   defp restore_picker_origin(state), do: state

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -360,7 +360,7 @@ defmodule MingaEditor.RenderPipeline.Input do
   @doc """
   Syncs the active window's cursor from the buffer process.
 
-  Equivalent to `EditorState.sync_active_window_cursor/1` but operates
+  Equivalent to `MingaEditor.WindowFocus.remember_active_cursor/1` but operates
   on the Input's workspace map.
   """
   @spec sync_active_window_cursor(t()) :: t()

--- a/lib/minga_editor/session/state.ex
+++ b/lib/minga_editor/session/state.ex
@@ -118,8 +118,7 @@ defmodule MingaEditor.Session.State do
   # ── Pure workspace operations ─────────────────────────────────────────────
   #
   # These are pure functions (no side effects) on SessionState. The
-  # Editor GenServer calls these through EditorState wrappers that handle
-  # cross-cutting concerns (tab bar sync, process monitoring, etc.).
+  # Editor workflows compose these values with process and presentation work.
 
   alias MingaEditor.Window
   alias MingaEditor.Window.Content
@@ -170,53 +169,165 @@ defmodule MingaEditor.Session.State do
   @spec mark_frontend_reset_pending(t()) :: t()
   def mark_frontend_reset_pending(%__MODULE__{} = wspace), do: wspace
 
-  @doc """
-  Switches to the buffer at `idx`, making it active for the current window.
+  @typedoc "A leaf-owned buffer selection to activate in this session."
+  @type buffer_activation :: integer() | Buffers.t()
 
-  Pure workspace operation: updates Buffers and syncs the active window.
+  @doc """
+  Activates a buffer selection and synchronizes every session-owned observation.
+
+  Integer selections delegate wrapping and index semantics to `Buffers`. A prepared `Buffers` value supports close, restore, and add workflows that already performed their leaf transition. By default non-buffer surfaces remain visible; `replace_window_content?: true` lets a shell intentionally replace one with the activated buffer.
   """
-  @spec switch_buffer(t(), non_neg_integer()) :: t()
-  def switch_buffer(%__MODULE__{buffers: bs} = wspace, idx) do
-    %{wspace | buffers: Buffers.switch_to(bs, idx)}
-    |> sync_active_window_buffer()
+  @spec activate_buffer(t(), buffer_activation()) :: t()
+  @spec activate_buffer(t(), buffer_activation(), keyword()) :: t()
+  def activate_buffer(workspace, activation, opts \\ [])
+
+  def activate_buffer(%__MODULE__{buffers: buffers} = workspace, index, opts)
+      when is_integer(index) do
+    activate_buffer(workspace, Buffers.switch_to(buffers, index), opts)
   end
 
-  @doc """
-  Syncs the active window's buffer reference with `buffers.active`.
+  def activate_buffer(%__MODULE__{} = workspace, %Buffers{} = buffers, opts) do
+    workspace = %{
+      workspace
+      | buffers: buffers,
+        cmd_hover_link: nil,
+        cmd_hover_cell: nil
+    }
 
-  Call after any operation that changes `buffers.active` to keep the
-  window tree consistent. No-op when windows aren't initialized.
-  """
-  @spec sync_active_window_buffer(t()) :: t()
-  def sync_active_window_buffer(%__MODULE__{buffers: %{active: nil}} = wspace), do: wspace
+    synchronize_activated_window(
+      workspace,
+      Keyword.get(opts, :replace_window_content?, false)
+    )
+  end
 
-  def sync_active_window_buffer(%__MODULE__{windows: ws, buffers: buffers} = wspace) do
-    id = ws.active
+  @doc "Commits a pure window-focus transition after its required buffer calls succeed."
+  @spec focus_window(t(), Window.id(), position() | nil) :: t()
+  def focus_window(%__MODULE__{windows: %{active: active}} = workspace, target_id, _cursor)
+      when target_id == active,
+      do: workspace
 
-    case Windows.fetch(ws, id) do
-      {:ok, %Window{buffer: existing, content: {:buffer, _}}} when existing != buffers.active ->
-        windows =
-          Windows.update(ws, id, fn window ->
-            %{
-              window
-              | buffer: buffers.active,
-                content: Content.buffer(buffers.active)
-            }
-            |> Window.set_document_symbols([])
-          end)
-
-        %{wspace | windows: windows}
-
-      # A buffer became active while the window showed the launchpad:
-      # leave the empty state in the same frame (#2689).
-      {:ok, %Window{content: {:empty, :semantic}}} ->
-        windows = Windows.update(ws, id, &Window.show_buffer(&1, buffers.active))
-        %{wspace | windows: windows, launchpad: nil}
-
-      _ ->
-        wspace
+  def focus_window(%__MODULE__{windows: windows} = workspace, target_id, outgoing_cursor) do
+    with {:ok, old_window} <- Windows.fetch(windows, windows.active),
+         {:ok, target_window} <- Windows.fetch(windows, target_id) do
+      windows = remember_outgoing_cursor(windows, old_window, outgoing_cursor)
+      commit_focused_window(workspace, windows, target_id, target_window)
+    else
+      :error -> workspace
     end
   end
+
+  @doc "Commits focus to a surviving window after the active split was removed."
+  @spec focus_surviving_window(t(), Windows.t(), Window.id()) :: t()
+  def focus_surviving_window(%__MODULE__{} = workspace, %Windows{} = windows, target_id) do
+    case Windows.fetch(windows, target_id) do
+      {:ok, target_window} ->
+        commit_focused_window(workspace, windows, target_id, target_window)
+
+      :error ->
+        workspace
+    end
+  end
+
+  @doc "Stores the active buffer cursor in its matching active window."
+  @spec remember_active_window_cursor(t(), position()) :: t()
+  def remember_active_window_cursor(
+        %__MODULE__{windows: windows, buffers: %{active: buffer}} = workspace,
+        cursor
+      )
+      when is_pid(buffer) do
+    case Windows.fetch(windows, windows.active) do
+      {:ok, %Window{buffer: ^buffer}} ->
+        %{
+          workspace
+          | windows: Windows.update(windows, windows.active, &Window.remember_cursor(&1, cursor))
+        }
+
+      _ ->
+        workspace
+    end
+  end
+
+  def remember_active_window_cursor(%__MODULE__{} = workspace, _cursor), do: workspace
+
+  @spec synchronize_activated_window(t(), boolean()) :: t()
+  defp synchronize_activated_window(%__MODULE__{buffers: %{active: nil}} = workspace, _replace?),
+    do: workspace
+
+  defp synchronize_activated_window(
+         %__MODULE__{windows: windows, buffers: %{active: buffer}} = workspace,
+         replace?
+       ) do
+    case Windows.fetch(windows, windows.active) do
+      {:ok, %Window{buffer: ^buffer, content: {:buffer, ^buffer}}} ->
+        normalize_buffer_surface(workspace, buffer)
+
+      {:ok, %Window{content: {:buffer, _}}} ->
+        activate_buffer_surface(workspace, windows, buffer)
+
+      {:ok, %Window{content: {:empty, :semantic}}} ->
+        activate_buffer_surface(workspace, windows, buffer)
+
+      {:ok, %Window{}} when replace? ->
+        activate_buffer_surface(workspace, windows, buffer)
+
+      _ ->
+        workspace
+    end
+  end
+
+  @spec activate_buffer_surface(t(), Windows.t(), pid()) :: t()
+  defp activate_buffer_surface(workspace, windows, buffer) do
+    workspace = %{
+      workspace
+      | windows: Windows.update(windows, windows.active, &Window.show_buffer(&1, buffer))
+    }
+
+    normalize_buffer_surface(workspace, buffer)
+  end
+
+  @spec normalize_buffer_surface(t(), pid()) :: t()
+  defp normalize_buffer_surface(workspace, buffer) do
+    %{
+      workspace
+      | keymap_scope: scope_for_content(Content.buffer(buffer), workspace.keymap_scope),
+        launchpad: nil
+    }
+  end
+
+  @spec remember_outgoing_cursor(Windows.t(), Window.t(), position() | nil) :: Windows.t()
+  defp remember_outgoing_cursor(windows, %Window{content: {:buffer, _}}, {_, _} = cursor),
+    do: Windows.update(windows, windows.active, &Window.remember_cursor(&1, cursor))
+
+  defp remember_outgoing_cursor(windows, _window, _cursor), do: windows
+
+  @spec commit_focused_window(t(), Windows.t(), Window.id(), Window.t()) :: t()
+  defp commit_focused_window(workspace, windows, target_id, target_window) do
+    buffers = buffers_for_focused_window(workspace.buffers, target_window)
+
+    %{
+      workspace
+      | windows: Windows.set_active(windows, target_id),
+        buffers: buffers,
+        keymap_scope: scope_for_content(target_window.content, workspace.keymap_scope),
+        launchpad: launchpad_after_focus(workspace.launchpad, target_window),
+        cmd_hover_link: nil,
+        cmd_hover_cell: nil
+    }
+  end
+
+  @spec buffers_for_focused_window(Buffers.t(), Window.t()) :: Buffers.t()
+  defp buffers_for_focused_window(buffers, %Window{content: {:buffer, buffer}})
+       when is_pid(buffer) do
+    selected = Buffers.switch_to_pid(buffers, buffer)
+    if selected.active == buffer, do: selected, else: Buffers.set_active_override(buffers, buffer)
+  end
+
+  defp buffers_for_focused_window(buffers, %Window{}),
+    do: Buffers.set_active_override(buffers, nil)
+
+  @spec launchpad_after_focus(MingaEditor.State.Launchpad.t() | nil, Window.t()) ::
+          MingaEditor.State.Launchpad.t() | nil
+  defp launchpad_after_focus(launchpad, %Window{}), do: launchpad
 
   @doc """
   Enters the zero-buffers launchpad (#2689).
@@ -251,12 +362,11 @@ defmodule MingaEditor.Session.State do
   @doc """
   Derives the keymap scope from a window's content type.
 
-  Agent chat windows always use `:agent` scope. Buffer windows use
-  `:editor` when coming from `:agent` scope, and preserve the current
-  scope otherwise.
+  Agent chat windows use `:agent`, launchpad windows use `:editor`, and buffer windows return from `:agent` to `:editor` while preserving other scopes.
   """
   @spec scope_for_content(Content.t(), Scope.scope_name()) :: Scope.scope_name()
   def scope_for_content({:agent_chat, _pid}, _current_scope), do: :agent
+  def scope_for_content({:empty, :semantic}, _current_scope), do: :editor
   def scope_for_content({:buffer, _pid}, :agent), do: :editor
   def scope_for_content({:buffer, _pid}, current_scope), do: current_scope
 

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -40,7 +40,6 @@ defmodule MingaEditor.Shell.Traditional do
   alias MingaEditor.State.Windows
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
-  alias MingaEditor.Window.Content
   alias Minga.Log
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.Session.State, as: SessionState
@@ -258,7 +257,7 @@ defmodule MingaEditor.Shell.Traditional do
          _buffer_pid,
          _context
        ) do
-    workspace = SessionState.sync_active_window_buffer(workspace)
+    workspace = SessionState.activate_buffer(workspace, workspace.buffers)
     {shell_state, workspace, []}
   end
 
@@ -285,7 +284,7 @@ defmodule MingaEditor.Shell.Traditional do
             # Preview: sync window content only, leave tab bar unchanged.
             # The tab label stays as-is so confirm can detect "no tab for
             # this buffer" and create a new one.
-            workspace = SessionState.sync_active_window_buffer(workspace)
+            workspace = SessionState.activate_buffer(workspace, workspace.buffers)
             {shell_state, workspace, []}
 
           {_, :agent} ->
@@ -319,7 +318,7 @@ defmodule MingaEditor.Shell.Traditional do
        ) do
     {tb, tab} = TabBar.add(tb, :file, label)
     tb = TabBar.switch_to(tb, tab.id)
-    workspace = SessionState.sync_active_window_buffer(workspace)
+    workspace = SessionState.activate_buffer(workspace, workspace.buffers)
     {%{shell_state | tab_bar: tb}, workspace, []}
   end
 
@@ -356,7 +355,7 @@ defmodule MingaEditor.Shell.Traditional do
   @spec on_buffer_died(ShellState.t(), SessionState.t(), pid()) ::
           {ShellState.t(), SessionState.t(), [MingaEditor.effect()]}
   def on_buffer_died(shell_state, workspace, _dead_pid) do
-    workspace = SessionState.sync_active_window_buffer(workspace)
+    workspace = SessionState.activate_buffer(workspace, workspace.buffers)
     {shell_state, workspace, []}
   end
 
@@ -721,8 +720,8 @@ defmodule MingaEditor.Shell.Traditional do
       |> SessionState.set_agent_ui(UIState.new())
       |> SessionState.set_keymap_scope(:editor)
 
-    workspace = reset_active_window_to_buffer(workspace)
-    workspace = SessionState.sync_active_window_buffer(workspace)
+    workspace =
+      SessionState.activate_buffer(workspace, workspace.buffers, replace_window_content?: true)
 
     # Snapshot the new tab's context
     new_context = SessionState.to_tab_context(workspace)
@@ -761,7 +760,7 @@ defmodule MingaEditor.Shell.Traditional do
     # Create file tab (TabBar.add auto-activates it)
     {tb, new_tab} = TabBar.add(tb, :file, label)
     tb = TabBar.move_tab_to_workspace(tb, new_tab.id, workspace_id)
-    workspace = SessionState.sync_active_window_buffer(workspace)
+    workspace = SessionState.activate_buffer(workspace, workspace.buffers)
 
     # Snapshot the new tab's context
     new_context = SessionState.to_tab_context(workspace)
@@ -772,29 +771,6 @@ defmodule MingaEditor.Shell.Traditional do
       |> TabBar.update_context(new_tab.id, new_context)
 
     {%{shell_state | tab_bar: tb}, workspace, []}
-  end
-
-  # Resets the active window's content type from agent_chat back to buffer.
-  @spec reset_active_window_to_buffer(SessionState.t()) :: SessionState.t()
-  defp reset_active_window_to_buffer(workspace) do
-    %{windows: windows, buffers: buffers} = workspace
-    id = windows.active
-
-    case Windows.fetch(windows, id) do
-      {:ok, %Window{content: {:buffer, _}}} ->
-        workspace
-
-      {:ok, %Window{}} ->
-        windows =
-          Windows.update(windows, id, fn window ->
-            %{window | buffer: buffers.active, content: Content.buffer(buffers.active)}
-          end)
-
-        SessionState.set_windows(workspace, windows)
-
-      :error ->
-        workspace
-    end
   end
 
   @spec sync_file_tab_ref(TabBar.t(), Tab.id(), pid() | nil, SessionState.t()) :: TabBar.t()

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -58,7 +58,6 @@ defmodule MingaEditor.State do
   alias MingaEditor.Viewport
   alias MingaEditor.VimState
   alias MingaEditor.Window
-  alias MingaEditor.Window.Content
   alias MingaEditor.WindowTree
   alias MingaEditor.Frontend.Capabilities
   alias Minga.Log
@@ -1647,17 +1646,6 @@ defmodule MingaEditor.State do
 
   # ── Cross-cutting window + buffer helpers ─────────────────────────────────
 
-  @doc """
-  Syncs the active window's buffer reference with `state.workspace.buffers.active`.
-
-  Call this after any operation that changes `state.workspace.buffers.active` to keep the
-  window tree consistent. No-op when windows aren't initialized.
-  """
-  @spec sync_active_window_buffer(t()) :: t()
-  def sync_active_window_buffer(%__MODULE__{} = state) do
-    update_workspace(state, &SessionState.sync_active_window_buffer/1)
-  end
-
   @doc "Returns the set of buffer pids known to the live workspace and tab snapshots."
   @spec known_open_buffer_pids(t()) :: [pid()]
   def known_open_buffer_pids(%__MODULE__{} = state) do
@@ -1863,44 +1851,11 @@ defmodule MingaEditor.State do
   end
 
   @doc """
-  Switches to the buffer at `idx`, making it active for the current window.
-
-  Centralizes `Buffers.switch_to` + window sync so callers don't need to
-  remember to call `sync_active_window_buffer/1`. Shell-specific
-  presentation logic (tab label updates, etc.) is dispatched through
-  `shell.on_buffer_switched/2`.
-  """
-  @spec switch_buffer(t(), non_neg_integer()) :: t()
-  def switch_buffer(%__MODULE__{} = state, idx) do
-    state =
-      state
-      |> update_workspace(&SessionState.switch_buffer(&1, idx))
-      |> MingaEditor.Shell.Workflow.ensure_available()
-
-    case state.buffer_add_context do
-      :preview ->
-        %{state | buffer_add_context: :open}
-
-      :open ->
-        {runtime, workspace, shell_effects} =
-          ShellRuntime.route_buffer_switched(state.shell_runtime, state.workspace)
-
-        state =
-          state
-          |> apply_shell_runtime_transition(runtime)
-          |> set_workspace(workspace)
-
-        apply_buffer_effects(state, shell_effects)
-    end
-  end
-
-  @doc """
   Enters the zero-buffers launchpad (#2689).
 
   Removes all file tabs from the tab bar (agent tabs stay), clears the
   buffer list, and switches the active window to the empty-state surface.
-  The reverse transition happens automatically in
-  `sync_active_window_buffer/1` when any buffer becomes active.
+  `MingaEditor.Session.State.activate_buffer/2` performs the reverse transition when a buffer becomes active.
   """
   @spec enter_empty_state(t()) :: t()
   def enter_empty_state(%__MODULE__{} = state) do
@@ -1924,157 +1879,6 @@ defmodule MingaEditor.State do
   end
 
   defp clear_file_tabs(%__MODULE__{} = state), do: state
-
-  @doc """
-  Re-syncs shell presentation (tab label, file ref, tab context) with the
-  active buffer.
-
-  Use when the active buffer's identity changes in place, e.g. save-as
-  retargeting an untitled buffer to a real file, so the tab bar reflects the
-  new name without a buffer switch.
-  """
-  @spec refresh_active_buffer_presentation(t()) :: t()
-  def refresh_active_buffer_presentation(%__MODULE__{} = state) do
-    state = MingaEditor.Shell.Workflow.ensure_available(state)
-
-    {runtime, workspace, shell_effects} =
-      ShellRuntime.route_buffer_switched(state.shell_runtime, state.workspace)
-
-    state
-    |> apply_shell_runtime_transition(runtime)
-    |> set_workspace(workspace)
-    |> apply_buffer_effects(shell_effects)
-  end
-
-  @doc """
-  Snapshots the active buffer's cursor into the active window struct.
-
-  Call this before rendering split views so inactive windows have a fresh
-  cursor position for the active window when it becomes inactive later.
-  """
-  @spec sync_active_window_cursor(t()) :: t()
-  def sync_active_window_cursor(%__MODULE__{workspace: %{buffers: %{active: nil}}} = state),
-    do: state
-
-  def sync_active_window_cursor(
-        %__MODULE__{
-          workspace:
-            %{windows: %{map: windows, active: id} = ws, buffers: %{active: buf}} = wspace
-        } = state
-      ) do
-    case Map.fetch(windows, id) do
-      {:ok, %{buffer: ^buf} = window} ->
-        cursor = Buffer.cursor(buf)
-
-        %{
-          state
-          | workspace: %{
-              wspace
-              | windows: %{ws | map: Map.put(windows, id, %{window | cursor: cursor})}
-            }
-        }
-
-      {:ok, _window} ->
-        state
-
-      :error ->
-        state
-    end
-  catch
-    :exit, _ -> state
-  end
-
-  @doc """
-  Switches focus to the given window, saving the current cursor to the
-  outgoing window and restoring the target window's stored cursor.
-
-  No-op if `target_id` is already the active window or windows aren't set up.
-  """
-  @spec focus_window(t(), Window.id()) :: t()
-  def focus_window(%__MODULE__{workspace: %{windows: %{active: active}}} = state, target_id)
-      when target_id == active do
-    set_bottom_panel(state, BottomPanel.blur(bottom_panel(state)))
-  end
-
-  def focus_window(
-        %__MODULE__{
-          workspace: %{windows: %{map: windows, active: old_id} = ws, buffers: buffers} = wspace
-        } = state,
-        target_id
-      ) do
-    case {Map.fetch(windows, old_id), Map.fetch(windows, target_id)} do
-      {{:ok, old_win}, {:ok, target_win}} ->
-        windows = Map.put(windows, old_id, save_window_cursor(old_win, buffers.active))
-
-        restore_window_cursor(target_win)
-
-        # Derive keymap_scope from the target window's content type.
-        # Agent chat windows use :agent scope; buffer windows use the
-        # current scope (preserving :file_tree if the tree is focused).
-        scope = scope_for_content(target_win.content, wspace.keymap_scope)
-
-        state = set_bottom_panel(state, BottomPanel.blur(bottom_panel(state)))
-
-        %{
-          state
-          | workspace: %{
-              wspace
-              | windows: %{ws | map: windows, active: target_id},
-                buffers: %{buffers | active: target_win.buffer},
-                keymap_scope: scope,
-                # Focusing another window can swap the active buffer; drop any
-                # standing Cmd/Ctrl-hover link so it never draws against the new
-                # buffer's coordinates before the next motion (#2630).
-                cmd_hover_link: nil,
-                cmd_hover_cell: nil
-            }
-        }
-
-      _ ->
-        state
-    end
-  catch
-    :exit, _ -> state
-  end
-
-  @spec save_window_cursor(Window.t(), pid() | nil) :: Window.t()
-  defp save_window_cursor(%Window{content: {:buffer, _pid}} = window, active_buffer)
-       when is_pid(active_buffer) do
-    %{window | cursor: Buffer.cursor(active_buffer)}
-  end
-
-  defp save_window_cursor(%Window{} = window, _active_buffer), do: window
-
-  @spec restore_window_cursor(Window.t()) :: :ok
-  defp restore_window_cursor(%Window{content: {:buffer, pid}, cursor: cursor}) when is_pid(pid) do
-    Buffer.move_to(pid, cursor)
-    :ok
-  end
-
-  defp restore_window_cursor(%Window{}), do: :ok
-
-  @doc """
-  Derives the keymap scope from a window's content type.
-
-  Agent chat windows always use `:agent` scope. Buffer windows use
-  `:editor` when coming from `:agent` scope, and preserve the current
-  scope otherwise (e.g., `:file_tree` stays as `:file_tree`).
-  """
-  @spec scope_for_content(Content.t(), Minga.Keymap.Scope.scope_name()) ::
-          Minga.Keymap.Scope.scope_name()
-  def scope_for_content(content, current_scope),
-    do: SessionState.scope_for_content(content, current_scope)
-
-  @doc """
-  Returns the appropriate keymap scope for the active window's content type.
-
-  Used when leaving the file tree (toggle, close, navigate right) to restore
-  the correct scope. Returns :agent for agent chat windows, :editor otherwise.
-  """
-  @spec scope_for_active_window(t()) :: atom()
-  def scope_for_active_window(%{workspace: ws}) do
-    SessionState.scope_for_active_window(ws)
-  end
 
   # ── Tab bar helpers ───────────────────────────────────────────────────────
 
@@ -2155,7 +1959,8 @@ defmodule MingaEditor.State do
 
   @spec sync_file_tab_active_window_buffer(t(), Tab.t() | nil) :: t()
   defp sync_file_tab_active_window_buffer(%__MODULE__{} = state, %Tab{kind: :file}) do
-    sync_active_window_buffer(state)
+    workspace = SessionState.activate_buffer(state.workspace, state.workspace.buffers)
+    set_workspace(state, workspace)
   end
 
   defp sync_file_tab_active_window_buffer(%__MODULE__{} = state, _tab), do: state

--- a/lib/minga_editor/ui/picker/buffer_source.ex
+++ b/lib/minga_editor/ui/picker/buffer_source.ex
@@ -91,7 +91,7 @@ defmodule MingaEditor.UI.Picker.BufferSource do
   end
 
   def on_select(%Item{id: idx}, state) when is_integer(idx) do
-    EditorState.switch_buffer(state, idx)
+    MingaEditor.BufferActivation.activate(state, idx)
   end
 
   @impl true
@@ -181,9 +181,7 @@ defmodule MingaEditor.UI.Picker.BufferSource do
   defp apply_kill_result(%Buffers{} = new_bs, pids, _bs, state) do
     Enum.each(pids, &stop_buffer/1)
 
-    state
-    |> EditorState.set_buffers(new_bs)
-    |> EditorState.sync_active_window_buffer()
+    MingaEditor.BufferActivation.activate(state, new_bs, notify_shell?: false)
   end
 
   @spec item_pid(Item.t(), [pid()]) :: pid() | nil

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -162,7 +162,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   @spec switch_existing_buffer_target(term(), non_neg_integer(), term()) :: term()
   defp switch_existing_buffer_target(state, idx, _tab)
        when state.buffer_add_context == :preview do
-    EditorState.switch_buffer(state, idx)
+    MingaEditor.BufferActivation.activate(state, idx)
   end
 
   defp switch_existing_buffer_target(state, _idx, %{id: tab_id}) do
@@ -170,7 +170,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   end
 
   defp switch_existing_buffer_target(state, idx, _tab) do
-    EditorState.switch_buffer(state, idx)
+    MingaEditor.BufferActivation.activate(state, idx)
   end
 
   @impl true

--- a/lib/minga_editor/ui/picker/location_source.ex
+++ b/lib/minga_editor/ui/picker/location_source.ex
@@ -119,7 +119,7 @@ defmodule MingaEditor.UI.Picker.LocationSource do
         end
 
       i ->
-        EditorState.switch_buffer(state, i)
+        MingaEditor.BufferActivation.activate(state, i)
     end
   end
 

--- a/lib/minga_editor/ui/picker/project_search_source.ex
+++ b/lib/minga_editor/ui/picker/project_search_source.ex
@@ -118,7 +118,7 @@ defmodule MingaEditor.UI.Picker.ProjectSearchSource do
 
   @spec jump_to_buffer(map(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: map()
   defp jump_to_buffer(state, buf_idx, line, col) do
-    new_state = EditorState.switch_buffer(state, buf_idx)
+    new_state = MingaEditor.BufferActivation.activate(state, buf_idx)
     pid = Enum.at(state.workspace.buffers.list, buf_idx)
     Buffer.move_to(pid, {line, col})
     new_state

--- a/lib/minga_editor/ui/picker/recent_file_source.ex
+++ b/lib/minga_editor/ui/picker/recent_file_source.ex
@@ -70,7 +70,7 @@ defmodule MingaEditor.UI.Picker.RecentFileSource do
         end
 
       idx ->
-        EditorState.switch_buffer(state, idx)
+        MingaEditor.BufferActivation.activate(state, idx)
     end
   end
 

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -39,7 +39,6 @@ defmodule MingaEditor.UI.Picker.Source do
   """
 
   alias MingaEditor.Frontend.Emit.Context, as: EmitContext
-  alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Picker
   alias MingaEditor.UI.Picker.Context
 
@@ -198,7 +197,7 @@ defmodule MingaEditor.UI.Picker.Source do
   def restore_or_keep(state) do
     case state.shell_runtime.state.modal do
       {:picker, %{picker_ui: %{restore: idx}}} when is_integer(idx) ->
-        EditorState.switch_buffer(state, idx)
+        MingaEditor.BufferActivation.activate(state, idx)
 
       _ ->
         state

--- a/lib/minga_editor/ui/picker/symbol_source.ex
+++ b/lib/minga_editor/ui/picker/symbol_source.ex
@@ -29,7 +29,7 @@ defmodule MingaEditor.UI.Picker.SymbolSource do
   def on_select(%Item{id: {row, col}}, %{workspace: %{buffers: %{active: buffer}}} = state)
       when is_integer(row) and is_integer(col) and is_pid(buffer) do
     Buffer.move_to(buffer, {row, col})
-    EditorState.sync_active_window_cursor(state)
+    MingaEditor.WindowFocus.remember_active_cursor(state)
   end
 
   def on_select(_item, state), do: state

--- a/lib/minga_editor/ui/picker/todo_search_source.ex
+++ b/lib/minga_editor/ui/picker/todo_search_source.ex
@@ -182,7 +182,7 @@ defmodule MingaEditor.UI.Picker.TodoSearchSource do
 
   @spec jump_to_buffer(term(), non_neg_integer(), non_neg_integer(), non_neg_integer()) :: term()
   defp jump_to_buffer(state, buf_idx, line, col) do
-    new_state = EditorState.switch_buffer(state, buf_idx)
+    new_state = MingaEditor.BufferActivation.activate(state, buf_idx)
     pid = Enum.at(state.workspace.buffers.list, buf_idx)
     Buffer.move_to(pid, {line, col})
     new_state

--- a/lib/minga_editor/ui/picker/workspace_symbol_source.ex
+++ b/lib/minga_editor/ui/picker/workspace_symbol_source.ex
@@ -146,7 +146,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceSymbolSource do
         end
 
       i ->
-        EditorState.switch_buffer(state, i)
+        MingaEditor.BufferActivation.activate(state, i)
     end
   end
 

--- a/lib/minga_editor/ui/popup/lifecycle.ex
+++ b/lib/minga_editor/ui/popup/lifecycle.ex
@@ -241,7 +241,7 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   defp update_popup_windows(state, windows, next_id, true) do
     state
     |> EditorState.set_windows(windows)
-    |> EditorState.focus_window(next_id)
+    |> MingaEditor.WindowFocus.focus(next_id)
   end
 
   defp update_popup_windows(state, windows, _next_id, false) do
@@ -250,32 +250,45 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
 
   @spec do_close(state(), Window.id(), PopupActive.t()) :: state()
   defp do_close(state, window_id, %PopupActive{} = meta) do
-    ws = state.workspace.windows
+    focused? = state.workspace.windows.active == window_id
+    state = maybe_restore_popup_focus(state, window_id, meta, focused?)
+    finish_popup_close(state, window_id, meta, focused?)
+  end
 
-    # If the popup is focused, switch focus to the previously active window
-    state =
-      if ws.active == window_id do
-        # Restore focus to the previous active window, or find any non-popup window
-        restore_id =
-          case Windows.fetch(ws, meta.previous_active) do
-            {:ok, _window} -> meta.previous_active
-            :error -> find_non_popup_window(ws, window_id)
-          end
+  @spec maybe_restore_popup_focus(state(), Window.id(), PopupActive.t(), boolean()) :: state()
+  defp maybe_restore_popup_focus(state, window_id, meta, true) do
+    windows = state.workspace.windows
 
-        EditorState.focus_window(state, restore_id)
-      else
-        state
+    restore_id =
+      case Windows.fetch(windows, meta.previous_active) do
+        {:ok, _window} -> meta.previous_active
+        :error -> find_non_popup_window(windows, window_id)
       end
 
-    ws = state.workspace.windows
+    MingaEditor.WindowFocus.restore_focus(state, restore_id)
+  end
 
+  defp maybe_restore_popup_focus(state, _window_id, _meta, false), do: state
+
+  @spec finish_popup_close(state(), Window.id(), PopupActive.t(), boolean()) :: state()
+  defp finish_popup_close(
+         %{workspace: %{windows: %{active: active}}} = state,
+         window_id,
+         _meta,
+         true
+       )
+       when active == window_id,
+       do: state
+
+  defp finish_popup_close(state, window_id, meta, _focused?) do
     # Remove just this popup's window from the current tree (like
     # delete-window in Emacs). We used to restore a full tree snapshot,
     # but that clobbers any other popups that were opened after this one.
-    new_windows = remove_popup_window(ws, window_id, meta)
-    state = EditorState.set_windows(state, new_windows)
+    new_windows = remove_popup_window(state.workspace.windows, window_id, meta)
 
-    Layout.invalidate(state)
+    state
+    |> EditorState.set_windows(new_windows)
+    |> Layout.invalidate()
   end
 
   @spec split_direction(Rule.side()) :: WindowTree.direction()

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -152,6 +152,12 @@ defmodule MingaEditor.Window do
     }
   end
 
+  @doc "Remembers the buffer cursor last observed while this window was active."
+  @spec remember_cursor(t(), Buffer.position()) :: t()
+  def remember_cursor(%__MODULE__{} = window, {line, col} = cursor)
+      when is_integer(line) and line >= 0 and is_integer(col) and col >= 0,
+      do: %{window | cursor: cursor}
+
   @doc "Updates the viewport dimensions for this window, marking all lines dirty."
   @spec resize(t(), non_neg_integer(), non_neg_integer()) :: t()
   def resize(%__MODULE__{} = window, rows, cols)

--- a/lib/minga_editor/window_focus.ex
+++ b/lib/minga_editor/window_focus.ex
@@ -1,0 +1,111 @@
+defmodule MingaEditor.WindowFocus do
+  @moduledoc "Focused workflow for window focus, buffer cursor calls, and shell focus presentation."
+
+  alias Minga.Buffer
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Windows
+  alias MingaEditor.BottomPanel
+  alias MingaEditor.Window
+
+  @type state :: EditorState.t()
+
+  @doc "Focuses a window after saving and restoring its buffer cursor state."
+  @spec focus(state(), Window.id()) :: state()
+  def focus(%EditorState{workspace: %{windows: %{active: active}}} = state, target_id)
+      when target_id == active,
+      do: blur_bottom_panel(state)
+
+  def focus(%EditorState{} = state, target_id) do
+    windows = state.workspace.windows
+
+    with {:ok, old_window} <- Windows.fetch(windows, windows.active),
+         {:ok, target_window} <- Windows.fetch(windows, target_id),
+         {:ok, outgoing_cursor} <- outgoing_cursor(old_window, state.workspace.buffers.active),
+         :ok <- restore_target_cursor(target_window) do
+      workspace = SessionState.focus_window(state.workspace, target_id, outgoing_cursor)
+
+      state
+      |> EditorState.set_workspace(workspace)
+      |> blur_bottom_panel()
+    else
+      :error -> state
+    end
+  catch
+    :exit, _reason -> state
+  end
+
+  @doc "Restores focus without reading the outgoing window's buffer, for popup dismissal."
+  @spec restore_focus(state(), Window.id()) :: state()
+  def restore_focus(%EditorState{} = state, target_id) do
+    with {:ok, target_window} <- Windows.fetch(state.workspace.windows, target_id),
+         :ok <- restore_target_cursor(target_window) do
+      workspace = SessionState.focus_window(state.workspace, target_id, nil)
+
+      state
+      |> EditorState.set_workspace(workspace)
+      |> blur_bottom_panel()
+    else
+      :error -> state
+    end
+  catch
+    :exit, _reason -> state
+  end
+
+  @doc "Focuses a surviving window after the active split was removed."
+  @spec focus_surviving_window(state(), Windows.t(), Window.id()) :: state()
+  def focus_surviving_window(%EditorState{} = state, %Windows{} = windows, target_id) do
+    with {:ok, target_window} <- Windows.fetch(windows, target_id),
+         :ok <- restore_target_cursor(target_window) do
+      workspace = SessionState.focus_surviving_window(state.workspace, windows, target_id)
+
+      state
+      |> EditorState.set_workspace(workspace)
+      |> blur_bottom_panel()
+    else
+      :error -> state
+    end
+  catch
+    :exit, _reason -> state
+  end
+
+  @doc "Snapshots the active buffer cursor into its matching window."
+  @spec remember_active_cursor(state()) :: state()
+  def remember_active_cursor(%EditorState{workspace: %{buffers: %{active: buffer}}} = state)
+      when is_pid(buffer) do
+    cursor = Buffer.cursor(buffer)
+    workspace = SessionState.remember_active_window_cursor(state.workspace, cursor)
+    EditorState.set_workspace(state, workspace)
+  catch
+    :exit, _reason -> state
+  end
+
+  def remember_active_cursor(%EditorState{} = state), do: state
+
+  @spec outgoing_cursor(Window.t(), pid() | nil) :: {:ok, SessionState.position() | nil}
+  defp outgoing_cursor(%Window{content: {:buffer, _}}, active_buffer) when is_pid(active_buffer),
+    do: {:ok, Buffer.cursor(active_buffer)}
+
+  defp outgoing_cursor(%Window{}, _active_buffer), do: {:ok, nil}
+
+  @spec restore_target_cursor(Window.t()) :: :ok
+  defp restore_target_cursor(%Window{content: {:buffer, buffer}, cursor: cursor})
+       when is_pid(buffer) do
+    Buffer.move_to(buffer, cursor)
+  end
+
+  defp restore_target_cursor(%Window{}), do: :ok
+
+  @spec blur_bottom_panel(state()) :: state()
+  defp blur_bottom_panel(%EditorState{} = state) do
+    runtime =
+      Runtime.update_traditional_state(state.shell_runtime, fn shell_state ->
+        panel = shell_state |> TraditionalState.bottom_panel() |> BottomPanel.blur()
+        TraditionalState.set_bottom_panel(shell_state, panel)
+      end)
+
+    EditorState.apply_shell_runtime_transition(state, runtime)
+  end
+end

--- a/test/minga/extension/editor_api_test.exs
+++ b/test/minga/extension/editor_api_test.exs
@@ -70,7 +70,7 @@ defmodule MingaEditor.Extension.EditorAPITest do
     state =
       state
       |> put_in([Access.key!(:workspace), Access.key!(:windows)], windows)
-      |> EditorState.focus_window(new_window_id)
+      |> MingaEditor.WindowFocus.focus(new_window_id)
 
     assert EditorAPI.focus_buffer(state, original_buffer).workspace.windows.active ==
              original_window

--- a/test/minga_editor/buffer_activation_test.exs
+++ b/test/minga_editor/buffer_activation_test.exs
@@ -1,0 +1,42 @@
+defmodule MingaEditor.BufferActivationTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.BufferActivation
+  alias MingaEditor.Handlers.EffectHandler
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  test "shell activation effects switch buffers without recursively notifying the shell" do
+    state = base_state(content: "first")
+    first_buffer = state.workspace.buffers.active
+    second_buffer = start_supervised!({BufferProcess, content: "second"})
+    buffers = Buffers.add(state.workspace.buffers, second_buffer)
+
+    state =
+      EditorState.set_workspace(state, SessionState.activate_buffer(state.workspace, buffers))
+
+    activated =
+      EffectHandler.apply_buffer_activation_effects(state, [{:switch_buffer, first_buffer}])
+
+    assert activated.workspace.buffers.active == first_buffer
+  end
+
+  test "negative selections preserve leaf-owned wraparound behavior" do
+    state = base_state(content: "first")
+    first_buffer = state.workspace.buffers.active
+    second_buffer = start_supervised!({BufferProcess, content: "second"})
+    buffers = Buffers.add(state.workspace.buffers, second_buffer)
+
+    state =
+      EditorState.set_workspace(state, SessionState.activate_buffer(state.workspace, buffers))
+
+    activated = BufferActivation.activate(state, -2, notify_shell?: false)
+
+    assert activated.workspace.buffers.active == first_buffer
+    refute activated.workspace.buffers.active == second_buffer
+  end
+end

--- a/test/minga_editor/file_tree/rows_test.exs
+++ b/test/minga_editor/file_tree/rows_test.exs
@@ -270,7 +270,7 @@ defmodule MingaEditor.FileTree.RowsTest do
 
       assert active_row_name(state) == "alpha.ex"
 
-      switched_state = EditorState.switch_buffer(state, 1)
+      switched_state = MingaEditor.BufferActivation.activate(state, 1)
 
       assert active_row_name(switched_state) == "beta.ex"
     end

--- a/test/minga_editor/input/popup_test.exs
+++ b/test/minga_editor/input/popup_test.exs
@@ -63,7 +63,7 @@ defmodule MingaEditor.Input.PopupTest do
     }
 
     if focus_popup do
-      EditorState.focus_window(state, 2)
+      MingaEditor.WindowFocus.focus(state, 2)
     else
       state
     end

--- a/test/minga_editor/layout_preset_test.exs
+++ b/test/minga_editor/layout_preset_test.exs
@@ -93,6 +93,24 @@ defmodule MingaEditor.LayoutPresetTest do
   end
 
   describe "restore_default/1" do
+    test "keeps the agent pane when its focus restore target has died" do
+      state = make_state()
+      file_buffer = state.workspace.buffers.active
+
+      state =
+        state
+        |> LayoutPreset.apply(:agent_right, nil)
+        |> MingaEditor.WindowFocus.focus(2)
+
+      monitor = Process.monitor(file_buffer)
+      GenServer.stop(file_buffer, :normal)
+      assert_receive {:DOWN, ^monitor, :process, ^file_buffer, :normal}
+
+      assert LayoutPreset.restore_default(state) == state
+      assert state.workspace.windows.active == 2
+      assert Map.has_key?(state.workspace.windows.map, 2)
+    end
+
     test "switches active window away from agent before removing" do
       state = make_state()
       file_buffer = state.workspace.buffers.active
@@ -100,7 +118,7 @@ defmodule MingaEditor.LayoutPresetTest do
       state =
         state
         |> LayoutPreset.apply(:agent_right, nil)
-        |> EditorState.focus_window(2)
+        |> MingaEditor.WindowFocus.focus(2)
 
       assert state.workspace.windows.active == 2
       assert state.workspace.buffers.active == nil

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -635,7 +635,7 @@ defmodule MingaEditor.MouseTest do
       other_id =
         Enum.find(Map.keys(state.workspace.windows.map), &(&1 != state.workspace.windows.active))
 
-      state = EditorState.focus_window(state, other_id)
+      state = MingaEditor.WindowFocus.focus(state, other_id)
       assert state.workspace.cmd_hover_link == nil
       assert state.workspace.cmd_hover_cell == nil
     end

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -34,7 +34,7 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
   # exposing the primary window model, any additional models, and the cursor,
   # so these builder tests can assert against the window model directly.
   defp build_content(%EditorState{} = state) do
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = MingaEditor.RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, input} = Scroll.scroll_windows(state, layout)
@@ -139,7 +139,7 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
   end
 
   defp build_window_model(%EditorState{} = state, ctx_overrides) do
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = MingaEditor.RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, input} = Scroll.scroll_windows(state, layout)

--- a/test/minga_editor/render_pipeline/chrome_dirty_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_dirty_test.exs
@@ -278,7 +278,9 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
             list: [first_buf, second_buf],
             active_index: 1
         })
-        |> update_in([Access.key!(:workspace)], &SessionState.sync_active_window_buffer/1)
+        |> update_in([Access.key!(:workspace)], fn workspace ->
+          SessionState.activate_buffer(workspace, workspace.buffers)
+        end)
 
       state2 = TestHelpers.run_pipeline(switched)
       renderer_cache = :sys.get_state(state2.renderer).caches

--- a/test/minga_editor/render_pipeline/chrome_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_test.exs
@@ -10,13 +10,12 @@ defmodule MingaEditor.RenderPipeline.ChromeTest do
   alias MingaEditor.RenderPipeline.Chrome
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Scroll
-  alias MingaEditor.State, as: EditorState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
   # Helper to run through scroll and content
   defp run_through_content(state) do
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, state} = Scroll.scroll_windows(state, layout)

--- a/test/minga_editor/render_pipeline/compose_test.exs
+++ b/test/minga_editor/render_pipeline/compose_test.exs
@@ -12,13 +12,12 @@ defmodule MingaEditor.RenderPipeline.ComposeTest do
   alias MingaEditor.RenderPipeline.Compose
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Scroll
-  alias MingaEditor.State, as: EditorState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
   # Helper to run through scroll, content, and chrome
   defp run_through_chrome(state) do
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, state} = Scroll.scroll_windows(state, layout)

--- a/test/minga_editor/render_pipeline/content_test.exs
+++ b/test/minga_editor/render_pipeline/content_test.exs
@@ -23,13 +23,12 @@ defmodule MingaEditor.RenderPipeline.ContentTest do
   alias MingaEditor.Renderer.State, as: RendererState
   alias MingaEditor.Viewport
   alias MingaEditor.Window
-  alias MingaEditor.State, as: EditorState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
   # Helper to run through scroll and get {scrolls, state}
   defp run_through_scroll(state) do
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, state} = Scroll.scroll_windows(state, layout)

--- a/test/minga_editor/render_pipeline/resident_incremental_test.exs
+++ b/test/minga_editor/render_pipeline/resident_incremental_test.exs
@@ -29,7 +29,7 @@ defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
   end
 
   defp build_frame(%{editor: editor, renderer: renderer}) do
-    editor = EditorState.sync_active_window_cursor(editor)
+    editor = MingaEditor.WindowFocus.remember_active_cursor(editor)
     intent = Intent.from_editor_state(editor)
     {renderer, input} = BufferChanges.prepare(renderer, intent)
     input = Content.reset_rows_rasterized(input)
@@ -150,7 +150,7 @@ defmodule MingaEditor.RenderPipeline.ResidentIncrementalTest do
       BufferProcess.move_to(buffer, {32, 0})
       BufferProcess.insert_text(buffer, "A")
 
-      editor = EditorState.sync_active_window_cursor(state.editor)
+      editor = MingaEditor.WindowFocus.remember_active_cursor(state.editor)
       intent = Intent.from_editor_state(editor)
       {renderer, stale_input} = BufferChanges.prepare(state.renderer, intent)
 

--- a/test/minga_editor/render_pipeline/scroll_test.exs
+++ b/test/minga_editor/render_pipeline/scroll_test.exs
@@ -22,7 +22,7 @@ defmodule MingaEditor.RenderPipeline.ScrollTest do
 
   # Helper to run through layout and scroll
   defp run_through_scroll(%EditorState{} = state) do
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, input} = Scroll.scroll_windows(state, layout)

--- a/test/minga_editor/render_pipeline/viewport_row_accounting_test.exs
+++ b/test/minga_editor/render_pipeline/viewport_row_accounting_test.exs
@@ -18,13 +18,12 @@ defmodule MingaEditor.RenderPipeline.ViewportRowAccountingTest do
   alias MingaEditor.RenderPipeline
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Scroll
-  alias MingaEditor.State, as: EditorState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
   # Runs scroll + content and returns the flattened window models keyed by id.
   defp emitted_models(state) do
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, state} = Scroll.scroll_windows(state, layout)

--- a/test/minga_editor/session/state_test.exs
+++ b/test/minga_editor/session/state_test.exs
@@ -12,14 +12,16 @@ defmodule MingaEditor.Session.StateTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Language.Symbol
   alias MingaEditor.VimState
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.Tab.Context
+  alias MingaEditor.State.Windows
   alias MingaEditor.Window
   alias MingaEditor.Window.Content
   alias MingaEditor.Session.State, as: SessionState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
-  describe "sync_active_window_buffer/1" do
+  describe "activate_buffer/2" do
     test "syncs buffer content when window shows a buffer" do
       state = base_state()
       ws = state.workspace
@@ -37,7 +39,7 @@ defmodule MingaEditor.Session.StateTest do
       assert window.content == {:buffer, original_buf}
 
       # sync should update the window to point at the new buffer
-      ws = SessionState.sync_active_window_buffer(ws)
+      ws = SessionState.activate_buffer(ws, ws.buffers)
 
       updated_window = Map.get(ws.windows.map, win_id)
       assert updated_window.buffer == new_buf
@@ -58,7 +60,7 @@ defmodule MingaEditor.Session.StateTest do
       ws = %{ws | buffers: %{ws.buffers | active: new_buf}}
 
       # sync should NOT touch the agent_chat window
-      ws = SessionState.sync_active_window_buffer(ws)
+      ws = SessionState.activate_buffer(ws, ws.buffers)
 
       result_window = Map.get(ws.windows.map, win_id)
       assert result_window.content == {:agent_chat, :semantic}
@@ -86,10 +88,88 @@ defmodule MingaEditor.Session.StateTest do
           }
         end)
 
-      synced = SessionState.sync_active_window_buffer(workspace)
+      synced = SessionState.activate_buffer(workspace, workspace.buffers)
       window = Map.fetch!(synced.windows.map, win_id)
 
       assert window.document_symbols == []
+    end
+
+    test "preserves window observations when the requested buffer is already active" do
+      state = base_state(content: "defmodule Same do\nend\n")
+      window_id = state.workspace.windows.active
+      symbols = [%Symbol{kind: :module, name: "Same", range: {0, 0, 1, 3}}]
+
+      workspace =
+        SessionState.update_window(
+          state.workspace,
+          window_id,
+          &Window.set_document_symbols(&1, symbols)
+        )
+
+      activated = SessionState.activate_buffer(workspace, workspace.buffers)
+      assert Map.fetch!(activated.windows.map, window_id).document_symbols == symbols
+    end
+
+    test "leaves the launchpad with editor scope and clears stale hover observations" do
+      workspace = SessionState.enter_empty_state(base_state().workspace)
+      {:ok, buffer} = BufferProcess.start_link(content: "opened")
+      buffers = Buffers.add(workspace.buffers, buffer)
+
+      workspace =
+        workspace
+        |> SessionState.set_keymap_scope(:agent)
+        |> SessionState.set_cmd_hover_link({{0, 0}, {0, 4}})
+        |> SessionState.set_cmd_hover_cell({3, 8})
+
+      activated = SessionState.activate_buffer(workspace, buffers)
+      window = Map.fetch!(activated.windows.map, activated.windows.active)
+
+      assert activated.buffers.active == buffer
+      assert activated.keymap_scope == :editor
+      assert activated.launchpad == nil
+      assert activated.cmd_hover_link == nil
+      assert activated.cmd_hover_cell == nil
+      assert window.content == {:buffer, buffer}
+    end
+  end
+
+  describe "focus_window/3" do
+    test "atomically focuses split buffer and agent windows from process observations" do
+      workspace = base_state().workspace
+      first_buffer = workspace.buffers.active
+      {:ok, second_buffer} = BufferProcess.start_link(content: "second")
+      buffers = workspace.buffers |> Buffers.add(second_buffer) |> Buffers.switch_to(0)
+
+      windows =
+        workspace.windows
+        |> Windows.add_window(Window.new(2, second_buffer, 24, 80, {1, 2}))
+        |> Windows.add_window(Window.new_agent_chat(3, 24, 80))
+
+      workspace =
+        workspace
+        |> SessionState.activate_buffer(buffers)
+        |> SessionState.set_windows(windows)
+        |> SessionState.set_keymap_scope(:file_tree)
+        |> SessionState.set_cmd_hover_link({{0, 0}, {0, 4}})
+        |> SessionState.set_cmd_hover_cell({3, 8})
+
+      focused = SessionState.focus_window(workspace, 2, {2, 3})
+
+      assert focused.windows.active == 2
+      assert Map.fetch!(focused.windows.map, 1).cursor == {2, 3}
+      assert focused.buffers.active == second_buffer
+      assert focused.buffers.active_index == 1
+      assert focused.keymap_scope == :file_tree
+      assert focused.cmd_hover_link == nil
+      assert focused.cmd_hover_cell == nil
+      assert focused.launchpad == nil
+
+      agent_focused = SessionState.focus_window(focused, 3, {1, 2})
+      assert agent_focused.windows.active == 3
+      assert agent_focused.buffers.active == nil
+      assert agent_focused.keymap_scope == :agent
+      assert SessionState.focus_window(agent_focused, 99, nil) == agent_focused
+      assert first_buffer in agent_focused.buffers.list
     end
   end
 

--- a/test/minga_editor/shell/traditional/chrome/gui_test.exs
+++ b/test/minga_editor/shell/traditional/chrome/gui_test.exs
@@ -7,12 +7,11 @@ defmodule MingaEditor.Shell.Traditional.Chrome.GUITest do
   alias MingaEditor.Shell.Traditional.Chrome.GUI, as: ChromeGUI
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Scroll
-  alias MingaEditor.State, as: EditorState
 
   import MingaEditor.RenderPipeline.TestHelpers
 
   defp run_through_content(state) do
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, state} = Scroll.scroll_windows(state, layout)

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -216,14 +216,14 @@ defmodule MingaEditor.State.BufferLifecycleTest do
     end
   end
 
-  describe "switch_buffer/2" do
+  describe "BufferActivation.activate/2" do
     test "open switches refresh active file tab context, while preview switches keep the original context" do
       state = state_with_file_tab()
       original_buf = state.workspace.buffers.active
       other_buf = start_buffer("other")
       state = with_buffer_pool(state, [original_buf, other_buf])
 
-      opened = EditorState.switch_buffer(state, 1)
+      opened = MingaEditor.BufferActivation.activate(state, 1)
       assert opened.workspace.buffers.active == other_buf
 
       assert %Buffers{active: ^other_buf} =
@@ -236,7 +236,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
         |> with_buffer_pool([original_buf, preview_buf])
         |> EditorState.set_buffer_add_context(:preview)
 
-      previewed = EditorState.switch_buffer(preview_state, 1)
+      previewed = MingaEditor.BufferActivation.activate(preview_state, 1)
       assert previewed.workspace.buffers.active == preview_buf
       assert previewed.buffer_add_context == :open
 

--- a/test/minga_editor/state/shell_callbacks_test.exs
+++ b/test/minga_editor/state/shell_callbacks_test.exs
@@ -104,15 +104,15 @@ defmodule MingaEditor.State.ShellCallbacksTest do
     state
   end
 
-  # ── on_buffer_switched via switch_buffer/2 ───────────────────────────────────
+  # ── on_buffer_switched via BufferActivation ─────────────────────────────────
 
-  describe "switch_buffer/2 dispatches on_buffer_switched" do
+  describe "BufferActivation.activate/2 dispatches on_buffer_switched" do
     test "Traditional: tab context.buffers.active tracks workspace after switch" do
       state = state_with_file_tab()
       buf2 = start_buffer("second.ex")
       state = EditorState.add_buffer(state, buf2)
 
-      new_state = EditorState.switch_buffer(state, 1)
+      new_state = MingaEditor.BufferActivation.activate(state, 1)
 
       assert new_state.workspace.buffers.active == buf2
 
@@ -133,7 +133,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
           %{buffers | active: buf1, list: [buf1, buf2], active_index: 0}
         end)
 
-      new_state = EditorState.switch_buffer(state, 1)
+      new_state = MingaEditor.BufferActivation.activate(state, 1)
 
       assert new_state.workspace.buffers.active == buf2
 
@@ -148,7 +148,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
       buf2 = start_buffer("second.ex")
       state = EditorState.add_buffer(state, buf2)
 
-      new_state = EditorState.switch_buffer(state, 1)
+      new_state = MingaEditor.BufferActivation.activate(state, 1)
 
       tab = EditorState.find_tab_by_buffer(new_state, buf2)
       assert %Tab{kind: :file} = tab
@@ -165,7 +165,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
       assert BufferProcess.dirty?(buf1)
       refute BufferProcess.dirty?(buf2)
 
-      new_state = EditorState.switch_buffer(state, 1)
+      new_state = MingaEditor.BufferActivation.activate(state, 1)
 
       active_tab = TabBar.active(EditorState.tab_bar(new_state))
       tab_buf = active_tab.context.buffers.active
@@ -180,13 +180,13 @@ defmodule MingaEditor.State.ShellCallbacksTest do
       state = EditorState.add_buffer(state, buf2)
       state = EditorState.add_buffer(state, buf3)
 
-      state = EditorState.switch_buffer(state, 1)
+      state = MingaEditor.BufferActivation.activate(state, 1)
       assert TabBar.active(EditorState.tab_bar(state)).context.buffers.active == buf2
 
-      state = EditorState.switch_buffer(state, 2)
+      state = MingaEditor.BufferActivation.activate(state, 2)
       assert TabBar.active(EditorState.tab_bar(state)).context.buffers.active == buf3
 
-      state = EditorState.switch_buffer(state, 0)
+      state = MingaEditor.BufferActivation.activate(state, 0)
       buf1 = state.workspace.buffers.active
       assert TabBar.active(EditorState.tab_bar(state)).context.buffers.active == buf1
 
@@ -199,7 +199,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
       state = EditorState.add_buffer(state, buf2)
 
       # Switch back to first buffer
-      new_state = EditorState.switch_buffer(state, 0)
+      new_state = MingaEditor.BufferActivation.activate(state, 0)
 
       # The active buffer changed without error
       refute new_state.workspace.buffers.active == buf2
@@ -218,7 +218,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
       assert Content.agent_chat?(window.content)
 
       # Switch to the only file buffer. The agent window content stays semantic.
-      new_state = EditorState.switch_buffer(state, 0)
+      new_state = MingaEditor.BufferActivation.activate(state, 0)
       assert new_state.workspace.buffers.active == file_buf
 
       # Window content should still be agent_chat

--- a/test/minga_editor/state_test.exs
+++ b/test/minga_editor/state_test.exs
@@ -58,7 +58,7 @@ defmodule MingaEditor.StateTest do
   end
 
   describe "buffer and window selection" do
-    test "add_buffer and switch_buffer sync the active window while preserving inactive split windows" do
+    test "buffer activation synchronizes the active window while preserving inactive split windows" do
       {state, buf1} = state_with_buffer()
       buf2 = start_buffer("world")
 
@@ -68,13 +68,13 @@ defmodule MingaEditor.StateTest do
       assert added.workspace.buffers.list == [buf1, buf2]
       assert active_window(added).buffer == buf2
 
-      switched = EditorState.switch_buffer(added, 0)
+      switched = MingaEditor.BufferActivation.activate(added, 0)
       assert switched.workspace.buffers.active == buf1
       assert switched.workspace.buffers.active_index == 0
       assert active_window(switched).buffer == buf1
 
       split_state = added |> with_split_window(2, buf2)
-      split_switched = EditorState.switch_buffer(split_state, 0)
+      split_switched = MingaEditor.BufferActivation.activate(split_state, 0)
       assert Map.fetch!(split_switched.workspace.windows.map, 1).buffer == buf1
       assert Map.fetch!(split_switched.workspace.windows.map, 2).buffer == buf2
 
@@ -89,32 +89,32 @@ defmodule MingaEditor.StateTest do
       assert is_pid(no_window.workspace.buffers.active)
     end
 
-    test "focus_window and sync_active_window_cursor snapshot and restore buffer cursors" do
+    test "window focus snapshots and restores buffer cursors" do
       {state, buf} = state_with_buffer("hello\nworld\nfoo")
       BufferProcess.move_to(buf, {2, 0})
 
       state = state |> with_split_window(2, buf, second_cursor: {0, 0})
-      state = EditorState.sync_active_window_cursor(state)
+      state = MingaEditor.WindowFocus.remember_active_cursor(state)
       assert Map.fetch!(state.workspace.windows.map, 1).cursor == {2, 0}
 
       BufferProcess.move_to(buf, {1, 3})
-      focused = EditorState.focus_window(state, 2)
+      focused = MingaEditor.WindowFocus.focus(state, 2)
       assert focused.workspace.windows.active == 2
       assert BufferProcess.cursor(buf) == {0, 0}
       assert Map.fetch!(focused.workspace.windows.map, 1).cursor == {1, 3}
 
-      assert EditorState.focus_window(focused, 2) == focused
-      assert EditorState.focus_window(new_state(), 2) == new_state()
-      assert EditorState.sync_active_window_cursor(new_state()) == new_state()
+      assert MingaEditor.WindowFocus.focus(focused, 2) == focused
+      assert MingaEditor.WindowFocus.focus(new_state(), 2) == new_state()
+      assert MingaEditor.WindowFocus.remember_active_cursor(new_state()) == new_state()
     end
 
-    test "sync_active_window_cursor does not write active buffer cursor into another buffer window" do
+    test "cursor snapshot does not write an active buffer cursor into another buffer window" do
       {state, files_buf} = state_with_buffer("files")
       file_buf = start_buffer("typed text")
       BufferProcess.move_to(file_buf, {0, 5})
 
       state = put_in(state.workspace.buffers, Buffers.add(state.workspace.buffers, file_buf))
-      synced = EditorState.sync_active_window_cursor(state)
+      synced = MingaEditor.WindowFocus.remember_active_cursor(state)
 
       assert active_window(synced).buffer == files_buf
       assert active_window(synced).cursor == active_window(state).cursor
@@ -145,17 +145,26 @@ defmodule MingaEditor.StateTest do
   end
 
   describe "window content synchronization" do
-    test "screen rect and buffer sync update buffer windows without rewriting agent chat content" do
+    test "screen rect and buffer activation update buffer windows without rewriting agent chat content" do
       {state, buf1} = state_with_buffer("hello")
       assert EditorState.screen_rect(state) == {0, 0, 80, 23}
 
-      unchanged = EditorState.sync_active_window_buffer(state)
+      unchanged =
+        MingaEditor.BufferActivation.activate(state, state.workspace.buffers,
+          notify_shell?: false
+        )
+
       assert active_window(unchanged).buffer == buf1
       assert active_window(unchanged).content == active_window(state).content
 
       buf2 = start_buffer("world")
       state = put_in(state.workspace.buffers, Buffers.add(state.workspace.buffers, buf2))
-      synced = EditorState.sync_active_window_buffer(state)
+
+      synced =
+        MingaEditor.BufferActivation.activate(state, state.workspace.buffers,
+          notify_shell?: false
+        )
+
       assert active_window(synced).buffer == buf2
       assert Content.buffer?(active_window(synced).content)
       assert Content.buffer_pid(active_window(synced).content) == buf2
@@ -169,7 +178,11 @@ defmodule MingaEditor.StateTest do
           Buffers.add(agent_state.workspace.buffers, file_buf)
         )
 
-      synced_agent = EditorState.sync_active_window_buffer(agent_state)
+      synced_agent =
+        MingaEditor.BufferActivation.activate(agent_state, agent_state.workspace.buffers,
+          notify_shell?: false
+        )
+
       assert active_window(synced_agent).buffer == nil
       assert Content.agent_chat?(active_window(synced_agent).content)
     end

--- a/test/minga_editor/ui/picker/symbol_source_test.exs
+++ b/test/minga_editor/ui/picker/symbol_source_test.exs
@@ -38,7 +38,7 @@ defmodule MingaEditor.UI.Picker.SymbolSourceTest do
 
       new_state = SymbolSource.on_select(%Item{id: {2, 1}, label: "ƒ run"}, state)
 
-      assert new_state == EditorState.sync_active_window_cursor(state)
+      assert new_state == MingaEditor.WindowFocus.remember_active_cursor(state)
       assert Buffer.cursor(state.workspace.buffers.active) == {2, 1}
     end
   end

--- a/test/minga_editor/ui/picker/todo_search_source_test.exs
+++ b/test/minga_editor/ui/picker/todo_search_source_test.exs
@@ -56,7 +56,7 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
       state = base_state(content: "scratch")
       path_buffer = start_supervised!({BufferProcess, file_path: path})
       state = EditorState.add_buffer(state, path_buffer)
-      state = EditorState.switch_buffer(state, 0)
+      state = MingaEditor.BufferActivation.activate(state, 0)
 
       item = %Item{id: %{path: path, line: 3}, label: "todo"}
       new_state = TodoSearchSource.on_select(item, state)

--- a/test/minga_editor/ui/popup/lifecycle_test.exs
+++ b/test/minga_editor/ui/popup/lifecycle_test.exs
@@ -179,6 +179,62 @@ defmodule MingaEditor.UI.Popup.LifecycleTest do
       assert restored.workspace.buffers.active == state.workspace.buffers.active
     end
 
+    test "focused popup restores launchpad state and scope", %{
+      state: state,
+      popup_buf: popup_buf,
+      table: table
+    } do
+      workspace = MingaEditor.Session.State.enter_empty_state(state.workspace)
+      state = EditorState.set_workspace(state, workspace)
+      PopupRegistry.register(Rule.new("*Warnings*", focus: true), table)
+
+      {:ok, with_popup} = Lifecycle.open_popup(state, "*Warnings*", popup_buf, registry: table)
+      assert with_popup.workspace.launchpad != nil
+
+      restored = Lifecycle.close_popup(with_popup, 2)
+
+      assert restored.workspace.windows.active == 1
+      assert restored.workspace.buffers.active == nil
+      assert restored.workspace.keymap_scope == :editor
+      assert restored.workspace.launchpad == workspace.launchpad
+      assert Map.fetch!(restored.workspace.windows.map, 1).content == {:empty, :semantic}
+    end
+
+    test "focused popup closes even when its outgoing buffer process has died", %{
+      state: state,
+      popup_buf: popup_buf,
+      table: table
+    } do
+      PopupRegistry.register(Rule.new("*Warnings*", focus: true), table)
+      {:ok, with_popup} = Lifecycle.open_popup(state, "*Warnings*", popup_buf, registry: table)
+      monitor = Process.monitor(popup_buf)
+      Process.exit(popup_buf, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^popup_buf, :killed}
+
+      restored = Lifecycle.close_popup(with_popup, 2)
+
+      assert restored.workspace.windows.active == 1
+      refute Map.has_key?(restored.workspace.windows.map, 2)
+    end
+
+    test "focused popup stays open when its restore target process has died", %{
+      state: state,
+      main_buf: main_buf,
+      popup_buf: popup_buf,
+      table: table
+    } do
+      PopupRegistry.register(Rule.new("*Warnings*", focus: true), table)
+      {:ok, with_popup} = Lifecycle.open_popup(state, "*Warnings*", popup_buf, registry: table)
+      monitor = Process.monitor(main_buf)
+      Process.exit(main_buf, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^main_buf, :killed}
+
+      unchanged = Lifecycle.close_popup(with_popup, 2)
+
+      assert unchanged.workspace.windows.active == 2
+      assert Map.has_key?(unchanged.workspace.windows.map, 2)
+    end
+
     test "falls back to a remaining editor window when previous_active is gone", %{
       state: state,
       popup_buf: popup_buf

--- a/test/minga_editor/window_focus_test.exs
+++ b/test/minga_editor/window_focus_test.exs
@@ -1,0 +1,122 @@
+defmodule MingaEditor.WindowFocusTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.BottomPanel
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Windows
+  alias MingaEditor.Window
+  alias MingaEditor.WindowFocus
+  alias MingaEditor.WindowTree
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  test "focus saves the outgoing cursor, restores the target, updates session state, and blurs the panel" do
+    {state, first_buffer, second_buffer} = split_state()
+    :ok = BufferProcess.move_to(first_buffer, {2, 0})
+
+    panel = %BottomPanel{} |> BottomPanel.show() |> BottomPanel.focus()
+    state = EditorState.set_bottom_panel(state, panel)
+
+    focused = WindowFocus.focus(state, 2)
+
+    assert focused.workspace.windows.active == 2
+    assert focused.workspace.buffers.active == second_buffer
+    assert focused.workspace.buffers.active_index == 1
+    assert Map.fetch!(focused.workspace.windows.map, 1).cursor == {2, 0}
+    assert BufferProcess.cursor(second_buffer) == {0, 1}
+    refute BottomPanel.focused?(EditorState.bottom_panel(focused))
+  end
+
+  test "focusing a surviving split commits the same session and presentation invariant" do
+    {state, _first_buffer, second_buffer} = split_state()
+    {:ok, remaining_windows} = Windows.remove_window(state.workspace.windows, 1)
+    panel = %BottomPanel{} |> BottomPanel.show() |> BottomPanel.focus()
+
+    state =
+      state
+      |> EditorState.set_bottom_panel(panel)
+      |> EditorState.set_cmd_hover_link({{0, 0}, {0, 3}})
+      |> EditorState.set_cmd_hover_cell({4, 7})
+
+    focused = WindowFocus.focus_surviving_window(state, remaining_windows, 2)
+
+    assert focused.workspace.windows.active == 2
+    assert focused.workspace.buffers.active == second_buffer
+    assert focused.workspace.buffers.active_index == 1
+    assert focused.workspace.cmd_hover_link == nil
+    assert focused.workspace.cmd_hover_cell == nil
+    assert BufferProcess.cursor(second_buffer) == {0, 1}
+    refute BottomPanel.focused?(EditorState.bottom_panel(focused))
+  end
+
+  test "focusing the active window only blurs Traditional bottom-panel presentation" do
+    state = base_state()
+    panel = %BottomPanel{} |> BottomPanel.show() |> BottomPanel.focus()
+    state = EditorState.set_bottom_panel(state, panel)
+
+    focused = WindowFocus.focus(state, state.workspace.windows.active)
+
+    assert focused.workspace == state.workspace
+    refute BottomPanel.focused?(EditorState.bottom_panel(focused))
+  end
+
+  test "missing windows and dead buffer processes leave focus state unchanged" do
+    {state, _first_buffer, second_buffer} = split_state()
+    assert WindowFocus.focus(state, 99) == state
+
+    monitor = Process.monitor(second_buffer)
+    GenServer.stop(second_buffer, :normal)
+    assert_receive {:DOWN, ^monitor, :process, ^second_buffer, :normal}
+
+    assert WindowFocus.focus(state, 2) == state
+
+    {state, first_buffer, _second_buffer} = split_state()
+    monitor = Process.monitor(first_buffer)
+    GenServer.stop(first_buffer, :normal)
+    assert_receive {:DOWN, ^monitor, :process, ^first_buffer, :normal}
+
+    assert WindowFocus.focus(state, 2) == state
+  end
+
+  test "active cursor snapshots require a matching live buffer window" do
+    {state, first_buffer, _second_buffer} = split_state()
+    :ok = BufferProcess.move_to(first_buffer, {1, 2})
+
+    remembered = WindowFocus.remember_active_cursor(state)
+    assert Map.fetch!(remembered.workspace.windows.map, 1).cursor == {1, 2}
+
+    mismatched =
+      EditorState.set_workspace(
+        state,
+        SessionState.set_buffers(state.workspace, Buffers.switch_to(state.workspace.buffers, 1))
+      )
+
+    assert WindowFocus.remember_active_cursor(mismatched) == mismatched
+  end
+
+  defp split_state do
+    state = base_state(content: "first\nline\nend")
+    first_buffer = state.workspace.buffers.active
+    second_buffer = start_supervised!({BufferProcess, content: "second line"})
+    :ok = BufferProcess.move_to(second_buffer, {0, 1})
+
+    buffers = state.workspace.buffers |> Buffers.add(second_buffer) |> Buffers.switch_to(0)
+
+    {:ok, tree} = WindowTree.split(state.workspace.windows.tree, 1, :vertical, 2)
+
+    windows =
+      state.workspace.windows
+      |> Windows.add_window(Window.new(2, second_buffer, 24, 80, {0, 1}))
+      |> Windows.set_tree(tree)
+
+    workspace =
+      state.workspace
+      |> SessionState.activate_buffer(buffers)
+      |> SessionState.set_windows(windows)
+
+    {EditorState.set_workspace(state, workspace), first_buffer, second_buffer}
+  end
+end

--- a/test/support/render_pipeline_test_helpers.ex
+++ b/test/support/render_pipeline_test_helpers.ex
@@ -135,7 +135,7 @@ defmodule MingaEditor.RenderPipeline.TestHelpers do
   """
   @spec build_frame_with_window(EditorState.t(), keyword()) :: ComposedFrame.t()
   def build_frame_with_window(state, _opts) do
-    state = EditorState.sync_active_window_cursor(state)
+    state = MingaEditor.WindowFocus.remember_active_cursor(state)
     state = MingaEditor.RenderPipeline.compute_layout(state)
     layout = Layout.get(state)
     {scrolls, state} = Scroll.scroll_windows(state, layout)


### PR DESCRIPTION
# TL;DR

Buffer activation and window focus now have one pure session invariant and focused workflows for process and shell work. Every editor, popup, split, picker, and bundled-extension caller uses those workflows, including failure-atomic handling for dead buffer processes.

Closes #2865

## Context

This is the activation and focus ownership slice of #2861. It removes broad root forwarding functions while keeping `MingaEditor` as the single authoritative GenServer.

## Changes

- Add `Session.State.activate_buffer/2,3` to coordinate leaf-owned buffer selection with active-window content, keymap scope, launchpad state, and hover observations.
- Add `MingaEditor.WindowFocus` for cursor process calls, active-window commits, split survivors, popup restoration, and Traditional bottom-panel presentation.
- Add `MingaEditor.BufferActivation` for shell callback and effect coordination, including non-recursive shell-requested buffer switches.
- Migrate editor commands, pickers, mouse paths, popup lifecycle, layout presets, Tutor, benchmarks, and the bundled Git Porcelain extension away from removed root APIs.
- Preserve failure atomicity when popup, split, or agent-pane focus targets die, and preserve launchpad and same-buffer render observations across transient focus changes.
- Document the aggregate/workflow ownership boundary in ADR-0002.

## Verification

- Focused aggregate, activation, focus, popup, layout, Tutor, shell, and lifecycle suites passed.
- `make lint` passed format, Credo, compile, and incremental Dialyzer.
- `mix test.llm` passed 9,295 tests, 97 properties, and 58 doctests with zero failures.
- Repo-wide search excluding build artifacts found no callers of the removed activation/focus APIs.
- Final broad bug hunt and final acceptance review returned no blockers.

## Acceptance Criteria Addressed

- One intent-named Session aggregate transition owns buffer activation and active-window synchronization ✅
- Focused workflow owns buffer process calls and composes session and shell owners ✅
- Monitoring, logging, rendering, and presentation effects stay outside pure Session transitions ✅
- Active buffer/window, scope, launchpad, hover, and bottom-panel behavior remain coherent ✅
- Switching, split focus, tab restoration, closed buffers, and missing processes remain compatible ✅
- Root forwarding functions and duplicated deep focus updates are removed ✅
- Pure aggregate and focused workflow tests cover normal and failure paths ✅
