### PR TITLE
refactor(editor): own Traditional sidebar agent and input state

### DIFF
--- a/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
@@ -18,6 +18,7 @@ defmodule MingaGitPorcelain.Commands do
   alias MingaEditor.Shell.Traditional.GitToast
   alias MingaEditor.Shell.Traditional.GitToastWorkflow
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias Minga.Git
@@ -89,8 +90,7 @@ defmodule MingaGitPorcelain.Commands do
     if state.workspace.keymap_scope == :git_status do
       state
       |> EditorState.set_keymap_scope(:editor)
-      |> EditorState.close_git_status_panel()
-      |> EditorState.set_sidebar_active_id(nil)
+      |> SidebarWorkflow.close_git_status()
       |> Layout.invalidate()
       |> EditorState.invalidate_all_windows()
     else
@@ -1309,8 +1309,8 @@ defmodule MingaGitPorcelain.Commands do
           EditorState.set_keymap_scope(state, :git_status)
 
         state
-        |> EditorState.set_git_status_panel(panel_data)
-        |> EditorState.set_sidebar_active_id("git_status")
+        |> SidebarWorkflow.replace_git_status(panel_data)
+        |> SidebarWorkflow.select("git_status")
         |> Layout.invalidate()
         |> EditorState.invalidate_all_windows()
     end
@@ -1335,15 +1335,15 @@ defmodule MingaGitPorcelain.Commands do
       EditorState.set_keymap_scope(state, :git_status)
 
     state
-    |> EditorState.set_git_status_panel(panel_data)
-    |> EditorState.set_sidebar_active_id("git_status")
+    |> SidebarWorkflow.replace_git_status(panel_data)
+    |> SidebarWorkflow.select("git_status")
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
 
   @spec git_status_last_commit_message(state()) :: String.t()
   defp git_status_last_commit_message(state) do
-    case EditorState.git_status_panel(state) do
+    case SidebarWorkflow.git_status_panel(state) do
       nil -> ""
       panel -> Map.get(panel, :last_commit_message, "")
     end

--- a/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
@@ -13,6 +13,7 @@ defmodule MingaGitPorcelain.Input.GitStatus do
 
   alias Minga.Buffer
   alias MingaEditor.Commands
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
   alias Minga.Git
   alias Minga.Log
@@ -262,7 +263,7 @@ defmodule MingaGitPorcelain.Input.GitStatus do
   defp close_panel(state) do
     state
     |> EditorState.set_keymap_scope(:editor)
-    |> EditorState.close_git_status_panel()
+    |> SidebarWorkflow.close_git_status()
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
@@ -316,7 +317,7 @@ defmodule MingaGitPorcelain.Input.GitStatus do
 
   @spec get_discard_confirmation(EditorState.t()) :: {Git.StatusEntry.t(), String.t()} | nil
   defp get_discard_confirmation(state) do
-    case EditorState.git_status_panel(state) do
+    case SidebarWorkflow.git_status_panel(state) do
       nil -> nil
       _panel -> git_status_tui_state(state).discard_confirmation
     end
@@ -375,19 +376,21 @@ defmodule MingaGitPorcelain.Input.GitStatus do
 
   @spec update_tui_state(EditorState.t(), (TuiState.t(), [Git.StatusEntry.t()] -> TuiState.t())) ::
           EditorState.t()
-  defp update_tui_state(%{shell_runtime: %{state: %{git_status_panel: nil}}} = state, _fun),
-    do: state
-
   defp update_tui_state(state, fun) do
-    panel = EditorState.git_status_panel(state)
-    entries = Map.get(panel, :entries) || []
-    tui = git_status_tui_state(state)
+    case SidebarWorkflow.git_status_panel(state) do
+      nil ->
+        state
 
-    updated =
-      fun.(tui, entries)
-      |> TuiState.clamp_cursor(entries)
+      panel ->
+        entries = panel.entries || []
+        tui = git_status_tui_state(state)
 
-    EditorState.set_git_status_tui_state(state, updated)
+        updated =
+          fun.(tui, entries)
+          |> TuiState.clamp_cursor(entries)
+
+        SidebarWorkflow.replace_git_status_tui(state, updated)
+    end
   end
 
   @spec with_selected_file(EditorState.t(), (Git.StatusEntry.t(), String.t() -> EditorState.t())) ::
@@ -398,7 +401,7 @@ defmodule MingaGitPorcelain.Input.GitStatus do
         MingaEditor.Shell.Traditional.NoticeWorkflow.publish(state, "Not in a git repository")
 
       git_root ->
-        panel = EditorState.git_status_panel(state)
+        panel = SidebarWorkflow.git_status_panel(state)
         entries = Map.get(panel || %{}, :entries) || []
         tui = git_status_tui_state(state)
 
@@ -452,10 +455,10 @@ defmodule MingaGitPorcelain.Input.GitStatus do
   end
 
   @spec git_status_tui_state(EditorState.t()) :: TuiState.t()
-  defp git_status_tui_state(%{
-         shell_runtime: %{state: %{git_status_tui_state: %TuiState{} = tui}}
-       }),
-       do: tui
-
-  defp git_status_tui_state(_state), do: TuiState.new()
+  defp git_status_tui_state(state) do
+    case SidebarWorkflow.git_status_tui_state(state) do
+      %TuiState{} = tui -> tui
+      nil -> TuiState.new()
+    end
+  end
 end

--- a/extensions/git_porcelain/lib/minga_git_porcelain/shell/traditional/git_status_renderer.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/shell/traditional/git_status_renderer.ex
@@ -14,6 +14,8 @@ defmodule MingaGitPorcelain.Shell.Traditional.GitStatusRenderer do
   alias MingaEditor.DisplayList
   alias MingaEditor.Layout
   alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Theme
 
@@ -42,11 +44,17 @@ defmodule MingaGitPorcelain.Shell.Traditional.GitStatusRenderer do
   def render(_state, nil), do: []
 
   def render(state, rect) do
-    case EditorState.git_status_panel(state) do
+    case git_status_panel(state) do
       nil -> []
       panel -> do_render(panel, tui_state(state), rect, state.theme)
     end
   end
+
+  @spec git_status_panel(state()) :: MingaEditor.GitStatus.Panel.t() | nil
+  defp git_status_panel(%EditorState{} = state), do: SidebarWorkflow.git_status_panel(state)
+
+  defp git_status_panel(%{shell_state: %TraditionalState{} = shell_state}),
+    do: TraditionalState.git_status_panel(shell_state)
 
   @spec do_render(map(), TuiState.t(), Layout.rect(), Theme.t()) :: [DisplayList.draw()]
   defp do_render(panel, tui, {row_off, col_off, width, height}, theme) do
@@ -56,8 +64,19 @@ defmodule MingaGitPorcelain.Shell.Traditional.GitStatusRenderer do
   end
 
   @spec tui_state(state()) :: TuiState.t()
-  defp tui_state(%{shell_state: %{git_status_tui_state: %TuiState{} = tui}}), do: tui
-  defp tui_state(_state), do: TuiState.new()
+  defp tui_state(%EditorState{} = state) do
+    case SidebarWorkflow.git_status_tui_state(state) do
+      %TuiState{} = tui -> tui
+      nil -> TuiState.new()
+    end
+  end
+
+  defp tui_state(%{shell_state: %TraditionalState{} = shell_state}) do
+    case TraditionalState.git_status_tui_state(shell_state) do
+      %TuiState{} = tui -> tui
+      nil -> TuiState.new()
+    end
+  end
 
   @spec render_panel(
           map(),

--- a/extensions/git_porcelain/test/minga_git_porcelain/input/status_diff_open_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/input/status_diff_open_test.exs
@@ -7,6 +7,7 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
   alias Minga.Git
   alias Minga.Git.Stub, as: GitStub
   alias MingaGitPorcelain.Input.GitStatus
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
 
@@ -117,8 +118,8 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
       },
       focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
     }
-    |> EditorState.set_git_status_panel(panel_data)
-    |> EditorState.set_git_status_tui_state(tui)
+    |> SidebarWorkflow.replace_git_status(panel_data)
+    |> SidebarWorkflow.replace_git_status_tui(tui)
   end
 
   defp buffer_content(buf) do

--- a/extensions/git_porcelain/test/minga_git_porcelain/input/status_input_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/input/status_input_test.exs
@@ -12,6 +12,7 @@ defmodule MingaGitPorcelain.Input.GitStatusInputTest do
   alias MingaGitPorcelain.Input.GitStatus
   alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
@@ -48,13 +49,13 @@ defmodule MingaGitPorcelain.Input.GitStatusInputTest do
       },
       focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
     }
-    |> EditorState.set_git_status_panel(panel_data)
-    |> EditorState.set_git_status_tui_state(TuiState.new())
+    |> SidebarWorkflow.replace_git_status(panel_data)
+    |> SidebarWorkflow.replace_git_status_tui(TuiState.new())
   end
 
   test "git status panel keeps shared data separate from tui state" do
     state = make_state_with_git_panel()
-    panel = EditorState.git_status_panel(state)
+    panel = SidebarWorkflow.git_status_panel(state)
     assert panel != nil
     refute Map.has_key?(panel, :tui_state)
 

--- a/extensions/git_porcelain/test/minga_git_porcelain/shell/traditional/status_renderer_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/shell/traditional/status_renderer_test.exs
@@ -5,6 +5,7 @@ defmodule MingaGitPorcelain.Shell.Traditional.GitStatusRendererTest do
   alias Minga.Git.StatusEntry
   alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
   alias MingaGitPorcelain.Shell.Traditional.GitStatusRenderer
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
 
   @rect {1, 0, 30, 21}
 
@@ -14,13 +15,18 @@ defmodule MingaGitPorcelain.Shell.Traditional.GitStatusRendererTest do
     viewport_cols = Keyword.get(opts, :cols, 80)
     tui_state = Keyword.get(opts, :tui_state)
 
+    shell_state =
+      %TraditionalState{}
+      |> TraditionalState.replace_git_status_panel(panel)
+      |> TraditionalState.replace_git_status_tui_state(tui_state)
+
     %{
       workspace: %{
         file_tree: %{tree: %Minga.Project.FileTree{root: "/tmp", width: 30}},
         viewport: %{rows: viewport_rows, cols: viewport_cols},
         keymap_scope: :git_status
       },
-      shell_state: %{git_status_panel: panel, git_status_tui_state: tui_state},
+      shell_state: shell_state,
       theme: theme
     }
   end

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -87,6 +87,7 @@ defmodule MingaEditor do
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.State, as: TraditionalShellState
 
   alias MingaEditor.MouseHoverTooltip
@@ -613,8 +614,8 @@ defmodule MingaEditor do
 
   # ── TUI SPC leader timeout ──────────────────────────────────────────────
 
-  def handle_info(:space_leader_timeout, state) do
-    new_state = MingaEditor.Input.CUA.TUISpaceLeader.handle_timeout(state)
+  def handle_info({:space_leader_timeout, generation}, state) do
+    new_state = MingaEditor.Input.CUA.TUISpaceLeader.handle_timeout(state, generation)
     {:noreply, new_state}
   end
 
@@ -624,8 +625,14 @@ defmodule MingaEditor do
   # :observatory_data_result clause), not here, so a collection that takes
   # longer than the 1s interval is effectively skipped, never queued.
   def handle_info({:observatory_tick, token}, state) do
-    if current_observatory_token?(state, token), do: spawn_observatory_collection(token)
-    {:noreply, state}
+    case SidebarWorkflow.expire_observatory_refresh(state, token) do
+      {:collect, new_state} ->
+        spawn_observatory_collection(token)
+        {:noreply, new_state}
+
+      {:stale, new_state} ->
+        {:noreply, new_state}
+    end
   end
 
   def handle_info(:observatory_tick, state) do
@@ -638,16 +645,19 @@ defmodule MingaEditor do
   # A result carrying a stale token (panel closed, or a newer tick already
   # superseded this one) is dropped without scheduling anything.
   def handle_info({:observatory_data_result, token, data}, state) do
-    if current_observatory_token?(state, token) do
+    if SidebarWorkflow.observatory_collection_current?(state, token) do
       next_token = make_ref()
       timer = Process.send_after(self(), {:observatory_tick, next_token}, 1_000)
 
-      new_state =
-        state
-        |> EditorState.set_observatory_data(data)
-        |> EditorState.set_observatory_timer({timer, next_token})
-
-      {:noreply, Renderer.render_or_async(new_state)}
+      case SidebarWorkflow.complete_observatory_refresh(
+             state,
+             token,
+             data,
+             {timer, next_token}
+           ) do
+        {:accepted, new_state} -> {:noreply, Renderer.render_or_async(new_state)}
+        {:stale, new_state} -> {:noreply, new_state}
+      end
     else
       {:noreply, state}
     end
@@ -1090,19 +1100,6 @@ defmodule MingaEditor do
   end
 
   defp apply_fetch_status(state, _meta), do: state
-
-  @spec current_observatory_token?(state(), reference()) :: boolean()
-  defp current_observatory_token?(
-         %{
-           shell_runtime: %{
-             state: %{observatory_visible: true, observatory_timer: {_timer, token}}
-           }
-         },
-         token
-       ),
-       do: true
-
-  defp current_observatory_token?(_state, _token), do: false
 
   # Run the blocking SystemObserver collection in a supervised Task so the
   # Editor GenServer mailbox stays free. The token is echoed back with the

--- a/lib/minga_editor/agent/ui_state.ex
+++ b/lib/minga_editor/agent/ui_state.ex
@@ -546,13 +546,18 @@ defmodule MingaEditor.Agent.UIState do
   end
 
   @doc "Activates the view, saving the current window layout."
-  @spec activate(t(), Windows.t(), FileTreeState.t()) :: t()
+  @spec activate(t(), Windows.t() | nil, FileTreeState.t() | nil) :: t()
   def activate(%__MODULE__{view: view} = state, windows, file_tree) do
     %{state | view: View.activate(view, windows, file_tree)}
   end
 
   @doc "Activates the view with a recorded editor return target."
-  @spec activate(t(), Windows.t(), FileTreeState.t(), View.return_target() | nil) :: t()
+  @spec activate(
+          t(),
+          Windows.t() | nil,
+          FileTreeState.t() | nil,
+          View.return_target() | nil
+        ) :: t()
   def activate(%__MODULE__{view: view} = state, windows, file_tree, return_target) do
     %{state | view: View.activate(view, windows, file_tree, return_target)}
   end

--- a/lib/minga_editor/agent/ui_state/presentation.ex
+++ b/lib/minga_editor/agent/ui_state/presentation.ex
@@ -1,0 +1,111 @@
+defmodule MingaEditor.Agent.UIState.Presentation do
+  @moduledoc """
+  Pure lifecycle owner for activation of the full-screen agent presentation.
+
+  Activation records one coherent editor return target and saved layout.
+  Completion or cancellation deactivates the presentation and clears every
+  activation-local field together, preventing stale return targets or key
+  prefixes from leaking into a replacement activation.
+  """
+
+  alias MingaEditor.Agent.UIState.ReturnTarget
+  alias MingaEditor.State.FileTree, as: FileTreeState
+  alias MingaEditor.State.Windows
+
+  @type focus :: :chat | :file_viewer
+  @type prefix :: nil | :g | :z | :bracket_next | :bracket_prev | Minga.Keymap.Bindings.Node.t()
+  @type t :: %__MODULE__{
+          active: boolean(),
+          focus: focus(),
+          saved_windows: Windows.t() | nil,
+          saved_file_tree: FileTreeState.t() | nil,
+          return_target: ReturnTarget.t() | nil,
+          pending_prefix: prefix()
+        }
+
+  defstruct active: false,
+            focus: :chat,
+            saved_windows: nil,
+            saved_file_tree: nil,
+            return_target: nil,
+            pending_prefix: nil
+
+  @doc "Activates or replaces the presentation's complete return context."
+  @spec activate(
+          t(),
+          Windows.t() | nil,
+          FileTreeState.t() | nil,
+          ReturnTarget.t() | nil
+        ) :: t()
+  def activate(%__MODULE__{} = presentation, windows, file_tree, return_target) do
+    %{
+      presentation
+      | active: true,
+        focus: :chat,
+        saved_windows: windows,
+        saved_file_tree: file_tree,
+        return_target: return_target,
+        pending_prefix: nil
+    }
+  end
+
+  @doc "Completes presentation use and returns the layout to restore."
+  @spec complete(t()) :: {t(), Windows.t() | nil, FileTreeState.t() | nil}
+  def complete(%__MODULE__{} = presentation) do
+    {reset(presentation), presentation.saved_windows, presentation.saved_file_tree}
+  end
+
+  @doc "Cancels presentation use with the same cleanup guarantee as completion."
+  @spec cancel(t()) :: {t(), Windows.t() | nil, FileTreeState.t() | nil}
+  def cancel(%__MODULE__{} = presentation), do: complete(presentation)
+
+  @doc "Replaces the editor return target for the active presentation."
+  @spec replace_return_target(t(), ReturnTarget.t() | nil) :: t()
+  def replace_return_target(%__MODULE__{} = presentation, return_target),
+    do: %{presentation | return_target: return_target}
+
+  @doc "Switches keyboard focus inside the agent presentation."
+  @spec focus(t(), focus()) :: t()
+  def focus(%__MODULE__{} = presentation, focus) when focus in [:chat, :file_viewer],
+    do: %{presentation | focus: focus}
+
+  @doc "Installs a pending multi-key prefix."
+  @spec install_prefix(t(), prefix()) :: t()
+  def install_prefix(%__MODULE__{} = presentation, prefix)
+      when prefix in [nil, :g, :z, :bracket_next, :bracket_prev] or is_map(prefix),
+      do: %{presentation | pending_prefix: prefix}
+
+  @doc "Clears a pending multi-key prefix."
+  @spec reset_prefix(t()) :: t()
+  def reset_prefix(%__MODULE__{} = presentation),
+    do: %{presentation | pending_prefix: nil}
+
+  @doc "Returns whether the agent presentation is active."
+  @spec active?(t()) :: boolean()
+  def active?(%__MODULE__{active: active}), do: active
+
+  @doc "Returns the focused agent panel."
+  @spec current_focus(t()) :: focus()
+  def current_focus(%__MODULE__{focus: focus}), do: focus
+
+  @doc "Returns the editor return target."
+  @spec return_target(t()) :: ReturnTarget.t() | nil
+  def return_target(%__MODULE__{return_target: target}), do: target
+
+  @doc "Returns the pending multi-key prefix."
+  @spec pending_prefix(t()) :: prefix()
+  def pending_prefix(%__MODULE__{pending_prefix: prefix}), do: prefix
+
+  @spec reset(t()) :: t()
+  defp reset(%__MODULE__{} = presentation) do
+    %{
+      presentation
+      | active: false,
+        focus: :chat,
+        saved_windows: nil,
+        saved_file_tree: nil,
+        return_target: nil,
+        pending_prefix: nil
+    }
+  end
+end

--- a/lib/minga_editor/agent/ui_state/view.ex
+++ b/lib/minga_editor/agent/ui_state/view.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.Agent.UIState.View do
 
   alias MingaEditor.Agent.EditTimeline
   alias MingaEditor.Agent.Activity
+  alias MingaEditor.Agent.UIState.Presentation
   alias MingaEditor.Agent.UIState.ReturnTarget
   alias MingaEditor.Agent.View.Preview
   alias Minga.Config
@@ -20,10 +21,10 @@ defmodule MingaEditor.Agent.UIState.View do
   alias MingaEditor.State.Windows
 
   @typedoc "Which panel has keyboard focus inside the agentic view."
-  @type focus :: :chat | :file_viewer
+  @type focus :: Presentation.focus()
 
   @typedoc "Active prefix key awaiting a follow-up keystroke."
-  @type prefix :: nil | :g | :z | :bracket_next | :bracket_prev | Minga.Keymap.Bindings.Node.t()
+  @type prefix :: Presentation.prefix()
 
   @typedoc "A search match: message index, byte start, byte end."
   @type search_match ::
@@ -47,14 +48,9 @@ defmodule MingaEditor.Agent.UIState.View do
 
   @typedoc "Layout, search, preview, and toast state."
   @type t :: %__MODULE__{
-          active: boolean(),
-          focus: focus(),
+          presentation: Presentation.t(),
           preview: Preview.t(),
-          saved_windows: Windows.t() | nil,
-          pending_prefix: prefix(),
           chat_width_pct: non_neg_integer(),
-          saved_file_tree: FileTreeState.t() | nil,
-          return_target: return_target() | nil,
           help_visible: boolean(),
           search: search_state() | nil,
           toast: toast() | nil,
@@ -73,14 +69,9 @@ defmodule MingaEditor.Agent.UIState.View do
   @max_chat_pct 80
   @resize_step 5
 
-  defstruct active: false,
-            focus: :chat,
+  defstruct presentation: %Presentation{},
             preview: Preview.new(),
-            saved_windows: nil,
-            pending_prefix: nil,
             chat_width_pct: 65,
-            saved_file_tree: nil,
-            return_target: nil,
             help_visible: false,
             search: nil,
             toast: nil,
@@ -140,67 +131,75 @@ defmodule MingaEditor.Agent.UIState.View do
   end
 
   @doc "Activates the view, saving the current window layout."
-  @spec activate(t(), Windows.t(), FileTreeState.t()) :: t()
+  @spec activate(t(), Windows.t() | nil, FileTreeState.t() | nil) :: t()
   def activate(%__MODULE__{} = view, windows, file_tree) do
     activate(view, windows, file_tree, nil)
   end
 
   @doc "Activates the view with a recorded editor return target."
-  @spec activate(t(), Windows.t(), FileTreeState.t(), return_target() | nil) :: t()
-  def activate(%__MODULE__{} = view, windows, file_tree, return_target) do
-    %{
+  @spec activate(
+          t(),
+          Windows.t() | nil,
+          FileTreeState.t() | nil,
+          return_target() | nil
+        ) :: t()
+  def activate(%__MODULE__{} = view, windows, file_tree, return_target),
+    do: %{
       view
-      | active: true,
-        focus: :chat,
-        saved_windows: windows,
-        saved_file_tree: file_tree,
-        return_target: return_target,
-        pending_prefix: nil
+      | presentation: Presentation.activate(view.presentation, windows, file_tree, return_target)
     }
-  end
 
   @doc "Sets the editor return target."
   @spec set_return_target(t(), return_target() | nil) :: t()
-  def set_return_target(%__MODULE__{} = view, return_target) do
-    %{view | return_target: return_target}
-  end
+  def set_return_target(%__MODULE__{} = view, return_target),
+    do: %{
+      view
+      | presentation: Presentation.replace_return_target(view.presentation, return_target)
+    }
 
   @doc "Clears the editor return target."
   @spec clear_return_target(t()) :: t()
-  def clear_return_target(%__MODULE__{} = view), do: %{view | return_target: nil}
+  def clear_return_target(%__MODULE__{} = view), do: set_return_target(view, nil)
 
   @doc "Deactivates the view and returns the restored window layout."
   @spec deactivate(t()) :: {t(), Windows.t() | nil, FileTreeState.t() | nil}
-  def deactivate(
-        %__MODULE__{saved_windows: saved_windows, saved_file_tree: saved_file_tree} = view
-      ) do
-    {%{
-       view
-       | active: false,
-         focus: :chat,
-         saved_windows: nil,
-         saved_file_tree: nil,
-         return_target: nil,
-         pending_prefix: nil
-     }, saved_windows, saved_file_tree}
+  def deactivate(%__MODULE__{} = view) do
+    {presentation, saved_windows, saved_file_tree} = Presentation.complete(view.presentation)
+    {%{view | presentation: presentation}, saved_windows, saved_file_tree}
   end
+
+  @doc "Returns whether the full-screen agent presentation is active."
+  @spec active?(t()) :: boolean()
+  def active?(%__MODULE__{presentation: presentation}), do: Presentation.active?(presentation)
+
+  @doc "Returns the focused agent panel."
+  @spec focus(t()) :: focus()
+  def focus(%__MODULE__{presentation: presentation}), do: Presentation.current_focus(presentation)
+
+  @doc "Returns the editor target restored when presentation completes."
+  @spec return_target(t()) :: return_target() | nil
+  def return_target(%__MODULE__{presentation: presentation}),
+    do: Presentation.return_target(presentation)
+
+  @doc "Returns the pending multi-key prefix."
+  @spec pending_prefix(t()) :: prefix()
+  def pending_prefix(%__MODULE__{presentation: presentation}),
+    do: Presentation.pending_prefix(presentation)
 
   @doc "Switches focus to the given panel."
   @spec set_focus(t(), focus()) :: t()
-  def set_focus(%__MODULE__{} = view, focus) when focus in [:chat, :file_viewer] do
-    %{view | focus: focus}
-  end
+  def set_focus(%__MODULE__{} = view, focus) when focus in [:chat, :file_viewer],
+    do: %{view | presentation: Presentation.focus(view.presentation, focus)}
 
   @doc "Sets the pending prefix for multi-key sequences."
   @spec set_prefix(t(), prefix()) :: t()
-  def set_prefix(%__MODULE__{} = view, prefix)
-      when prefix in [nil, :g, :z, :bracket_next, :bracket_prev] or is_map(prefix) do
-    %{view | pending_prefix: prefix}
-  end
+  def set_prefix(%__MODULE__{} = view, prefix),
+    do: %{view | presentation: Presentation.install_prefix(view.presentation, prefix)}
 
   @doc "Clears any pending prefix."
   @spec clear_prefix(t()) :: t()
-  def clear_prefix(%__MODULE__{} = view), do: %{view | pending_prefix: nil}
+  def clear_prefix(%__MODULE__{} = view),
+    do: %{view | presentation: Presentation.reset_prefix(view.presentation)}
 
   @doc "Toggles the help overlay visibility."
   @spec toggle_help(t()) :: t()

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -26,6 +26,8 @@ defmodule MingaEditor.Commands do
 
   alias Minga.Buffer
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.Shell.Traditional.ToolPrompts
+  alias MingaEditor.Shell.Traditional.ToolPromptWorkflow
   alias Minga.Command
   alias Minga.Git
   alias MingaEditor.Commands.Agent, as: AgentCommands
@@ -229,19 +231,16 @@ defmodule MingaEditor.Commands do
   end
 
   def execute(state, {:tool_confirm_decline, name}) do
-    state =
-      EditorState.set_tool_prompt_state(
-        state,
-        state.shell_runtime.state.tool_prompt_queue,
-        MapSet.put(state.shell_runtime.state.tool_declined, name)
-      )
-
+    prompts = ToolPromptWorkflow.prompts(state)
+    declined = MapSet.put(ToolPrompts.declined(prompts), name)
+    state = ToolPromptWorkflow.replace(state, ToolPrompts.queue(prompts), declined)
     drain_tool_prompt_queue(state)
   end
 
   def execute(state, {:tool_confirm_dismiss, declined_set}) do
-    declined = MapSet.union(state.shell_runtime.state.tool_declined, declined_set)
-    EditorState.set_tool_prompt_state(state, [], declined)
+    prompts = ToolPromptWorkflow.prompts(state)
+    declined = MapSet.union(ToolPrompts.declined(prompts), declined_set)
+    ToolPromptWorkflow.replace(state, [], declined)
   end
 
   # ── File tree delete confirmation commands ─────────────────────────────────
@@ -857,12 +856,7 @@ defmodule MingaEditor.Commands do
     end
   end
 
-  defp drain_tool_prompt_queue(state) do
-    case state.shell_runtime.state.tool_prompt_queue do
-      [_current | rest] -> EditorState.set_tool_prompt_queue(state, rest)
-      [] -> state
-    end
-  end
+  defp drain_tool_prompt_queue(state), do: ToolPromptWorkflow.advance(state)
 
   @spec accept_command_candidate(state()) :: state()
   defp accept_command_candidate(state) do

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -288,7 +288,7 @@ defmodule MingaEditor.Commands.Agent do
   @doc "Returns from the agent view to the recorded editor context without stopping the session."
   @spec return_to_editor(state()) :: state()
   def return_to_editor(state) do
-    return_target = AgentAccess.view(state).return_target
+    return_target = state |> AgentAccess.view() |> UIState.View.return_target()
 
     case target_file_tab_id(EditorState.tab_bar(state), return_target) do
       {:exact, id} ->
@@ -1518,7 +1518,7 @@ defmodule MingaEditor.Commands.Agent do
   @doc "Switches focus between chat and file viewer panels."
   @spec scope_switch_focus(state()) :: state()
   def scope_switch_focus(state) do
-    if AgentAccess.view(state).focus == :chat do
+    if state |> AgentAccess.view() |> UIState.View.focus() == :chat do
       update_agent_ui(state, &UIState.set_focus(&1, :file_viewer))
     else
       update_agent_ui(state, &UIState.set_focus(&1, :chat))
@@ -1649,12 +1649,17 @@ defmodule MingaEditor.Commands.Agent do
   end
 
   @spec dismiss_agent_prefix_or_modal(state(), UIState.View.t()) :: state()
-  defp dismiss_agent_prefix_or_modal(state, %{pending_prefix: nil}) do
+  defp dismiss_agent_prefix_or_modal(state, view) do
+    dismiss_agent_prefix(state, UIState.View.pending_prefix(view))
+  end
+
+  @spec dismiss_agent_prefix(state(), UIState.View.prefix()) :: state()
+  defp dismiss_agent_prefix(state, nil) do
     panel = AgentAccess.panel(state)
     dismiss_agent_panel_or_modal(state, panel)
   end
 
-  defp dismiss_agent_prefix_or_modal(state, _view) do
+  defp dismiss_agent_prefix(state, _prefix) do
     update_agent_ui(state, &UIState.clear_prefix/1)
   end
 

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -11,6 +11,8 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   alias MingaAgent.Session
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.Shell.Traditional.ToolPrompts
+  alias MingaEditor.Shell.Traditional.ToolPromptWorkflow
   alias MingaAgent.ProjectView
   alias Minga.Buffer
   alias Minga.Project.FileRef, as: ProjectFileRef
@@ -2356,29 +2358,34 @@ defmodule MingaEditor.Commands.BufferManagement do
         state
 
       recipe ->
-        if EditorState.skip_tool_prompt?(state, recipe.name) do
+        if ToolPromptWorkflow.skip?(state, recipe.name) do
           state
         else
-          queue = Enum.concat(state.shell_runtime.state.tool_prompt_queue, [recipe.name])
-          state = EditorState.set_tool_prompt_queue(state, queue)
-          show_tool_prompt_if_normal(state)
+          state
+          |> ToolPromptWorkflow.enqueue(recipe.name)
+          |> show_tool_prompt_if_normal()
         end
     end
   end
 
   @spec show_tool_prompt_if_normal(state()) :: state()
-  defp show_tool_prompt_if_normal(
-         %{
-           workspace: %{editing: %{mode: :normal}},
-           shell_runtime: %{state: %{tool_prompt_queue: pending}}
-         } = state
-       )
-       when pending != [] do
-    ms = %ToolConfirmState{pending: pending, declined: state.shell_runtime.state.tool_declined}
-    EditorState.transition_mode(state, :tool_confirm, ms)
+  defp show_tool_prompt_if_normal(%{workspace: %{editing: %{mode: :normal}}} = state) do
+    prompts = ToolPromptWorkflow.prompts(state)
+    show_tool_prompt(state, ToolPrompts.queue(prompts), ToolPrompts.declined(prompts))
   end
 
   defp show_tool_prompt_if_normal(state), do: state
+
+  @spec show_tool_prompt(state(), [atom()], MapSet.t(atom())) :: state()
+  defp show_tool_prompt(state, [], _declined), do: state
+
+  defp show_tool_prompt(state, pending, declined) do
+    EditorState.transition_mode(
+      state,
+      :tool_confirm,
+      %ToolConfirmState{pending: pending, declined: declined}
+    )
+  end
 
   @spec apply_whitespace_transforms(pid()) :: :ok
   defp apply_whitespace_transforms(buf) do

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.Commands.FileTree do
   alias MingaEditor.Commands.Helpers
   alias MingaEditor.Handlers.BufferRegistry
   alias MingaEditor.Layout
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias Minga.Mode.DeleteConfirmState
@@ -59,7 +60,7 @@ defmodule MingaEditor.Commands.FileTree do
     state
     |> EditorState.update_file_tree(&FileTreeState.focus/1)
     |> EditorState.set_keymap_scope(:file_tree)
-    |> EditorState.set_sidebar_active_id("file_tree")
+    |> SidebarWorkflow.select("file_tree")
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
@@ -71,7 +72,7 @@ defmodule MingaEditor.Commands.FileTree do
     state
     |> EditorState.update_file_tree(&FileTreeState.show/1)
     |> EditorState.set_keymap_scope(:file_tree)
-    |> EditorState.set_sidebar_active_id("file_tree")
+    |> SidebarWorkflow.select("file_tree")
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
@@ -86,7 +87,7 @@ defmodule MingaEditor.Commands.FileTree do
     state
     |> EditorState.update_file_tree(&FileTreeState.hide/1)
     |> EditorState.set_keymap_scope(scope)
-    |> EditorState.set_sidebar_active_id(nil)
+    |> SidebarWorkflow.select(nil)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
@@ -659,7 +660,7 @@ defmodule MingaEditor.Commands.FileTree do
 
         state
         |> EditorState.set_keymap_scope(:file_tree)
-        |> EditorState.set_sidebar_active_id("file_tree")
+        |> SidebarWorkflow.select("file_tree")
         |> Layout.invalidate()
         |> EditorState.invalidate_all_windows()
     end
@@ -690,7 +691,7 @@ defmodule MingaEditor.Commands.FileTree do
     state
     |> EditorState.update_file_tree(&FileTreeState.close/1)
     |> EditorState.set_keymap_scope(scope)
-    |> EditorState.set_sidebar_active_id(nil)
+    |> SidebarWorkflow.select(nil)
   end
 
   # ── Private helpers ───────────────────────────────────────────────────────
@@ -927,14 +928,17 @@ defmodule MingaEditor.Commands.FileTree do
   # Explicitly resets keymap_scope to :editor so we don't leave orphaned
   # :git_status scope if a future refactor separates the open steps.
   @spec close_git_status_if_open(state()) :: state()
-  defp close_git_status_if_open(%{shell_runtime: %{state: %{git_status_panel: nil}}} = state),
-    do: state
+  defp close_git_status_if_open(state) do
+    case SidebarWorkflow.git_status_panel(state) do
+      nil ->
+        state
 
-  defp close_git_status_if_open(state),
-    do:
-      state
-      |> EditorState.set_keymap_scope(:editor)
-      |> EditorState.close_git_status_panel()
+      _panel ->
+        state
+        |> EditorState.set_keymap_scope(:editor)
+        |> SidebarWorkflow.close_git_status()
+    end
+  end
 
   # Opens a file from the tree, reusing an existing buffer when one exists
   # for the same path. Without the dedup check, the file tree creates
@@ -1051,7 +1055,7 @@ defmodule MingaEditor.Commands.FileTree do
       if error_reason, do: FileTreeState.refresh_failed(file_tree, error_reason), else: file_tree
     end)
     |> EditorState.set_keymap_scope(:file_tree)
-    |> EditorState.set_sidebar_active_id("file_tree")
+    |> SidebarWorkflow.select("file_tree")
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end

--- a/lib/minga_editor/commands/formatting.ex
+++ b/lib/minga_editor/commands/formatting.ex
@@ -14,6 +14,8 @@ defmodule MingaEditor.Commands.Formatting do
   alias MingaEditor.EffectScheduler
   alias MingaEditor.Effects.ExternalFormat
   alias MingaEditor.LSP.FormatLifecycle
+  alias MingaEditor.Shell.Traditional.ToolPrompts
+  alias MingaEditor.Shell.Traditional.ToolPromptWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.LSP, as: LSPState
   alias MingaEditor.State.OperationFeedback
@@ -235,7 +237,7 @@ defmodule MingaEditor.Commands.Formatting do
         )
 
       recipe ->
