### PR TITLE
fix(project): keep loose files outside workspaces

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -255,6 +255,7 @@ graph TD
     LSPSUP --> LSP2["LSP Client: lua-ls"]
     SVC --> SYNC["LSP.SyncServer"]
     SVC --> PROJ["Project"]
+    PROJ -. "one per active inventory" .-> DISC["Project.FileFind.Worker<br/><i>monitored, cancellable</i>"]
     SVC --> AGENTSUP["Agent.Supervisor<br/><i>DynamicSupervisor</i>"]
     AGENTSUP --> AS1["Agent.Session<br/><i>Claude (refactoring)</i>"]
     AGENTSUP --> AS2["Agent.Session<br/><i>Claude (tests)</i>"]
@@ -264,11 +265,14 @@ graph TD
     style LSPSUP fill:#1a5276,stroke:#154360,color:#fff
     style AGENTSUP fill:#1a5276,stroke:#154360,color:#fff
     style TASKSUP fill:#1a5276,stroke:#154360,color:#fff
+    style DISC fill:#1a5276,stroke:#154360,color:#fff
     style AS1 fill:#884ea0,stroke:#6c3483,color:#fff
     style AS2 fill:#884ea0,stroke:#6c3483,color:#fff
     style LSP1 fill:#2471a3,stroke:#1a5276,color:#fff
     style LSP2 fill:#2471a3,stroke:#1a5276,color:#fff
 ```
+
+`Minga.Project` only starts recursive file inventory for an explicit directory workspace root. Each inventory runs in a monitored `Minga.Project.FileFind.Worker` that owns the external `git`, `fd`, or `find` process. Switching or closing the workspace, timing out, or stopping the Project service cancels the worker and terminates the external process tree.
 
 ### Runtime tier
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -272,7 +272,7 @@ graph TD
     style LSP2 fill:#2471a3,stroke:#1a5276,color:#fff
 ```
 
-`Minga.Project` only starts recursive file inventory for an explicit directory workspace root. Each inventory runs in a monitored `Minga.Project.FileFind.Worker` that owns the external `git`, `fd`, or `find` process. Switching or closing the workspace, timing out, or stopping the Project service cancels the worker and terminates the external process tree.
+`Minga.Project` only starts recursive file inventory for an explicit directory workspace root. Root paths are canonicalized before authorization so symlink aliases cannot bypass broad-root protection. Each inventory runs in a monitored `Minga.Project.FileFind.Worker` that owns the external `git`, `fd`, or `find` process, bounds command output, and enforces a timeout for synchronous callers. Switching or closing the workspace, timing out, or stopping the Project service waits for the worker to terminate the external process tree.
 
 ### Runtime tier
 

--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -448,7 +448,7 @@ defmodule Minga.Project do
   end
 
   def handle_info({:rebuild_timeout, pid}, %{rebuild_pid: pid} = state) do
-    state.file_find_module.cancel(pid)
+    cancel_discovery(state, pid)
     Minga.Log.warning(:editor, "Project file cache rebuild timed out")
     {:noreply, clear_rebuild(state)}
   end
@@ -464,7 +464,7 @@ defmodule Minga.Project do
   @impl true
   @spec terminate(term(), t()) :: :ok
   def terminate(_reason, state) do
-    if is_pid(state.rebuild_pid), do: state.file_find_module.cancel(state.rebuild_pid)
+    if is_pid(state.rebuild_pid), do: cancel_discovery(state, state.rebuild_pid)
     :ok
   end
 
@@ -566,8 +566,25 @@ defmodule Minga.Project do
   defp cancel_rebuild(%{rebuild_pid: nil} = state), do: state
 
   defp cancel_rebuild(state) do
-    state.file_find_module.cancel(state.rebuild_pid)
+    cancel_discovery(state, state.rebuild_pid)
     clear_rebuild(state)
+  end
+
+  @spec cancel_discovery(t(), pid()) :: :ok
+  defp cancel_discovery(state, pid) do
+    case state.file_find_module.cancel(pid) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Minga.Log.error(:editor, "Project file discovery cancellation failed: #{reason}")
+
+      other ->
+        Minga.Log.error(
+          :editor,
+          "Project file discovery cancellation returned: #{inspect(other)}"
+        )
+    end
   end
 
   @spec clear_rebuild(t()) :: t()

--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -1,15 +1,15 @@
 defmodule Minga.Project do
   @moduledoc """
-  Project awareness GenServer, modeled after Emacs projectile.
+  Owns the active explicit directory workspace and its project services.
 
-  Tracks the current project root, caches the file list, and persists a
+  Tracks the current workspace root, caches the file list, and persists a
   known-projects list to `~/.config/minga/known-projects` so that `SPC p p`
   works across editor sessions.
 
   ## State
 
-  * `current_root` — the active project root (detected from the first opened file)
-  * `project_type` — the type of project (`:git`, `:mix`, `:cargo`, etc.)
+  * `current_root` — the path of the active explicit directory workspace
+  * `workspace_root` — the typed root that authorizes recursive project behavior
   * `cached_files` — the file list for the current project (populated by a background Task)
   * `known_projects` — list of all project roots the user has visited, persisted to disk
   * `recent_files` — per-project list of recently opened files, most recent first, persisted to disk
@@ -29,18 +29,21 @@ defmodule Minga.Project do
 
   alias Minga.Command
   alias Minga.Config
-  alias Minga.Git.Repo.Profile
-  alias Minga.Project.Detector
+  alias Minga.Project.Root
 
   defstruct current_root: nil,
-            project_type: nil,
+            workspace_root: nil,
             cached_files: [],
             known_projects: [],
             recent_files: %{},
             frecency_events: %{},
             command_frecency: %{},
             rebuilding?: false,
+            rebuild_pid: nil,
             rebuild_ref: nil,
+            rebuild_timer_ref: nil,
+            rebuild_timeout_ms: 30_000,
+            file_find_module: Minga.Project.FileFind,
             events_registry: Minga.Events.default_registry()
 
   @typedoc "Per-project recent files map: project root => list of relative paths (most recent first)."
@@ -58,14 +61,18 @@ defmodule Minga.Project do
   @typedoc "Project GenServer state."
   @type t :: %__MODULE__{
           current_root: String.t() | nil,
-          project_type: Detector.project_type() | nil,
+          workspace_root: Root.t() | nil,
           cached_files: [String.t()],
           known_projects: [String.t()],
           recent_files: recent_files_map(),
           frecency_events: frecency_events_map(),
           command_frecency: command_frecency_map(),
           rebuilding?: boolean(),
+          rebuild_pid: pid() | nil,
           rebuild_ref: reference() | nil,
+          rebuild_timer_ref: reference() | nil,
+          rebuild_timeout_ms: pos_integer(),
+          file_find_module: module(),
           events_registry: Minga.Events.registry()
         }
 
@@ -85,38 +92,24 @@ defmodule Minga.Project do
     GenServer.start_link(__MODULE__, opts, name: name)
   end
 
-  @doc """
-  Detects the project root for a file and sets it as the current project.
-
-  Automatically adds the detected root to the known-projects list and triggers
-  a background cache rebuild. No-op if detection finds no project markers.
-  """
-  @spec detect_and_set(GenServer.server(), String.t()) :: :ok
-  def detect_and_set(server \\ __MODULE__, file_path) when is_binary(file_path) do
-    GenServer.cast(server, {:detect_and_set, file_path})
-  end
-
   @doc "Returns the current project root, or nil if none is detected."
   @spec root(GenServer.server()) :: String.t() | nil
   def root(server \\ __MODULE__) do
     GenServer.call(server, :root)
   end
 
-  @doc """
-  Returns the current project root, falling back to `File.cwd!()`.
-
-  Safe to call even when the Project GenServer is not running (e.g., during
-  early startup or in tests): catches `:exit` from the GenServer call and
-  falls back to the working directory.
-  """
-  @spec resolve_root() :: String.t()
+  @doc "Returns the active project root without inventing a cwd fallback."
+  @spec resolve_root() :: String.t() | nil
   def resolve_root do
-    case root() do
-      nil -> File.cwd!()
-      r -> r
-    end
+    root()
   catch
-    :exit, _ -> File.cwd!()
+    :exit, _ -> nil
+  end
+
+  @doc "Returns the explicit directory workspace root used by recursive project features."
+  @spec workspace_root(GenServer.server()) :: Root.t() | nil
+  def workspace_root(server \\ __MODULE__) do
+    GenServer.call(server, :workspace_root)
   end
 
   @doc """
@@ -147,10 +140,37 @@ defmodule Minga.Project do
     GenServer.call(server, :known_projects)
   end
 
-  @doc "Switches to a known project root, triggering a cache rebuild."
-  @spec switch(GenServer.server(), String.t()) :: :ok
-  def switch(server \\ __MODULE__, root_path) when is_binary(root_path) do
-    GenServer.cast(server, {:switch, root_path})
+  @doc "Switches to an explicit directory workspace, triggering one cache rebuild."
+  @spec switch(String.t() | Root.t()) :: :ok
+  def switch(root), do: switch(__MODULE__, root, [])
+
+  @spec switch(String.t(), keyword()) :: :ok
+  def switch(root_path, opts) when is_binary(root_path) and is_list(opts),
+    do: switch(__MODULE__, root_path, opts)
+
+  @spec switch(GenServer.server(), String.t() | Root.t()) :: :ok
+  def switch(server, root), do: switch(server, root, [])
+
+  @spec switch(GenServer.server(), String.t() | Root.t(), keyword()) :: :ok
+  def switch(server, %Root{kind: :directory} = root, _opts) do
+    GenServer.cast(server, {:switch, root})
+  end
+
+  def switch(server, %Root{} = root, _opts) do
+    GenServer.cast(server, {:switch_rejected, root.path, :not_a_directory_root})
+  end
+
+  def switch(server, root_path, opts) when is_binary(root_path) and is_list(opts) do
+    case Root.directory(root_path, opts) do
+      {:ok, root} -> GenServer.cast(server, {:switch, root})
+      {:error, reason} -> GenServer.cast(server, {:switch_rejected, root_path, reason})
+    end
+  end
+
+  @doc "Closes the active directory workspace and cancels file discovery."
+  @spec close(GenServer.server()) :: :ok
+  def close(server \\ __MODULE__) do
+    GenServer.cast(server, :close)
   end
 
   @doc "Invalidates the file cache and triggers a rebuild."
@@ -247,8 +267,7 @@ defmodule Minga.Project do
   @impl true
   @spec init(keyword()) :: {:ok, t()}
   def init(opts) do
-    # Subscribe to buffer-open events so we detect projects and record
-    # recent files automatically, without the Editor wiring it up.
+    # Buffer-open events record recency only when an explicit directory workspace is active.
     # Tests pass subscribe: false to avoid cross-test event contamination.
     events_registry = Keyword.get(opts, :events_registry, Minga.Events.default_registry())
 
@@ -267,6 +286,8 @@ defmodule Minga.Project do
        recent_files: recent,
        frecency_events: frecency,
        command_frecency: command_frecency,
+       rebuild_timeout_ms: Keyword.get(opts, :rebuild_timeout_ms, 30_000),
+       file_find_module: Keyword.get(opts, :file_find_module, Minga.Project.FileFind),
        events_registry: events_registry
      }}
   end
@@ -275,6 +296,10 @@ defmodule Minga.Project do
   @spec handle_call(term(), GenServer.from(), t()) :: {:reply, term(), t()}
   def handle_call(:root, _from, state) do
     {:reply, state.current_root, state}
+  end
+
+  def handle_call(:workspace_root, _from, state) do
+    {:reply, state.workspace_root, state}
   end
 
   def handle_call(:files, _from, state) do
@@ -333,30 +358,35 @@ defmodule Minga.Project do
 
   @impl true
   @spec handle_cast(term(), t()) :: {:noreply, t()}
-  def handle_cast({:detect_and_set, file_path}, state) do
-    {:noreply, do_detect_and_set(state, file_path)}
+  def handle_cast({:switch, %Root{kind: :directory} = root}, state) do
+    state =
+      state
+      |> cancel_rebuild()
+      |> set_project(root)
+      |> add_to_known(root.path)
+      |> start_rebuild()
+
+    {:noreply, state}
   end
 
-  def handle_cast({:switch, root_path}, state) do
-    expanded = Path.expand(root_path)
+  def handle_cast({:switch_rejected, root_path, reason}, state) do
+    Minga.Log.warning(
+      :editor,
+      "Project.switch rejected #{Path.expand(root_path)}: #{inspect(reason)}"
+    )
 
-    if File.dir?(expanded) do
-      state =
-        state
-        |> set_project(expanded, nil)
-        |> add_to_known(expanded)
-        |> start_rebuild()
+    {:noreply, state}
+  end
 
-      {:noreply, state}
-    else
-      Minga.Log.warning(:editor, "Project.switch: directory not found: #{expanded}")
-      {:noreply, state}
-    end
+  def handle_cast(:close, state) do
+    state = cancel_rebuild(state)
+    {:noreply, %{state | current_root: nil, workspace_root: nil, cached_files: []}}
   end
 
   def handle_cast(:invalidate, state) do
-    state = %{state | cached_files: []} |> start_rebuild()
-    {:noreply, state}
+    state = cancel_rebuild(state)
+    state = %{state | cached_files: []}
+    {:noreply, start_rebuild(state)}
   end
 
   def handle_cast({:add, root_path}, state) do
@@ -392,72 +422,53 @@ defmodule Minga.Project do
 
   @impl true
   @spec handle_info(term(), t()) :: {:noreply, t()}
-  def handle_info({ref, {:rebuild_done, root, files}}, %{rebuild_ref: ref} = state)
-      when is_reference(ref) do
-    # Task completed successfully
-    Process.demonitor(ref, [:flush])
+  def handle_info({:file_find_done, pid, result}, %{rebuild_pid: pid} = state) do
+    state = clear_rebuild(state)
+    files = discovery_files(result)
+    root = state.current_root
 
-    if root == state.current_root do
-      Minga.Events.broadcast(
-        :project_rebuilt,
-        %Minga.Events.ProjectRebuiltEvent{root: root},
-        state.events_registry
-      )
+    Minga.Events.broadcast(
+      :project_rebuilt,
+      %Minga.Events.ProjectRebuiltEvent{root: root},
+      state.events_registry
+    )
 
-      {:noreply, %{state | cached_files: files, rebuilding?: false, rebuild_ref: nil}}
-    else
-      # Root changed while rebuild was in progress; discard stale result
-      {:noreply, %{state | rebuilding?: false, rebuild_ref: nil}}
-    end
+    {:noreply, %{state | cached_files: files}}
   end
 
-  def handle_info({:DOWN, ref, :process, _pid, reason}, %{rebuild_ref: ref} = state) do
+  def handle_info(
+        {:DOWN, ref, :process, pid, reason},
+        %{rebuild_pid: pid, rebuild_ref: ref} = state
+      ) do
     if reason != :normal do
       Minga.Log.warning(:editor, "Project file cache rebuild failed: #{inspect(reason)}")
     end
 
-    {:noreply, %{state | rebuilding?: false, rebuild_ref: nil}}
+    {:noreply, clear_rebuild(state)}
+  end
+
+  def handle_info({:rebuild_timeout, pid}, %{rebuild_pid: pid} = state) do
+    state.file_find_module.cancel(pid)
+    Minga.Log.warning(:editor, "Project file cache rebuild timed out")
+    {:noreply, clear_rebuild(state)}
   end
 
   def handle_info({:minga_event, :buffer_opened, %Minga.Events.BufferEvent{path: path}}, state) do
-    state = do_detect_and_set(state, path)
-    state = do_record_file(state, path)
-    {:noreply, state}
+    {:noreply, do_record_file(state, path)}
   end
 
   def handle_info(_msg, state) do
     {:noreply, state}
   end
 
-  # ── Private ─────────────────────────────────────────────────────────────────
-
-  @spec do_detect_and_set(t(), String.t()) :: t()
-  defp do_detect_and_set(state, file_path) do
-    case Detector.detect(file_path) do
-      {:ok, detected_root, type} ->
-        root = sparse_cone_root(detected_root, type)
-
-        if root == state.current_root do
-          state
-        else
-          state
-          |> set_project(root, type)
-          |> add_to_known(root)
-          |> start_rebuild()
-        end
-
-      :none ->
-        state
-    end
+  @impl true
+  @spec terminate(term(), t()) :: :ok
+  def terminate(_reason, state) do
+    if is_pid(state.rebuild_pid), do: state.file_find_module.cancel(state.rebuild_pid)
+    :ok
   end
 
-  # When detection falls back to the git root (no nearer marker, so `type` is
-  # `:git`) and the repo is a single-cone sparse checkout, root the project at
-  # the cone directory instead of git-root. Non-`:git` matches and non-sparse or
-  # multi-cone repos are returned unchanged.
-  @spec sparse_cone_root(String.t(), Detector.project_type()) :: String.t()
-  defp sparse_cone_root(root, :git), do: Profile.single_cone_dir(root) || root
-  defp sparse_cone_root(root, _type), do: root
+  # ── Private ─────────────────────────────────────────────────────────────────
 
   @spec do_record_file(t(), String.t()) :: t()
   defp do_record_file(%{current_root: nil} = state, _file_path), do: state
@@ -512,9 +523,9 @@ defmodule Minga.Project do
     state
   end
 
-  @spec set_project(t(), String.t(), Detector.project_type() | nil) :: t()
-  defp set_project(state, root, type) do
-    %{state | current_root: root, project_type: type, cached_files: []}
+  @spec set_project(t(), Root.t()) :: t()
+  defp set_project(state, %Root{kind: :directory} = root) do
+    %{state | current_root: root.path, workspace_root: root, cached_files: []}
   end
 
   @spec add_to_known(t(), String.t()) :: t()
@@ -529,20 +540,49 @@ defmodule Minga.Project do
   end
 
   @spec start_rebuild(t()) :: t()
-  defp start_rebuild(%{current_root: nil} = state), do: state
+  defp start_rebuild(%{workspace_root: nil} = state), do: state
 
   defp start_rebuild(state) do
-    root = state.current_root
+    case state.file_find_module.start(state.workspace_root, self()) do
+      {:ok, pid} ->
+        ref = Process.monitor(pid)
+        timer_ref = Process.send_after(self(), {:rebuild_timeout, pid}, state.rebuild_timeout_ms)
 
-    task =
-      Task.async(fn ->
-        case Minga.Project.list_files(root) do
-          {:ok, files} -> {:rebuild_done, root, files}
-          {:error, _msg} -> {:rebuild_done, root, []}
-        end
-      end)
+        %{
+          state
+          | rebuilding?: true,
+            rebuild_pid: pid,
+            rebuild_ref: ref,
+            rebuild_timer_ref: timer_ref
+        }
 
-    %{state | rebuilding?: true, rebuild_ref: task.ref}
+      {:error, reason} ->
+        Minga.Log.warning(:editor, "Project file cache rebuild rejected: #{reason}")
+        state
+    end
+  end
+
+  @spec cancel_rebuild(t()) :: t()
+  defp cancel_rebuild(%{rebuild_pid: nil} = state), do: state
+
+  defp cancel_rebuild(state) do
+    state.file_find_module.cancel(state.rebuild_pid)
+    clear_rebuild(state)
+  end
+
+  @spec clear_rebuild(t()) :: t()
+  defp clear_rebuild(state) do
+    if is_reference(state.rebuild_ref), do: Process.demonitor(state.rebuild_ref, [:flush])
+    if is_reference(state.rebuild_timer_ref), do: Process.cancel_timer(state.rebuild_timer_ref)
+    %{state | rebuilding?: false, rebuild_pid: nil, rebuild_ref: nil, rebuild_timer_ref: nil}
+  end
+
+  @spec discovery_files(Minga.Project.FileFind.result()) :: [String.t()]
+  defp discovery_files({:ok, files}), do: files
+
+  defp discovery_files({:error, reason}) do
+    Minga.Log.warning(:editor, "Project file cache rebuild failed: #{reason}")
+    []
   end
 
   # ── Persistence ─────────────────────────────────────────────────────────────
