### PR TITLE
fix(macos): publish frame versions to leaf views

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -891,22 +891,6 @@ Render and command code selects the semantic path with `Capabilities.semantic_ui
 
 When adding chrome data (diagnostic counts, indent info, selection size, etc.), design the semantic model fields first, extend the wire format in `docs/PROTOCOL.md` / `docs/GUI_PROTOCOL.md`, update the adapter encoder and `gui_protocol_test.exs`, then ensure each frontend that should display it decodes and renders the new fields. Cross-frontend coverage (macOS SwiftUI, Charm/Go TUI) is tracked in the Semantic UI inventory (#2113); forgetting to update a frontend is a common mistake.
 
-### Semantic-surface freeze (in effect)
-
-The semantic UI protocol surface is frozen while the frontend remediation epics are in flight. Until [#2216](https://github.com/jsmestad/minga/issues/2216) (Go-only TUI), [#2218](https://github.com/jsmestad/minga/issues/2218) (semantic-only paradigm), and [#2219](https://github.com/jsmestad/minga/issues/2219) (transactional, layout-authoritative, fully generated protocol) are complete, do not add:
-
-- new semantic UI opcodes to `docs/protocol_schema.toml`,
-- new semantic surface payload types or `Minga.RenderModel.UI.*` chrome models,
-- new chrome message types for agent or extension features.
-
-Every new surface multiplies across every frontend decoder and renderer and expands the exact contract those epics are stabilizing.
-
-**Exemptions:** bug fixes to existing surfaces, and protocol changes required by #2218 or #2219 themselves (opcode retirement, frame transactions, rect/z fields, codegen).
-
-**Enforcement:** reviewers and ticket runners treat a PR that adds a new opcode or semantic surface during the freeze as a blocker unless the PR cites one of the exemptions. If a feature genuinely needs a new surface before the freeze lifts, it needs an explicit user decision on the ticket, not a reviewer waiver.
-
-The freeze lifts when all three linked epics are closed. Remove this section at that point.
-
 ### New command
 1. Add the command to the appropriate `Commands.*` sub-module's `__commands__/0` (implements `Minga.Command.Provider` behaviour). Include name, description, `requires_buffer` flag, and execute function. If no existing sub-module fits, create a new one and add it to the `@command_modules` list in `Minga.Command.Registry`.
 2. Add keybinding in `Minga.Keymap.Defaults`

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -2756,8 +2756,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
   Parity oracle / future wiring (#2119): this opcode has no live BEAM emitter.
   The macOS frontend has a fully wired decode -> `ToolManagerState` -> `ToolManagerView`
   path designed to be BEAM-driven, but the BEAM half (a semantic tool-manager
-  model and emission) was never built, and building it is out of scope here and
-  blocked by the semantic-surface freeze. Rather than orphan the frontend decoder
+  model and emission) was never built. Rather than orphan the frontend decoder
   and break the GUI protocol round-trip tests, this encoder is retained as the
   byte-for-byte parity oracle until a tool-manager feature is built on the
   semantic path. The `gui_protocol_test.exs` round-trip suite exercises it.

--- a/lib/minga_editor/ui/picker/location_source.ex
+++ b/lib/minga_editor/ui/picker/location_source.ex
@@ -37,9 +37,10 @@ defmodule MingaEditor.UI.Picker.LocationSource do
 
   @impl true
   @spec candidates(Context.t()) :: [Item.t()]
-  def candidates(%Context{picker_ui: %{context: %{locations: locations}}})
+  def candidates(%Context{picker_ui: %{context: %{locations: locations}}} = ctx)
       when is_list(locations) do
-    Enum.map(locations, &format_location/1)
+    root = project_root(ctx)
+    Enum.map(locations, &format_location(&1, root))
   end
 
   def candidates(_state), do: []
@@ -58,10 +59,12 @@ defmodule MingaEditor.UI.Picker.LocationSource do
 
   # ── Private ────────────────────────────────────────────────────────────────
 
-  @spec format_location({String.t(), non_neg_integer(), non_neg_integer(), String.t()}) ::
-          Item.t()
-  defp format_location({path, line, col, label}) do
-    display_path = shorten_path(path)
+  @spec format_location(
+          {String.t(), non_neg_integer(), non_neg_integer(), String.t()},
+          String.t() | nil
+        ) :: Item.t()
+  defp format_location({path, line, col, label}, root) do
+    display_path = shorten_path(path, root)
     line_num = line + 1
     col_num = col + 1
 
@@ -138,11 +141,15 @@ defmodule MingaEditor.UI.Picker.LocationSource do
 
   defp set_jump_mark(state), do: state
 
-  @spec shorten_path(String.t()) :: String.t()
-  defp shorten_path(path) do
-    case Minga.Project.root() do
-      nil -> path
-      root -> Path.relative_to(path, root)
-    end
-  end
+  @spec project_root(Context.t()) :: String.t() | nil
+  defp project_root(%Context{picker_ui: %{context: %{project_root: root}}})
+       when is_binary(root) or is_nil(root),
+       do: root
+
+  defp project_root(%Context{file_tree: %{project_root: root}}) when is_binary(root), do: root
+  defp project_root(_ctx), do: Minga.Project.root()
+
+  @spec shorten_path(String.t(), String.t() | nil) :: String.t()
+  defp shorten_path(path, nil), do: path
+  defp shorten_path(path, root), do: Path.relative_to(path, root)
 end

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -92,6 +92,7 @@
 		4A3BE630EECDBD2A557A4027 /* WorkspaceIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671A222860B90E08D7975099 /* WorkspaceIconPicker.swift */; };
 		4ADE54090FEEF5AA2A6C86A0 /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		4B2CF3C29FD0F4B63C7E7027 /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A733EF649EF21A761608D75 /* MingaWindow.swift */; };
+		4D276F4F3C0C19A3E184D09B /* GUIFrameSwiftUIInvalidationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 510D1033E87B077777E8FD64 /* GUIFrameSwiftUIInvalidationTests.swift */; };
 		4E1EEFA65935DCE58528E02B /* PipelineCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */; };
 		4E4B8BDBAEF50E45C26C0057 /* LatencyHUDOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E1059DF5F524F5FC2B697EC /* LatencyHUDOverlay.swift */; };
 		4ECF7F97FFFD5B2A74914AAB /* NotificationCenterState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DCCEC5865DAE0AAF754F2E2 /* NotificationCenterState.swift */; };
@@ -494,6 +495,7 @@
 		4BC98120D82BD7548347875E /* FontFace.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FontFace.swift; sourceTree = "<group>"; };
 		4CDC572B6F7D2CD90E07CA61 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		5066C470DAA195F0DA9FE491 /* GUIFrameStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIFrameStore.swift; sourceTree = "<group>"; };
+		510D1033E87B077777E8FD64 /* GUIFrameSwiftUIInvalidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIFrameSwiftUIInvalidationTests.swift; sourceTree = "<group>"; };
 		51E88C12915EC4EBE96165AF /* FileTreeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeHeaderView.swift; sourceTree = "<group>"; };
 		53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Instrumentation.swift; sourceTree = "<group>"; };
 		54D2036E3609EB1C3E575CFC /* BottomPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelView.swift; sourceTree = "<group>"; };
@@ -1059,6 +1061,7 @@
 				E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */,
 				754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */,
 				6577A488A042D7974A1EA661 /* GUIFrameStoreTests.swift */,
+				510D1033E87B077777E8FD64 /* GUIFrameSwiftUIInvalidationTests.swift */,
 				F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */,
 				7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */,
 				DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */,
@@ -1644,6 +1647,7 @@
 				CD2952CCEB2FD594B269A75D /* GUIActionEncoderTests.swift in Sources */,
 				30E31170A79F30413D15D858 /* GUIChromeDecoderTests.swift in Sources */,
 				19117A3BA17ACBBD58E55A9E /* GUIFrameStoreTests.swift in Sources */,
+				4D276F4F3C0C19A3E184D09B /* GUIFrameSwiftUIInvalidationTests.swift in Sources */,
 				312DC4940992B35ED9EE7648 /* IMEComposition.swift in Sources */,
 				1631D7B76B33CD897C48F263 /* IMECompositionTests.swift in Sources */,
 				25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */,

--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -97,15 +97,28 @@ private struct PaneWidthKey: PreferenceKey {
     }
 }
 
+enum ContentViewFrameProbePoint: Hashable {
+    case shell
+    case editor
+    case editorOverlay
+    case extensionOverlay
+    case windowOverlay
+}
+
+struct ContentViewFrameProbe {
+    let makeView: (ContentViewFrameProbePoint, AnyObject) -> AnyView
+}
+
 private struct ShellFramePresentationHost<Content: View>: View {
     let channel: GUIFrameChannel
     let metrics: GUIFramePresentationMetrics
     @ViewBuilder let content: () -> Content
 
     var body: some View {
-        _ = channel.value
+        let version = channel.value
         return content()
-            .frameNativeDrawProbe(domain: .shell, version: channel.value, metrics: metrics)
+            .environment(\.guiFrameVersion, version)
+            .frameNativeDrawProbe(domain: .shell, version: version, metrics: metrics)
     }
 }
 
@@ -115,8 +128,10 @@ private struct UnifiedToolbarHost<Content: View>: View {
     @ViewBuilder let content: (ShellHostInput) -> Content
 
     var body: some View {
-        _ = channel.value
-        return content(input).environment(\.themeColors, input.currentTheme)
+        let version = channel.value
+        return content(input)
+            .environment(\.themeColors, input.currentTheme)
+            .environment(\.guiFrameVersion, version)
     }
 }
 
@@ -126,8 +141,10 @@ private struct SidebarHost<Content: View>: View {
     @ViewBuilder let content: (ShellHostInput) -> Content
 
     var body: some View {
-        _ = channel.value
-        return content(input).environment(\.themeColors, input.currentTheme)
+        let version = channel.value
+        return content(input)
+            .environment(\.themeColors, input.currentTheme)
+            .environment(\.guiFrameVersion, version)
     }
 }
 
@@ -137,8 +154,10 @@ private struct EditorColumnHost<Content: View>: View {
     @ViewBuilder let content: (ShellHostInput) -> Content
 
     var body: some View {
-        _ = channel.value
-        return content(input).environment(\.themeColors, input.currentTheme)
+        let version = channel.value
+        return content(input)
+            .environment(\.themeColors, input.currentTheme)
+            .environment(\.guiFrameVersion, version)
     }
 }
 
@@ -148,8 +167,10 @@ private struct EditorSurfaceHost<Content: View>: View {
     @ViewBuilder let content: (EditorHostInput) -> Content
 
     var body: some View {
-        _ = channel.value
-        return content(input).environment(\.themeColors, input.currentTheme)
+        let version = channel.value
+        return content(input)
+            .environment(\.themeColors, input.currentTheme)
+            .environment(\.guiFrameVersion, version)
     }
 }
 
@@ -159,19 +180,10 @@ private struct StatusBarHost<Content: View>: View {
     @ViewBuilder let content: (ShellHostInput) -> Content
 
     var body: some View {
-        _ = channel.value
-        return content(input).environment(\.themeColors, input.currentTheme)
-    }
-}
-
-private struct FrontendExtensionRuntimeHost<Content: View>: View {
-    let channel: GUIFrameChannel
-    let input: WindowOverlayHostInput
-    @ViewBuilder let content: (WindowOverlayHostInput) -> Content
-
-    var body: some View {
-        _ = channel.value
-        return content(input).environment(\.themeColors, input.currentTheme)
+        let version = channel.value
+        return content(input)
+            .environment(\.themeColors, input.currentTheme)
+            .environment(\.guiFrameVersion, version)
     }
 }
 
@@ -182,23 +194,26 @@ private struct WindowOverlayHost<Content: View>: View {
     @ViewBuilder let content: (WindowOverlayHostInput) -> Content
 
     var body: some View {
-        _ = channel.value
+        let version = channel.value
         return content(input)
             .environment(\.themeColors, input.currentTheme)
-            .frameNativeDrawProbe(domain: .windowOverlay, version: channel.value, metrics: metrics)
+            .environment(\.guiFrameVersion, version)
+            .frameNativeDrawProbe(domain: .windowOverlay, version: version, metrics: metrics)
     }
 }
 
-private struct EditorOverlayHost: View {
+private struct EditorOverlayHost<ExtensionContent: View>: View {
     let channel: GUIFrameChannel
     let input: EditorOverlayHostInput
     let metrics: GUIFramePresentationMetrics
     let geometry: EditorGeometry
     let viewportHeight: CGFloat
     let encoder: InputEncoder?
+    let frameProbe: ContentViewFrameProbe?
+    @ViewBuilder let extensionContent: () -> ExtensionContent
 
     var body: some View {
-        _ = channel.value
+        let version = channel.value
         return ZStack(alignment: .topLeading) {
             if input.signatureHelpState.visible {
                 anchoredOverlay(row: input.signatureHelpState.anchorRow, col: input.signatureHelpState.anchorCol, preferredSide: .above, maxHeight: 220) { _ in
@@ -219,12 +234,25 @@ private struct EditorOverlayHost: View {
             if input.completionState.visible {
                 anchoredOverlay(row: input.completionState.anchorRow, col: input.completionState.anchorCol, preferredSide: .below, maxHeight: 420, gap: 2) { _ in
                     CompletionOverlay(state: input.completionState, encoder: encoder)
+                        .background {
+                            probe(.editorOverlay, stateObject: input.completionState)
+                        }
                 }
                 .zIndex(30)
             }
+
+            extensionContent()
         }
         .environment(\.themeColors, input.currentTheme)
-        .frameNativeDrawProbe(domain: .editorOverlay, version: channel.value, metrics: metrics)
+        .environment(\.guiFrameVersion, version)
+        .frameNativeDrawProbe(domain: .editorOverlay, version: version, metrics: metrics)
+    }
+
+    @ViewBuilder
+    private func probe(_ point: ContentViewFrameProbePoint, stateObject: AnyObject) -> some View {
+        if let frameProbe {
+            frameProbe.makeView(point, stateObject)
+        }
     }
 
     private func anchoredOverlay<Content: View>(
@@ -497,6 +525,8 @@ public struct ContentView<EditorSurface: View>: View {
     @State private var changeSummaryWidth: CGFloat = 280
     @Namespace private var frontendExtensionNamespace
 
+    let frameProbe: ContentViewFrameProbe?
+
     public init(
         gui: GUIState,
         encoder: @escaping () -> InputEncoder?,
@@ -511,6 +541,32 @@ public struct ContentView<EditorSurface: View>: View {
         self.chrome = chrome
         self.onAgentChatVisibleChange = onAgentChatVisibleChange
         self.makeEditorSurface = makeEditorSurface
+        frameProbe = nil
+    }
+
+    init(
+        gui: GUIState,
+        encoder: @escaping () -> InputEncoder?,
+        editorGeometry: @escaping () -> EditorGeometry,
+        chrome: WindowChrome,
+        onAgentChatVisibleChange: @escaping (Bool) -> Void,
+        frameProbe: ContentViewFrameProbe,
+        @ViewBuilder makeEditorSurface: @escaping () -> EditorSurface
+    ) {
+        self.gui = gui
+        self.encoderProvider = encoder
+        self.editorGeometry = editorGeometry
+        self.chrome = chrome
+        self.onAgentChatVisibleChange = onAgentChatVisibleChange
+        self.makeEditorSurface = makeEditorSurface
+        self.frameProbe = frameProbe
+    }
+
+    @ViewBuilder
+    private func frameProbeView(_ point: ContentViewFrameProbePoint, stateObject: AnyObject) -> some View {
+        if let frameProbe {
+            frameProbe.makeView(point, stateObject)
+        }
     }
 
     private let activityBarWidth: CGFloat = 32
@@ -582,14 +638,11 @@ public struct ContentView<EditorSurface: View>: View {
                     }
                 }
             }
-            FrontendExtensionRuntimeHost(
-                channel: frameStore.windowOverlay,
-                input: windowOverlayInput
-            ) { input in
-                frontendExtensionRuntimeLayer(input)
-            }
             WindowOverlayHost(channel: frameStore.windowOverlay, input: windowOverlayInput, metrics: metrics) { input in
-                windowOverlays(input)
+                ZStack {
+                    frontendExtensionRuntimeLayer(input)
+                    windowOverlays(input)
+                }
             }
         }
         .navigationTitle(chrome.title)
@@ -651,11 +704,14 @@ public struct ContentView<EditorSurface: View>: View {
                         )
                     }
 
-                    if !input.tabBarState.tabs.isEmpty || !input.workspaceState.visibleTabs.isEmpty {
+                    if !input.tabBarState.displayTabs.isEmpty {
                         TabBarView(
                             tabBarState: input.tabBarState,
                             encoder: encoder
                         )
+                        .background {
+                            frameProbeView(.shell, stateObject: input.tabBarState)
+                        }
                         .accessibilityIdentifier("workspace-tabbar")
                     } else {
                         Spacer()
@@ -897,6 +953,9 @@ public struct ContentView<EditorSurface: View>: View {
                     state: input.emptyStateState,
                     encoder: encoder
                 )
+                .background {
+                    frameProbeView(.editor, stateObject: input.emptyStateState)
+                }
             }
 
             EditorOverlayHost(
@@ -905,10 +964,11 @@ public struct ContentView<EditorSurface: View>: View {
                 metrics: metrics,
                 geometry: geo,
                 viewportHeight: rightPaneHeight,
-                encoder: encoder
-            )
-
-            extensionOverlayLayer(overlayInput)
+                encoder: encoder,
+                frameProbe: frameProbe
+            ) {
+                extensionOverlayLayer(overlayInput)
+            }
         }
     }
 
@@ -970,6 +1030,9 @@ public struct ContentView<EditorSurface: View>: View {
                     columnCount: geometry?.textRect.width ?? 0,
                     rowCount: geometry?.textRect.height ?? 0
                 )
+                .background {
+                    frameProbeView(.extensionOverlay, stateObject: input.extensionOverlayState)
+                }
             }
         }
     }
@@ -1148,6 +1211,9 @@ public struct ContentView<EditorSurface: View>: View {
             state: input.pickerState,
             encoder: encoder
         )
+        .background {
+            frameProbeView(.windowOverlay, stateObject: input.pickerState)
+        }
 
         ToolManagerView(
             state: input.toolManagerState,

--- a/macos/Sources/Views/Agent/AgentChatHeaderView.swift
+++ b/macos/Sources/Views/Agent/AgentChatHeaderView.swift
@@ -8,11 +8,13 @@ public struct AgentChatHeaderView: View {
     public let state: AgentChatState
     public let encoder: InputEncoder?
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     @State private var isModelHovered: Bool = false
     @State private var isThinkingHovered: Bool = false
     @State private var isHelpHovered: Bool = false
 
     public var body: some View {
+        let _ = frameVersion
         HStack(spacing: 8) {
             // Status indicator
             Circle()

--- a/macos/Sources/Views/Agent/AgentChatView.swift
+++ b/macos/Sources/Views/Agent/AgentChatView.swift
@@ -26,6 +26,7 @@ public struct AgentChatView: View {
     }
     public let state: AgentChatState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let isInsertMode: Bool
     public let encoder: InputEncoder?
     /// Cell dimensions from the Metal renderer, used to size the prompt gap.
@@ -40,6 +41,7 @@ public struct AgentChatView: View {
     private var shouldAutoScroll: Bool { !userHasScrolledUp }
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 0) {
             // Header bar
             AgentChatHeaderView(state: state, encoder: encoder)

--- a/macos/Sources/Views/Agent/AgentContextBar.swift
+++ b/macos/Sources/Views/Agent/AgentContextBar.swift
@@ -13,6 +13,7 @@ public struct AgentContextBar: View {
     }
     public let state: AgentContextBarState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     private let barHeight: CGFloat = 28
@@ -22,6 +23,7 @@ public struct AgentContextBar: View {
     @State private var elapsedDisplay: String = "0s"
 
     public var body: some View {
+        let _ = frameVersion
         if state.visible {
             HStack(spacing: 12) {
                 // Task description (left-aligned)

--- a/macos/Sources/Views/Agent/AgentPromptView.swift
+++ b/macos/Sources/Views/Agent/AgentPromptView.swift
@@ -9,6 +9,7 @@ public struct AgentPromptView: View {
     }
     public let state: AgentChatState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let isInsertMode: Bool
     public let encoder: InputEncoder?
 
@@ -55,6 +56,7 @@ public struct AgentPromptView: View {
     }
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 0) {
             // Prompt completion popup (floats above the prompt area)
             if let completion = state.promptCompletion {

--- a/macos/Sources/Views/EditorChrome/BottomPanelView.swift
+++ b/macos/Sources/Views/EditorChrome/BottomPanelView.swift
@@ -14,6 +14,7 @@ public struct BottomPanelView: View {
     }
     public let state: BottomPanelState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
     /// Total height of the right pane (tab bar + editor + panel + status bar).
     /// Used to cap the panel at 60% of available space. Measured by the parent
@@ -30,6 +31,7 @@ public struct BottomPanelView: View {
     @State private var hoveredTabId: Int? = nil
 
     public var body: some View {
+        let _ = frameVersion
         let maxH = availableHeight * maxHeightFraction
         let panelH = min(max(state.userHeight, minHeight), maxH)
 

--- a/macos/Sources/Views/EditorChrome/BreadcrumbBar.swift
+++ b/macos/Sources/Views/EditorChrome/BreadcrumbBar.swift
@@ -30,11 +30,13 @@ public struct BreadcrumbBar: View {
     }
     public let state: BreadcrumbState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     private let barHeight: CGFloat = 26
 
     public var body: some View {
+        let _ = frameVersion
         if !state.segments.isEmpty {
             HStack(spacing: 0) {
                 // Path segments with chevron separators

--- a/macos/Sources/Views/EditorChrome/EmptyStateView.swift
+++ b/macos/Sources/Views/EditorChrome/EmptyStateView.swift
@@ -18,6 +18,7 @@ public struct EmptyStateView: View {
 
     public let state: EmptyStateState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     @Environment(\.accessibilityReduceMotion) private var reduceMotion
     public let encoder: InputEncoder?
 
@@ -32,6 +33,7 @@ public struct EmptyStateView: View {
     private let nerdFont = "Symbols Nerd Font Mono"
 
     public var body: some View {
+        let _ = frameVersion
         ZStack {
             // Solid backdrop so the hidden Metal surface never shows through.
             theme.editorBg

--- a/macos/Sources/Views/EditorChrome/SearchToolbar.swift
+++ b/macos/Sources/Views/EditorChrome/SearchToolbar.swift
@@ -19,6 +19,7 @@ public struct SearchToolbar: View {
     }
     public let searchState: SearchState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: (any InputEncoder)?
 
     @State private var searchText: String = ""
@@ -44,6 +45,7 @@ public struct SearchToolbar: View {
     }
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 0) {
             // Top border
             Rectangle()

--- a/macos/Sources/Views/EditorChrome/StatusBarView.swift
+++ b/macos/Sources/Views/EditorChrome/StatusBarView.swift
@@ -46,6 +46,7 @@ public struct StatusBarView: View {
     public let state: StatusBarState
     public var feedbackState: FeedbackState?
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
     public var isFileTreeVisible: Bool = false
     public var isGitStatusVisible: Bool = false
@@ -60,6 +61,7 @@ public struct StatusBarView: View {
     private let maxCenterStatusWidth: CGFloat = 320
 
     public var body: some View {
+        let _ = frameVersion
         GeometryReader { proxy in
             let layout = modelineLayout(totalWidth: proxy.size.width)
 

--- a/macos/Sources/Views/EditorChrome/TabBarView.swift
+++ b/macos/Sources/Views/EditorChrome/TabBarView.swift
@@ -40,6 +40,7 @@ public struct TabBarView: View {
     }
     public let tabBarState: TabBarState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     @State private var hoverTabId: UInt32?
@@ -55,10 +56,11 @@ public struct TabBarView: View {
     private let swipeThreshold: CGFloat = 80
 
     public var body: some View {
+        let _ = frameVersion
         // Collapse the whole strip when there are no tabs (e.g. the launchpad
         // empty state). Otherwise the nav/new-tab/split controls render a
         // phantom bar over an editor with nothing open.
-        if displayTabs.isEmpty {
+        if tabBarState.displayTabs.isEmpty {
             EmptyView()
         } else {
             tabStrip
@@ -174,10 +176,6 @@ public struct TabBarView: View {
         )
     }
 
-    private var displayTabs: [TabEntry] {
-        tabBarState.displayTabs
-    }
-
     public func performTabContextMenuAction(_ action: TabContextMenuAction, for tab: TabEntry) {
         switch action {
         case .pin:
@@ -211,7 +209,7 @@ public struct TabBarView: View {
     /// Flat tab strip (no workspaces active, Tier 0).
     @ViewBuilder
     private var flatTabStrip: some View {
-        let tabs = displayTabs
+        let tabs = tabBarState.displayTabs
         let pinnedCount = tabs.filter(\.isPinned).count
 
         ForEach(Array(tabs.enumerated()), id: \.element.id) { index, tab in
@@ -538,7 +536,7 @@ public struct TabBarView: View {
     /// Group 0 (manual) always comes first; agent workspaces sorted by id.
     /// Within each group, tab order is preserved from the BEAM's tab list.
     private func groupedTabs() -> [TabGroup] {
-        Dictionary(grouping: displayTabs, by: \.groupId)
+        Dictionary(grouping: tabBarState.displayTabs, by: \.groupId)
             .sorted { $0.key < $1.key }
             .map { TabGroup(groupId: $0.key, tabs: $0.value) }
     }

--- a/macos/Sources/Views/EditorChrome/WorkspaceHeaderView.swift
+++ b/macos/Sources/Views/EditorChrome/WorkspaceHeaderView.swift
@@ -8,6 +8,7 @@ public struct WorkspaceHeaderView: View {
     }
     public let workspaceState: WorkspaceState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     @State private var isRenaming = false
@@ -18,6 +19,7 @@ public struct WorkspaceHeaderView: View {
     private let rowHeight: CGFloat = 26
 
     public var body: some View {
+        let _ = frameVersion
         HStack(spacing: 8) {
             if let activeWorkspace = workspaceState.activeWorkspace {
                 activeWorkspacePill(activeWorkspace)

--- a/macos/Sources/Views/Extensions/ExtensionOverlayView.swift
+++ b/macos/Sources/Views/Extensions/ExtensionOverlayView.swift
@@ -27,8 +27,10 @@ public struct ExtensionOverlayView: View {
     public var firstColumn: UInt16 = 0
     public var columnCount: UInt16 = 0
     public var rowCount: UInt16 = 0
+    @Environment(\.guiFrameVersion) private var frameVersion
 
     public var body: some View {
+        let _ = frameVersion
         let entries = overlayState.entries(forWindow: windowID).filter {
             ExtensionOverlayState.isVisible(
                 $0,

--- a/macos/Sources/Views/Extensions/ToolManagerView.swift
+++ b/macos/Sources/Views/Extensions/ToolManagerView.swift
@@ -15,6 +15,7 @@ public struct ToolManagerView: View {
     }
     public let state: ToolManagerState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     private let panelWidth: CGFloat = 680
@@ -29,6 +30,7 @@ public struct ToolManagerView: View {
     }
 
     public var body: some View {
+        let _ = frameVersion
         if state.visible {
             ZStack {
                 // Dimmed background scrim

--- a/macos/Sources/Views/Overlays/CompletionOverlay.swift
+++ b/macos/Sources/Views/Overlays/CompletionOverlay.swift
@@ -14,6 +14,7 @@ public struct CompletionOverlay: View {
     }
     public let state: CompletionState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     @Environment(\.anchoredOverlayContext) private var overlayContext
     public let encoder: InputEncoder?
 
@@ -26,6 +27,7 @@ public struct CompletionOverlay: View {
     private let docPaneMaxHeight: CGFloat = 160
 
     public var body: some View {
+        let _ = frameVersion
         if state.visible && !state.items.isEmpty {
             VStack(spacing: 0) {
                 ScrollViewReader { proxy in

--- a/macos/Sources/Views/Overlays/FloatPopupOverlay.swift
+++ b/macos/Sources/Views/Overlays/FloatPopupOverlay.swift
@@ -14,6 +14,7 @@ public struct FloatPopupOverlay: View {
     }
     public let state: FloatPopupState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let cellWidth: CGFloat
     public let cellHeight: CGFloat
 
@@ -34,6 +35,7 @@ public struct FloatPopupOverlay: View {
     }
 
     public var body: some View {
+        let _ = frameVersion
         if state.visible && !state.lines.isEmpty {
             VStack(spacing: 0) {
                 // Title bar

--- a/macos/Sources/Views/Overlays/HoverPopupOverlay.swift
+++ b/macos/Sources/Views/Overlays/HoverPopupOverlay.swift
@@ -15,6 +15,7 @@ public struct HoverPopupOverlay: View {
     }
     public let state: HoverPopupState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     @Environment(\.anchoredOverlayContext) private var overlayContext
     public let encoder: InputEncoder?
 
@@ -25,6 +26,7 @@ public struct HoverPopupOverlay: View {
     }
 
     public var body: some View {
+        let _ = frameVersion
         if state.visible && !state.lines.isEmpty {
             popupContent
                 .frame(maxWidth: maxWidth)

--- a/macos/Sources/Views/Overlays/MessagesContentView.swift
+++ b/macos/Sources/Views/Overlays/MessagesContentView.swift
@@ -19,6 +19,7 @@ public struct MessagesContentView: View {
     }
     @Bindable public var state: MessagesContentState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
     /// Snapshot-only: render the list as a plain, non-lazy stack so every row
     /// lays out for capture. The live lazy ScrollView path renders blank in the
@@ -26,6 +27,7 @@ public struct MessagesContentView: View {
     public var usesPreviewEagerLayout: Bool = false
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 0) {
             MessagesFilterBar(state: state)
             entryList
@@ -123,8 +125,10 @@ public struct MessagesContentView: View {
 private struct MessagesFilterBar: View {
     @Bindable var state: MessagesContentState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
 
     var body: some View {
+        let _ = frameVersion
         HStack(spacing: Spacing.sm) {
             levelDots
             subsystemMenu

--- a/macos/Sources/Views/Overlays/MinibufferView.swift
+++ b/macos/Sources/Views/Overlays/MinibufferView.swift
@@ -18,6 +18,7 @@ public struct MinibufferView: View {
     }
     public let state: MinibufferState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     @Environment(\.colorSchemeContrast) private var colorSchemeContrast
     public let encoder: InputEncoder?
 
@@ -28,6 +29,7 @@ public struct MinibufferView: View {
     private let maxCandidateCount: Int = 15
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 0) {
             // Candidate list (expands upward above the input bar)
             if state.hasCandidates {

--- a/macos/Sources/Views/Overlays/NotificationCenterView.swift
+++ b/macos/Sources/Views/Overlays/NotificationCenterView.swift
@@ -12,10 +12,12 @@ public struct NotificationCenterView: View {
     }
     public let state: NotificationCenterState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
     public let bottomInset: CGFloat
 
     public var body: some View {
+        let _ = frameVersion
         VStack(alignment: .trailing, spacing: 10) {
             ForEach(state.notifications) { notification in
                 NotificationCard(notification: notification, encoder: encoder)

--- a/macos/Sources/Views/Overlays/PickerOverlay.swift
+++ b/macos/Sources/Views/Overlays/PickerOverlay.swift
@@ -14,6 +14,7 @@ public struct PickerOverlay: View {
     }
     public let state: PickerState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     private let panelWidth: CGFloat = 600
@@ -26,6 +27,7 @@ public struct PickerOverlay: View {
     }
 
     public var body: some View {
+        let _ = frameVersion
         if state.visible {
             GeometryReader { geo in
                 VStack(spacing: 0) {

--- a/macos/Sources/Views/Overlays/ProtocolErrorOverlay.swift
+++ b/macos/Sources/Views/Overlays/ProtocolErrorOverlay.swift
@@ -13,8 +13,10 @@ public struct ProtocolErrorOverlay: View {
     }
     public var state: ProtocolErrorState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
 
     public var body: some View {
+        let _ = frameVersion
         if let message = state.message {
             ZStack {
                 theme.editorBg

--- a/macos/Sources/Views/Overlays/ResyncOverlay.swift
+++ b/macos/Sources/Views/Overlays/ResyncOverlay.swift
@@ -17,9 +17,11 @@ public struct ResyncOverlay: View {
     public var state: ResyncState
     public var onRetry: ((UInt32, UInt32) -> Void)?
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     @State private var retryVisible = false
 
     public var body: some View {
+        let _ = frameVersion
         if state.pending {
             VStack {
                 Spacer()

--- a/macos/Sources/Views/Overlays/SignatureHelpOverlay.swift
+++ b/macos/Sources/Views/Overlays/SignatureHelpOverlay.swift
@@ -13,11 +13,13 @@ public struct SignatureHelpOverlay: View {
     }
     public let state: SignatureHelpState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     @Environment(\.anchoredOverlayContext) private var overlayContext
 
     private let maxWidth: CGFloat = 600
 
     public var body: some View {
+        let _ = frameVersion
         if state.visible && !state.signatures.isEmpty {
             VStack(alignment: .leading, spacing: 4) {
                 signatureLabel

--- a/macos/Sources/Views/Overlays/WhichKeyOverlay.swift
+++ b/macos/Sources/Views/Overlays/WhichKeyOverlay.swift
@@ -13,6 +13,7 @@ public struct WhichKeyOverlay: View {
     }
     public let state: WhichKeyState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
 
     private let columnWidth: CGFloat = 220
     private let rowHeight: CGFloat = 22
@@ -25,6 +26,7 @@ public struct WhichKeyOverlay: View {
     }
 
     public var body: some View {
+        let _ = frameVersion
         if state.visible && !state.bindings.isEmpty {
             VStack(spacing: 0) {
                 // Prefix header

--- a/macos/Sources/Views/Shared/EditTimelineView.swift
+++ b/macos/Sources/Views/Shared/EditTimelineView.swift
@@ -7,9 +7,11 @@ public struct EditTimelineView: View {
     }
     public let state: EditTimelineState
     @Environment(\.themeColors) private var themeColors
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     public var body: some View {
+        let _ = frameVersion
         if state.visible && !state.files.isEmpty {
             HStack(spacing: 8) {
                 ForEach(state.files) { file in

--- a/macos/Sources/Views/Shared/GUIFrameStore.swift
+++ b/macos/Sources/Views/Shared/GUIFrameStore.swift
@@ -1,4 +1,5 @@
 import Observation
+import SwiftUI
 
 /// Consumer regions invalidated by one atomic GUI publication.
 public struct GUIFrameImpact: OptionSet, Sendable, Equatable, Hashable {
@@ -41,6 +42,18 @@ public struct GUIFrameVersion: Equatable, Sendable {
         self.revision = revision
         self.lastCommitted = lastCommitted
         self.source = source
+    }
+}
+
+private struct GUIFrameVersionEnvironmentKey: EnvironmentKey {
+    static let defaultValue = GUIFrameVersion(revision: 0, lastCommitted: nil, source: .local)
+}
+
+extension EnvironmentValues {
+    /// Focused publication version for the nearest shell, editor, or overlay host.
+    public var guiFrameVersion: GUIFrameVersion {
+        get { self[GUIFrameVersionEnvironmentKey.self] }
+        set { self[GUIFrameVersionEnvironmentKey.self] = newValue }
     }
 }
 

--- a/macos/Sources/Views/Sidebar/ActivityBar.swift
+++ b/macos/Sources/Views/Sidebar/ActivityBar.swift
@@ -14,12 +14,14 @@ public struct ActivityBar: View {
     public let input: ShellHostInput
     public let sidebarHostState: SidebarHostState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     private let width: CGFloat = 32
     private let buttonSize: CGFloat = 28
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 4) {
             ForEach(sidebarHostState.visibleSidebars) { item in
                 activityButton(for: item)

--- a/macos/Sources/Views/Sidebar/ChangeSummarySidebarView.swift
+++ b/macos/Sources/Views/Sidebar/ChangeSummarySidebarView.swift
@@ -10,12 +10,14 @@ public struct ChangeSummarySidebarView: View {
     public let encoder: InputEncoder?
     @Binding public var width: CGFloat
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
 
     @State private var minWidth: CGFloat = 200
     @State private var maxWidth: CGFloat = 400
     @State private var isDraggingResize: Bool = false
 
     public var body: some View {
+        let _ = frameVersion
         HStack(spacing: 0) {
             VStack(spacing: 0) {
                 ChangeSummaryView(

--- a/macos/Sources/Views/Sidebar/ChangeSummaryView.swift
+++ b/macos/Sources/Views/Sidebar/ChangeSummaryView.swift
@@ -16,9 +16,11 @@ public struct ChangeSummaryView: View {
     }
     public let state: ChangeSummaryState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 0) {
             // Header
             HStack(spacing: 8) {

--- a/macos/Sources/Views/Sidebar/FileTreeHeaderView.swift
+++ b/macos/Sources/Views/Sidebar/FileTreeHeaderView.swift
@@ -15,6 +15,7 @@ public struct FileTreeHeaderView: View {
     }
     public let fileTreeState: FileTreeState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
     public let branchName: String
     public let leadingPadding: CGFloat
@@ -28,6 +29,7 @@ public struct FileTreeHeaderView: View {
     }
 
     public var body: some View {
+        let _ = frameVersion
         HStack(spacing: 8) {
             projectContext
                 .layoutPriority(2)

--- a/macos/Sources/Views/Sidebar/FileTreeView.swift
+++ b/macos/Sources/Views/Sidebar/FileTreeView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 public struct FileTreeView: View {
     public let fileTreeState: FileTreeState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
     public let usesPreviewEagerLayout: Bool
 
@@ -62,6 +63,7 @@ public struct FileTreeView: View {
     }
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 0) {
             entryList
         }

--- a/macos/Sources/Views/Sidebar/GitStatusHeaderView.swift
+++ b/macos/Sources/Views/Sidebar/GitStatusHeaderView.swift
@@ -13,10 +13,12 @@ public struct GitStatusHeaderView: View {
     }
     public let state: GitStatusState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let projectName: String
     public let leadingPadding: CGFloat
 
     public var body: some View {
+        let _ = frameVersion
         HStack(spacing: 6) {
             Text("\u{F0256}")
                 .font(.custom("Symbols Nerd Font Mono", size: 12))

--- a/macos/Sources/Views/Sidebar/GitStatusView.swift
+++ b/macos/Sources/Views/Sidebar/GitStatusView.swift
@@ -9,6 +9,7 @@ import SwiftUI
 public struct GitStatusView: View {
     public let state: GitStatusState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
     public let usesPreviewEagerLayout: Bool
 
@@ -39,6 +40,7 @@ public struct GitStatusView: View {
     @State private var fileToDiscard: GitStatusEntry? = nil
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 0) {
             // Toast banner
             if let toast = state.toastMessage {

--- a/macos/Sources/Views/Sidebar/NativeSidebarRegistry.swift
+++ b/macos/Sources/Views/Sidebar/NativeSidebarRegistry.swift
@@ -144,9 +144,11 @@ private struct ObservatorySidebarHeader: View {
     let item: SidebarItem
     let state: ObservatoryState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     let leadingPadding: CGFloat
 
     var body: some View {
+        let _ = frameVersion
         HStack(spacing: 8) {
             Image(systemName: item.icon.isEmpty ? "network" : item.icon)
                 .font(.system(size: 13, weight: .semibold))

--- a/macos/Sources/Views/Sidebar/ObservatoryView.swift
+++ b/macos/Sources/Views/Sidebar/ObservatoryView.swift
@@ -9,6 +9,7 @@ public struct ObservatoryView: View {
     }
     public let state: ObservatoryState
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     @State private var expandedNodeIds: Set<String> = []
@@ -16,6 +17,7 @@ public struct ObservatoryView: View {
     @State private var hasInitializedExpansion = false
 
     public var body: some View {
+        let _ = frameVersion
         VStack(spacing: 0) {
             header
             Divider().overlay(theme.treeSeparatorFg.opacity(0.4))

--- a/macos/Sources/Views/Sidebar/SidebarContainer.swift
+++ b/macos/Sources/Views/Sidebar/SidebarContainer.swift
@@ -45,6 +45,7 @@ public struct SidebarContainer: View {
     public let input: ShellHostInput
     public let activeSidebar: SidebarItem
     @Environment(\.themeColors) private var theme
+    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
     public let projectName: String
     public let gitBranch: String
@@ -55,6 +56,7 @@ public struct SidebarContainer: View {
     @State private var dragStartWidth: CGFloat = 0
 
     public var body: some View {
+        let _ = frameVersion
         HStack(spacing: 0) {
             VStack(spacing: 0) {
                 NativeSidebarRegistry

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -200,6 +200,89 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.tabBarState.activeIndex == 0)
     }
 
+    @Test("canonical chrome payloads keep compatibility mirrors in presentation parity")
+    @MainActor func canonicalChromeCompatibilityParity() {
+        let (dispatcher, gui) = makeDispatcher()
+        let workspaces = [
+            Wire.WorkspaceEntry(
+                id: 7, kind: 1, status: 0, flags: 0,
+                colorR: 0x11, colorG: 0x22, colorB: 0x33,
+                tabCount: 1, draftCount: 0, conflictCount: 0,
+                runningBackgroundCount: 0, label: "Review", icon: "cpu"
+            )
+        ]
+        let workspaceTabs = [
+            Wire.WorkspaceTabEntry(
+                id: 42, workspaceId: 7, kind: 0, flags: 0,
+                pathHash: 42, tintColorRGB: 0, icon: "", label: "review.ex",
+                path: "/tmp/review.ex"
+            )
+        ]
+
+        dispatcher.applyForTesting(.guiWorkspaces(
+            version: 1,
+            activeWorkspaceId: 7,
+            mode: 1,
+            flags: 0,
+            workspaces: workspaces,
+            visibleTabs: workspaceTabs
+        ))
+        dispatcher.applyForTesting(.guiSidebars(
+            version: 1,
+            activeId: "file_tree",
+            sidebars: [Wire.SidebarMetadata(
+                id: "file_tree",
+                displayName: "File Tree",
+                semanticKind: "file_tree",
+                icon: "folder",
+                order: 10,
+                visible: true,
+                focused: true,
+                preferredWidth: 30,
+                badgeCount: nil
+            )]
+        ))
+        dispatcher.applyForTesting(.guiFileTree(
+            version: 1,
+            treeFlags: 0x03,
+            treeState: FileTreeVisibilityState.ready.rawValue,
+            selectedId: "",
+            treeWidth: 30,
+            rootPath: "/tmp",
+            errorReason: "",
+            entries: []
+        ))
+        dispatcher.applyForTesting(.guiStatusBar(StatusBarUpdate(
+            contentKind: 0, mode: 0, cursorLine: 1, cursorCol: 1, lineCount: 1,
+            flags: 0x02, lspStatus: 0, gitBranch: "feature/publication",
+            message: "", filetype: "elixir", errorCount: 0, warningCount: 0,
+            modelName: "", messageCount: 0, sessionStatus: 0, infoCount: 0,
+            hintCount: 0, macroRecording: 0, parserStatus: 0, agentStatus: 0,
+            gitAdded: 0, gitModified: 0, gitDeleted: 0, icon: "",
+            iconColorR: 0, iconColorG: 0, iconColorB: 0, filename: "",
+            diagnosticHint: "", backgroundSubagentCount: 0,
+            backgroundSubagentLabel: ""
+        )))
+        dispatcher.applyForTesting(.guiGitStatus(
+            repoState: 0,
+            syncing: false,
+            ahead: 0,
+            behind: 0,
+            branchName: "feature/publication",
+            entries: [],
+            toast: nil,
+            entryBasePath: "/tmp",
+            lastCommitMessage: "",
+            stashCount: 0
+        ))
+
+        #expect(gui.workspaceState.activeWorkspaceId == gui.tabBarState.activeWorkspaceId)
+        #expect(gui.workspaceState.visibleTabs.map(\.id) == gui.tabBarState.displayTabs.map(\.id))
+        #expect(gui.sidebarHostState.activeSidebar?.semanticKind == "file_tree")
+        #expect(gui.fileTreeState.visible)
+        #expect(gui.statusBarState.gitBranch == gui.gitStatusState.branchName)
+    }
+
     @Test("guiObservatory updates observatoryState")
     @MainActor func guiObservatoryRouting() throws {
         let (dispatcher, gui) = makeDispatcher()

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -213,12 +213,18 @@ struct CommandDispatcherRoutingTests {
         ]
         let workspaceTabs = [
             Wire.WorkspaceTabEntry(
-                id: 42, workspaceId: 7, kind: 0, flags: 0,
-                pathHash: 42, tintColorRGB: 0, icon: "", label: "review.ex",
+                id: 41, workspaceId: 7, kind: 0, flags: 0x0023,
+                pathHash: 41, tintColorRGB: 0x112233, icon: "file-code", label: "first.ex",
+                path: "/tmp/first.ex"
+            ),
+            Wire.WorkspaceTabEntry(
+                id: 42, workspaceId: 7, kind: 0, flags: 0x0040,
+                pathHash: 42, tintColorRGB: 0, icon: "file", label: "review.ex",
                 path: "/tmp/review.ex"
-            )
+            ),
         ]
 
+        dispatcher.applyForTesting(.guiTabBar(activeIndex: 1, tabs: []))
         dispatcher.applyForTesting(.guiWorkspaces(
             version: 1,
             activeWorkspaceId: 7,
@@ -276,11 +282,33 @@ struct CommandDispatcherRoutingTests {
             stashCount: 0
         ))
 
-        #expect(gui.workspaceState.activeWorkspaceId == gui.tabBarState.activeWorkspaceId)
-        #expect(gui.workspaceState.visibleTabs.map(\.id) == gui.tabBarState.displayTabs.map(\.id))
+        #expect(gui.workspaceState.activeWorkspaceId == 7)
+        #expect(gui.tabBarState.activeWorkspaceId == 7)
+        #expect(gui.workspaceState.visibleTabs.map(\.id) == [41, 42])
+        #expect(gui.tabBarState.workspaceTabs.map(\.id) == [41, 42])
+        #expect(gui.workspaceState.visibleTabs.map(\.workspaceId) == [7, 7])
+        #expect(gui.tabBarState.workspaceTabs.map(\.workspaceId) == [7, 7])
+        #expect(gui.workspaceState.visibleTabs.map(\.label) == ["first.ex", "review.ex"])
+        #expect(gui.tabBarState.workspaceTabs.map(\.label) == ["first.ex", "review.ex"])
+        #expect(gui.workspaceState.visibleTabs.map(\.path) == ["/tmp/first.ex", "/tmp/review.ex"])
+        #expect(gui.tabBarState.workspaceTabs.map(\.path) == ["/tmp/first.ex", "/tmp/review.ex"])
+        #expect(gui.workspaceState.visibleTabs.map(\.flags) == [0x0023, 0x0040])
+        #expect(gui.tabBarState.workspaceTabs.map(\.flags) == [0x0023, 0x0040])
+
+        let displayedTabs = gui.tabBarState.displayTabs
+        #expect(displayedTabs.map(\.id) == [41, 42])
+        #expect(displayedTabs.map(\.label) == ["first.ex", "review.ex"])
+        #expect(displayedTabs.map(\.groupId) == [7, 7])
+        #expect(displayedTabs.map(\.isActive) == [false, true])
+        #expect(displayedTabs.map(\.isDirty) == [true, false])
+        #expect(displayedTabs.map(\.hasAttention) == [true, false])
+        #expect(displayedTabs.map(\.isPinned) == [true, false])
+        #expect(displayedTabs.map(\.isEphemeral) == [false, true])
+
         #expect(gui.sidebarHostState.activeSidebar?.semanticKind == "file_tree")
         #expect(gui.fileTreeState.visible)
-        #expect(gui.statusBarState.gitBranch == gui.gitStatusState.branchName)
+        #expect(gui.statusBarState.gitBranch == "feature/publication")
+        #expect(gui.gitStatusState.branchName == "feature/publication")
     }
 
     @Test("guiObservatory updates observatoryState")

--- a/macos/Tests/MingaTests/ContentViewTests.swift
+++ b/macos/Tests/MingaTests/ContentViewTests.swift
@@ -165,6 +165,62 @@ struct ContentViewTests {
 
         #expect(strings.contains("canonical.ex"))
         #expect(!strings.contains("legacy.ex"))
+        #expect((try? root.inspect().find(viewWithAccessibilityIdentifier: "workspace-tabbar")) != nil)
+
+        gui.tabBarState.updateWorkspaces(
+            activeWorkspaceId: 7,
+            mode: 1,
+            flags: 0,
+            entries: [],
+            visibleTabs: []
+        )
+        let canonicalEmptyRoot = ContentView(
+            gui: gui,
+            encoder: { nil },
+            editorGeometry: { .preview },
+            chrome: .preview,
+            onAgentChatVisibleChange: { _ in }
+        ) {
+            Color.clear
+        }
+        let canonicalEmptyStrings = try canonicalEmptyRoot.inspect()
+            .findAll(ViewType.Text.self)
+            .compactMap { try? $0.string() }
+
+        #expect(!canonicalEmptyStrings.contains("legacy.ex"))
+        #expect((try? canonicalEmptyRoot.inspect().find(viewWithAccessibilityIdentifier: "workspace-tabbar")) == nil)
+
+        let legacyOnlyGUI = GUIState()
+        legacyOnlyGUI.tabBarState.update(activeIndex: 0, entries: [
+            Wire.TabEntry(
+                id: 9,
+                groupId: 0,
+                isActive: true,
+                isDirty: false,
+                isAgent: false,
+                hasAttention: false,
+                agentStatus: 0,
+                isPinned: false,
+                tintColorRGB: 0,
+                icon: "",
+                label: "fallback.ex"
+            )
+        ])
+        let legacyOnlyRoot = ContentView(
+            gui: legacyOnlyGUI,
+            encoder: { nil },
+            editorGeometry: { .preview },
+            chrome: .preview,
+            onAgentChatVisibleChange: { _ in }
+        ) {
+            Color.clear
+        }
+        let legacyOnlyStrings = try legacyOnlyRoot.inspect()
+            .findAll(ViewType.Text.self)
+            .compactMap { try? $0.string() }
+
+        #expect(legacyOnlyStrings.contains("fallback.ex"))
+        #expect((try? legacyOnlyRoot.inspect().find(viewWithAccessibilityIdentifier: "workspace-tabbar")) != nil)
     }
 
     @Test(

--- a/macos/Tests/MingaTests/ContentViewTests.swift
+++ b/macos/Tests/MingaTests/ContentViewTests.swift
@@ -4,6 +4,7 @@ import MingaProtocol
 @testable import MingaUI
 import SwiftUI
 import Testing
+import ViewInspector
 
 @MainActor
 private final class MountedEditorRecorder {
@@ -99,6 +100,71 @@ struct ContentViewTests {
         #expect(view.encoder === first)
         current = second
         #expect(view.encoder === second)
+    }
+
+    @Test("toolbar mounting and rendering use canonical display tabs over legacy tabs")
+    func canonicalDisplayTabsMountToolbar() throws {
+        let gui = GUIState()
+        gui.tabBarState.update(activeIndex: 0, entries: [
+            Wire.TabEntry(
+                id: 1,
+                groupId: 0,
+                isActive: true,
+                isDirty: false,
+                isAgent: false,
+                hasAttention: false,
+                agentStatus: 0,
+                isPinned: false,
+                tintColorRGB: 0,
+                icon: "",
+                label: "legacy.ex"
+            )
+        ])
+        gui.tabBarState.updateWorkspaces(
+            activeWorkspaceId: 7,
+            mode: 1,
+            flags: 0,
+            entries: [Wire.WorkspaceEntry(
+                id: 7,
+                kind: 1,
+                status: 0,
+                flags: 0,
+                colorR: 0x11,
+                colorG: 0x22,
+                colorB: 0x33,
+                tabCount: 1,
+                draftCount: 0,
+                conflictCount: 0,
+                runningBackgroundCount: 0,
+                label: "Review",
+                icon: "cpu"
+            )],
+            visibleTabs: [Wire.WorkspaceTabEntry(
+                id: 42,
+                workspaceId: 7,
+                kind: 0,
+                flags: 0,
+                pathHash: 42,
+                tintColorRGB: 0,
+                icon: "",
+                label: "canonical.ex",
+                path: "/tmp/canonical.ex"
+            )]
+        )
+        let root = ContentView(
+            gui: gui,
+            encoder: { nil },
+            editorGeometry: { .preview },
+            chrome: .preview,
+            onAgentChatVisibleChange: { _ in }
+        ) {
+            Color.clear
+        }
+
+        let strings = try root.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+
+        #expect(strings.contains("canonical.ex"))
+        #expect(!strings.contains("legacy.ex"))
     }
 
     @Test(

--- a/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
@@ -22,6 +22,7 @@ private final class FrameProbeRecorder {
     }
 
     private var entries: [ContentViewFrameProbePoint: Entry] = [:]
+    private var presentationSnapshots: [String] = []
     private let updates: AsyncStream<ContentViewFrameProbePoint>
     private let continuation: AsyncStream<ContentViewFrameProbePoint>.Continuation
 
@@ -37,6 +38,7 @@ private final class FrameProbeRecorder {
     func record(
         point: ContentViewFrameProbePoint,
         stateObject: AnyObject,
+        presentationSnapshot: String,
         view: FrameProbeNSView
     ) {
         let prior = entries[point]
@@ -47,6 +49,7 @@ private final class FrameProbeRecorder {
             updateCount: (prior?.updateCount ?? 0) + 1,
             stateObjectIDs: stateObjectIDs
         )
+        presentationSnapshots.append(presentationSnapshot)
         continuation.yield(point)
     }
 
@@ -60,6 +63,10 @@ private final class FrameProbeRecorder {
 
     func stateObjectIDs(for point: ContentViewFrameProbePoint) -> Set<ObjectIdentifier> {
         entries[point]?.stateObjectIDs ?? []
+    }
+
+    func snapshots() -> [String] {
+        presentationSnapshots
     }
 
     func waitForValue(_ value: String, point: ContentViewFrameProbePoint) async {
@@ -78,6 +85,7 @@ private final class FrameProbeRecorder {
 private struct FrameProbeRepresentable: NSViewRepresentable {
     let point: ContentViewFrameProbePoint
     let value: String
+    let presentationSnapshot: String
     let stateObject: AnyObject
     let swiftUILocalIdentity: UUID
     let recorder: FrameProbeRecorder
@@ -95,7 +103,55 @@ private struct FrameProbeRepresentable: NSViewRepresentable {
     private func update(_ view: FrameProbeNSView) {
         view.publishedValue = value
         view.swiftUILocalIdentity = swiftUILocalIdentity
-        recorder.record(point: point, stateObject: stateObject, view: view)
+        recorder.record(
+            point: point,
+            stateObject: stateObject,
+            presentationSnapshot: presentationSnapshot,
+            view: view
+        )
+    }
+}
+
+@MainActor
+private func productionPresentationSnapshot(_ gui: GUIState) -> String {
+    let tabs = gui.tabBarState.displayTabs.map { tab in
+        "\(tab.id):\(tab.label):\(tab.isActive)"
+    }.joined(separator: ",")
+    let editor = gui.windowContents.values
+        .sorted { $0.windowId < $1.windowId }
+        .flatMap(\.rows)
+        .map(\.text)
+        .joined(separator: "\n")
+    let selectedFile = gui.fileTreeState.entries
+        .first(where: \.isSelected)?
+        .name ?? ""
+    let overlays = [
+        gui.emptyStateState.sections.flatMap(\.items).map(\.label).joined(separator: ","),
+        gui.completionState.items.map(\.label).joined(separator: ","),
+        gui.extensionOverlayState.entries.map(\.content).joined(separator: ","),
+        gui.pickerState.items.map(\.label).joined(separator: ","),
+    ].joined(separator: "|")
+    return "\(tabs)|\(editor)|\(selectedFile)|\(overlays)"
+}
+
+private struct ProductionEditorSurface: View {
+    let gui: GUIState
+    let recorder: FrameProbeRecorder
+    @State private var localIdentity = UUID()
+
+    var body: some View {
+        FrameProbeRepresentable(
+            point: .editor,
+            value: gui.windowContents.values
+                .sorted { $0.windowId < $1.windowId }
+                .flatMap(\.rows)
+                .map(\.text)
+                .joined(separator: "\n"),
+            presentationSnapshot: productionPresentationSnapshot(gui),
+            stateObject: gui,
+            swiftUILocalIdentity: localIdentity,
+            recorder: recorder
+        )
     }
 }
 
@@ -104,18 +160,21 @@ private struct ProductionFrameProbe: View {
     let gui: GUIState
     let stateObject: AnyObject
     let recorder: FrameProbeRecorder
-    @Environment(\.guiFrameVersion) private var frameVersion
     @State private var localIdentity = UUID()
 
     var body: some View {
-        let _ = frameVersion
         FrameProbeRepresentable(
             point: point,
             value: publishedValue,
+            presentationSnapshot: presentationSnapshot,
             stateObject: stateObject,
             swiftUILocalIdentity: localIdentity,
             recorder: recorder
         )
+    }
+
+    private var presentationSnapshot: String {
+        productionPresentationSnapshot(gui)
     }
 
     private var publishedValue: String {
@@ -204,6 +263,7 @@ struct GUIFrameSwiftUIInvalidationTests {
         await waitForValues(baseline, recorder: recorder)
         hostingView.layoutSubtreeIfNeeded()
         await Task.yield()
+        let baselinePresentation = productionPresentationSnapshot(gui)
 
         let shellInput = gui.shellInput
         let editorInput = gui.editorInput
@@ -274,25 +334,32 @@ struct GUIFrameSwiftUIInvalidationTests {
         hostingView.layoutSubtreeIfNeeded()
         await Task.yield()
 
-        var counts = updateCounts(recorder)
+        let committedPresentation = productionPresentationSnapshot(gui)
+        let coherentSnapshots = Set([baselinePresentation, committedPresentation])
+        #expect(recorder.snapshots().allSatisfy { coherentSnapshots.contains($0) })
+
         gui.frameStore.publishLocal(impact: .shell) {
             gui.tabBarState.update(activeIndex: 0, entries: [Self.tab(label: "local.ex")])
         }
         await recorder.waitForValue("local.ex", point: .shell)
         hostingView.layoutSubtreeIfNeeded()
         await Task.yield()
-        expectOnly([.shell], changedSince: counts, recorder: recorder)
+        expectValues(
+            ("local.ex", committed.editor, committed.editorOverlay, committed.extensionOverlay, committed.windowOverlay),
+            recorder: recorder
+        )
 
-        counts = updateCounts(recorder)
         gui.frameStore.publishLocal(impact: .editor) {
             Self.updateEmptyState(gui, label: "Local launchpad")
         }
         await recorder.waitForValue("Local launchpad", point: .editor)
         hostingView.layoutSubtreeIfNeeded()
         await Task.yield()
-        expectOnly([.editor], changedSince: counts, recorder: recorder)
+        expectValues(
+            ("local.ex", "Local launchpad", committed.editorOverlay, committed.extensionOverlay, committed.windowOverlay),
+            recorder: recorder
+        )
 
-        counts = updateCounts(recorder)
         gui.frameStore.publishLocal(impact: .editorOverlay) {
             Self.updateCompletion(gui, label: "localCompletion")
             gui.extensionOverlayState.update([Self.extensionOverlay(content: "localExtension")])
@@ -301,16 +368,21 @@ struct GUIFrameSwiftUIInvalidationTests {
         await recorder.waitForValue("localExtension", point: .extensionOverlay)
         hostingView.layoutSubtreeIfNeeded()
         await Task.yield()
-        expectOnly([.editorOverlay, .extensionOverlay], changedSince: counts, recorder: recorder)
+        expectValues(
+            ("local.ex", "Local launchpad", "localCompletion", "localExtension", committed.windowOverlay),
+            recorder: recorder
+        )
 
-        counts = updateCounts(recorder)
         gui.frameStore.publishLocal(impact: .windowOverlay) {
             Self.updatePicker(gui, label: "localPicker")
         }
         await recorder.waitForValue("localPicker", point: .windowOverlay)
         hostingView.layoutSubtreeIfNeeded()
         await Task.yield()
-        expectOnly([.windowOverlay], changedSince: counts, recorder: recorder)
+        expectValues(
+            ("local.ex", "Local launchpad", "localCompletion", "localExtension", "localPicker"),
+            recorder: recorder
+        )
 
         #expect(gui.shellInput === shellInput)
         #expect(gui.editorInput === editorInput)
@@ -325,6 +397,173 @@ struct GUIFrameSwiftUIInvalidationTests {
             #expect(recorder.stateObjectIDs(for: point) == [ObjectIdentifier(expectedStateObject)])
         }
         #expect(window.firstResponder === shellView)
+    }
+
+    @Test(
+        "persistent ContentView keeps canonical tabs, editor content, and file tree selection coherent",
+        .timeLimit(.minutes(1))
+    )
+    func persistentContentViewPublishesCanonicalPresentationCoherently() async throws {
+        let gui = GUIState()
+        let dispatcher = CommandDispatcher(cols: 80, rows: 24, guiState: gui)
+        try publishCanonicalFrame(
+            dispatcher,
+            frameSeq: 1,
+            baseFrameSeq: 0,
+            tabs: [Self.workspaceTab(id: 1, label: "old.ex", path: "/tmp/old.ex")],
+            activeIndex: 0,
+            editorText: "old editor content",
+            selectedFile: "old.ex"
+        )
+
+        let recorder = FrameProbeRecorder()
+        let root = ContentView(
+            gui: gui,
+            encoder: { nil },
+            editorGeometry: { .preview },
+            chrome: .preview,
+            onAgentChatVisibleChange: { _ in },
+            frameProbe: ContentViewFrameProbe { point, stateObject in
+                AnyView(ProductionFrameProbe(
+                    point: point,
+                    gui: gui,
+                    stateObject: stateObject,
+                    recorder: recorder
+                ))
+            }
+        ) {
+            ProductionEditorSurface(gui: gui, recorder: recorder)
+        }
+
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let hostingView = NSHostingView(rootView: root)
+        hostingView.frame = frame
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
+        defer { window.contentView = nil }
+        hostingView.layoutSubtreeIfNeeded()
+
+        await recorder.waitForValue("old.ex", point: .shell)
+        await recorder.waitForValue("old editor content", point: .editor)
+        let baseline = productionPresentationSnapshot(gui)
+        #expect(gui.tabBarState.displayTabs.map(\.label) == ["old.ex"])
+        #expect(gui.tabBarState.displayTabs.map(\.isActive) == [true])
+        #expect(gui.fileTreeState.entries.first(where: \.isSelected)?.name == "old.ex")
+
+        let shellView = try #require(recorder.view(for: .shell))
+        shellView.nativeLocalValue = "hover-old-tab"
+
+        try publishCanonicalFrame(
+            dispatcher,
+            frameSeq: 2,
+            baseFrameSeq: 1,
+            tabs: [
+                Self.workspaceTab(id: 1, label: "old.ex", path: "/tmp/old.ex"),
+                Self.workspaceTab(id: 2, label: "new.ex", path: "/tmp/new.ex"),
+            ],
+            activeIndex: 1,
+            editorText: "new editor content",
+            selectedFile: "new.ex"
+        )
+        await recorder.waitForValue("old.ex,new.ex", point: .shell)
+        await recorder.waitForValue("new editor content", point: .editor)
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+
+        let committed = productionPresentationSnapshot(gui)
+        #expect(gui.tabBarState.displayTabs.map(\.label) == ["old.ex", "new.ex"])
+        #expect(gui.tabBarState.displayTabs.map(\.isActive) == [false, true])
+        #expect(gui.fileTreeState.entries.first(where: \.isSelected)?.name == "new.ex")
+        #expect(recorder.snapshots().allSatisfy { $0 == baseline || $0 == committed })
+        #expect(recorder.view(for: .shell) === shellView)
+        #expect(shellView.nativeLocalValue == "hover-old-tab")
+
+        try publishCanonicalFrame(
+            dispatcher,
+            frameSeq: 3,
+            baseFrameSeq: 2,
+            tabs: [
+                Self.workspaceTab(id: 1, label: "old.ex", path: "/tmp/old.ex"),
+                Self.workspaceTab(id: 2, label: "new.ex", path: "/tmp/new.ex"),
+            ],
+            activeIndex: 0,
+            editorText: "old editor content reopened",
+            selectedFile: "old.ex"
+        )
+        await recorder.waitForValue("old editor content reopened", point: .editor)
+
+        #expect(gui.tabBarState.displayTabs.count == 2)
+        #expect(gui.tabBarState.displayTabs.map(\.label) == ["old.ex", "new.ex"])
+        #expect(gui.tabBarState.displayTabs.map(\.isActive) == [true, false])
+        #expect(gui.fileTreeState.entries.first(where: \.isSelected)?.name == "old.ex")
+        #expect(recorder.view(for: .shell) === shellView)
+        #expect(shellView.nativeLocalValue == "hover-old-tab")
+    }
+
+    private func publishCanonicalFrame(
+        _ dispatcher: CommandDispatcher,
+        frameSeq: UInt32,
+        baseFrameSeq: UInt32,
+        tabs: [Wire.WorkspaceTabEntry],
+        activeIndex: UInt8,
+        editorText: String,
+        selectedFile: String
+    ) throws {
+        dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: 1))
+        if baseFrameSeq == 0 {
+            dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        }
+        dispatcher.dispatch(.guiTabBar(activeIndex: activeIndex, tabs: []))
+        dispatcher.dispatch(.guiWorkspaces(
+            version: UInt8(clamping: frameSeq),
+            activeWorkspaceId: 0,
+            mode: 0,
+            flags: 0,
+            workspaces: [],
+            visibleTabs: tabs
+        ))
+        dispatcher.dispatch(.guiSidebars(
+            version: UInt8(clamping: frameSeq),
+            activeId: "file_tree",
+            sidebars: [Wire.SidebarMetadata(
+                id: "file_tree",
+                displayName: "File Tree",
+                semanticKind: "file_tree",
+                icon: "folder",
+                order: 0,
+                visible: true,
+                focused: true,
+                preferredWidth: 30,
+                badgeCount: nil
+            )]
+        ))
+        dispatcher.dispatch(.guiFileTree(
+            version: UInt8(clamping: frameSeq),
+            treeFlags: 0x03,
+            treeState: FileTreeVisibilityState.ready.rawValue,
+            selectedId: selectedFile,
+            treeWidth: 30,
+            rootPath: "/tmp",
+            errorReason: "",
+            entries: tabs.enumerated().map { index, tab in
+                Self.fileTreeEntry(
+                    index: index,
+                    id: tab.label,
+                    path: tab.path,
+                    selected: tab.label == selectedFile
+                )
+            }
+        ))
+        dispatcher.dispatch(.guiWindowContent(data: try Self.windowContent(
+            text: editorText,
+            epoch: frameSeq
+        )))
+        dispatcher.dispatch(.commitFrame(frameSeq: frameSeq, seq: 0))
     }
 
     private func publishFrame(
@@ -386,20 +625,6 @@ struct GUIFrameSwiftUIInvalidationTests {
     ) {
         for point in points {
             #expect(recorder.updateCount(for: point) == expected[point])
-        }
-    }
-
-    private func expectOnly(
-        _ changed: Set<ContentViewFrameProbePoint>,
-        changedSince prior: [ContentViewFrameProbePoint: Int],
-        recorder: FrameProbeRecorder
-    ) {
-        for point in points {
-            if changed.contains(point) {
-                #expect(recorder.updateCount(for: point) > (prior[point] ?? 0))
-            } else {
-                #expect(recorder.updateCount(for: point) == prior[point])
-            }
         }
     }
 
@@ -514,6 +739,89 @@ struct GUIFrameSwiftUIInvalidationTests {
             colorB: 50,
             opacity: 255,
             content: content
+        )
+    }
+
+    private static func workspaceTab(id: UInt32, label: String, path: String) -> Wire.WorkspaceTabEntry {
+        Wire.WorkspaceTabEntry(
+            id: id,
+            workspaceId: 0,
+            kind: 0,
+            flags: 0,
+            pathHash: id,
+            tintColorRGB: 0,
+            icon: "",
+            label: label,
+            path: path
+        )
+    }
+
+    private static func fileTreeEntry(
+        index: Int,
+        id: String,
+        path: String,
+        selected: Bool
+    ) -> Wire.FileTreeEntry {
+        Wire.FileTreeEntry(
+            pathHash: UInt32(index + 1),
+            id: id,
+            path: path,
+            isDir: false,
+            isExpanded: false,
+            isSelected: selected,
+            isFocused: selected,
+            isActive: selected,
+            isDirty: false,
+            isEditing: false,
+            isLastChild: index > 0,
+            depth: 0,
+            gitStatus: 0,
+            diagnosticErrorCount: 0,
+            diagnosticWarningCount: 0,
+            diagnosticInfoCount: 0,
+            diagnosticHintCount: 0,
+            guides: [],
+            icon: "",
+            iconColorR: 0,
+            iconColorG: 0,
+            iconColorB: 0,
+            name: id,
+            relPath: id,
+            editingType: 0xFF,
+            editingText: ""
+        )
+    }
+
+    private static func windowContent(text: String, epoch: UInt32) throws -> GUIWindowContent {
+        let span = GUIHighlightSpan(
+            startCol: 0,
+            endCol: UInt16(clamping: text.count),
+            fg: 0xFFFFFF,
+            bg: 0,
+            attrs: 0,
+            fontWeight: 0,
+            fontId: 0
+        )
+        let row = GUIVisualRow(
+            rowType: .normal,
+            rowId: UInt64(epoch),
+            bufLine: 0,
+            contentHash: epoch,
+            text: text,
+            spans: [span]
+        )
+        return try GUIWindowContent(
+            windowId: 1,
+            fullRefresh: true,
+            contentEpoch: epoch,
+            cursorRow: 0,
+            cursorCol: 0,
+            cursorShape: .block,
+            rows: [row],
+            selection: nil,
+            searchMatches: [],
+            diagnosticUnderlines: [],
+            documentHighlights: []
         )
     }
 

--- a/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
@@ -1,0 +1,535 @@
+import AppKit
+import MingaProtocol
+@testable import MingaUI
+import SwiftUI
+import Testing
+
+@MainActor
+private final class FrameProbeNSView: NSView {
+    var publishedValue = ""
+    var swiftUILocalIdentity = UUID()
+    var nativeLocalValue = ""
+
+    override var acceptsFirstResponder: Bool { true }
+}
+
+@MainActor
+private final class FrameProbeRecorder {
+    struct Entry {
+        weak var view: FrameProbeNSView?
+        var updateCount: Int
+        var stateObjectIDs: Set<ObjectIdentifier>
+    }
+
+    private var entries: [ContentViewFrameProbePoint: Entry] = [:]
+    private let updates: AsyncStream<ContentViewFrameProbePoint>
+    private let continuation: AsyncStream<ContentViewFrameProbePoint>.Continuation
+
+    init() {
+        let stream = AsyncStream.makeStream(
+            of: ContentViewFrameProbePoint.self,
+            bufferingPolicy: .bufferingNewest(32)
+        )
+        updates = stream.stream
+        continuation = stream.continuation
+    }
+
+    func record(
+        point: ContentViewFrameProbePoint,
+        stateObject: AnyObject,
+        view: FrameProbeNSView
+    ) {
+        let prior = entries[point]
+        var stateObjectIDs = prior?.stateObjectIDs ?? []
+        stateObjectIDs.insert(ObjectIdentifier(stateObject))
+        entries[point] = Entry(
+            view: view,
+            updateCount: (prior?.updateCount ?? 0) + 1,
+            stateObjectIDs: stateObjectIDs
+        )
+        continuation.yield(point)
+    }
+
+    func view(for point: ContentViewFrameProbePoint) -> FrameProbeNSView? {
+        entries[point]?.view
+    }
+
+    func updateCount(for point: ContentViewFrameProbePoint) -> Int {
+        entries[point]?.updateCount ?? 0
+    }
+
+    func stateObjectIDs(for point: ContentViewFrameProbePoint) -> Set<ObjectIdentifier> {
+        entries[point]?.stateObjectIDs ?? []
+    }
+
+    func waitForValue(_ value: String, point: ContentViewFrameProbePoint) async {
+        if view(for: point)?.publishedValue == value {
+            return
+        }
+
+        for await updatedPoint in updates where updatedPoint == point {
+            if view(for: point)?.publishedValue == value {
+                return
+            }
+        }
+    }
+}
+
+private struct FrameProbeRepresentable: NSViewRepresentable {
+    let point: ContentViewFrameProbePoint
+    let value: String
+    let stateObject: AnyObject
+    let swiftUILocalIdentity: UUID
+    let recorder: FrameProbeRecorder
+
+    func makeNSView(context: Context) -> FrameProbeNSView {
+        let view = FrameProbeNSView(frame: .zero)
+        update(view)
+        return view
+    }
+
+    func updateNSView(_ nsView: FrameProbeNSView, context: Context) {
+        update(nsView)
+    }
+
+    private func update(_ view: FrameProbeNSView) {
+        view.publishedValue = value
+        view.swiftUILocalIdentity = swiftUILocalIdentity
+        recorder.record(point: point, stateObject: stateObject, view: view)
+    }
+}
+
+private struct ProductionFrameProbe: View {
+    let point: ContentViewFrameProbePoint
+    let gui: GUIState
+    let stateObject: AnyObject
+    let recorder: FrameProbeRecorder
+    @Environment(\.guiFrameVersion) private var frameVersion
+    @State private var localIdentity = UUID()
+
+    var body: some View {
+        let _ = frameVersion
+        FrameProbeRepresentable(
+            point: point,
+            value: publishedValue,
+            stateObject: stateObject,
+            swiftUILocalIdentity: localIdentity,
+            recorder: recorder
+        )
+    }
+
+    private var publishedValue: String {
+        switch point {
+        case .shell:
+            gui.tabBarState.displayTabs.map(\.label).joined(separator: ",")
+        case .editor:
+            gui.emptyStateState.sections.flatMap(\.items).map(\.label).joined(separator: ",")
+        case .editorOverlay:
+            gui.completionState.items.map(\.label).joined(separator: ",")
+        case .extensionOverlay:
+            gui.extensionOverlayState.entries.map(\.content).joined(separator: ",")
+        case .windowOverlay:
+            gui.pickerState.items.map(\.label).joined(separator: ",")
+        }
+    }
+}
+
+@Suite("Persistent SwiftUI GUI frame invalidation")
+@MainActor
+struct GUIFrameSwiftUIInvalidationTests {
+    private typealias Labels = (
+        shell: String,
+        editor: String,
+        editorOverlay: String,
+        extensionOverlay: String,
+        windowOverlay: String
+    )
+
+    private let points: [ContentViewFrameProbePoint] = [
+        .shell,
+        .editor,
+        .editorOverlay,
+        .extensionOverlay,
+        .windowOverlay,
+    ]
+
+    @Test(
+        "ContentView production hosts publish only committed or focused domain changes",
+        .timeLimit(.minutes(1))
+    )
+    func contentViewProductionHostsFollowAtomicPublication() async throws {
+        let gui = GUIState()
+        let dispatcher = CommandDispatcher(cols: 80, rows: 24, guiState: gui)
+        let baseline: Labels = (
+            "before.ex",
+            "Before launchpad",
+            "beforeCompletion",
+            "beforeExtension",
+            "beforePicker"
+        )
+        publishFrame(dispatcher, frameSeq: 1, baseFrameSeq: 0, labels: baseline)
+
+        let recorder = FrameProbeRecorder()
+        let root = ContentView(
+            gui: gui,
+            encoder: { nil },
+            editorGeometry: { .preview },
+            chrome: .preview,
+            onAgentChatVisibleChange: { _ in },
+            frameProbe: ContentViewFrameProbe { point, stateObject in
+                AnyView(ProductionFrameProbe(
+                    point: point,
+                    gui: gui,
+                    stateObject: stateObject,
+                    recorder: recorder
+                ))
+            }
+        ) {
+            Color.clear
+        }
+
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let hostingView = NSHostingView(rootView: root)
+        hostingView.frame = frame
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
+        defer { window.contentView = nil }
+        hostingView.layoutSubtreeIfNeeded()
+
+        await waitForValues(baseline, recorder: recorder)
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+
+        let shellInput = gui.shellInput
+        let editorInput = gui.editorInput
+        let editorOverlayInput = gui.editorOverlayInput
+        let windowOverlayInput = gui.windowOverlayInput
+        let expectedStateObjects: [ContentViewFrameProbePoint: AnyObject] = [
+            .shell: gui.tabBarState,
+            .editor: gui.emptyStateState,
+            .editorOverlay: gui.completionState,
+            .extensionOverlay: gui.extensionOverlayState,
+            .windowOverlay: gui.pickerState,
+        ]
+        let originalViews = try Dictionary(uniqueKeysWithValues: points.map { point in
+            (point, try #require(recorder.view(for: point)))
+        })
+        let originalSwiftUIIdentities = originalViews.mapValues(\.swiftUILocalIdentity)
+        for (index, point) in points.enumerated() {
+            originalViews[point]?.nativeLocalValue = "native-local-\(index)"
+            let expectedStateObject = try #require(expectedStateObjects[point])
+            #expect(recorder.stateObjectIDs(for: point) == [ObjectIdentifier(expectedStateObject)])
+        }
+        let shellView = try #require(originalViews[.shell])
+        #expect(window.makeFirstResponder(shellView))
+
+        let countsBeforeStaging = updateCounts(recorder)
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
+        stageDomainCommands(
+            dispatcher,
+            labels: (
+                "staged.ex",
+                "Staged launchpad",
+                "stagedCompletion",
+                "stagedExtension",
+                "stagedPicker"
+            )
+        )
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        expectValues(baseline, recorder: recorder)
+        expectUnchangedCounts(countsBeforeStaging, recorder: recorder)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 1, generation: 1))
+        stageDomainCommands(
+            dispatcher,
+            labels: (
+                "rejected.ex",
+                "Rejected launchpad",
+                "rejectedCompletion",
+                "rejectedExtension",
+                "rejectedPicker"
+            )
+        )
+        dispatcher.dispatch(.commitFrame(frameSeq: 99, seq: 0))
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        expectValues(baseline, recorder: recorder)
+        expectUnchangedCounts(countsBeforeStaging, recorder: recorder)
+
+        let committed: Labels = (
+            "after.ex",
+            "After launchpad",
+            "afterCompletion",
+            "afterExtension",
+            "afterPicker"
+        )
+        publishFrame(dispatcher, frameSeq: 4, baseFrameSeq: 0, labels: committed)
+        await waitForValues(committed, recorder: recorder)
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+
+        var counts = updateCounts(recorder)
+        gui.frameStore.publishLocal(impact: .shell) {
+            gui.tabBarState.update(activeIndex: 0, entries: [Self.tab(label: "local.ex")])
+        }
+        await recorder.waitForValue("local.ex", point: .shell)
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        expectOnly([.shell], changedSince: counts, recorder: recorder)
+
+        counts = updateCounts(recorder)
+        gui.frameStore.publishLocal(impact: .editor) {
+            Self.updateEmptyState(gui, label: "Local launchpad")
+        }
+        await recorder.waitForValue("Local launchpad", point: .editor)
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        expectOnly([.editor], changedSince: counts, recorder: recorder)
+
+        counts = updateCounts(recorder)
+        gui.frameStore.publishLocal(impact: .editorOverlay) {
+            Self.updateCompletion(gui, label: "localCompletion")
+            gui.extensionOverlayState.update([Self.extensionOverlay(content: "localExtension")])
+        }
+        await recorder.waitForValue("localCompletion", point: .editorOverlay)
+        await recorder.waitForValue("localExtension", point: .extensionOverlay)
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        expectOnly([.editorOverlay, .extensionOverlay], changedSince: counts, recorder: recorder)
+
+        counts = updateCounts(recorder)
+        gui.frameStore.publishLocal(impact: .windowOverlay) {
+            Self.updatePicker(gui, label: "localPicker")
+        }
+        await recorder.waitForValue("localPicker", point: .windowOverlay)
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        expectOnly([.windowOverlay], changedSince: counts, recorder: recorder)
+
+        #expect(gui.shellInput === shellInput)
+        #expect(gui.editorInput === editorInput)
+        #expect(gui.editorOverlayInput === editorOverlayInput)
+        #expect(gui.windowOverlayInput === windowOverlayInput)
+        for (index, point) in points.enumerated() {
+            let updatedView = try #require(recorder.view(for: point))
+            let expectedStateObject = try #require(expectedStateObjects[point])
+            #expect(updatedView === originalViews[point])
+            #expect(updatedView.swiftUILocalIdentity == originalSwiftUIIdentities[point])
+            #expect(updatedView.nativeLocalValue == "native-local-\(index)")
+            #expect(recorder.stateObjectIDs(for: point) == [ObjectIdentifier(expectedStateObject)])
+        }
+        #expect(window.firstResponder === shellView)
+    }
+
+    private func publishFrame(
+        _ dispatcher: CommandDispatcher,
+        frameSeq: UInt32,
+        baseFrameSeq: UInt32,
+        labels: Labels
+    ) {
+        dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: 1))
+        if baseFrameSeq == 0 {
+            dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        }
+        stageDomainCommands(dispatcher, labels: labels)
+        dispatcher.dispatch(.commitFrame(frameSeq: frameSeq, seq: 0))
+    }
+
+    private func stageDomainCommands(_ dispatcher: CommandDispatcher, labels: Labels) {
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Self.tab(label: labels.shell)]))
+        dispatcher.dispatch(Self.emptyStateCommand(label: labels.editor))
+        dispatcher.dispatch(.guiCompletion(
+            visible: true,
+            anchorRow: 0,
+            anchorCol: 0,
+            selectedIndex: 0,
+            items: [Wire.CompletionItem(kind: 1, label: labels.editorOverlay, detail: "")],
+            documentation: ""
+        ))
+        dispatcher.dispatch(.guiExtensionOverlay([
+            Self.extensionOverlay(content: labels.extensionOverlay),
+        ]))
+        dispatcher.dispatch(Self.pickerCommand(label: labels.windowOverlay))
+    }
+
+    private func waitForValues(_ labels: Labels, recorder: FrameProbeRecorder) async {
+        await recorder.waitForValue(labels.shell, point: .shell)
+        await recorder.waitForValue(labels.editor, point: .editor)
+        await recorder.waitForValue(labels.editorOverlay, point: .editorOverlay)
+        await recorder.waitForValue(labels.extensionOverlay, point: .extensionOverlay)
+        await recorder.waitForValue(labels.windowOverlay, point: .windowOverlay)
+    }
+
+    private func expectValues(_ labels: Labels, recorder: FrameProbeRecorder) {
+        #expect(recorder.view(for: .shell)?.publishedValue == labels.shell)
+        #expect(recorder.view(for: .editor)?.publishedValue == labels.editor)
+        #expect(recorder.view(for: .editorOverlay)?.publishedValue == labels.editorOverlay)
+        #expect(recorder.view(for: .extensionOverlay)?.publishedValue == labels.extensionOverlay)
+        #expect(recorder.view(for: .windowOverlay)?.publishedValue == labels.windowOverlay)
+    }
+
+    private func updateCounts(
+        _ recorder: FrameProbeRecorder
+    ) -> [ContentViewFrameProbePoint: Int] {
+        Dictionary(uniqueKeysWithValues: points.map { ($0, recorder.updateCount(for: $0)) })
+    }
+
+    private func expectUnchangedCounts(
+        _ expected: [ContentViewFrameProbePoint: Int],
+        recorder: FrameProbeRecorder
+    ) {
+        for point in points {
+            #expect(recorder.updateCount(for: point) == expected[point])
+        }
+    }
+
+    private func expectOnly(
+        _ changed: Set<ContentViewFrameProbePoint>,
+        changedSince prior: [ContentViewFrameProbePoint: Int],
+        recorder: FrameProbeRecorder
+    ) {
+        for point in points {
+            if changed.contains(point) {
+                #expect(recorder.updateCount(for: point) > (prior[point] ?? 0))
+            } else {
+                #expect(recorder.updateCount(for: point) == prior[point])
+            }
+        }
+    }
+
+    private func completeThemeSlots() -> [(UInt8, UInt8, UInt8, UInt8)] {
+        CommandDispatcher.requiredThemeSlots.map { slot in
+            (slot, slot, slot, slot)
+        }
+    }
+
+    private static func updateEmptyState(_ gui: GUIState, label: String) {
+        gui.emptyStateState.update(
+            crashed: false,
+            version: "test",
+            focusedId: "launchpad",
+            sections: [emptyStateSection(label: label)]
+        )
+    }
+
+    private static func updateCompletion(_ gui: GUIState, label: String) {
+        gui.completionState.update(
+            visible: true,
+            anchorRow: 0,
+            anchorCol: 0,
+            selectedIndex: 0,
+            rawItems: [Wire.CompletionItem(kind: 1, label: label, detail: "")],
+            documentation: ""
+        )
+    }
+
+    private static func updatePicker(_ gui: GUIState, label: String) {
+        gui.pickerState.update(
+            visible: true,
+            selectedIndex: 0,
+            filteredCount: 1,
+            totalCount: 1,
+            markedCount: 0,
+            title: "Files",
+            query: "",
+            hasPreview: false,
+            rawItems: [pickerItem(label: label)],
+            actionMenu: nil,
+            modePrefix: "",
+            loadStatus: .ready
+        )
+    }
+
+    private static func emptyStateCommand(label: String) -> RenderCommand {
+        .guiEmptyState(
+            visible: true,
+            crashed: false,
+            version: "test",
+            focusedId: "launchpad",
+            sections: [emptyStateSection(label: label)]
+        )
+    }
+
+    private static func emptyStateSection(label: String) -> Wire.EmptyStateSection {
+        Wire.EmptyStateSection(
+            sectionId: 2,
+            title: "Start",
+            items: [Wire.EmptyStateItem(
+                kind: 2,
+                id: "launchpad",
+                label: label,
+                detail: "",
+                jumpKey: "",
+                chord: "",
+                icon: "",
+                iconColorRGB: 0
+            )]
+        )
+    }
+
+    private static func pickerCommand(label: String) -> RenderCommand {
+        .guiPicker(
+            visible: true,
+            selectedIndex: 0,
+            filteredCount: 1,
+            totalCount: 1,
+            markedCount: 0,
+            title: "Files",
+            query: "",
+            hasPreview: false,
+            items: [pickerItem(label: label)],
+            actionMenu: nil,
+            modePrefix: "",
+            loadStatus: .ready
+        )
+    }
+
+    private static func pickerItem(label: String) -> Wire.PickerItem {
+        Wire.PickerItem(
+            iconColor: 0,
+            flags: 0,
+            label: label,
+            description: "",
+            annotation: "",
+            matchPositions: []
+        )
+    }
+
+    private static func extensionOverlay(content: String) -> Wire.ExtensionOverlayEntry {
+        Wire.ExtensionOverlayEntry(
+            extensionName: "frame-test",
+            overlayID: "cursor",
+            windowID: 1,
+            row: 0,
+            col: 0,
+            shape: 2,
+            colorR: 200,
+            colorG: 100,
+            colorB: 50,
+            opacity: 255,
+            content: content
+        )
+    }
+
+    private static func tab(label: String) -> Wire.TabEntry {
+        Wire.TabEntry(
+            id: 1,
+            groupId: 0,
+            isActive: true,
+            isDirty: false,
+            isAgent: false,
+            hasAttention: false,
+            agentStatus: 0,
+            isPinned: false,
+            tintColorRGB: 0,
+            icon: "",
+            label: label
+        )
+    }
+}

--- a/test/minga/buffer/dirty_flag_property_test.exs
+++ b/test/minga/buffer/dirty_flag_property_test.exs
@@ -12,25 +12,28 @@ defmodule Minga.Buffer.DirtyFlagPropertyTest do
     check all(
             operations <- StreamData.list_of(operation_generator(), min_length: 1, max_length: 40)
           ) do
-      path = Path.join(dir, "dirty-property-#{System.unique_integer([:positive])}.txt")
+      case_id = System.unique_integer([:positive])
+      child_id = {BufferProcess, case_id}
+      path = Path.join(dir, "dirty-property-#{case_id}.txt")
       File.write!(path, "start")
 
-      buffer =
-        start_supervised!({BufferProcess, file_path: path},
-          id: {BufferProcess, System.unique_integer([:positive])}
-        )
+      buffer = start_supervised!({BufferProcess, file_path: path}, id: child_id)
 
-      initial = %{id: 0, content: "start", cursor: 0}
-      model = %{current: initial, saved_id: 0, undo: [], redo: [], next_id: 1}
+      try do
+        initial = %{id: 0, content: "start", cursor: 0}
+        model = %{current: initial, saved_id: 0, undo: [], redo: [], next_id: 1}
 
-      Enum.reduce(operations, model, fn operation, model ->
-        model = apply_operation(buffer, operation, model)
+        Enum.reduce(operations, model, fn operation, model ->
+          model = apply_operation(buffer, operation, model)
 
-        assert BufferProcess.content(buffer) == model.current.content
-        assert BufferProcess.dirty?(buffer) == (model.current.id != model.saved_id)
+          assert BufferProcess.content(buffer) == model.current.content
+          assert BufferProcess.dirty?(buffer) == (model.current.id != model.saved_id)
 
-        model
-      end)
+          model
+        end)
+      after
+        :ok = stop_supervised(child_id)
+      end
     end
   end
 

--- a/test/minga_editor/lsp_actions/references_test.exs
+++ b/test/minga_editor/lsp_actions/references_test.exs
@@ -6,7 +6,9 @@ defmodule MingaEditor.LspActions.ReferencesTest do
   alias MingaEditor.LspActions
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.OperationFeedback
+  alias MingaEditor.UI.Picker.LocationSource
   alias MingaEditor.Viewport
 
   test "error, nil, and empty responses finish the same correlated operation" do
@@ -35,7 +37,7 @@ defmodule MingaEditor.LspActions.ReferencesTest do
 
     File.write!(path, "first\nsecond\n")
     on_exit(fn -> File.rm(path) end)
-    {state, operation} = start_operation()
+    {state, operation} = start_operation(Path.dirname(path))
 
     locations = [location(path, 0), location(path, 1)]
     state = LspActions.handle_references_response(state, {:ok, locations}, operation.id)
@@ -43,6 +45,16 @@ defmodule MingaEditor.LspActions.ReferencesTest do
     assert OperationFeedback.selected(state.operation_feedback).status == :success
     assert OperationFeedback.selected(state.operation_feedback).message == "Found 2 references"
     assert state.shell_runtime.state.notice.message == nil
+
+    assert {:picker, %{picker_ui: %{source: LocationSource, picker: picker}}} =
+             state.shell_runtime.state.modal
+
+    assert Enum.map(picker.items, & &1.id) == [{path, 0, 0}, {path, 1, 0}]
+
+    assert Enum.map(picker.items, & &1.label) == [
+             "#{Path.basename(path)}:1:1",
+             "#{Path.basename(path)}:2:1"
+           ]
   end
 
   test "a response for a replaced identity cannot mutate feedback or perform picker effects" do
@@ -86,12 +98,12 @@ defmodule MingaEditor.LspActions.ReferencesTest do
     }
   end
 
-  @spec start_operation() :: {EditorState.t(), MingaEditor.State.Operation.t()}
-  defp start_operation do
-    state = %EditorState{
-      port_manager: nil,
-      workspace: %SessionState{viewport: Viewport.new(40, 120)}
-    }
+  @spec start_operation(String.t() | nil) ::
+          {EditorState.t(), MingaEditor.State.Operation.t()}
+  defp start_operation(project_root \\ nil) do
+    workspace = %SessionState{viewport: Viewport.new(40, 120)}
+    workspace = with_project_root(workspace, project_root)
+    state = %EditorState{port_manager: nil, workspace: workspace}
 
     OperationFeedback.start_in(
       state,
@@ -100,5 +112,13 @@ defmodule MingaEditor.LspActions.ReferencesTest do
       "Finding references...",
       cancelable?: false
     )
+  end
+
+  @spec with_project_root(SessionState.t(), String.t() | nil) :: SessionState.t()
+  defp with_project_root(workspace, nil), do: workspace
+
+  defp with_project_root(workspace, root) do
+    file_tree = FileTreeState.set_project_root(%FileTreeState{}, root)
+    SessionState.set_file_tree(workspace, file_tree)
   end
 end

--- a/test/minga_editor/render_model/ui/chrome_builders_parity_test.exs
+++ b/test/minga_editor/render_model/ui/chrome_builders_parity_test.exs
@@ -1,0 +1,69 @@
+defmodule MingaEditor.RenderModel.UI.ChromeBuildersParityTest do
+  use ExUnit.Case, async: true
+
+  @moduletag :tmp_dir
+
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.RenderModel.UI.TabBarBuilder
+  alias MingaEditor.RenderModel.UI.WorkspacesBuilder
+  alias MingaEditor.Session.ChromeState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
+  alias MingaEditor.State.TabBar
+
+  test "tab bar and workspaces preserve the same committed chrome tab projection", %{
+    tmp_dir: tmp_dir
+  } do
+    first = file_tab(1, "first.ex", Path.join(tmp_dir, "first.ex"))
+    second = file_tab(2, "second.ex", Path.join(tmp_dir, "second.ex"))
+    tab_bar = %TabBar{tabs: [first, second], active_id: 2, next_id: 3}
+    ctx = context(tab_bar)
+    committed = ChromeState.from_editor_state(ctx)
+
+    tab_bar_model = TabBarBuilder.build(ctx)
+    workspaces_model = WorkspacesBuilder.build(ctx)
+
+    assert Enum.map(tab_bar_model.tabs, & &1.id) == Enum.map(committed.visible_tabs, & &1.id)
+
+    assert Enum.map(workspaces_model.visible_tabs, & &1.id) ==
+             Enum.map(committed.visible_tabs, & &1.id)
+
+    assert Enum.map(tab_bar_model.tabs, & &1.workspace_id) ==
+             Enum.map(workspaces_model.visible_tabs, & &1.workspace_id)
+
+    assert Enum.map(tab_bar_model.tabs, & &1.label) ==
+             Enum.map(workspaces_model.visible_tabs, & &1.label)
+
+    assert tab_bar_model.active_tab_id == committed.active_tab_id
+    assert workspaces_model.active_workspace_id == committed.active_workspace_id
+  end
+
+  defp file_tab(id, label, path) do
+    File.write!(path, "")
+    buffer = start_supervised!({BufferProcess, file_path: path}, id: make_ref())
+    context = TabContext.from_workspace_map(%{buffers: %Buffers{active: buffer, list: [buffer]}})
+
+    id
+    |> Tab.new_file(label)
+    |> Tab.set_context(context)
+  end
+
+  defp context(tab_bar) do
+    %MingaEditor.Frontend.Emit.Context{
+      port_manager: self(),
+      capabilities: MingaEditor.Frontend.Capabilities.default(),
+      theme: MingaEditor.UI.Theme.get!(:doom_one),
+      font_registry: MingaEditor.UI.FontRegistry.new(),
+      windows: %MingaEditor.State.Windows{map: %{}, active: 1},
+      layout: %MingaEditor.Layout{
+        terminal: {0, 0, 80, 24},
+        editor_area: {0, 0, 80, 24},
+        minibuffer: {23, 0, 80, 1},
+        window_layouts: %{}
+      },
+      shell: MingaEditor.Shell.Traditional,
+      shell_state: %{tab_bar: tab_bar}
+    }
+  end
+end

--- a/test/minga_editor/render_model/ui/chrome_builders_parity_test.exs
+++ b/test/minga_editor/render_model/ui/chrome_builders_parity_test.exs
@@ -15,38 +15,126 @@ defmodule MingaEditor.RenderModel.UI.ChromeBuildersParityTest do
   test "tab bar and workspaces preserve the same committed chrome tab projection", %{
     tmp_dir: tmp_dir
   } do
-    first = file_tab(1, "first.ex", Path.join(tmp_dir, "first.ex"))
+    first = file_tab(1, "first.ex", Path.join(tmp_dir, "first.ex"), dirty?: true, pinned?: true)
     second = file_tab(2, "second.ex", Path.join(tmp_dir, "second.ex"))
-    tab_bar = %TabBar{tabs: [first, second], active_id: 2, next_id: 3}
+
+    agent =
+      3
+      |> Tab.new_agent("Agent Review")
+      |> Tab.set_group(1)
+      |> Tab.set_attention(true)
+
+    first = Tab.set_group(first, 1)
+    second = Tab.set_group(second, 1)
+    seed = TabBar.new(first, tmp_dir)
+    {seed, workspace} = TabBar.add_workspace(seed, "Review")
+
+    tab_bar = %TabBar{
+      seed
+      | tabs: [first, second, agent],
+        active_id: 2,
+        next_id: 4
+    }
+
     ctx = context(tab_bar)
     committed = ChromeState.from_editor_state(ctx)
-
     tab_bar_model = TabBarBuilder.build(ctx)
     workspaces_model = WorkspacesBuilder.build(ctx)
 
-    assert Enum.map(tab_bar_model.tabs, & &1.id) == Enum.map(committed.visible_tabs, & &1.id)
+    assert workspace.id == 1
+    assert committed.active_tab_id == 2
+    assert committed.active_workspace_id == 1
+    assert Enum.map(committed.visible_tabs, & &1.id) == [3, 1, 2]
 
-    assert Enum.map(workspaces_model.visible_tabs, & &1.id) ==
-             Enum.map(committed.visible_tabs, & &1.id)
+    assert Enum.map(tab_bar_model.tabs, &tab_projection/1) == [
+             %{
+               id: 3,
+               workspace_id: 1,
+               label: "Agent Review",
+               kind: :agent,
+               dirty?: false,
+               attention?: true,
+               pinned?: false
+             },
+             %{
+               id: 1,
+               workspace_id: 1,
+               label: "first.ex",
+               kind: :file,
+               dirty?: true,
+               attention?: false,
+               pinned?: true
+             },
+             %{
+               id: 2,
+               workspace_id: 1,
+               label: "second.ex",
+               kind: :file,
+               dirty?: false,
+               attention?: false,
+               pinned?: false
+             }
+           ]
 
-    assert Enum.map(tab_bar_model.tabs, & &1.workspace_id) ==
-             Enum.map(workspaces_model.visible_tabs, & &1.workspace_id)
+    assert Enum.map(workspaces_model.visible_tabs, &workspace_tab_projection/1) == [
+             %{
+               id: 3,
+               workspace_id: 1,
+               label: "Agent Review",
+               path: nil,
+               kind: :agent,
+               dirty?: false,
+               attention?: true,
+               pinned?: false
+             },
+             %{
+               id: 1,
+               workspace_id: 1,
+               label: "first.ex",
+               path: Path.join(tmp_dir, "first.ex"),
+               kind: :file,
+               dirty?: true,
+               attention?: false,
+               pinned?: true
+             },
+             %{
+               id: 2,
+               workspace_id: 1,
+               label: "second.ex",
+               path: Path.join(tmp_dir, "second.ex"),
+               kind: :file,
+               dirty?: false,
+               attention?: false,
+               pinned?: false
+             }
+           ]
 
-    assert Enum.map(tab_bar_model.tabs, & &1.label) ==
-             Enum.map(workspaces_model.visible_tabs, & &1.label)
-
-    assert tab_bar_model.active_tab_id == committed.active_tab_id
-    assert workspaces_model.active_workspace_id == committed.active_workspace_id
+    assert tab_bar_model.active_tab_id == 2
+    assert workspaces_model.active_workspace_id == 1
   end
 
-  defp file_tab(id, label, path) do
+  defp file_tab(id, label, path, opts \\ []) do
     File.write!(path, "")
     buffer = start_supervised!({BufferProcess, file_path: path}, id: make_ref())
+
+    if opts[:dirty?] do
+      :ok = BufferProcess.insert_char(buffer, "x")
+    end
+
     context = TabContext.from_workspace_map(%{buffers: %Buffers{active: buffer, list: [buffer]}})
 
     id
     |> Tab.new_file(label)
     |> Tab.set_context(context)
+    |> Tab.set_pinned(opts[:pinned?] || false)
+  end
+
+  defp tab_projection(tab) do
+    Map.take(tab, [:id, :workspace_id, :label, :kind, :dirty?, :attention?, :pinned?])
+  end
+
+  defp workspace_tab_projection(tab) do
+    Map.take(tab, [:id, :workspace_id, :label, :path, :kind, :dirty?, :attention?, :pinned?])
   end
 
   defp context(tab_bar) do
@@ -63,7 +151,8 @@ defmodule MingaEditor.RenderModel.UI.ChromeBuildersParityTest do
         window_layouts: %{}
       },
       shell: MingaEditor.Shell.Traditional,
-      shell_state: %{tab_bar: tab_bar}
+      shell_state: %{tab_bar: tab_bar},
+      tab_bar: tab_bar
     }
   end
 end


### PR DESCRIPTION
# TL;DR
Committed macOS frames now invalidate the SwiftUI leaves that directly read each frame domain, so FileTree navigation cannot show new editor content under a stale tab identity. The fix preserves atomic publication, focused domain updates, and native view-local state.

Closes #2894

## Context
The frame store already staged, validated, and committed editor and chrome mutations atomically. The stale tab appeared because SwiftUI host wrappers observed frame versions, but descendants received unchanged reference-type state and did not establish their own publication dependency.

## Changes
- Publish domain-scoped `GUIFrameVersion` values through the shell, editor, editor-overlay, and window-overlay host boundaries.
- Bind all 36 audited direct consumers to their matching domain version while leaving value-semantic and independently observed views unchanged.
- Keep extension overlays inside the editor-overlay publication boundary and window overlays inside their focused boundary.
- Use `TabBarState.displayTabs` for both tab-strip mounting and rendering, with canonical workspace tabs taking precedence over the legacy fallback.
- Add compatibility-mirror and BEAM `ChromeState` parity coverage for tabs, workspace identity, sidebar visibility, and Git branch presentation.
- Add persistent production `ContentView` regressions that verify staged and rejected frames remain invisible, canonical old/new tabs stay coherent with editor content and FileTree selection, reopening an existing tab does not duplicate it, and NSView, SwiftUI `@State`, host input, native local state, and first-responder identity survive.
- Make references-picker tests use their context-owned project root and release each generated dirty-flag property buffer after its case, removing shared-process contention exposed by the review validation runs.
- Remove the obsolete semantic-surface freeze guidance and stale freeze reference now that the freeze has been lifted.

No protocol schema, opcode, or frame transaction ordering changed. The long-term replacement of manual invalidation tokens with first-party Swift Observation is tracked separately in #2899.

## Verification
- `mix swift.build`
- `cd macos && xcodebuild test -scheme Minga -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO` (1,206 tests, 160 suites)
- `mix test.debug test/minga/frontend/adapter/gui/tab_bar_encoder_test.exs` (8 passed)
- `mix test.debug test/minga/frontend/adapter/gui/workspaces_encoder_test.exs` (7 passed)
- `mix test.debug test/minga_editor/render_model/ui/chrome_builders_parity_test.exs` (1 passed)
- `make lint`
- `mix test.llm` (9,345 tests, 58 doctests, 97 properties, 0 failures)

The prior `mix swift.test` ticket command no longer exists, so verification uses the current CI `xcodebuild test` command.

## Acceptance Criteria Addressed
- FileTree opens publish the matching active tab while preserving existing tab behavior ✅
- Editor content, tab identity, active state, and shell chrome publish coherently ✅
- Staged, rejected, and superseded frames remain invisible; keyframe recovery restores one committed state ✅
- Routine publication preserves native view identity and local interaction state without `.id(revision)` ✅
- Tab mounting and rendering share the canonical `displayTabs` projection ✅
- Every audited macOS frame-domain consumer has a direct committed-version dependency ✅
- Persistent production-host coverage reproduces the stable-reference invalidation failure without rebuilding the root view ✅

## Remaining Risk
Interactive FileTree hover and drag behavior was not manually exercised in a running app. Persistent host tests verify that the native view, SwiftUI local state, native local state, and first responder survive routine publication.

---
**Updated after review:** Completed the missing Git, Messages, and Observatory leaf dependencies; replaced probe-only coverage with a persistent canonical FileTree/tab/editor regression; strengthened compatibility parity; and fixed two full-suite resource-contention defects found while validating the review changes.