-        if EditorState.skip_tool_prompt?(state, recipe.name) do
+        if ToolPromptWorkflow.skip?(state, recipe.name) do
           MingaEditor.Shell.Traditional.NoticeWorkflow.publish(
             state,
             "Formatter not found: #{command}"
@@ -248,18 +250,18 @@ defmodule MingaEditor.Commands.Formatting do
 
   @spec queue_and_show_prompt(state(), atom()) :: state()
   defp queue_and_show_prompt(%{workspace: %{editing: %{mode: :normal}}} = state, tool_name) do
-    queue = Enum.concat(state.shell_runtime.state.tool_prompt_queue, [tool_name])
-    state = EditorState.set_tool_prompt_queue(state, queue)
-    ms = %ToolConfirmState{pending: queue, declined: state.shell_runtime.state.tool_declined}
+    state = ToolPromptWorkflow.enqueue(state, tool_name)
+    prompts = ToolPromptWorkflow.prompts(state)
+
+    ms = %ToolConfirmState{
+      pending: ToolPrompts.queue(prompts),
+      declined: ToolPrompts.declined(prompts)
+    }
+
     EditorState.transition_mode(state, :tool_confirm, ms)
   end
 
-  defp queue_and_show_prompt(state, tool_name) do
-    EditorState.set_tool_prompt_queue(
-      state,
-      Enum.concat(state.shell_runtime.state.tool_prompt_queue, [tool_name])
-    )
-  end
+  defp queue_and_show_prompt(state, tool_name), do: ToolPromptWorkflow.enqueue(state, tool_name)
 
   command(:format_buffer, "Format buffer", requires_buffer: true, execute: &format_buffer/1)
 end

--- a/lib/minga_editor/commands/inline_ask.ex
+++ b/lib/minga_editor/commands/inline_ask.ex
@@ -54,10 +54,8 @@ defmodule MingaEditor.Commands.InlineAsk do
         context_text(state, buffer_pid, line)
       )
 
-    asks = state |> EditorState.inline_asks() |> InlineAsk.put(ask)
-
     state
-    |> EditorState.set_inline_asks(asks)
+    |> AgentAccess.replace_inline_ask(ask)
     |> MingaEditor.Shell.Traditional.NoticeWorkflow.publish("Inline ask: type a question")
   end
 
@@ -156,8 +154,8 @@ defmodule MingaEditor.Commands.InlineAsk do
 
   @spec dismiss_without_stop(state(), pid()) :: state()
   defp dismiss_without_stop(state, buffer_pid) when is_pid(buffer_pid) do
-    {asks, _session_pid} = state |> EditorState.inline_asks() |> InlineAsk.dismiss(buffer_pid)
-    EditorState.set_inline_asks(state, asks)
+    {state, _session_pid} = AgentAccess.cancel_inline_ask(state, buffer_pid)
+    state
   end
 
   @spec file_ref_for_active_buffer(state(), pid()) ::

--- a/lib/minga_editor/commands/inline_edit.ex
+++ b/lib/minga_editor/commands/inline_edit.ex
@@ -10,6 +10,7 @@ defmodule MingaEditor.Commands.InlineEdit do
   alias Minga.Mode.VisualState
   alias Minga.Project.FileRef
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.InlineEdit
 
   @type state :: EditorState.t()
@@ -42,10 +43,9 @@ defmodule MingaEditor.Commands.InlineEdit do
     {:ok, file_ref, label} = file_ref_for_active_buffer(state, buffer_pid)
     original = Buffer.content_on_lines(buffer_pid, first, last)
     edit = InlineEdit.new(buffer_pid, file_ref, label, {first, last}, original)
-    edits = state |> EditorState.inline_edits() |> InlineEdit.put(edit)
 
     state
-    |> EditorState.set_inline_edits(edits)
+    |> AgentAccess.replace_inline_edit(edit)
     |> MingaEditor.Shell.Traditional.NoticeWorkflow.publish(
       "Inline edit: type rewrite instruction"
     )
@@ -89,11 +89,9 @@ defmodule MingaEditor.Commands.InlineEdit do
 
   @spec accept_success(state(), InlineEdit.t()) :: state()
   defp accept_success(state, %InlineEdit{} = edit) do
-    {edits, _session_pid} =
-      state |> EditorState.inline_edits() |> InlineEdit.dismiss(edit.buffer_pid)
+    {state, _session_pid} = AgentAccess.cancel_inline_edit(state, edit.buffer_pid)
 
     state
-    |> EditorState.set_inline_edits(edits)
     |> EditorState.transition_mode(:normal)
     |> MingaEditor.Shell.Traditional.NoticeWorkflow.publish("Inline edit accepted")
   end
@@ -103,10 +101,8 @@ defmodule MingaEditor.Commands.InlineEdit do
   def reject(state, %InlineEdit{} = edit) do
     MingaAgent.EphemeralSession.stop(edit.session_pid)
 
-    {edits, _session_pid} =
-      state |> EditorState.inline_edits() |> InlineEdit.dismiss(edit.buffer_pid)
-
-    EditorState.set_inline_edits(state, edits)
+    {state, _session_pid} = AgentAccess.cancel_inline_edit(state, edit.buffer_pid)
+    state
   end
 
   @spec selection_range(state()) :: {non_neg_integer(), non_neg_integer()}

--- a/lib/minga_editor/commands/ui.ex
+++ b/lib/minga_editor/commands/ui.ex
@@ -9,6 +9,8 @@ defmodule MingaEditor.Commands.UI do
 
   alias MingaEditor.BottomPanel
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.Frontend
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.PickerUI
@@ -98,7 +100,7 @@ defmodule MingaEditor.Commands.UI do
   @spec toggle_beam_observatory(EditorState.t()) :: EditorState.t()
   defp toggle_beam_observatory(state) do
     if observatory_supported?(state) do
-      if EditorState.observatory_visible?(state),
+      if SidebarWorkflow.observatory_visible?(state),
         do: close_beam_observatory(state),
         else: open_beam_observatory(state)
     else
@@ -115,8 +117,7 @@ defmodule MingaEditor.Commands.UI do
 
       state
       |> focus_observatory_sidebar()
-      |> EditorState.open_observatory({timer, token})
-      |> EditorState.set_sidebar_active_id("observatory")
+      |> SidebarWorkflow.open_observatory({timer, token})
     else
       state
     end
@@ -132,11 +133,7 @@ defmodule MingaEditor.Commands.UI do
   @spec close_beam_observatory(EditorState.t()) :: EditorState.t()
   defp close_beam_observatory(state) do
     unsubscribe_observatory()
-    cancel_timer(state.shell_runtime.state.observatory_timer)
-
-    state
-    |> EditorState.close_observatory()
-    |> EditorState.set_sidebar_active_id(nil)
+    SidebarWorkflow.close_observatory(state)
   end
 
   @spec subscribe_observatory() :: :ok
@@ -153,14 +150,6 @@ defmodule MingaEditor.Commands.UI do
     :exit, _ -> :ok
   end
 
-  @spec cancel_timer(reference() | nil) :: :ok
-  defp cancel_timer(nil), do: :ok
-
-  defp cancel_timer({timer, _token}) do
-    Process.cancel_timer(timer)
-    :ok
-  end
-
   @spec observatory_supported?(EditorState.t()) :: boolean()
   defp observatory_supported?(state) do
     observatory_shell_supported?(state) and
@@ -170,12 +159,8 @@ defmodule MingaEditor.Commands.UI do
   end
 
   @spec observatory_shell_supported?(EditorState.t()) :: boolean()
-  defp observatory_shell_supported?(%{shell_runtime: %{state: shell_state}}) do
-    Map.has_key?(shell_state, :observatory_visible) and
-      Map.has_key?(shell_state, :observatory_timer) and
-      Map.has_key?(shell_state, :observatory_data) and
-      Map.has_key?(shell_state, :observatory_inspection)
-  end
+  defp observatory_shell_supported?(%{shell_runtime: %{state: %TraditionalState{}}}), do: true
+  defp observatory_shell_supported?(%EditorState{}), do: false
 
   @spec execute_parser_restart(EditorState.t()) :: EditorState.t()
   defp execute_parser_restart(state) do

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -10,6 +10,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Workflow
   alias MingaEditor.State, as: EditorState
 
@@ -97,7 +98,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
        ) do
     state = FileTreeFreshness.refresh_git_status(state, event)
 
-    case EditorState.git_status_panel(state) do
+    case SidebarWorkflow.git_status_panel(state) do
       nil ->
         if FileTreeFreshness.open?(state), do: {state, [{:render, 16}]}, else: {state, []}
 
@@ -115,7 +116,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
 
         state =
           state
-          |> EditorState.set_git_status_panel(GitStatusPanel.new(git_status_data))
+          |> SidebarWorkflow.replace_git_status(GitStatusPanel.new(git_status_data))
           |> Workflow.ensure_available()
 
         {runtime, workspace} =

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -13,6 +13,8 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   alias Minga.Buffer
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.Shell.Traditional.Observatory, as: ObservatoryState
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias Minga.Clipboard
   alias Minga.Editing.Completion
   alias Minga.FileWatcher
@@ -223,15 +225,12 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   end
 
   defp dispatch_action(
-         %{shell_runtime: %{state: shell_state}} = state,
+         %{shell_runtime: %{state: %MingaEditor.Shell.Traditional.State{}}} = state,
          {:observatory_inspect, pid_string}
-       ) do
-    if Map.has_key?(shell_state, :observatory_inspection) do
-      Observatory.inspect_process(state, pid_string)
-    else
-      state
-    end
-  end
+       ),
+       do: Observatory.inspect_process(state, pid_string)
+
+  defp dispatch_action(state, {:observatory_inspect, _pid_string}), do: state
 
   defp dispatch_action(state, {:timeline_navigate, index}) do
     MingaEditor.Commands.EditTimeline.navigate_to_index(state, index)
@@ -1058,9 +1057,9 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   @spec remember_visible_sidebar(EditorState.t(), String.t()) :: EditorState.t()
   defp remember_visible_sidebar(state, sidebar_id) do
     if sidebar_visible?(state, sidebar_id) do
-      EditorState.set_sidebar_active_id(state, sidebar_id)
+      SidebarWorkflow.select(state, sidebar_id)
     else
-      EditorState.set_sidebar_active_id(state, nil)
+      SidebarWorkflow.select(state, nil)
     end
   end
 
@@ -1072,8 +1071,8 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     |> FileTreeState.visible_status?()
   end
 
-  defp sidebar_visible?(state, "git_status"), do: EditorState.git_status_panel(state) != nil
-  defp sidebar_visible?(state, "observatory"), do: EditorState.observatory_visible?(state)
+  defp sidebar_visible?(state, "git_status"), do: SidebarWorkflow.git_status_panel(state) != nil
+  defp sidebar_visible?(state, "observatory"), do: SidebarWorkflow.observatory_visible?(state)
   defp sidebar_visible?(_state, _sidebar_id), do: false
 
   @spec ignored_sidebar_action(EditorState.t(), String.t(), String.t(), String.t()) ::
@@ -1154,7 +1153,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec git_status_panel_entries(state()) :: [Git.StatusEntry.t()]
   defp git_status_panel_entries(state) do
-    case EditorState.git_status_panel(state) do
+    case SidebarWorkflow.git_status_panel(state) do
       nil -> []
       panel -> Map.get(panel, :entries) || []
     end
@@ -1802,13 +1801,22 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   # (the builder checks it first); otherwise close the :float popup window via
   # the popup lifecycle. Returns state unchanged when neither is present.
   @spec dismiss_float_popup(state()) :: state()
-  defp dismiss_float_popup(
-         %{shell_runtime: %{state: %{observatory_inspection: %{visible: true}}}} = state
-       ) do
-    Observatory.inspect_process(state, "")
+  defp dismiss_float_popup(state) do
+    case SidebarWorkflow.observatory(state) do
+      %ObservatoryState{} = observatory ->
+        dismiss_float_popup(state, ObservatoryState.inspection(observatory))
+
+      nil ->
+        dismiss_window_popup(state)
+    end
   end
 
-  defp dismiss_float_popup(state) do
+  @spec dismiss_float_popup(state(), MingaEditor.Observatory.Inspection.t() | nil) :: state()
+  defp dismiss_float_popup(state, %{visible: true}), do: Observatory.inspect_process(state, "")
+  defp dismiss_float_popup(state, _inspection), do: dismiss_window_popup(state)
+
+  @spec dismiss_window_popup(state()) :: state()
+  defp dismiss_window_popup(state) do
     case find_float_popup_window_id(state) do
       nil -> state
       window_id -> PopupLifecycle.close_popup(state, window_id)

--- a/lib/minga_editor/handlers/tool_handler.ex
+++ b/lib/minga_editor/handlers/tool_handler.ex
@@ -6,11 +6,12 @@ defmodule MingaEditor.Handlers.ToolHandler do
   GenServer into pure `{state, [effect]}` functions. The Editor delegates
   to this module via catch-all clauses and applies the returned effects.
 
-  Each function reads and writes only tool-related state slices
-  (`state.shell_runtime.state.tool_prompt_queue`, `state.shell_runtime.state.tool_declined`,
-  status messages).
+  Each function reads and writes only the focused tool-prompt owner and
+  status notices.
   """
 
+  alias MingaEditor.Shell.Traditional.ToolPrompts
+  alias MingaEditor.Shell.Traditional.ToolPromptWorkflow
   alias MingaEditor.State, as: EditorState
 
   @typedoc "Effects that the tool handler may return."
@@ -111,36 +112,14 @@ defmodule MingaEditor.Handlers.ToolHandler do
     {new_state, [:render]}
   end
 
-  # ── Tool missing prompt (suppressed) ─────────────────────────────────────
-
-  def handle(
-        %{shell_runtime: %{state: %{suppress_tool_prompts: true}}} = state,
-        {:minga_event, :tool_missing, %Minga.Events.ToolMissingEvent{command: command}}
-      ) do
-    {state, [{:log, :editor, :debug, "[Editor] tool_missing suppressed for #{command}"}]}
-  end
-
-  # ── Tool missing prompt (active) ─────────────────────────────────────────
+  # ── Tool missing prompt ──────────────────────────────────────────────────
 
   def handle(
         state,
         {:minga_event, :tool_missing, %Minga.Events.ToolMissingEvent{command: command}}
       ) do
-    recipe = Minga.Tool.Recipe.Registry.for_command(command)
-
-    new_state =
-      if recipe && not EditorState.skip_tool_prompt?(state, recipe.name) do
-        queue = Enum.concat(state.shell_runtime.state.tool_prompt_queue, [recipe.name])
-
-        state_with_queue =
-          EditorState.set_tool_prompt_queue(state, queue)
-
-        maybe_show_tool_prompt(state_with_queue)
-      else
-        state
-      end
-
-    {new_state, [:render]}
+    prompts = ToolPromptWorkflow.prompts(state)
+    handle_tool_missing(state, command, ToolPrompts.suppressed?(prompts))
   end
 
   # ── Catch-all ────────────────────────────────────────────────────────────
@@ -151,24 +130,46 @@ defmodule MingaEditor.Handlers.ToolHandler do
 
   # ── Private helpers ──────────────────────────────────────────────────────
 
+  @spec handle_tool_missing(EditorState.t(), String.t(), boolean()) ::
+          {EditorState.t(), [tool_effect()]}
+  defp handle_tool_missing(state, command, true) do
+    {state, [{:log, :editor, :debug, "[Editor] tool_missing suppressed for #{command}"}]}
+  end
+
+  defp handle_tool_missing(state, command, false) do
+    recipe = Minga.Tool.Recipe.Registry.for_command(command)
+
+    new_state =
+      if recipe && not ToolPromptWorkflow.skip?(state, recipe.name) do
+        state
+        |> ToolPromptWorkflow.enqueue(recipe.name)
+        |> maybe_show_tool_prompt()
+      else
+        state
+      end
+
+    {new_state, [:render]}
+  end
+
   # Transitions to :tool_confirm mode if in normal mode and there are
   # pending tool prompts. Otherwise the prompt waits until the user
   # returns to normal mode.
   @spec maybe_show_tool_prompt(EditorState.t()) :: EditorState.t()
-  defp maybe_show_tool_prompt(
-         %{
-           workspace: %{editing: %{mode: :normal}},
-           shell_runtime: %{state: %{tool_prompt_queue: pending}}
-         } = state
-       )
-       when pending != [] do
-    ms = %Minga.Mode.ToolConfirmState{
-      pending: pending,
-      declined: state.shell_runtime.state.tool_declined
-    }
-
-    EditorState.transition_mode(state, :tool_confirm, ms)
+  defp maybe_show_tool_prompt(%{workspace: %{editing: %{mode: :normal}}} = state) do
+    prompts = ToolPromptWorkflow.prompts(state)
+    show_tool_prompt(state, ToolPrompts.queue(prompts), ToolPrompts.declined(prompts))
   end
 
   defp maybe_show_tool_prompt(state), do: state
+
+  @spec show_tool_prompt(EditorState.t(), [atom()], MapSet.t(atom())) :: EditorState.t()
+  defp show_tool_prompt(state, [], _declined), do: state
+
+  defp show_tool_prompt(state, pending, declined) do
+    EditorState.transition_mode(
+      state,
+      :tool_confirm,
+      %Minga.Mode.ToolConfirmState{pending: pending, declined: declined}
+    )
+  end
 end

--- a/lib/minga_editor/inline_ask/events.ex
+++ b/lib/minga_editor/inline_ask/events.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.InlineAsk.Events do
   alias MingaAgent.EphemeralSession
   alias MingaEditor.InlineOverlay.Events, as: Overlay
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.InlineAsk
 
   @type state :: EditorState.t()
@@ -34,15 +35,11 @@ defmodule MingaEditor.InlineAsk.Events do
   @spec spec() :: Overlay.spec()
   defp spec do
     %{
-      store: &store/1,
-      set_store: &EditorState.set_inline_asks/2,
+      store: &AgentAccess.inline_asks/1,
+      replace: &AgentAccess.replace_inline_ask/2,
       session?: &InlineAsk.session?/2
     }
   end
-
-  @spec store(state()) :: InlineAsk.store() | nil
-  defp store(%{shell_runtime: %{state: %{inline_asks: asks}}}) when is_map(asks), do: asks
-  defp store(_state), do: nil
 
   @spec fail(InlineAsk.t(), term()) :: InlineAsk.t()
   defp fail(%InlineAsk{} = ask, reason),

--- a/lib/minga_editor/inline_ask/render.ex
+++ b/lib/minga_editor/inline_ask/render.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.InlineAsk.Render do
   alias Minga.Core.Decorations
   alias Minga.Core.Face
   alias MingaEditor.InlineOverlay.Render, as: Overlay
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.InlineAsk
 
   @group :inline_ask
@@ -80,7 +81,5 @@ defmodule MingaEditor.InlineAsk.Render do
   defp face(:help), do: Face.new(fg: 0x808080)
 
   @spec inline_asks(term()) :: InlineAsk.store()
-  defp inline_asks(%{shell_runtime: %{state: %{inline_asks: asks}}}) when is_map(asks), do: asks
-  defp inline_asks(%{shell_state: %{inline_asks: asks}}) when is_map(asks), do: asks
-  defp inline_asks(_state), do: %{}
+  defp inline_asks(state), do: AgentAccess.inline_asks(state)
 end

--- a/lib/minga_editor/inline_edit/events.ex
+++ b/lib/minga_editor/inline_edit/events.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.InlineEdit.Events do
   alias MingaAgent.EphemeralSession
   alias MingaEditor.InlineOverlay.Events, as: Overlay
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.InlineEdit
 
   @type state :: EditorState.t()
@@ -34,15 +35,11 @@ defmodule MingaEditor.InlineEdit.Events do
   @spec spec() :: Overlay.spec()
   defp spec do
     %{
-      store: &store/1,
-      set_store: &EditorState.set_inline_edits/2,
+      store: &AgentAccess.inline_edits/1,
+      replace: &AgentAccess.replace_inline_edit/2,
       session?: &InlineEdit.session?/2
     }
   end
-
-  @spec store(state()) :: InlineEdit.store() | nil
-  defp store(%{shell_runtime: %{state: %{inline_edits: edits}}}) when is_map(edits), do: edits
-  defp store(_state), do: nil
 
   @spec fail(InlineEdit.t(), term()) :: InlineEdit.t()
   defp fail(%InlineEdit{} = edit, reason),

--- a/lib/minga_editor/inline_edit/render.ex
+++ b/lib/minga_editor/inline_edit/render.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.InlineEdit.Render do
   alias Minga.Core.Decorations
   alias Minga.Core.Face
   alias MingaEditor.InlineOverlay.Render, as: Overlay
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.InlineEdit
 
   @group :inline_edit
@@ -80,9 +81,5 @@ defmodule MingaEditor.InlineEdit.Render do
   defp face(:help), do: Face.new(fg: 0x808080)
 
   @spec inline_edits(term()) :: InlineEdit.store()
-  defp inline_edits(%{shell_runtime: %{state: %{inline_edits: edits}}}) when is_map(edits),
-    do: edits
-
-  defp inline_edits(%{shell_state: %{inline_edits: edits}}) when is_map(edits), do: edits
-  defp inline_edits(_state), do: %{}
+  defp inline_edits(state), do: AgentAccess.inline_edits(state)
 end

--- a/lib/minga_editor/inline_overlay/events.ex
+++ b/lib/minga_editor/inline_overlay/events.ex
@@ -10,8 +10,8 @@ defmodule MingaEditor.InlineOverlay.Events do
   variant-specific transitions (`apply_event`, the failure message) stay
   in the adapters and are passed in as callbacks.
 
-  The `spec` map carries the store accessor, store setter, and the
-  `session?` predicate over the variant's state store.
+  The `spec` map carries the store accessor, focused replacement operation,
+  and the `session?` predicate over the variant's state store.
   """
 
   alias MingaAgent.EphemeralSession
@@ -21,12 +21,12 @@ defmodule MingaEditor.InlineOverlay.Events do
   Variant behaviour for an inline overlay event router.
 
   * `:store` reads the variant's per-buffer overlay store off editor state.
-  * `:set_store` writes an updated store back onto editor state.
+  * `:replace` writes one transitioned overlay through its focused owner.
   * `:session?` is true when a session pid belongs to this variant's store.
   """
   @type spec :: %{
           store: (EditorState.t() -> %{pid() => struct()} | nil),
-          set_store: (EditorState.t(), %{pid() => struct()} -> EditorState.t()),
+          replace: (EditorState.t(), struct() -> EditorState.t()),
           session?: (%{pid() => struct()}, pid() -> boolean())
         }
 
@@ -78,13 +78,9 @@ defmodule MingaEditor.InlineOverlay.Events do
   def update_for_session(state, session_pid, spec, fun) do
     case spec.store.(state) do
       store when is_map(store) ->
-        {buffer_pid, overlay} = find_by_session(store, session_pid)
+        {_buffer_pid, overlay} = find_by_session(store, session_pid)
 
-        if overlay do
-          spec.set_store.(state, Map.put(store, buffer_pid, fun.(overlay)))
-        else
-          state
-        end
+        if overlay, do: spec.replace.(state, fun.(overlay)), else: state
 
       _ ->
         state

--- a/lib/minga_editor/input/agent_nav.ex
+++ b/lib/minga_editor/input/agent_nav.ex
@@ -44,7 +44,7 @@ defmodule MingaEditor.Input.AgentNav do
     else
       view = AgentAccess.view(state)
 
-      case view.focus do
+      case UIState.View.focus(view) do
         :chat -> handle_chat_nav(state, cp, mods)
         :file_viewer -> handle_viewer_nav(state, cp, mods)
       end

--- a/lib/minga_editor/input/cua/tui_space_leader.ex
+++ b/lib/minga_editor/input/cua/tui_space_leader.ex
@@ -29,6 +29,8 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
 
   alias Minga.Buffer
   alias MingaEditor.Commands
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias Minga.Keymap
   alias Minga.Keymap.Bindings
@@ -53,15 +55,9 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
         end
       end
 
-      # Start the timeout timer
-      timer = Process.send_after(self(), :space_leader_timeout, @timeout_ms)
-
-      state =
-        state
-        |> put_space_leader_pending(true)
-        |> put_space_leader_timer(timer)
-
-      {:handled, state}
+      {generation, state} = begin_window(state)
+      timer = Process.send_after(self(), {:space_leader_timeout, generation}, @timeout_ms)
+      {:handled, install_timer(state, generation, timer)}
     else
       {:passthrough, state}
     end
@@ -82,8 +78,7 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
         ) ::
           MingaEditor.Input.Handler.result()
   defp handle_non_space_key(state, cp, mods, true, _node) do
-    state = cancel_timer(state)
-    state = put_space_leader_pending(state, false)
+    state = cancel(state)
 
     trie = leader_trie(state)
     key = {cp, mods}
@@ -107,17 +102,30 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
     {:passthrough, state}
   end
 
-  @doc """
-  Handles the timeout message. Called from Editor's handle_info.
+  @doc "Expires a matching timeout generation and ignores stale deliveries."
+  @spec handle_timeout(EditorState.t(), non_neg_integer()) :: EditorState.t()
+  def handle_timeout(%EditorState{} = state, generation) do
+    case Runtime.state(state.shell_runtime) do
+      %TraditionalState{} = shell_state ->
+        {_result, shell_state} = TraditionalState.expire_space_leader(shell_state, generation)
+        install_shell_state(state, shell_state)
 
-  The space was real (no follow-up key within the timeout window).
-  Clear the pending state.
-  """
-  @spec handle_timeout(EditorState.t()) :: EditorState.t()
-  def handle_timeout(state) do
-    state
-    |> put_space_leader_pending(false)
-    |> put_space_leader_timer(nil)
+      _extension_state ->
+        state
+    end
+  end
+
+  @doc "Cancels and resets the current timeout window."
+  @spec cancel(EditorState.t()) :: EditorState.t()
+  def cancel(%EditorState{} = state) do
+    case Runtime.state(state.shell_runtime) do
+      %TraditionalState{} = shell_state ->
+        cancel_timer(TraditionalState.space_leader_timer(shell_state))
+        install_shell_state(state, TraditionalState.reset_space_leader(shell_state))
+
+      _extension_state ->
+        state
+    end
   end
 
   @doc """