@@ -924,8 +964,8 @@ defmodule Minga.Project do
 
   # ── Domain delegates ──────────────────────────────────────────────────────
 
-  @doc "Lists all files in the given directory, respecting .gitignore."
-  @spec list_files(String.t()) :: {:ok, [String.t()]} | {:error, String.t()}
+  @doc "Lists all files under an explicit directory workspace root."
+  @spec list_files(Root.t()) :: {:ok, [String.t()]} | {:error, String.t()}
   defdelegate list_files(root), to: Minga.Project.FileFind
 
   @doc "Finds alternate files (test <> implementation) for the given file."

--- a/lib/minga/project/file_find.ex
+++ b/lib/minga/project/file_find.ex
@@ -1,26 +1,14 @@
 defmodule Minga.Project.FileFind do
   @moduledoc """
-  Discovers project files for the `SPC f f` (find file) picker.
+  Discovers files for an explicit directory workspace.
 
-  Uses the cheapest available tool to list files in the project directory:
+  Recursive discovery accepts `Minga.Project.Root` values rather than path strings. This keeps opened files, detected ancestors, and cwd fallbacks from becoming authorization to inventory a directory.
 
-  1. `git ls-files` — preferred inside git repos, reads the index instead of
-     walking the filesystem, and respects `.gitignore`
-  2. `fd` — preferred outside git repos, fast, respects `.gitignore`
-  3. `find` — universally available fallback, slower, no gitignore support
-
-  In a large monorepo the git index is far cheaper than a full filesystem
-  walk, so git wins whenever the root is a git repository or worktree root
-  (it has a `.git` entry). `fd` no longer follows symlinks, so symlinked or
-  cyclic trees are never traversed.
-
-  Because `git ls-files` reads the index, files inside git **submodules** appear
-  only as their gitlink entry, not as individual files. This matches git's own
-  view of the worktree; open the submodule directly to browse its files. (The
-  previous `fd`-first behaviour walked into submodules.)
-
-  All paths are returned relative to the given root directory.
+  Uses the cheapest available tool: `git ls-files` for repository roots, `fd` elsewhere, and `find` as the universal fallback. Every command runs in a cancellable worker that owns and terminates the external process tree.
   """
+
+  alias Minga.Project.FileFind.Worker
+  alias Minga.Project.Root
 
   @typedoc "A file discovery strategy."
   @type strategy :: :fd | :git | :find | :none
@@ -28,46 +16,106 @@ defmodule Minga.Project.FileFind do
   @typedoc "Result of file discovery."
   @type result :: {:ok, [String.t()]} | {:error, String.t()}
 
-  @doc """
-  Lists all files under `root`, returning `{:ok, paths}` with paths relative
-  to `root`, sorted alphabetically.
+  @doc "Lists files under an explicit directory workspace root."
+  @spec list_files(Root.t()) :: result()
+  def list_files(%Root{} = root) do
+    owner = self()
 
-  Detects the best available tool automatically. Returns an error tuple if
-  no suitable tool is found.
-  """
-  @spec list_files(String.t()) :: result()
-  def list_files(root \\ File.cwd!()) do
-    if File.dir?(root) do
-      case detect_strategy(root) do
-        :fd ->
-          list_with_fd(root)
-
-        :git ->
-          list_with_git(root)
-
-        :find ->
-          list_with_find(root)
-
-        :none ->
-          {:error, "No file-finding tool available. Install `fd` or `git` for best results."}
-      end
-    else
-      {:error, "Directory not found: #{root}"}
+    case start(root, owner) do
+      {:ok, worker} -> await_worker(worker)
+      {:error, reason} -> {:error, reason}
     end
   end
 
-  @doc """
-  Detects which file-finding strategy to use for the given root directory.
+  def list_files(_root),
+    do: {:error, "Project inventory requires an explicit directory workspace root"}
 
-  Git repos prefer `:git` whenever `git` is available and `root` is a git
-  repository or worktree root (it has a `.git` entry), since reading the index
-  avoids traversing the filesystem. Otherwise `fd` is preferred, falling back
-  to `find`.
-  """
+  @doc "Starts cancellable discovery for an explicit directory workspace root."
+  @spec start(Root.t(), pid()) :: {:ok, pid()} | {:error, String.t()}
+  def start(%Root{} = root, owner) when is_pid(owner) do
+    with {:ok, path} <- inventory_path(root),
+         {:ok, command, strategy} <- command(path) do
+      Worker.start(owner, command, fn output, status -> parse_result(strategy, output, status) end)
+    else
+      {:error, reason} when is_atom(reason) -> {:error, root_error(reason, root.path)}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @doc "Cancels an in-flight discovery worker."
+  @spec cancel(pid()) :: :ok
+  defdelegate cancel(worker), to: Worker
+
+  @doc "Detects the file-finding strategy for a directory path without starting inventory."
   @spec detect_strategy(String.t()) :: strategy()
-  def detect_strategy(root) do
+  def detect_strategy(root) when is_binary(root) do
     detect_strategy(git_strategy_available?(root), root)
   end
+
+  @spec fd_args([String.t()]) :: [String.t()]
+  def fd_args(exclude_list \\ excludes()) do
+    exclude_args = Enum.flat_map(exclude_list, &["--exclude", &1])
+    ["--type", "f", "--hidden"] ++ Enum.concat(exclude_args, ["."])
+  end
+
+  @spec await_worker(pid()) :: result()
+  defp await_worker(worker) do
+    ref = Process.monitor(worker)
+
+    receive do
+      {:file_find_done, ^worker, result} ->
+        Process.demonitor(ref, [:flush])
+        result
+
+      {:DOWN, ^ref, :process, ^worker, reason} ->
+        {:error, "Project file discovery stopped: #{inspect(reason)}"}
+    end
+  end
+
+  @spec inventory_path(Root.t()) :: {:ok, String.t()} | {:error, Root.error()}
+  defp inventory_path(root), do: Root.inventory_path(root)
+
+  @spec command(String.t()) :: {:ok, Worker.command(), strategy()} | {:error, String.t()}
+  defp command(root) do
+    command(detect_strategy(root), root)
+  end
+
+  @spec command(strategy(), String.t()) ::
+          {:ok, Worker.command(), strategy()} | {:error, String.t()}
+  defp command(:git, root) do
+    args = ["ls-files", "--cached", "--others", "--exclude-standard"]
+    {:ok, {System.find_executable("git"), args, root}, :git}
+  end
+
+  defp command(:fd, root) do
+    {:ok, {fd_executable(), fd_args(), root}, :fd}
+  end
+
+  defp command(:find, root) do
+    exclude_args = Enum.flat_map(excludes(), &["-not", "-path", "*/#{&1}/*", "-not", "-name", &1])
+    args = [".", "-type", "f"] ++ exclude_args
+    {:ok, {System.find_executable("find"), args, root}, :find}
+  end
+
+  defp command(:none, _root) do
+    {:error, "No file-finding tool available. Install `fd` or `git` for best results."}
+  end
+
+  @spec parse_result(strategy(), String.t(), non_neg_integer()) :: result()
+  defp parse_result(:fd, output, 0), do: {:ok, parse_lines(output)}
+  defp parse_result(:fd, output, _status), do: {:error, "fd failed: #{String.trim(output)}"}
+
+  defp parse_result(:git, output, 0) do
+    {:ok, output |> parse_lines() |> filter_excludes()}
+  end
+
+  defp parse_result(:git, output, _status),
+    do: {:error, "git ls-files failed: #{String.trim(output)}"}
+
+  defp parse_result(:find, output, status) when status in [0, 1],
+    do: {:ok, parse_lines(output)}
+
+  defp parse_result(:find, output, _status), do: {:error, "find failed: #{output}"}
 
   @spec detect_strategy(boolean(), String.t()) :: strategy()
   defp detect_strategy(true, _root), do: :git
@@ -83,73 +131,11 @@ defmodule Minga.Project.FileFind do
 
   @spec detect_find_strategy() :: strategy()
   defp detect_find_strategy do
-    if executable_available?("find") do
-      :find
-    else
-      :none
-    end
+    if executable_available?("find"), do: :find, else: :none
   end
-
-  # ── Strategies ──────────────────────────────────────────────────────────────
 
   @spec excludes() :: [String.t()]
   defp excludes, do: Minga.Config.get(:file_find_excludes)
-
-  @doc """
-  Builds the argument list for the `fd` file-discovery command.
-
-  Symlinks are deliberately not followed (no `--follow`), so large or cyclic
-  symlinked trees are never traversed. Configured excludes are passed through
-  as `--exclude` pairs.
-  """
-  @spec fd_args([String.t()]) :: [String.t()]
-  def fd_args(exclude_list \\ excludes()) do
-    exclude_args = Enum.flat_map(exclude_list, &["--exclude", &1])
-    ["--type", "f", "--hidden"] ++ Enum.concat(exclude_args, ["."])
-  end
-
-  @spec list_with_fd(String.t()) :: result()
-  defp list_with_fd(root) do
-    case System.cmd(fd_executable(), fd_args(), cd: root, stderr_to_stdout: true) do
-      {output, 0} ->
-        {:ok, parse_lines(output)}
-
-      {error, _code} ->
-        {:error, "fd failed: #{String.trim(error)}"}
-    end
-  end
-
-  @spec list_with_git(String.t()) :: result()
-  defp list_with_git(root) do
-    args = ["ls-files", "--cached", "--others", "--exclude-standard"]
-
-    case System.cmd("git", args, cd: root, stderr_to_stdout: true) do
-      {output, 0} ->
-        {:ok, output |> parse_lines() |> filter_excludes()}
-
-      {error, _code} ->
-        {:error, "git ls-files failed: #{String.trim(error)}"}
-    end
-  end
-
-  @spec list_with_find(String.t()) :: result()
-  defp list_with_find(root) do
-    exclude_args =
-      Enum.flat_map(excludes(), &["-not", "-path", "*/#{&1}/*", "-not", "-name", &1])
-
-    args = [".", "-type", "f"] ++ exclude_args
-
-    case System.cmd("find", args, cd: root, stderr_to_stdout: true) do
-      {output, code} when code in [0, 1] ->
-        # find may exit 1 with permission errors but still produce output
-        {:ok, parse_lines(output)}
-
-      {error, _code} ->
-        {:error, "find failed: #{error}"}
-    end
-  end
-
-  # ── Helpers ─────────────────────────────────────────────────────────────────
 
   @spec filter_excludes([String.t()]) :: [String.t()]
   defp filter_excludes(paths) do
@@ -175,32 +161,25 @@ defmodule Minga.Project.FileFind do
   defp normalize_path(path), do: path
 
   @spec executable_available?(String.t()) :: boolean()
-  defp executable_available?(name) do
-    System.find_executable(name) != nil
-  end
+  defp executable_available?(name), do: System.find_executable(name) != nil
 
-  # Ubuntu's fd-find package installs the binary as `fdfind`.
   @spec fd_executable() :: String.t() | nil
-  defp fd_executable do
-    System.find_executable("fd") || System.find_executable("fdfind")
-  end
+  defp fd_executable, do: System.find_executable("fd") || System.find_executable("fdfind")
 
   @spec git_strategy_available?(String.t()) :: boolean()
   defp git_strategy_available?(root) do
     executable_available?("git") and git_repo_root?(root)
   end
 
-  # True when `root` is the top of a git repository or worktree, i.e. it has a
-  # `.git` entry. Uses `File.exists?` (not `File.dir?`) because git worktrees
-  # store `.git` as a *file* pointing at the real git dir.
-  #
-  # Deliberately does not walk up the tree (as `git rev-parse` would): the file
-  # picker's root is the project root, and a non-repo directory that merely sits
-  # *inside* a larger repo (e.g. an ignored build/tmp dir) should fall back to
-  # `fd` rather than run `git ls-files`, which would list nothing for an ignored
-  # subtree.
   @spec git_repo_root?(String.t()) :: boolean()
-  defp git_repo_root?(root) do
-    File.exists?(Path.join(root, ".git"))
-  end
+  defp git_repo_root?(root), do: File.exists?(Path.join(root, ".git"))
+
+  @spec root_error(Root.error(), String.t()) :: String.t()
+  defp root_error(:not_a_directory, path), do: "Directory not found: #{path}"
+
+  defp root_error(:broad_root_confirmation_required, path),
+    do: "Broad project root requires explicit confirmation: #{path}"
+
+  defp root_error(:not_a_directory_root, _path),
+    do: "Project inventory requires an explicit directory workspace root"
 end

--- a/lib/minga/project/file_find.ex
+++ b/lib/minga/project/file_find.ex
@@ -16,34 +16,53 @@ defmodule Minga.Project.FileFind do
   @typedoc "Result of file discovery."
   @type result :: {:ok, [String.t()]} | {:error, String.t()}
 
-  @doc "Lists files under an explicit directory workspace root."
-  @spec list_files(Root.t()) :: result()
-  def list_files(%Root{} = root) do
+  @typedoc "Discovery options shared by synchronous and managed callers."
+  @type option ::
+          {:timeout, pos_integer()}
+          | {:max_output_bytes, pos_integer()}
+          | {:max_file_count, pos_integer()}
+
+  @default_timeout_ms 30_000
+
+  @doc "Lists files under an explicit directory workspace root with bounded execution."
+  @spec list_files(Root.t(), [option()]) :: result()
+  def list_files(root, opts \\ [])
+
+  def list_files(%Root{} = root, opts) when is_list(opts) do
     owner = self()
 
-    case start(root, owner) do
-      {:ok, worker} -> await_worker(worker)
+    case start(root, owner, opts) do
+      {:ok, worker} -> await_result(worker, Keyword.get(opts, :timeout, @default_timeout_ms))
       {:error, reason} -> {:error, reason}
     end
   end
 
-  def list_files(_root),
+  def list_files(_root, _opts),
     do: {:error, "Project inventory requires an explicit directory workspace root"}
 
   @doc "Starts cancellable discovery for an explicit directory workspace root."
-  @spec start(Root.t(), pid()) :: {:ok, pid()} | {:error, String.t()}
-  def start(%Root{} = root, owner) when is_pid(owner) do
+  @spec start(Root.t(), pid(), [option()]) :: {:ok, pid()} | {:error, String.t()}
+  def start(root, owner, opts \\ [])
+
+  def start(%Root{} = root, owner, opts) when is_pid(owner) and is_list(opts) do
     with {:ok, path} <- inventory_path(root),
          {:ok, command, strategy} <- command(path) do
-      Worker.start(owner, command, fn output, status -> parse_result(strategy, output, status) end)
+      worker_opts = Keyword.take(opts, [:max_output_bytes, :max_file_count])
+
+      Worker.start(
+        owner,
+        command,
+        fn output, status -> parse_result(strategy, output, status) end,
+        worker_opts
+      )
     else
       {:error, reason} when is_atom(reason) -> {:error, root_error(reason, root.path)}
       {:error, reason} -> {:error, reason}
     end
   end
 
-  @doc "Cancels an in-flight discovery worker."
-  @spec cancel(pid()) :: :ok
+  @doc "Cancels an in-flight discovery worker and waits for process-tree termination."
+  @spec cancel(pid()) :: Worker.cancel_result()
   defdelegate cancel(worker), to: Worker
 
   @doc "Detects the file-finding strategy for a directory path without starting inventory."
@@ -58,8 +77,9 @@ defmodule Minga.Project.FileFind do
     ["--type", "f", "--hidden"] ++ Enum.concat(exclude_args, ["."])
   end
 
-  @spec await_worker(pid()) :: result()
-  defp await_worker(worker) do
+  @doc false
+  @spec await_result(pid(), pos_integer()) :: result()
+  def await_result(worker, timeout) when is_integer(timeout) and timeout > 0 do
     ref = Process.monitor(worker)
 
     receive do
@@ -69,8 +89,29 @@ defmodule Minga.Project.FileFind do
 
       {:DOWN, ^ref, :process, ^worker, reason} ->
         {:error, "Project file discovery stopped: #{inspect(reason)}"}
+    after
+      timeout ->
+        cancel_result = cancel(worker)
+        Process.demonitor(ref, [:flush])
+        flush_worker_result(worker)
+        timeout_error(cancel_result)
     end
   end
+
+  @spec flush_worker_result(pid()) :: :ok
+  defp flush_worker_result(worker) do
+    receive do
+      {:file_find_done, ^worker, _result} -> :ok
+    after
+      0 -> :ok
+    end
+  end
+
+  @spec timeout_error(Worker.cancel_result()) :: result()
+  defp timeout_error(:ok), do: {:error, "Project file discovery timed out"}
+
+  defp timeout_error({:error, reason}),
+    do: {:error, "Project file discovery timed out; #{reason}"}
 
   @spec inventory_path(Root.t()) :: {:ok, String.t()} | {:error, Root.error()}
   defp inventory_path(root), do: Root.inventory_path(root)
@@ -182,4 +223,10 @@ defmodule Minga.Project.FileFind do
 
   defp root_error(:not_a_directory_root, _path),
     do: "Project inventory requires an explicit directory workspace root"
+
+  defp root_error(:invalid_broad_root_confirmation, path),
+    do: "Broad project root confirmation must be true or false: #{path}"
+
+  defp root_error(:root_changed, path),
+    do: "Project root changed after authorization: #{path}"
 end

--- a/lib/minga/project/file_find/worker.ex
+++ b/lib/minga/project/file_find/worker.ex
@@ -2,13 +2,27 @@ defmodule Minga.Project.FileFind.Worker do
   @moduledoc """
   Owns one external project-file discovery process.
 
-  The worker monitors its requester and terminates the external process tree when cancelled or when the requester exits. Port output is accumulated asynchronously so project root switches and shutdown never leave a blocked `System.cmd/3` caller behind.
+  The worker monitors its requester and terminates the external process tree when cancelled or when the requester exits. Port output is accumulated asynchronously with byte and file-count bounds so project discovery cannot exhaust the VM.
   """
 
   use GenServer
 
+  @cancel_timeout_ms 5_000
+  @default_max_output_bytes 16 * 1024 * 1024
+  @default_max_file_count 1_000_000
+
   @enforce_keys [:owner, :owner_ref, :port, :parser]
-  defstruct [:owner, :owner_ref, :port, :parser, output: []]
+  defstruct [
+    :owner,
+    :owner_ref,
+    :port,
+    :parser,
+    output: [],
+    output_bytes: 0,
+    file_count: 0,
+    max_output_bytes: @default_max_output_bytes,
+    max_file_count: @default_max_file_count
+  ]
 
   @typedoc "An external command with an executable, arguments, and working directory."
   @type command :: {executable :: String.t(), args :: [String.t()], directory :: String.t()}
@@ -16,30 +30,45 @@ defmodule Minga.Project.FileFind.Worker do
   @typedoc "Transforms command output and exit status into a discovery result."
   @type parser :: (String.t(), non_neg_integer() -> term())
 
