### PR TITLE
refactor(extension): decouple bundled Git actions

### DIFF
--- a/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
@@ -56,11 +56,31 @@ defmodule MingaGitPorcelain.Commands do
     {:handled, open_diff_for_path(state, git_root, rel_path, abs_path, current_content, opts)}
   end
 
+  def handle_editor_event(
+        state,
+        {:editor_action, :branch_delete_confirm, {git_root, name, force}}
+      )
+      when is_binary(git_root) and is_binary(name) and is_boolean(force) do
+    {:handled, execute(state, {:branch_delete_confirm, git_root, name, force})}
+  end
+
+  def handle_editor_event(state, {:editor_action, :branch_delete_cancel, nil}) do
+    {:handled, execute(state, :branch_delete_cancel)}
+  end
+
+  def handle_editor_event(state, {:editor_action, :git_accept_conflict, {choice, start_line}})
+      when choice in [:current, :incoming, :both] and is_integer(start_line) and start_line >= 0 do
+    {:handled, execute(state, {:git_accept_conflict, choice, start_line})}
+  end
+
   def handle_editor_event(state, {:editor_action, :execute_git_command, command}) do
     {:handled, execute(state, command)}
   end
 
-  def handle_editor_event(state, {:source_unload, @source}), do: {:handled, state}
+  def handle_editor_event(state, {:source_unload, @source}) do
+    {:handled, leave_branch_delete_mode(state)}
+  end
+
   def handle_editor_event(_state, _event), do: :not_matched
 
   @command_specs [
@@ -100,12 +120,37 @@ defmodule MingaGitPorcelain.Commands do
 
   @spec execute(
           state(),
-          atom() | {:git_accept_conflict, MergeConflict.choice(), non_neg_integer()}
+          atom()
+          | {:branch_delete_confirm, String.t(), String.t(), boolean()}
+          | {:git_accept_conflict, MergeConflict.choice(), non_neg_integer()}
         ) :: state()
 
   for {command_name, _description, _requires_buffer} <- @command_specs do
     @spec unquote(command_name)(state()) :: state()
     def unquote(command_name)(state), do: execute(state, unquote(command_name))
+  end
+
+  # ── Branch deletion ────────────────────────────────────────────────────────
+
+  def execute(state, {:branch_delete_confirm, git_root, name, force}) do
+    case Git.branch_delete(git_root, name, force) do
+      :ok ->
+        refresh_repo(git_root)
+        Minga.Log.info(:editor, "[git] Deleted branch: #{name}")
+
+        state
+        |> NoticeWorkflow.publish("Deleted branch #{name}")
+        |> reopen_git_branch_picker()
+
+      {:error, reason} ->
+        handle_branch_delete_error(state, git_root, name, force, reason)
+    end
+  end
+
+  def execute(state, :branch_delete_cancel) do
+    state
+    |> NoticeWorkflow.publish("Branch delete cancelled")
+    |> reopen_git_branch_picker()
   end
 
   # ── Status panel toggle ────────────────────────────────────────────────────
@@ -1688,6 +1733,51 @@ defmodule MingaGitPorcelain.Commands do
   defp get_base_lines(git_pid) do
     # Access the base_lines from the git buffer's state
     :sys.get_state(git_pid).base_lines
+  end
+
+  @spec leave_branch_delete_mode(state()) :: state()
+  defp leave_branch_delete_mode(%{workspace: %{editing: %{mode: :branch_delete_confirm}}} = state) do
+    %{state | workspace: SessionState.transition_mode(state.workspace, :normal)}
+  end
+
+  defp leave_branch_delete_mode(state), do: state
+
+  @spec reopen_git_branch_picker(state()) :: state()
+  defp reopen_git_branch_picker(state) do
+    PickerUI.open(state, MingaGitPorcelain.UI.Picker.GitBranchSource)
+  end
+
+  @spec handle_branch_delete_error(state(), String.t(), String.t(), boolean(), String.t()) ::
+          state()
+  defp handle_branch_delete_error(state, git_root, name, false, reason) do
+    if forceable_branch_delete_error?(reason) do
+      mode_state =
+        git_root
+        |> Minga.Mode.BranchDeleteConfirmState.new(name)
+        |> Minga.Mode.BranchDeleteConfirmState.to_force(reason)
+
+      state = NoticeWorkflow.publish(state, "Delete failed: #{reason}")
+
+      workspace =
+        SessionState.transition_mode(state.workspace, :branch_delete_confirm, mode_state)
+
+      %{state | workspace: workspace}
+    else
+      NoticeWorkflow.publish(state, "Delete failed: #{reason}")
+    end
+  end
+
+  defp handle_branch_delete_error(state, _git_root, _name, true, reason) do
+    NoticeWorkflow.publish(state, "Force delete failed: #{reason}")
+  end
+
+  @spec forceable_branch_delete_error?(String.t()) :: boolean()
+  defp forceable_branch_delete_error?(reason) do
+    normalized = String.downcase(reason)
+
+    String.contains?(normalized, "not fully merged") or
+      String.contains?(normalized, "unmerged") or
+      String.contains?(normalized, "not merged")
   end
 
   @spec generate_commit_message(state()) :: state()

--- a/extensions/git_porcelain/lib/minga_git_porcelain/ui/picker/git_branch_source.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/ui/picker/git_branch_source.ex
@@ -71,6 +71,11 @@ defmodule MingaGitPorcelain.UI.Picker.GitBranchSource do
   def actions(_item), do: []
 
   @impl true
+  @spec shortcut_action(Item.t(), MingaEditor.UI.Picker.Source.shortcut()) :: atom() | nil
+  def shortcut_action(%Item{id: {:branch, _name, _current?, false}}, {:ctrl, ?d}), do: :delete
+  def shortcut_action(_item, _shortcut), do: nil
+
+  @impl true
   @spec on_action(atom(), Item.t(), term()) :: term()
   def on_action(:delete, %Item{id: {:branch, _name, true, false}}, state) do
     NoticeWorkflow.publish(state, "Cannot delete current branch")

--- a/extensions/git_porcelain/test/minga_git_porcelain/commands/branch_delete_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/commands/branch_delete_test.exs
@@ -7,8 +7,11 @@ defmodule MingaGitPorcelain.CommandsBranchDeleteTest do
   alias Minga.Git
   alias Minga.Git.Stub, as: GitStub
   alias Minga.Mode.BranchDeleteConfirmState
-  alias MingaEditor.Commands
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.EffectScheduler
+  alias MingaEditor.KeyDispatch
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaGitPorcelain.Commands, as: GitCommands
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Picker
   alias MingaEditor.Viewport
@@ -25,22 +28,41 @@ defmodule MingaGitPorcelain.CommandsBranchDeleteTest do
     Minga.Project.switch(dir)
     await_project_rebuild(dir)
 
+    task_supervisor =
+      start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
+
+    scheduler =
+      start_supervised!(
+        Supervisor.child_spec(
+          {EffectScheduler, task_supervisor: task_supervisor, observer: self()},
+          id: make_ref()
+        )
+      )
+
+    :ok = EffectScheduler.attach(scheduler, self())
+
     on_exit(fn ->
       GitStub.clear(dir)
       reset_global_project!()
     end)
 
-    %{git_root: dir}
+    %{git_root: dir, scheduler: scheduler}
   end
 
   @tag :tmp_dir
-  test "successful branch delete reports success and reopens the branch picker", %{
-    git_root: git_root
+  test "confirmed branch deletion applies after the mode transition and reopens the picker", %{
+    git_root: git_root,
+    scheduler: scheduler
   } do
-    state = build_state()
+    pending =
+      git_root
+      |> state_in_delete_mode(scheduler)
+      |> KeyDispatch.handle_key(?y, 0)
 
-    result = Commands.execute(state, {:branch_delete_confirm, git_root, "feature", false})
+    assert pending.workspace.editing.mode == :normal
+    assert %Minga.Mode.State{} = pending.workspace.editing.mode_state
 
+    result = receive_effect(pending, scheduler)
     assert result.shell_runtime.state.notice.message == "Deleted branch feature"
 
     assert {:picker,
@@ -52,11 +74,35 @@ defmodule MingaGitPorcelain.CommandsBranchDeleteTest do
   end
 
   @tag :tmp_dir
+  test "cancel applies after the mode transition and reopens the picker", %{
+    git_root: git_root,
+    scheduler: scheduler
+  } do
+    pending =
+      git_root
+      |> state_in_delete_mode(scheduler)
+      |> KeyDispatch.handle_key(?n, 0)
+
+    assert pending.workspace.editing.mode == :normal
+    assert %Minga.Mode.State{} = pending.workspace.editing.mode_state
+
+    result = receive_effect(pending, scheduler)
+    assert result.shell_runtime.state.notice.message == "Branch delete cancelled"
+
+    assert {:picker,
+            %{picker_ui: %{source: MingaGitPorcelain.UI.Picker.GitBranchSource, picker: picker}}} =
+             MingaEditor.Shell.Runtime.state(result.shell_runtime).modal
+
+    assert %Picker{items: items} = picker
+    assert Enum.any?(items, fn item -> item.label == "feature" end)
+  end
+
+  @tag :tmp_dir
   test "unmerged safe-delete failure enters force confirmation", %{git_root: git_root} do
     GitStub.set_branch_delete_result(git_root, "feature", false, {:error, "not fully merged"})
     state = build_state()
 
-    result = Commands.execute(state, {:branch_delete_confirm, git_root, "feature", false})
+    result = GitCommands.execute(state, {:branch_delete_confirm, git_root, "feature", false})
 
     assert result.shell_runtime.state.notice.message == "Delete failed: not fully merged"
     assert result.workspace.editing.mode == :branch_delete_confirm
@@ -70,16 +116,49 @@ defmodule MingaGitPorcelain.CommandsBranchDeleteTest do
     GitStub.set_branch_delete_result(git_root, "feature", true, {:error, "branch not found"})
     state = build_state()
 
-    result = Commands.execute(state, {:branch_delete_confirm, git_root, "feature", true})
+    result = GitCommands.execute(state, {:branch_delete_confirm, git_root, "feature", true})
 
     assert result.shell_runtime.state.notice.message == "Force delete failed: branch not found"
   end
 
-  defp build_state do
+  @tag :tmp_dir
+  test "source unload exits branch delete confirmation" do
+    mode_state = BranchDeleteConfirmState.new("/repo", "feature")
+    state = build_state()
+    workspace = SessionState.transition_mode(state.workspace, :branch_delete_confirm, mode_state)
+
+    assert {:handled, result} =
+             MingaGitPorcelain.Commands.handle_editor_event(
+               %{state | workspace: workspace},
+               {:source_unload, {:extension, :minga_git_porcelain}}
+             )
+
+    assert result.workspace.editing.mode == :normal
+    assert %Minga.Mode.State{} = result.workspace.editing.mode_state
+  end
+
+  defp state_in_delete_mode(git_root, scheduler) do
+    mode_state = BranchDeleteConfirmState.new(git_root, "feature")
+    state = build_state(scheduler)
+    workspace = SessionState.transition_mode(state.workspace, :branch_delete_confirm, mode_state)
+    %{state | workspace: workspace}
+  end
+
+  defp build_state(scheduler \\ nil) do
     %EditorState{
+      effect_scheduler: scheduler,
       frontend: %MingaEditor.State.Frontend{port_manager: nil},
       workspace: %SessionState{viewport: Viewport.new(24, 80)}
     }
+  end
+
+  defp receive_effect(state, scheduler) do
+    assert_receive {:effect_lifecycle, %Outcome{status: :running} = running}, 2_000
+    {:noreply, state} = MingaEditor.handle_info({:effect_lifecycle, running}, state)
+
+    assert_receive {:effect_result, ^scheduler, %Outcome{} = outcome}, 2_000
+    {:noreply, state} = MingaEditor.handle_info({:effect_result, scheduler, outcome}, state)
+    state
   end
 
   defp reset_global_project! do

--- a/lib/minga/mode/branch_delete_confirm.ex
+++ b/lib/minga/mode/branch_delete_confirm.ex
@@ -17,20 +17,20 @@ defmodule Minga.Mode.BranchDeleteConfirm do
 
   def handle_key({?y, _mods}, %BranchDeleteConfirmState{phase: :delete} = state) do
     commands = [{:branch_delete_confirm, state.git_root, state.name, false}]
-    {:execute_then_transition, commands, :normal, state}
+    {:execute_then_transition, commands, :normal, Mode.initial_state()}
   end
 
   def handle_key({?y, _mods}, %BranchDeleteConfirmState{phase: :force} = state) do
     commands = [{:branch_delete_confirm, state.git_root, state.name, true}]
-    {:execute_then_transition, commands, :normal, state}
+    {:execute_then_transition, commands, :normal, Mode.initial_state()}
   end
 
-  def handle_key({?n, _mods}, %BranchDeleteConfirmState{} = state) do
-    {:execute_then_transition, [:branch_delete_cancel], :normal, state}
+  def handle_key({?n, _mods}, %BranchDeleteConfirmState{}) do
+    {:execute_then_transition, [:branch_delete_cancel], :normal, Mode.initial_state()}
   end
 
-  def handle_key({@escape, _mods}, %BranchDeleteConfirmState{} = state) do
-    {:execute_then_transition, [:branch_delete_cancel], :normal, state}
+  def handle_key({@escape, _mods}, %BranchDeleteConfirmState{}) do
+    {:execute_then_transition, [:branch_delete_cancel], :normal, Mode.initial_state()}
   end
 
   def handle_key(_key, %BranchDeleteConfirmState{} = state) do

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -26,13 +26,11 @@ defmodule MingaEditor.Commands do
 
   alias Minga.Buffer
   alias Minga.Extension.CallbackInvoker
-  alias Minga.Extension.InvocationContext
   alias MingaEditor.Extension.EventWorkflow, as: ExtensionEventWorkflow
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
   alias MingaEditor.Shell.Traditional.ToolPrompts
   alias MingaEditor.Shell.Traditional.ToolPromptWorkflow
   alias Minga.Command
-  alias Minga.Git
   alias MingaEditor.Commands.Agent, as: AgentCommands
   alias MingaEditor.Commands.BufferManagement
   alias MingaEditor.Commands.Editing, as: EditingCommands
@@ -295,27 +293,14 @@ defmodule MingaEditor.Commands do
     restore_file_tree_scope(state)
   end
 
-  # ── Branch delete confirmation commands ───────────────────────────────────
+  # ── Source-owned parameterized actions ─────────────────────────────────────
 
   def execute(state, {:branch_delete_confirm, git_root, name, force}) do
-    case Git.branch_delete(git_root, name, force) do
-      :ok ->
-        refresh_branch_delete_repo(git_root)
-        Minga.Log.info(:editor, "[git] Deleted branch: #{name}")
-
-        state
-        |> NoticeWorkflow.publish("Deleted branch #{name}")
-        |> reopen_git_branch_picker()
-
-      {:error, reason} ->
-        handle_branch_delete_error(state, git_root, name, force, reason)
-    end
+    dispatch_editor_action(state, :branch_delete_confirm, {git_root, name, force})
   end
 
   def execute(state, :branch_delete_cancel) do
-    state
-    |> NoticeWorkflow.publish("Branch delete cancelled")
-    |> reopen_git_branch_picker()
+    dispatch_editor_action(state, :branch_delete_cancel, nil)
   end
 
   # ── Agent tuple commands ──────────────────────────────────────────────────
@@ -332,8 +317,10 @@ defmodule MingaEditor.Commands do
 
   # ── Parameterized git commands ────────────────────────────────────────────
 
-  def execute(state, {:git_accept_conflict, _choice, _start_line} = cmd) do
-    guard_buffer(state, fn -> execute_git_porcelain_command(state, cmd) end)
+  def execute(state, {:git_accept_conflict, choice, start_line}) do
+    guard_buffer(state, fn ->
+      dispatch_editor_action(state, :git_accept_conflict, {choice, start_line})
+    end)
   end
 
   # ── Parameterized movement ────────────────────────────────────────────────
@@ -811,92 +798,9 @@ defmodule MingaEditor.Commands do
     end
   end
 
-  @spec reopen_git_branch_picker(state()) :: state()
-  defp reopen_git_branch_picker(state) do
-    source = :"Elixir.MingaGitPorcelain.UI.Picker.GitBranchSource"
-
-    if git_porcelain_running?() and Code.ensure_loaded?(source) do
-      InvocationContext.with_source({:extension, :minga_git_porcelain}, fn ->
-        MingaEditor.PickerUI.open(state, source)
-      end)
-    else
-      state
-    end
-  end
-
-  @spec execute_git_porcelain_command(state(), atom() | tuple()) :: state()
-  defp execute_git_porcelain_command(state, command) do
-    if git_porcelain_running?() do
-      ExtensionEventWorkflow.dispatch(
-        state,
-        {:editor_action, :execute_git_command, command}
-      )
-    else
-      state
-    end
-  end
-
-  @spec git_porcelain_running?() :: boolean()
-  defp git_porcelain_running? do
-    case Process.whereis(Minga.Extension.Registry) do
-      nil -> false
-      _pid -> git_porcelain_running_in_registry?()
-    end
-  catch
-    :exit, _reason -> false
-  end
-
-  @spec git_porcelain_running_in_registry?() :: boolean()
-  defp git_porcelain_running_in_registry? do
-    case Minga.Extension.Registry.get(:minga_git_porcelain) do
-      {:ok, %{status: :running}} -> true
-      _ -> false
-    end
-  end
-
-  @spec handle_branch_delete_error(state(), String.t(), String.t(), boolean(), String.t()) ::
-          state()
-  defp handle_branch_delete_error(state, git_root, name, false, reason) do
-    if forceable_branch_delete_error?(reason) do
-      mode_state =
-        git_root
-        |> Minga.Mode.BranchDeleteConfirmState.new(name)
-        |> Minga.Mode.BranchDeleteConfirmState.to_force(reason)
-
-      state = NoticeWorkflow.publish(state, "Delete failed: #{reason}")
-
-      workspace =
-        MingaEditor.Session.State.transition_mode(
-          state.workspace,
-          :branch_delete_confirm,
-          mode_state
-        )
-
-      %{state | workspace: workspace}
-    else
-      NoticeWorkflow.publish(state, "Delete failed: #{reason}")
-    end
-  end
-
-  defp handle_branch_delete_error(state, _git_root, _name, true, reason) do
-    NoticeWorkflow.publish(state, "Force delete failed: #{reason}")
-  end
-
-  @spec forceable_branch_delete_error?(String.t()) :: boolean()
-  defp forceable_branch_delete_error?(reason) do
-    normalized = String.downcase(reason)
-
-    String.contains?(normalized, "not fully merged") or
-      String.contains?(normalized, "unmerged") or
-      String.contains?(normalized, "not merged")
-  end
-
-  @spec refresh_branch_delete_repo(String.t()) :: :ok
-  defp refresh_branch_delete_repo(git_root) do
-    case Git.lookup_repo(git_root) do
-      nil -> :ok
-      pid -> Git.Repo.refresh(pid)
-    end
+  @spec dispatch_editor_action(state(), atom(), term()) :: state()
+  defp dispatch_editor_action(state, action, arguments) do
+    ExtensionEventWorkflow.dispatch(state, {:editor_action, action, arguments})
   end
 
   # Remove the current tool from the prompt queue after accept/decline.

--- a/lib/minga_editor/extension/event_effect.ex
+++ b/lib/minga_editor/extension/event_effect.ex
@@ -272,6 +272,14 @@ defmodule MingaEditor.Extension.EventEffect do
        ),
        do: NoticeWorkflow.publish(state, "Git command #{status}: #{bounded_inspect(reason)}")
 
+  defp terminal_feedback(state, {:editor_action, action, _arguments}, status, reason)
+       when action in [:branch_delete_confirm, :branch_delete_cancel],
+       do:
+         NoticeWorkflow.publish(
+           state,
+           "Branch delete action #{status}: #{bounded_inspect(reason)}"
+         )
+
   defp terminal_feedback(state, _event, _status, _reason), do: state
 
   @spec interactive_failure(EditorState.t(), EventHandler.event()) :: EditorState.t()
@@ -281,6 +289,10 @@ defmodule MingaEditor.Extension.EventEffect do
   defp interactive_failure(state, {:editor_action, :execute_git_command, _command}),
     do: NoticeWorkflow.publish(state, "Git command callback failed")
 
+  defp interactive_failure(state, {:editor_action, action, _arguments})
+       when action in [:branch_delete_confirm, :branch_delete_cancel],
+       do: NoticeWorkflow.publish(state, "Branch delete action failed")
+
   defp interactive_failure(state, _event), do: state
 
   @spec interactive_unavailable(EditorState.t(), EventHandler.event()) :: EditorState.t()
@@ -289,6 +301,10 @@ defmodule MingaEditor.Extension.EventEffect do
 
   defp interactive_unavailable(state, {:editor_action, :execute_git_command, _command}),
     do: NoticeWorkflow.publish(state, "Git command unavailable")
+
+  defp interactive_unavailable(state, {:editor_action, action, _arguments})
+       when action in [:branch_delete_confirm, :branch_delete_cancel],
+       do: NoticeWorkflow.publish(state, "Branch delete action unavailable")
 
   defp interactive_unavailable(state, _event), do: state
 

--- a/lib/minga_editor/extension/event_workflow.ex
+++ b/lib/minga_editor/extension/event_workflow.ex
@@ -76,6 +76,10 @@ defmodule MingaEditor.Extension.EventWorkflow do
   defp admission_failure(state, {:editor_action, :execute_git_command, _command}, reason),
     do: NoticeWorkflow.publish(state, "Git command not scheduled: #{inspect(reason)}")
 
+  defp admission_failure(state, {:editor_action, action, _arguments}, reason)
+       when action in [:branch_delete_confirm, :branch_delete_cancel],
+       do: NoticeWorkflow.publish(state, "Branch delete action not scheduled: #{inspect(reason)}")
+
   defp admission_failure(state, _event, _reason), do: state
 
   @spec admit(EditorState.t(), MingaEditor.Effect.Request.t()) :: :ok | {:error, term()}

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -451,7 +451,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   end
 
   defp dispatch_action(state, {:toggle_panel, 2}) do
-    execute_git_porcelain_command(state, :git_status_toggle)
+    execute_registered_command(state, :git_status_toggle)
   end
 
   defp dispatch_action(state, {:toggle_panel, 3}) do
@@ -695,15 +695,15 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   end
 
   defp dispatch_action(state, :git_push) do
-    execute_git_porcelain_command(state, :git_push)
+    execute_registered_command(state, :git_push)
   end
 
   defp dispatch_action(state, :git_pull) do
-    execute_git_porcelain_command(state, :git_pull)
+    execute_registered_command(state, :git_pull)
   end
 
   defp dispatch_action(state, :git_fetch) do
-    execute_git_porcelain_command(state, :git_fetch)
+    execute_registered_command(state, :git_fetch)
   end
 
   defp dispatch_action(state, {:git_commit_amend, message}) do
@@ -833,7 +833,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   defp dispatch_action(state, :git_pull_and_retry) do
     state
     |> MingaEditor.Shell.Traditional.GitToastWorkflow.dismiss()
-    |> execute_git_porcelain_command(:git_pull_and_retry)
+    |> execute_registered_command(:git_pull_and_retry)
   end
 
   # ── GUI search toolbar actions ──────────────────────────────────────
@@ -1094,7 +1094,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     do: Commands.FileTree.toggle(state)
 
   defp dispatch_sidebar_toggle(state, "git_status", _kind),
-    do: execute_git_porcelain_command(state, :git_status_toggle)
+    do: execute_registered_command(state, :git_status_toggle)
 
   defp dispatch_sidebar_toggle(state, "observatory", _kind) do
     state
@@ -1268,13 +1268,9 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     end
   end
 
-  @spec execute_git_porcelain_command(state(), atom()) :: state()
-  defp execute_git_porcelain_command(state, command) do
-    if git_porcelain_running?() do
-      Commands.execute(state, command)
-    else
-      git_porcelain_unavailable(state)
-    end
+  @spec execute_registered_command(state(), atom()) :: state()
+  defp execute_registered_command(state, command) do
+    ExtensionEventWorkflow.dispatch(state, {:editor_action, :execute_git_command, command})
   end
 
   @spec open_git_diff_for_path(state(), String.t(), String.t(), String.t(), String.t(), keyword()) ::
@@ -1286,31 +1282,6 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
       state,
       {:editor_action, :open_git_diff_for_path, arguments}
     )
-  end
-
-  @spec git_porcelain_unavailable(state()) :: state()
-  defp git_porcelain_unavailable(state) do
-    message = "Git porcelain extension is disabled or failed to load"
-    Minga.Log.warning(:editor, message)
-    NoticeWorkflow.publish(state, message)
-  end
-
-  @spec git_porcelain_running?() :: boolean()
-  defp git_porcelain_running? do
-    case Process.whereis(Minga.Extension.Registry) do
-      nil -> false
-      _pid -> git_porcelain_running_in_registry?()
-    end
-  catch
-    :exit, _reason -> false
-  end
-
-  @spec git_porcelain_running_in_registry?() :: boolean()
-  defp git_porcelain_running_in_registry? do
-    case Minga.Extension.Registry.get(:minga_git_porcelain) do
-      {:ok, %{status: :running}} -> true
-      _ -> false
-    end
   end
 
   @spec open_git_diff_for_entry(state(), String.t(), Git.StatusEntry.t()) :: state()

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -555,32 +555,28 @@ defmodule MingaEditor.PickerUI do
     end
   end
 
-  # C-d → branch picker delete flow only. Keeps printable `d` available for
-  # normal picker filtering, including sources that define alternative delete
-  # actions for other purposes.
+  # C-d invokes a source-declared delete action. Sources that do not expose
+  # delete keep printable `d` available for normal picker filtering.
   def handle_key(
         %{
           shell_runtime: %{
             state: %{modal: {:picker, %{picker_ui: %{picker: picker, source: source}}}}
           }
-        } =
-          state,
+        } = state,
         ?d,
         mods
       )