@@ -128,7 +136,8 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
   """
   @spec active?(map()) :: boolean()
   def active?(state) do
-    Minga.Editing.active_model(state) == Minga.Editing.Model.CUA and
+    match?(%TraditionalState{}, Runtime.state(state.shell_runtime)) and
+      Minga.Editing.active_model(state) == Minga.Editing.Model.CUA and
       Minga.Config.get(:space_leader) == :chord and
       state.backend == :tui
   catch
@@ -138,7 +147,9 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
   # ── Private ──────────────────────────────────────────────────────────────
 
   @spec pending?(map()) :: boolean()
-  defp pending?(%{shell_runtime: %{state: %{space_leader_pending: true}}}), do: true
+  defp pending?(%{shell_runtime: %{state: %TraditionalState{} = shell_state}}),
+    do: TraditionalState.space_leader_pending?(shell_state)
+
   defp pending?(_state), do: false
 
   @spec active_leader_node(EditorState.t()) :: Bindings.node_t() | nil
@@ -146,22 +157,37 @@ defmodule MingaEditor.Input.CUA.TUISpaceLeader do
     if active?(state), do: state.shell_runtime.state.whichkey.node, else: nil
   end
 
-  @spec put_space_leader_pending(EditorState.t(), boolean()) :: EditorState.t()
-  defp put_space_leader_pending(state, value) do
-    EditorState.set_space_leader_pending(state, value)
+  @spec begin_window(EditorState.t()) :: {non_neg_integer(), EditorState.t()}
+  defp begin_window(%EditorState{} = state) do
+    %TraditionalState{} = shell_state = Runtime.state(state.shell_runtime)
+    {generation, shell_state} = TraditionalState.begin_space_leader(shell_state)
+    {generation, install_shell_state(state, shell_state)}
   end
 
-  @spec put_space_leader_timer(EditorState.t(), reference() | nil) :: EditorState.t()
-  defp put_space_leader_timer(state, timer) do
-    EditorState.set_space_leader_timer(state, timer)
+  @spec install_timer(EditorState.t(), non_neg_integer(), reference()) :: EditorState.t()
+  defp install_timer(%EditorState{} = state, generation, timer) do
+    %TraditionalState{} = shell_state = Runtime.state(state.shell_runtime)
+
+    install_shell_state(
+      state,
+      TraditionalState.install_space_leader_timer(shell_state, generation, timer)
+    )
   end
 
-  @spec cancel_timer(EditorState.t()) :: EditorState.t()
-  defp cancel_timer(%{shell_runtime: %{state: %{space_leader_timer: nil}}} = state), do: state
+  @spec install_shell_state(EditorState.t(), TraditionalState.t()) :: EditorState.t()
+  defp install_shell_state(%EditorState{} = state, %TraditionalState{} = shell_state) do
+    runtime =
+      Runtime.update_traditional_state(state.shell_runtime, fn _current -> shell_state end)
 
-  defp cancel_timer(%{shell_runtime: %{state: %{space_leader_timer: timer}}} = state) do
+    EditorState.apply_shell_runtime_transition(state, runtime)
+  end
+
+  @spec cancel_timer(reference() | nil) :: :ok
+  defp cancel_timer(nil), do: :ok
+
+  defp cancel_timer(timer) when is_reference(timer) do
     Process.cancel_timer(timer)
-    put_space_leader_timer(state, nil)
+    :ok
   end
 
   @spec retract_space(EditorState.t()) :: EditorState.t()

--- a/lib/minga_editor/input/diff_review.ex
+++ b/lib/minga_editor/input/diff_review.ex
@@ -12,6 +12,7 @@ defmodule MingaEditor.Input.DiffReview do
 
   @type state :: MingaEditor.Input.Handler.handler_state()
 
+  alias MingaEditor.Agent.UIState.View
   alias MingaEditor.Agent.View.Preview
   alias MingaEditor.Commands
   alias MingaEditor.State, as: EditorState
@@ -25,7 +26,7 @@ defmodule MingaEditor.Input.DiffReview do
     view = AgentAccess.view(state)
     panel = AgentAccess.panel(state)
 
-    if view.focus == :file_viewer and
+    if View.focus(view) == :file_viewer and
          match?(%Preview{content: {:diff, _}}, view.preview) and
          not panel.input_focused do
       dispatch_diff_key(state, cp)

--- a/lib/minga_editor/input/inline_ask.ex
+++ b/lib/minga_editor/input/inline_ask.ex
@@ -14,7 +14,7 @@ defmodule MingaEditor.Input.InlineAsk do
   alias MingaAgent.EphemeralSession
   alias MingaEditor.Commands.InlineAsk, as: InlineAskCommand
   alias MingaEditor.Input.InlineOverlay, as: Overlay
-  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.InlineAsk
 
   @type state :: MingaEditor.Input.Handler.handler_state()
@@ -82,8 +82,9 @@ defmodule MingaEditor.Input.InlineAsk do
   @spec spec(keyword()) :: Overlay.spec()
   defp spec(opts) do
     %{
-      store: &EditorState.inline_asks/1,
-      set_store: &EditorState.set_inline_asks/2,
+      store: &AgentAccess.inline_asks/1,
+      replace: &AgentAccess.replace_inline_ask/2,
+      cancel: &AgentAccess.cancel_inline_ask/2,
       state_module: InlineAsk,
       session_starter: Keyword.get(opts, :session_asker, &EphemeralSession.ask/3),
       fail_prefix: "Failed to start inline ask: "

--- a/lib/minga_editor/input/inline_edit.ex
+++ b/lib/minga_editor/input/inline_edit.ex
@@ -15,7 +15,7 @@ defmodule MingaEditor.Input.InlineEdit do
   alias MingaAgent.EphemeralSession
   alias MingaEditor.Commands.InlineEdit, as: InlineEditCommand
   alias MingaEditor.Input.InlineOverlay, as: Overlay
-  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.InlineEdit
 
   @type state :: MingaEditor.Input.Handler.handler_state()
@@ -78,8 +78,9 @@ defmodule MingaEditor.Input.InlineEdit do
   @spec spec() :: Overlay.spec()
   defp spec do
     %{
-      store: &EditorState.inline_edits/1,
-      set_store: &EditorState.set_inline_edits/2,
+      store: &AgentAccess.inline_edits/1,
+      replace: &AgentAccess.replace_inline_edit/2,
+      cancel: &AgentAccess.cancel_inline_edit/2,
       state_module: InlineEdit,
       session_starter: &EphemeralSession.rewrite/3,
       fail_prefix: "Failed to start inline edit: "

--- a/lib/minga_editor/input/inline_overlay.ex
+++ b/lib/minga_editor/input/inline_overlay.ex
@@ -24,7 +24,8 @@ defmodule MingaEditor.Input.InlineOverlay do
   Variant behaviour for an inline overlay input handler.
 
   * `:store` reads the variant's per-buffer overlay store off editor state.
-  * `:set_store` writes an updated store back onto editor state.
+  * `:replace` replaces one overlay through the focused surface owner.
+  * `:cancel` removes one overlay through the focused surface owner.
   * `:state_module` is the variant state module (for `active/2`, `put/2`,
     `dismiss/2`, `thinking/2`, `fail/2`, `append_input/2`, `backspace/1`,
     `agent_prompt/1`).
@@ -34,7 +35,8 @@ defmodule MingaEditor.Input.InlineOverlay do
   """
   @type spec :: %{
           store: (EditorState.t() -> %{pid() => struct()}),
-          set_store: (EditorState.t(), %{pid() => struct()} -> EditorState.t()),
+          replace: (EditorState.t(), struct() -> EditorState.t()),
+          cancel: (EditorState.t(), pid() | nil -> {EditorState.t(), pid() | nil}),
           state_module: module(),
           session_starter: (String.t(), String.t(), keyword() -> {:ok, pid()} | {:error, term()}),
           fail_prefix: String.t()
@@ -59,22 +61,15 @@ defmodule MingaEditor.Input.InlineOverlay do
 
   @doc "Writes an updated overlay back into its store on editor state."
   @spec update(state(), struct(), spec()) :: state()
-  def update(state, overlay, spec) do
-    state
-    |> spec.store.()
-    |> spec.state_module.put(overlay)
-    |> then(&spec.set_store.(state, &1))
-  end
+  def update(state, overlay, spec), do: spec.replace.(state, overlay)
 
   @doc "Stops the overlay's session and removes it from its store."
   @spec dismiss(state(), struct(), spec()) :: state()
   def dismiss(state, overlay, spec) do
     MingaAgent.EphemeralSession.stop(overlay.session_pid)
 
-    {store, _session_pid} =
-      state |> spec.store.() |> spec.state_module.dismiss(overlay.buffer_pid)
-
-    spec.set_store.(state, store)
+    {state, _session_pid} = spec.cancel.(state, overlay.buffer_pid)
+    state
   end
 
   @doc "Appends a printable codepoint to the prompt, honouring modifier gating."

--- a/lib/minga_editor/input/interrupt.ex
+++ b/lib/minga_editor/input/interrupt.ex
@@ -137,7 +137,7 @@ defmodule MingaEditor.Input.Interrupt do
 
   @spec maybe_clear_agent_prefix(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
   defp maybe_clear_agent_prefix(state, resets) do
-    case AgentAccess.view(state).pending_prefix do
+    case state |> AgentAccess.view() |> UIState.View.pending_prefix() do
       nil ->
         {state, resets}
 

--- a/lib/minga_editor/input/observatory.ex
+++ b/lib/minga_editor/input/observatory.ex
@@ -7,6 +7,8 @@ defmodule MingaEditor.Input.Observatory do
 
   alias Minga.Buffer
   alias MingaEditor.Observatory.Inspection
+  alias MingaEditor.Shell.Traditional.Observatory
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
 
   @type state :: EditorState.t()
@@ -15,7 +17,7 @@ defmodule MingaEditor.Input.Observatory do
   @doc "Inspects a process selected in the BEAM Observatory."
   @spec inspect_process(state(), String.t()) :: state()
   def inspect_process(state, "") do
-    EditorState.set_observatory_inspection(state, nil)
+    SidebarWorkflow.inspect_observatory(state, nil)
   end
 
   def inspect_process(state, pid_string) when is_binary(pid_string) do
@@ -24,7 +26,7 @@ defmodule MingaEditor.Input.Observatory do
       |> parse_pid()
       |> build_inspection(state, pid_string)
 
-    EditorState.set_observatory_inspection(state, inspection)
+    SidebarWorkflow.inspect_observatory(state, inspection)
   end
 
   @spec parse_pid(String.t()) :: {:ok, pid()} | :error
@@ -59,7 +61,15 @@ defmodule MingaEditor.Input.Observatory do
   end
 
   @spec find_process_class(state(), pid()) :: process_class()
-  defp find_process_class(%{shell_runtime: %{state: %{observatory_data: %{tree: tree}}}}, pid) do
+  defp find_process_class(state, pid) do
+    case SidebarWorkflow.observatory(state) do
+      %Observatory{} = observatory -> process_class(Observatory.data(observatory), pid)
+      nil -> :worker
+    end
+  end
+
+  @spec process_class(MingaEditor.Observatory.Data.t() | nil, pid()) :: process_class()
+  defp process_class(%{tree: tree}, pid) do
     tree
     |> Minga.SystemObserver.TreeNode.flatten()
     |> Enum.find_value(:worker, fn node ->
@@ -67,7 +77,7 @@ defmodule MingaEditor.Input.Observatory do
     end)
   end
 
-  defp find_process_class(_state, _pid), do: :worker
+  defp process_class(nil, _pid), do: :worker
 
   @spec format_process_state(term(), process_class(), pid()) :: [String.t()]
   defp format_process_state(process_state, :buffer, pid) do

--- a/lib/minga_editor/input/scoped.ex
+++ b/lib/minga_editor/input/scoped.ex
@@ -202,7 +202,7 @@ defmodule MingaEditor.Input.Scoped do
     key = {cp, mods}
 
     # Check if we're continuing a prefix sequence
-    case AgentAccess.view(state).pending_prefix do
+    case state |> AgentAccess.view() |> UIState.View.pending_prefix() do
       nil ->
         # Fresh lookup
         resolve_scope_key(state, :agent, vim_state, key, cp, mods)

--- a/lib/minga_editor/key_dispatch.ex
+++ b/lib/minga_editor/key_dispatch.ex
@@ -22,6 +22,8 @@ defmodule MingaEditor.KeyDispatch do
   alias MingaEditor.MinibufferData
   alias MingaEditor.ModeTransitions
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Shell.Traditional.ToolPrompts
+  alias MingaEditor.Shell.Traditional.ToolPromptWorkflow
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.ModalOverlay.CommandCompletion, as: CommandCompletionPayload
   alias Minga.Keymap
@@ -107,11 +109,13 @@ defmodule MingaEditor.KeyDispatch do
 
     # When leaving :tool_confirm, check if more tools were queued during
     # the session and re-enter :tool_confirm to prompt for them.
-    if old_mode == :tool_confirm and CoreEditing.mode(result) == :normal and
-         result.shell_runtime.state.tool_prompt_queue != [] do
+    prompts = ToolPromptWorkflow.prompts(result)
+    pending = ToolPrompts.queue(prompts)
+
+    if old_mode == :tool_confirm and CoreEditing.mode(result) == :normal and pending != [] do
       ms = %Minga.Mode.ToolConfirmState{
-        pending: result.shell_runtime.state.tool_prompt_queue,
-        declined: result.shell_runtime.state.tool_declined
+        pending: pending,
+        declined: ToolPrompts.declined(prompts)
       }
 
       EditorState.transition_mode(result, :tool_confirm, ms)

--- a/lib/minga_editor/layout/footer_overlays.ex
+++ b/lib/minga_editor/layout/footer_overlays.ex
@@ -65,6 +65,8 @@ defmodule MingaEditor.Layout.FooterOverlays do
   """
 
   alias MingaEditor.RenderModel.UI.AgentContextBuilder
+  alias MingaEditor.Shell.Traditional.Observatory
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
 
   @typedoc "A visible footer overlay: its registry surface id and its band content height."
   @type entry :: {surface_id :: atom(), content_height :: non_neg_integer() | :max}
@@ -136,15 +138,18 @@ defmodule MingaEditor.Layout.FooterOverlays do
   defp notification_actions?(_item), do: false
 
   @spec content_height_observatory(map()) :: non_neg_integer()
-  defp content_height_observatory(%{shell_runtime: %{state: shell_state}}) do
-    content_height_observatory(%{shell_state: shell_state})
+  defp content_height_observatory(state) do
+    case observatory(state) do
+      %Observatory{} = observatory -> observatory_content_height(Observatory.data(observatory))
+      nil -> 1
+    end
   end
 
-  defp content_height_observatory(%{shell_state: %{observatory_data: %{tree: tree}}}) do
-    1 + Enum.count(Minga.SystemObserver.TreeNode.flatten(tree))
-  end
+  @spec observatory_content_height(MingaEditor.Observatory.Data.t() | nil) :: non_neg_integer()
+  defp observatory_content_height(%{tree: tree}),
+    do: 1 + Enum.count(Minga.SystemObserver.TreeNode.flatten(tree))
 
-  defp content_height_observatory(_state), do: 1
+  defp observatory_content_height(nil), do: 1
 
   @spec content_height_edit_timeline(map()) :: non_neg_integer()
   defp content_height_edit_timeline(state) do
@@ -173,17 +178,18 @@ defmodule MingaEditor.Layout.FooterOverlays do
   # Float popup: an observatory inspection float, or a window carrying a :float
   # popup rule. Mirrors MingaEditor.RenderModel.UI.FloatPopupBuilder.
   @spec float_popup_visible?(map()) :: boolean()
-  defp float_popup_visible?(%{shell_runtime: %{state: shell_state}} = state) do
-    state
-    |> Map.delete(:shell_runtime)
-    |> Map.put(:shell_state, shell_state)
-    |> float_popup_visible?()
+  defp float_popup_visible?(state) do
+    observatory_inspection_visible?(observatory(state)) or float_window_visible?(state)
   end
 
-  defp float_popup_visible?(%{shell_state: %{observatory_inspection: %{visible: true}}}),
-    do: true
+  @spec observatory_inspection_visible?(Observatory.t() | nil) :: boolean()
+  defp observatory_inspection_visible?(%Observatory{} = observatory),
+    do: match?(%{visible: true}, Observatory.inspection(observatory))
 
-  defp float_popup_visible?(%{workspace: %{windows: %{map: map}}}) when is_map(map) do
+  defp observatory_inspection_visible?(nil), do: false
+
+  @spec float_window_visible?(map()) :: boolean()
+  defp float_window_visible?(%{workspace: %{windows: %{map: map}}}) when is_map(map) do
     Enum.any?(map, fn
       {_id,
        %{
@@ -198,7 +204,7 @@ defmodule MingaEditor.Layout.FooterOverlays do
     end)
   end
 
-  defp float_popup_visible?(_state), do: false
+  defp float_window_visible?(_state), do: false
 
   # Agent context: live BEAM-owned agent activity projection. The builder's
   # visibility predicate reads the same live editor state as the render model but
@@ -224,11 +230,21 @@ defmodule MingaEditor.Layout.FooterOverlays do
   # Observatory: the BEAM observatory panel is toggled on in shell_state.
   # Mirrors MingaEditor.RenderModel.UI.ObservatoryBuilder.
   @spec observatory_visible?(map()) :: boolean()
-  defp observatory_visible?(%{shell_runtime: %{state: shell_state}}),
-    do: observatory_visible?(%{shell_state: shell_state})
+  defp observatory_visible?(state) do
+    case observatory(state) do
+      %Observatory{} = observatory -> Observatory.visible?(observatory)
+      nil -> false
+    end
+  end
 
-  defp observatory_visible?(%{shell_state: %{observatory_visible: true}}), do: true
-  defp observatory_visible?(_state), do: false
+  @spec observatory(map()) :: Observatory.t() | nil
+  defp observatory(%{shell_runtime: %{state: %TraditionalState{} = shell_state}}),
+    do: TraditionalState.observatory(shell_state)
+
+  defp observatory(%{shell_state: %TraditionalState{} = shell_state}),
+    do: TraditionalState.observatory(shell_state)
+
+  defp observatory(_state), do: nil
 
   # Edit timeline: the active buffer has timeline entries.
   # Mirrors MingaEditor.RenderModel.UI.EditTimelineBuilder.

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -1792,9 +1792,9 @@ defmodule MingaEditor.Mouse do
 
   @spec close_tab_at(state(), non_neg_integer(), non_neg_integer()) :: state()
   defp close_tab_at(state, row, col) do
-    case find_tab_bar_region(state.shell_runtime.state.tab_bar_click_regions, row, col) do
-      {:command, cmd} -> close_tab_by_command(state, cmd)
-      :not_tab_bar -> state
+    case tab_bar_command_at(state, row, col) do
+      nil -> state
+      command -> close_tab_by_command(state, command)
     end
   end
 
@@ -1846,37 +1846,24 @@ defmodule MingaEditor.Mouse do
           {:command, tab_command()} | :not_tab_bar
   defp tab_bar_click(state, row, col) do
     if SurfaceRegistry.within?(state, :tab_bar, row, col) do
-      find_tab_bar_region(state.shell_runtime.state.tab_bar_click_regions, row, col)
+      case tab_bar_command_at(state, row, col) do
+        nil -> :not_tab_bar
+        command -> {:command, command}
+      end
     else
       :not_tab_bar
     end
   end
 
-  @spec find_tab_bar_region(
-          [TraditionalState.tab_bar_click_region()],
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: {:command, tab_command()} | :not_tab_bar
-  defp find_tab_bar_region(regions, row, col) do
-    case Enum.find(regions, &tab_bar_region_hit?(&1, row, col)) do
-      {_, _, cmd} -> {:command, cmd}
-      {_, _, _, cmd} -> {:command, cmd}
-      nil -> :not_tab_bar
-    end
-  end
+  @spec tab_bar_command_at(state(), non_neg_integer(), non_neg_integer()) :: tab_command() | nil
+  defp tab_bar_command_at(
+         %{shell_runtime: %{state: %TraditionalState{} = shell_state}},
+         row,
+         col
+       ),
+       do: TraditionalState.tab_bar_command_at(shell_state, row, col)
 
-  @spec tab_bar_region_hit?(
-          TraditionalState.tab_bar_click_region(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: boolean()
-  defp tab_bar_region_hit?({start_col, end_col, _cmd}, _row, col) do
-    col >= start_col and col <= end_col
-  end
-
-  defp tab_bar_region_hit?({region_row, start_col, end_col, _cmd}, row, col) do
-    row == region_row and col >= start_col and col <= end_col
-  end
+  defp tab_bar_command_at(_state, _row, _col), do: nil
 
   # ── Modeline segment click detection ─────────────────────────────────────
 
@@ -1896,7 +1883,10 @@ defmodule MingaEditor.Mouse do
       end)
 
     if is_modeline do
-      find_click_region(state.shell_runtime.state.modeline_click_regions, col)
+      case modeline_command_at(state, col) do
+        nil -> :not_modeline
+        command -> {:command, command}
+      end
     else
       :not_modeline
     end
@@ -1927,17 +1917,12 @@ defmodule MingaEditor.Mouse do
   defp update_current_viewport(state, new_vp),
     do: EditorState.update_current_viewport(state, new_vp)
 
-  @spec find_click_region(
-          [MingaEditor.Shell.Traditional.Modeline.click_region()],
-          non_neg_integer()
-        ) ::
-          {:command, atom()} | :not_modeline
-  defp find_click_region(regions, col) do
-    case Enum.find(regions, fn {col_start, col_end, _cmd} ->
-           col >= col_start and col < col_end
-         end) do
-      {_start, _end, command} -> {:command, command}
-      nil -> :not_modeline
-    end
-  end
+  @spec modeline_command_at(state(), non_neg_integer()) :: atom() | nil
+  defp modeline_command_at(
+         %{shell_runtime: %{state: %TraditionalState{} = shell_state}},
+         col
+       ),
+       do: TraditionalState.modeline_command_at(shell_state, col)
+
+  defp modeline_command_at(_state, _col), do: nil
 end

--- a/lib/minga_editor/render_model/ui/agent_chat_builder.ex
+++ b/lib/minga_editor/render_model/ui/agent_chat_builder.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
   alias MingaEditor.Agent.SemanticUI.Registry, as: SemanticUIRegistry
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.Agent.View.PromptRenderWindow
   alias MingaEditor.UI.Theme
   alias Minga.Buffer
@@ -59,7 +60,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
     {messages_with_ids, styled_cache} =
       visible_message_slice(panel, full_pairs, full_styled_cache)
 
-    pending_approval = ctx.shell_state.agent.pending_approval
+    pending_approval = AgentAccess.agent(ctx).pending_approval
 
     gui_messages =
       messages_with_ids
@@ -81,7 +82,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
 
     help_groups =
       if help_visible do
-        Minga.Keymap.Scope.Agent.help_groups(view.focus)
+        Minga.Keymap.Scope.Agent.help_groups(UIState.View.focus(view))
       else
         []
       end
@@ -90,7 +91,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilder do
 
     %AgentChat{
       visible?: true,
-      status: ctx.shell_state.agent.runtime.status || :idle,
+      status: AgentAccess.agent(ctx).runtime.status || :idle,
       model_name: display_model_name(panel.model_name),
       thinking_level: panel.thinking_level,
       prompt: prompt_text,

--- a/lib/minga_editor/render_model/ui/agent_context_builder.ex
+++ b/lib/minga_editor/render_model/ui/agent_context_builder.ex
@@ -63,8 +63,7 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilder do
   defp get_activity_from_state(state), do: AgentAccess.view(state).activity
 
   @spec agent_status(Context.t()) :: atom()
-  defp agent_status(%{shell_state: %{agent: %{runtime: %{status: status}}}}), do: status
-  defp agent_status(_ctx), do: :idle
+  defp agent_status(%Context{} = ctx), do: AgentAccess.agent(ctx).runtime.status
 
   @spec agent_status_from_state(map()) :: atom()
   defp agent_status_from_state(state), do: AgentAccess.agent(state).runtime.status
@@ -97,8 +96,7 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilder do
   defp context_status(_status, false), do: :idle
 
   @spec can_approve?(Context.t()) :: boolean()
-  defp can_approve?(%{shell_state: %{agent: %{pending_approval: approval}}}), do: approval != nil
-  defp can_approve?(_ctx), do: false
+  defp can_approve?(%Context{} = ctx), do: AgentAccess.agent(ctx).pending_approval != nil
 
   @spec progress(Activity.t()) :: Progress.t()
   defp progress(%Activity{} = activity) do

--- a/lib/minga_editor/render_model/ui/builder.ex
+++ b/lib/minga_editor/render_model/ui/builder.ex
@@ -28,6 +28,7 @@ defmodule MingaEditor.RenderModel.UI.Builder do
   alias MingaEditor.RenderModel.UI.SidebarsBuilder
   alias MingaEditor.RenderModel.UI.SignatureHelpBuilder
   alias MingaEditor.RenderModel.UI.SplitSeparatorsBuilder
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.RenderModel.UI.StatusBarBuilder
   alias MingaEditor.RenderModel.UI.TabBarBuilder
   alias MingaEditor.RenderModel.UI.ThemeBuilder
@@ -96,11 +97,11 @@ defmodule MingaEditor.RenderModel.UI.Builder do
 
   @spec build_git_status(Context.t()) :: Minga.RenderModel.UI.GitStatus.t()
   defp build_git_status(%{
-         shell_state: %{git_status_panel: %{} = data},
+         shell_state: %TraditionalState{} = shell_state,
          git_syncing: syncing,
          git_toast: toast
        }) do
-    GitStatusBuilder.build(data, syncing, toast)
+    GitStatusBuilder.build(TraditionalState.git_status_panel(shell_state), syncing, toast)
   end
 
   defp build_git_status(%{git_syncing: syncing, git_toast: toast}) do

--- a/lib/minga_editor/render_model/ui/float_popup_builder.ex
+++ b/lib/minga_editor/render_model/ui/float_popup_builder.ex
@@ -4,15 +4,24 @@ defmodule MingaEditor.RenderModel.UI.FloatPopupBuilder do
   alias Minga.Buffer
   alias Minga.RenderModel.UI.FloatPopup
   alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.Observatory.Inspection
+  alias MingaEditor.Shell.Traditional.Observatory
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
 
   @max_native_popup_lines 400
 
   @spec build(Context.t()) :: FloatPopup.t()
-  def build(%Context{shell_state: %{observatory_inspection: %{visible: true} = data}} = _ctx) do
-    float_popup_model(data)
+  def build(%Context{shell_state: %TraditionalState{} = shell_state} = ctx) do
+    case shell_state |> TraditionalState.observatory() |> Observatory.inspection() do
+      %{visible: true} = inspection -> float_popup_model(inspection)
+      _hidden -> build_window_popup(ctx)
+    end
   end
 
-  def build(%Context{} = ctx) do
+  def build(%Context{} = ctx), do: build_window_popup(ctx)
+
+  @spec build_window_popup(Context.t()) :: FloatPopup.t()
+  defp build_window_popup(%Context{} = ctx) do
     case find_float_popup_window(ctx) do
       nil -> %FloatPopup{}
       float_window -> build_float_popup_model(ctx, float_window)
@@ -59,8 +68,8 @@ defmodule MingaEditor.RenderModel.UI.FloatPopupBuilder do
     %FloatPopup{visible?: true, title: title, lines: lines, width: width, height: height}
   end
 
-  @spec float_popup_model(map()) :: FloatPopup.t()
-  defp float_popup_model(%{
+  @spec float_popup_model(Inspection.t()) :: FloatPopup.t()
+  defp float_popup_model(%Inspection{
          visible: true,
          title: title,
          lines: lines,
@@ -69,8 +78,6 @@ defmodule MingaEditor.RenderModel.UI.FloatPopupBuilder do
        }) do
     %FloatPopup{visible?: true, title: title, lines: lines, width: width, height: height}
   end
-
-  defp float_popup_model(_data), do: %FloatPopup{}
 
   @spec resolve_float_dim(Minga.Popup.Rule.t(), :width | :height, pos_integer()) ::
           pos_integer()

--- a/lib/minga_editor/render_model/ui/observatory_builder.ex
+++ b/lib/minga_editor/render_model/ui/observatory_builder.ex
@@ -5,17 +5,21 @@ defmodule MingaEditor.RenderModel.UI.ObservatoryBuilder do
   alias Minga.RenderModel.UI.Observatory.Node
   alias Minga.SystemObserver.TreeNode
   alias MingaEditor.Observatory.Data, as: ObservatoryData
+  alias MingaEditor.Shell.Traditional.Observatory, as: ObservatoryState
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
 
-  @spec build(map()) :: Observatory.t()
-  def build(%{observatory_visible: true, observatory_data: %ObservatoryData{} = data}) do
-    observatory_model(data)
-  end
-
-  def build(%{observatory_visible: true}) do
-    observatory_model(ObservatoryData.visible(nil, []))
+  @spec build(term()) :: Observatory.t()
+  def build(%TraditionalState{} = shell_state) do
+    observatory = TraditionalState.observatory(shell_state)
+    build_observatory(ObservatoryState.visible?(observatory), ObservatoryState.data(observatory))
   end
 
   def build(_shell_state), do: %Observatory{}
+
+  @spec build_observatory(boolean(), ObservatoryData.t() | nil) :: Observatory.t()
+  defp build_observatory(true, %ObservatoryData{} = data), do: observatory_model(data)
+  defp build_observatory(true, nil), do: observatory_model(ObservatoryData.visible(nil, []))
+  defp build_observatory(false, _data), do: %Observatory{}
 
   @spec observatory_model(ObservatoryData.t()) :: Observatory.t()
   defp observatory_model(%ObservatoryData{visible: false}), do: %Observatory{}

--- a/lib/minga_editor/render_model/ui/sidebars_builder.ex
+++ b/lib/minga_editor/render_model/ui/sidebars_builder.ex
@@ -5,6 +5,7 @@ defmodule MingaEditor.RenderModel.UI.SidebarsBuilder do
   alias Minga.RenderModel.UI.Sidebars.Sidebar, as: SidebarModel
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
 
   @spec build(Context.t()) :: Sidebars.t()
   def build(%Context{} = ctx) do
@@ -45,13 +46,19 @@ defmodule MingaEditor.RenderModel.UI.SidebarsBuilder do
   @spec active_sidebar_id(Context.t(), [SidebarModel.t()], Sidebar.entry() | nil) :: String.t()
   defp active_sidebar_id(ctx, sidebars, registered_active) do
     registered_id = active_registered_sidebar_id(sidebars, registered_active)
-    preferred_id = (ctx.shell_state || %{}) |> Map.get(:sidebar_active_id)
+    preferred_id = preferred_sidebar_id(ctx.shell_state)
 
     case registered_id || sidebar_visible_id(sidebars, preferred_id) do
       id when is_binary(id) -> id
       nil -> fallback_active_sidebar_id(sidebars)
     end
   end
+
+  @spec preferred_sidebar_id(term()) :: String.t() | nil
+  defp preferred_sidebar_id(%TraditionalState{} = shell_state),
+    do: TraditionalState.sidebar_active_id(shell_state)
+
+  defp preferred_sidebar_id(_shell_state), do: nil
 
   @spec active_registered_sidebar_id([SidebarModel.t()], Sidebar.entry() | nil) ::
           String.t() | nil

--- a/lib/minga_editor/render_pipeline.ex
+++ b/lib/minga_editor/render_pipeline.ex
@@ -38,6 +38,7 @@ defmodule MingaEditor.RenderPipeline do
   alias MingaEditor.RenderPipeline.Content
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.Scroll
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.WindowTree
   alias MingaEditor.Frontend.Emit
   alias MingaEditor.UI.FontRegistry
@@ -173,7 +174,7 @@ defmodule MingaEditor.RenderPipeline do
       | caches: %{input.caches | chrome_prev_fingerprint: chrome_fp, chrome_prev_result: chrome}
     }
 
-    # Cache click regions on input for mouse hit-testing write-back when the active shell state owns those fields.
+    # Cache the correlated render's click regions through the Traditional input owner.
     input = %{input | shell_state: update_shell_click_regions(input.shell_state, chrome)}
 
     # Stage 6: Compose
@@ -199,21 +200,16 @@ defmodule MingaEditor.RenderPipeline do
     end)
   end
 
-  @spec update_shell_click_regions(map(), Chrome.t()) :: map()
-  defp update_shell_click_regions(shell_state, %Chrome{} = chrome) do
-    shell_state
-    |> maybe_put_shell_field(:modeline_click_regions, chrome.modeline_click_regions)
-    |> maybe_put_shell_field(:tab_bar_click_regions, chrome.tab_bar_click_regions)
+  @spec update_shell_click_regions(term(), Chrome.t()) :: term()
+  defp update_shell_click_regions(%TraditionalState{} = shell_state, %Chrome{} = chrome) do
+    TraditionalState.install_click_regions(
+      shell_state,
+      chrome.modeline_click_regions,
+      chrome.tab_bar_click_regions
+    )
   end
 
-  @spec maybe_put_shell_field(map(), atom(), term()) :: map()
-  defp maybe_put_shell_field(shell_state, field, value) do
-    if Map.has_key?(shell_state, field) do
-      Map.put(shell_state, field, value)
-    else
-      shell_state
-    end
-  end
+  defp update_shell_click_regions(shell_state, %Chrome{}), do: shell_state
 
   # ── Stage 1: Invalidation ─────────────────────────────────────────────────
 

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -55,11 +55,13 @@ defmodule MingaEditor.RenderPipeline.Input do
   alias MingaEditor.Viewport
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.LSP, as: LSPState
   alias MingaEditor.State.RenderCorrelation
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.UI.FontRegistry
   alias MingaEditor.UI.NotificationCenter
   alias MingaEditor.UI.Panel.MessageStore
@@ -317,7 +319,7 @@ defmodule MingaEditor.RenderPipeline.Input do
       # completion)
       input.shell_state |> Map.get(:modal),
       # Agent state (status, pending approval)
-      input.shell_state |> Map.get(:agent),
+      AgentAccess.agent(input),
       # Viewport dimensions (overlay positioning)
       input.terminal_viewport.rows,
       input.terminal_viewport.cols,
@@ -328,11 +330,17 @@ defmodule MingaEditor.RenderPipeline.Input do
       # GUI notification center
       input.notifications,
       # Git status panel
-      input.shell_state |> Map.get(:git_status_panel),
+      git_status_panel(input),
       # Shell-owned chrome state that does not belong in the generic pipeline contract
       input.shell.chrome_fingerprint(input)
     })
   end
+
+  @spec git_status_panel(t()) :: MingaEditor.GitStatus.Panel.t() | nil
+  defp git_status_panel(%__MODULE__{shell_state: %TraditionalState{} = shell_state}),
+    do: TraditionalState.git_status_panel(shell_state)
+
+  defp git_status_panel(%__MODULE__{}), do: nil
 
   @spec status_bar_fingerprint(t()) :: integer()
   defp status_bar_fingerprint(%__MODULE__{} = input) do

--- a/lib/minga_editor/renderer/render_receipt.ex
+++ b/lib/minga_editor/renderer/render_receipt.ex
@@ -9,6 +9,8 @@ defmodule MingaEditor.Renderer.RenderReceipt do
 
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.Renderer.WindowObservation
+  alias MingaEditor.Shell.Traditional.ClickRegions
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State.Windows
 
   @enforce_keys [
@@ -16,8 +18,7 @@ defmodule MingaEditor.Renderer.RenderReceipt do
     :focus_tree,
     :shell_id,
     :shell_identity,
-    :modeline_click_regions,
-    :tab_bar_click_regions,
+    :click_regions,
     :frame_seq,
     :keyframe?,
     :render_sent_at
@@ -27,8 +28,7 @@ defmodule MingaEditor.Renderer.RenderReceipt do
     :focus_tree,
     :shell_id,
     :shell_identity,
-    :modeline_click_regions,
-    :tab_bar_click_regions,
+    :click_regions,
     :frame_seq,
     :keyframe?,
     :render_sent_at,
@@ -41,8 +41,7 @@ defmodule MingaEditor.Renderer.RenderReceipt do
           focus_tree: MingaEditor.FocusTree.t() | nil,
           shell_id: atom(),
           shell_identity: MingaEditor.Shell.Identity.t() | nil,
-          modeline_click_regions: term(),
-          tab_bar_click_regions: term(),
+          click_regions: ClickRegions.t() | nil,
           frame_seq: non_neg_integer(),
           keyframe?: boolean(),
           render_sent_at: integer(),
@@ -59,8 +58,7 @@ defmodule MingaEditor.Renderer.RenderReceipt do
       focus_tree: output.focus_tree,
       shell_id: output.shell_id,
       shell_identity: output.shell_identity,
-      modeline_click_regions: shell_field(output.shell_state, :modeline_click_regions),
-      tab_bar_click_regions: shell_field(output.shell_state, :tab_bar_click_regions),
+      click_regions: click_regions(output.shell_state),
       frame_seq: frame_seq,
       keyframe?: output.caches.last_frame_keyframe?,
       render_sent_at: sent_at,
@@ -87,7 +85,9 @@ defmodule MingaEditor.Renderer.RenderReceipt do
     end)
   end
 
-  @spec shell_field(term(), atom()) :: term()
-  defp shell_field(shell_state, field) when is_map(shell_state), do: Map.get(shell_state, field)
-  defp shell_field(_shell_state, _field), do: nil
+  @spec click_regions(term()) :: ClickRegions.t() | nil
+  defp click_regions(%TraditionalState{} = shell_state),
+    do: TraditionalState.click_regions(shell_state)
+
+  defp click_regions(_shell_state), do: nil
 end

--- a/lib/minga_editor/shell/runtime.ex
+++ b/lib/minga_editor/shell/runtime.ex
@@ -141,32 +141,6 @@ defmodule MingaEditor.Shell.Runtime do
       else: runtime
   end
 
-  @doc "Merges renderer-owned click regions into a matching active shell state."
-  @spec merge_renderer_observation(t(), atom(), Identity.t(), map()) :: t()
-  def merge_renderer_observation(
-        %__MODULE__{} = runtime,
-        shell_id,
-        %Identity{} = identity,
-        fields
-      ) do
-    if runtime.entry.id == shell_id and Identity.matches?(identity, runtime.entry) do
-      state = Enum.reduce(fields, runtime.state, &merge_renderer_field/2)
-      %__MODULE__{runtime | state: state}
-    else
-      runtime
-    end
-  end
-
-  @spec merge_renderer_field({atom(), term()}, shell_state()) :: shell_state()
-  defp merge_renderer_field({field, value}, shell_state) when is_map(shell_state) do
-    case Map.fetch(shell_state, field) do
-      {:ok, _current} -> Map.put(shell_state, field, value)
-      :error -> shell_state
-    end
-  end
-
-  defp merge_renderer_field({_field, _value}, shell_state), do: shell_state
-
   @doc "Installs state returned by persistence for the exact active or stashed registration."
   @spec accept_persisted_state(t(), Entry.t(), shell_state()) :: t()
   def accept_persisted_state(%__MODULE__{} = runtime, %Entry{} = entry, persisted_state) do

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -48,7 +48,7 @@ defmodule MingaEditor.Shell.Traditional do
   @spec handle_event(ShellState.t(), MingaEditor.Session.State.t(), term()) ::
           {ShellState.t(), MingaEditor.Session.State.t()}
   def handle_event(%ShellState{} = shell_state, workspace, {:git_status_changed, entries}) do
-    {ShellState.refresh_git_status_tui_state(shell_state, entries), workspace}
+    {refresh_git_status_tui_state(shell_state, entries), workspace}
   end
 
   def handle_event(%ShellState{tab_bar: nil} = shell_state, workspace, _event) do
@@ -87,6 +87,54 @@ defmodule MingaEditor.Shell.Traditional do
 
   def handle_event(shell_state, workspace, _event) do
     {shell_state, workspace}
+  end
+
+  @git_status_tui_state_module :"Elixir.MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState"
+
+  @spec refresh_git_status_tui_state(ShellState.t(), [Minga.Git.StatusEntry.t()]) ::
+          ShellState.t()
+  defp refresh_git_status_tui_state(%ShellState{} = shell_state, entries) do
+    case ShellState.git_status_tui_state(shell_state) do
+      nil -> shell_state
+      tui -> maybe_refresh_git_status_tui_state(shell_state, tui, entries)
+    end
+  end
+
+  @spec maybe_refresh_git_status_tui_state(ShellState.t(), struct(), [Minga.Git.StatusEntry.t()]) ::
+          ShellState.t()
+  defp maybe_refresh_git_status_tui_state(shell_state, tui, entries) do
+    if git_status_tui_refresh_available?() do
+      refreshed = :erlang.apply(@git_status_tui_state_module, :refresh, [tui, entries])
+      install_refreshed_git_status_tui_state(shell_state, refreshed)
+    else
+      shell_state
+    end
+  end
+
+  @spec install_refreshed_git_status_tui_state(ShellState.t(), term()) :: ShellState.t()
+  defp install_refreshed_git_status_tui_state(shell_state, refreshed) do
+    if is_struct(refreshed, @git_status_tui_state_module),
+      do: ShellState.replace_git_status_tui_state(shell_state, refreshed),
+      else: shell_state
+  end
+
+  @spec git_status_tui_refresh_available?() :: boolean()
+  defp git_status_tui_refresh_available? do
+    git_porcelain_running?() and Code.ensure_loaded?(@git_status_tui_state_module) and
+      function_exported?(@git_status_tui_state_module, :refresh, 2)
+  end
+
+  @spec git_porcelain_running?() :: boolean()
+  defp git_porcelain_running? do
+    case Process.whereis(Minga.Extension.Registry) do
+      nil ->
+        false
+
+      _pid ->
+        match?({:ok, %{status: :running}}, Minga.Extension.Registry.get(:minga_git_porcelain))
+    end
+  catch
+    :exit, _reason -> false
   end
 
   @impl true

--- a/lib/minga_editor/shell/traditional/agent_surfaces.ex
+++ b/lib/minga_editor/shell/traditional/agent_surfaces.ex
@@ -1,0 +1,135 @@
+defmodule MingaEditor.Shell.Traditional.AgentSurfaces do
+  @moduledoc """
+  Pure owner of Traditional agent presentation and inline session surfaces.
+
+  The full agent presentation cache and both per-buffer inline stores are
+  replaced only through this owner. Inline completion and cancellation match
+  the originating session or buffer, so delayed events cannot update a
+  replacement surface.
+  """
+
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.InlineAsk
+  alias MingaEditor.State.InlineEdit
+
+  @type t :: %__MODULE__{
+          presentation: AgentState.t(),
+          asks: InlineAsk.store(),
+          edits: InlineEdit.store()
+        }
+
+  defstruct presentation: %AgentState{}, asks: %{}, edits: %{}
+
+  @doc "Returns the full agent presentation cache."
+  @spec presentation(t()) :: AgentState.t()
+  def presentation(%__MODULE__{presentation: presentation}), do: presentation
+
+  @doc "Replaces the full agent presentation cache."
+  @spec replace_presentation(t(), AgentState.t()) :: t()
+  def replace_presentation(%__MODULE__{} = surfaces, %AgentState{} = presentation),
+    do: %{surfaces | presentation: presentation}
+
+  @doc "Returns the inline ask store."
+  @spec asks(t()) :: InlineAsk.store()
+  def asks(%__MODULE__{asks: asks}), do: asks
+
+  @doc "Returns the inline edit store."
+  @spec edits(t()) :: InlineEdit.store()
+  def edits(%__MODULE__{edits: edits}), do: edits
+
+  @doc "Activates or replaces the inline ask for its buffer."
+  @spec activate_ask(t(), InlineAsk.t()) :: t()
+  def activate_ask(%__MODULE__{} = surfaces, %InlineAsk{} = ask),
+    do: %{surfaces | asks: InlineAsk.put(surfaces.asks, ask)}
+
+  @doc "Replaces a current inline ask after an input transition."
+  @spec replace_ask(t(), InlineAsk.t()) :: t()
+  def replace_ask(%__MODULE__{} = surfaces, %InlineAsk{} = ask),
+    do: activate_ask(surfaces, ask)
+
+  @doc "Completes the matching inline ask session."
+  @spec complete_ask(t(), pid()) :: t()
+  def complete_ask(%__MODULE__{} = surfaces, session_pid) when is_pid(session_pid),
+    do: update_ask_session(surfaces, session_pid, &InlineAsk.answered/1)
+
+  @doc "Fails the matching inline ask session."
+  @spec fail_ask(t(), pid(), String.t()) :: t()
+  def fail_ask(%__MODULE__{} = surfaces, session_pid, message)
+      when is_pid(session_pid) and is_binary(message),
+      do: update_ask_session(surfaces, session_pid, &InlineAsk.fail(&1, message))
+
+  @doc "Appends output only to the matching inline ask session."
+  @spec append_ask_response(t(), pid(), String.t()) :: t()
+  def append_ask_response(%__MODULE__{} = surfaces, session_pid, delta)
+      when is_pid(session_pid) and is_binary(delta),
+      do: update_ask_session(surfaces, session_pid, &InlineAsk.append_response(&1, delta))
+
+  @doc "Cancels the inline ask for a buffer and returns its session pid."
+  @spec cancel_ask(t(), pid() | nil) :: {t(), pid() | nil}
+  def cancel_ask(%__MODULE__{} = surfaces, buffer_pid) do
+    {asks, session_pid} = InlineAsk.dismiss(surfaces.asks, buffer_pid)
+    {%{surfaces | asks: asks}, session_pid}
+  end
+
+  @doc "Activates or replaces the inline edit for its buffer."
+  @spec activate_edit(t(), InlineEdit.t()) :: t()
+  def activate_edit(%__MODULE__{} = surfaces, %InlineEdit{} = edit),
+    do: %{surfaces | edits: InlineEdit.put(surfaces.edits, edit)}
+
+  @doc "Replaces a current inline edit after an input transition."
+  @spec replace_edit(t(), InlineEdit.t()) :: t()
+  def replace_edit(%__MODULE__{} = surfaces, %InlineEdit{} = edit),
+    do: activate_edit(surfaces, edit)
+
+  @doc "Completes the matching inline edit session."
+  @spec complete_edit(t(), pid()) :: t()
+  def complete_edit(%__MODULE__{} = surfaces, session_pid) when is_pid(session_pid),
+    do: update_edit_session(surfaces, session_pid, &InlineEdit.proposed/1)
+
+  @doc "Fails the matching inline edit session."
+  @spec fail_edit(t(), pid(), String.t()) :: t()
+  def fail_edit(%__MODULE__{} = surfaces, session_pid, message)
+      when is_pid(session_pid) and is_binary(message),
+      do: update_edit_session(surfaces, session_pid, &InlineEdit.fail(&1, message))
+
+  @doc "Appends output only to the matching inline edit session."
+  @spec append_edit_proposal(t(), pid(), String.t()) :: t()
+  def append_edit_proposal(%__MODULE__{} = surfaces, session_pid, delta)
+      when is_pid(session_pid) and is_binary(delta),
+      do: update_edit_session(surfaces, session_pid, &InlineEdit.append_proposal(&1, delta))
+
+  @doc "Installs a tool-produced proposal only on the matching inline edit session."
+  @spec set_edit_proposal(t(), pid(), String.t()) :: t()
+  def set_edit_proposal(%__MODULE__{} = surfaces, session_pid, proposal)
+      when is_pid(session_pid) and is_binary(proposal),
+      do: update_edit_session(surfaces, session_pid, &InlineEdit.set_proposal(&1, proposal))
+
+  @doc "Cancels the inline edit for a buffer and returns its session pid."
+  @spec cancel_edit(t(), pid() | nil) :: {t(), pid() | nil}
+  def cancel_edit(%__MODULE__{} = surfaces, buffer_pid) do
+    {edits, session_pid} = InlineEdit.dismiss(surfaces.edits, buffer_pid)
+    {%{surfaces | edits: edits}, session_pid}
+  end
+
+  @spec update_ask_session(t(), pid(), (InlineAsk.t() -> InlineAsk.t())) :: t()
+  defp update_ask_session(%__MODULE__{} = surfaces, session_pid, update) do
+    asks =
+      Map.new(surfaces.asks, fn
+        {buffer_pid, %InlineAsk{session_pid: ^session_pid} = ask} -> {buffer_pid, update.(ask)}
+        entry -> entry
+      end)
+
+    %{surfaces | asks: asks}
+  end
+
+  @spec update_edit_session(t(), pid(), (InlineEdit.t() -> InlineEdit.t())) :: t()
+  defp update_edit_session(%__MODULE__{} = surfaces, session_pid, update) do
+    edits =
+      Map.new(surfaces.edits, fn
+        {buffer_pid, %InlineEdit{session_pid: ^session_pid} = edit} -> {buffer_pid, update.(edit)}
+        entry -> entry
+      end)
+
+    %{surfaces | edits: edits}
+  end
+end

--- a/lib/minga_editor/shell/traditional/click_regions.ex
+++ b/lib/minga_editor/shell/traditional/click_regions.ex
@@ -1,0 +1,64 @@
+defmodule MingaEditor.Shell.Traditional.ClickRegions do
+  @moduledoc """
+  Pure owner of renderer-installed Traditional click regions.
+
+  Both region sets come from one correlated render receipt and are installed or
+  reset together, preventing mouse hit testing from combining different frames.
+  """
+
+  alias MingaEditor.Shell.Traditional.Modeline
+
+  @type tab_bar_command ::
+          atom() | {:workspace_goto, non_neg_integer()} | {:tab_goto_id, pos_integer()}
+  @type tab_bar_region ::
+          {col_start :: non_neg_integer(), col_end :: non_neg_integer(),
+           command :: tab_bar_command()}
+          | {row :: non_neg_integer(), col_start :: non_neg_integer(),
+             col_end :: non_neg_integer(), command :: tab_bar_command()}
+
+  @type t :: %__MODULE__{
+          modeline: [Modeline.click_region()],
+          tab_bar: [tab_bar_region()]
+        }
+
+  defstruct modeline: [], tab_bar: []
+
+  @doc "Installs both region sets from one render observation."
+  @spec install(t(), [Modeline.click_region()], [tab_bar_region()]) :: t()
+  def install(%__MODULE__{} = regions, modeline, tab_bar)
+      when is_list(modeline) and is_list(tab_bar),
+      do: %{regions | modeline: modeline, tab_bar: tab_bar}
+
+  @doc "Returns the modeline command under a rendered column."
+  @spec modeline_command_at(t(), non_neg_integer()) :: atom() | nil
+  def modeline_command_at(%__MODULE__{modeline: regions}, col) do
+    case Enum.find(regions, fn {col_start, col_end, _command} ->
+           col >= col_start and col < col_end
+         end) do
+      {_col_start, _col_end, command} -> command
+      nil -> nil
+    end
+  end
+
+  @doc "Returns the tab-bar command under a rendered cell."
+  @spec tab_bar_command_at(t(), non_neg_integer(), non_neg_integer()) ::
+          tab_bar_command() | nil
+  def tab_bar_command_at(%__MODULE__{tab_bar: regions}, row, col) do
+    case Enum.find(regions, &tab_bar_region_hit?(&1, row, col)) do
+      {_col_start, _col_end, command} -> command
+      {_region_row, _col_start, _col_end, command} -> command
+      nil -> nil
+    end
+  end
+
+  @doc "Clears all regions when their render identity is no longer active."
+  @spec reset(t()) :: t()
+  def reset(%__MODULE__{} = regions), do: %{regions | modeline: [], tab_bar: []}
+
+  @spec tab_bar_region_hit?(tab_bar_region(), non_neg_integer(), non_neg_integer()) :: boolean()
+  defp tab_bar_region_hit?({col_start, col_end, _command}, _row, col),
+    do: col >= col_start and col <= col_end
+
+  defp tab_bar_region_hit?({region_row, col_start, col_end, _command}, row, col),
+    do: row == region_row and col >= col_start and col <= col_end
+end

--- a/lib/minga_editor/shell/traditional/deactivation_workflow.ex
+++ b/lib/minga_editor/shell/traditional/deactivation_workflow.ex
@@ -1,13 +1,18 @@
 defmodule MingaEditor.Shell.Traditional.DeactivationWorkflow do
   @moduledoc "Cancels and clears Traditional transient lifecycles before the shell is stashed."
 
+  alias MingaEditor.Input.CUA.TUISpaceLeader
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.FlashesWorkflow
   alias MingaEditor.Shell.Traditional.GitToastWorkflow
   alias MingaEditor.Shell.Traditional.HoverPopupWorkflow
   alias MingaEditor.Shell.Traditional.ModalWorkflow
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.SignatureHelpWorkflow
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.Shell.Traditional.WhichKeyWorkflow
+  alias MingaEditor.State, as: EditorState
 
   @doc "Ends transient Traditional presentation before another shell becomes active."
   @spec run(map()) :: map()
@@ -21,7 +26,21 @@ defmodule MingaEditor.Shell.Traditional.DeactivationWorkflow do
     |> HoverPopupWorkflow.dismiss()
     |> SignatureHelpWorkflow.dismiss()
     |> ModalWorkflow.dismiss()
+    |> SidebarWorkflow.close_observatory()
+    |> TUISpaceLeader.cancel()
+    |> reset_click_regions()
   end
 
   def run(state), do: state
+
+  @spec reset_click_regions(EditorState.t()) :: EditorState.t()
+  defp reset_click_regions(%EditorState{} = state) do
+    runtime =
+      Runtime.update_traditional_state(
+        state.shell_runtime,
+        &TraditionalState.reset_click_regions/1
+      )
+
+    EditorState.apply_shell_runtime_transition(state, runtime)
+  end
 end

--- a/lib/minga_editor/shell/traditional/input_state.ex
+++ b/lib/minga_editor/shell/traditional/input_state.ex
@@ -1,0 +1,81 @@
+defmodule MingaEditor.Shell.Traditional.InputState do
+  @moduledoc """
+  Pure aggregate for Traditional renderer-authored hit regions and TUI leader input.
+  """
+
+  alias MingaEditor.Shell.Traditional.ClickRegions
+  alias MingaEditor.Shell.Traditional.SpaceLeader
+
+  @type t :: %__MODULE__{click_regions: ClickRegions.t(), space_leader: SpaceLeader.t()}
+
+  defstruct click_regions: %ClickRegions{}, space_leader: %SpaceLeader{}
+
+  @doc "Returns the renderer-authored click-region value."
+  @spec click_regions(t()) :: ClickRegions.t()
+  def click_regions(%__MODULE__{click_regions: regions}), do: regions
+
+  @doc "Installs click regions from one correlated render."
+  @spec install_click_regions(
+          t(),
+          [MingaEditor.Shell.Traditional.Modeline.click_region()],
+          [ClickRegions.tab_bar_region()]
+        ) :: t()
+  def install_click_regions(%__MODULE__{} = input, modeline, tab_bar) do
+    %{input | click_regions: ClickRegions.install(input.click_regions, modeline, tab_bar)}
+  end
+
+  @doc "Installs one already-correlated click-region value."
+  @spec install_click_regions(t(), ClickRegions.t()) :: t()
+  def install_click_regions(%__MODULE__{} = input, %ClickRegions{} = regions),
+    do: %{input | click_regions: regions}
+
+  @doc "Returns the modeline command under a rendered column."
+  @spec modeline_command_at(t(), non_neg_integer()) :: atom() | nil
+  def modeline_command_at(%__MODULE__{click_regions: regions}, col),
+    do: ClickRegions.modeline_command_at(regions, col)
+
+  @doc "Returns the tab-bar command under a rendered cell."
+  @spec tab_bar_command_at(t(), non_neg_integer(), non_neg_integer()) ::
+          ClickRegions.tab_bar_command() | nil
+  def tab_bar_command_at(%__MODULE__{click_regions: regions}, row, col),
+    do: ClickRegions.tab_bar_command_at(regions, row, col)
+
+  @doc "Resets renderer-authored hit regions."
+  @spec reset_click_regions(t()) :: t()
+  def reset_click_regions(%__MODULE__{} = input),
+    do: %{input | click_regions: ClickRegions.reset(input.click_regions)}
+
+  @doc "Begins a new space-leader timeout generation."
+  @spec begin_space_leader(t()) :: {SpaceLeader.generation(), t()}
+  def begin_space_leader(%__MODULE__{} = input) do
+    {generation, leader} = SpaceLeader.begin(input.space_leader)
+    {generation, %{input | space_leader: leader}}
+  end
+
+  @doc "Records the current space-leader timer handle."
+  @spec install_space_leader_timer(t(), SpaceLeader.generation(), reference()) :: t()
+  def install_space_leader_timer(%__MODULE__{} = input, generation, timer) do
+    %{input | space_leader: SpaceLeader.install_timer(input.space_leader, generation, timer)}
+  end
+
+  @doc "Expires only a matching space-leader generation."
+  @spec expire_space_leader(t(), SpaceLeader.generation()) :: {:expired | :stale, t()}
+  def expire_space_leader(%__MODULE__{} = input, generation) do
+    case SpaceLeader.expire(input.space_leader, generation) do
+      {result, leader} -> {result, %{input | space_leader: leader}}
+    end
+  end
+
+  @doc "Returns whether a space-leader window is pending."
+  @spec space_leader_pending?(t()) :: boolean()
+  def space_leader_pending?(%__MODULE__{space_leader: leader}), do: SpaceLeader.pending?(leader)
+
+  @doc "Returns the current space-leader timer handle."
+  @spec space_leader_timer(t()) :: reference() | nil
+  def space_leader_timer(%__MODULE__{space_leader: leader}), do: SpaceLeader.timer(leader)
+
+  @doc "Resets the current space-leader window."
+  @spec reset_space_leader(t()) :: t()
+  def reset_space_leader(%__MODULE__{} = input),
+    do: %{input | space_leader: SpaceLeader.reset(input.space_leader)}
+end

--- a/lib/minga_editor/shell/traditional/observatory.ex
+++ b/lib/minga_editor/shell/traditional/observatory.ex
@@ -1,0 +1,126 @@
+defmodule MingaEditor.Shell.Traditional.Observatory do
+  @moduledoc """
+  Pure lifecycle owner for the Traditional shell's BEAM Observatory.
+
+  Refresh timers are correlated by semantic tokens. Expiring a scheduled
+  refresh moves it to an in-flight state, and only the matching result can
+  install data and arm the next refresh. Closing clears every surface value,
+  so delayed ticks and results cannot restore a hidden observatory.
+  """
+
+  alias MingaEditor.Observatory.Data
+  alias MingaEditor.Observatory.Inspection
+
+  @type phase :: :idle | :scheduled | :collecting
+  @type timer :: {reference(), reference()}
+  @type t :: %__MODULE__{
+          visible: boolean(),
+          data: Data.t() | nil,
+          timer: reference() | nil,
+          token: reference() | nil,
+          phase: phase(),
+          inspection: Inspection.t() | nil
+        }
+
+  defstruct visible: false,
+            data: nil,
+            timer: nil,
+            token: nil,
+            phase: :idle,
+            inspection: nil
+
+  @doc "Returns whether the Observatory surface is visible."
+  @spec visible?(t()) :: boolean()
+  def visible?(%__MODULE__{visible: visible}), do: visible
+
+  @doc "Opens the surface and installs its first scheduled refresh."
+  @spec open(t(), timer() | nil) :: t()
+  def open(%__MODULE__{} = observatory, {timer, token})
+      when is_reference(timer) and is_reference(token) do
+    %{
+      observatory
+      | visible: true,
+        timer: timer,
+        token: token,
+        phase: :scheduled,
+        inspection: nil
+    }
+  end
+
+  def open(%__MODULE__{} = observatory, nil) do
+    %{observatory | visible: true, timer: nil, token: nil, phase: :idle, inspection: nil}
+  end
+
+  @doc "Closes the surface and invalidates scheduled or in-flight refreshes."
+  @spec close(t()) :: t()
+  def close(%__MODULE__{} = observatory) do
+    %__MODULE__{
+      observatory
+      | visible: false,
+        data: nil,
+        timer: nil,
+        token: nil,
+        phase: :idle,
+        inspection: nil
+    }
+  end
+
+  @doc "Returns the latest collected Observatory data."
+  @spec data(t()) :: Data.t() | nil
+  def data(%__MODULE__{data: data}), do: data
+
+  @doc "Returns the active process inspection, when present."
+  @spec inspection(t()) :: Inspection.t() | nil
+  def inspection(%__MODULE__{inspection: inspection}), do: inspection
+
+  @doc "Returns the timer handle that an effectful workflow should cancel."
+  @spec timer(t()) :: reference() | nil
+  def timer(%__MODULE__{timer: timer}), do: timer
+
+  @doc "Expires a matching scheduled refresh and marks its collection in flight."
+  @spec expire(t(), reference()) :: {:collect | :stale, t()}
+  def expire(
+        %__MODULE__{visible: true, phase: :scheduled, token: token} = observatory,
+        token
+      ) do
+    {:collect, %{observatory | timer: nil, phase: :collecting}}
+  end
+
+  def expire(%__MODULE__{} = observatory, _token), do: {:stale, observatory}
+
+  @doc "Returns whether a collection token is currently in flight."
+  @spec collecting?(t(), reference()) :: boolean()
+  def collecting?(%__MODULE__{visible: true, phase: :collecting, token: token}, token), do: true
+  def collecting?(%__MODULE__{}, _token), do: false
+
+  @doc "Completes a matching collection and schedules the next refresh."
+  @spec complete(t(), reference(), Data.t(), timer()) :: {:accepted | :stale, t()}
+  def complete(
+        %__MODULE__{visible: true, phase: :collecting, token: token} = observatory,
+        token,
+        %Data{} = data,
+        {timer, next_token}
+      )
+      when is_reference(timer) and is_reference(next_token) do
+    {:accepted,
+     %{
+       observatory
+       | data: data,
+         timer: timer,
+         token: next_token,
+         phase: :scheduled
+     }}
+  end
+
+  def complete(%__MODULE__{} = observatory, _token, %Data{}, {_timer, _next_token}),
+    do: {:stale, observatory}
+
+  @doc "Installs data without changing refresh correlation."
+  @spec replace_data(t(), Data.t() | nil) :: t()
+  def replace_data(%__MODULE__{} = observatory, data), do: %{observatory | data: data}
+
+  @doc "Shows or dismisses the process inspection float."
+  @spec inspect(t(), Inspection.t() | nil) :: t()
+  def inspect(%__MODULE__{} = observatory, inspection),
+    do: %{observatory | inspection: inspection}
+end

--- a/lib/minga_editor/shell/traditional/sidebar_workflow.ex
+++ b/lib/minga_editor/shell/traditional/sidebar_workflow.ex
@@ -1,0 +1,222 @@
+defmodule MingaEditor.Shell.Traditional.SidebarWorkflow do
+  @moduledoc """
+  Effect boundary for Traditional sidebar selection and built-in surfaces.
+
+  Registry synchronization, logging, and timer cancellation stay here. The
+  immutable sidebar and Observatory transitions remain in their value owners.
+  """
+
+  alias Minga.Log
+  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.Observatory
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.Sidebar.BuiltinSurfaces
+  alias MingaEditor.State, as: EditorState
+
+  @type state :: EditorState.t()
+
+  @doc "Returns the selected Traditional sidebar id."
+  @spec active_id(state()) :: String.t() | nil
+  def active_id(%EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}}),
+    do: TraditionalState.sidebar_active_id(shell_state)
+
+  def active_id(%EditorState{}), do: nil
+
+  @doc "Selects a native sidebar and synchronizes registry focus."
+  @spec select(state(), String.t() | nil) :: state()
+  def select(%EditorState{} = state, id) when is_binary(id) or is_nil(id) do
+    sync_active_sidebar(state, id)
+    update(state, &TraditionalState.select_sidebar(&1, id))
+  end
+
+  @doc "Returns the Traditional Git status panel."
+  @spec git_status_panel(state()) :: GitStatusPanel.t() | nil
+  def git_status_panel(%EditorState{
+        shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}
+      }),
+      do: TraditionalState.git_status_panel(shell_state)
+
+  def git_status_panel(%EditorState{}), do: nil
+
+  @doc "Replaces Git status and synchronizes its registered surface."
+  @spec replace_git_status(state(), GitStatusPanel.t() | map() | nil) :: state()
+  def replace_git_status(%EditorState{} = state, panel) do
+    panel = if is_nil(panel), do: nil, else: GitStatusPanel.new(panel)
+    sync_git_status_sidebar(state, panel)
+    update(state, &TraditionalState.replace_git_status_panel(&1, panel))
+  end
+
+  @doc "Returns the TUI-specific Git status presentation value."
+  @spec git_status_tui_state(state()) :: struct() | nil
+  def git_status_tui_state(%EditorState{
+        shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}
+      }),
+      do: TraditionalState.git_status_tui_state(shell_state)
+
+  def git_status_tui_state(%EditorState{}), do: nil
+
+  @doc "Replaces the TUI-specific Git status presentation value."
+  @spec replace_git_status_tui(state(), struct() | nil) :: state()
+  def replace_git_status_tui(%EditorState{} = state, tui),
+    do: update(state, &TraditionalState.replace_git_status_tui_state(&1, tui))
+
+  @doc "Closes Git status and synchronizes its registered surface."
+  @spec close_git_status(state()) :: state()
+  def close_git_status(%EditorState{} = state) do
+    sync_git_status_sidebar(state, nil)
+    update(state, &TraditionalState.close_git_status_panel/1)
+  end
+
+  @doc "Returns whether the Traditional Observatory is visible."
+  @spec observatory_visible?(state()) :: boolean()
+  def observatory_visible?(%EditorState{
+        shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}
+      }),
+      do: TraditionalState.observatory_visible?(shell_state)
+
+  def observatory_visible?(%EditorState{}), do: false
+
+  @doc "Returns the Observatory owner when Traditional is active."
+  @spec observatory(state()) :: Observatory.t() | nil
+  def observatory(%EditorState{
+        shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}
+      }),
+      do: TraditionalState.observatory(shell_state)
+
+  def observatory(%EditorState{}), do: nil
+
+  @doc "Opens or replaces Observatory after the caller creates its first timer."
+  @spec open_observatory(state(), Observatory.timer() | nil) :: state()
+  def open_observatory(%EditorState{} = state, timer) do
+    case observatory(state) do
+      %Observatory{} = observatory -> cancel_timer(Observatory.timer(observatory))
+      nil -> :ok
+    end
+
+    sync_observatory_sidebar(state, true)
+    update(state, &TraditionalState.open_observatory(&1, timer))
+  end
+
+  @doc "Closes Observatory, cancelling its timer and invalidating in-flight work."
+  @spec close_observatory(state()) :: state()
+  def close_observatory(%EditorState{} = state) do
+    case observatory(state) do
+      %Observatory{} = observatory -> cancel_timer(Observatory.timer(observatory))
+      nil -> :ok
+    end
+
+    sync_observatory_sidebar(state, false)
+    update(state, &TraditionalState.close_observatory/1)
+  end
+
+  @doc "Replaces Observatory data without changing refresh correlation."
+  @spec replace_observatory_data(state(), MingaEditor.Observatory.Data.t() | nil) :: state()
+  def replace_observatory_data(%EditorState{} = state, data),
+    do: update(state, &TraditionalState.replace_observatory_data(&1, data))
+
+  @doc "Shows or dismisses an Observatory inspection float."
+  @spec inspect_observatory(state(), MingaEditor.Observatory.Inspection.t() | nil) :: state()
+  def inspect_observatory(%EditorState{} = state, inspection),
+    do: update(state, &TraditionalState.inspect_observatory(&1, inspection))
+
+  @doc "Expires a matching refresh token and returns whether collection should start."
+  @spec expire_observatory_refresh(state(), reference()) :: {:collect | :stale, state()}
+  def expire_observatory_refresh(%EditorState{} = state, token) do
+    transition_with_result(state, &TraditionalState.expire_observatory_refresh(&1, token))
+  end
+
+  @doc "Returns whether an Observatory collection token is still current."
+  @spec observatory_collection_current?(state(), reference()) :: boolean()
+  def observatory_collection_current?(%EditorState{} = state, token) do
+    case observatory(state) do
+      %Observatory{} = observatory -> Observatory.collecting?(observatory, token)
+      nil -> false
+    end
+  end
+
+  @doc "Completes a matching collection and installs the caller-created next timer."
+  @spec complete_observatory_refresh(
+          state(),
+          reference(),
+          MingaEditor.Observatory.Data.t(),
+          Observatory.timer()
+        ) :: {:accepted | :stale, state()}
+  def complete_observatory_refresh(%EditorState{} = state, token, data, next_timer) do
+    case transition_with_result(
+           state,
+           &TraditionalState.complete_observatory_refresh(&1, token, data, next_timer)
+         ) do
+      {:accepted, new_state} ->
+        {:accepted, new_state}
+
+      {:stale, new_state} ->
+        {timer, _next_token} = next_timer
+        cancel_timer(timer)
+        {:stale, new_state}
+    end
+  end
+
+  @spec update(state(), (TraditionalState.t() -> TraditionalState.t())) :: state()
+  defp update(%EditorState{} = state, transition) do
+    runtime = Runtime.update_traditional_state(state.shell_runtime, transition)
+    EditorState.apply_shell_runtime_transition(state, runtime)
+  end
+
+  @spec transition_with_result(
+          state(),
+          (TraditionalState.t() -> {term(), TraditionalState.t()})
+        ) :: {term(), state()}
+  defp transition_with_result(%EditorState{} = state, transition) do
+    case Runtime.state(state.shell_runtime) do
+      %TraditionalState{} = shell_state ->
+        {result, shell_state} = transition.(shell_state)
+
+        runtime =
+          Runtime.update_traditional_state(state.shell_runtime, fn _current -> shell_state end)
+
+        {result, EditorState.apply_shell_runtime_transition(state, runtime)}
+
+      _extension_state ->
+        {:stale, state}
+    end
+  end
+
+  @spec sync_active_sidebar(state(), String.t() | nil) :: :ok
+  defp sync_active_sidebar(state, id) do
+    case MingaEditor.Extension.Sidebar.focus_left(EditorState.sidebar_registry(state), id) do
+      :ok -> :ok
+      {:error, reason} -> Log.warning(:editor, "Sidebar focus sync failed: #{inspect(reason)}")
+    end
+  end
+
+  @spec sync_git_status_sidebar(state(), GitStatusPanel.t() | nil) :: :ok
+  defp sync_git_status_sidebar(state, panel) do
+    case BuiltinSurfaces.sync_git_status_panel(panel, EditorState.sidebar_registry(state)) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Log.warning(:editor, "Git Status sidebar sync failed: #{inspect(reason)}")
+    end
+  end
+
+  @spec sync_observatory_sidebar(state(), boolean()) :: :ok
+  defp sync_observatory_sidebar(state, visible?) do
+    case BuiltinSurfaces.sync_observatory(visible?, EditorState.sidebar_registry(state)) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Log.warning(:editor, "Observatory sidebar sync failed: #{inspect(reason)}")
+    end
+  end
+
+  @spec cancel_timer(reference() | nil) :: :ok
+  defp cancel_timer(nil), do: :ok
+
+  defp cancel_timer(timer) when is_reference(timer) do
+    Process.cancel_timer(timer)
+    :ok
+  end
+end

--- a/lib/minga_editor/shell/traditional/sidebars.ex
+++ b/lib/minga_editor/shell/traditional/sidebars.ex
@@ -1,0 +1,124 @@
+defmodule MingaEditor.Shell.Traditional.Sidebars do
+  @moduledoc """
+  Pure aggregate for Traditional sidebar selection and built-in surfaces.
+
+  The selected sidebar, Git status panel pair, and Observatory lifecycle are
+  kept together so opening, closing, and replacing one built-in surface cannot
+  leave an unrelated stale selection behind.
+  """
+
+  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
+  alias MingaEditor.Shell.Traditional.Observatory
+
+  @type git_status_tui_state :: struct()
+  @type t :: %__MODULE__{
+          active_id: String.t() | nil,
+          git_status_panel: GitStatusPanel.t() | nil,
+          git_status_tui_state: git_status_tui_state() | nil,
+          observatory: Observatory.t()
+        }
+
+  defstruct active_id: nil,
+            git_status_panel: nil,
+            git_status_tui_state: nil,
+            observatory: %Observatory{}
+
+  @doc "Returns the selected native sidebar id."
+  @spec active_id(t()) :: String.t() | nil
+  def active_id(%__MODULE__{active_id: id}), do: id
+
+  @doc "Selects a visible sidebar, or clears selection with nil."
+  @spec select(t(), String.t() | nil) :: t()
+  def select(%__MODULE__{} = sidebars, id) when is_binary(id) or is_nil(id),
+    do: %{sidebars | active_id: id}
+
+  @doc "Returns the Git status panel."
+  @spec git_status_panel(t()) :: GitStatusPanel.t() | nil
+  def git_status_panel(%__MODULE__{git_status_panel: panel}), do: panel
+
+  @doc "Returns the TUI-specific Git status view state."
+  @spec git_status_tui_state(t()) :: git_status_tui_state() | nil
+  def git_status_tui_state(%__MODULE__{git_status_tui_state: state}), do: state
+
+  @doc "Replaces the Git status panel while retaining its TUI view state."
+  @spec replace_git_status(t(), GitStatusPanel.t() | map() | nil) :: t()
+  def replace_git_status(%__MODULE__{} = sidebars, nil),
+    do: %{sidebars | git_status_panel: nil}
+
+  def replace_git_status(%__MODULE__{} = sidebars, %GitStatusPanel{} = panel),
+    do: %{sidebars | git_status_panel: panel}
+
+  def replace_git_status(%__MODULE__{} = sidebars, %{} = panel),
+    do: %{sidebars | git_status_panel: GitStatusPanel.new(panel)}
+
+  @doc "Replaces the TUI-specific Git status view state."
+  @spec replace_git_status_tui(t(), git_status_tui_state() | nil) :: t()
+  def replace_git_status_tui(%__MODULE__{} = sidebars, state),
+    do: %{sidebars | git_status_tui_state: state}
+
+  @doc "Closes Git status and clears both shared and TUI-specific state."
+  @spec close_git_status(t()) :: t()
+  def close_git_status(%__MODULE__{} = sidebars) do
+    active_id = if sidebars.active_id == "git_status", do: nil, else: sidebars.active_id
+
+    %{
+      sidebars
+      | active_id: active_id,
+        git_status_panel: nil,
+        git_status_tui_state: nil
+    }
+  end
+
+  @doc "Returns the Observatory lifecycle value."
+  @spec observatory(t()) :: Observatory.t()
+  def observatory(%__MODULE__{observatory: observatory}), do: observatory
+
+  @doc "Opens and selects the Observatory surface."
+  @spec open_observatory(t(), Observatory.timer() | nil) :: t()
+  def open_observatory(%__MODULE__{} = sidebars, timer) do
+    %{
+      sidebars
+      | active_id: "observatory",
+        observatory: Observatory.open(sidebars.observatory, timer)
+    }
+  end
+
+  @doc "Closes Observatory and clears its selection when selected."
+  @spec close_observatory(t()) :: t()
+  def close_observatory(%__MODULE__{} = sidebars) do
+    active_id = if sidebars.active_id == "observatory", do: nil, else: sidebars.active_id
+    %{sidebars | active_id: active_id, observatory: Observatory.close(sidebars.observatory)}
+  end
+
+  @doc "Expires a matching Observatory refresh token."
+  @spec expire_observatory(t(), reference()) :: {:collect | :stale, t()}
+  def expire_observatory(%__MODULE__{} = sidebars, token) do
+    case Observatory.expire(sidebars.observatory, token) do
+      {result, observatory} -> {result, %{sidebars | observatory: observatory}}
+    end
+  end
+
+  @doc "Completes a matching Observatory collection."
+  @spec complete_observatory(
+          t(),
+          reference(),
+          MingaEditor.Observatory.Data.t(),
+          Observatory.timer()
+        ) ::
+          {:accepted | :stale, t()}
+  def complete_observatory(%__MODULE__{} = sidebars, token, data, next_timer) do
+    case Observatory.complete(sidebars.observatory, token, data, next_timer) do
+      {result, observatory} -> {result, %{sidebars | observatory: observatory}}
+    end
+  end
+
+  @doc "Replaces Observatory data without changing refresh correlation."
+  @spec replace_observatory_data(t(), MingaEditor.Observatory.Data.t() | nil) :: t()
+  def replace_observatory_data(%__MODULE__{} = sidebars, data),
+    do: %{sidebars | observatory: Observatory.replace_data(sidebars.observatory, data)}
+
+  @doc "Shows or dismisses Observatory process inspection."
+  @spec inspect_observatory(t(), MingaEditor.Observatory.Inspection.t() | nil) :: t()
+  def inspect_observatory(%__MODULE__{} = sidebars, inspection),
+    do: %{sidebars | observatory: Observatory.inspect(sidebars.observatory, inspection)}
+end

--- a/lib/minga_editor/shell/traditional/space_leader.ex
+++ b/lib/minga_editor/shell/traditional/space_leader.ex
@@ -1,0 +1,56 @@
+defmodule MingaEditor.Shell.Traditional.SpaceLeader do
+  @moduledoc """
+  Pure lifecycle owner for the TUI CUA space-leader timeout window.
+
+  Each installation advances a generation. Timeout delivery carries that
+  generation, so cancellation and replacement remain safe even when an old
+  timer message is already in the Editor mailbox.
+  """
+
+  @type generation :: non_neg_integer()
+  @type t :: %__MODULE__{
+          pending: boolean(),
+          generation: generation(),
+          timer: reference() | nil
+        }
+
+  defstruct pending: false, generation: 0, timer: nil
+
+  @doc "Begins a new pending leader window and returns its generation."
+  @spec begin(t()) :: {generation(), t()}
+  def begin(%__MODULE__{} = leader) do
+    generation = leader.generation + 1
+    {generation, %__MODULE__{pending: true, generation: generation}}
+  end
+
+  @doc "Records the timer handle only for the current pending generation."
+  @spec install_timer(t(), generation(), reference()) :: t()
+  def install_timer(
+        %__MODULE__{pending: true, generation: generation} = leader,
+        generation,
+        timer
+      )
+      when is_reference(timer),
+      do: %{leader | timer: timer}
+
+  def install_timer(%__MODULE__{} = leader, _generation, _timer), do: leader
+
+  @doc "Expires only the current pending generation."
+  @spec expire(t(), generation()) :: {:expired | :stale, t()}
+  def expire(%__MODULE__{pending: true, generation: generation} = leader, generation),
+    do: {:expired, reset(leader)}
+
+  def expire(%__MODULE__{} = leader, _generation), do: {:stale, leader}
+
+  @doc "Cancels or consumes the current pending window without changing identity."
+  @spec reset(t()) :: t()
+  def reset(%__MODULE__{} = leader), do: %{leader | pending: false, timer: nil}
+
+  @doc "Returns whether a space-leader window is pending."
+  @spec pending?(t()) :: boolean()
+  def pending?(%__MODULE__{pending: pending}), do: pending
+
+  @doc "Returns the timer handle for best-effort cancellation by a handler."
+  @spec timer(t()) :: reference() | nil
+  def timer(%__MODULE__{timer: timer}), do: timer
+end

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -2,42 +2,35 @@ defmodule MingaEditor.Shell.Traditional.State do
   @moduledoc """
   Presentation state for the traditional tab-based editor shell.
 
-  These fields are presentation concerns: they control how the editor
-  looks and behaves visually, but have no effect on the core editing
-  model. Each field was migrated from `MingaEditor.State` as part of
-  Phase F of the Core/Shell separation.
-
-  All `set_X`/`get_X` methods that operate on shell fields live here.
-  `MingaEditor.State` retains thin wrappers that delegate through
-  `update_shell_state/2` for backward compatibility.
+  This value coordinates focused owners for sidebar, agent-surface, input,
+  and existing independent transient lifecycles. Effects and Editor-root
+  transitions remain in their focused workflows and handlers.
   """
 
   alias MingaEditor.BottomPanel
   alias MingaEditor.HoverPopup
-  alias MingaEditor.Observatory
+  alias MingaEditor.Shell.Traditional.AgentSurfaces
+  alias MingaEditor.Shell.Traditional.ClickRegions
   alias MingaEditor.Shell.Traditional.Flashes
   alias MingaEditor.Shell.Traditional.GitToast
+  alias MingaEditor.Shell.Traditional.InputState
   alias MingaEditor.Shell.Traditional.Notice
+  alias MingaEditor.Shell.Traditional.Observatory
+  alias MingaEditor.Shell.Traditional.Sidebars
+  alias MingaEditor.Shell.Traditional.SpaceLeader
+  alias MingaEditor.Shell.Traditional.ToolPrompts
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.InlineAsk
   alias MingaEditor.State.InlineEdit
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.WhichKey
-  alias Minga.Tool.Manager, as: ToolManager
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
 
   @type git_status_panel :: GitStatusPanel.t()
-  @type git_status_tui_state :: struct()
-  @type tab_bar_command ::
-          atom() | {:workspace_goto, non_neg_integer()} | {:tab_goto_id, pos_integer()}
-  @type tab_bar_click_region ::
-          {col_start :: non_neg_integer(), col_end :: non_neg_integer(),
-           command :: tab_bar_command()}
-          | {row :: non_neg_integer(), col_start :: non_neg_integer(),
-             col_end :: non_neg_integer(), command :: tab_bar_command()}
-
-  @git_status_tui_state_module :"Elixir.MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState"
+  @type git_status_tui_state :: Sidebars.git_status_tui_state()
+  @type tab_bar_command :: ClickRegions.tab_bar_command()
+  @type tab_bar_click_region :: ClickRegions.tab_bar_region()
 
   @type t :: %__MODULE__{
           flashes: Flashes.t(),
@@ -45,27 +38,14 @@ defmodule MingaEditor.Shell.Traditional.State do
           notice: Notice.t(),
           whichkey: WhichKey.t(),
           bottom_panel: BottomPanel.t(),
-          git_status_panel: git_status_panel() | nil,
-          git_status_tui_state: git_status_tui_state() | nil,
-          sidebar_active_id: String.t() | nil,
-          observatory_visible: boolean(),
-          observatory_data: Observatory.Data.t() | nil,
-          observatory_timer: {reference(), reference()} | nil,
-          observatory_inspection: Observatory.Inspection.t() | nil,
+          sidebars: Sidebars.t(),
           git_toast: GitToast.t(),
           tab_bar: TabBar.t() | nil,
-          agent: AgentState.t(),
+          agent_surfaces: AgentSurfaces.t(),
           modal: ModalOverlay.t(),
-          inline_asks: InlineAsk.store(),
-          inline_edits: InlineEdit.store(),
-          modeline_click_regions: [MingaEditor.Shell.Traditional.Modeline.click_region()],
-          tab_bar_click_regions: [tab_bar_click_region()],
+          input: InputState.t(),
           signature_help: MingaEditor.SignatureHelp.t() | nil,
-          tool_declined: MapSet.t(),
-          tool_prompt_queue: [atom()],
-          suppress_tool_prompts: boolean(),
-          space_leader_pending: boolean(),
-          space_leader_timer: reference() | nil
+          tool_prompts: ToolPrompts.t()
         }
 
   defstruct flashes: %Flashes{},
@@ -73,32 +53,19 @@ defmodule MingaEditor.Shell.Traditional.State do
             notice: %Notice{},
             whichkey: %WhichKey{},
             bottom_panel: %BottomPanel{},
-            git_status_panel: nil,
-            git_status_tui_state: nil,
-            sidebar_active_id: nil,
-            observatory_visible: false,
-            observatory_data: nil,
-            observatory_timer: nil,
-            observatory_inspection: nil,
+            sidebars: %Sidebars{},
             git_toast: %GitToast{},
             tab_bar: nil,
-            agent: %AgentState{},
+            agent_surfaces: %AgentSurfaces{},
             modal: :none,
-            inline_asks: %{},
-            inline_edits: %{},
-            modeline_click_regions: [],
-            tab_bar_click_regions: [],
+            input: %InputState{},
             signature_help: nil,
-            tool_declined: MapSet.new(),
-            tool_prompt_queue: [],
-            suppress_tool_prompts: false,
-            space_leader_pending: false,
-            space_leader_timer: nil
+            tool_prompts: %ToolPrompts{}
 
   @doc "Controls whether missing-tool prompts are suppressed."
   @spec set_suppress_tool_prompts(t(), boolean()) :: t()
   def set_suppress_tool_prompts(%__MODULE__{} = state, suppress?) when is_boolean(suppress?) do
-    %{state | suppress_tool_prompts: suppress?}
+    %{state | tool_prompts: ToolPrompts.suppress(state.tool_prompts, suppress?)}
   end
 
   # ── Focused transient owners ──────────────────────────────────────────────
@@ -318,130 +285,94 @@ defmodule MingaEditor.Shell.Traditional.State do
     %{ss | bottom_panel: panel}
   end
 
-  # ── Git status panel ───────────────────────────────────────────────────────
+  # ── Sidebar and Observatory lifecycle ─────────────────────────────────────
+
+  @doc "Returns the focused sidebar aggregate."
+  @spec sidebars(t()) :: Sidebars.t()
+  def sidebars(%__MODULE__{sidebars: sidebars}), do: sidebars
 
   @doc "Returns the git status panel data, or nil."
   @spec git_status_panel(t()) :: git_status_panel() | nil
-  def git_status_panel(%{git_status_panel: data}), do: data
+  def git_status_panel(%__MODULE__{sidebars: sidebars}), do: Sidebars.git_status_panel(sidebars)
 
-  @doc "Sets the git status panel data."
-  @spec set_git_status_panel(t(), git_status_panel() | nil) :: t()
-  def set_git_status_panel(%{} = ss, nil), do: %{ss | git_status_panel: nil}
-
-  def set_git_status_panel(%{} = ss, data) do
-    %{ss | git_status_panel: GitStatusPanel.new(data)}
-  end
+  @doc "Replaces the Git status panel through the sidebar owner."
+  @spec replace_git_status_panel(t(), git_status_panel() | map() | nil) :: t()
+  def replace_git_status_panel(%__MODULE__{} = state, panel),
+    do: %{state | sidebars: Sidebars.replace_git_status(state.sidebars, panel)}
 
   @doc "Returns the TUI-only git status view state, or nil."
   @spec git_status_tui_state(t()) :: git_status_tui_state() | nil
-  def git_status_tui_state(%{git_status_tui_state: tui}), do: tui
+  def git_status_tui_state(%__MODULE__{sidebars: sidebars}),
+    do: Sidebars.git_status_tui_state(sidebars)
 
-  @doc "Sets the TUI-only git status view state."
-  @spec set_git_status_tui_state(t(), git_status_tui_state() | nil) :: t()
-  def set_git_status_tui_state(%{} = ss, nil), do: %{ss | git_status_tui_state: nil}
+  @doc "Replaces the TUI-only Git status view state."
+  @spec replace_git_status_tui_state(t(), git_status_tui_state() | nil) :: t()
+  def replace_git_status_tui_state(%__MODULE__{} = state, tui),
+    do: %{state | sidebars: Sidebars.replace_git_status_tui(state.sidebars, tui)}
 
-  def set_git_status_tui_state(%{} = ss, tui) do
-    if git_status_tui_state?(tui), do: %{ss | git_status_tui_state: tui}, else: ss
-  end
-
-  @doc "Refreshes existing TUI-only git status view state after shared entries change."
-  @spec refresh_git_status_tui_state(t(), [Minga.Git.StatusEntry.t()]) :: t()
-  def refresh_git_status_tui_state(%{git_status_tui_state: nil} = ss, _entries), do: ss
-
-  def refresh_git_status_tui_state(%{git_status_tui_state: tui} = ss, entries) do
-    module = :"Elixir.MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState"
-
-    if git_porcelain_running?() and Code.ensure_loaded?(module) and
-         function_exported?(module, :refresh, 2) do
-      refreshed = :erlang.apply(module, :refresh, [tui, entries])
-
-      if git_status_tui_state?(refreshed), do: %{ss | git_status_tui_state: refreshed}, else: ss
-    else
-      ss
-    end
-  end
-
-  @spec git_status_tui_state?(term()) :: boolean()
-  defp git_status_tui_state?(value) do
-    Code.ensure_loaded?(@git_status_tui_state_module) and
-      is_struct(value, @git_status_tui_state_module)
-  end
-
-  @spec git_porcelain_running?() :: boolean()
-  defp git_porcelain_running? do
-    case Process.whereis(Minga.Extension.Registry) do
-      nil -> false
-      _pid -> git_porcelain_running_in_registry?()
-    end
-  catch
-    :exit, _reason -> false
-  end
-
-  @spec git_porcelain_running_in_registry?() :: boolean()
-  defp git_porcelain_running_in_registry? do
-    case Minga.Extension.Registry.get(:minga_git_porcelain) do
-      {:ok, %{status: :running}} -> true
-      _ -> false
-    end
-  end
-
-  @doc "Clears the git status panel."
+  @doc "Closes the Git status sidebar and its paired TUI state."
   @spec close_git_status_panel(t()) :: t()
-  def close_git_status_panel(%{} = ss) do
-    %{ss | git_status_panel: nil, git_status_tui_state: nil}
-  end
+  def close_git_status_panel(%__MODULE__{} = state),
+    do: %{state | sidebars: Sidebars.close_git_status(state.sidebars)}
 
-  @doc "Returns the active native sidebar id, or nil when the renderer should derive one."
+  @doc "Returns the active native sidebar id."
   @spec sidebar_active_id(t()) :: String.t() | nil
-  def sidebar_active_id(%{sidebar_active_id: id}), do: id
+  def sidebar_active_id(%__MODULE__{sidebars: sidebars}), do: Sidebars.active_id(sidebars)
 
-  @doc "Sets the active native sidebar id."
-  @spec set_sidebar_active_id(t(), String.t() | nil) :: t()
-  def set_sidebar_active_id(%{} = ss, id) when is_binary(id) or is_nil(id) do
-    %{ss | sidebar_active_id: id}
-  end
+  @doc "Selects the active native sidebar id."
+  @spec select_sidebar(t(), String.t() | nil) :: t()
+  def select_sidebar(%__MODULE__{} = state, id),
+    do: %{state | sidebars: Sidebars.select(state.sidebars, id)}
 
-  # ── BEAM Observatory ──────────────────────────────────────────────────────
+  @doc "Returns the BEAM Observatory lifecycle value."
+  @spec observatory(t()) :: Observatory.t()
+  def observatory(%__MODULE__{sidebars: sidebars}), do: Sidebars.observatory(sidebars)
 
   @doc "Returns true when the BEAM Observatory sidebar is visible."
   @spec observatory_visible?(t()) :: boolean()
-  def observatory_visible?(%{observatory_visible: visible}), do: visible
+  def observatory_visible?(%__MODULE__{} = state),
+    do: state |> observatory() |> Observatory.visible?()
 
-  @doc "Opens the BEAM Observatory sidebar."
-  @spec open_observatory(t(), {reference(), reference()} | nil) :: t()
-  def open_observatory(%{} = ss, timer) do
-    %{ss | observatory_visible: true, observatory_timer: timer, observatory_inspection: nil}
-  end
+  @doc "Opens and selects the BEAM Observatory sidebar."
+  @spec open_observatory(t(), Observatory.timer() | nil) :: t()
+  def open_observatory(%__MODULE__{} = state, timer),
+    do: %{state | sidebars: Sidebars.open_observatory(state.sidebars, timer)}
 
   @doc "Closes the BEAM Observatory sidebar."
   @spec close_observatory(t()) :: t()
-  def close_observatory(%{} = ss) do
-    %{
-      ss
-      | observatory_visible: false,
-        observatory_data: nil,
-        observatory_timer: nil,
-        observatory_inspection: nil
-    }
+  def close_observatory(%__MODULE__{} = state),
+    do: %{state | sidebars: Sidebars.close_observatory(state.sidebars)}
+
+  @doc "Expires a matching Observatory refresh token."
+  @spec expire_observatory_refresh(t(), reference()) :: {:collect | :stale, t()}
+  def expire_observatory_refresh(%__MODULE__{} = state, token) do
+    case Sidebars.expire_observatory(state.sidebars, token) do
+      {result, sidebars} -> {result, %{state | sidebars: sidebars}}
+    end
   end
 
-  @doc "Stores the latest BEAM Observatory tree data."
-  @spec set_observatory_data(t(), Observatory.Data.t() | nil) :: t()
-  def set_observatory_data(%{} = ss, data) do
-    %{ss | observatory_data: data}
+  @doc "Completes a matching Observatory refresh and installs the next timer."
+  @spec complete_observatory_refresh(
+          t(),
+          reference(),
+          MingaEditor.Observatory.Data.t(),
+          Observatory.timer()
+        ) :: {:accepted | :stale, t()}
+  def complete_observatory_refresh(%__MODULE__{} = state, token, data, next_timer) do
+    case Sidebars.complete_observatory(state.sidebars, token, data, next_timer) do
+      {result, sidebars} -> {result, %{state | sidebars: sidebars}}
+    end
   end
 
-  @doc "Stores the timer reference for the next BEAM Observatory refresh."
-  @spec set_observatory_timer(t(), {reference(), reference()} | nil) :: t()
-  def set_observatory_timer(%{} = ss, timer) do
-    %{ss | observatory_timer: timer}
-  end
+  @doc "Replaces Observatory data without changing refresh correlation."
+  @spec replace_observatory_data(t(), MingaEditor.Observatory.Data.t() | nil) :: t()
+  def replace_observatory_data(%__MODULE__{} = state, data),
+    do: %{state | sidebars: Sidebars.replace_observatory_data(state.sidebars, data)}
 
-  @doc "Stores process inspection data for the native float popup."
-  @spec set_observatory_inspection(t(), Observatory.Inspection.t() | nil) :: t()
-  def set_observatory_inspection(%{} = ss, inspection) do
-    %{ss | observatory_inspection: inspection}
-  end
+  @doc "Shows or dismisses the Observatory process inspection."
+  @spec inspect_observatory(t(), MingaEditor.Observatory.Inspection.t() | nil) :: t()
+  def inspect_observatory(%__MODULE__{} = state, inspection),
+    do: %{state | sidebars: Sidebars.inspect_observatory(state.sidebars, inspection)}
 
   # ── Tab bar ────────────────────────────────────────────────────────────────
 
@@ -455,17 +386,21 @@ defmodule MingaEditor.Shell.Traditional.State do
     %{ss | tab_bar: tb}
   end
 
-  # ── Agent lifecycle ────────────────────────────────────────────────────────
+  # ── Agent presentation and inline surfaces ────────────────────────────────
 
-  @doc "Returns the agent session lifecycle state."
+  @doc "Returns the focused agent-surface owner."
+  @spec agent_surfaces(t()) :: AgentSurfaces.t()
+  def agent_surfaces(%__MODULE__{agent_surfaces: surfaces}), do: surfaces
+
+  @doc "Returns the agent presentation cache."
   @spec agent(t()) :: AgentState.t()
-  def agent(%{agent: a}), do: a
+  def agent(%__MODULE__{agent_surfaces: surfaces}),
+    do: AgentSurfaces.presentation(surfaces)
 
-  @doc "Replaces the agent session lifecycle state."
-  @spec set_agent(t(), AgentState.t()) :: t()
-  def set_agent(%{} = ss, agent) do
-    %{ss | agent: agent}
-  end
+  @doc "Replaces the agent presentation cache."
+  @spec replace_agent(t(), AgentState.t()) :: t()
+  def replace_agent(%__MODULE__{} = state, agent),
+    do: %{state | agent_surfaces: AgentSurfaces.replace_presentation(state.agent_surfaces, agent)}
 
   # ── Modal overlay ──────────────────────────────────────────────────────────
 
@@ -512,72 +447,147 @@ defmodule MingaEditor.Shell.Traditional.State do
   def dismiss_stale_modal_completion(%__MODULE__{} = state, active_tab_id),
     do: %{state | modal: ModalOverlay.dismiss_if_stale(state.modal, active_tab_id)}
 
-  # ── Inline ask ─────────────────────────────────────────────────────────────
+  # ── Inline agent surfaces ──────────────────────────────────────────────────
 
   @doc "Returns the inline ask store."
-  @spec inline_asks(t() | map()) :: InlineAsk.store()
-  def inline_asks(%{inline_asks: asks}), do: asks
-  def inline_asks(_ss), do: %{}
+  @spec inline_asks(t()) :: InlineAsk.store()
+  def inline_asks(%__MODULE__{agent_surfaces: surfaces}), do: AgentSurfaces.asks(surfaces)
 
-  @doc "Replaces the inline ask store."
-  @spec set_inline_asks(t() | map(), InlineAsk.store()) :: t() | map()
-  def set_inline_asks(%{inline_asks: _} = ss, asks) when is_map(asks) do
-    %{ss | inline_asks: asks}
+  @doc "Activates or replaces an inline ask."
+  @spec activate_inline_ask(t(), InlineAsk.t()) :: t()
+  def activate_inline_ask(%__MODULE__{} = state, ask),
+    do: %{state | agent_surfaces: AgentSurfaces.activate_ask(state.agent_surfaces, ask)}
+
+  @doc "Replaces an inline ask after a leaf transition."
+  @spec replace_inline_ask(t(), InlineAsk.t()) :: t()
+  def replace_inline_ask(%__MODULE__{} = state, ask),
+    do: %{state | agent_surfaces: AgentSurfaces.replace_ask(state.agent_surfaces, ask)}
+
+  @doc "Cancels an inline ask and returns its session pid."
+  @spec cancel_inline_ask(t(), pid() | nil) :: {t(), pid() | nil}
+  def cancel_inline_ask(%__MODULE__{} = state, buffer_pid) do
+    {surfaces, session_pid} = AgentSurfaces.cancel_ask(state.agent_surfaces, buffer_pid)
+    {%{state | agent_surfaces: surfaces}, session_pid}
   end
-
-  def set_inline_asks(ss, _asks), do: ss
 
   @doc "Returns the inline edit store."
-  @spec inline_edits(t() | map()) :: InlineEdit.store()
-  def inline_edits(%{inline_edits: edits}), do: edits
-  def inline_edits(_ss), do: %{}
+  @spec inline_edits(t()) :: InlineEdit.store()
+  def inline_edits(%__MODULE__{agent_surfaces: surfaces}), do: AgentSurfaces.edits(surfaces)
 
-  @doc "Replaces the inline edit store."
-  @spec set_inline_edits(t() | map(), InlineEdit.store()) :: t() | map()
-  def set_inline_edits(%{inline_edits: _} = ss, edits) when is_map(edits) do
-    %{ss | inline_edits: edits}
+  @doc "Activates or replaces an inline edit."
+  @spec activate_inline_edit(t(), InlineEdit.t()) :: t()
+  def activate_inline_edit(%__MODULE__{} = state, edit),
+    do: %{state | agent_surfaces: AgentSurfaces.activate_edit(state.agent_surfaces, edit)}
+
+  @doc "Replaces an inline edit after a leaf transition."
+  @spec replace_inline_edit(t(), InlineEdit.t()) :: t()
+  def replace_inline_edit(%__MODULE__{} = state, edit),
+    do: %{state | agent_surfaces: AgentSurfaces.replace_edit(state.agent_surfaces, edit)}
+
+  @doc "Cancels an inline edit and returns its session pid."
+  @spec cancel_inline_edit(t(), pid() | nil) :: {t(), pid() | nil}
+  def cancel_inline_edit(%__MODULE__{} = state, buffer_pid) do
+    {surfaces, session_pid} = AgentSurfaces.cancel_edit(state.agent_surfaces, buffer_pid)
+    {%{state | agent_surfaces: surfaces}, session_pid}
   end
 
-  def set_inline_edits(ss, _edits), do: ss
+  # ── Tool prompt lifecycle ──────────────────────────────────────────────────
 
-  # ── Tool prompt helpers ────────────────────────────────────────────────────
+  @doc "Returns the focused tool-prompt owner."
+  @spec tool_prompts(t()) :: ToolPrompts.t()
+  def tool_prompts(%__MODULE__{tool_prompts: prompts}), do: prompts
 
-  @doc """
-  Returns true if the given tool should NOT be prompted for installation.
+  @doc "Returns whether a tool was declined or is already queued."
+  @spec tool_prompt_decided?(t(), atom()) :: boolean()
+  def tool_prompt_decided?(%__MODULE__{} = state, tool_name),
+    do: ToolPrompts.decided?(state.tool_prompts, tool_name)
 
-  A tool is skipped when it's already declined this session, already
-  installed, currently being installed, or already in the prompt queue.
-  """
-  @spec skip_tool_prompt?(t(), atom()) :: boolean()
-  def skip_tool_prompt?(%{} = ss, tool_name) do
-    MapSet.member?(ss.tool_declined, tool_name) or
-      ToolManager.installed?(tool_name) or
-      MapSet.member?(ToolManager.installing(), tool_name) or
-      tool_name in ss.tool_prompt_queue
+  @doc "Queues a missing tool once."
+  @spec enqueue_tool_prompt(t(), atom()) :: t()
+  def enqueue_tool_prompt(%__MODULE__{} = state, tool_name),
+    do: %{state | tool_prompts: ToolPrompts.enqueue(state.tool_prompts, tool_name)}
+
+  @doc "Replaces tool-prompt decisions and pending queue atomically."
+  @spec replace_tool_prompts(t(), [atom()], MapSet.t(atom())) :: t()
+  def replace_tool_prompts(%__MODULE__{} = state, queue, declined),
+    do: %{state | tool_prompts: ToolPrompts.replace(state.tool_prompts, queue, declined)}
+
+  @doc "Advances to the next missing-tool prompt."
+  @spec advance_tool_prompt(t()) :: t()
+  def advance_tool_prompt(%__MODULE__{} = state),
+    do: %{state | tool_prompts: ToolPrompts.advance(state.tool_prompts)}
+
+  # ── Input lifecycle ────────────────────────────────────────────────────────
+
+  @doc "Returns Traditional input state."
+  @spec input(t()) :: InputState.t()
+  def input(%__MODULE__{input: input}), do: input
+
+  @doc "Returns the renderer-authored click-region value."
+  @spec click_regions(t()) :: ClickRegions.t()
+  def click_regions(%__MODULE__{input: input}), do: InputState.click_regions(input)
+
+  @doc "Installs both click-region sets from one render."
+  @spec install_click_regions(
+          t(),
+          [MingaEditor.Shell.Traditional.Modeline.click_region()],
+          [ClickRegions.tab_bar_region()]
+        ) :: t()
+  def install_click_regions(%__MODULE__{} = state, modeline, tab_bar),
+    do: %{state | input: InputState.install_click_regions(state.input, modeline, tab_bar)}
+
+  @doc "Installs one already-correlated click-region value."
+  @spec install_click_regions(t(), ClickRegions.t()) :: t()
+  def install_click_regions(%__MODULE__{} = state, %ClickRegions{} = regions),
+    do: %{state | input: InputState.install_click_regions(state.input, regions)}
+
+  @doc "Returns the modeline command under a rendered column."
+  @spec modeline_command_at(t(), non_neg_integer()) :: atom() | nil
+  def modeline_command_at(%__MODULE__{input: input}, col),
+    do: InputState.modeline_command_at(input, col)
+
+  @doc "Returns the tab-bar command under a rendered cell."
+  @spec tab_bar_command_at(t(), non_neg_integer(), non_neg_integer()) ::
+          tab_bar_command() | nil
+  def tab_bar_command_at(%__MODULE__{input: input}, row, col),
+    do: InputState.tab_bar_command_at(input, row, col)
+
+  @doc "Resets all renderer-authored click regions."
+  @spec reset_click_regions(t()) :: t()
+  def reset_click_regions(%__MODULE__{} = state),
+    do: %{state | input: InputState.reset_click_regions(state.input)}
+
+  @doc "Begins a new space-leader generation."
+  @spec begin_space_leader(t()) :: {SpaceLeader.generation(), t()}
+  def begin_space_leader(%__MODULE__{} = state) do
+    {generation, input} = InputState.begin_space_leader(state.input)
+    {generation, %{state | input: input}}
   end
 
-  @doc "Replaces the pending tool-install prompt queue."
-  @spec set_tool_prompt_queue(t(), [atom()]) :: t()
-  def set_tool_prompt_queue(%__MODULE__{} = state, queue) when is_list(queue) do
-    %{state | tool_prompt_queue: queue}
+  @doc "Records the current space-leader timer."
+  @spec install_space_leader_timer(t(), SpaceLeader.generation(), reference()) :: t()
+  def install_space_leader_timer(%__MODULE__{} = state, generation, timer),
+    do: %{state | input: InputState.install_space_leader_timer(state.input, generation, timer)}
+
+  @doc "Expires only the matching space-leader generation."
+  @spec expire_space_leader(t(), SpaceLeader.generation()) :: {:expired | :stale, t()}
+  def expire_space_leader(%__MODULE__{} = state, generation) do
+    case InputState.expire_space_leader(state.input, generation) do
+      {result, input} -> {result, %{state | input: input}}
+    end
   end
 
-  @doc "Replaces tool-prompt decisions and the pending queue atomically."
-  @spec set_tool_prompt_state(t(), [atom()], MapSet.t(atom())) :: t()
-  def set_tool_prompt_state(%__MODULE__{} = state, queue, declined)
-      when is_list(queue) do
-    %{state | tool_prompt_queue: queue, tool_declined: declined}
-  end
+  @doc "Returns whether the space-leader window is pending."
+  @spec space_leader_pending?(t()) :: boolean()
+  def space_leader_pending?(%__MODULE__{input: input}),
+    do: InputState.space_leader_pending?(input)
 
-  @doc "Sets whether a CUA space leader sequence is pending."
-  @spec set_space_leader_pending(t(), boolean()) :: t()
-  def set_space_leader_pending(%{} = ss, value) when is_boolean(value) do
-    %{ss | space_leader_pending: value}
-  end
+  @doc "Returns the current space-leader timer handle."
+  @spec space_leader_timer(t()) :: reference() | nil
+  def space_leader_timer(%__MODULE__{input: input}), do: InputState.space_leader_timer(input)
 
-  @doc "Sets the CUA space leader timer reference."
-  @spec set_space_leader_timer(t(), reference() | nil) :: t()
-  def set_space_leader_timer(%{} = ss, timer) do
-    %{ss | space_leader_timer: timer}
-  end
+  @doc "Resets the current space-leader window."
+  @spec reset_space_leader(t()) :: t()
+  def reset_space_leader(%__MODULE__{} = state),
+    do: %{state | input: InputState.reset_space_leader(state.input)}
 end

--- a/lib/minga_editor/shell/traditional/tool_prompt_workflow.ex
+++ b/lib/minga_editor/shell/traditional/tool_prompt_workflow.ex
@@ -1,0 +1,62 @@
+defmodule MingaEditor.Shell.Traditional.ToolPromptWorkflow do
+  @moduledoc """
+  Focused boundary for Traditional missing-tool prompt lifecycle.
+
+  Tool-manager process queries stay here; the shell value only records queue,
+  suppression, and session-local decisions.
+  """
+
+  alias Minga.Tool.Manager, as: ToolManager
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.Shell.Traditional.ToolPrompts
+  alias MingaEditor.State, as: EditorState
+
+  @type state :: EditorState.t()
+
+  @doc "Returns the current prompt owner, or defaults outside Traditional."
+  @spec prompts(state()) :: ToolPrompts.t()
+  def prompts(%EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}}),
+    do: TraditionalState.tool_prompts(shell_state)
+
+  def prompts(%EditorState{}), do: %ToolPrompts{}
+
+  @doc "Returns whether a missing tool should not produce another prompt."
+  @spec skip?(state(), atom()) :: boolean()
+  def skip?(
+        %EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}},
+        tool_name
+      ) do
+    TraditionalState.tool_prompt_decided?(shell_state, tool_name) or
+      ToolManager.installed?(tool_name) or
+      MapSet.member?(ToolManager.installing(), tool_name)
+  end
+
+  def skip?(%EditorState{}, _tool_name), do: true
+
+  @doc "Controls whether missing-tool prompts are suppressed."
+  @spec suppress(state(), boolean()) :: state()
+  def suppress(%EditorState{} = state, suppressed?) when is_boolean(suppressed?),
+    do: update(state, &TraditionalState.set_suppress_tool_prompts(&1, suppressed?))
+
+  @doc "Queues a missing tool once."
+  @spec enqueue(state(), atom()) :: state()
+  def enqueue(%EditorState{} = state, tool_name),
+    do: update(state, &TraditionalState.enqueue_tool_prompt(&1, tool_name))
+
+  @doc "Replaces pending queue and declined decisions atomically."
+  @spec replace(state(), [atom()], MapSet.t(atom())) :: state()
+  def replace(%EditorState{} = state, queue, declined),
+    do: update(state, &TraditionalState.replace_tool_prompts(&1, queue, declined))
+
+  @doc "Drops the current pending prompt."
+  @spec advance(state()) :: state()
+  def advance(%EditorState{} = state),
+    do: update(state, &TraditionalState.advance_tool_prompt/1)
+
+  @spec update(state(), (TraditionalState.t() -> TraditionalState.t())) :: state()
+  defp update(%EditorState{} = state, transition) do
+    runtime = Runtime.update_traditional_state(state.shell_runtime, transition)
+    EditorState.apply_shell_runtime_transition(state, runtime)
+  end
+end

--- a/lib/minga_editor/shell/traditional/tool_prompts.ex
+++ b/lib/minga_editor/shell/traditional/tool_prompts.ex
@@ -1,0 +1,56 @@
+defmodule MingaEditor.Shell.Traditional.ToolPrompts do
+  @moduledoc """
+  Pure owner of Traditional missing-tool prompt decisions and queue state.
+
+  Tool discovery and installation checks remain in handlers. This value only
+  owns the user's session-local decisions and ordered prompt lifecycle.
+  """
+
+  @type t :: %__MODULE__{
+          declined: MapSet.t(atom()),
+          queue: [atom()],
+          suppressed?: boolean()
+        }
+
+  defstruct declined: MapSet.new(), queue: [], suppressed?: false
+
+  @doc "Controls whether missing-tool prompts are suppressed."
+  @spec suppress(t(), boolean()) :: t()
+  def suppress(%__MODULE__{} = prompts, suppressed?) when is_boolean(suppressed?),
+    do: %{prompts | suppressed?: suppressed?}
+
+  @doc "Returns whether prompts are suppressed."
+  @spec suppressed?(t()) :: boolean()
+  def suppressed?(%__MODULE__{suppressed?: suppressed?}), do: suppressed?
+
+  @doc "Returns the ordered pending tool queue."
+  @spec queue(t()) :: [atom()]
+  def queue(%__MODULE__{queue: queue}), do: queue
+
+  @doc "Returns the set of tools declined during this editor session."
+  @spec declined(t()) :: MapSet.t(atom())
+  def declined(%__MODULE__{declined: declined}), do: declined
+
+  @doc "Returns whether a tool was declined or is already queued."
+  @spec decided?(t(), atom()) :: boolean()
+  def decided?(%__MODULE__{} = prompts, tool_name),
+    do: MapSet.member?(prompts.declined, tool_name) or tool_name in prompts.queue
+
+  @doc "Queues a tool once."
+  @spec enqueue(t(), atom()) :: t()
+  def enqueue(%__MODULE__{} = prompts, tool_name) when is_atom(tool_name) do
+    if decided?(prompts, tool_name),
+      do: prompts,
+      else: %{prompts | queue: List.insert_at(prompts.queue, -1, tool_name)}
+  end
+
+  @doc "Replaces prompt decisions and queue atomically."
+  @spec replace(t(), [atom()], MapSet.t(atom())) :: t()
+  def replace(%__MODULE__{} = prompts, queue, declined) when is_list(queue),
+    do: %{prompts | queue: queue, declined: declined}
+
+  @doc "Drops the current queued prompt."
+  @spec advance(t()) :: t()
+  def advance(%__MODULE__{queue: [_current | rest]} = prompts), do: %{prompts | queue: rest}
+  def advance(%__MODULE__{} = prompts), do: prompts
+end

--- a/lib/minga_editor/shell/workflow.ex
+++ b/lib/minga_editor/shell/workflow.ex
@@ -121,9 +121,16 @@ defmodule MingaEditor.Shell.Workflow do
 
   @spec initialize_shell_state(module(), term()) :: term()
   defp initialize_shell_state(MingaEditor.Shell.Traditional, previous_state) do
-    %TraditionalState{
-      suppress_tool_prompts: Map.get(previous_state, :suppress_tool_prompts, false)
-    }
+    suppressed? =
+      case previous_state do
+        %TraditionalState{tool_prompts: prompts} ->
+          MingaEditor.Shell.Traditional.ToolPrompts.suppressed?(prompts)
+
+        _other ->
+          false
+      end
+
+    TraditionalState.set_suppress_tool_prompts(%TraditionalState{}, suppressed?)
   end
 
   defp initialize_shell_state(module, _previous_state), do: module.init([])

--- a/lib/minga_editor/sidebar/builtin_surfaces.ex
+++ b/lib/minga_editor/sidebar/builtin_surfaces.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Layout
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
 
@@ -70,7 +71,7 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
   end
 
   def handle_git_status_action(%EditorState{} = state, "activate", _context) do
-    if EditorState.git_status_panel(state) do
+    if SidebarWorkflow.git_status_panel(state) do
       focus_git_status(state)
     else
       execute_git_porcelain_command(state, :git_status_toggle)
@@ -88,7 +89,7 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
   end
 
   def handle_observatory_action(%EditorState{} = state, "activate", _context) do
-    if EditorState.observatory_visible?(state) do
+    if SidebarWorkflow.observatory_visible?(state) do
       focus_observatory(state)
     else
       state
@@ -131,23 +132,19 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
 
   @spec focus_git_status(EditorState.t()) :: EditorState.t()
   defp focus_git_status(state) do
-    :ok = Sidebar.focus_left(EditorState.sidebar_registry(state), @git_status_id)
-
     state
     |> EditorState.set_keymap_scope(:git_status)
-    |> EditorState.set_sidebar_active_id(@git_status_id)
+    |> SidebarWorkflow.select(@git_status_id)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end
 
   @spec focus_observatory(EditorState.t()) :: EditorState.t()
   defp focus_observatory(state) do
-    :ok = Sidebar.focus_left(EditorState.sidebar_registry(state), @observatory_id)
-
     state
     |> EditorState.update_file_tree(&FileTreeState.unfocus/1)
     |> EditorState.set_keymap_scope(:editor)
-    |> EditorState.set_sidebar_active_id(@observatory_id)
+    |> SidebarWorkflow.select(@observatory_id)
     |> Layout.invalidate()
     |> EditorState.invalidate_all_windows()
   end

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -429,7 +429,7 @@ defmodule MingaEditor.Startup do
   @spec agent_view_state() :: {atom(), UIState.t()}
   defp agent_view_state do
     base = UIState.new()
-    av = %UIState{base | view: %{base.view | active: true, focus: :chat}}
+    av = %UIState{base | view: MingaEditor.Agent.UIState.View.activate(base.view, nil, nil)}
     {:agent, av}
   end
 
@@ -605,9 +605,10 @@ defmodule MingaEditor.Startup do
 
   @spec init_shell_state(module(), keyword()) :: term()
   defp init_shell_state(MingaEditor.Shell.Traditional, opts) do
-    %MingaEditor.Shell.Traditional.State{
-      suppress_tool_prompts: Keyword.get(opts, :suppress_tool_prompts, false)
-    }
+    MingaEditor.Shell.Traditional.State.set_suppress_tool_prompts(
+      %MingaEditor.Shell.Traditional.State{},
+      Keyword.get(opts, :suppress_tool_prompts, false)
+    )
   end
 
   defp init_shell_state(module, opts) do

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -32,8 +32,6 @@ defmodule MingaEditor.State do
   alias MingaEditor.BottomPanel
   alias MingaEditor.KeystrokeHistory
   alias MingaEditor.FileTree.Feature, as: FileTreeFeature
-  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
-  alias MingaEditor.Sidebar.BuiltinSurfaces
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Dired, as: DiredState
@@ -95,7 +93,7 @@ defmodule MingaEditor.State do
   @default_options_server Minga.Config.Options.default_server()
   @default_events_registry Minga.Events.default_registry()
 
-  alias MingaEditor.Observatory
+  alias MingaEditor.Shell.Traditional.ClickRegions
   alias MingaEditor.Shell.Traditional.State, as: ShellState
 
   @enforce_keys [:port_manager, :workspace]
@@ -835,12 +833,17 @@ defmodule MingaEditor.State do
   @spec merge_renderer_receipt(ShellRuntime.t(), MingaEditor.Renderer.RenderReceipt.t()) ::
           ShellRuntime.t()
   defp merge_renderer_receipt(runtime, receipt) do
-    case receipt.shell_identity do
-      %ShellIdentity{} = identity ->
-        ShellRuntime.merge_renderer_observation(runtime, receipt.shell_id, identity, %{
-          modeline_click_regions: receipt.modeline_click_regions,
-          tab_bar_click_regions: receipt.tab_bar_click_regions
-        })
+    case {receipt.shell_identity, receipt.click_regions} do
+      {%ShellIdentity{} = identity, %ClickRegions{} = regions} ->
+        if receipt.shell_id == ShellRuntime.id(runtime) and
+             ShellRuntime.matches_identity?(runtime, identity) do
+          ShellRuntime.update_traditional_state(
+            runtime,
+            &ShellState.install_click_regions(&1, regions)
+          )
+        else
+          runtime
+        end
 
       _missing_or_invalid ->
         runtime
@@ -872,126 +875,11 @@ defmodule MingaEditor.State do
   defp update_traditional_shell_state(%__MODULE__{} = state, fun),
     do: update_shell_state(state, fun)
 
-  @spec set_suppress_tool_prompts(t(), boolean()) :: t()
-  def set_suppress_tool_prompts(s, suppress?) when is_boolean(suppress?) do
-    update_traditional_shell_state(s, &ShellState.set_suppress_tool_prompts(&1, suppress?))
-  end
-
   @spec bottom_panel(t()) :: BottomPanel.t()
   def bottom_panel(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.bottom_panel(ss)
   @spec set_bottom_panel(t(), BottomPanel.t()) :: t()
   def set_bottom_panel(s, panel),
     do: update_traditional_shell_state(s, &ShellState.set_bottom_panel(&1, panel))
-
-  @spec git_status_panel(t()) :: ShellState.git_status_panel() | nil
-  def git_status_panel(%{shell_runtime: %ShellRuntime{state: ss}}),
-    do: ShellState.git_status_panel(ss)
-
-  @spec set_git_status_tui_state(t(), term()) :: t()
-  def set_git_status_tui_state(state, tui_state) do
-    update_traditional_shell_state(
-      state,
-      &ShellState.set_git_status_tui_state(&1, tui_state)
-    )
-  end
-
-  @spec set_git_status_panel(t(), ShellState.git_status_panel() | nil) :: t()
-  def set_git_status_panel(s, nil) do
-    sync_git_status_sidebar(s, nil)
-    update_traditional_shell_state(s, &ShellState.set_git_status_panel(&1, nil))
-  end
-
-  def set_git_status_panel(s, data) do
-    panel = GitStatusPanel.new(data)
-    sync_git_status_sidebar(s, panel)
-    update_traditional_shell_state(s, &ShellState.set_git_status_panel(&1, panel))
-  end
-
-  @spec sync_git_status_sidebar(t(), GitStatusPanel.t() | nil) :: :ok
-  defp sync_git_status_sidebar(state, panel) do
-    case BuiltinSurfaces.sync_git_status_panel(panel, sidebar_registry(state)) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Log.warning(:editor, "Git Status sidebar sync failed: #{inspect(reason)}")
-    end
-  end
-
-  @spec close_git_status_panel(t()) :: t()
-  def close_git_status_panel(s) do
-    sync_git_status_sidebar(s, nil)
-    update_traditional_shell_state(s, &ShellState.close_git_status_panel/1)
-  end
-
-  @spec sidebar_active_id(t()) :: String.t() | nil
-  def sidebar_active_id(%{
-        shell_runtime: %ShellRuntime{
-          entry: %{module: MingaEditor.Shell.Traditional},
-          state: %{sidebar_active_id: id}
-        }
-      }),
-      do: id
-
-  def sidebar_active_id(_state), do: nil
-
-  @spec set_sidebar_active_id(t(), String.t() | nil) :: t()
-  def set_sidebar_active_id(s, id) when is_binary(id) or is_nil(id) do
-    sync_active_sidebar(s, id)
-
-    update_traditional_shell_state(s, fn ss ->
-      if Map.has_key?(ss, :sidebar_active_id),
-        do: ShellState.set_sidebar_active_id(ss, id),
-        else: ss
-    end)
-  end
-
-  @spec sync_active_sidebar(t(), String.t() | nil) :: :ok
-  defp sync_active_sidebar(state, id) do
-    case MingaEditor.Extension.Sidebar.focus_left(sidebar_registry(state), id) do
-      :ok -> :ok
-      {:error, reason} -> Log.warning(:editor, "Sidebar focus sync failed: #{inspect(reason)}")
-    end
-  end
-
-  @spec observatory_visible?(t()) :: boolean()
-  def observatory_visible?(%{shell_runtime: %ShellRuntime{state: ss}}),
-    do: ShellState.observatory_visible?(ss)
-
-  @spec open_observatory(t(), {reference(), reference()} | nil) :: t()
-  def open_observatory(s, timer) do
-    sync_observatory_sidebar(s, true)
-    update_traditional_shell_state(s, &ShellState.open_observatory(&1, timer))
-  end
-
-  @spec close_observatory(t()) :: t()
-  def close_observatory(s) do
-    sync_observatory_sidebar(s, false)
-    update_traditional_shell_state(s, &ShellState.close_observatory/1)
-  end
-
-  @spec sync_observatory_sidebar(t(), boolean()) :: :ok
-  defp sync_observatory_sidebar(state, visible?) do
-    case BuiltinSurfaces.sync_observatory(visible?, sidebar_registry(state)) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Log.warning(:editor, "Observatory sidebar sync failed: #{inspect(reason)}")
-    end
-  end
-
-  @spec set_observatory_data(t(), Observatory.Data.t() | nil) :: t()
-  def set_observatory_data(s, data),
-    do: update_traditional_shell_state(s, &ShellState.set_observatory_data(&1, data))
-
-  @spec set_observatory_timer(t(), {reference(), reference()} | nil) :: t()
-  def set_observatory_timer(s, timer),
-    do: update_traditional_shell_state(s, &ShellState.set_observatory_timer(&1, timer))
-
-  @spec set_observatory_inspection(t(), Observatory.Inspection.t() | nil) :: t()
-  def set_observatory_inspection(s, inspection),
-    do: update_traditional_shell_state(s, &ShellState.set_observatory_inspection(&1, inspection))
 
   @spec tab_bar(t()) :: TabBar.t() | nil
   def tab_bar(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.tab_bar(ss)
@@ -1044,50 +932,6 @@ defmodule MingaEditor.State do
       )
 
     apply_shell_runtime_transition(state, runtime)
-  end
-
-  @spec agent(t()) :: AgentState.t()
-  def agent(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.agent(ss)
-  @spec set_agent(t(), AgentState.t()) :: t()
-  def set_agent(s, agent), do: update_traditional_shell_state(s, &ShellState.set_agent(&1, agent))
-
-  @spec inline_asks(t()) :: MingaEditor.State.InlineAsk.store()
-  def inline_asks(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.inline_asks(ss)
-  @spec set_inline_asks(t(), MingaEditor.State.InlineAsk.store()) :: t()
-  def set_inline_asks(s, asks),
-    do: update_traditional_shell_state(s, &ShellState.set_inline_asks(&1, asks))
-
-  @spec inline_edits(t()) :: MingaEditor.State.InlineEdit.store()
-  def inline_edits(%{shell_runtime: %ShellRuntime{state: ss}}), do: ShellState.inline_edits(ss)
-  @spec set_inline_edits(t(), MingaEditor.State.InlineEdit.store()) :: t()
-  def set_inline_edits(s, edits),
-    do: update_traditional_shell_state(s, &ShellState.set_inline_edits(&1, edits))
-
-  @doc "Replaces the Traditional tool-install prompt queue."
-  @spec set_tool_prompt_queue(t(), [atom()]) :: t()
-  def set_tool_prompt_queue(state, queue) do
-    update_traditional_shell_state(state, &ShellState.set_tool_prompt_queue(&1, queue))
-  end
-
-  @doc "Replaces Traditional tool-prompt decisions and pending queue atomically."
-  @spec set_tool_prompt_state(t(), [atom()], MapSet.t(atom())) :: t()
-  def set_tool_prompt_state(state, queue, declined) do
-    update_traditional_shell_state(
-      state,
-      &ShellState.set_tool_prompt_state(&1, queue, declined)
-    )
-  end
-
-  @doc "Sets whether the Traditional CUA space-leader sequence is pending."
-  @spec set_space_leader_pending(t(), boolean()) :: t()
-  def set_space_leader_pending(state, value) do
-    update_traditional_shell_state(state, &ShellState.set_space_leader_pending(&1, value))
-  end
-
-  @doc "Replaces the Traditional CUA space-leader timer."
-  @spec set_space_leader_timer(t(), reference() | nil) :: t()
-  def set_space_leader_timer(state, timer) do
-    update_traditional_shell_state(state, &ShellState.set_space_leader_timer(&1, timer))
   end
 
   # ── Global field accessors ─────────────────────────────────────────────────
@@ -2255,7 +2099,7 @@ defmodule MingaEditor.State do
   Rebuilds the agent rendering cache from the Session process when
   switching to an agent tab. The Session is the source of truth for
   status, pending approval, and error; the cache lives on
-  `state.shell_runtime.state.agent` and is repopulated from the Tab's session
+  the Traditional agent-surface owner and is repopulated from the Tab's session
   pid on every tab switch.
 
   The session pid itself lives on `Tab.session` (see `set_tab_session/3`),
@@ -2313,29 +2157,6 @@ defmodule MingaEditor.State do
   def transition_mode(%__MODULE__{} = state, mode, mode_state \\ nil) do
     update_workspace(state, &SessionState.transition_mode(&1, mode, mode_state))
   end
-
-  # ── Tool prompt helpers ──────────────────────────────────────────────────────
-
-  @doc """
-  Returns true if the given tool should NOT be prompted for installation.
-
-  A tool is skipped when it's already declined this session, already
-  installed, currently being installed, or already in the prompt queue.
-  """
-  @spec skip_tool_prompt?(t(), atom()) :: boolean()
-  def skip_tool_prompt?(
-        %__MODULE__{
-          shell_runtime: %ShellRuntime{
-            entry: %{module: MingaEditor.Shell.Traditional},
-            state: ss
-          }
-        },
-        tool_name
-      ) do
-    ShellState.skip_tool_prompt?(ss, tool_name)
-  end
-
-  def skip_tool_prompt?(%__MODULE__{}, _tool_name), do: true
 
   # ── Buffer lifecycle effect application ──────────────────────────────────────
   #

--- a/lib/minga_editor/state/agent_access.ex
+++ b/lib/minga_editor/state/agent_access.ex
@@ -10,8 +10,12 @@ defmodule MingaEditor.State.AgentAccess do
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Agent.UIState.View
+  alias MingaEditor.Shell.Traditional.AgentSurfaces
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.InlineAsk
+  alias MingaEditor.State.InlineEdit
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace
   alias MingaEditor.Shell.Entry
@@ -23,8 +27,15 @@ defmodule MingaEditor.State.AgentAccess do
 
   @doc "Returns the agent session lifecycle state."
   @spec agent(EditorState.t() | map()) :: AgentState.t()
-  def agent(%EditorState{shell_runtime: %Runtime{state: %{agent: a}}}), do: a
-  def agent(%{agent: a}), do: a
+  def agent(%EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}}),
+    do: TraditionalState.agent(shell_state)
+
+  def agent(%{shell_state: %TraditionalState{} = shell_state}),
+    do: TraditionalState.agent(shell_state)
+
+  def agent(%{agent_surfaces: %AgentSurfaces{} = surfaces}),
+    do: AgentSurfaces.presentation(surfaces)
+
   def agent(_), do: %AgentState{}
 
   @doc "Returns the full agent UI state (wrapping Panel and View)."
@@ -67,19 +78,83 @@ defmodule MingaEditor.State.AgentAccess do
 
   @doc "Returns the agent UI focus."
   @spec focus(EditorState.t() | map()) :: atom()
-  def focus(state), do: view(state).focus
+  def focus(state), do: state |> view() |> View.focus()
 
   # ── Writers ────────────────────────────────────────────────────────────────
 
-  @doc "Updates agent session lifecycle state via a transform function."
-  @spec update_agent(EditorState.t() | map(), (AgentState.t() -> AgentState.t())) ::
-          EditorState.t() | map()
+  @doc "Updates agent session lifecycle state via the Traditional surface owner."
+  @spec update_agent(EditorState.t(), (AgentState.t() -> AgentState.t())) :: EditorState.t()
   def update_agent(%EditorState{} = state, fun) do
-    EditorState.set_agent(state, fun.(agent(state)))
+    runtime =
+      Runtime.update_traditional_state(state.shell_runtime, fn shell_state ->
+        TraditionalState.replace_agent(shell_state, fun.(TraditionalState.agent(shell_state)))
+      end)
+
+    EditorState.apply_shell_runtime_transition(state, runtime)
   end
 
-  def update_agent(%{agent: a} = state, fun) do
-    %{state | agent: fun.(a)}
+  @doc "Returns the Traditional inline ask store."
+  @spec inline_asks(EditorState.t() | map()) :: InlineAsk.store()
+  def inline_asks(%EditorState{
+        shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}
+      }),
+      do: TraditionalState.inline_asks(shell_state)
+
+  def inline_asks(%{shell_state: %TraditionalState{} = shell_state}),
+    do: TraditionalState.inline_asks(shell_state)
+
+  def inline_asks(%{agent_surfaces: %AgentSurfaces{} = surfaces}),
+    do: AgentSurfaces.asks(surfaces)
+
+  def inline_asks(_state), do: %{}
+
+  @doc "Returns the Traditional inline edit store."
+  @spec inline_edits(EditorState.t() | map()) :: InlineEdit.store()
+  def inline_edits(%EditorState{
+        shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}
+      }),
+      do: TraditionalState.inline_edits(shell_state)
+
+  def inline_edits(%{shell_state: %TraditionalState{} = shell_state}),
+    do: TraditionalState.inline_edits(shell_state)
+
+  def inline_edits(%{agent_surfaces: %AgentSurfaces{} = surfaces}),
+    do: AgentSurfaces.edits(surfaces)
+
+  def inline_edits(_state), do: %{}
+
+  @doc "Activates or replaces one inline ask through its surface owner."
+  @spec replace_inline_ask(EditorState.t(), InlineAsk.t()) :: EditorState.t()
+  def replace_inline_ask(%EditorState{} = state, %InlineAsk{} = ask),
+    do: update_traditional(state, &TraditionalState.replace_inline_ask(&1, ask))
+
+  @doc "Cancels one inline ask and returns its session pid."
+  @spec cancel_inline_ask(EditorState.t(), pid() | nil) :: {EditorState.t(), pid() | nil}
+  def cancel_inline_ask(%EditorState{} = state, buffer_pid) do
+    shell_state = Runtime.state(state.shell_runtime)
+    {shell_state, session_pid} = TraditionalState.cancel_inline_ask(shell_state, buffer_pid)
+
+    runtime =
+      Runtime.update_traditional_state(state.shell_runtime, fn _current -> shell_state end)
+
+    {EditorState.apply_shell_runtime_transition(state, runtime), session_pid}
+  end
+
+  @doc "Activates or replaces one inline edit through its surface owner."
+  @spec replace_inline_edit(EditorState.t(), InlineEdit.t()) :: EditorState.t()
+  def replace_inline_edit(%EditorState{} = state, %InlineEdit{} = edit),
+    do: update_traditional(state, &TraditionalState.replace_inline_edit(&1, edit))
+
+  @doc "Cancels one inline edit and returns its session pid."
+  @spec cancel_inline_edit(EditorState.t(), pid() | nil) :: {EditorState.t(), pid() | nil}
+  def cancel_inline_edit(%EditorState{} = state, buffer_pid) do
+    shell_state = Runtime.state(state.shell_runtime)
+    {shell_state, session_pid} = TraditionalState.cancel_inline_edit(shell_state, buffer_pid)
+
+    runtime =
+      Runtime.update_traditional_state(state.shell_runtime, fn _current -> shell_state end)
+
+    {EditorState.apply_shell_runtime_transition(state, runtime), session_pid}
   end
 
   @doc deprecated: "Use update_panel/2 or update_view/2 for targeted sub-struct updates"
@@ -199,5 +274,12 @@ defmodule MingaEditor.State.AgentAccess do
 
   defp set_live_agent_ui(workspace, %UIState{} = agent_ui) when is_map(workspace) do
     Map.put(workspace, :agent_ui, agent_ui)
+  end
+
+  @spec update_traditional(EditorState.t(), (TraditionalState.t() -> TraditionalState.t())) ::
+          EditorState.t()
+  defp update_traditional(%EditorState{} = state, update) do
+    runtime = Runtime.update_traditional_state(state.shell_runtime, update)
+    EditorState.apply_shell_runtime_transition(state, runtime)
   end
 end

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -273,9 +273,7 @@ defmodule MingaEditor.StatusBar.Data do
   defp active_register_name(_state), do: ""
 
   @spec agent_state(EditorState.t() | map()) :: AgentState.t()
-  defp agent_state(%EditorState{} = state), do: AgentAccess.agent(state)
-  defp agent_state(%{shell_state: %{agent: %AgentState{} = agent}}), do: agent
-  defp agent_state(_state), do: %AgentState{}
+  defp agent_state(state), do: AgentAccess.agent(state)
 
   @spec agent_session(EditorState.t() | map()) :: pid() | nil
   defp agent_session(%EditorState{} = state), do: AgentAccess.session(state)

--- a/test/minga_editor/agent/concurrent_sessions_test.exs
+++ b/test/minga_editor/agent/concurrent_sessions_test.exs
@@ -41,10 +41,13 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
       shell_runtime:
         Runtime.new(
           Registry.get(:traditional),
-          %MingaEditor.Shell.Traditional.State{
-            agent: %AgentState{},
-            tab_bar: tb
-          }
+          MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.replace_agent(
+              %MingaEditor.Shell.Traditional.State{},
+              %AgentState{}
+            ),
+            tb
+          )
         )
     }
   end
@@ -179,7 +182,7 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
     end
 
     test "switch_tab repopulates the rendering cache from the incoming tab's session" do
-      # The session struct on shell_state.agent is a rendering cache,
+      # The Traditional agent-surface presentation value is a rendering cache,
       # not the source of truth. After switch_tab/2, status/error/
       # pending_approval should reflect the *incoming* tab's session.
       {:ok, session_a} = StubServer.start_link()

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -37,6 +37,18 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
   defp workspace, do: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()}
 
+  defp event_state(agent) do
+    %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{viewport: Viewport.new(24, 80), agent_ui: UIState.new()},
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          TraditionalState.replace_agent(%TraditionalState{}, agent)
+        )
+    }
+  end
+
   defp fake_session_pid do
     pid =
       spawn(fn ->
@@ -75,10 +87,11 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         Tab.new_agent(2, "B") |> Tab.set_session(session_b)
       ]
 
-      shell_state = %TraditionalState{
-        agent: %AgentState{},
-        tab_bar: tab_bar(tabs, 1)
-      }
+      shell_state =
+        TraditionalState.set_tab_bar(
+          TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
+          tab_bar(tabs, 1)
+        )
 
       %{shell_state: shell_state, session_a: session_a, session_b: session_b}
     end
@@ -93,7 +106,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
       # ...but the active rendering cache is untouched (it routes through
       # Agent.Events for the foreground path, not through this callback).
-      assert ss2.agent == ss.agent
+      assert TraditionalState.agent(ss2) == TraditionalState.agent(ss)
 
       # Workspace is also untouched: background events must not nudge the
       # active tab's editing surface.
@@ -179,7 +192,10 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            %TraditionalState{agent: %AgentState{}, tab_bar: tab_bar}
+            TraditionalState.set_tab_bar(
+              TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
+              tab_bar
+            )
           )
       }
 
@@ -226,26 +242,27 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       assert effects == [{:render, 16}]
     end
 
-    test "tool_started and tool_ended fall back for map states without a session" do
-      state = %{agent: %AgentState{}, agent_ui: UIState.new()}
+    test "tool_started and tool_ended update an editor without an agent session" do
+      state = event_state(%AgentState{})
 
       {state, effects} = Events.handle(state, {:tool_started, "read_file", %{}})
-      assert AgentState.active_tool_name(state.agent) == "read_file"
+      assert AgentState.active_tool_name(AgentAccess.agent(state)) == "read_file"
       assert effects == [{:render, 16}]
 
       {state, effects} = Events.handle(state, {:tool_ended, "read_file", "contents", :done})
-      assert AgentState.active_tool_name(state.agent) == nil
+      assert AgentState.active_tool_name(AgentAccess.agent(state)) == nil
       assert effects == [{:render, 16}]
     end
 
     test "status_changed clears active_tool_name outside tool execution" do
-      state = %{agent: %AgentState{} |> AgentState.set_active_tool_name("read_file")}
+      agent = %AgentState{} |> AgentState.set_active_tool_name("read_file")
+      state = event_state(agent)
 
       {state, _effects} = Events.handle(state, {:status_changed, :tool_executing})
-      assert AgentState.active_tool_name(state.agent) == "read_file"
+      assert AgentState.active_tool_name(AgentAccess.agent(state)) == "read_file"
 
       {state, effects} = Events.handle(state, {:status_changed, :idle})
-      assert AgentState.active_tool_name(state.agent) == nil
+      assert AgentState.active_tool_name(AgentAccess.agent(state)) == nil
       assert effects == [:render]
     end
 
@@ -262,7 +279,13 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         port_manager: self(),
         workspace: %SessionState{viewport: Viewport.new(24, 80), agent_ui: UIState.new()},
         shell_runtime:
-          Runtime.new(Runtime.default_entry(), %TraditionalState{agent: agent, tab_bar: tab_bar})
+          Runtime.new(
+            Runtime.default_entry(),
+            TraditionalState.set_tab_bar(
+              TraditionalState.replace_agent(%TraditionalState{}, agent),
+              tab_bar
+            )
+          )
       }
 
       {state, effects} = Events.handle(state, {:context_usage, 95, 100})
@@ -304,7 +327,10 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+            TraditionalState.set_tab_bar(
+              TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
+              tb
+            )
           )
       }
 
@@ -355,7 +381,10 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+            TraditionalState.set_tab_bar(
+              TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
+              tb
+            )
           )
       }
 
@@ -402,7 +431,10 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+            TraditionalState.set_tab_bar(
+              TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
+              tb
+            )
           )
       }
 
@@ -435,7 +467,10 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            %TraditionalState{agent: %AgentState{}, tab_bar: tb}
+            TraditionalState.set_tab_bar(
+              TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
+              tb
+            )
           )
       }
 

--- a/test/minga_editor/agent/ingest_approval_regression_test.exs
+++ b/test/minga_editor/agent/ingest_approval_regression_test.exs
@@ -31,6 +31,7 @@ defmodule MingaEditor.Agent.IngestApprovalRegressionTest do
   alias MingaEditor.Commands.AgentSession
   alias MingaEditor.Commands.AgentSubStates
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -172,10 +173,9 @@ defmodule MingaEditor.Agent.IngestApprovalRegressionTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{
-            tab_bar: tb,
-            agent: agent
-          }
+          %TraditionalState{}
+          |> TraditionalState.replace_agent(agent)
+          |> TraditionalState.set_tab_bar(tb)
         )
     }
   end

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -233,11 +233,13 @@ defmodule MingaEditor.Agent.SlashCommandTest do
         }
       }
       |> EditorState.set_tab_bar(tab_bar)
-      |> EditorState.set_agent(%AgentState{
-        runtime: %RuntimeState{status: :idle},
-        error: nil,
-        spinner_timer: nil
-      })
+      |> AgentAccess.update_agent(fn _current ->
+        %AgentState{
+          runtime: %RuntimeState{status: :idle},
+          error: nil,
+          spinner_timer: nil
+        }
+      end)
     end
 
     test "returns error for non-slash input" do
@@ -335,7 +337,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
       assert Session.status(session) == :plan
       assert state.shell_runtime.state.notice.message == "Plan mode enabled"
-      assert state.shell_runtime.state.agent.runtime.status == :plan
+      assert AgentAccess.agent(state).runtime.status == :plan
 
       assert Enum.any?(Session.messages(session), fn
                {:system, text, :info} -> text =~ "Plan mode" and text =~ "/exec"
@@ -350,7 +352,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
 
       assert Session.status(session) == :idle
       assert state.shell_runtime.state.notice.message == "Execution mode enabled"
-      assert state.shell_runtime.state.agent.runtime.status == :idle
+      assert AgentAccess.agent(state).runtime.status == :idle
 
       assert Enum.any?(Session.messages(session), fn
                {:system, text, :info} -> text =~ "Execution mode" and text =~ "/plan"

--- a/test/minga_editor/agent/ui_state/presentation_test.exs
+++ b/test/minga_editor/agent/ui_state/presentation_test.exs
@@ -1,0 +1,61 @@
+defmodule MingaEditor.Agent.UIState.PresentationTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Agent.UIState.Presentation
+  alias MingaEditor.Agent.UIState.ReturnTarget
+  alias MingaEditor.State.FileTree
+  alias MingaEditor.State.Windows
+
+  test "replacement activation installs one coherent return context and clears local input state" do
+    first_windows = %Windows{active: 1, next_id: 2}
+    second_windows = %Windows{active: 2, next_id: 3}
+    first_tree = %FileTree{focused: true}
+    second_tree = %FileTree{focused: false}
+    first_target = return_target(1, first_windows, first_tree)
+    second_target = return_target(2, second_windows, second_tree)
+
+    presentation =
+      %Presentation{}
+      |> Presentation.activate(first_windows, first_tree, first_target)
+      |> Presentation.focus(:file_viewer)
+      |> Presentation.install_prefix(:g)
+      |> Presentation.activate(second_windows, second_tree, second_target)
+
+    assert Presentation.active?(presentation)
+    assert Presentation.current_focus(presentation) == :chat
+    assert Presentation.pending_prefix(presentation) == nil
+    assert Presentation.return_target(presentation) == second_target
+
+    {completed, restored_windows, restored_tree} = Presentation.complete(presentation)
+
+    refute Presentation.active?(completed)
+    assert Presentation.return_target(completed) == nil
+    assert restored_windows == second_windows
+    assert restored_tree == second_tree
+  end
+
+  test "cancellation returns the saved layout and clears every activation-local field" do
+    windows = %Windows{active: 1, next_id: 2}
+    file_tree = %FileTree{focused: true}
+    target = return_target(1, windows, file_tree)
+
+    presentation =
+      %Presentation{}
+      |> Presentation.activate(windows, file_tree, target)
+      |> Presentation.focus(:file_viewer)
+      |> Presentation.install_prefix(:bracket_next)
+
+    {canceled, restored_windows, restored_tree} = Presentation.cancel(presentation)
+
+    refute Presentation.active?(canceled)
+    assert Presentation.current_focus(canceled) == :chat
+    assert Presentation.pending_prefix(canceled) == nil
+    assert Presentation.return_target(canceled) == nil
+    assert restored_windows == windows
+    assert restored_tree == file_tree
+  end
+
+  defp return_target(tab_id, windows, file_tree) do
+    ReturnTarget.new(tab_id, nil, windows, file_tree, :editor, false)
+  end
+end

--- a/test/minga_editor/agent/view/prompt_renderer_test.exs
+++ b/test/minga_editor/agent/view/prompt_renderer_test.exs
@@ -35,18 +35,17 @@ defmodule MingaEditor.Agent.View.PromptRendererTest do
       spinner_timer: nil
     }
 
-    agentic = %UIState{
-      panel: %UIState.Panel{
-        visible: true,
-        input_focused: Keyword.get(opts, :input_focused, false),
-        credentials_configured: Keyword.get(opts, :credentials_configured, true),
-        prompt_buffer: prompt_buf
-      },
-      view: %UIState.View{
-        active: true,
-        focus: Keyword.get(opts, :focus, :chat)
+    agentic =
+      %UIState{
+        panel: %UIState.Panel{
+          visible: true,
+          input_focused: Keyword.get(opts, :input_focused, false),
+          credentials_configured: Keyword.get(opts, :credentials_configured, true),
+          prompt_buffer: prompt_buf
+        }
       }
-    }
+      |> UIState.activate(nil, nil)
+      |> UIState.set_focus(Keyword.get(opts, :focus, :chat))
 
     %EditorState{
       port_manager: self(),
@@ -61,7 +60,10 @@ defmodule MingaEditor.Agent.View.PromptRendererTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: agent}
+          MingaEditor.Shell.Traditional.State.replace_agent(
+            %MingaEditor.Shell.Traditional.State{},
+            agent
+          )
         ),
       theme: Theme.get!(:doom_one)
     }

--- a/test/minga_editor/agent/view/ui_state_view_test.exs
+++ b/test/minga_editor/agent/view/ui_state_view_test.exs
@@ -2,18 +2,19 @@ defmodule MingaEditor.Agent.UIState.ViewFunctionsTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.View
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Windows
 
   describe "new/0" do
     test "starts inactive" do
       ui = UIState.new()
-      refute ui.view.active
+      refute View.active?(ui.view)
     end
 
     test "starts with focus on :chat" do
       ui = UIState.new()
-      assert ui.view.focus == :chat
+      assert View.focus(ui.view) == :chat
     end
 
     test "starts with preview scroll at 0" do
@@ -23,17 +24,17 @@ defmodule MingaEditor.Agent.UIState.ViewFunctionsTest do
 
     test "starts with no saved windows" do
       ui = UIState.new()
-      assert ui.view.saved_windows == nil
+      assert ui.view.presentation.saved_windows == nil
     end
 
     test "starts with no pending prefix" do
       ui = UIState.new()
-      assert ui.view.pending_prefix == nil
+      assert View.pending_prefix(ui.view) == nil
     end
 
     test "starts with no saved file tree" do
       ui = UIState.new()
-      assert ui.view.saved_file_tree == nil
+      assert ui.view.presentation.saved_file_tree == nil
     end
 
     test "starts with chat_width_pct at 65" do
@@ -45,31 +46,31 @@ defmodule MingaEditor.Agent.UIState.ViewFunctionsTest do
   describe "activate/3" do
     test "sets active to true" do
       ui = UIState.new() |> UIState.activate(%Windows{}, %FileTreeState{})
-      assert ui.view.active
+      assert View.active?(ui.view)
     end
 
     test "saves the windows layout" do
       windows = %Windows{tree: nil, map: %{}, active: 1, next_id: 3}
       ui = UIState.new() |> UIState.activate(windows, %FileTreeState{})
-      assert ui.view.saved_windows == windows
+      assert ui.view.presentation.saved_windows == windows
     end
 
     test "saves the file tree state" do
       ft = %FileTreeState{focused: true}
       ui = UIState.new() |> UIState.activate(%Windows{}, ft)
-      assert ui.view.saved_file_tree == ft
+      assert ui.view.presentation.saved_file_tree == ft
     end
 
     test "resets focus to :chat" do
-      ui = put_in(UIState.new().view.focus, :file_viewer)
+      ui = UIState.new() |> UIState.set_focus(:file_viewer)
       ui = UIState.activate(ui, %Windows{}, %FileTreeState{})
-      assert ui.view.focus == :chat
+      assert View.focus(ui.view) == :chat
     end
 
     test "clears pending prefix" do
-      ui = put_in(UIState.new().view.pending_prefix, :z)
+      ui = UIState.new() |> UIState.set_prefix(:z)
       ui = UIState.activate(ui, %Windows{}, %FileTreeState{})
-      assert ui.view.pending_prefix == nil
+      assert View.pending_prefix(ui.view) == nil
     end
   end
 
@@ -83,7 +84,7 @@ defmodule MingaEditor.Agent.UIState.ViewFunctionsTest do
         |> UIState.activate(windows, ft)
 
       {new_ui, restored_win, restored_ft} = UIState.deactivate(ui)
-      refute new_ui.view.active
+      refute View.active?(new_ui.view)
       assert restored_win == windows
       assert restored_ft == ft
     end
@@ -94,8 +95,8 @@ defmodule MingaEditor.Agent.UIState.ViewFunctionsTest do
         |> UIState.activate(%Windows{}, %FileTreeState{})
 
       {new_ui, _, _} = UIState.deactivate(ui)
-      assert new_ui.view.saved_windows == nil
-      assert new_ui.view.saved_file_tree == nil
+      assert new_ui.view.presentation.saved_windows == nil
+      assert new_ui.view.presentation.saved_file_tree == nil
     end
 
     test "returns nil when no saved state exists" do
@@ -105,51 +106,50 @@ defmodule MingaEditor.Agent.UIState.ViewFunctionsTest do
     end
 
     test "resets focus to :chat" do
-      base = UIState.new()
-      ui = %{base | view: %{base.view | active: true, focus: :file_viewer}}
+      ui = UIState.new() |> UIState.activate(nil, nil) |> UIState.set_focus(:file_viewer)
       {new_ui, _, _} = UIState.deactivate(ui)
-      assert new_ui.view.focus == :chat
+      assert View.focus(new_ui.view) == :chat
     end
 
     test "clears pending prefix" do
-      base = UIState.new()
-      ui = %{base | view: %{base.view | active: true, pending_prefix: :bracket_next}}
+      ui = UIState.new() |> UIState.activate(nil, nil) |> UIState.set_prefix(:bracket_next)
       {new_ui, _, _} = UIState.deactivate(ui)
-      assert new_ui.view.pending_prefix == nil
+      assert View.pending_prefix(new_ui.view) == nil
     end
   end
 
   describe "set_focus/2" do
     test "switches focus to :file_viewer" do
       ui = UIState.new() |> UIState.set_focus(:file_viewer)
-      assert ui.view.focus == :file_viewer
+      assert View.focus(ui.view) == :file_viewer
     end
 
     test "switches focus to :chat" do
       ui =
-        put_in(UIState.new().view.focus, :file_viewer)
+        UIState.new()
+        |> UIState.set_focus(:file_viewer)
         |> UIState.set_focus(:chat)
 
-      assert ui.view.focus == :chat
+      assert View.focus(ui.view) == :chat
     end
   end
 
   describe "prefix state machine" do
     test "set_prefix/2 sets the pending prefix" do
       ui = UIState.new() |> UIState.set_prefix(:g)
-      assert ui.view.pending_prefix == :g
+      assert View.pending_prefix(ui.view) == :g
     end
 
     test "set_prefix/2 accepts all valid prefixes" do
       for prefix <- [:g, :z, :bracket_next, :bracket_prev, nil] do
         ui = UIState.new() |> UIState.set_prefix(prefix)
-        assert ui.view.pending_prefix == prefix
+        assert View.pending_prefix(ui.view) == prefix
       end
     end
 
     test "clear_prefix/1 resets to nil" do
-      ui = put_in(UIState.new().view.pending_prefix, :z) |> UIState.clear_prefix()
-      assert ui.view.pending_prefix == nil
+      ui = UIState.new() |> UIState.set_prefix(:z) |> UIState.clear_prefix()
+      assert View.pending_prefix(ui.view) == nil
     end
   end
 

--- a/test/minga_editor/commands/agent_code_block_test.exs
+++ b/test/minga_editor/commands/agent_code_block_test.exs
@@ -23,7 +23,10 @@ defmodule MingaEditor.Commands.AgentCodeBlockTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: %AgentState{}}
+          MingaEditor.Shell.Traditional.State.replace_agent(
+            %MingaEditor.Shell.Traditional.State{},
+            %AgentState{}
+          )
         )
     }
   end

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -18,6 +18,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
   alias MingaEditor.Agent.Transcript
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
+  alias MingaEditor.Agent.UIState.View
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Project.FileRef
   alias MingaEditor.Commands.Agent, as: AgentCommands
@@ -115,7 +116,13 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb}
+          MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.replace_agent(
+              %MingaEditor.Shell.Traditional.State{},
+              agent
+            ),
+            tb
+          )
         ),
       focus_stack: Input.default_stack()
     }
@@ -805,26 +812,30 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       state = base_state(panel_visible: true)
 
       state =
-        AgentAccess.update_view(state, fn v ->
-          %{v | active: true, focus: :chat}
+        AgentAccess.update_view(state, fn view ->
+          view
+          |> View.activate(nil, nil)
+          |> View.set_focus(:chat)
         end)
 
       new_state = AgentCommands.scope_switch_focus(state)
 
-      assert AgentAccess.view(new_state).focus == :file_viewer
+      assert new_state |> AgentAccess.view() |> View.focus() == :file_viewer
     end
 
     test "switches from non-chat back to chat" do
       state = base_state(panel_visible: true)
 
       state =
-        AgentAccess.update_view(state, fn v ->
-          %{v | active: true, focus: :file_viewer}
+        AgentAccess.update_view(state, fn view ->
+          view
+          |> View.activate(nil, nil)
+          |> View.set_focus(:file_viewer)
         end)
 
       new_state = AgentCommands.scope_switch_focus(state)
 
-      assert AgentAccess.view(new_state).focus == :chat
+      assert new_state |> AgentAccess.view() |> View.focus() == :chat
     end
   end
 

--- a/test/minga_editor/commands/agent_split_test.exs
+++ b/test/minga_editor/commands/agent_split_test.exs
@@ -79,7 +79,13 @@ defmodule MingaEditor.Commands.AgentSplitTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb}
+          MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.replace_agent(
+              %MingaEditor.Shell.Traditional.State{},
+              agent
+            ),
+            tb
+          )
         )
     }
   end

--- a/test/minga_editor/commands/agent_split_toggle_test.exs
+++ b/test/minga_editor/commands/agent_split_toggle_test.exs
@@ -3,7 +3,6 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
 
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.Panel
-  alias MingaEditor.Agent.View.Preview
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.Commands.Agent, as: AgentCommands
   alias MingaEditor.Shell.Runtime
@@ -44,15 +43,19 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
         visible: false,
         input_focused: false,
         prompt_buffer: prompt_buf
-      },
-      view: %UIState.View{
-        active: active,
-        focus: :chat,
-        preview: Preview.new(),
-        saved_windows: Keyword.get(opts, :saved_windows, nil),
-        saved_file_tree: Keyword.get(opts, :saved_file_tree, nil)
       }
     }
+
+    agentic =
+      if active do
+        UIState.activate(
+          agentic,
+          Keyword.get(opts, :saved_windows),
+          Keyword.get(opts, :saved_file_tree)
+        )
+      else
+        agentic
+      end
 
     file_tab = Tab.new_file(1, "test.ex")
     tb = TabBar.new(file_tab)
@@ -76,7 +79,13 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tb}
+          MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.replace_agent(
+              %MingaEditor.Shell.Traditional.State{},
+              agent
+            ),
+            tb
+          )
         )
     }
 
@@ -104,11 +113,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
         |> TabBar.update_context(at.id, agent_ctx)
         |> TabBar.switch_to(file_tab.id)
 
-      state =
-        put_in(state.workspace.agent_ui, %{
-          agentic
-          | view: %{agentic.view | active: true, focus: :chat}
-        })
+      state = put_in(state.workspace.agent_ui, agentic)
 
       state = MingaEditor.State.set_tab_bar(state, tb)
 

--- a/test/minga_editor/commands/inline_ask_test.exs
+++ b/test/minga_editor/commands/inline_ask_test.exs
@@ -13,6 +13,7 @@ defmodule MingaEditor.Commands.InlineAskTest do
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.InlineAsk
@@ -60,7 +61,7 @@ defmodule MingaEditor.Commands.InlineAskTest do
 
     state = InlineAskCommand.open(state)
     ask = active_ask(state, buffer) |> InlineAsk.thinking(session_pid)
-    state = EditorState.set_inline_asks(state, InlineAsk.put(EditorState.inline_asks(state), ask))
+    state = AgentAccess.replace_inline_ask(state, ask)
 
     state = InlineAskEvents.handle_prompt_result(state, session_pid, {:error, :provider_down})
 
@@ -211,7 +212,7 @@ defmodule MingaEditor.Commands.InlineAskTest do
   end
 
   defp active_ask(state, buffer) do
-    state |> EditorState.inline_asks() |> InlineAsk.active(buffer)
+    state |> AgentAccess.inline_asks() |> InlineAsk.active(buffer)
   end
 
   defp put_active_buffer(state, buffer) do

--- a/test/minga_editor/commands/inline_edit_test.exs
+++ b/test/minga_editor/commands/inline_edit_test.exs
@@ -10,6 +10,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.InlineEdit
@@ -30,7 +31,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
     assert MingaEditor.Shell.Traditional.NoticeWorkflow.message(state) ==
              "Inline edit requires a visual selection"
 
-    assert state |> EditorState.inline_edits() |> InlineEdit.active(buffer) == nil
+    assert state |> AgentAccess.inline_edits() |> InlineEdit.active(buffer) == nil
   end
 
   test "open stores selected lines and header", %{tmp_dir: root} do
@@ -69,7 +70,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
     edit = active_edit(state, buffer) |> InlineEdit.thinking(fake_session)
 
     state =
-      EditorState.set_inline_edits(state, InlineEdit.put(EditorState.inline_edits(state), edit))
+      AgentAccess.replace_inline_edit(state, edit)
 
     state =
       InlineEditEvents.handle_event(
@@ -93,7 +94,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
     edit = active_edit(state, buffer) |> InlineEdit.thinking(session_pid)
 
     state =
-      EditorState.set_inline_edits(state, InlineEdit.put(EditorState.inline_edits(state), edit))
+      AgentAccess.replace_inline_edit(state, edit)
 
     state = InlineEditEvents.handle_prompt_result(state, session_pid, {:error, :provider_down})
 
@@ -111,7 +112,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
     edit = %{active_edit(state, buffer) | proposed_rewrite: "ONE\nTWO"} |> InlineEdit.proposed()
 
     state =
-      EditorState.set_inline_edits(state, InlineEdit.put(EditorState.inline_edits(state), edit))
+      AgentAccess.replace_inline_edit(state, edit)
 
     assert {:handled, state} = InlineEditInput.handle_key(state, ?y, 0)
     assert active_edit(state, buffer) == nil
@@ -127,7 +128,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
     edit = %{active_edit(state, buffer) | proposed_rewrite: "X"} |> InlineEdit.proposed()
 
     state =
-      EditorState.set_inline_edits(state, InlineEdit.put(EditorState.inline_edits(state), edit))
+      AgentAccess.replace_inline_edit(state, edit)
 
     assert {:handled, _state} = InlineEditInput.handle_key(state, ?y, 0)
     assert Buffer.content(buffer) == "X\nthree"
@@ -139,7 +140,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
     edit = %{active_edit(state, buffer) | proposed_rewrite: ""} |> InlineEdit.proposed()
 
     state =
-      EditorState.set_inline_edits(state, InlineEdit.put(EditorState.inline_edits(state), edit))
+      AgentAccess.replace_inline_edit(state, edit)
 
     assert {:handled, _state} = InlineEditInput.handle_key(state, ?y, 0)
     assert Buffer.content(buffer) == "two"
@@ -151,7 +152,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
     edit = %{active_edit(state, buffer) | proposed_rewrite: "ONE"} |> InlineEdit.proposed()
 
     state =
-      EditorState.set_inline_edits(state, InlineEdit.put(EditorState.inline_edits(state), edit))
+      AgentAccess.replace_inline_edit(state, edit)
 
     assert {:handled, state} = InlineEditInput.handle_key(state, ?y, 0)
 
@@ -212,7 +213,7 @@ defmodule MingaEditor.Commands.InlineEditTest do
   end
 
   defp active_edit(state, buffer) do
-    state |> EditorState.inline_edits() |> InlineEdit.active(buffer)
+    state |> AgentAccess.inline_edits() |> InlineEdit.active(buffer)
   end
 
   defp put_visual_selection(state, anchor) do

--- a/test/minga_editor/commands/ui_frontend_test.exs
+++ b/test/minga_editor/commands/ui_frontend_test.exs
@@ -9,6 +9,8 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Entry
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.Observatory, as: ObservatoryState
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
 
@@ -92,8 +94,8 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
         state =
           Commands.execute(base_state(unquote(Macro.escape(caps))), :toggle_beam_observatory)
 
-        assert state.shell_runtime.state.observatory_visible == true
-        assert {timer, _token} = state.shell_runtime.state.observatory_timer
+        assert state |> observatory() |> ObservatoryState.visible?()
+        assert timer = state |> observatory() |> ObservatoryState.timer()
 
         Process.cancel_timer(timer)
       end
@@ -103,14 +105,16 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       token = make_ref()
       timer = Process.send_after(self(), {:observatory_tick, token}, 60_000)
 
-      state = MingaEditor.State.open_observatory(base_state(@gui), {timer, token})
+      state = SidebarWorkflow.open_observatory(base_state(@gui), {timer, token})
 
-      state = MingaEditor.State.set_observatory_data(state, %{tree: :placeholder})
+      state =
+        SidebarWorkflow.replace_observatory_data(state, Observatory.Data.visible(nil, []))
+
       state = Commands.execute(state, :toggle_beam_observatory)
 
-      assert state.shell_runtime.state.observatory_visible == false
-      assert state.shell_runtime.state.observatory_timer == nil
-      assert state.shell_runtime.state.observatory_data == nil
+      refute state |> observatory() |> ObservatoryState.visible?()
+      assert state |> observatory() |> ObservatoryState.timer() == nil
+      assert state |> observatory() |> ObservatoryState.data() == nil
     end
 
     test "is a no-op for the legacy Zig cell-grid frontend (no semantic_ui)" do
@@ -138,7 +142,7 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
 
     test "ignores stale refresh ticks" do
       state = Commands.execute(base_state(@gui), :toggle_beam_observatory)
-      assert {timer, _token} = state.shell_runtime.state.observatory_timer
+      assert timer = state |> observatory() |> ObservatoryState.timer()
 
       assert {:noreply, ^state} = MingaEditor.handle_info({:observatory_tick, make_ref()}, state)
 
@@ -151,10 +155,13 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       token = make_ref()
       state = observatory_state(@gui, token)
 
-      # The tick handler returns the *unchanged* state: collection does not run
-      # inline (no data set) and no next tick is scheduled here.
-      assert {:noreply, ^state} = MingaEditor.handle_info({:observatory_tick, token}, state)
-      assert state.shell_runtime.state.observatory_data == nil
+      # The tick handler only marks this token collecting: data remains unset
+      # and no next tick is scheduled until the async result lands.
+      assert {:noreply, collecting_state} =
+               MingaEditor.handle_info({:observatory_tick, token}, state)
+
+      assert collecting_state |> observatory() |> ObservatoryState.data() == nil
+      assert ObservatoryState.collecting?(observatory(collecting_state), token)
 
       # The collection ran in a supervised Task and reported back as a message,
       # exactly like a picker/async-action result.
@@ -174,13 +181,16 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       token = make_ref()
       state = observatory_state(@gui, token)
       data = Observatory.Data.visible(nil, [])
+      {:noreply, collecting_state} = MingaEditor.handle_info({:observatory_tick, token}, state)
 
       assert {:noreply, new_state} =
-               MingaEditor.handle_info({:observatory_data_result, token, data}, state)
+               MingaEditor.handle_info({:observatory_data_result, token, data}, collecting_state)
 
-      assert new_state.shell_runtime.state.observatory_data == data
+      assert new_state |> observatory() |> ObservatoryState.data() == data
 
-      assert {next_timer, next_token} = new_state.shell_runtime.state.observatory_timer
+      next_observatory = observatory(new_state)
+      next_timer = ObservatoryState.timer(next_observatory)
+      next_token = next_observatory.token
       assert is_reference(next_timer)
       # A fresh token gates the next cycle; the prior token is now stale.
       assert next_token != token
@@ -199,13 +209,15 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
       assert {:noreply, ^state} =
                MingaEditor.handle_info({:observatory_data_result, make_ref(), data}, state)
 
-      assert state.shell_runtime.state.observatory_data == nil
+      assert state |> observatory() |> ObservatoryState.data() == nil
     end
   end
 
   # Builds editor state with the observatory open and a known refresh token, so
   # current_observatory_token?/2 matches without scheduling a real timer.
   defp observatory_state(caps, token) do
-    MingaEditor.State.open_observatory(base_state(caps), {make_ref(), token})
+    SidebarWorkflow.open_observatory(base_state(caps), {make_ref(), token})
   end
+
+  defp observatory(state), do: SidebarWorkflow.observatory(state)
 end

--- a/test/minga_editor/delayed_callback_shell_switch_test.exs
+++ b/test/minga_editor/delayed_callback_shell_switch_test.exs
@@ -6,8 +6,12 @@ defmodule MingaEditor.DelayedCallbackShellSwitchTest do
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Shell.Registry
   alias MingaEditor.Shell.Runtime
-  alias MingaEditor.Shell.Workflow, as: ShellWorkflow
+  alias MingaEditor.Shell.Traditional.ClickRegions
+  alias MingaEditor.Shell.Traditional.Observatory
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.State, as: TraditionalShellState
+  alias MingaEditor.Shell.Workflow, as: ShellWorkflow
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.Test.FakeShell
   alias MingaEditor.UI.Picker.Candidate
   alias MingaEditor.UI.Picker.Item
@@ -80,6 +84,68 @@ defmodule MingaEditor.DelayedCallbackShellSwitchTest do
     assert Runtime.state(restored.shell_runtime).modal == :none
     assert Runtime.state(restored.shell_runtime).notice.message == nil
     assert restored.message_store == message_store
+  end
+
+  test "Observatory tick after a shell switch cannot touch the foreign shell" do
+    token = make_ref()
+    timer = Process.send_after(self(), {:observatory_tick, token}, 60_000)
+
+    state =
+      TestHelpers.base_state()
+      |> Map.put(:rendering, :disabled)
+      |> SidebarWorkflow.open_observatory({timer, token})
+      |> ShellWorkflow.switch(:fake)
+
+    foreign_shell_state = Runtime.state(state.shell_runtime)
+
+    assert Process.read_timer(timer) == false
+    assert {:noreply, new_state} = MingaEditor.handle_info({:observatory_tick, token}, state)
+    assert new_state == state
+    assert Runtime.state(new_state.shell_runtime) == foreign_shell_state
+
+    restored = ShellWorkflow.switch(new_state, :traditional)
+    observatory = restored.shell_runtime |> Runtime.state() |> TraditionalShellState.observatory()
+    refute Observatory.visible?(observatory)
+    assert Observatory.timer(observatory) == nil
+  end
+
+  test "space-leader timeout after a shell switch cannot touch the foreign shell" do
+    state = TestHelpers.base_state() |> Map.put(:rendering, :disabled)
+
+    {generation, shell_state} =
+      state.shell_runtime
+      |> Runtime.state()
+      |> TraditionalShellState.begin_space_leader()
+
+    timer = Process.send_after(self(), {:space_leader_timeout, generation}, 60_000)
+
+    shell_state =
+      shell_state
+      |> TraditionalShellState.install_space_leader_timer(generation, timer)
+      |> TraditionalShellState.install_click_regions([{0, 2, :modeline}], [{0, 2, :next_tab}])
+
+    runtime =
+      Runtime.update_traditional_state(state.shell_runtime, fn _current -> shell_state end)
+
+    state =
+      state
+      |> EditorState.apply_shell_runtime_transition(runtime)
+      |> ShellWorkflow.switch(:fake)
+
+    foreign_shell_state = Runtime.state(state.shell_runtime)
+
+    assert {:noreply, new_state} =
+             MingaEditor.handle_info({:space_leader_timeout, generation}, state)
+
+    assert Process.read_timer(timer) == false
+    assert new_state == state
+    assert Runtime.state(new_state.shell_runtime) == foreign_shell_state
+
+    restored = ShellWorkflow.switch(new_state, :traditional)
+    restored_shell_state = Runtime.state(restored.shell_runtime)
+    refute TraditionalShellState.space_leader_pending?(restored_shell_state)
+    assert TraditionalShellState.space_leader_timer(restored_shell_state) == nil
+    assert TraditionalShellState.click_regions(restored_shell_state) == %ClickRegions{}
   end
 
   defp assert_commit_generation_result_is_dropped(message) do

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -16,6 +16,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
   alias Minga.Project.FileTree
   alias MingaEditor.Handlers.FileEventHandler
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -33,7 +34,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       state = base_state()
 
       state =
-        EditorState.set_git_status_panel(state, %{
+        SidebarWorkflow.replace_git_status(state, %{
           repo_state: :normal,
           branch: "main",
           ahead: 0,
@@ -55,7 +56,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
 
       {new_state, effects} = FileEventHandler.handle(state, event)
 
-      panel = EditorState.git_status_panel(new_state)
+      panel = SidebarWorkflow.git_status_panel(new_state)
       assert panel.branch == "develop"
       assert panel.ahead == 1
       assert panel.last_commit_message == "feat: previous subject"
@@ -66,7 +67,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
     test "does not create tui state during generic panel refresh" do
       state =
         base_state()
-        |> EditorState.set_git_status_panel(%{
+        |> SidebarWorkflow.replace_git_status(%{
           repo_state: :normal,
           branch: "main",
           ahead: 0,
@@ -86,7 +87,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
 
       {new_state, _effects} = FileEventHandler.handle(state, event)
 
-      panel = EditorState.git_status_panel(new_state)
+      panel = SidebarWorkflow.git_status_panel(new_state)
       refute Map.has_key?(panel, :tui_state)
       assert ShellState.git_status_tui_state(Runtime.state(new_state.shell_runtime)) == nil
     end

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -19,6 +19,8 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Shell.Entry
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.Observatory
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Window
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -128,9 +130,9 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
     assert EditorState.file_tree_state(file_tree_active).focused
     assert file_tree_active.workspace.keymap_scope == :file_tree
-    assert EditorState.sidebar_active_id(file_tree_active) == "file_tree"
+    assert SidebarWorkflow.active_id(file_tree_active) == "file_tree"
 
-    git_state = EditorState.set_git_status_panel(state, %{entries: []})
+    git_state = SidebarWorkflow.replace_git_status(state, %{entries: []})
 
     git_active =
       GuiActionHandler.dispatch(
@@ -139,11 +141,11 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
       )
 
     assert git_active.workspace.keymap_scope == :git_status
-    assert EditorState.sidebar_active_id(git_active) == "git_status"
+    assert SidebarWorkflow.active_id(git_active) == "git_status"
 
     observatory_state =
       state
-      |> EditorState.open_observatory(nil)
+      |> SidebarWorkflow.open_observatory(nil)
       |> EditorState.set_keymap_scope(:file_tree)
 
     observatory_active =
@@ -154,7 +156,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
     refute EditorState.file_tree_state(observatory_active).focused
     assert observatory_active.workspace.keymap_scope == :editor
-    assert EditorState.sidebar_active_id(observatory_active) == "observatory"
+    assert SidebarWorkflow.active_id(observatory_active) == "observatory"
   end
 
   @tag :tmp_dir
@@ -176,7 +178,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
     assert EditorState.file_tree_state(opened).tree != nil
     assert EditorState.file_tree_state(opened).focused
-    assert EditorState.sidebar_active_id(opened) == "file_tree"
+    assert SidebarWorkflow.active_id(opened) == "file_tree"
 
     focused =
       GuiActionHandler.dispatch(
@@ -186,7 +188,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
     assert EditorState.file_tree_state(focused).focused
     assert focused.workspace.keymap_scope == :file_tree
-    assert EditorState.sidebar_active_id(focused) == "file_tree"
+    assert SidebarWorkflow.active_id(focused) == "file_tree"
 
     hidden =
       GuiActionHandler.dispatch(focused, {:sidebar_action, "file_tree", "file_tree", "toggle"})
@@ -198,7 +200,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
     assert hidden_state.tree != nil
     refute FileTreeState.visible?(hidden_state)
     refute hidden_state.focused
-    assert EditorState.sidebar_active_id(hidden) == nil
+    assert SidebarWorkflow.active_id(hidden) == nil
   end
 
   test "git porcelain GUI actions report disabled extension instead of no-op", %{
@@ -212,7 +214,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
              "Git porcelain extension is disabled or failed to load"
 
     assert toggled.workspace.keymap_scope == state.workspace.keymap_scope
-    assert EditorState.sidebar_active_id(toggled) == EditorState.sidebar_active_id(state)
+    assert SidebarWorkflow.active_id(toggled) == SidebarWorkflow.active_id(state)
 
     activated =
       GuiActionHandler.dispatch(state, {:sidebar_action, "git_status", "git_status", "activate"})
@@ -221,7 +223,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
              "Git porcelain extension is disabled or failed to load"
 
     assert activated.workspace.keymap_scope == state.workspace.keymap_scope
-    assert EditorState.sidebar_active_id(activated) == nil
+    assert SidebarWorkflow.active_id(activated) == nil
   end
 
   test "extension panel actions route semantic registry entries before legacy extensions", %{
@@ -350,12 +352,12 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
         %FileTreeState{tree_status: :loading, focused: true}
       end)
       |> EditorState.set_keymap_scope(:file_tree)
-      |> EditorState.set_sidebar_active_id("git_status")
+      |> SidebarWorkflow.select("git_status")
 
     new_state = Commands.execute(state, :toggle_beam_observatory)
 
-    assert EditorState.sidebar_active_id(new_state) == "observatory"
-    assert EditorState.observatory_visible?(new_state)
+    assert SidebarWorkflow.active_id(new_state) == "observatory"
+    assert SidebarWorkflow.observatory_visible?(new_state)
     refute EditorState.file_tree_state(new_state).focused
     assert new_state.workspace.keymap_scope == :editor
   end
@@ -392,11 +394,11 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
       height: 10
     }
 
-    state = base_state(table) |> EditorState.set_observatory_inspection(inspection)
+    state = base_state(table) |> SidebarWorkflow.inspect_observatory(inspection)
 
     new_state = GuiActionHandler.dispatch(state, :float_popup_dismiss)
 
-    assert Runtime.state(new_state.shell_runtime).observatory_inspection == nil
+    assert new_state |> SidebarWorkflow.observatory() |> Observatory.inspection() == nil
   end
 
   test "float_popup_dismiss closes the open :float popup window (#2338)", %{

--- a/test/minga_editor/handlers/tool_handler_test.exs
+++ b/test/minga_editor/handlers/tool_handler_test.exs
@@ -9,7 +9,7 @@ defmodule MingaEditor.Handlers.ToolHandlerTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.Handlers.ToolHandler
-  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Shell.Traditional.ToolPromptWorkflow
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -156,7 +156,7 @@ defmodule MingaEditor.Handlers.ToolHandlerTest do
   describe "tool_missing (suppressed)" do
     test "returns log effect when prompts are suppressed" do
       state = base_state()
-      state = EditorState.set_suppress_tool_prompts(state, true)
+      state = ToolPromptWorkflow.suppress(state, true)
 
       event = {:minga_event, :tool_missing, %Minga.Events.ToolMissingEvent{command: "rg"}}
       {new_state, effects} = ToolHandler.handle(state, event)

--- a/test/minga_editor/inline_ask/events_test.exs
+++ b/test/minga_editor/inline_ask/events_test.exs
@@ -10,6 +10,7 @@ defmodule MingaEditor.InlineAsk.EventsTest do
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.InlineAsk
   alias MingaEditor.Viewport
 
@@ -106,7 +107,7 @@ defmodule MingaEditor.InlineAsk.EventsTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %TraditionalState{inline_asks: %{buffer_pid => ask}}
+          TraditionalState.activate_inline_ask(%TraditionalState{}, ask)
         )
     }
 
@@ -114,6 +115,6 @@ defmodule MingaEditor.InlineAsk.EventsTest do
   end
 
   defp active_ask(state, buffer_pid) do
-    state |> EditorState.inline_asks() |> InlineAsk.active(buffer_pid)
+    state |> AgentAccess.inline_asks() |> InlineAsk.active(buffer_pid)
   end
 end

--- a/test/minga_editor/inline_ask/render_test.exs
+++ b/test/minga_editor/inline_ask/render_test.exs
@@ -4,8 +4,10 @@ defmodule MingaEditor.InlineAsk.RenderTest do
   alias Minga.Core.Decorations
   alias Minga.Project.FileRef
   alias MingaEditor.InlineAsk.Render
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.InlineAsk
 
   test "merge_decorations adds one dynamic block for the active buffer" do
@@ -23,11 +25,13 @@ defmodule MingaEditor.InlineAsk.RenderTest do
 
     ask = InlineAsk.append_input(ask, "why?")
 
-    state = %{
+    state = %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{viewport: MingaEditor.Viewport.new(24, 80)},
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %TraditionalState{inline_asks: %{buffer_pid => ask}}
+          TraditionalState.activate_inline_ask(%TraditionalState{}, ask)
         )
     }
 
@@ -62,7 +66,7 @@ defmodule MingaEditor.InlineAsk.RenderTest do
         0
       )
 
-    state = %{shell_state: %TraditionalState{inline_asks: %{buffer_pid => ask}}}
+    state = %{shell_state: TraditionalState.activate_inline_ask(%TraditionalState{}, ask)}
     decorations = Render.merge_decorations(Decorations.new(), state, buffer_pid)
 
     assert Decorations.has_block_decorations?(decorations)
@@ -82,11 +86,13 @@ defmodule MingaEditor.InlineAsk.RenderTest do
         0
       )
 
-    state = %{
+    state = %EditorState{
+      port_manager: nil,
+      workspace: %SessionState{viewport: MingaEditor.Viewport.new(24, 80)},
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %TraditionalState{inline_asks: %{active_buffer => ask}}
+          TraditionalState.activate_inline_ask(%TraditionalState{}, ask)
         )
     }
 

--- a/test/minga_editor/inline_edit/render_test.exs
+++ b/test/minga_editor/inline_edit/render_test.exs
@@ -19,7 +19,7 @@ defmodule MingaEditor.InlineEdit.RenderTest do
         "old text"
       )
 
-    state = %{shell_state: %TraditionalState{inline_edits: %{buffer_pid => edit}}}
+    state = %{shell_state: TraditionalState.activate_inline_edit(%TraditionalState{}, edit)}
     decorations = Render.merge_decorations(Decorations.new(), state, buffer_pid)
 
     assert Decorations.has_block_decorations?(decorations)

--- a/test/minga_editor/input/agent_mouse_test.exs
+++ b/test/minga_editor/input/agent_mouse_test.exs
@@ -63,7 +63,13 @@ defmodule MingaEditor.Input.AgentMouseTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tab_bar}
+          MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.replace_agent(
+              %MingaEditor.Shell.Traditional.State{},
+              agent
+            ),
+            tab_bar
+          )
         )
     }
   end

--- a/test/minga_editor/input/agent_nav_test.exs
+++ b/test/minga_editor/input/agent_nav_test.exs
@@ -24,18 +24,17 @@ defmodule MingaEditor.Input.AgentNavTest do
       Scroll.new(Keyword.get(opts, :offset, 5))
       |> Scroll.update_metrics(40, 10)
 
-    agent_ui = %UIState{
-      panel: %UIState.Panel{
-        visible: true,
-        input_focused: Keyword.get(opts, :input_focused, false),
-        scroll: scroll,
-        prompt_buffer: prompt_buf
-      },
-      view: %UIState.View{
-        active: true,
-        focus: Keyword.get(opts, :focus, :chat)
+    agent_ui =
+      %UIState{
+        panel: %UIState.Panel{
+          visible: true,
+          input_focused: Keyword.get(opts, :input_focused, false),
+          scroll: scroll,
+          prompt_buffer: prompt_buf
+        }
       }
-    }
+      |> UIState.activate(nil, nil)
+      |> UIState.set_focus(Keyword.get(opts, :focus, :chat))
 
     window = Window.new_agent_chat(1, 24, 80)
 
@@ -56,7 +55,10 @@ defmodule MingaEditor.Input.AgentNavTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: %AgentState{}}
+          MingaEditor.Shell.Traditional.State.replace_agent(
+            %MingaEditor.Shell.Traditional.State{},
+            %AgentState{}
+          )
         )
     }
   end

--- a/test/minga_editor/input/agent_panel_nav_test.exs
+++ b/test/minga_editor/input/agent_panel_nav_test.exs
@@ -52,7 +52,10 @@ defmodule MingaEditor.Input.AgentPanelNavTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: %AgentState{}}
+          MingaEditor.Shell.Traditional.State.replace_agent(
+            %MingaEditor.Shell.Traditional.State{},
+            %AgentState{}
+          )
         ),
       focus_stack: [Scoped, MingaEditor.Input.ModeFSM]
     }

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.Input.InterruptTest do
   alias Minga.Editing.Completion
   alias Minga.Mode
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.View
   alias MingaEditor.HoverPopup
   alias MingaEditor.Input
   alias MingaEditor.Input.Interrupt
@@ -111,7 +112,7 @@ defmodule MingaEditor.Input.InterruptTest do
     assert Runtime.state(state.shell_runtime).modal == :none
     assert Runtime.state(state.shell_runtime).whichkey.node == nil
     assert Runtime.state(state.shell_runtime).whichkey.show == false
-    assert AgentAccess.view(state).pending_prefix == nil
+    assert state |> AgentAccess.view() |> View.pending_prefix() == nil
     assert state.shell_runtime.state.notice.message == nil
     assert state.shell_runtime.state.hover_popup == nil
   end

--- a/test/minga_editor/input/observatory_test.exs
+++ b/test/minga_editor/input/observatory_test.exs
@@ -4,8 +4,11 @@ defmodule MingaEditor.Input.ObservatoryTest do
   alias Minga.SystemObserver.ProcessSnapshot
   alias Minga.SystemObserver.TreeNode
   alias MingaEditor.Input.Observatory
+  alias MingaEditor.Observatory.Data, as: ObservatoryData
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.Observatory, as: ObservatoryState
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
@@ -18,8 +21,7 @@ defmodule MingaEditor.Input.ObservatoryTest do
 
       state = Observatory.inspect_process(state, pid_string)
 
-      assert %{visible: true, title: title, lines: lines} =
-               state.shell_runtime.state.observatory_inspection
+      assert %{visible: true, title: title, lines: lines} = inspection(state)
 
       assert title == "Process #{pid_string}"
       assert "Class: agent session" in lines
@@ -30,14 +32,14 @@ defmodule MingaEditor.Input.ObservatoryTest do
       state = Observatory.inspect_process(base_state(), "not-a-pid")
 
       assert %{visible: true, title: "Process not-a-pid", lines: ["Invalid BEAM PID"]} =
-               state.shell_runtime.state.observatory_inspection
+               inspection(state)
     end
 
     test "empty PID dismisses the inspection popup" do
       state = Observatory.inspect_process(base_state(), "not-a-pid")
       state = Observatory.inspect_process(state, "")
 
-      assert state.shell_runtime.state.observatory_inspection == nil
+      assert inspection(state) == nil
     end
 
     test "falls back to process info when GenServer state is unavailable" do
@@ -47,7 +49,7 @@ defmodule MingaEditor.Input.ObservatoryTest do
 
       state = Observatory.inspect_process(base_state(), :erlang.pid_to_list(pid) |> to_string())
 
-      assert %{visible: true, lines: lines} = state.shell_runtime.state.observatory_inspection
+      assert %{visible: true, lines: lines} = inspection(state)
       assert Enum.any?(lines, &String.starts_with?(&1, "GenServer state unavailable:"))
       assert "Process info:" in lines
     end
@@ -63,7 +65,13 @@ defmodule MingaEditor.Input.ObservatoryTest do
 
   defp state_with_tree(pid, process_class) do
     tree = %TreeNode{pid: pid, snapshot: snapshot(process_class), children: [], depth: 0}
-    EditorState.set_observatory_data(base_state(), %{tree: tree})
+    SidebarWorkflow.replace_observatory_data(base_state(), ObservatoryData.visible(tree, []))
+  end
+
+  defp inspection(state) do
+    state
+    |> SidebarWorkflow.observatory()
+    |> ObservatoryState.inspection()
   end
 
   defp snapshot(process_class) do

--- a/test/minga_editor/input/scoped_editor_agent_test.exs
+++ b/test/minga_editor/input/scoped_editor_agent_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
   import Minga.Test.ScopedInputHelpers
 
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.View
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.TabBar
@@ -124,8 +125,9 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
       file_buffer: file_buffer
     } do
       assert state.workspace.keymap_scope == :agent
-      assert AgentAccess.view(state).return_target.active_tab_id == 1
-      assert AgentAccess.view(state).return_target.active_buffer == file_buffer
+      return_target = state |> AgentAccess.view() |> View.return_target()
+      assert return_target.active_tab_id == 1
+      assert return_target.active_buffer == file_buffer
 
       {:handled, new_state} = Scoped.handle_key(state, ?q, 0)
       assert new_state.workspace.keymap_scope == :editor
@@ -140,7 +142,9 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
 
     test "ESC returns to the recorded file tab when nothing transient is open", %{state: state} do
       assert state.workspace.keymap_scope == :agent
-      assert AgentAccess.view(state).return_target.active_tab_id == 1
+
+      assert state |> AgentAccess.view() |> View.return_target() |> Map.fetch!(:active_tab_id) ==
+               1
 
       {:handled, new_state} = Scoped.handle_key(state, 27, 0)
       assert new_state.workspace.keymap_scope == :editor
@@ -182,7 +186,7 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
 
     test "Tab switches focus", %{state: state} do
       {:handled, new_state} = Scoped.handle_key(state, 9, 0)
-      assert AgentAccess.view(new_state).focus == :file_viewer
+      assert new_state |> AgentAccess.view() |> View.focus() == :file_viewer
     end
 
     test "i focuses input", %{state: state} do
@@ -193,7 +197,7 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
     test "prefix keys start a prefix sequence", %{state: state} do
       for key <- [?g, ?z, 93, 91] do
         {:handled, new_state} = Scoped.handle_key(state, key, 0)
-        assert AgentAccess.view(new_state).pending_prefix != nil
+        assert new_state |> AgentAccess.view() |> View.pending_prefix() != nil
       end
     end
 
@@ -345,7 +349,7 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
     test "Tab switches back to chat from viewer" do
       state = base_state(keymap_scope: :agent, agentic_active: true, focus: :file_viewer)
       {:handled, new_state} = Scoped.handle_key(state, 9, 0)
-      assert AgentAccess.view(new_state).focus == :chat
+      assert new_state |> AgentAccess.view() |> View.focus() == :chat
     end
   end
 end

--- a/test/minga_editor/input/sub_state_handlers_test.exs
+++ b/test/minga_editor/input/sub_state_handlers_test.exs
@@ -48,12 +48,15 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
         model_name: "claude-sonnet-4",
         thinking_level: "medium",
         prompt_buffer: prompt_buf
-      },
-      view: %UIState.View{
-        active: Keyword.get(opts, :agentic_active, false),
-        focus: Keyword.get(opts, :focus, :chat)
       }
     }
+
+    agentic =
+      if Keyword.get(opts, :agentic_active, false),
+        do: UIState.activate(agentic, nil, nil),
+        else: agentic
+
+    agentic = UIState.set_focus(agentic, Keyword.get(opts, :focus, :chat))
 
     tab_bar =
       if Keyword.get(opts, :agentic_active, false) do
@@ -75,7 +78,13 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tab_bar}
+          MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.replace_agent(
+              %MingaEditor.Shell.Traditional.State{},
+              agent
+            ),
+            tab_bar
+          )
         )
     }
   end

--- a/test/minga_editor/layout/footer_band_overlays_test.exs
+++ b/test/minga_editor/layout/footer_band_overlays_test.exs
@@ -29,7 +29,8 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
   alias MingaEditor.Layout
   alias MingaEditor.Layout.OverlayBand
   alias MingaEditor.Layout.SurfaceRegistry
-  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Observatory.Data, as: ObservatoryData
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
   alias MingaEditor.UI.Notification
@@ -48,7 +49,7 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
     %{state | notifications: center}
   end
 
-  defp with_observatory(state), do: EditorState.open_observatory(state, nil)
+  defp with_observatory(state), do: SidebarWorkflow.open_observatory(state, nil)
 
   defp with_agent_context(state) do
     approval = %{tool_call_id: "tc1", name: "shell", args: %{}}
@@ -79,7 +80,7 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
 
     state
     |> with_observatory()
-    |> EditorState.set_observatory_data(%{tree: tree})
+    |> SidebarWorkflow.replace_observatory_data(ObservatoryData.visible(tree, []))
   end
 
   # Records `count` agent edits for the active buffer's path and wires the

--- a/test/minga_editor/layout_test.exs
+++ b/test/minga_editor/layout_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.LayoutTest do
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.AgentAccess
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Windows
   alias MingaEditor.Viewport
@@ -91,7 +92,7 @@ defmodule MingaEditor.LayoutTest do
     state
     |> EditorState.set_agent_ui(agentic)
     |> EditorState.set_tab_bar(tb)
-    |> EditorState.set_agent(agent)
+    |> AgentAccess.update_agent(fn _current -> agent end)
   end
 
   defp with_vsplit(state) do

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -398,7 +398,11 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
       windows: %Windows{map: %{1 => window}, active: 1},
       layout: nil,
       shell: Traditional,
-      shell_state: %TraditionalState{agent: %AgentState{}, tab_bar: tab_bar},
+      shell_state:
+        TraditionalState.set_tab_bar(
+          TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
+          tab_bar
+        ),
       agent_ui: %UIState{panel: panel},
       viewport: Viewport.new(24, 80),
       editing: VimState.new()

--- a/test/minga_editor/render_model/ui/agent_context_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_context_builder_test.exs
@@ -9,6 +9,8 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.RenderModel.UI.AgentContextBuilder
+  alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
 
@@ -25,6 +27,11 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
 
       agent_ui = UIState.update_activity(UIState.new(), fn _ -> activity end)
 
+      agent =
+        %AgentState{}
+        |> AgentState.set_status(:tool_executing)
+        |> AgentState.set_pending_approval(%{tool_call_id: "tc", name: "shell", args: %{}})
+
       ctx = %Context{
         port_manager: self(),
         capabilities: nil,
@@ -33,7 +40,7 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
         windows: nil,
         layout: nil,
         shell: MingaEditor.Shell.Traditional,
-        shell_state: %{agent: %{runtime: %{status: :tool_executing}, pending_approval: :approval}},
+        shell_state: TraditionalState.replace_agent(%TraditionalState{}, agent),
         agent_ui: agent_ui
       }
 
@@ -56,10 +63,10 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
       approval = %{tool_call_id: "tc-approval", name: "shell", args: %{}}
 
       state =
-        %{
-          agent: AgentState.set_pending_approval(%AgentState{}, approval),
-          workspace: %{agent_ui: UIState.new()}
-        }
+        TestHelpers.base_state()
+        |> AgentAccess.update_agent(fn _agent ->
+          AgentState.set_pending_approval(%AgentState{}, approval)
+        end)
         |> then(fn state -> elem(AgentEvents.handle(state, {:approval_pending, approval}), 0) end)
 
       started_at = AgentAccess.view(state).activity.started_at
@@ -73,7 +80,8 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
         windows: nil,
         layout: nil,
         shell: MingaEditor.Shell.Traditional,
-        shell_state: %{agent: AgentAccess.agent(state)},
+        shell_state:
+          TraditionalState.replace_agent(%TraditionalState{}, AgentAccess.agent(state)),
         agent_ui: AgentAccess.agent_ui(state)
       }
 

--- a/test/minga_editor/render_model/ui/float_popup_builder_test.exs
+++ b/test/minga_editor/render_model/ui/float_popup_builder_test.exs
@@ -3,7 +3,9 @@ defmodule MingaEditor.RenderModel.UI.FloatPopupBuilderTest do
 
   alias Minga.Popup.Rule
   alias Minga.RenderModel.UI.FloatPopup
+  alias MingaEditor.Observatory.Inspection
   alias MingaEditor.RenderModel.UI.FloatPopupBuilder
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.UI.Popup.Active
   alias MingaEditor.Window
 
@@ -21,7 +23,7 @@ defmodule MingaEditor.RenderModel.UI.FloatPopupBuilderTest do
     end
 
     test "builds observatory inspection float popup" do
-      inspection_data = %{
+      inspection_data = %Inspection{
         visible: true,
         title: "Inspect",
         lines: ["line1"],
@@ -29,7 +31,8 @@ defmodule MingaEditor.RenderModel.UI.FloatPopupBuilderTest do
         height: 20
       }
 
-      ctx = build_minimal_context(%{observatory_inspection: inspection_data})
+      shell_state = TraditionalState.inspect_observatory(%TraditionalState{}, inspection_data)
+      ctx = build_minimal_context(shell_state)
 
       model = FloatPopupBuilder.build(ctx)
 
@@ -42,8 +45,9 @@ defmodule MingaEditor.RenderModel.UI.FloatPopupBuilderTest do
     end
 
     test "hidden observatory inspection falls through to float window check" do
-      inspection_data = %{visible: false}
-      ctx = build_minimal_context(%{observatory_inspection: inspection_data})
+      inspection_data = %Inspection{visible: false, title: "", lines: [], width: 1, height: 1}
+      shell_state = TraditionalState.inspect_observatory(%TraditionalState{}, inspection_data)
+      ctx = build_minimal_context(shell_state)
 
       model = FloatPopupBuilder.build(ctx)
 

--- a/test/minga_editor/render_model/ui/observatory_builder_test.exs
+++ b/test/minga_editor/render_model/ui/observatory_builder_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.RenderModel.UI.ObservatoryBuilderTest do
   alias Minga.SystemObserver.TreeNode
   alias MingaEditor.Observatory.Data, as: ObservatoryData
   alias MingaEditor.RenderModel.UI.ObservatoryBuilder
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
 
   describe "build/1" do
     test "builds hidden observatory when not visible" do
@@ -17,8 +18,8 @@ defmodule MingaEditor.RenderModel.UI.ObservatoryBuilderTest do
       assert model.nodes == []
     end
 
-    test "builds hidden observatory when observatory_visible is false" do
-      model = ObservatoryBuilder.build(%{observatory_visible: false})
+    test "builds hidden observatory when Traditional observatory is closed" do
+      model = ObservatoryBuilder.build(%TraditionalState{})
 
       refute model.visible?
     end
@@ -27,7 +28,10 @@ defmodule MingaEditor.RenderModel.UI.ObservatoryBuilderTest do
       data =
         ObservatoryData.visible(tree_node(), [%{processes: %{self() => %{message_queue_len: 5}}}])
 
-      shell_state = %{observatory_visible: true, observatory_data: data}
+      shell_state =
+        %TraditionalState{}
+        |> TraditionalState.open_observatory(nil)
+        |> TraditionalState.replace_observatory_data(data)
 
       model = ObservatoryBuilder.build(shell_state)
 
@@ -52,7 +56,7 @@ defmodule MingaEditor.RenderModel.UI.ObservatoryBuilderTest do
     end
 
     test "builds visible observatory with nil data as empty visible" do
-      shell_state = %{observatory_visible: true, observatory_data: nil}
+      shell_state = TraditionalState.open_observatory(%TraditionalState{}, nil)
 
       model = ObservatoryBuilder.build(shell_state)
 

--- a/test/minga_editor/render_pipeline/chrome_dirty_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_dirty_test.exs
@@ -7,7 +7,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Session.State, as: SessionState
-  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
 
   setup do
     table = Module.concat(__MODULE__, "Sidebar#{System.unique_integer([:positive])}")
@@ -183,7 +183,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
       fp1 = Input.chrome_fingerprint(input)
 
       state =
-        EditorState.set_git_status_panel(state, %{
+        SidebarWorkflow.replace_git_status(state, %{
           repo_state: :normal,
           branch: "main",
           ahead: 0,

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -8,6 +8,8 @@ defmodule MingaEditor.RenderPipeline.InputTest do
   alias MingaEditor.RenderPipeline.WindowIntent
   alias MingaEditor.Shell.Entry
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.ClickRegions
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -149,8 +151,10 @@ defmodule MingaEditor.RenderPipeline.InputTest do
         receipt(input, 10, false,
           layout: :rendered_layout,
           focus_tree: focus_tree,
-          modeline_click_regions: [{:modeline, 1}],
-          tab_bar_click_regions: [{:tab, 2}]
+          click_regions: %ClickRegions{
+            modeline: [{0, 1, :modeline}],
+            tab_bar: [{0, 1, :tab}]
+          }
         )
 
       result = integrate_receipt(state, receipt)
@@ -159,8 +163,11 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       assert result.focus_tree == focus_tree
       assert result.workspace.windows == windows
       refute Map.has_key?(Map.from_struct(result), :caches)
-      assert Runtime.state(result.shell_runtime).modeline_click_regions == [{:modeline, 1}]
-      assert Runtime.state(result.shell_runtime).tab_bar_click_regions == [{:tab, 2}]
+
+      assert TraditionalState.click_regions(Runtime.state(result.shell_runtime)) == %ClickRegions{
+               modeline: [{0, 1, :modeline}],
+               tab_bar: [{0, 1, :tab}]
+             }
     end
 
     test "fresh receipt commits renderer-computed viewport observations", %{state: state} do
@@ -311,8 +318,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
           focus_tree: nil,
           shell_id: input.shell_id,
           shell_identity: input.shell_identity,
-          modeline_click_regions: [],
-          tab_bar_click_regions: [],
+          click_regions: %ClickRegions{},
           frame_seq: frame_seq,
           keyframe?: keyframe?,
           render_sent_at: 0,

--- a/test/minga_editor/renderer/buffer_changes_test.exs
+++ b/test/minga_editor/renderer/buffer_changes_test.exs
@@ -6,6 +6,7 @@ defmodule MingaEditor.Renderer.BufferChangesTest do
   alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.Renderer.BufferChanges
   alias MingaEditor.Renderer.State
+  alias MingaEditor.Shell.Traditional.ClickRegions
   alias MingaEditor.State.Windows
   alias MingaEditor.UI.Theme.Fallback
   alias MingaEditor.Window
@@ -117,8 +118,7 @@ defmodule MingaEditor.Renderer.BufferChangesTest do
       focus_tree: nil,
       shell_id: :traditional,
       shell_identity: nil,
-      modeline_click_regions: [],
-      tab_bar_click_regions: [],
+      click_regions: %ClickRegions{},
       frame_seq: 1,
       keyframe?: false,
       render_sent_at: 0

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -1174,8 +1174,7 @@ defmodule MingaEditor.Shell.RegistryTest do
       focus_tree: :rendered_focus_tree,
       shell_id: :fake,
       shell_identity: input.shell_identity,
-      modeline_click_regions: [{:old, 1}],
-      tab_bar_click_regions: [],
+      click_regions: nil,
       frame_seq: 1,
       keyframe?: false,
       render_sent_at: 0

--- a/test/minga_editor/shell/traditional/agent_surfaces_test.exs
+++ b/test/minga_editor/shell/traditional/agent_surfaces_test.exs
@@ -1,0 +1,78 @@
+defmodule MingaEditor.Shell.Traditional.AgentSurfacesTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Project.FileRef
+  alias MingaEditor.Shell.Traditional.AgentSurfaces
+  alias MingaEditor.State.InlineAsk
+  alias MingaEditor.State.InlineEdit
+
+  test "replacement inline ask ignores the old session and cancellation returns the current session" do
+    buffer = self()
+    old_session = spawn_session()
+    current_session = spawn_session()
+
+    on_exit(fn ->
+      Process.exit(old_session, :kill)
+      Process.exit(current_session, :kill)
+    end)
+
+    old_ask = buffer |> ask() |> InlineAsk.thinking(old_session)
+    current_ask = buffer |> ask() |> InlineAsk.thinking(current_session)
+
+    surfaces =
+      %AgentSurfaces{}
+      |> AgentSurfaces.activate_ask(old_ask)
+      |> AgentSurfaces.activate_ask(current_ask)
+      |> AgentSurfaces.append_ask_response(old_session, "stale")
+
+    assert InlineAsk.active(AgentSurfaces.asks(surfaces), buffer) == current_ask
+
+    surfaces = AgentSurfaces.append_ask_response(surfaces, current_session, "current")
+    assert InlineAsk.active(AgentSurfaces.asks(surfaces), buffer).response == "current"
+
+    {canceled, session_pid} = AgentSurfaces.cancel_ask(surfaces, buffer)
+    assert session_pid == current_session
+    assert InlineAsk.active(AgentSurfaces.asks(canceled), buffer) == nil
+  end
+
+  test "replacement inline edit ignores stale completion and completes the current session" do
+    buffer = self()
+    old_session = spawn_session()
+    current_session = spawn_session()
+
+    on_exit(fn ->
+      Process.exit(old_session, :kill)
+      Process.exit(current_session, :kill)
+    end)
+
+    old_edit = buffer |> edit() |> InlineEdit.thinking(old_session)
+    current_edit = buffer |> edit() |> InlineEdit.thinking(current_session)
+
+    surfaces =
+      %AgentSurfaces{}
+      |> AgentSurfaces.activate_edit(old_edit)
+      |> AgentSurfaces.activate_edit(current_edit)
+      |> AgentSurfaces.complete_edit(old_session)
+
+    assert InlineEdit.active(AgentSurfaces.edits(surfaces), buffer) == current_edit
+
+    completed = AgentSurfaces.complete_edit(surfaces, current_session)
+
+    assert %InlineEdit{status: :proposed, session_pid: nil} =
+             InlineEdit.active(AgentSurfaces.edits(completed), buffer)
+  end
+
+  defp ask(buffer) do
+    InlineAsk.new(buffer, file_ref(buffer), "scratch.ex", 0)
+  end
+
+  defp edit(buffer) do
+    InlineEdit.new(buffer, file_ref(buffer), "scratch.ex", {0, 0}, "before")
+  end
+
+  defp file_ref(buffer) do
+    %FileRef{kind: :buffer, display_name: "scratch.ex", buffer_pid: buffer}
+  end
+
+  defp spawn_session, do: spawn(fn -> receive do: (:stop -> :ok) end)
+end

--- a/test/minga_editor/shell/traditional/input_state_test.exs
+++ b/test/minga_editor/shell/traditional/input_state_test.exs
@@ -1,0 +1,70 @@
+defmodule MingaEditor.Shell.Traditional.InputStateTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.ClickRegions
+  alias MingaEditor.Shell.Traditional.InputState
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State, as: EditorState
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  test "one render installs both click-region sets and reset clears both" do
+    input =
+      InputState.install_click_regions(
+        %InputState{},
+        [{2, 6, :show_messages}],
+        [{0, 3, :previous_tab}, {1, 4, 8, {:tab_goto_id, 7}}]
+      )
+
+    assert InputState.modeline_command_at(input, 2) == :show_messages
+    assert InputState.modeline_command_at(input, 6) == nil
+    assert InputState.tab_bar_command_at(input, 0, 3) == :previous_tab
+    assert InputState.tab_bar_command_at(input, 1, 5) == {:tab_goto_id, 7}
+
+    assert InputState.click_regions(InputState.reset_click_regions(input)) == %ClickRegions{}
+  end
+
+  test "a stale leader generation cannot expire its replacement" do
+    {first_generation, input} = InputState.begin_space_leader(%InputState{})
+    input = InputState.install_space_leader_timer(input, first_generation, make_ref())
+    input = InputState.reset_space_leader(input)
+    {replacement_generation, input} = InputState.begin_space_leader(input)
+
+    assert {:stale, unchanged} = InputState.expire_space_leader(input, first_generation)
+    assert unchanged == input
+    assert InputState.space_leader_pending?(unchanged)
+
+    assert {:expired, expired} =
+             InputState.expire_space_leader(unchanged, replacement_generation)
+
+    refute InputState.space_leader_pending?(expired)
+    assert InputState.space_leader_timer(expired) == nil
+  end
+
+  test "Editor timeout delivery ignores an old generation and expires the current one" do
+    shell_state = %TraditionalState{}
+    {old_generation, shell_state} = TraditionalState.begin_space_leader(shell_state)
+    shell_state = TraditionalState.reset_space_leader(shell_state)
+    {current_generation, shell_state} = TraditionalState.begin_space_leader(shell_state)
+
+    state = install_shell_state(base_state(), shell_state)
+
+    assert {:noreply, stale_state} =
+             MingaEditor.handle_info({:space_leader_timeout, old_generation}, state)
+
+    assert TraditionalState.space_leader_pending?(Runtime.state(stale_state.shell_runtime))
+
+    assert {:noreply, expired_state} =
+             MingaEditor.handle_info({:space_leader_timeout, current_generation}, stale_state)
+
+    refute TraditionalState.space_leader_pending?(Runtime.state(expired_state.shell_runtime))
+  end
+
+  defp install_shell_state(state, shell_state) do
+    runtime =
+      Runtime.update_traditional_state(state.shell_runtime, fn _current -> shell_state end)
+
+    EditorState.apply_shell_runtime_transition(state, runtime)
+  end
+end

--- a/test/minga_editor/shell/traditional/sidebars_test.exs
+++ b/test/minga_editor/shell/traditional/sidebars_test.exs
@@ -1,0 +1,87 @@
+defmodule MingaEditor.Shell.Traditional.SidebarsTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Observatory.Data
+  alias MingaEditor.Observatory.Inspection
+  alias MingaEditor.Shell.Traditional.Observatory
+  alias MingaEditor.Shell.Traditional.Sidebars
+
+  test "Git status close clears its selected surface and paired TUI state" do
+    sidebars =
+      %Sidebars{}
+      |> Sidebars.replace_git_status(%{entries: []})
+      |> Sidebars.replace_git_status_tui(%URI{path: "/status"})
+      |> Sidebars.select("git_status")
+
+    closed = Sidebars.close_git_status(sidebars)
+
+    assert Sidebars.active_id(closed) == nil
+    assert Sidebars.git_status_panel(closed) == nil
+    assert Sidebars.git_status_tui_state(closed) == nil
+  end
+
+  test "closing Observatory clears every surface value and invalidates delayed work" do
+    timer = make_ref()
+    token = make_ref()
+    data = Data.visible(nil, [])
+    inspection = %Inspection{visible: true, title: "Process", lines: [], width: 20, height: 10}
+
+    sidebars =
+      %Sidebars{}
+      |> Sidebars.open_observatory({timer, token})
+      |> Sidebars.replace_observatory_data(data)
+      |> Sidebars.inspect_observatory(inspection)
+
+    closed = Sidebars.close_observatory(sidebars)
+    observatory = Sidebars.observatory(closed)
+
+    assert Sidebars.active_id(closed) == nil
+    refute Observatory.visible?(observatory)
+    assert Observatory.timer(observatory) == nil
+    assert Observatory.data(observatory) == nil
+    assert Observatory.inspection(observatory) == nil
+    assert {:stale, ^closed} = Sidebars.expire_observatory(closed, token)
+
+    next_timer = {make_ref(), make_ref()}
+    assert {:stale, ^closed} = Sidebars.complete_observatory(closed, token, data, next_timer)
+  end
+
+  test "replacement tokens reject an old tick and accept only the current collection" do
+    first_token = make_ref()
+    second_token = make_ref()
+
+    sidebars =
+      %Sidebars{}
+      |> Sidebars.open_observatory({make_ref(), first_token})
+      |> Sidebars.open_observatory({make_ref(), second_token})
+
+    assert {:stale, ^sidebars} = Sidebars.expire_observatory(sidebars, first_token)
+    assert {:collect, collecting} = Sidebars.expire_observatory(sidebars, second_token)
+
+    data = Data.visible(nil, [])
+    next_timer = make_ref()
+    next_token = make_ref()
+
+    assert {:stale, ^collecting} =
+             Sidebars.complete_observatory(
+               collecting,
+               first_token,
+               data,
+               {next_timer, next_token}
+             )
+
+    assert {:accepted, scheduled} =
+             Sidebars.complete_observatory(
+               collecting,
+               second_token,
+               data,
+               {next_timer, next_token}
+             )
+
+    observatory = Sidebars.observatory(scheduled)
+    assert Observatory.visible?(observatory)
+    assert Observatory.data(observatory) == data
+    assert Observatory.timer(observatory) == next_timer
+    assert observatory.token == next_token
+  end
+end

--- a/test/minga_editor/shell/traditional/tool_prompts_test.exs
+++ b/test/minga_editor/shell/traditional/tool_prompts_test.exs
@@ -1,0 +1,22 @@
+defmodule MingaEditor.Shell.Traditional.ToolPromptsTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Shell.Traditional.ToolPrompts
+
+  test "queue, decline decisions, and suppression stay coherent" do
+    prompts =
+      %ToolPrompts{}
+      |> ToolPrompts.enqueue(:ripgrep)
+      |> ToolPrompts.enqueue(:ripgrep)
+      |> ToolPrompts.enqueue(:zls)
+      |> ToolPrompts.suppress(true)
+
+    assert ToolPrompts.queue(prompts) == [:ripgrep, :zls]
+    assert ToolPrompts.decided?(prompts, :ripgrep)
+    assert ToolPrompts.suppressed?(prompts)
+
+    prompts = ToolPrompts.replace(prompts, [:zls], MapSet.new([:ripgrep]))
+    assert ToolPrompts.decided?(prompts, :ripgrep)
+    assert ToolPrompts.queue(ToolPrompts.advance(prompts)) == []
+  end
+end

--- a/test/minga_editor/startup_view_state_test.exs
+++ b/test/minga_editor/startup_view_state_test.exs
@@ -2,13 +2,14 @@ defmodule MingaEditor.StartupViewStateTest do
   # Mutates the global :cli_startup_flags Application environment while verifying the startup boundary.
   use ExUnit.Case, async: false
 
+  alias MingaEditor.Agent.UIState.View
   alias MingaEditor.Startup
 
   test "defaults to editor view for TUI startup" do
     {scope, ui_state} = Startup.startup_view_state(:tui)
 
     assert scope == :editor
-    assert ui_state.view.active == false
+    assert View.active?(ui_state.view) == false
   end
 
   test "CLI startup flags select editor, agentic, and native GUI auto modes" do
@@ -24,7 +25,7 @@ defmodule MingaEditor.StartupViewStateTest do
     {scope, agentic} = Startup.startup_view_state(backend)
 
     assert scope == expected_scope
-    assert agentic.view.active == expected_active?
+    assert View.active?(agentic.view) == expected_active?
   after
     # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
     Application.delete_env(:minga, :cli_startup_flags)

--- a/test/minga_editor/state/event_routing_test.exs
+++ b/test/minga_editor/state/event_routing_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.State.EventRoutingTest do
   alias MingaEditor.Agent.Events, as: AgentEvents
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaAgent.RuntimeState
   alias MingaEditor.State.Agent, as: AgentState
@@ -26,10 +27,11 @@ defmodule MingaEditor.State.EventRoutingTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{
-            tab_bar: tb,
-            agent: %AgentState{runtime: %RuntimeState{status: :idle}}
-          }
+          %TraditionalState{}
+          |> TraditionalState.replace_agent(%AgentState{
+            runtime: %RuntimeState{status: :idle}
+          })
+          |> TraditionalState.set_tab_bar(tb)
         )
     }
 

--- a/test/support/scoped_input_helpers.ex
+++ b/test/support/scoped_input_helpers.ex
@@ -6,6 +6,7 @@ defmodule Minga.Test.ScopedInputHelpers do
   alias MingaEditor.Agent.UIState
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.AgentAccess
@@ -37,12 +38,17 @@ defmodule Minga.Test.ScopedInputHelpers do
         visible: Keyword.get(opts, :panel_visible, false),
         input_focused: Keyword.get(opts, :input_focused, false),
         prompt_buffer: prompt_buf
-      },
-      view: %UIState.View{
-        active: Keyword.get(opts, :agentic_active, false),
-        focus: Keyword.get(opts, :focus, :chat)
       }
     }
+
+    agentic =
+      if Keyword.get(opts, :agentic_active, false) do
+        agentic
+        |> UIState.activate(nil, nil)
+        |> UIState.set_focus(Keyword.get(opts, :focus, :chat))
+      else
+        agentic
+      end
 
     tab_bar =
       if Keyword.get(opts, :agentic_active, false) do
@@ -69,7 +75,9 @@ defmodule Minga.Test.ScopedInputHelpers do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          %MingaEditor.Shell.Traditional.State{agent: agent, tab_bar: tab_bar}
+          %TraditionalState{}
+          |> TraditionalState.replace_agent(agent)
+          |> TraditionalState.set_tab_bar(tab_bar)
         )
     }
   end


### PR DESCRIPTION
## Summary

- Move Traditional sidebar, Git status, and Observatory lifecycle state into focused pure owners with effectful workflow boundaries.
- Move agent presentation, return context, inline asks, inline edits, and tool prompt lifecycle state behind owner APIs.
- Move renderer click regions and TUI space-leader correlation into focused input owners, including shell-deactivation cleanup.
- Remove superseded root delegates, direct field paths, compatibility reads, and foreign-struct writes.
- Add pure lifecycle and focused integration coverage for replacement, cancellation, stale timers, hidden surfaces, renderer receipts, and shell switching.

## Validation

- `make lint`
- `mix test.llm` (58 doctests, 97 properties, 9,357 tests, 0 failures, 1 skipped)
- Git porcelain focused extension suite (17 tests, 0 failures)
- Focused deactivation and render-owner regressions (36 tests, 0 failures)
- Final reviewer: PASS

Closes #2867