+  @typedoc "Worker options."
+  @type option :: {:max_output_bytes, pos_integer()} | {:max_file_count, pos_integer()}
+
   @typedoc "Worker state."
   @type t :: %__MODULE__{
           owner: pid(),
           owner_ref: reference(),
           port: port() | nil,
           parser: parser(),
-          output: [binary()]
+          output: [binary()],
+          output_bytes: non_neg_integer(),
+          file_count: non_neg_integer(),
+          max_output_bytes: pos_integer(),
+          max_file_count: pos_integer()
         }
 
+  @typedoc "Cancellation result."
+  @type cancel_result :: :ok | {:error, String.t()}
+
   @doc "Starts an unlinked discovery worker monitored by its owner."
-  @spec start(pid(), command(), parser()) :: GenServer.on_start()
-  def start(owner, command, parser) when is_pid(owner) and is_function(parser, 2) do
-    GenServer.start(__MODULE__, {owner, command, parser})
+  @spec start(pid(), command(), parser(), [option()]) :: GenServer.on_start()
+  def start(owner, command, parser, opts \\ [])
+      when is_pid(owner) and is_function(parser, 2) and is_list(opts) do
+    GenServer.start(__MODULE__, {owner, command, parser, opts})
   end
 
-  @doc "Cancels discovery and terminates its external process tree."
-  @spec cancel(pid()) :: :ok
+  @doc "Cancels discovery and waits for its external process tree to terminate."
+  @spec cancel(pid()) :: cancel_result()
   def cancel(pid) when is_pid(pid) do
-    GenServer.cast(pid, :cancel)
+    GenServer.call(pid, :cancel, @cancel_timeout_ms)
+  catch
+    :exit, {:noproc, _call} -> :ok
+    :exit, {:normal, _call} -> :ok
+    :exit, reason -> {:error, "Discovery cancellation failed: #{inspect(reason)}"}
   end
 
   @impl true
-  @spec init({pid(), command(), parser()}) :: {:ok, t()} | {:stop, term()}
-  def init({owner, {executable, args, directory}, parser}) do
+  @spec init({pid(), command(), parser(), [option()]}) :: {:ok, t()} | {:stop, term()}
+  def init({owner, {executable, args, directory}, parser, opts}) do
     owner_ref = Process.monitor(owner)
 
     port =
@@ -55,20 +84,36 @@ defmodule Minga.Project.FileFind.Worker do
         ]
       )
 
-    {:ok, %__MODULE__{owner: owner, owner_ref: owner_ref, port: port, parser: parser}}
+    {:ok,
+     %__MODULE__{
+       owner: owner,
+       owner_ref: owner_ref,
+       port: port,
+       parser: parser,
+       max_output_bytes: Keyword.get(opts, :max_output_bytes, @default_max_output_bytes),
+       max_file_count: Keyword.get(opts, :max_file_count, @default_max_file_count)
+     }}
   rescue
     error -> {:stop, error}
   end
 
   @impl true
-  @spec handle_cast(term(), t()) :: {:noreply, t()} | {:stop, term(), t()}
-  def handle_cast(:cancel, state), do: {:stop, :normal, state}
-  def handle_cast(_message, state), do: {:noreply, state}
+  @spec handle_call(term(), GenServer.from(), t()) ::
+          {:reply, term(), t()} | {:stop, term(), term(), t()}
+  def handle_call(:cancel, _from, state) do
+    {result, state} = stop_external_process(state)
+    {:stop, :normal, result, state}
+  end
+
+  def handle_call(_message, _from, state), do: {:reply, {:error, :unsupported}, state}
 
   @impl true
   @spec handle_info(term(), t()) :: {:noreply, t()} | {:stop, term(), t()}
   def handle_info({port, {:data, data}}, %__MODULE__{port: port} = state) do
-    {:noreply, %{state | output: [data | state.output]}}
+    output_bytes = state.output_bytes + byte_size(data)
+    file_count = state.file_count + newline_count(data)
+
+    handle_output_chunk(state, data, output_bytes, file_count)
   end
 
   def handle_info({port, {:exit_status, status}}, %__MODULE__{port: port} = state) do
@@ -89,37 +134,98 @@ defmodule Minga.Project.FileFind.Worker do
 
   @impl true
   @spec terminate(term(), t()) :: :ok
-  def terminate(_reason, %__MODULE__{port: nil}), do: :ok
-
-  def terminate(_reason, %__MODULE__{port: port}) do
-    terminate_process_tree(port)
-    :ok
+  def terminate(_reason, state) do
+    {result, _state} = stop_external_process(state)
+    log_termination_error(result)
   end
 
-  @spec terminate_process_tree(port()) :: :ok
+  @spec handle_output_chunk(t(), binary(), non_neg_integer(), non_neg_integer()) ::
+          {:noreply, t()} | {:stop, :normal, t()}
+  defp handle_output_chunk(state, _data, output_bytes, _file_count)
+       when output_bytes > state.max_output_bytes do
+    stop_for_limit(state, "byte")
+  end
+
+  defp handle_output_chunk(state, _data, _output_bytes, file_count)
+       when file_count > state.max_file_count do
+    stop_for_limit(state, "file-count")
+  end
+
+  defp handle_output_chunk(state, data, output_bytes, file_count) do
+    {:noreply,
+     %{
+       state
+       | output: [data | state.output],
+         output_bytes: output_bytes,
+         file_count: file_count
+     }}
+  end
+
+  @spec stop_for_limit(t(), String.t()) :: {:stop, :normal, t()}
+  defp stop_for_limit(state, limit_name) do
+    send(
+      state.owner,
+      {:file_find_done, self(),
+       {:error, "Project file discovery exceeded the #{limit_name} limit"}}
+    )
+
+    {:stop, :normal, state}
+  end
+
+  @spec newline_count(binary()) :: non_neg_integer()
+  defp newline_count(data), do: length(:binary.matches(data, "\n"))
+
+  @spec stop_external_process(t()) :: {cancel_result(), t()}
+  defp stop_external_process(%__MODULE__{port: nil} = state), do: {:ok, state}
+
+  defp stop_external_process(%__MODULE__{port: port} = state) do
+    result = terminate_process_tree(port)
+    {result, %{state | port: nil}}
+  end
+
+  @spec terminate_process_tree(port()) :: cancel_result()
   defp terminate_process_tree(port) do
-    case Port.info(port, :os_pid) do
-      {:os_pid, os_pid} -> terminate_os_processes([os_pid | descendant_pids(os_pid)])
-      nil -> :ok
-    end
+    result =
+      case Port.info(port, :os_pid) do
+        {:os_pid, os_pid} -> terminate_os_processes(os_pid)
+        nil -> :ok
+      end
 
     close_port(port)
+    result
   end
 
-  @spec descendant_pids(pos_integer()) :: [pos_integer()]
+  @spec terminate_os_processes(pos_integer()) :: cancel_result()
+  defp terminate_os_processes(root_pid) do
+    with {:ok, descendants} <- descendant_pids(root_pid),
+         pids = [root_pid | descendants],
+         :ok <- signal_processes("-TERM", pids) do
+      signal_processes("-KILL", pids)
+    end
+  end
+
+  @spec descendant_pids(pos_integer()) :: {:ok, [pos_integer()]} | {:error, String.t()}
   defp descendant_pids(root_pid) do
     case System.find_executable("ps") do
-      nil -> []
+      nil -> {:error, "Cannot inspect discovery descendants: ps not found"}
       ps -> descendants_from_ps(ps, root_pid)
     end
   end
 
-  @spec descendants_from_ps(String.t(), pos_integer()) :: [pos_integer()]
+  @spec descendants_from_ps(String.t(), pos_integer()) ::
+          {:ok, [pos_integer()]} | {:error, String.t()}
   defp descendants_from_ps(ps, root_pid) do
     case System.cmd(ps, ["-axo", "pid=,ppid="], stderr_to_stdout: true) do
-      {output, 0} -> output |> parse_process_table() |> collect_descendants([root_pid], [])
-      {_output, _status} -> []
+      {output, 0} ->
+        descendants = output |> parse_process_table() |> collect_descendants([root_pid], [])
+        {:ok, descendants}
+
+      {output, status} ->
+        {:error,
+         "Cannot inspect discovery descendants (ps status #{status}): #{String.trim(output)}"}
     end
+  rescue
+    error -> {:error, "Cannot inspect discovery descendants: #{Exception.message(error)}"}
   end
 
   @spec parse_process_table(String.t()) :: %{pos_integer() => [pos_integer()]}
@@ -155,26 +261,50 @@ defmodule Minga.Project.FileFind.Worker do
     collect_descendants(table, children ++ pending, children ++ descendants)
   end
 
-  @spec terminate_os_processes([pos_integer(), ...]) :: :ok
-  defp terminate_os_processes(pids) do
-    signal_processes("-TERM", pids)
-    signal_processes("-KILL", pids)
-  end
-
-  @spec signal_processes(String.t(), [pos_integer()]) :: :ok
+  @spec signal_processes(String.t(), [pos_integer()]) :: cancel_result()
   defp signal_processes(signal, pids) do
     case System.find_executable("kill") do
-      nil -> :ok
+      nil -> {:error, "Cannot signal discovery processes: kill not found"}
       kill -> run_kill(kill, signal, pids)
     end
   end
 
-  @spec run_kill(String.t(), String.t(), [pos_integer()]) :: :ok
+  @spec run_kill(String.t(), String.t(), [pos_integer()]) :: cancel_result()
   defp run_kill(kill, signal, pids) do
     args = [signal | Enum.map(pids, &Integer.to_string/1)]
-    _result = System.cmd(kill, args, stderr_to_stdout: true)
-    :ok
+
+    case System.cmd(kill, args, stderr_to_stdout: true) do
+      {_output, 0} -> :ok
+      {output, status} -> normalize_kill_failure(signal, status, output)
+    end
+  rescue
+    error ->
+      {:error, "Failed to signal discovery processes with #{signal}: #{Exception.message(error)}"}
   end
+
+  @spec normalize_kill_failure(String.t(), non_neg_integer(), String.t()) :: cancel_result()
+  defp normalize_kill_failure(signal, status, output) do
+    errors = String.split(output, "\n", trim: true)
+
+    normalize_kill_errors(
+      Enum.all?(errors, &no_such_process?/1) and errors != [],
+      signal,
+      status,
+      output
+    )
+  end
+
+  @spec normalize_kill_errors(boolean(), String.t(), non_neg_integer(), String.t()) ::
+          cancel_result()
+  defp normalize_kill_errors(true, _signal, _status, _output), do: :ok
+
+  defp normalize_kill_errors(false, signal, status, output) do
+    {:error,
+     "Failed to signal discovery processes with #{signal} (status #{status}): #{String.trim(output)}"}
+  end
+
+  @spec no_such_process?(String.t()) :: boolean()
+  defp no_such_process?(line), do: String.contains?(String.downcase(line), "no such process")
 
   @spec close_port(port()) :: :ok
   defp close_port(port) do
@@ -182,5 +312,13 @@ defmodule Minga.Project.FileFind.Worker do
     :ok
   catch
     :error, :badarg -> :ok
+  end
+
+  @spec log_termination_error(cancel_result()) :: :ok
+  defp log_termination_error(:ok), do: :ok
+
+  defp log_termination_error({:error, reason}) do
+    Minga.Log.error(:editor, reason)
+    :ok
   end
 end

--- a/lib/minga/project/file_find/worker.ex
+++ b/lib/minga/project/file_find/worker.ex
@@ -1,0 +1,186 @@
+defmodule Minga.Project.FileFind.Worker do
+  @moduledoc """
+  Owns one external project-file discovery process.
+
+  The worker monitors its requester and terminates the external process tree when cancelled or when the requester exits. Port output is accumulated asynchronously so project root switches and shutdown never leave a blocked `System.cmd/3` caller behind.
+  """
+
+  use GenServer
+
+  @enforce_keys [:owner, :owner_ref, :port, :parser]
+  defstruct [:owner, :owner_ref, :port, :parser, output: []]
+
+  @typedoc "An external command with an executable, arguments, and working directory."
+  @type command :: {executable :: String.t(), args :: [String.t()], directory :: String.t()}
+
+  @typedoc "Transforms command output and exit status into a discovery result."
+  @type parser :: (String.t(), non_neg_integer() -> term())
+
+  @typedoc "Worker state."
+  @type t :: %__MODULE__{
+          owner: pid(),
+          owner_ref: reference(),
+          port: port() | nil,
+          parser: parser(),
+          output: [binary()]
+        }
+
+  @doc "Starts an unlinked discovery worker monitored by its owner."
+  @spec start(pid(), command(), parser()) :: GenServer.on_start()
+  def start(owner, command, parser) when is_pid(owner) and is_function(parser, 2) do
+    GenServer.start(__MODULE__, {owner, command, parser})
+  end
+
+  @doc "Cancels discovery and terminates its external process tree."
+  @spec cancel(pid()) :: :ok
+  def cancel(pid) when is_pid(pid) do
+    GenServer.cast(pid, :cancel)
+  end
+
+  @impl true
+  @spec init({pid(), command(), parser()}) :: {:ok, t()} | {:stop, term()}
+  def init({owner, {executable, args, directory}, parser}) do
+    owner_ref = Process.monitor(owner)
+
+    port =
+      Port.open(
+        {:spawn_executable, String.to_charlist(executable)},
+        [
+          :binary,
+          :exit_status,
+          :stderr_to_stdout,
+          :hide,
+          {:args, Enum.map(args, &String.to_charlist/1)},
+          {:cd, String.to_charlist(directory)}
+        ]
+      )
+
+    {:ok, %__MODULE__{owner: owner, owner_ref: owner_ref, port: port, parser: parser}}
+  rescue
+    error -> {:stop, error}
+  end
+
+  @impl true
+  @spec handle_cast(term(), t()) :: {:noreply, t()} | {:stop, term(), t()}
+  def handle_cast(:cancel, state), do: {:stop, :normal, state}
+  def handle_cast(_message, state), do: {:noreply, state}
+
+  @impl true
+  @spec handle_info(term(), t()) :: {:noreply, t()} | {:stop, term(), t()}
+  def handle_info({port, {:data, data}}, %__MODULE__{port: port} = state) do
+    {:noreply, %{state | output: [data | state.output]}}
+  end
+
+  def handle_info({port, {:exit_status, status}}, %__MODULE__{port: port} = state) do
+    output = state.output |> Enum.reverse() |> IO.iodata_to_binary()
+    result = state.parser.(output, status)
+    send(state.owner, {:file_find_done, self(), result})
+    {:stop, :normal, %{state | port: nil}}
+  end
+
+  def handle_info(
+        {:DOWN, ref, :process, owner, _reason},
+        %__MODULE__{owner: owner, owner_ref: ref} = state
+      ) do
+    {:stop, :normal, state}
+  end
+
+  def handle_info(_message, state), do: {:noreply, state}
+
+  @impl true
+  @spec terminate(term(), t()) :: :ok
+  def terminate(_reason, %__MODULE__{port: nil}), do: :ok
+
+  def terminate(_reason, %__MODULE__{port: port}) do
+    terminate_process_tree(port)
+    :ok
+  end
+
+  @spec terminate_process_tree(port()) :: :ok
+  defp terminate_process_tree(port) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} -> terminate_os_processes([os_pid | descendant_pids(os_pid)])
+      nil -> :ok
+    end
+
+    close_port(port)
+  end
+
+  @spec descendant_pids(pos_integer()) :: [pos_integer()]
+  defp descendant_pids(root_pid) do
+    case System.find_executable("ps") do
+      nil -> []
+      ps -> descendants_from_ps(ps, root_pid)
+    end
+  end
+
+  @spec descendants_from_ps(String.t(), pos_integer()) :: [pos_integer()]
+  defp descendants_from_ps(ps, root_pid) do
+    case System.cmd(ps, ["-axo", "pid=,ppid="], stderr_to_stdout: true) do
+      {output, 0} -> output |> parse_process_table() |> collect_descendants([root_pid], [])
+      {_output, _status} -> []
+    end
+  end
+
+  @spec parse_process_table(String.t()) :: %{pos_integer() => [pos_integer()]}
+  defp parse_process_table(output) do
+    output
+    |> String.split("\n", trim: true)
+    |> Enum.reduce(%{}, &add_process_row/2)
+  end
+
+  @spec add_process_row(String.t(), %{pos_integer() => [pos_integer()]}) ::
+          %{pos_integer() => [pos_integer()]}
+  defp add_process_row(row, table) do
+    case String.split(row, ~r/\s+/, trim: true) do
+      [pid, parent_pid] ->
+        Map.update(
+          table,
+          String.to_integer(parent_pid),
+          [String.to_integer(pid)],
+          &[String.to_integer(pid) | &1]
+        )
+
+      _other ->
+        table
+    end
+  end
+
+  @spec collect_descendants(%{pos_integer() => [pos_integer()]}, [pos_integer()], [pos_integer()]) ::
+          [pos_integer()]
+  defp collect_descendants(_table, [], descendants), do: descendants
+
+  defp collect_descendants(table, [parent | pending], descendants) do
+    children = Map.get(table, parent, [])
+    collect_descendants(table, children ++ pending, children ++ descendants)
+  end
+
+  @spec terminate_os_processes([pos_integer(), ...]) :: :ok
+  defp terminate_os_processes(pids) do
+    signal_processes("-TERM", pids)
+    signal_processes("-KILL", pids)
+  end
+
+  @spec signal_processes(String.t(), [pos_integer()]) :: :ok
+  defp signal_processes(signal, pids) do
+    case System.find_executable("kill") do
+      nil -> :ok
+      kill -> run_kill(kill, signal, pids)
+    end
+  end
+
+  @spec run_kill(String.t(), String.t(), [pos_integer()]) :: :ok
+  defp run_kill(kill, signal, pids) do
+    args = [signal | Enum.map(pids, &Integer.to_string/1)]
+    _result = System.cmd(kill, args, stderr_to_stdout: true)
+    :ok
+  end
+
+  @spec close_port(port()) :: :ok
+  defp close_port(port) do
+    if Port.info(port) != nil, do: Port.close(port)
+    :ok
+  catch
+    :error, :badarg -> :ok
+  end
+end