-      when band(mods, @ctrl) != 0 and
-             source == :"Elixir.MingaGitPorcelain.UI.Picker.GitBranchSource" do
+      when band(mods, @ctrl) != 0 do
     case Picker.selected_item(picker) do
-      %Item{id: {:branch, _name, _current?, true}} ->
-        state
+      %Item{} = item ->
+        callback_source = current_callback_source(state)
 
-      %Item{id: {:branch, _name, true, false}} = item ->
-        run_source_action_and_close(state, source, :delete, item)
+        case Picker.Source.shortcut_action(source, item, {:ctrl, ?d}, callback_source) do
+          nil -> state
+          action -> run_source_action_and_close(state, source, action, item)
+        end
 
-      %Item{id: {:branch, _name, false, false}} = item ->
-        run_source_action_and_close(state, source, :delete, item)
-
-      _other ->
+      nil ->
         state
     end
   end

--- a/lib/minga_editor/sidebar/builtin_surfaces.ex
+++ b/lib/minga_editor/sidebar/builtin_surfaces.ex
@@ -6,6 +6,7 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
   """
 
   alias MingaEditor.Commands
+  alias MingaEditor.Extension.EventWorkflow
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Layout
@@ -68,14 +69,14 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
   @doc "Handles native sidebar actions for the Git Status surface."
   @spec handle_git_status_action(EditorState.t(), String.t(), map()) :: EditorState.t()
   def handle_git_status_action(%EditorState{} = state, "toggle", _context) do
-    execute_git_porcelain_command(state, :git_status_toggle)
+    execute_registered_command(state, :git_status_toggle)
   end
 
   def handle_git_status_action(%EditorState{} = state, "activate", _context) do
     if SidebarWorkflow.git_status_panel(state) do
       focus_git_status(state)
     else
-      execute_git_porcelain_command(state, :git_status_toggle)
+      execute_registered_command(state, :git_status_toggle)
     end
   end
 
@@ -161,37 +162,8 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
   defp normalize_command_result({state, _effect}), do: state
   defp normalize_command_result(state), do: state
 
-  @spec execute_git_porcelain_command(EditorState.t(), atom()) :: EditorState.t()
-  defp execute_git_porcelain_command(state, command) do
-    if git_porcelain_running?() do
-      Commands.execute(state, command)
-    else
-      git_porcelain_unavailable(state)
-    end
-  end
-
-  @spec git_porcelain_unavailable(EditorState.t()) :: EditorState.t()
-  defp git_porcelain_unavailable(state) do
-    message = "Git porcelain extension is disabled or failed to load"
-    Minga.Log.warning(:editor, message)
-    MingaEditor.Shell.Traditional.NoticeWorkflow.publish(state, message)
-  end
-
-  @spec git_porcelain_running?() :: boolean()
-  defp git_porcelain_running? do
-    case Process.whereis(Minga.Extension.Registry) do
-      nil -> false
-      _pid -> git_porcelain_running_in_registry?()
-    end
-  catch
-    :exit, _reason -> false
-  end
-
-  @spec git_porcelain_running_in_registry?() :: boolean()
-  defp git_porcelain_running_in_registry? do
-    case Minga.Extension.Registry.get(:minga_git_porcelain) do
-      {:ok, %{status: :running}} -> true
-      _ -> false
-    end
+  @spec execute_registered_command(EditorState.t(), atom()) :: EditorState.t()
+  defp execute_registered_command(state, command) do
+    EventWorkflow.dispatch(state, {:editor_action, :execute_git_command, command})
   end
 end

--- a/lib/minga_editor/ui/picker/source.ex
+++ b/lib/minga_editor/ui/picker/source.ex
@@ -93,11 +93,17 @@ defmodule MingaEditor.UI.Picker.Source do
   @typedoc "An alternative action: display name and action identifier."
   @type action_entry :: {name :: String.t(), action_id :: term()}
 
+  @typedoc "A normalized picker keyboard shortcut."
+  @type shortcut :: {:ctrl, non_neg_integer()}
+
   @doc """
   Returns the list of alternative actions available for a picker item.
   The first entry is conventionally the default action.
   """
   @callback actions(Picker.item()) :: [action_entry()]
+
+  @doc "Returns the action identifier for a source-owned keyboard shortcut, or nil."
+  @callback shortcut_action(Picker.item(), shortcut()) :: term() | nil
 
   @doc """
   Executes an alternative action on a picker item.
