### PR TITLE
fix(editor): recover popup focus after dead buffers

### DIFF
--- a/lib/minga_editor/ui/popup/lifecycle.ex
+++ b/lib/minga_editor/ui/popup/lifecycle.ex
@@ -258,17 +258,59 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   @spec maybe_restore_popup_focus(state(), Window.id(), PopupActive.t(), boolean()) :: state()
   defp maybe_restore_popup_focus(state, window_id, meta, true) do
     windows = state.workspace.windows
+    candidates = restore_candidates(windows, window_id, meta.previous_active)
 
-    restore_id =
-      case Windows.fetch(windows, meta.previous_active) do
-        {:ok, _window} -> meta.previous_active
-        :error -> find_non_popup_window(windows, window_id)
-      end
-
-    MingaEditor.WindowFocus.restore_focus(state, restore_id)
+    case restore_first_focus(state, candidates) do
+      {:ok, restored} -> restored
+      :error -> repair_popup_focus(state, windows, window_id, meta.previous_active)
+    end
   end
 
   defp maybe_restore_popup_focus(state, _window_id, _meta, false), do: state
+
+  @spec restore_first_focus(state(), [Window.id()]) :: {:ok, state()} | :error
+  defp restore_first_focus(state, candidates) do
+    Enum.reduce_while(candidates, :error, fn candidate_id, :error ->
+      case MingaEditor.WindowFocus.restore_focus(state, candidate_id) do
+        {:ok, restored} -> {:halt, {:ok, restored}}
+        :error -> {:cont, :error}
+      end
+    end)
+  end
+
+  @spec repair_popup_focus(state(), Windows.t(), Window.id(), Window.id()) :: state()
+  defp repair_popup_focus(state, windows, window_id, previous_active) do
+    case non_popup_window_ids(windows, window_id, previous_active) do
+      [fallback_id | _] ->
+        case MingaEditor.WindowFocus.repair_focus(state, fallback_id) do
+          {:ok, repaired} -> repaired
+          :error -> state
+        end
+
+      [] ->
+        state
+    end
+  end
+
+  @spec restore_candidates(Windows.t(), Window.id(), Window.id()) :: [Window.id()]
+  defp restore_candidates(windows, window_id, previous_active) do
+    [previous_active | non_popup_window_ids(windows, window_id, previous_active)]
+    |> Enum.reject(&(&1 == window_id))
+    |> Enum.uniq()
+  end
+
+  @spec non_popup_window_ids(Windows.t(), Window.id(), Window.id()) :: [Window.id()]
+  defp non_popup_window_ids(%Windows{map: window_map}, window_id, previous_active) do
+    ids =
+      window_map
+      |> Enum.filter(fn {id, window} -> id != window_id and not Window.popup?(window) end)
+      |> Enum.map(&elem(&1, 0))
+      |> Enum.sort()
+
+    if previous_active in ids,
+      do: [previous_active | List.delete(ids, previous_active)],
+      else: ids
+  end
 
   @spec finish_popup_close(state(), Window.id(), PopupActive.t(), boolean()) :: state()
   defp finish_popup_close(
@@ -352,16 +394,6 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
     case Windows.remove_window(ws, window_id) do
       {:ok, windows} -> windows
       :error -> Windows.delete_window(ws, window_id)
-    end
-  end
-
-  @spec find_non_popup_window(Windows.t(), Window.id()) :: Window.id()
-  defp find_non_popup_window(windows, exclude_id) do
-    case Windows.find_by_content(windows, fn window ->
-           window.id != exclude_id and not Window.popup?(window)
-         end) do
-      {id, _window} -> id
-      nil -> exclude_id
     end
   end
 end

--- a/lib/minga_editor/window_focus.ex
+++ b/lib/minga_editor/window_focus.ex
@@ -6,6 +6,7 @@ defmodule MingaEditor.WindowFocus do
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
   alias MingaEditor.State.Windows
   alias MingaEditor.BottomPanel
   alias MingaEditor.Window
@@ -38,20 +39,30 @@ defmodule MingaEditor.WindowFocus do
   end
 
   @doc "Restores focus without reading the outgoing window's buffer, for popup dismissal."
-  @spec restore_focus(state(), Window.id()) :: state()
+  @spec restore_focus(state(), Window.id()) :: {:ok, state()} | :error
   def restore_focus(%EditorState{} = state, target_id) do
     with {:ok, target_window} <- Windows.fetch(state.workspace.windows, target_id),
          :ok <- restore_target_cursor(target_window) do
       workspace = SessionState.focus_window(state.workspace, target_id, nil)
 
-      state
-      |> EditorState.set_workspace(workspace)
-      |> blur_bottom_panel()
-    else
-      :error -> state
+      restored =
+        state
+        |> EditorState.set_workspace(workspace)
+        |> blur_bottom_panel()
+
+      {:ok, restored}
     end
   catch
-    :exit, _reason -> state
+    :exit, _reason -> :error
+  end
+
+  @doc "Repairs a window with a viable buffer or empty surface, then restores focus to it."
+  @spec repair_focus(state(), Window.id()) :: {:ok, state()} | :error
+  def repair_focus(%EditorState{} = state, target_id) do
+    case Windows.fetch(state.workspace.windows, target_id) do
+      {:ok, target_window} -> repair_focus_target(state, target_id, target_window)
+      :error -> :error
+    end
   end
 
   @doc "Focuses a surviving window after the active split was removed."
@@ -97,6 +108,60 @@ defmodule MingaEditor.WindowFocus do
   end
 
   defp restore_target_cursor(%Window{}), do: :ok
+
+  @spec repair_focus_target(state(), Window.id(), Window.t()) :: {:ok, state()}
+  defp repair_focus_target(%EditorState{} = state, target_id, %Window{cursor: cursor}) do
+    case find_restorable_buffer(state.workspace.buffers.list, cursor) do
+      {:ok, buffer} -> repair_focus_with_buffer(state, target_id, buffer)
+      :error -> repair_focus_with_empty_surface(state, target_id)
+    end
+  end
+
+  @spec find_restorable_buffer([pid()], SessionState.position()) :: {:ok, pid()} | :error
+  defp find_restorable_buffer(buffers, cursor) do
+    Enum.reduce_while(buffers, :error, fn buffer, :error ->
+      case restore_buffer_cursor(buffer, cursor) do
+        :ok -> {:halt, {:ok, buffer}}
+        :error -> {:cont, :error}
+      end
+    end)
+  end
+
+  @spec restore_buffer_cursor(pid(), SessionState.position()) :: :ok | :error
+  defp restore_buffer_cursor(buffer, cursor) when is_pid(buffer) do
+    Buffer.move_to(buffer, cursor)
+  catch
+    :exit, _reason -> :error
+  end
+
+  @spec repair_focus_with_buffer(state(), Window.id(), pid()) :: {:ok, state()}
+  defp repair_focus_with_buffer(%EditorState{} = state, target_id, buffer) do
+    workspace = SessionState.focus_window(state.workspace, target_id, nil)
+    buffers = Buffers.switch_to_pid(workspace.buffers, buffer)
+    workspace = SessionState.activate_buffer(workspace, buffers)
+
+    repaired =
+      state
+      |> EditorState.set_workspace(workspace)
+      |> blur_bottom_panel()
+
+    {:ok, repaired}
+  end
+
+  @spec repair_focus_with_empty_surface(state(), Window.id()) :: {:ok, state()}
+  defp repair_focus_with_empty_surface(%EditorState{} = state, target_id) do
+    workspace =
+      state.workspace
+      |> SessionState.focus_window(target_id, nil)
+      |> SessionState.enter_empty_state()
+
+    repaired =
+      state
+      |> EditorState.set_workspace(workspace)
+      |> blur_bottom_panel()
+
+    {:ok, repaired}
+  end
 
   @spec blur_bottom_panel(state()) :: state()
   defp blur_bottom_panel(%EditorState{} = state) do

--- a/test/minga_editor/ui/popup/lifecycle_test.exs
+++ b/test/minga_editor/ui/popup/lifecycle_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.UI.Popup.LifecycleTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.Layout
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Windows
@@ -217,7 +218,43 @@ defmodule MingaEditor.UI.Popup.LifecycleTest do
       refute Map.has_key?(restored.workspace.windows.map, 2)
     end
 
-    test "focused popup stays open when its restore target process has died", %{
+    test "focused popup skips a dead restore target for another viable editor window", %{
+      state: state,
+      main_buf: main_buf,
+      popup_buf: popup_buf,
+      table: table
+    } do
+      other_buf = fake_pid()
+      on_exit(fn -> Process.exit(other_buf, :kill) end)
+      {:ok, tree} = WindowTree.split(state.workspace.windows.tree, 1, :vertical, 2)
+
+      windows =
+        state.workspace.windows
+        |> Windows.add_window(Window.new(2, other_buf, 24, 80))
+        |> Windows.set_tree(tree)
+        |> Windows.set_next_id(3)
+
+      workspace =
+        state.workspace
+        |> SessionState.set_windows(windows)
+        |> SessionState.set_buffers(Buffers.add_background(state.workspace.buffers, other_buf))
+
+      state = EditorState.set_workspace(state, workspace)
+      PopupRegistry.register(Rule.new("*Warnings*", focus: true), table)
+      {:ok, with_popup} = Lifecycle.open_popup(state, "*Warnings*", popup_buf, registry: table)
+      monitor = Process.monitor(main_buf)
+      Process.exit(main_buf, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^main_buf, :killed}
+
+      restored = Lifecycle.close_popup(with_popup, 3)
+
+      assert restored.workspace.windows.active == 2
+      assert restored.workspace.buffers.active == other_buf
+      assert Map.has_key?(restored.workspace.windows.map, 2)
+      refute Map.has_key?(restored.workspace.windows.map, 3)
+    end
+
+    test "focused popup repairs the remaining editor surface when every buffer target is dead", %{
       state: state,
       main_buf: main_buf,
       popup_buf: popup_buf,
@@ -229,10 +266,14 @@ defmodule MingaEditor.UI.Popup.LifecycleTest do
       Process.exit(main_buf, :kill)
       assert_receive {:DOWN, ^monitor, :process, ^main_buf, :killed}
 
-      unchanged = Lifecycle.close_popup(with_popup, 2)
+      restored = Lifecycle.close_popup(with_popup, 2)
 
-      assert unchanged.workspace.windows.active == 2
-      assert Map.has_key?(unchanged.workspace.windows.map, 2)
+      assert restored.workspace.windows.active == 1
+      assert Map.has_key?(restored.workspace.windows.map, restored.workspace.windows.active)
+      refute Map.has_key?(restored.workspace.windows.map, 2)
+      assert restored.workspace.buffers.active == nil
+      assert restored.workspace.buffers.list == []
+      assert Map.fetch!(restored.workspace.windows.map, 1).content == {:empty, :semantic}
     end
 
     test "falls back to a remaining editor window when previous_active is gone", %{

--- a/test/minga_editor/window_focus_test.exs
+++ b/test/minga_editor/window_focus_test.exs
@@ -97,6 +97,15 @@ defmodule MingaEditor.WindowFocusTest do
     assert WindowFocus.remember_active_cursor(mismatched) == mismatched
   end
 
+  test "active cursor snapshot leaves state unchanged when the matching buffer has died" do
+    {state, first_buffer, _second_buffer} = split_state()
+    monitor = Process.monitor(first_buffer)
+    GenServer.stop(first_buffer, :normal)
+    assert_receive {:DOWN, ^monitor, :process, ^first_buffer, :normal}
+
+    assert WindowFocus.remember_active_cursor(state) == state
+  end
+
   defp split_state do
     state = base_state(content: "first\nline\nend")
     first_buffer = state.workspace.buffers.active


### PR DESCRIPTION
# TL;DR

This follow-up lets focused popups close safely when their original buffer has died, restoring another live editor target or repairing the remaining window to an empty semantic surface.

Follow-up to #2886 and #2865.

## Context

Post-merge review found that popup dismissal could leave the popup focused and undismissable when its restore buffer exited. The focus workflow caught the process exit but could not distinguish restoration failure from success.

## Changes

- Return an explicit success or failure result from focus restoration.
- Try viable non-popup windows in deterministic order when the original restore target is dead.
- Repair the remaining editor window with another live buffer or the empty semantic surface when no buffer target survives.
- Cover dead active-buffer cursor snapshots without mutating state.

## Verification

- `make lint`
- `mix test.llm` (9,318 tests, 0 failures)
- `git diff --check`
- Final acceptance review: PASS

## Acceptance Criteria Addressed

- Closing a focused popup always leaves a valid active non-popup window. ✅
- Dead restore buffers do not trap the user in an undismissable popup. ✅
- Cursor snapshot recovery remains failure-atomic when the active buffer dies. ✅