--- a/lib/minga/project/root.ex
+++ b/lib/minga/project/root.ex
@@ -1,0 +1,81 @@
+defmodule Minga.Project.Root do
+  @moduledoc """
+  Identifies the kind and authorization of a project root.
+
+  Recursive project features accept only explicit directory roots. Broad roots such as the user's home directory, the filesystem root, and mounted-volume roots additionally require confirmation from the user flow that created the value.
+  """
+
+  @enforce_keys [:kind, :path]
+  defstruct [:kind, :path, broad_root_confirmed?: false]
+
+  @typedoc "The filesystem object represented by a root."
+  @type kind :: :file | :directory
+
+  @typedoc "A project root with explicit kind and broad-root authorization."
+  @type t :: %__MODULE__{
+          kind: kind(),
+          path: String.t(),
+          broad_root_confirmed?: boolean()
+        }
+
+  @typedoc "Why a root cannot authorize recursive project behavior."
+  @type error :: :not_a_directory | :broad_root_confirmation_required | :not_a_directory_root
+
+  @doc "Builds a file-scoped root that cannot authorize recursive inventory."
+  @spec file(String.t()) :: t()
+  def file(path) when is_binary(path) do
+    %__MODULE__{kind: :file, path: Path.expand(path)}
+  end
+
+  @doc "Builds an explicit directory workspace root."
+  @spec directory(String.t(), keyword()) :: {:ok, t()} | {:error, error()}
+  def directory(path, opts \\ []) when is_binary(path) and is_list(opts) do
+    expanded = Path.expand(path)
+    confirmed? = Keyword.get(opts, :broad_root_confirmed, false)
+
+    build_directory(expanded, confirmed?, File.dir?(expanded), broad_path?(expanded))
+  end
+
+  @doc "Returns the authorized path for recursive inventory."
+  @spec inventory_path(t()) :: {:ok, String.t()} | {:error, error()}
+  def inventory_path(%__MODULE__{kind: :directory, path: path, broad_root_confirmed?: confirmed?}) do
+    build_inventory_path(path, confirmed?, File.dir?(path), broad_path?(path))
+  end
+
+  def inventory_path(%__MODULE__{}), do: {:error, :not_a_directory_root}
+
+  @doc "Returns true when a path names a root whose recursive traversal needs explicit confirmation."
+  @spec broad_path?(String.t()) :: boolean()
+  def broad_path?(path) when is_binary(path) do
+    expanded = Path.expand(path)
+    expanded == Path.expand("~") or broad_segments?(Path.split(expanded))
+  end
+
+  @spec build_directory(String.t(), boolean(), boolean(), boolean()) ::
+          {:ok, t()} | {:error, error()}
+  defp build_directory(_path, _confirmed?, false, _broad?), do: {:error, :not_a_directory}
+
+  defp build_directory(_path, false, true, true),
+    do: {:error, :broad_root_confirmation_required}
+
+  defp build_directory(path, confirmed?, true, _broad?) do
+    {:ok, %__MODULE__{kind: :directory, path: path, broad_root_confirmed?: confirmed?}}
+  end
+
+  @spec build_inventory_path(String.t(), boolean(), boolean(), boolean()) ::
+          {:ok, String.t()} | {:error, error()}
+  defp build_inventory_path(_path, _confirmed?, false, _broad?), do: {:error, :not_a_directory}
+
+  defp build_inventory_path(_path, false, true, true),
+    do: {:error, :broad_root_confirmation_required}
+
+  defp build_inventory_path(path, _confirmed?, true, _broad?), do: {:ok, path}
+
+  @spec broad_segments?([String.t()]) :: boolean()
+  defp broad_segments?(["/"]), do: true
+  defp broad_segments?(["/", "Volumes", _volume]), do: true
+  defp broad_segments?(["/", "mnt", _volume]), do: true
+  defp broad_segments?(["/", "media", _volume]), do: true
+  defp broad_segments?(["/", "run", "media", _user, _volume]), do: true
+  defp broad_segments?(_segments), do: false
+end

--- a/lib/minga/project/root.ex
+++ b/lib/minga/project/root.ex
@@ -2,8 +2,10 @@ defmodule Minga.Project.Root do
   @moduledoc """
   Identifies the kind and authorization of a project root.
 
-  Recursive project features accept only explicit directory roots. Broad roots such as the user's home directory, the filesystem root, and mounted-volume roots additionally require confirmation from the user flow that created the value.
+  Recursive project features accept only explicit directory roots. Broad roots such as the user's home directory, the filesystem root, and mounted-volume roots additionally require confirmation from the user flow that created the value. Directory paths are canonicalized so symlink aliases cannot bypass that boundary.
   """
+
+  @max_symlink_depth 40
 
   @enforce_keys [:kind, :path]
   defstruct [:kind, :path, broad_root_confirmed?: false]
@@ -19,57 +21,175 @@ defmodule Minga.Project.Root do
         }
 
   @typedoc "Why a root cannot authorize recursive project behavior."
-  @type error :: :not_a_directory | :broad_root_confirmation_required | :not_a_directory_root
+  @type error ::
+          :not_a_directory
+          | :broad_root_confirmation_required
+          | :invalid_broad_root_confirmation
+          | :not_a_directory_root
+          | :root_changed
+
+  @typedoc "Why a filesystem path could not be canonicalized."
+  @type canonical_error :: File.posix() | :too_many_symlinks
 
   @doc "Builds a file-scoped root that cannot authorize recursive inventory."
   @spec file(String.t()) :: t()
   def file(path) when is_binary(path) do
-    %__MODULE__{kind: :file, path: Path.expand(path)}
+    expanded = Path.expand(path)
+
+    canonical =
+      case canonical_path(expanded) do
+        {:ok, resolved} -> resolved
+        {:error, _reason} -> expanded
+      end
+
+    %__MODULE__{kind: :file, path: canonical}
   end
 
   @doc "Builds an explicit directory workspace root."
   @spec directory(String.t(), keyword()) :: {:ok, t()} | {:error, error()}
   def directory(path, opts \\ []) when is_binary(path) and is_list(opts) do
-    expanded = Path.expand(path)
-    confirmed? = Keyword.get(opts, :broad_root_confirmed, false)
-
-    build_directory(expanded, confirmed?, File.dir?(expanded), broad_path?(expanded))
+    with {:ok, confirmed?} <- confirmation(Keyword.get(opts, :broad_root_confirmed, false)),
+         {:ok, canonical} <- canonical_directory(path),
+         :ok <- authorize_broad_root(canonical, confirmed?) do
+      {:ok,
+       %__MODULE__{
+         kind: :directory,
+         path: canonical,
+         broad_root_confirmed?: confirmed?
+       }}
+    else
+      {:error, :invalid_broad_root_confirmation} = error -> error
+      {:error, :broad_root_confirmation_required} = error -> error
+      {:error, _reason} -> {:error, :not_a_directory}
+    end
   end
 
-  @doc "Returns the authorized path for recursive inventory."
+  @doc "Returns the authorized canonical path for recursive inventory."
   @spec inventory_path(t()) :: {:ok, String.t()} | {:error, error()}
   def inventory_path(%__MODULE__{kind: :directory, path: path, broad_root_confirmed?: confirmed?}) do
-    build_inventory_path(path, confirmed?, File.dir?(path), broad_path?(path))
+    with {:ok, valid_confirmation?} <- confirmation(confirmed?),
+         {:ok, canonical} <- canonical_directory(path),
+         :ok <- unchanged_root(path, canonical),
+         :ok <- authorize_broad_root(canonical, valid_confirmation?) do
+      {:ok, canonical}
+    else
+      {:error, :invalid_broad_root_confirmation} = error -> error
+      {:error, :root_changed} = error -> error
+      {:error, :broad_root_confirmation_required} = error -> error
+      {:error, _reason} -> {:error, :not_a_directory}
+    end
   end
 
   def inventory_path(%__MODULE__{}), do: {:error, :not_a_directory_root}
+
+  @doc "Returns the canonical target of an existing filesystem path."
+  @spec canonical_path(String.t()) :: {:ok, String.t()} | {:error, canonical_error()}
+  def canonical_path(path) when is_binary(path) do
+    path
+    |> Path.expand()
+    |> canonical_path([], 0)
+  end
 
   @doc "Returns true when a path names a root whose recursive traversal needs explicit confirmation."
   @spec broad_path?(String.t()) :: boolean()
   def broad_path?(path) when is_binary(path) do
     expanded = Path.expand(path)
-    expanded == Path.expand("~") or broad_segments?(Path.split(expanded))
+    expanded == canonical_home() or broad_segments?(Path.split(expanded))
   end
 
-  @spec build_directory(String.t(), boolean(), boolean(), boolean()) ::
-          {:ok, t()} | {:error, error()}
-  defp build_directory(_path, _confirmed?, false, _broad?), do: {:error, :not_a_directory}
+  @spec canonical_home() :: String.t()
+  defp canonical_home do
+    expanded_home = Path.expand("~")
 
-  defp build_directory(_path, false, true, true),
-    do: {:error, :broad_root_confirmation_required}
-
-  defp build_directory(path, confirmed?, true, _broad?) do
-    {:ok, %__MODULE__{kind: :directory, path: path, broad_root_confirmed?: confirmed?}}
+    case canonical_path(expanded_home) do
+      {:ok, canonical} -> canonical
+      {:error, _reason} -> expanded_home
+    end
   end
 
-  @spec build_inventory_path(String.t(), boolean(), boolean(), boolean()) ::
-          {:ok, String.t()} | {:error, error()}
-  defp build_inventory_path(_path, _confirmed?, false, _broad?), do: {:error, :not_a_directory}
+  @spec canonical_directory(String.t()) :: {:ok, String.t()} | {:error, canonical_error()}
+  defp canonical_directory(path) do
+    case canonical_path(path) do
+      {:ok, canonical} -> existing_directory(canonical, File.dir?(canonical))
+      {:error, reason} -> {:error, reason}
+    end
+  end
 
-  defp build_inventory_path(_path, false, true, true),
-    do: {:error, :broad_root_confirmation_required}
+  @spec existing_directory(String.t(), boolean()) ::
+          {:ok, String.t()} | {:error, :enotdir}
+  defp existing_directory(path, true), do: {:ok, path}
+  defp existing_directory(_path, false), do: {:error, :enotdir}
 
-  defp build_inventory_path(path, _confirmed?, true, _broad?), do: {:ok, path}
+  @spec confirmation(term()) :: {:ok, boolean()} | {:error, :invalid_broad_root_confirmation}
+  defp confirmation(true), do: {:ok, true}
+  defp confirmation(false), do: {:ok, false}
+  defp confirmation(_value), do: {:error, :invalid_broad_root_confirmation}
+
+  @spec authorize_broad_root(String.t(), boolean()) ::
+          :ok | {:error, :broad_root_confirmation_required}
+  defp authorize_broad_root(path, confirmed?) do
+    broad_root_authorization(broad_path?(path), confirmed?)
+  end
+
+  @spec broad_root_authorization(boolean(), boolean()) ::
+          :ok | {:error, :broad_root_confirmation_required}
+  defp broad_root_authorization(false, _confirmed?), do: :ok
+  defp broad_root_authorization(true, true), do: :ok
+  defp broad_root_authorization(true, false), do: {:error, :broad_root_confirmation_required}
+
+  @spec unchanged_root(String.t(), String.t()) :: :ok | {:error, :root_changed}
+  defp unchanged_root(path, path), do: :ok
+  defp unchanged_root(_authorized_path, _current_path), do: {:error, :root_changed}
+
+  @spec canonical_path(String.t(), [String.t()], non_neg_integer()) ::
+          {:ok, String.t()} | {:error, canonical_error()}
+  defp canonical_path(_path, _seen, depth) when depth >= @max_symlink_depth,
+    do: {:error, :too_many_symlinks}
+
+  defp canonical_path(path, seen, depth) do
+    {anchor, parts} = split_anchor(path)
+    resolve_components(parts, anchor, seen, depth)
+  end
+
+  @spec resolve_components([String.t()], String.t(), [String.t()], non_neg_integer()) ::
+          {:ok, String.t()} | {:error, canonical_error()}
+  defp resolve_components([], current, _seen, _depth), do: {:ok, current}
+
+  defp resolve_components([part | rest], current, seen, depth) do
+    candidate = Path.join(current, part)
+
+    case File.lstat(candidate) do
+      {:ok, %File.Stat{type: :symlink}} -> resolve_symlink(candidate, rest, seen, depth)
+      {:ok, _stat} -> resolve_components(rest, candidate, seen, depth)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec resolve_symlink(String.t(), [String.t()], [String.t()], non_neg_integer()) ::
+          {:ok, String.t()} | {:error, canonical_error()}
+  defp resolve_symlink(candidate, rest, seen, depth) do
+    if candidate in seen do
+      {:error, :too_many_symlinks}
+    else
+      case File.read_link(candidate) do
+        {:ok, target} ->
+          resolved_target = Path.expand(target, Path.dirname(candidate))
+          combined = Enum.reduce(rest, resolved_target, &Path.join(&2, &1))
+          canonical_path(combined, [candidate | seen], depth + 1)
+
+        {:error, reason} ->
+          {:error, reason}
+      end
+    end
+  end
+
+  @spec split_anchor(String.t()) :: {String.t(), [String.t()]}
+  defp split_anchor(path) do
+    case Path.split(path) do
+      [anchor | parts] -> {anchor, parts}
+      [] -> {path, []}
+    end
+  end
 
   @spec broad_segments?([String.t()]) :: boolean()
   defp broad_segments?(["/"]), do: true

--- a/lib/minga_agent/file_mention.ex
+++ b/lib/minga_agent/file_mention.ex
@@ -141,7 +141,7 @@ defmodule MingaAgent.FileMention do
   - `{:ok, [ContentPart.t()]}` when images are present (mixed text + image parts)
   - `{:error, message}` if any file doesn't exist or can't be read
   """
-  @spec resolve_prompt(String.t(), String.t()) ::
+  @spec resolve_prompt(String.t(), String.t() | nil) ::
           {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
   def resolve_prompt(text, project_root) do
     resolve_prompt(text, project_root, [])
@@ -153,9 +153,16 @@ defmodule MingaAgent.FileMention do
   Options:
     - `:model` — the model string for vision capability checking
   """
-  @spec resolve_prompt(String.t(), String.t(), keyword()) ::
+  @spec resolve_prompt(String.t(), String.t() | nil, keyword()) ::
           {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
-  def resolve_prompt(text, project_root, opts) do
+  def resolve_prompt(text, nil, _opts) do
+    case extract_mentions(text) do
+      [] -> {:ok, text}
+      _mentions -> {:error, "Cannot resolve file mentions without an active directory workspace"}
+    end
+  end
+
+  def resolve_prompt(text, project_root, opts) when is_binary(project_root) do
     mentions = extract_mentions(text)
 
     if mentions == [] do

--- a/lib/minga_agent/file_mention.ex
+++ b/lib/minga_agent/file_mention.ex
@@ -43,6 +43,7 @@ defmodule MingaAgent.FileMention do
           anchor_col: non_neg_integer()
         }
 
+  alias Minga.Project.Root
   alias MingaAgent.Config, as: AgentConfig
   alias MingaAgent.ModelLimits
   alias ReqLLM.Message.ContentPart