@@ -181,6 +187,7 @@ defmodule MingaEditor.UI.Picker.Source do
     gui_preview?: 0,
     preview: 2,
     actions: 1,
+    shortcut_action: 2,
     on_action: 3,
     on_bulk_select: 2,
     bulk_actions: 1,
@@ -314,6 +321,36 @@ defmodule MingaEditor.UI.Picker.Source do
       []
     end
   end
+
+  @doc "Returns the source action for a keyboard shortcut, with a common delete fallback."
+  @spec shortcut_action(
+          module(),
+          Picker.item(),
+          shortcut(),
+          ContributionCleanup.contribution_source() | nil
+        ) :: term() | nil
+  def shortcut_action(module, item, shortcut, source \\ nil) do
+    if exported?(module, :shortcut_action, 2) do
+      invoke_value(module, :shortcut_action, [item, shortcut], source, fn _value -> true end, nil)
+    else
+      default_shortcut_action(module, item, shortcut, source)
+    end
+  end
+
+  @spec default_shortcut_action(
+          module(),
+          Picker.item(),
+          shortcut(),
+          ContributionCleanup.contribution_source() | nil
+        ) :: term() | nil
+  defp default_shortcut_action(module, item, {:ctrl, ?d}, source) do
+    case List.keyfind(actions(module, item, source), :delete, 1) do
+      {_label, :delete} -> :delete
+      nil -> nil
+    end
+  end
+
+  defp default_shortcut_action(_module, _item, _shortcut, _source), do: nil
 
   @doc "Runs a validated alternative action."
   @spec on_action(

--- a/test/minga/extension/core_decoupling_guardrail_test.exs
+++ b/test/minga/extension/core_decoupling_guardrail_test.exs
@@ -1,0 +1,116 @@
+defmodule Minga.Extension.CoreDecouplingGuardrailTest do
+  @moduledoc "Guards the runtime boundary between editor core and bundled extensions."
+
+  use ExUnit.Case, async: true
+
+  @core_files Path.wildcard("lib/**/*.ex")
+  @registry_key_allowlist [
+    "lib/minga/config/loader.ex",
+    "lib/minga/extension/bundled_applications.ex"
+  ]
+  @concrete_namespace "MingaGitPorcelain"
+  @extension_registry_key :minga_git_porcelain
+
+  test "core contains no concrete bundled extension namespaces or optional probes" do
+    violations =
+      Enum.flat_map(@core_files, fn file ->
+        file
+        |> File.read!()
+        |> Code.string_to_quoted!(file: file, columns: true)
+        |> collect_namespace_violations(file)
+      end)
+
+    assert violations == [], format_violations(violations)
+  end
+
+  test "only bundled extension composition roots name the extension registry key" do
+    violations =
+      @core_files
+      |> Enum.reject(&(&1 in @registry_key_allowlist))
+      |> Enum.flat_map(fn file ->
+        file
+        |> File.read!()
+        |> Code.string_to_quoted!(file: file, columns: true)
+        |> collect_registry_key_violations(file)
+      end)
+
+    assert violations == [], format_violations(violations)
+  end
+
+  @spec collect_namespace_violations(Macro.t(), String.t()) :: [tuple()]
+  defp collect_namespace_violations(ast, file) do
+    {_ast, violations} =
+      Macro.prewalk(ast, [], fn
+        {{:., _, [receiver, function]}, meta, arguments} = node, acc
+        when function in [:ensure_loaded?, :function_exported?] ->
+          violation =
+            if concrete_extension_term?(receiver) or
+                 Enum.any?(arguments, &concrete_extension_term?/1) do
+              [{file, Keyword.get(meta, :line, 0), :optional_extension_probe}]
+            else
+              []
+            end
+
+          {node, violation ++ acc}
+
+        {:__aliases__, meta, parts} = node, acc ->
+          violation =
+            if Enum.all?(parts, &is_atom/1) and concrete_namespace?(Module.concat(parts)) do
+              [{file, Keyword.get(meta, :line, 0), :concrete_extension_namespace}]
+            else
+              []
+            end
+
+          {node, violation ++ acc}
+
+        atom, acc when is_atom(atom) ->
+          violation =
+            if concrete_namespace?(atom),
+              do: [{file, 0, :concrete_extension_namespace}],
+              else: []
+
+          {atom, violation ++ acc}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    Enum.uniq(violations)
+  end
+
+  @spec collect_registry_key_violations(Macro.t(), String.t()) :: [tuple()]
+  defp collect_registry_key_violations(ast, file) do
+    {_ast, violations} =
+      Macro.prewalk(ast, [], fn
+        @extension_registry_key = node, acc ->
+          {node, [{file, 0, :extension_registry_key} | acc]}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    Enum.uniq(violations)
+  end
+
+  @spec concrete_extension_term?(Macro.t()) :: boolean()
+  defp concrete_extension_term?({:__aliases__, _meta, parts}) do
+    Enum.all?(parts, &is_atom/1) and concrete_namespace?(Module.concat(parts))
+  end
+
+  defp concrete_extension_term?(atom) when is_atom(atom), do: concrete_namespace?(atom)
+  defp concrete_extension_term?(_term), do: false
+
+  @spec concrete_namespace?(atom()) :: boolean()
+  defp concrete_namespace?(module) when is_atom(module) do
+    module
+    |> Atom.to_string()
+    |> String.contains?(@concrete_namespace)
+  end
+
+  @spec format_violations([tuple()]) :: String.t()
+  defp format_violations(violations) do
+    Enum.map_join(violations, "\n", fn {file, line, kind} ->
+      "#{file}:#{line}: #{kind}"
+    end)
+  end
+end

--- a/test/minga/mode/branch_delete_confirm_test.exs
+++ b/test/minga/mode/branch_delete_confirm_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Mode.BranchDeleteConfirmTest do
   @moduledoc "Tests for git branch delete confirmation mode."
   use ExUnit.Case, async: true
 
+  alias Minga.Mode
   alias Minga.Mode.BranchDeleteConfirm
   alias Minga.Mode.BranchDeleteConfirmState
 
@@ -10,7 +11,7 @@ defmodule Minga.Mode.BranchDeleteConfirmTest do
       state = BranchDeleteConfirmState.new("/repo", "feature")
 
       assert {:execute_then_transition, [{:branch_delete_confirm, "/repo", "feature", false}],
-              :normal, ^state} = BranchDeleteConfirm.handle_key({?y, 0}, state)
+              :normal, %Mode.State{}} = BranchDeleteConfirm.handle_key({?y, 0}, state)
     end
 
     test "y confirms force branch deletion in force phase" do
@@ -20,16 +21,16 @@ defmodule Minga.Mode.BranchDeleteConfirmTest do
         |> BranchDeleteConfirmState.to_force("not fully merged")
 
       assert {:execute_then_transition, [{:branch_delete_confirm, "/repo", "feature", true}],
-              :normal, ^state} = BranchDeleteConfirm.handle_key({?y, 0}, state)
+              :normal, %Mode.State{}} = BranchDeleteConfirm.handle_key({?y, 0}, state)
     end
 
     test "n and escape cancel" do
       state = BranchDeleteConfirmState.new("/repo", "feature")
 
-      assert {:execute_then_transition, [:branch_delete_cancel], :normal, ^state} =
+      assert {:execute_then_transition, [:branch_delete_cancel], :normal, %Mode.State{}} =
                BranchDeleteConfirm.handle_key({?n, 0}, state)
 
-      assert {:execute_then_transition, [:branch_delete_cancel], :normal, ^state} =
+      assert {:execute_then_transition, [:branch_delete_cancel], :normal, %Mode.State{}} =
                BranchDeleteConfirm.handle_key({27, 0}, state)
     end
 

--- a/test/minga_editor/extension/event_effect_test.exs
+++ b/test/minga_editor/extension/event_effect_test.exs
@@ -165,6 +165,32 @@ defmodule MingaEditor.Extension.EventEffectTest do
     EffectScheduler.finalize(ctx.scheduler, applied)
   end
 
+  test "declined source-owned actions restore visible feedback", ctx do
+    actions = [
+      {{:editor_action, :execute_git_command, :status}, "Git command unavailable"},
+      {{:editor_action, :branch_delete_confirm, {"/repo", "feature", false}},
+       "Branch delete action unavailable"},
+      {{:editor_action, :branch_delete_cancel, nil}, "Branch delete action unavailable"}
+    ]
+
+    Enum.each(actions, fn {event, message} ->
+      state =
+        EventWorkflow.dispatch(ctx.state, event,
+          callback_registry: ctx.registry,
+          callback_admission: ctx.code_lease
+        )
+
+      assert_receive {:effect_lifecycle, %Outcome{status: :running, request: %{id: request_id}}},
+                     @timeout
+
+      outcome = receive_outcome(ctx.scheduler, request_id, :completed)
+      assert :ok = EffectScheduler.claim(ctx.scheduler, outcome)
+      assert {result, %Outcome{status: :completed} = applied} = EventEffect.apply(state, outcome)
+      assert result.shell_runtime.state.notice.message == message
+      EffectScheduler.finalize(ctx.scheduler, applied)
+    end)
+  end
+
   test "failing unload callbacks complete the deferred Editor reply with an error", ctx do
     {:ok, token} = CodeLease.quiesce_source(ctx.source, server: ctx.code_lease)
     reply_tag = make_ref()

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -257,7 +257,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
     assert SidebarWorkflow.active_id(hidden) == nil
   end
 
-  test "git porcelain GUI actions report disabled extension instead of no-op", %{
+  test "optional GUI commands report scheduling failures instead of no-op", %{
     sidebar_registry: table
   } do
     state = base_state(table)
@@ -265,7 +265,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
     toggled = GuiActionHandler.dispatch(state, {:toggle_panel, 2})
 
     assert MingaEditor.Shell.Traditional.NoticeWorkflow.message(toggled) ==
-             "Git porcelain extension is disabled or failed to load"
+             "Git command not scheduled: :scheduler_unavailable"
 
     assert toggled.workspace.keymap_scope == state.workspace.keymap_scope
     assert SidebarWorkflow.active_id(toggled) == SidebarWorkflow.active_id(state)
@@ -274,7 +274,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
       GuiActionHandler.dispatch(state, {:sidebar_action, "git_status", "git_status", "activate"})
 
     assert MingaEditor.Shell.Traditional.NoticeWorkflow.message(activated) ==
-             "Git porcelain extension is disabled or failed to load"
+             "Git command not scheduled: :scheduler_unavailable"
 
     assert activated.workspace.keymap_scope == state.workspace.keymap_scope
     assert SidebarWorkflow.active_id(activated) == nil

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -323,6 +323,32 @@ defmodule MingaEditor.PickerUITest do
       assert result.shell_runtime.state.notice.message == nil
       assert result.workspace.editing.mode == :normal
     end
+
+    test "C-d invokes a generic source-declared delete action" do
+      picker =
+        Picker.new([%Item{id: :delete_me, label: "Delete me"}], title: "Delete Action Test")
+
+      picker_state = %PickerState{
+        picker: picker,
+        source: Minga.Test.DeleteActionPickerSource,
+        restore: 0
+      }
+
+      state = %EditorState{
+        frontend: %MingaEditor.State.Frontend{port_manager: nil},
+        workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()},
+        shell_runtime:
+          Runtime.new(
+            Runtime.default_entry(),
+            %ShellState{modal: {:picker, PickerPayload.new(picker_state)}}
+          )
+      }
+
+      result = PickerUI.handle_key(state, ?d, MingaEditor.Input.mod_ctrl())
+
+      assert result.shell_runtime.state.modal == :none
+      assert result.shell_runtime.state.notice.message == "Deleted via action"
+    end
   end
 
   describe "bulk action fallback for sources without bulk support" do


### PR DESCRIPTION
# TL;DR

Editor core no longer names, probes, or reads registry state for the bundled Git Porcelain extension. Git commands and branch actions now cross a generic, scheduler-backed extension boundary, while picker shortcuts are declared by each source.

## Context

The original PR predated the extension lifecycle migration. Merged PRs #2957 through #2963 replaced its artifact, callback, scheduling, and lifecycle implementation, but concrete Git Porcelain knowledge still remained in editor core.

This refresh starts from current `main`, drops every superseded lifecycle hunk, and keeps only the missing decoupling behavior. `Minga.Extension.Instance`, `CodeLease`, and the extension supervisor remain unchanged.

## Changes

- Route parameterized branch deletion, conflict actions, GUI Git commands, and Git Status sidebar commands through generic extension editor actions.
- Keep those dynamic callbacks off the Editor mailbox by using `MingaEditor.Extension.EventWorkflow` and the shared effect scheduler.
- Move branch deletion execution and error handling into the Git Porcelain command provider.
- Add an optional picker `shortcut_action/2` contract with a default delete fallback, then use it for Ctrl-D instead of checking a concrete picker module.
- Finalize branch-confirmation mode before scheduling confirmation or cancellation so asynchronous results cannot be rejected as stale after Git changes.
- Exit branch-delete confirmation when its source unloads and preserve visible unavailable, callback-failure, success, and cancellation feedback.
- Add an AST guardrail that rejects concrete Git Porcelain namespaces, optional probes, and registry keys in editor core outside the bundled composition roots.

## Compatibility

Existing picker sources do not need to implement `shortcut_action/2`. The default implementation maps Ctrl-D to an existing `:delete` action when one is declared. Changed extension code still follows the fresh-VM activation contract, and this PR does not alter lifecycle authority or runtime code loading.

## Verification

- `make lint`, passed with Credo clean and Dialyzer reporting 0 errors.
- `mix test.llm`, passed: 9,777 tests, 58 doctests, 97 properties, 0 failures, 1 skipped.
- Standalone Git Porcelain suite, passed: 111 tests, 0 failures.
- Scheduler-backed branch confirmation and cancellation regression suite, passed: 5 tests, 0 failures.
- Focused mode and extension-event suite, passed: 12 tests, 0 failures.
- `git diff --check`, passed.
- Generated `extensions/git_porcelain/_build`, `deps`, and `mix.lock` artifacts are absent.
- Final targeted acceptance review passed after fixing the stale branch-confirmation transition.

## Acceptance Criteria Addressed

- Core has no concrete Git Porcelain runtime namespace, optional probe, or registry-key coupling. ✅
- Git actions cross a source-owned generic contract. ✅
- Dynamic extension editor callbacks remain scheduler-backed and bounded. ✅
- Picker shortcuts are source-declared instead of hard-coded to a bundled module. ✅
- Branch confirmation, cancellation, source unload, and unavailable paths preserve visible behavior. ✅
- Merged extension lifecycle authority remains untouched. ✅
- Focused behavior tests and an AST guardrail protect the boundary. ✅

---
**Updated after refresh:** Rebuilt the PR on current `main` after #2963, removed superseded lifecycle changes, and updated verification for commit `e0460966c`.