@@ -198,16 +199,7 @@ defmodule MingaAgent.FileMention do
   @spec resolve_all([mention()], String.t(), String.t()) ::
           {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
   defp resolve_all(mentions, text, root) do
-    results =
-      Enum.map(mentions, fn %{path: path} ->
-        abs_path = Path.expand(path, root)
-
-        if image_path?(path) do
-          {path, read_image_safe(abs_path)}
-        else
-          {path, read_file_safe(abs_path)}
-        end
-      end)
+    results = Enum.map(mentions, &resolve_mention(&1, root))
 
     errors = Enum.filter(results, fn {_path, result} -> match?({:error, _}, result) end)
 
@@ -226,6 +218,55 @@ defmodule MingaAgent.FileMention do
         build_text_prompt(results, body)
       end
     end
+  end
+
+  @spec resolve_mention(mention(), String.t()) ::
+          {String.t(),
+           {:ok, String.t()}
+           | {:ok, {:image, binary(), String.t(), non_neg_integer()}}
+           | {:error, String.t()}}
+  defp resolve_mention(%{path: path}, root) do
+    case contained_path(path, root) do
+      {:ok, abs_path} -> {path, read_mention(path, abs_path)}
+      {:error, reason} -> {path, {:error, reason}}
+    end
+  end
+
+  @spec read_mention(String.t(), String.t()) ::
+          {:ok, String.t()}
+          | {:ok, {:image, binary(), String.t(), non_neg_integer()}}
+          | {:error, String.t()}
+  defp read_mention(path, abs_path) do
+    if image_path?(path), do: read_image_safe(abs_path), else: read_file_safe(abs_path)
+  end
+
+  @spec contained_path(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
+  defp contained_path(path, root) do
+    contained_path(Path.type(path), path, root)
+  end
+
+  @spec contained_path(:absolute | :relative | :volumerelative, String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp contained_path(:absolute, _path, _root),
+    do: {:error, "absolute paths are outside the active workspace"}
+
+  defp contained_path(_path_type, path, root) do
+    with {:ok, canonical_root} <- Root.canonical_path(root),
+         {:ok, canonical_target} <- Root.canonical_path(Path.expand(path, canonical_root)),
+         true <- path_within_root?(canonical_target, canonical_root) do
+      {:ok, canonical_target}
+    else
+      false -> {:error, "path is outside the active workspace"}
+      {:error, :enoent} -> {:error, "file not found"}
+      {:error, reason} -> {:error, "cannot resolve path (#{reason})"}
+    end
+  end
+
+  @spec path_within_root?(String.t(), String.t()) :: boolean()
+  defp path_within_root?(_path, "/"), do: true
+
+  defp path_within_root?(path, root) do
+    path == root or String.starts_with?(path, root <> "/")
   end
 
   @spec build_text_prompt([{String.t(), {:ok, String.t()}}], String.t()) :: {:ok, String.t()}

--- a/lib/minga_agent/instructions.ex
+++ b/lib/minga_agent/instructions.ex
@@ -30,8 +30,11 @@ defmodule MingaAgent.Instructions do
   path of the file the user is currently editing (optional, used for
   directory-scoped discovery in monorepos).
   """
-  @spec discover(String.t(), String.t() | nil) :: [instruction()]
-  def discover(project_root, current_file \\ nil) when is_binary(project_root) do
+  @spec discover(String.t() | nil, String.t() | nil) :: [instruction()]
+  def discover(project_root, current_file \\ nil)
+  def discover(nil, _current_file), do: global_instructions()
+
+  def discover(project_root, current_file) when is_binary(project_root) do
     global_instructions() ++
       project_instructions(project_root) ++
       directory_instructions(project_root, current_file)
@@ -42,7 +45,7 @@ defmodule MingaAgent.Instructions do
 
   Returns nil if no instruction files were found.
   """
-  @spec assemble(String.t(), String.t() | nil) :: String.t() | nil
+  @spec assemble(String.t() | nil, String.t() | nil) :: String.t() | nil
   def assemble(project_root, current_file \\ nil) do
     instructions = discover(project_root, current_file)
 
@@ -62,8 +65,17 @@ defmodule MingaAgent.Instructions do
 
   Useful for the `/instructions` slash command.
   """
-  @spec summary(String.t(), String.t() | nil) :: String.t()
-  def summary(project_root, current_file \\ nil) do
+  @spec summary(String.t() | nil, String.t() | nil) :: String.t()
+  def summary(project_root, current_file \\ nil)
+
+  def summary(nil, current_file) do
+    case discover(nil, current_file) do
+      [] -> "No instruction files found.\n\nSearched:\n  ~/.config/minga/AGENTS.md"
+      found -> instruction_summary(found)
+    end
+  end
+
+  def summary(project_root, current_file) when is_binary(project_root) do
     instructions = discover(project_root, current_file)
 
     case instructions do
@@ -74,16 +86,21 @@ defmodule MingaAgent.Instructions do
           "  #{project_root}/.minga/AGENTS.md"
 
       found ->
-        header = "Loaded #{Enum.count(found)} instruction file(s):\n"
-
-        lines =
-          Enum.map_join(found, "\n", fn %Instruction{label: label, path: path, content: content} ->
-            size = String.length(content)
-            "  ✓ #{label} (#{path}, #{size} chars)"
-          end)
-
-        header <> lines
+        instruction_summary(found)
     end
+  end
+
+  @spec instruction_summary([instruction()]) :: String.t()
+  defp instruction_summary(found) do
+    header = "Loaded #{Enum.count(found)} instruction file(s):\n"
+
+    lines =
+      Enum.map_join(found, "\n", fn %Instruction{label: label, path: path, content: content} ->
+        size = String.length(content)
+        "  ✓ #{label} (#{path}, #{size} chars)"
+      end)
+
+    header <> lines
   end
 
   # ── Private ─────────────────────────────────────────────────────────────────

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -1573,8 +1573,13 @@ defmodule MingaEditor do
 
   @spec resolve_git_root() :: String.t() | nil
   def resolve_git_root do
-    root = Minga.Project.resolve_root()
+    resolve_git_root(Minga.Project.resolve_root())
+  end
 
+  @spec resolve_git_root(String.t() | nil) :: String.t() | nil
+  defp resolve_git_root(nil), do: nil
+
+  defp resolve_git_root(root) do
     case Minga.Git.root_for(root) do
       {:ok, git_root} -> git_root
       :not_git -> nil

--- a/lib/minga_editor/agent/slash_command.ex
+++ b/lib/minga_editor/agent/slash_command.ex
@@ -1351,7 +1351,7 @@ defmodule MingaEditor.Agent.SlashCommand do
     emit_system_message(state, summary)
   end
 
-  @spec detect_project_root() :: String.t()
+  @spec detect_project_root() :: String.t() | nil
   defp detect_project_root, do: Minga.Project.resolve_root()
 
   @spec emit_system_message(state(), String.t()) :: state()

--- a/lib/minga_editor/agent/view/prompt_render_window.ex
+++ b/lib/minga_editor/agent/view/prompt_render_window.ex
@@ -43,7 +43,7 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
         }
   @type token_context :: %{
           project_files: MapSet.t(String.t()),
-          project_root: String.t()
+          project_root: String.t() | nil
         }
 
   @doc "Reserved window_id for the agent prompt RenderWindow."
@@ -387,7 +387,9 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
     MapSet.member?(project_files, normalize_project_file(path))
   end
 
-  @spec existing_project_file?(String.t(), String.t()) :: boolean()
+  @spec existing_project_file?(String.t(), String.t() | nil) :: boolean()
+  defp existing_project_file?(_path, nil), do: false
+
   defp existing_project_file?(path, project_root) do
     path
     |> Path.expand(project_root)
@@ -509,11 +511,11 @@ defmodule MingaEditor.Agent.View.PromptRenderWindow do
     :exit, _ -> []
   end
 
-  @spec safe_project_root() :: String.t()
+  @spec safe_project_root() :: String.t() | nil
   defp safe_project_root do
     Minga.Project.resolve_root()
   catch
-    :exit, _ -> File.cwd!()
+    :exit, _ -> nil
   end
 
   @spec normalize_project_file(String.t()) :: String.t()

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -820,7 +820,7 @@ defmodule MingaEditor.Commands.Agent do
     FileMention.resolve_prompt(text, root, opts)
   end
 
-  @spec project_root() :: String.t()
+  @spec project_root() :: String.t() | nil
   defp project_root, do: Minga.Project.resolve_root()
 
   @doc "Clears the chat display without affecting conversation history."

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -537,41 +537,13 @@ defmodule MingaEditor.Commands.AgentSubStates do
   end
 
   @spec list_project_files() :: [String.t()]
-  defp list_project_files do
-    case cached_project_files() do
-      [] -> list_project_files_from_disk()
-      files -> files
-    end
-  end
+  defp list_project_files, do: cached_project_files()
 
   @spec cached_project_files() :: [String.t()]
   defp cached_project_files do
     Minga.Project.files()
   catch
     :exit, _ -> []
-  end
-
-  @spec list_project_files_from_disk() :: [String.t()]
-  defp list_project_files_from_disk do
-    case active_workspace_root() do
-      nil -> []
-      root -> list_workspace_files(root)
-    end
-  end
-
-  @spec active_workspace_root() :: Minga.Project.Root.t() | nil
-  defp active_workspace_root do
-    Minga.Project.workspace_root()
-  catch
-    :exit, _ -> nil
-  end
-
-  @spec list_workspace_files(Minga.Project.Root.t()) :: [String.t()]
-  defp list_workspace_files(root) do
-    case Minga.Project.list_files(root) do
-      {:ok, paths} -> paths
-      {:error, _} -> []
-    end
   end
 
   @spec run_search(state(), String.t()) :: state()

--- a/lib/minga_editor/commands/agent_sub_states.ex
+++ b/lib/minga_editor/commands/agent_sub_states.ex
@@ -553,16 +553,21 @@ defmodule MingaEditor.Commands.AgentSubStates do
 
   @spec list_project_files_from_disk() :: [String.t()]
   defp list_project_files_from_disk do
-    root =
-      try do
-        case Minga.Project.root() do
-          nil -> File.cwd!()
-          r -> r
-        end
-      catch
-        :exit, _ -> File.cwd!()
-      end
+    case active_workspace_root() do
+      nil -> []
+      root -> list_workspace_files(root)
+    end
+  end
 
+  @spec active_workspace_root() :: Minga.Project.Root.t() | nil
+  defp active_workspace_root do
+    Minga.Project.workspace_root()
+  catch
+    :exit, _ -> nil
+  end
+
+  @spec list_workspace_files(Minga.Project.Root.t()) :: [String.t()]
+  defp list_workspace_files(root) do
     case Minga.Project.list_files(root) do
       {:ok, paths} -> paths
       {:error, _} -> []

--- a/lib/minga_editor/commands/project.ex
+++ b/lib/minga_editor/commands/project.ex
@@ -8,7 +8,9 @@ defmodule MingaEditor.Commands.Project do
 
   alias MingaEditor.PickerUI
   alias MingaEditor.PromptUI
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias Minga.Mode
   alias Minga.Project
 
@@ -50,7 +52,7 @@ defmodule MingaEditor.Commands.Project do
 
     state
     |> MingaEditor.Commands.FileTree.close()
-    |> EditorState.update_file_tree(&MingaEditor.State.FileTree.set_project_root(&1, nil))
+    |> clear_file_tree_root()
   end
 
   def execute(state, :project_add) do
@@ -60,6 +62,12 @@ defmodule MingaEditor.Commands.Project do
 
   def execute(state, :project_remove) do
     PickerUI.open(state, MingaEditor.UI.Picker.ProjectRemoveSource)
+  end
+
+  @spec clear_file_tree_root(state()) :: state()
+  defp clear_file_tree_root(state) do
+    file_tree = FileTreeState.set_project_root(state.workspace.file_tree, nil)
+    %{state | workspace: SessionState.set_file_tree(state.workspace, file_tree)}
   end
 
   @spec project_add_default() :: String.t()

--- a/lib/minga_editor/commands/project.ex
+++ b/lib/minga_editor/commands/project.ex
@@ -17,6 +17,7 @@ defmodule MingaEditor.Commands.Project do
   @command_specs [
     {:project_find_file, "Find file in project", true},
     {:project_invalidate, "Invalidate project cache", true},
+    {:project_close, "Close project", false},
     {:project_add, "Add project", false},
     {:project_remove, "Remove project", false},
     {:project_switch, "Switch project", false},
@@ -44,13 +45,29 @@ defmodule MingaEditor.Commands.Project do
     :exit, _ -> MingaEditor.Shell.Traditional.NoticeWorkflow.publish(state, "No project active")
   end
 
+  def execute(state, :project_close) do
+    Project.close()
+
+    state
+    |> MingaEditor.Commands.FileTree.close()
+    |> EditorState.update_file_tree(&MingaEditor.State.FileTree.set_project_root(&1, nil))
+  end
+
   def execute(state, :project_add) do
-    default = Project.resolve_root() |> Project.collapse_home()
+    default = project_add_default()
     PromptUI.open(state, MingaEditor.UI.Prompt.ProjectAdd, default: default)
   end
 
   def execute(state, :project_remove) do
     PickerUI.open(state, MingaEditor.UI.Picker.ProjectRemoveSource)
+  end
+
+  @spec project_add_default() :: String.t()
+  defp project_add_default do
+    case Project.resolve_root() do
+      root when is_binary(root) -> Project.collapse_home(root)
+      nil -> ""
+    end
   end
 
   commands(@command_specs)

--- a/lib/minga_editor/git_repository_resolver.ex
+++ b/lib/minga_editor/git_repository_resolver.ex
@@ -14,11 +14,13 @@ defmodule MingaEditor.GitRepositoryResolver do
   @callback resolve(input()) :: {:ok, GitRepositoryIdentity.t()} | :not_git | {:error, term()}
 
   @doc "Resolves the current project root through the configured git backend."
-  @spec resolve(:current_project | String.t()) ::
+  @spec resolve(:current_project | String.t() | nil) ::
           {:ok, GitRepositoryIdentity.t()} | :not_git | {:error, term()}
   def resolve(:current_project) do
     resolve(Minga.Project.resolve_root())
   end
+
+  def resolve(nil), do: :not_git
 
   def resolve(source_root) when is_binary(source_root) do
     case Minga.Git.root_for(source_root) do

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -152,7 +152,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   defp handle_git_status_changed(
          state,
          %Minga.Events.GitStatusEvent{
-           git_root: _git_root,
+           git_root: git_root,
            entries: entries,
            branch: branch,
            ahead: ahead,
@@ -172,7 +172,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
           ahead: ahead,
           behind: behind,
           entries: entries,
-          entry_base_path: Minga.Project.resolve_root(),
+          entry_base_path: git_root,
           last_commit_message: event.last_commit_message,
           stash_count: event.stash_count
         }

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -17,6 +17,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.LspActions
+  alias MingaEditor.PickerUI
   alias MingaEditor.Renderer
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
@@ -284,9 +285,28 @@ defmodule MingaEditor.Handlers.FileEventHandler do
 
   @spec handle_project_rebuilt(EditorState.t(), String.t()) :: {EditorState.t(), [file_effect()]}
   defp handle_project_rebuilt(state, root) do
-    state = FileTreeFreshness.update_project_root(state, root)
+    state =
+      state
+      |> FileTreeFreshness.update_project_root(root)
+      |> maybe_refresh_file_picker()
+
     {state, [{:render, 16}]}
   end
+
+  @spec maybe_refresh_file_picker(EditorState.t()) :: EditorState.t()
+  defp maybe_refresh_file_picker(
+         %{
+           shell_runtime: %{
+             state: %{
+               modal: {:picker, %{picker_ui: %{source: MingaEditor.UI.Picker.FileSource}}}
+             }
+           }
+         } = state
+       ) do
+    PickerUI.refresh_items(state)
+  end
+
+  defp maybe_refresh_file_picker(state), do: state
 
   @spec handle_filter_walk_result(EditorState.t(), String.t(), String.t(), [
           Minga.Project.FileTree.entry()

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -28,6 +28,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   alias MingaEditor.Effects.GitMutation
   alias MingaEditor.Effects.GitMutationAdmission
   alias MingaEditor.GitRepositoryResolver
+  alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.Commands
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Handlers.BufferRegistry
@@ -1427,8 +1428,13 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   @spec git_status_abs_path(String.t(), String.t()) :: String.t()
   defp git_status_abs_path(git_root, path) do
-    project_root = Minga.Project.resolve_root()
+    git_status_abs_path(git_root, path, Minga.Project.resolve_root())
+  end
 
+  @spec git_status_abs_path(String.t(), String.t(), String.t() | nil) :: String.t()
+  defp git_status_abs_path(git_root, path, nil), do: Path.join(git_root, path)
+
+  defp git_status_abs_path(git_root, path, project_root) do
     if String.starts_with?(Path.expand(project_root), Path.expand(git_root)) do
       Path.join(project_root, path)
     else
@@ -1567,8 +1573,17 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   # process guarantees the cast reaches Project before any subsequent call.
   @spec open_dropped_directory(state(), String.t()) :: state()
   defp open_dropped_directory(state, dir_path) do
-    Minga.Project.switch(dir_path)
-    PickerUI.open(state, MingaEditor.UI.Picker.FileSource)
+    case Minga.Project.Root.directory(dir_path) do
+      {:ok, root} ->
+        Minga.Project.switch(root)
+
+        state
+        |> FileTreeFreshness.update_project_root(root.path)
+        |> PickerUI.open(MingaEditor.UI.Picker.FileSource, %{project_root: root})
+
+      {:error, _reason} ->
+        state
+    end
   end
 
   # Moves the tree cursor to a specific index (used by GUI context menu / header actions).

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -1576,6 +1576,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     case Minga.Project.Root.directory(dir_path) do
       {:ok, root} ->
         Minga.Project.switch(root)
+        _ = Minga.Project.workspace_root()
 
         state
         |> FileTreeFreshness.update_project_root(root.path)

--- a/lib/minga_editor/render_model/ui/picker_builder.ex
+++ b/lib/minga_editor/render_model/ui/picker_builder.ex
@@ -6,6 +6,7 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
   alias Minga.Buffer
   alias Minga.RenderModel.UI.Picker, as: PickerModel
   alias Minga.RenderModel.UI.Picker.ActionMenu
+  alias Minga.Project.Root
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.UI.Picker
 
@@ -127,21 +128,30 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
       nil ->
         nil
 
-      %Picker.Item{id: id} = item ->
+      %Picker.Item{} = item ->
         case Picker.Source.preview(source, item, ctx) do
-          nil -> build_preview_for_item(ctx, id)
+          nil -> build_preview_for_item(ctx, item)
           lines -> lines
         end
     end
   end
 
   # Build preview lines for a file path item.
-  @spec build_preview_for_item(Context.t(), term()) :: [[PickerModel.preview_segment()]] | nil
-  defp build_preview_for_item(ctx, id) when is_binary(id) do
-    build_file_preview(ctx, resolve_preview_path(id))
+  @spec build_preview_for_item(Context.t(), Picker.Item.t()) ::
+          [[PickerModel.preview_segment()]] | nil
+  defp build_preview_for_item(
+         ctx,
+         %Picker.Item{id: id, meta: %{workspace_root: %Root{path: root}}}
+       )
+       when is_binary(id) do
+    build_file_preview(ctx, resolve_preview_path(id, root))
   end
 
-  defp build_preview_for_item(ctx, idx) when is_integer(idx) do
+  defp build_preview_for_item(ctx, %Picker.Item{id: id}) when is_binary(id) do
+    build_file_preview(ctx, resolve_preview_path(id, Minga.Project.resolve_root()))
+  end
+
+  defp build_preview_for_item(ctx, %Picker.Item{id: idx}) when is_integer(idx) do
     case Enum.at(ctx.buffers.list, idx) do
       nil -> nil
       buf_pid -> preview_from_buffer(ctx, buf_pid)
@@ -225,9 +235,9 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
   defp face_to_rgb(%{fg: fg}, _default) when is_integer(fg), do: fg
   defp face_to_rgb(_, default), do: default
 
-  @spec resolve_preview_path(String.t()) :: String.t() | nil
-  defp resolve_preview_path(path) do
-    resolve_preview_path(Path.type(path), path, Minga.Project.resolve_root())
+  @spec resolve_preview_path(String.t(), String.t() | nil) :: String.t() | nil
+  defp resolve_preview_path(path, root) do
+    resolve_preview_path(Path.type(path), path, root)
   end
 
   @spec resolve_preview_path(

--- a/lib/minga_editor/render_model/ui/picker_builder.ex
+++ b/lib/minga_editor/render_model/ui/picker_builder.ex
@@ -138,15 +138,7 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
   # Build preview lines for a file path item.
   @spec build_preview_for_item(Context.t(), term()) :: [[PickerModel.preview_segment()]] | nil
   defp build_preview_for_item(ctx, id) when is_binary(id) do
-    abs_path = resolve_preview_path(id)
-
-    case find_buffer_for_path(ctx, abs_path) do
-      {buf_pid, highlight} when highlight != nil ->
-        build_highlighted_preview(buf_pid, highlight, ctx)
-
-      _ ->
-        read_file_preview(abs_path, ctx)
-    end
+    build_file_preview(ctx, resolve_preview_path(id))
   end
 
   defp build_preview_for_item(ctx, idx) when is_integer(idx) do
@@ -157,6 +149,20 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
   end
 
   defp build_preview_for_item(_ctx, _id), do: nil
+
+  @spec build_file_preview(Context.t(), String.t() | nil) ::
+          [[PickerModel.preview_segment()]] | nil
+  defp build_file_preview(_ctx, nil), do: nil
+
+  defp build_file_preview(ctx, abs_path) do
+    case find_buffer_for_path(ctx, abs_path) do
+      {buf_pid, highlight} when highlight != nil ->
+        build_highlighted_preview(buf_pid, highlight, ctx)
+
+      _ ->
+        read_file_preview(abs_path, ctx)
+    end
+  end
 
   @spec preview_from_buffer(Context.t(), pid()) :: [[PickerModel.preview_segment()]] | nil
   defp preview_from_buffer(ctx, buf_pid) do
@@ -219,13 +225,20 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
   defp face_to_rgb(%{fg: fg}, _default) when is_integer(fg), do: fg
   defp face_to_rgb(_, default), do: default
 
-  @spec resolve_preview_path(String.t()) :: String.t()
+  @spec resolve_preview_path(String.t()) :: String.t() | nil
   defp resolve_preview_path(path) do
-    case Path.type(path) do
-      :absolute -> path
-      _ -> Path.join(Minga.Project.resolve_root(), path)
-    end
+    resolve_preview_path(Path.type(path), path, Minga.Project.resolve_root())
   end
+
+  @spec resolve_preview_path(
+          :absolute | :relative | :volumerelative,
+          String.t(),
+          String.t() | nil
+        ) ::
+          String.t() | nil
+  defp resolve_preview_path(:absolute, path, _root), do: path
+  defp resolve_preview_path(_path_type, _path, nil), do: nil
+  defp resolve_preview_path(_path_type, path, root), do: Path.join(root, path)
 
   @spec read_file_preview(String.t(), Context.t()) :: [[PickerModel.preview_segment()]] | nil
   defp read_file_preview(abs_path, ctx) do

--- a/lib/minga_editor/shell/traditional/todo_search_workflow.ex
+++ b/lib/minga_editor/shell/traditional/todo_search_workflow.ex
@@ -3,6 +3,7 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
   Owns opening and scheduling the TODO-search picker workflow.
   """
 
+  alias Minga.Project.Root
   alias MingaEditor.EffectScheduler
   alias MingaEditor.Effects.TodoSearch
   alias MingaEditor.PickerUI
@@ -12,7 +13,11 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
   @spec open(MingaEditor.State.t()) :: MingaEditor.State.t()
   def open(state) do
     {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
-    schedule(state, Minga.Project.resolve_root(), revision)
+    schedule(state, workspace_root(state), revision)
+  end
+
+  defp schedule(state, nil, revision) do
+    apply_failure(state, revision, "No directory workspace active")
   end
 
   defp schedule(%{effect_scheduler: nil} = state, _root, revision) do
@@ -30,6 +35,39 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
   catch
     :exit, reason ->
       apply_failure(state, revision, "TODO search scheduler unavailable: #{inspect(reason)}")
+  end
+
+  @spec workspace_root(MingaEditor.State.t()) :: String.t() | nil
+  defp workspace_root(%{workspace: %{file_tree: %{project_root: file_tree_root}}}) do
+    resolve_workspace_root(file_tree_root, active_workspace_root())
+  end
+
+  @spec resolve_workspace_root(String.t() | nil, Root.t() | nil) :: String.t() | nil
+  defp resolve_workspace_root(path, %Root{path: path} = root), do: authorized_path(root)
+
+  defp resolve_workspace_root(path, _active_root) when is_binary(path) do
+    case Root.directory(path) do
+      {:ok, root} -> authorized_path(root)
+      {:error, _reason} -> nil
+    end
+  end
+
+  defp resolve_workspace_root(nil, %Root{} = root), do: authorized_path(root)
+  defp resolve_workspace_root(nil, nil), do: nil
+
+  @spec active_workspace_root() :: Root.t() | nil
+  defp active_workspace_root do
+    Minga.Project.workspace_root()
+  catch
+    :exit, _reason -> nil
+  end
+
+  @spec authorized_path(Root.t()) :: String.t() | nil
+  defp authorized_path(root) do
+    case Root.inventory_path(root) do
+      {:ok, path} -> path
+      {:error, _reason} -> nil
+    end
   end
 
   defp apply_failure(state, revision, message) do

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
 
   @behaviour MingaEditor.UI.Picker.Source
 
+  alias Minga.Project.Root
   alias MingaEditor.FileTree.ProjectCache
   alias MingaEditor.State, as: EditorState
   alias Minga.Git
@@ -42,7 +43,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
     case resolve_paths(root) do
       {:ok, paths} ->
         frecency_map = build_frecency_map()
-        git_status_map = build_git_status_map(root)
+        git_status_map = build_git_status_map(root.path)
         score_map = build_score_map(frecency_map, git_status_map)
 
         paths
@@ -61,16 +62,19 @@ defmodule MingaEditor.UI.Picker.FileSource do
   # project was just switched and the first rebuild has not finished), the picker
   # falls back to a one-shot `list_files/1` so it never opens empty. Roots that
   # are not the active project always use the direct discovery.
-  @spec resolve_paths(String.t()) :: {:ok, [String.t()]} | {:error, String.t()}
-  defp resolve_paths(root) do
-    if ProjectCache.active_root?(root) do
+  @spec resolve_paths(Root.t() | nil) :: {:ok, [String.t()]} | {:error, String.t()}
+  defp resolve_paths(nil),
+    do: {:error, "No directory workspace active. Open a folder or switch project."}
+
+  defp resolve_paths(%Root{} = root) do
+    if ProjectCache.active_root?(root.path) do
       resolve_active_paths(root, ProjectCache.files())
     else
       Minga.Project.list_files(root)
     end
   end
 
-  @spec resolve_active_paths(String.t(), [String.t()]) ::
+  @spec resolve_active_paths(Root.t(), [String.t()]) ::
           {:ok, [String.t()]} | {:error, String.t()}
   defp resolve_active_paths(root, []), do: Minga.Project.list_files(root)
   defp resolve_active_paths(_root, paths), do: {:ok, paths}
@@ -223,7 +227,26 @@ defmodule MingaEditor.UI.Picker.FileSource do
   end
 
   @spec absolute_path(String.t(), term()) :: String.t()
-  defp absolute_path(rel_path, state), do: Path.expand(rel_path, project_root(state))
+  defp absolute_path(rel_path, state) do
+    case selection_root(state) do
+      path when is_binary(path) -> Path.expand(rel_path, path)
+      nil -> Path.expand(rel_path)
+    end
+  end
+
+  @spec selection_root(term()) :: String.t() | nil
+  defp selection_root(%EditorState{} = state) do
+    case EditorState.file_tree_state(state).project_root do
+      path when is_binary(path) -> path
+      _other -> root_path(active_workspace_root())
+    end
+  end
+
+  defp selection_root(_state), do: root_path(active_workspace_root())
+
+  @spec root_path(Root.t() | nil) :: String.t() | nil
+  defp root_path(%Root{path: path}), do: path
+  defp root_path(nil), do: nil
 
   @spec record_selection(String.t(), term()) :: :ok
   defp record_selection(_abs_path, %{buffer_lifecycle: %{buffer_add_context: :preview}}),
@@ -295,18 +318,17 @@ defmodule MingaEditor.UI.Picker.FileSource do
   defp git_status_annotation(:conflict), do: "!"
   defp git_status_annotation(_), do: nil
 
-  @spec project_root(Context.t() | EditorState.t() | nil) :: String.t()
-  defp project_root(%Context{picker_ui: %{context: %{project_root: root}}}) when is_binary(root),
-    do: root
+  @spec project_root(Context.t() | EditorState.t() | nil) :: Root.t() | nil
+  defp project_root(%Context{picker_ui: %{context: %{project_root: nil}}}), do: nil
+  defp project_root(%Context{picker_ui: %{context: %{project_root: %Root{} = root}}}), do: root
+  defp project_root(%Context{file_tree: %{project_root: %Root{} = root}}), do: root
+  defp project_root(%EditorState{}), do: active_workspace_root()
+  defp project_root(_ctx), do: active_workspace_root()
 
-  defp project_root(%Context{file_tree: %{project_root: root}}) when is_binary(root), do: root
-
-  defp project_root(%EditorState{} = state) do
-    case state.workspace.file_tree.project_root do
-      root when is_binary(root) -> root
-      _ -> Minga.Project.resolve_root()
-    end
+  @spec active_workspace_root() :: Root.t() | nil
+  defp active_workspace_root do
+    Minga.Project.workspace_root()
+  catch
+    :exit, _ -> nil
   end
-
-  defp project_root(_ctx), do: Minga.Project.resolve_root()
 end

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -47,7 +47,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
         score_map = build_score_map(frecency_map, git_status_map)
 
         paths
-        |> Enum.map(&lean_candidate(&1, git_status_map))
+        |> Enum.map(&lean_candidate(&1, git_status_map, root))
         |> sort_by_score(score_map)
 
       {:error, msg} ->
@@ -55,41 +55,32 @@ defmodule MingaEditor.UI.Picker.FileSource do
     end
   end
 
-  # Reads the project's background-rebuilt file cache when `root` is the active
-  # project root, so opening the picker never shells out for a known project
-  # (#2377 AC1). A populated mid-rebuild cache returns the stale list instantly,
-  # which is fine for a picker. When the active cache is still empty (e.g. the
-  # project was just switched and the first rebuild has not finished), the picker
-  # falls back to a one-shot `list_files/1` so it never opens empty. Roots that
-  # are not the active project always use the direct discovery.
+  # The picker reads only the Project-owned cache.
+  # A managed `:project_rebuilt` event refreshes an open picker after an empty cache fills.
+  # Picker tasks never start recursive inventory.
   @spec resolve_paths(Root.t() | nil) :: {:ok, [String.t()]} | {:error, String.t()}
   defp resolve_paths(nil),
     do: {:error, "No directory workspace active. Open a folder or switch project."}
 
   defp resolve_paths(%Root{} = root) do
     if ProjectCache.active_root?(root.path) do
-      resolve_active_paths(root, ProjectCache.files())
+      {:ok, ProjectCache.files()}
     else
-      Minga.Project.list_files(root)
+      {:error, "Directory workspace is no longer active"}
     end
   end
-
-  @spec resolve_active_paths(Root.t(), [String.t()]) ::
-          {:ok, [String.t()]} | {:error, String.t()}
-  defp resolve_active_paths(root, []), do: Minga.Project.list_files(root)
-  defp resolve_active_paths(_root, paths), do: {:ok, paths}
 
   # Lean candidate: just enough to match (filename label, full-path search text)
   # and to enrich later (git status stashed in `meta`). Icon, color, two-line
   # description, and the status annotation are built in `enrich/1` for the
   # bounded winners only, so a 50k-file repo never materializes 50k rich items.
-  @spec lean_candidate(String.t(), %{String.t() => atom()}) :: Item.t()
-  defp lean_candidate(path, git_status_map) do
+  @spec lean_candidate(String.t(), %{String.t() => atom()}, Root.t()) :: Item.t()
+  defp lean_candidate(path, git_status_map, root) do
     %Item{
       id: path,
       label: Path.basename(path),
       search_text: path,
-      meta: %{git: Map.get(git_status_map, path)}
+      meta: %{git: Map.get(git_status_map, path), workspace_root: root}
     }
   end
 
@@ -123,11 +114,15 @@ defmodule MingaEditor.UI.Picker.FileSource do
 
   @impl true
   @spec on_select(Item.t(), term()) :: term()
-  def on_select(%Item{id: rel_path}, state) do
-    abs_path = absolute_path(rel_path, state)
-
+  def on_select(%Item{id: rel_path} = item, state) do
     Log.debug(:editor, "[file_picker] on_select path=#{rel_path}")
+    open_selected_file(absolute_path(item, state), state)
+  end
 
+  @spec open_selected_file({:ok, String.t()} | :error, term()) :: term()
+  defp open_selected_file(:error, state), do: state
+
+  defp open_selected_file({:ok, abs_path}, state) do
     case MingaEditor.Handlers.BufferRegistry.find_buffer_by_path(state, abs_path) do
       nil ->
         case MingaEditor.Commands.start_buffer(abs_path, state.interaction.options_server) do
@@ -190,9 +185,16 @@ defmodule MingaEditor.UI.Picker.FileSource do
   @spec on_action(term(), Item.t(), term()) :: term()
   def on_action(:open, item, state), do: on_select(item, state)
 
-  def on_action(:delete, %Item{id: rel_path}, state) do
-    abs_path = absolute_path(rel_path, state)
+  def on_action(:delete, %Item{} = item, state) do
+    delete_selected_file(absolute_path(item, state), state)
+  end
 
+  def on_action(_action, _item, state), do: state
+
+  @spec delete_selected_file({:ok, String.t()} | :error, term()) :: term()
+  defp delete_selected_file(:error, state), do: state
+
+  defp delete_selected_file({:ok, abs_path}, state) do
     case File.rm(abs_path) do
       :ok ->
         Minga.Log.info(:editor, "Deleted file: #{abs_path}")
@@ -203,8 +205,6 @@ defmodule MingaEditor.UI.Picker.FileSource do
         state
     end
   end
-
-  def on_action(_action, _item, state), do: state
 
   @impl true
   @spec on_bulk_select([Item.t()], term()) :: term()
@@ -226,11 +226,14 @@ defmodule MingaEditor.UI.Picker.FileSource do
     Enum.reduce(items, state, fn item, acc -> on_select(item, acc) end)
   end
 
-  @spec absolute_path(String.t(), term()) :: String.t()
-  defp absolute_path(rel_path, state) do
+  @spec absolute_path(Item.t(), term()) :: {:ok, String.t()} | :error
+  defp absolute_path(%Item{id: rel_path, meta: %{workspace_root: %Root{path: path}}}, _state),
+    do: {:ok, Path.expand(rel_path, path)}
+
+  defp absolute_path(%Item{id: rel_path}, state) do
     case selection_root(state) do
-      path when is_binary(path) -> Path.expand(rel_path, path)
-      nil -> Path.expand(rel_path)
+      path when is_binary(path) -> {:ok, Path.expand(rel_path, path)}
+      nil -> :error
     end
   end
 

--- a/lib/minga_editor/ui/picker/project_search_source.ex
+++ b/lib/minga_editor/ui/picker/project_search_source.ex
@@ -49,7 +49,17 @@ defmodule MingaEditor.UI.Picker.ProjectSearchSource do
           {:ok, [Item.t()], Source.fetch_meta()} | {:error, String.t()}
   def async_fetch(%Context{search: %{project_query: query}})
       when is_binary(query) and query != "" do
-    case ProjectSearch.search(query, Minga.Project.resolve_root()) do
+    search_project(query, Minga.Project.resolve_root())
+  end
+
+  def async_fetch(_ctx), do: {:ok, [], %{}}
+
+  @spec search_project(String.t(), String.t() | nil) ::
+          {:ok, [Item.t()], Source.fetch_meta()} | {:error, String.t()}
+  defp search_project(_query, nil), do: {:error, "No directory workspace active"}
+
+  defp search_project(query, root) do
+    case ProjectSearch.search(query, root) do
       {:ok, matches, truncated?} ->
         {:ok, build_items(matches), fetch_meta(truncated?)}
 
@@ -57,8 +67,6 @@ defmodule MingaEditor.UI.Picker.ProjectSearchSource do
         {:error, message}
     end
   end
-
-  def async_fetch(_ctx), do: {:ok, [], %{}}
 
   @impl true
   @spec on_select(Item.t(), term()) :: term()

--- a/lib/minga_editor/ui/picker/project_source.ex
+++ b/lib/minga_editor/ui/picker/project_source.ex
@@ -52,6 +52,7 @@ defmodule MingaEditor.UI.Picker.ProjectSource do
   @spec activate_project(Root.t(), term()) :: term()
   defp activate_project(%Root{path: path} = root, state) do
     Project.switch(root)
+    _ = Project.workspace_root()
 
     state
     |> FileTreeFreshness.update_project_root(path)

--- a/lib/minga_editor/ui/picker/project_source.ex
+++ b/lib/minga_editor/ui/picker/project_source.ex
@@ -15,6 +15,7 @@ defmodule MingaEditor.UI.Picker.ProjectSource do
   alias MingaEditor.UI.Picker.Item
 
   alias Minga.Project
+  alias Minga.Project.Root
 
   @impl true
   @spec title() :: String.t()
@@ -40,14 +41,21 @@ defmodule MingaEditor.UI.Picker.ProjectSource do
   @impl true
   @spec on_select(Item.t(), term()) :: term()
   def on_select(%Item{id: root_path}, state) do
-    expanded_root = Path.expand(root_path)
-    Project.switch(expanded_root)
-
-    state
-    |> FileTreeFreshness.update_project_root(expanded_root)
-    |> PickerUI.open(FileSource, %{project_root: expanded_root})
+    case Root.directory(root_path) do
+      {:ok, root} -> activate_project(root, state)
+      {:error, _reason} -> state
+    end
   catch
     :exit, _ -> state
+  end
+
+  @spec activate_project(Root.t(), term()) :: term()
+  defp activate_project(%Root{path: path} = root, state) do
+    Project.switch(root)
+
+    state
+    |> FileTreeFreshness.update_project_root(path)
+    |> PickerUI.open(FileSource, %{project_root: root})
   end
 
   @impl true

--- a/lib/minga_editor/ui/picker/recent_file_source.ex
+++ b/lib/minga_editor/ui/picker/recent_file_source.ex
@@ -54,7 +54,13 @@ defmodule MingaEditor.UI.Picker.RecentFileSource do
   @impl true
   @spec on_select(Item.t(), term()) :: term()
   def on_select(%Item{id: rel_path}, state) do
-    root = project_root()
+    open_recent_file(project_root(), rel_path, state)
+  end
+
+  @spec open_recent_file(String.t() | nil, String.t(), term()) :: term()
+  defp open_recent_file(nil, _rel_path, state), do: state
+
+  defp open_recent_file(root, rel_path, state) do
     abs_path = Path.join(root, rel_path)
 
     case MingaEditor.Handlers.BufferRegistry.find_buffer_by_path(state, abs_path) do
@@ -78,6 +84,6 @@ defmodule MingaEditor.UI.Picker.RecentFileSource do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
-  @spec project_root() :: term()
+  @spec project_root() :: String.t() | nil
   def project_root, do: Minga.Project.resolve_root()
 end

--- a/test/minga/project/file_find/worker_test.exs
+++ b/test/minga/project/file_find/worker_test.exs
@@ -30,6 +30,54 @@ defmodule Minga.Project.FileFind.WorkerTest do
     refute process_alive?(child_pid)
   end
 
+  test "owner shutdown terminates the external process and descendants", %{tmp_dir: tmp_dir} do
+    child_pid_file = Path.join(tmp_dir, "owner-child.pid")
+    script = Path.join(tmp_dir, "owner-discovery.sh")
+    File.write!(script, "#!/bin/sh\nsleep 60 &\necho $! > owner-child.pid\nwait\n")
+    File.chmod!(script, 0o755)
+    parent = self()
+
+    owner =
+      spawn(fn ->
+        command = {System.find_executable("sh"), [script], tmp_dir}
+        {:ok, worker} = Worker.start(self(), command, fn output, status -> {output, status} end)
+        send(parent, {:owner_worker, worker})
+
+        receive do
+          :keep_alive -> :ok
+        end
+      end)
+
+    assert_receive {:owner_worker, worker}, 1_000
+    ref = Process.monitor(worker)
+    assert :ok = await_file(child_pid_file, 100)
+    child_pid = child_pid_file |> File.read!() |> String.trim()
+    assert process_alive?(child_pid)
+
+    Process.exit(owner, :shutdown)
+
+    assert_receive {:DOWN, ^ref, :process, ^worker, :normal}, 5_000
+    refute process_alive?(child_pid)
+  end
+
+  test "output limits stop discovery and report an error", %{tmp_dir: tmp_dir} do
+    script = Path.join(tmp_dir, "oversized-discovery.sh")
+    File.write!(script, "#!/bin/sh\nprintf 'first\\nsecond\\n'\nsleep 60\n")
+    File.chmod!(script, 0o755)
+    command = {System.find_executable("sh"), [script], tmp_dir}
+
+    {:ok, worker} =
+      Worker.start(self(), command, fn output, status -> {output, status} end,
+        max_output_bytes: 1
+      )
+
+    ref = Process.monitor(worker)
+
+    assert_receive {:file_find_done, ^worker, {:error, message}}, 5_000
+    assert message =~ "byte limit"
+    assert_receive {:DOWN, ^ref, :process, ^worker, :normal}, 5_000
+  end
+
   @spec await_file(String.t(), non_neg_integer()) :: :ok | :timeout
   defp await_file(_path, 0), do: :timeout
 

--- a/test/minga/project/file_find/worker_test.exs
+++ b/test/minga/project/file_find/worker_test.exs
@@ -1,0 +1,53 @@
+defmodule Minga.Project.FileFind.WorkerTest do
+  @moduledoc "Tests cancellation against a real external process tree."
+
+  # This test spawns a real shell process and child, which requires serialized execution.
+  use ExUnit.Case, async: false
+
+  alias Minga.Project.FileFind.Worker
+
+  @moduletag :tmp_dir
+  @moduletag timeout: 10_000
+
+  test "cancelling discovery terminates the external process and descendants", %{tmp_dir: tmp_dir} do
+    child_pid_file = Path.join(tmp_dir, "child.pid")
+    script = Path.join(tmp_dir, "discovery.sh")
+
+    File.write!(script, "#!/bin/sh\nsleep 60 &\necho $! > child.pid\nwait\n")
+    File.chmod!(script, 0o755)
+
+    command = {System.find_executable("sh"), [script], tmp_dir}
+    {:ok, worker} = Worker.start(self(), command, fn output, status -> {output, status} end)
+    ref = Process.monitor(worker)
+
+    assert :ok = await_file(child_pid_file, 100)
+    child_pid = child_pid_file |> File.read!() |> String.trim()
+    assert process_alive?(child_pid)
+
+    Worker.cancel(worker)
+
+    assert_receive {:DOWN, ^ref, :process, ^worker, :normal}, 5_000
+    refute process_alive?(child_pid)
+  end
+
+  @spec await_file(String.t(), non_neg_integer()) :: :ok | :timeout
+  defp await_file(_path, 0), do: :timeout
+
+  defp await_file(path, attempts) do
+    if File.exists?(path) do
+      :ok
+    else
+      receive do
+      after
+        10 -> await_file(path, attempts - 1)
+      end
+    end
+  end
+
+  @spec process_alive?(String.t()) :: boolean()
+  defp process_alive?(pid) do
+    kill = System.find_executable("kill")
+    {_output, status} = System.cmd(kill, ["-0", pid], stderr_to_stdout: true)
+    status == 0
+  end
+end

--- a/test/minga/project/file_find_test.exs
+++ b/test/minga/project/file_find_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.Project.FileFindTest do
   use ExUnit.Case, async: true
 
   alias Minga.Project.FileFind
+  alias Minga.Project.Root
 
   describe "detect_strategy/1" do
     test "returns a known strategy atom" do
@@ -71,7 +72,7 @@ defmodule Minga.Project.FileFindTest do
     end
 
     test "returns a list of relative file paths", %{tmp_dir: tmp_dir} do
-      {:ok, files} = FileFind.list_files(tmp_dir)
+      {:ok, files} = FileFind.list_files(directory_root!(tmp_dir))
       assert is_list(files)
       assert Enum.count(files) >= 3
       assert "README.md" in files
@@ -80,31 +81,41 @@ defmodule Minga.Project.FileFindTest do
     end
 
     test "returns sorted results", %{tmp_dir: tmp_dir} do
-      {:ok, files} = FileFind.list_files(tmp_dir)
+      {:ok, files} = FileFind.list_files(directory_root!(tmp_dir))
       assert files == Enum.sort(files)
     end
 
     test "does not include directories", %{tmp_dir: tmp_dir} do
-      {:ok, files} = FileFind.list_files(tmp_dir)
+      {:ok, files} = FileFind.list_files(directory_root!(tmp_dir))
       refute "lib" in files
       refute "lib/sub" in files
     end
 
     test "paths are relative (no leading ./)", %{tmp_dir: tmp_dir} do
-      {:ok, files} = FileFind.list_files(tmp_dir)
+      {:ok, files} = FileFind.list_files(directory_root!(tmp_dir))
 
       for file <- files do
         refute String.starts_with?(file, "./"), "Path should not start with ./: #{file}"
       end
     end
 
-    test "returns error for nonexistent directory" do
-      result = FileFind.list_files("/nonexistent/path/#{System.unique_integer()}")
+    test "rejects raw paths and file roots at the inventory boundary", %{tmp_dir: tmp_dir} do
+      assert {:error, raw_error} = FileFind.list_files(tmp_dir)
+      assert raw_error =~ "explicit directory workspace root"
 
-      case result do
-        {:ok, files} -> assert is_list(files)
-        {:error, msg} -> assert is_binary(msg)
-      end
+      assert {:error, file_error} =
+               FileFind.list_files(Root.file(Path.join(tmp_dir, "README.md")))
+
+      assert file_error =~ "explicit directory workspace root"
+    end
+
+    test "rejects broad roots without current-flow confirmation" do
+      assert {:error, :broad_root_confirmation_required} = Root.directory(Path.expand("~"))
+      assert {:error, :broad_root_confirmation_required} = Root.directory("/")
+      assert {:ok, confirmed_root} = Root.directory("/", broad_root_confirmed: true)
+      assert Root.inventory_path(confirmed_root) == {:ok, "/"}
+      assert Root.broad_path?("/Volumes/External")
+      assert Root.broad_path?("/mnt/external")
     end
 
     test "excludes directories listed in file_find_excludes", %{
@@ -122,7 +133,7 @@ defmodule Minga.Project.FileFindTest do
         ["node_modules", "vendor"]
       )
 
-      {:ok, files} = FileFind.list_files(tmp_dir)
+      {:ok, files} = FileFind.list_files(directory_root!(tmp_dir))
 
       refute Enum.any?(files, &String.starts_with?(&1, "node_modules/"))
       refute Enum.any?(files, &String.starts_with?(&1, "vendor/"))
@@ -143,12 +154,18 @@ defmodule Minga.Project.FileFindTest do
         [".DS_Store"]
       )
 
-      {:ok, files} = FileFind.list_files(tmp_dir)
+      {:ok, files} = FileFind.list_files(directory_root!(tmp_dir))
 
       refute ".DS_Store" in files
       refute "lib/.DS_Store" in files
       assert "README.md" in files
     end
+  end
+
+  @spec directory_root!(String.t()) :: Root.t()
+  defp directory_root!(path) do
+    {:ok, root} = Root.directory(path)
+    root
   end
 
   defp make_tmp_dir(prefix) do

--- a/test/minga/project/file_find_test.exs
+++ b/test/minga/project/file_find_test.exs
@@ -109,13 +109,33 @@ defmodule Minga.Project.FileFindTest do
       assert file_error =~ "explicit directory workspace root"
     end
 
-    test "rejects broad roots without current-flow confirmation" do
+    test "rejects broad roots without literal current-flow confirmation", %{tmp_dir: tmp_dir} do
       assert {:error, :broad_root_confirmation_required} = Root.directory(Path.expand("~"))
       assert {:error, :broad_root_confirmation_required} = Root.directory("/")
+
+      assert {:error, :invalid_broad_root_confirmation} =
+               Root.directory(tmp_dir, broad_root_confirmed: nil)
+
+      unauthorized_root = %Root{kind: :directory, path: "/", broad_root_confirmed?: nil}
+      assert {:error, error} = FileFind.list_files(unauthorized_root)
+      assert error =~ "confirmation must be true or false"
+
       assert {:ok, confirmed_root} = Root.directory("/", broad_root_confirmed: true)
       assert Root.inventory_path(confirmed_root) == {:ok, "/"}
       assert Root.broad_path?("/Volumes/External")
       assert Root.broad_path?("/mnt/external")
+    end
+
+    test "canonicalizes directory symlinks before broad-root authorization", %{tmp_dir: tmp_dir} do
+      broad_alias = Path.join(tmp_dir, "broad-alias")
+      safe_target = Path.join(tmp_dir, "safe-target")
+      safe_alias = Path.join(tmp_dir, "safe-alias")
+      File.mkdir_p!(safe_target)
+      File.ln_s!("/", broad_alias)
+      File.ln_s!(safe_target, safe_alias)
+
+      assert {:error, :broad_root_confirmation_required} = Root.directory(broad_alias)
+      assert {:ok, %Root{path: ^safe_target}} = Root.directory(safe_alias)
     end
 
     test "excludes directories listed in file_find_excludes", %{

--- a/test/minga/project/file_find_timeout_test.exs
+++ b/test/minga/project/file_find_timeout_test.exs
@@ -1,0 +1,23 @@
+defmodule Minga.Project.FileFindTimeoutTest do
+  @moduledoc "Tests the bounded synchronous FileFind wait path with a controlled executable."
+
+  # This test spawns a real external process, which requires serialized execution.
+  use ExUnit.Case, async: false
+
+  alias Minga.Project.FileFind
+  alias Minga.Project.FileFind.Worker
+
+  @moduletag :tmp_dir
+  @moduletag timeout: 10_000
+
+  test "direct discovery wait times out and cancels its worker", %{tmp_dir: tmp_dir} do
+    script = Path.join(tmp_dir, "slow-discovery.sh")
+    File.write!(script, "#!/bin/sh\nsleep 60\n")
+    File.chmod!(script, 0o755)
+    command = {System.find_executable("sh"), [script], tmp_dir}
+    {:ok, worker} = Worker.start(self(), command, fn output, status -> {output, status} end)
+
+    assert FileFind.await_result(worker, 20) ==
+             {:error, "Project file discovery timed out"}
+  end
+end

--- a/test/minga/project_test.exs
+++ b/test/minga/project_test.exs
@@ -3,6 +3,7 @@ defmodule Minga.ProjectTest do
   use ExUnitProperties
 
   alias Minga.Project
+  alias Minga.Project.Root
 
   @moduletag :tmp_dir
 
@@ -25,13 +26,6 @@ defmodule Minga.ProjectTest do
   # casts in the GenServer mailbox, so when it returns we know all
   # prior casts have been handled.
   defp flush(name), do: :sys.get_state(name)
-
-  @spec write_sparse_checkout(String.t(), String.t()) :: :ok
-  defp write_sparse_checkout(dir, content) do
-    sparse_file = Path.join([dir, ".git", "info", "sparse-checkout"])
-    File.mkdir_p!(Path.dirname(sparse_file))
-    File.write!(sparse_file, content)
-  end
 
   # Waits for the async rebuild Task to complete.
   # Subscribes to :project_rebuilt and uses assert_receive if the
@@ -56,144 +50,39 @@ defmodule Minga.ProjectTest do
       {_pid, name} = start_project!()
       assert Project.root(name) == nil
     end
-
-    test "returns a valid path even when Project GenServer is not running" do
-      assert is_binary(Project.resolve_root())
-    end
   end
 
-  describe "detect_and_set/2" do
-    test "detects project root from a file inside a git repo", %{tmp_dir: tmp} do
-      project = Path.join(tmp, "myproject")
-      lib = Path.join(project, "lib")
-      File.mkdir_p!(lib)
-      File.mkdir_p!(Path.join(project, ".git"))
-      File.write!(Path.join(lib, "app.ex"), "")
+  describe "buffer-open isolation" do
+    test "opening loose files never promotes marker ancestors", %{tmp_dir: tmp} do
+      fake_home = Path.join(tmp, "home")
+      File.mkdir_p!(fake_home)
 
       {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(lib, "app.ex"))
-      flush(name)
 
-      assert Project.root(name) == project
-    end
+      for marker <- ["package.json", ".git", "mix.exs", ".minga"] do
+        ancestor = Path.join(fake_home, String.replace(marker, ".", "_"))
+        File.mkdir_p!(ancestor)
+        write_marker(ancestor, marker)
+        file = Path.join(ancestor, "notes.org")
+        File.write!(file, "notes")
 
-    test "roots a single-cone sparse checkout at the cone, not git-root", %{tmp_dir: tmp} do
-      project = Path.join(tmp, "sparse_repo")
-      cone = Path.join(project, "apps/web")
-      File.mkdir_p!(cone)
-      File.write!(Path.join(cone, "main.ex"), "")
+        send(
+          name,
+          {:minga_event, :buffer_opened, %Minga.Events.BufferEvent{buffer: self(), path: file}}
+        )
 
-      write_sparse_checkout(project, "/*\n!/*/\n/apps/\n!/apps/*/\n/apps/web/\n")
+        state = flush(name)
 
-      {_pid, name} = start_project!()
-      # A file in the cone with no nearer marker would otherwise resolve to git-root.
-      Project.detect_and_set(name, Path.join(cone, "main.ex"))
-      flush(name)
-
-      assert Project.root(name) == cone
-    end
-
-    test "keeps nearer markers ahead of sparse-cone fallback", %{tmp_dir: tmp} do
-      project = Path.join(tmp, "nearer_marker")
-      sparse_root = Path.join(project, "apps")
-      cone = Path.join(project, "apps/web")
-      lib = Path.join(cone, "lib")
-      File.mkdir_p!(lib)
-      File.write!(Path.join(cone, "mix.exs"), "")
-      File.write!(Path.join(lib, "main.ex"), "")
-
-      write_sparse_checkout(project, "/*\n!/*/\n/apps/\n")
-
-      {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(lib, "main.ex"))
-      flush(name)
-
-      assert Project.root(name) == cone
-      assert sparse_root != cone
-    end
-
-    test "keeps git-root for a multi-cone sparse checkout", %{tmp_dir: tmp} do
-      project = Path.join(tmp, "multi_cone")
-      web = Path.join(project, "apps/web")
-      File.mkdir_p!(web)
-      File.write!(Path.join(web, "main.ex"), "")
-
-      write_sparse_checkout(project, "/*\n!/*/\n/apps/\n!/apps/*/\n/apps/web/\n/apps/api/\n")
-
-      {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(web, "main.ex"))
-      flush(name)
-
-      assert Project.root(name) == project
-    end
-
-    test "detects mix project root", %{tmp_dir: tmp} do
-      project = Path.join(tmp, "mix_app")
-      lib = Path.join(project, "lib")
-      File.mkdir_p!(lib)
-      File.write!(Path.join(project, "mix.exs"), "")
-      File.write!(Path.join(lib, "foo.ex"), "")
-
-      {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(lib, "foo.ex"))
-      flush(name)
-
-      assert Project.root(name) == project
-    end
-
-    test "adds detected project to known projects", %{tmp_dir: tmp} do
-      project = Path.join(tmp, "known_test")
-      File.mkdir_p!(project)
-      File.write!(Path.join(project, "package.json"), "")
-      File.write!(Path.join(project, "index.js"), "")
-
-      {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(project, "index.js"))
-      flush(name)
-
-      known = Project.known_projects(name)
-      assert project in known
-    end
-
-    test "does not change root when detection finds the same project", %{tmp_dir: tmp} do
-      project = Path.join(tmp, "same_root")
-      File.mkdir_p!(project)
-      File.write!(Path.join(project, "mix.exs"), "")
-      File.write!(Path.join(project, "a.ex"), "")
-      File.write!(Path.join(project, "b.ex"), "")
-
-      {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(project, "a.ex"))
-      flush(name)
-      assert Project.root(name) == project
-
-      # Detecting from another file in the same project should not change root
-      Project.detect_and_set(name, Path.join(project, "b.ex"))
-      flush(name)
-      assert Project.root(name) == project
-    end
-
-    test "does not duplicate known projects on repeated detection", %{tmp_dir: tmp} do
-      project = Path.join(tmp, "dedup_test")
-      File.mkdir_p!(project)
-      File.write!(Path.join(project, "go.mod"), "")
-      File.write!(Path.join(project, "main.go"), "")
-
-      {_pid, name} = start_project!()
-      file = Path.join(project, "main.go")
-      Project.detect_and_set(name, file)
-      flush(name)
-      Project.detect_and_set(name, file)
-      flush(name)
-
-      known = Project.known_projects(name)
-      count = Enum.count(known, &(&1 == project))
-      assert count == 1
+        assert Project.root(name) == nil
+        assert Project.workspace_root(name) == nil
+        assert Project.known_projects(name) == []
+        assert state.rebuilding? == false
+      end
     end
   end
 
   describe "files/1" do
-    test "returns cached file list after detection", %{tmp_dir: tmp} do
+    test "returns cached file list after explicit folder activation", %{tmp_dir: tmp} do
       project = Path.join(tmp, "files_test")
       File.mkdir_p!(project)
       File.write!(Path.join(project, "mix.exs"), "")
@@ -203,7 +92,7 @@ defmodule Minga.ProjectTest do
       init_git_repo!(project)
 
       {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(project, "lib/app.ex"))
+      Project.switch(name, project)
       await_rebuild(name)
 
       files = Project.files(name)
@@ -227,13 +116,25 @@ defmodule Minga.ProjectTest do
       File.write!(Path.join(project_b, "Cargo.toml"), "")
 
       {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(project_a, "mix.exs"))
+      Project.switch(name, project_a)
       flush(name)
       assert Project.root(name) == project_a
 
       Project.switch(name, project_b)
       flush(name)
       assert Project.root(name) == project_b
+      assert %Root{kind: :directory, path: ^project_b} = Project.workspace_root(name)
+    end
+
+    test "rejects broad roots without explicit confirmation" do
+      {_pid, name} = start_project!()
+
+      Project.switch(name, Path.expand("~"))
+      state = flush(name)
+
+      assert Project.root(name) == nil
+      assert Project.workspace_root(name) == nil
+      assert state.rebuilding? == false
     end
 
     test "adds switched project to known projects", %{tmp_dir: tmp} do
@@ -268,6 +169,66 @@ defmodule Minga.ProjectTest do
     end
   end
 
+  describe "discovery lifecycle" do
+    test "switching roots and closing the workspace cancel in-flight discovery", %{tmp_dir: tmp} do
+      first = Path.join(tmp, "first")
+      second = Path.join(tmp, "second")
+      File.mkdir_p!(first)
+      File.mkdir_p!(second)
+      {_project_pid, name} = start_project!(file_find_module: Minga.Project.SlowFileFind)
+
+      Project.switch(name, first)
+      first_worker = flush(name).rebuild_pid
+      first_ref = Process.monitor(first_worker)
+
+      Project.switch(name, second)
+      second_worker = flush(name).rebuild_pid
+      second_ref = Process.monitor(second_worker)
+
+      assert_receive {:DOWN, ^first_ref, :process, ^first_worker, :normal}, 1_000
+      assert first_worker != second_worker
+
+      Project.close(name)
+      state = flush(name)
+
+      assert_receive {:DOWN, ^second_ref, :process, ^second_worker, :normal}, 1_000
+      assert state.current_root == nil
+      assert state.workspace_root == nil
+      assert state.rebuilding? == false
+    end
+
+    test "discovery timeout cancels the worker", %{tmp_dir: tmp} do
+      root = Path.join(tmp, "timeout")
+      File.mkdir_p!(root)
+
+      {_project_pid, name} =
+        start_project!(file_find_module: Minga.Project.SlowFileFind, rebuild_timeout_ms: 10)
+
+      Project.switch(name, root)
+      worker = flush(name).rebuild_pid
+      ref = Process.monitor(worker)
+
+      assert_receive {:DOWN, ^ref, :process, ^worker, :normal}, 1_000
+      state = flush(name)
+      assert state.rebuilding? == false
+      assert state.rebuild_pid == nil
+    end
+
+    test "project shutdown cancels the worker", %{tmp_dir: tmp} do
+      root = Path.join(tmp, "shutdown")
+      File.mkdir_p!(root)
+      {project_pid, name} = start_project!(file_find_module: Minga.Project.SlowFileFind)
+
+      Project.switch(name, root)
+      worker = flush(name).rebuild_pid
+      ref = Process.monitor(worker)
+
+      GenServer.stop(project_pid)
+
+      assert_receive {:DOWN, ^ref, :process, ^worker, :normal}, 1_000
+    end
+  end
+
   describe "invalidate/1" do
     test "clears cache and triggers rebuild", %{tmp_dir: tmp} do
       project = Path.join(tmp, "invalidate_test")
@@ -277,7 +238,7 @@ defmodule Minga.ProjectTest do
       init_git_repo!(project)
 
       {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(project, "file.ex"))
+      Project.switch(name, project)
       await_rebuild(name)
 
       # Should have files
@@ -347,7 +308,7 @@ defmodule Minga.ProjectTest do
       File.write!(Path.join(project, "lib/app.ex"), "")
 
       {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(project, "lib/app.ex"))
+      Project.switch(name, project)
       flush(name)
 
       Project.record_file(name, Path.join(project, "lib/app.ex"))
@@ -367,7 +328,7 @@ defmodule Minga.ProjectTest do
       File.write!(Path.join(lib, "c.ex"), "")
 
       {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(lib, "a.ex"))
+      Project.switch(name, project)
       flush(name)
 
       Project.record_file(name, Path.join(lib, "a.ex"))
@@ -390,7 +351,7 @@ defmodule Minga.ProjectTest do
       File.write!(Path.join(lib, "b.ex"), "")
 
       {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(lib, "a.ex"))
+      Project.switch(name, project)
       flush(name)
 
       Project.record_file(name, Path.join(lib, "a.ex"))
@@ -416,7 +377,7 @@ defmodule Minga.ProjectTest do
       File.write!(outside_file, "")
 
       {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(project, "mix.exs"))
+      Project.switch(name, project)
       flush(name)
 
       Project.record_file(name, outside_file)
@@ -452,7 +413,7 @@ defmodule Minga.ProjectTest do
       {_pid, name} = start_project!()
 
       # Record file in project A
-      Project.detect_and_set(name, Path.join(project_a, "a.ex"))
+      Project.switch(name, project_a)
       flush(name)
       Project.record_file(name, Path.join(project_a, "a.ex"))
       flush(name)
@@ -538,7 +499,7 @@ defmodule Minga.ProjectTest do
       File.write!(Path.join(lib, "cold.ex"), "")
 
       {_pid, name} = start_project!()
-      Project.detect_and_set(name, Path.join(lib, "hot.ex"))
+      Project.switch(name, project)
       flush(name)
 
       Enum.each(1..5, fn _ ->
@@ -552,6 +513,15 @@ defmodule Minga.ProjectTest do
       scores = Project.frecency_scores(name)
       assert scores["lib/hot.ex"] > scores["lib/cold.ex"]
     end
+  end
+
+  @spec write_marker(String.t(), String.t()) :: :ok
+  defp write_marker(ancestor, marker) when marker in [".git", ".minga"] do
+    File.mkdir_p!(Path.join(ancestor, marker))
+  end
+
+  defp write_marker(ancestor, marker) do
+    File.write!(Path.join(ancestor, marker), "")
   end
 
   # Makes a fixture directory a self-contained git repo so file discovery uses

--- a/test/minga_agent/file_mention_test.exs
+++ b/test/minga_agent/file_mention_test.exs
@@ -5,6 +5,17 @@ defmodule MingaAgent.FileMentionTest do
 
   @moduletag :tmp_dir
 
+  describe "resolve_prompt/3 without a workspace" do
+    test "keeps prompts without file mentions unchanged" do
+      assert FileMention.resolve_prompt("hello", nil, []) == {:ok, "hello"}
+    end
+
+    test "rejects relative file mentions instead of resolving them from cwd" do
+      assert FileMention.resolve_prompt("review @README.md", nil, []) ==
+               {:error, "Cannot resolve file mentions without an active directory workspace"}
+    end
+  end
+
   # ── Extraction ──────────────────────────────────────────────────────────────
 
   describe "extract_mentions/1" do

--- a/test/minga_agent/file_mention_test.exs
+++ b/test/minga_agent/file_mention_test.exs
@@ -116,6 +116,36 @@ defmodule MingaAgent.FileMentionTest do
       assert msg =~ "file not found"
     end
 
+    test "rejects absolute paths even when the file exists", %{tmp_dir: dir} do
+      path = Path.join(dir, "absolute.ex")
+      File.write!(path, "secret")
+
+      assert {:error, msg} = FileMention.resolve_prompt("@#{path} read this", dir)
+      assert msg =~ "absolute paths are outside the active workspace"
+    end
+
+    test "rejects traversal outside the workspace", %{tmp_dir: dir} do
+      outside = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}.txt")
+      File.write!(outside, "secret")
+      on_exit(fn -> File.rm(outside) end)
+
+      assert {:error, msg} =
+               FileMention.resolve_prompt("@../#{Path.basename(outside)} read this", dir)
+
+      assert msg =~ "path is outside the active workspace"
+    end
+
+    test "rejects symlinks whose canonical target escapes the workspace", %{tmp_dir: dir} do
+      outside = Path.join(Path.dirname(dir), "secret-#{System.unique_integer([:positive])}.txt")
+      link = Path.join(dir, "linked-secret.txt")
+      File.write!(outside, "secret")
+      File.ln_s!(outside, link)
+      on_exit(fn -> File.rm(outside) end)
+
+      assert {:error, msg} = FileMention.resolve_prompt("@linked-secret.txt read this", dir)
+      assert msg =~ "path is outside the active workspace"
+    end
+
     test "returns error for binary file", %{tmp_dir: dir} do
       path = Path.join(dir, "binary.bin")
       File.write!(path, <<0, 1, 2, 255, 254, 253>>)

--- a/test/minga_agent/instructions_test.exs
+++ b/test/minga_agent/instructions_test.exs
@@ -6,6 +6,18 @@ defmodule MingaAgent.InstructionsTest do
   @moduletag :tmp_dir
 
   describe "discover/2" do
+    test "a missing workspace root does not inspect cwd" do
+      results = Instructions.discover(nil)
+
+      refute Enum.any?(
+               results,
+               &(&1.label in ["Project Instructions", "Project Config Instructions"])
+             )
+
+      assert Instructions.summary(nil) =~ "~/.config/minga/AGENTS.md"
+      refute Instructions.summary(nil) =~ "//AGENTS.md"
+    end
+
     test "finds project root AGENTS.md", %{tmp_dir: dir} do
       File.write!(Path.join(dir, "AGENTS.md"), "Project rules here")
 

--- a/test/minga_editor/commands/project_test.exs
+++ b/test/minga_editor/commands/project_test.exs
@@ -6,11 +6,62 @@ defmodule MingaEditor.Commands.ProjectTest do
 
   alias Minga.Project
   alias MingaEditor.Commands.Project, as: ProjectCommands
+  alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.ProjectSource
   alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
 
   @moduletag :tmp_dir
+
+  test "switch project activates one workspace lifecycle end to end" do
+    root =
+      Path.join(System.tmp_dir!(), "minga-explicit-project-#{System.unique_integer([:positive])}")
+
+    file = Path.join(root, "inside.txt")
+    File.mkdir_p!(root)
+    File.write!(file, "content")
+    {_output, 0} = System.cmd("git", ["init"], cd: root, stderr_to_stdout: true)
+    {_output, 0} = System.cmd("git", ["add", "inside.txt"], cd: root, stderr_to_stdout: true)
+
+    on_exit(fn ->
+      Project.close()
+      _ = :sys.get_state(Project)
+      Project.remove(root)
+      _ = :sys.get_state(Project)
+      File.rm_rf!(root)
+    end)
+
+    Project.close()
+    _ = :sys.get_state(Project)
+    Minga.Events.subscribe(:project_rebuilt)
+    state = TestHelpers.base_state(content: "buffer")
+
+    state = ProjectSource.on_select(%Item{id: root, label: Path.basename(root)}, state)
+
+    assert Project.root() == root
+    assert %Minga.Project.Root{kind: :directory, path: ^root} = Project.workspace_root()
+    assert EditorState.file_tree_state(state).project_root == root
+    assert root in Project.known_projects()
+
+    assert_receive {:minga_event, :project_rebuilt,
+                    %Minga.Events.ProjectRebuiltEvent{root: ^root}},
+                   5_000
+
+    refute_receive {:minga_event, :project_rebuilt,
+                    %Minga.Events.ProjectRebuiltEvent{root: ^root}},
+                   100
+
+    Minga.Events.broadcast(
+      :buffer_opened,
+      %Minga.Events.BufferEvent{buffer: self(), path: file}
+    )
+
+    _ = :sys.get_state(Project)
+    assert Project.recent_files() == ["inside.txt"]
+    assert Project.frecency_scores()["inside.txt"] > 0
+  end
 
   test "closing a project clears the service and file tree root", %{tmp_dir: tmp_dir} do
     root = Path.join(tmp_dir, "workspace")
@@ -20,7 +71,7 @@ defmodule MingaEditor.Commands.ProjectTest do
 
     state =
       TestHelpers.base_state(content: "buffer")
-      |> EditorState.update_file_tree(&FileTreeState.set_project_root(&1, root))
+      |> set_file_tree_root(root)
 
     state = ProjectCommands.execute(state, :project_close)
     _ = :sys.get_state(Project)
@@ -28,5 +79,11 @@ defmodule MingaEditor.Commands.ProjectTest do
     assert Project.root() == nil
     assert Project.workspace_root() == nil
     assert EditorState.file_tree_state(state).project_root == nil
+  end
+
+  @spec set_file_tree_root(EditorState.t(), String.t()) :: EditorState.t()
+  defp set_file_tree_root(state, root) do
+    file_tree = FileTreeState.set_project_root(state.workspace.file_tree, root)
+    %{state | workspace: SessionState.set_file_tree(state.workspace, file_tree)}
   end
 end

--- a/test/minga_editor/commands/project_test.exs
+++ b/test/minga_editor/commands/project_test.exs
@@ -1,0 +1,32 @@
+defmodule MingaEditor.Commands.ProjectTest do
+  @moduledoc "Tests project commands that coordinate the global project service and editor state."
+
+  # Project commands intentionally mutate the application-wide Project service.
+  use ExUnit.Case, async: false
+
+  alias Minga.Project
+  alias MingaEditor.Commands.Project, as: ProjectCommands
+  alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  @moduletag :tmp_dir
+
+  test "closing a project clears the service and file tree root", %{tmp_dir: tmp_dir} do
+    root = Path.join(tmp_dir, "workspace")
+    File.mkdir_p!(root)
+    Project.switch(root)
+    _ = :sys.get_state(Project)
+
+    state =
+      TestHelpers.base_state(content: "buffer")
+      |> EditorState.update_file_tree(&FileTreeState.set_project_root(&1, root))
+
+    state = ProjectCommands.execute(state, :project_close)
+    _ = :sys.get_state(Project)
+
+    assert Project.root() == nil
+    assert Project.workspace_root() == nil
+    assert EditorState.file_tree_state(state).project_root == nil
+  end
+end

--- a/test/minga_editor/handlers/session_restore_test.exs
+++ b/test/minga_editor/handlers/session_restore_test.exs
@@ -66,6 +66,40 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
     assert switched.parser.injection_ranges == with_spans.parser.injection_ranges
   end
 
+  test "restoring loose files under a marker-bearing home keeps the workspace unset", %{
+    tmp_dir: dir
+  } do
+    fake_home = Path.join(dir, "home")
+    File.mkdir_p!(fake_home)
+    File.write!(Path.join(fake_home, "package.json"), "{}")
+    first_path = Path.join(fake_home, "notes.org")
+    second_path = Path.join(fake_home, "cacheless_design.org")
+    File.write!(first_path, "notes")
+    File.write!(second_path, "design")
+
+    snapshot = %Snapshot{
+      version: 1,
+      buffers: [%BufferEntry{file: first_path}, %BufferEntry{file: second_path}],
+      active_file: first_path
+    }
+
+    assert :ok = Session.save(snapshot, session_dir: dir)
+    Minga.Project.close()
+    _ = :sys.get_state(Minga.Project)
+    known_before = Minga.Project.known_projects()
+
+    restored = dir |> initial_state(project_root: nil) |> SessionRestore.restore_session()
+    project_state = :sys.get_state(Minga.Project)
+
+    assert Minga.Project.root() == nil
+    assert Minga.Project.workspace_root() == nil
+    assert project_state.rebuilding? == false
+    assert Minga.Project.files() == []
+    assert Minga.Project.known_projects() == known_before
+    refute fake_home in Minga.Project.known_projects()
+    assert EditorState.file_tree_state(restored).project_root == nil
+  end
+
   test "already-read recovered contents are applied by the SessionRestore owner", %{tmp_dir: dir} do
     path = Path.join(dir, "recovered.ex")
     File.write!(path, "old\n")
@@ -99,7 +133,8 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
     refute File.exists?(missing_path)
   end
 
-  defp initial_state(dir) do
+  @spec initial_state(String.t(), keyword()) :: EditorState.t()
+  defp initial_state(dir, opts \\ []) do
     manager_name = Module.concat(__MODULE__, "Parser#{System.unique_integer([:positive])}")
 
     manager =
@@ -114,7 +149,7 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
       parser_manager: manager,
       sidebar_registry: sidebar,
       session_dir: dir,
-      project_root: dir
+      project_root: Keyword.get(opts, :project_root, dir)
     )
   end
 end

--- a/test/minga_editor/render_model/ui/picker_builder_test.exs
+++ b/test/minga_editor/render_model/ui/picker_builder_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaEditor.RenderModel.UI.PickerBuilderTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Project.Root
   alias Minga.RenderModel.UI.Picker
   alias MingaEditor.RenderModel.UI.PickerBuilder
   alias MingaEditor.State.Buffers
@@ -121,6 +122,29 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilderTest do
 
       assert model.has_preview?
       assert model.preview_lines == [[{"alpha", 0xCCCCCC, false}], [{"beta", 0xCCCCCC, false}]]
+    end
+
+    test "relative file preview uses the candidate workspace root" do
+      root_path =
+        Path.join(System.tmp_dir!(), "picker-preview-root-#{System.unique_integer([:positive])}")
+
+      File.mkdir_p!(root_path)
+      File.write!(Path.join(root_path, "relative.txt"), "captured root")
+      on_exit(fn -> File.rm_rf!(root_path) end)
+      {:ok, root} = Root.directory(root_path)
+
+      item = %Item{
+        id: "relative.txt",
+        label: "relative.txt",
+        meta: %{workspace_root: root}
+      }
+
+      picker = %PickerState{items: [item], filtered: [item], title: "Files", selected: 0}
+      modal = picker_modal(picker, MingaEditor.UI.Picker.FileSource, nil, "", :ready)
+
+      model = PickerBuilder.build(build_context(modal))
+
+      assert model.preview_lines == [[{"captured root", 0xCCCCCC, false}]]
     end
 
     test "binary file preview shows a safe placeholder" do

--- a/test/minga_editor/ui/picker/file_source_async_test.exs
+++ b/test/minga_editor/ui/picker/file_source_async_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
 
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.State.FileTree
+  alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.FileSource
   alias MingaEditor.UI.Picker.Item
 
@@ -45,6 +46,14 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
     assert Path.join(lib, "one.ex") in paths
     assert Path.join(lib, "two.ex") in paths
     assert Minga.Buffer.file_path(state.workspace.buffers.active) == Path.join(lib, "two.ex")
+  end
+
+  test "no-workspace picker returns no candidates without a cwd fallback" do
+    context =
+      TestHelpers.base_state(content: "loose file")
+      |> Context.from_editor_state(%{project_root: nil})
+
+    assert FileSource.candidates(context) == []
   end
 
   test "bulk actions expose open all marked" do

--- a/test/minga_editor/ui/picker/file_source_async_test.exs
+++ b/test/minga_editor/ui/picker/file_source_async_test.exs
@@ -3,7 +3,9 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Project.Root
   alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.FileTree
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.FileSource
@@ -20,16 +22,7 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
 
     state =
       TestHelpers.base_state(content: "initial")
-      |> then(fn state ->
-        %{
-          state
-          | workspace:
-              then(
-                state.workspace,
-                &MingaEditor.Session.State.set_file_tree(&1, %FileTree{project_root: project})
-              )
-        }
-      end)
+      |> set_file_tree(%FileTree{project_root: project})
 
     initial_pids = state.workspace.buffers.list
 
@@ -54,6 +47,42 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
       |> Context.from_editor_state(%{project_root: nil})
 
     assert FileSource.candidates(context) == []
+  end
+
+  test "inactive picker roots do not start direct inventory", %{tmp_dir: tmp_dir} do
+    project = Path.join(tmp_dir, "inactive-project")
+    File.mkdir_p!(project)
+    File.write!(Path.join(project, "would-have-been-scanned.txt"), "content")
+    {:ok, root} = Root.directory(project)
+
+    context =
+      TestHelpers.base_state(content: "loose file")
+      |> Context.from_editor_state(%{project_root: root})
+
+    assert FileSource.candidates(context) == []
+  end
+
+  test "selection uses the candidate root after the file tree changes", %{tmp_dir: tmp_dir} do
+    original_root = Path.join(tmp_dir, "original")
+    current_tree_root = Path.join(tmp_dir, "current")
+    File.mkdir_p!(original_root)
+    File.mkdir_p!(current_tree_root)
+    File.write!(Path.join(original_root, "same.txt"), "original")
+    File.write!(Path.join(current_tree_root, "same.txt"), "current")
+    {:ok, root} = Root.directory(original_root)
+
+    state =
+      TestHelpers.base_state(content: "initial")
+      |> set_file_tree(%FileTree{project_root: current_tree_root})
+
+    initial_pids = state.workspace.buffers.list
+    item = %Item{id: "same.txt", label: "same.txt", meta: %{workspace_root: root}}
+    state = FileSource.on_select(item, state)
+    new_pids = Enum.reject(state.workspace.buffers.list, &Enum.member?(initial_pids, &1))
+    on_exit(fn -> Enum.each(new_pids, &stop_pid/1) end)
+
+    assert Minga.Buffer.file_path(state.workspace.buffers.active) ==
+             Path.join(original_root, "same.txt")
   end
 
   test "bulk actions expose open all marked" do
@@ -87,6 +116,11 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
       assert enriched.description == ""
       assert enriched.annotation == nil
     end
+  end
+
+  @spec set_file_tree(MingaEditor.State.t(), FileTree.t()) :: MingaEditor.State.t()
+  defp set_file_tree(state, file_tree) do
+    %{state | workspace: SessionState.set_file_tree(state.workspace, file_tree)}
   end
 
   defp stop_pid(pid) do

--- a/test/support/minga/project/slow_file_find.ex
+++ b/test/support/minga/project/slow_file_find.ex
@@ -1,0 +1,22 @@
+defmodule Minga.Project.SlowFileFind do
+  @moduledoc "A controllable file-discovery backend for Project lifecycle tests."
+
+  @spec start(Minga.Project.Root.t(), pid()) :: {:ok, pid()}
+  def start(_root, owner) do
+    {:ok, spawn(fn -> wait_for_cancel(owner, Process.monitor(owner)) end)}
+  end
+
+  @spec cancel(pid()) :: :ok
+  def cancel(pid) when is_pid(pid) do
+    send(pid, :cancel)
+    :ok
+  end
+
+  @spec wait_for_cancel(pid(), reference()) :: :ok
+  defp wait_for_cancel(owner, owner_ref) do
+    receive do
+      :cancel -> :ok
+      {:DOWN, ^owner_ref, :process, ^owner, _reason} -> :ok
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR
Loose files now remain outside directory workspaces, so opening or restoring a file cannot trigger recursive inventory of an ancestor. Explicit directory workspaces use a typed root boundary, and cancellable discovery workers ensure `git`, `fd`, and `find` processes stop with the workspace or application.

Closes #2887

## Context
Minga previously inferred an active project from every opened file. A marker in an ancestor directory could therefore turn a loose file into authorization to recursively inventory that ancestor, including broad roots such as the user's home directory.

## Changes
- Add `Minga.Project.Root` to distinguish file roots from explicitly activated directory workspaces and require confirmation metadata for broad roots.
- Stop project activation and known-project updates from `:buffer_opened`; file-open events now record recency only inside an already active workspace.
- Remove cwd fallbacks from project pickers, searches, previews, file mentions, Git resolution, and instruction discovery.
- Run project inventory through a monitored `FileFind.Worker` that owns the external Port and terminates the process tree on root switches, project close, timeout, or shutdown.
- Add a production `:project_close` command and keep explicit switch, dropped-folder, CLI-folder, file tree, cache, known-project, and frecency behavior aligned.
- Document the discovery worker lifecycle in `docs/ARCHITECTURE.md`.

## Review fixes
- Canonicalize workspace roots before broad-root authorization so symlink aliases cannot bypass the boundary.
- Preserve each picker candidate's originating root and remove unmanaged picker and agent fallback scans.
- Bound synchronous discovery by timeout, output bytes, and file count; make cancellation wait for process-tree termination and report failures.
- Reject absolute, traversal, and escaping-symlink agent file mentions before reading content.

## Verification
- `make lint`
- `mix test.llm` (9,426 tests, 0 failures, 1 skipped)
- Focused tests cover restored loose files, marker-bearing ancestors, no-workspace pickers, typed inventory boundaries, broad-root rejection, explicit switching, and external process-tree cancellation.

## Acceptance Criteria Addressed
- Restored loose files leave the workspace unset and start no inventory ✅
- Opened files do not promote marker-bearing ancestors or known projects ✅
- Recursive inventory requires an explicit typed directory root ✅
- The project file picker has a no-workspace path with no cwd fallback ✅
- Explicit folder and project switching retain cache, file tree, known-project, and frecency behavior ✅
- Broad roots require explicit confirmation metadata ✅
- Discovery is cancelled on switch, close, timeout, and shutdown, including descendants ✅
- Regression coverage includes every required scenario ✅


---
**Updated after review:** Resolved all Review DAG correctness, test, and security blockers. Focused security and final acceptance re-reviews now pass.
