### PR TITLE
refactor(macos): defer committed frame effects

### DIFF
--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -54,6 +54,23 @@ private enum CompletionNavigationCodepoints {
     static let ctrlModifier: UInt8 = 0x02
 }
 
+private enum CommitEffect {
+    case fontChanged(family: String, size: UInt16, ligatures: Bool, weight: UInt8)
+    case scrollPresentationReset(windowID: UInt16)
+    case titleChanged(String)
+    case windowBackgroundChanged(red: UInt8, green: UInt8, blue: UInt8)
+    case linkCursorChanged(Bool)
+    case lineSpacingChanged(Float)
+    case cursorAnimationChanged(Bool)
+    case modeChanged(String)
+    case agentChatVisibilityChanged(Bool)
+    case clipboardWrite(target: UInt8, text: String)
+    case extensionRuntime(FrontendExtensionRuntimeMessage)
+    case infoLog(String)
+    case warningLog(String)
+    case errorLog(String)
+}
+
 /// Dispatches render commands to FrameState (metadata) and GUIState (chrome).
 @MainActor
 final class CommandDispatcher {
@@ -287,7 +304,7 @@ final class CommandDispatcher {
         //   for font commands, but Swift actually applies them).
         case .guiConfigState:
             // Settings is an independently interactive scene and has no frame consumer.
-            apply(command)
+            applyImmediately(command)
 
         case .setTitle, .setWindowBg, .setLinkCursor, .protocolError,
              .setFont, .setFontFallback, .registerFont, .clipboardWrite:
@@ -439,25 +456,37 @@ final class CommandDispatcher {
             generation: transaction.generation,
             frameSeq: transaction.frameSeq
         )
+        var effects: [CommitEffect] = []
         guiState.frameStore.publishCommitted(
             generation: committed.generation,
             frameSeq: committed.frameSeq,
             impact: finalImpact
         ) {
-            if let theme = transaction.theme { apply(.guiTheme(slots: theme.slots)) }
-            if let resources = transaction.resources { resources.commands.forEach(apply) }
-            if let windows = transaction.windows { apply(windows) }
-            if let metadata = transaction.metadata { metadata.commands.forEach(apply) }
+            if let theme = transaction.theme {
+                apply(.guiTheme(slots: theme.slots), effects: &effects)
+            }
+            if let resources = transaction.resources {
+                for command in resources.commands { apply(command, effects: &effects) }
+            }
+            if let windows = transaction.windows { apply(windows, effects: &effects) }
+            if let metadata = transaction.metadata {
+                for command in metadata.commands { apply(command, effects: &effects) }
+            }
             if let chrome = transaction.chrome {
                 if let transcript = chrome.transcript {
                     guiState.agentChatState.publishTranscript(transcript)
                 }
-                chrome.commands.forEach(apply)
+                for command in chrome.commands { apply(command, effects: &effects) }
             }
-            if let overlays = transaction.overlays { overlays.commands.forEach(apply) }
-            if let focus = transaction.focus { focus.commands.forEach(apply) }
+            if let overlays = transaction.overlays {
+                for command in overlays.commands { apply(command, effects: &effects) }
+            }
+            if let focus = transaction.focus {
+                for command in focus.commands { apply(command, effects: &effects) }
+            }
             if clearsResync { guiState.resyncState.clear() }
         }
+        replay(effects)
         guiState.presentationMetrics.beginCommitted(frame: committed, impact: finalImpact)
         publicationCount += 1
         lastPublicationOperationCounts = transaction.operationCounts
@@ -466,25 +495,33 @@ final class CommandDispatcher {
     private func publishLocal(_ command: RenderCommand) {
         let impact = GUIFrameImpact.impact(for: command)
         guard !impact.isEmpty else {
-            apply(command)
+            applyImmediately(command)
             return
         }
+        var effects: [CommitEffect] = []
         guiState.frameStore.publishLocal(impact: impact) {
-            apply(command)
+            apply(command, effects: &effects)
         }
+        replay(effects)
     }
 
-    private func apply(_ updates: PreparedWindowUpdates) {
+    private func applyImmediately(_ command: RenderCommand) {
+        var effects: [CommitEffect] = []
+        apply(command, effects: &effects)
+        replay(effects)
+    }
+
+    private func apply(_ updates: PreparedWindowUpdates, effects: inout [CommitEffect]) {
         for (windowId, content) in updates.replacements {
             let previousScroll = guiState.windowContents[windowId]?.scrollPresentation
             guiState.windowContents[windowId] = content
             if shouldResetScrollPresentation(previous: previousScroll, next: content.scrollPresentation) {
-                discardLocalPresentation(.offset, windowId: windowId)
+                effects.append(.scrollPresentationReset(windowID: windowId))
             }
             frameState.cursorVisible = content.cursorVisible
             frameState.dirty = true
         }
-        updates.commands.forEach(apply)
+        for command in updates.commands { apply(command, effects: &effects) }
         if let authoritativeWindowIds = updates.authoritativeWindowIds {
             pruneAuthoritativeFrameState(liveWindowIds: authoritativeWindowIds)
         } else {
@@ -654,7 +691,7 @@ final class CommandDispatcher {
             )
             return
         }
-        apply(command)
+        applyImmediately(command)
     }
 
     // MARK: - View-driven FrameState mutations
@@ -745,12 +782,11 @@ final class CommandDispatcher {
         }
     }
 
-    /// Apply one domain command to the presented FrameState/GUIState. This is
-    /// called directly for out-of-band commands and from the focused prepared
-    /// publication boundary for committed domain updates. It must NOT handle frame
-    /// markers (begin/commit) — those drive the transaction state machine in
-    /// `dispatch`/`commitTransaction`, not the presented state.
-    private func apply(_ command: RenderCommand) {
+    /// Install one domain command into the presented FrameState/GUIState and
+    /// append any externally observable work to `effects`. It must NOT handle
+    /// frame markers (begin/commit) — those drive the transaction state machine
+    /// in `dispatch`/`commitTransaction`, not the presented state.
+    private func apply(_ command: RenderCommand, effects: inout [CommitEffect]) {
         switch command {
         case .setCursorShape(let shape):
             frameState.cursorShape = shape
@@ -763,32 +799,28 @@ final class CommandDispatcher {
             PortLogger.warn("Frame marker reached apply(_:); transaction routing bug")
 
         case .setTitle(let title):
-            onTitleChanged?(title)
+            effects.append(.titleChanged(title))
 
         case .setWindowBg(let r, let g, let b):
             let rgb: UInt32 = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
             frameState.defaultBg = rgb
-            let color = NSColor(
-                red: CGFloat(r) / 255.0,
-                green: CGFloat(g) / 255.0,
-                blue: CGFloat(b) / 255.0,
-                alpha: 1.0
-            )
-            PortLogger.info("Window bg received: r=\(r) g=\(g) b=\(b)")
-            onWindowBgChanged?(color)
+            effects.append(.windowBackgroundChanged(red: r, green: g, blue: b))
+            effects.append(.infoLog("Window bg received: r=\(r) g=\(g) b=\(b)"))
 
         case .setLinkCursor(let active):
-            onLinkCursorChanged?(active)
+            effects.append(.linkCursorChanged(active))
 
         case .protocolError(let message):
             // The BEAM rejected this frontend's handshake protocol_version, so
-            // we will never reach ready. Log to the port log and latch a blocking
-            // error overlay instead of leaving a blank window (ticket #2237).
-            PortLogger.error("Protocol error from BEAM: \(message)")
+            // we will never reach ready. Latch the blocking overlay during state
+            // installation and defer the port log until the frame is complete.
             guiState.protocolErrorState.present(message: message)
+            effects.append(.errorLog("Protocol error from BEAM: \(message)"))
 
         case .setFont(let family, let size, let ligatures, let weight):
-            onFontChanged?(family, size, ligatures, weight)
+            effects.append(.fontChanged(
+                family: family, size: size, ligatures: ligatures, weight: weight
+            ))
 
         case .setFontFallback(let families):
             fontManager?.setFallbackFonts(families)
@@ -853,14 +885,14 @@ final class CommandDispatcher {
             frameState.lineSpacing = max(spacing, 1.0)
             frameState.dirty = true
             if oldSpacing != frameState.lineSpacing {
-                onLineSpacingChanged?(frameState.lineSpacing)
+                effects.append(.lineSpacingChanged(frameState.lineSpacing))
             }
 
         case .guiCursorAnimation(let enabled):
-            onCursorAnimationChanged?(enabled)
+            effects.append(.cursorAnimationChanged(enabled))
 
         case .clipboardWrite(let target, let text):
-            handleClipboardWrite(target: target, text: text)
+            effects.append(.clipboardWrite(target: target, text: text))
 
         case .guiObservatory(let visible, _, let nodes):
             if visible {
@@ -904,7 +936,7 @@ final class CommandDispatcher {
             frameState.totalLineCount = update.lineCount
             if update.mode != lastMode {
                 lastMode = update.mode
-                onModeChanged?(guiState.statusBarState.modeName)
+                effects.append(.modeChanged(guiState.statusBarState.modeName))
             }
 
         case .guiPicker(let visible, let selectedIndex, let filteredCount, let totalCount, let markedCount, let title, let query, let hasPreview, let items, let actionMenu, let modePrefix, let loadStatus):
@@ -935,7 +967,7 @@ final class CommandDispatcher {
                 guiState.agentChatState.hide()
             }
             if guiState.agentChatState.visible != wasVisible {
-                onAgentChatVisibilityChanged?(guiState.agentChatState.visible)
+                effects.append(.agentChatVisibilityChanged(guiState.agentChatState.visible))
             }
 
         case .guiAgentTranscript:
@@ -975,7 +1007,7 @@ final class CommandDispatcher {
             guiState.windowContents[data.windowId] = data
             currentFrameWindowIds.insert(data.windowId)
             if shouldResetScrollPresentation(previous: previousScroll, next: data.scrollPresentation) {
-                discardLocalPresentation(.offset, windowId: data.windowId)
+                effects.append(.scrollPresentationReset(windowID: data.windowId))
             }
             frameState.cursorVisible = data.cursorVisible
 
@@ -998,7 +1030,7 @@ final class CommandDispatcher {
             guiState.windowContents[delta.windowId] = updated
             currentFrameWindowIds.insert(delta.windowId)
             if shouldResetScrollPresentation(previous: previousScroll, next: updated.scrollPresentation) {
-                discardLocalPresentation(.offset, windowId: delta.windowId)
+                effects.append(.scrollPresentationReset(windowID: delta.windowId))
             }
             frameState.cursorVisible = delta.cursorVisible
             frameState.dirty = true
@@ -1123,7 +1155,9 @@ final class CommandDispatcher {
                 let parsedLevel = ToastLevel(rawValue: t.level)
                 let parsedAction = ToastAction(rawValue: t.action)
                 if parsedLevel == nil || parsedAction == nil {
-                    PortLogger.warn("Invalid git toast metadata: level=\(t.level) action=\(t.action)")
+                    effects.append(.warningLog(
+                        "Invalid git toast metadata: level=\(t.level) action=\(t.action)"
+                    ))
                 }
                 return (t.message, parsedLevel ?? .error, parsedAction ?? .none)
             }
@@ -1133,12 +1167,12 @@ final class CommandDispatcher {
             } else {
                 let entries = rawEntries.compactMap { raw -> GitStatusEntry? in
                     guard let section = GitStatusSection(rawValue: raw.section) else {
-                        PortLogger.warn("Invalid git status section: \(raw.section)")
+                        effects.append(.warningLog("Invalid git status section: \(raw.section)"))
                         return nil
                     }
                     let status = GitFileStatus(rawValue: raw.status) ?? .unknown
                     if status == .unknown && raw.status != GitFileStatus.unknown.rawValue {
-                        PortLogger.warn("Invalid git file status: \(raw.status)")
+                        effects.append(.warningLog("Invalid git file status: \(raw.status)"))
                     }
                     return GitStatusEntry(
                         pathHash: raw.pathHash,
@@ -1168,7 +1202,7 @@ final class CommandDispatcher {
             guiState.extensionPanelState.update(panels)
 
         case .guiExtensionRuntime(let message):
-            guiState.frontendExtensions.dispatch(message)
+            effects.append(.extensionRuntime(message))
 
         case .guiSearchState(let active, let matchCount, let currentIndex, let flags):
             if active {
@@ -1220,9 +1254,49 @@ final class CommandDispatcher {
     func discardLocalPresentation(_ kind: TransformKind, windowId: UInt16 = 0) {
         switch kind {
         case .offset:
-            onScrollPresentationReset?()
+            replay([.scrollPresentationReset(windowID: windowId)])
         case .identity:
             break
+        }
+    }
+
+    private func replay(_ effects: [CommitEffect]) {
+        for effect in effects {
+            switch effect {
+            case .fontChanged(let family, let size, let ligatures, let weight):
+                onFontChanged?(family, size, ligatures, weight)
+            case .scrollPresentationReset:
+                onScrollPresentationReset?()
+            case .titleChanged(let title):
+                onTitleChanged?(title)
+            case .windowBackgroundChanged(let red, let green, let blue):
+                onWindowBgChanged?(NSColor(
+                    red: CGFloat(red) / 255.0,
+                    green: CGFloat(green) / 255.0,
+                    blue: CGFloat(blue) / 255.0,
+                    alpha: 1.0
+                ))
+            case .linkCursorChanged(let active):
+                onLinkCursorChanged?(active)
+            case .lineSpacingChanged(let spacing):
+                onLineSpacingChanged?(spacing)
+            case .cursorAnimationChanged(let enabled):
+                onCursorAnimationChanged?(enabled)
+            case .modeChanged(let mode):
+                onModeChanged?(mode)
+            case .agentChatVisibilityChanged(let visible):
+                onAgentChatVisibilityChanged?(visible)
+            case .clipboardWrite(let target, let text):
+                handleClipboardWrite(target: target, text: text)
+            case .extensionRuntime(let message):
+                guiState.frontendExtensions.dispatch(message)
+            case .infoLog(let message):
+                PortLogger.info(message)
+            case .warningLog(let message):
+                PortLogger.warn(message)
+            case .errorLog(let message):
+                PortLogger.error(message)
+            }
         }
     }
 

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -6,6 +6,7 @@
 
 import MingaUI
 import Observation
+import SwiftUI
 import Synchronization
 import Testing
 import Foundation
@@ -1560,7 +1561,12 @@ struct CommandDispatcherStagingTests {
                       icon: "", label: label)
     }
 
-    private func windowContent(windowId: UInt16 = 7, epoch: UInt32 = 42, fontId: UInt8 = 0) throws -> GUIWindowContent {
+    private func windowContent(
+        windowId: UInt16 = 7,
+        epoch: UInt32 = 42,
+        fontId: UInt8 = 0,
+        scrollPresentation: GUIScrollPresentation? = nil
+    ) throws -> GUIWindowContent {
         let span = GUIHighlightSpan(
             startCol: 0, endCol: 3, fg: 0xFFFFFF, bg: 0,
             attrs: 0, fontWeight: 0, fontId: fontId
@@ -1573,7 +1579,23 @@ struct CommandDispatcherStagingTests {
             windowId: windowId, fullRefresh: true, contentEpoch: epoch,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [row], selection: nil, searchMatches: [],
-            diagnosticUnderlines: [], documentHighlights: []
+            diagnosticUnderlines: [], documentHighlights: [],
+            scrollPresentation: scrollPresentation
+        )
+    }
+
+    private func status(mode: UInt8 = 1) -> StatusBarUpdate {
+        StatusBarUpdate(
+            contentKind: 0, mode: mode, cursorLine: 4, cursorCol: 2,
+            lineCount: 12, flags: 0, lspStatus: 0, gitBranch: "",
+            message: "committed", filetype: "swift", errorCount: 0,
+            warningCount: 0, modelName: "", messageCount: 0,
+            sessionStatus: 0, infoCount: 0, hintCount: 0,
+            macroRecording: 0, parserStatus: 0, agentStatus: 0,
+            gitAdded: 0, gitModified: 0, gitDeleted: 0, icon: "",
+            iconColorR: 0, iconColorG: 0, iconColorB: 0,
+            filename: "Commit.swift", diagnosticHint: "",
+            backgroundSubagentCount: 0, backgroundSubagentLabel: ""
         )
     }
 
@@ -2035,6 +2057,100 @@ struct CommandDispatcherStagingTests {
         #expect(gui.agentChatState.model == "prepared-model")
     }
 
+    @Test("an early prepared callback observes all later semantic state")
+    @MainActor func preparedCallbackObservesCompleteState() throws {
+        let (dispatcher, gui) = makeDispatcher()
+        var observation: (Bool, String?, String, Set<UInt16>, Bool)?
+        dispatcher.onFontChanged = { _, _, _, _ in
+            observation = (
+                gui.themeColors.hasAppliedTheme,
+                gui.windowContents[7]?.rows.first?.text,
+                gui.statusBarState.modeName,
+                dispatcher.currentFrameWindowIds,
+                gui.completionState.visible
+            )
+        }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.setFont(family: "Menlo", size: 14, ligatures: true, weight: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent()))
+        dispatcher.dispatch(.guiStatusBar(status()))
+        dispatcher.dispatch(.guiCompletion(
+            visible: true, anchorRow: 3, anchorCol: 4, selectedIndex: 0,
+            items: [Wire.CompletionItem(kind: 1, label: "commit", detail: "state")],
+            documentation: "installed after the resource domain"
+        ))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(observation?.0 == true)
+        #expect(observation?.1 == "old")
+        #expect(observation?.2 == "INSERT")
+        #expect(observation?.3 == Set([7]))
+        #expect(observation?.4 == true)
+    }
+
+    @Test("prepared effects replay once in canonical order before acknowledgement")
+    @MainActor func preparedEffectsReplayInCanonicalOrder() throws {
+        let (dispatcher, gui) = makeDispatcher()
+        var events: [String] = []
+        gui.frontendExtensions.register(
+            extensionID: "effects-test",
+            decoder: { _ in events.append("extension") },
+            view: { _ in AnyView(EmptyView()) }
+        )
+        dispatcher.onFontChanged = { _, _, _, _ in events.append("font") }
+        dispatcher.onScrollPresentationReset = { events.append("scroll") }
+        dispatcher.onTitleChanged = { _ in events.append("title") }
+        dispatcher.onWindowBgChanged = { _ in events.append("background") }
+        dispatcher.onModeChanged = { _ in events.append("mode") }
+        dispatcher.onLineSpacingChanged = { _ in events.append("spacing") }
+        dispatcher.onCursorAnimationChanged = { _ in events.append("cursor-animation") }
+        dispatcher.onAgentChatVisibilityChanged = { _ in events.append("agent-chat") }
+        dispatcher.onLinkCursorChanged = { _ in events.append("link") }
+        dispatcher.onTransactionResult = { _ in events.append("transaction") }
+        dispatcher.onFirstRender = { events.append("first-render") }
+        dispatcher.onFramePresented = { events.append("presented") }
+        dispatcher.onFrameReady = { events.append("ready") }
+
+        let reset = GUIScrollPresentation(
+            windowId: 7, resetRequired: true, anchorTop: 5, anchorLeft: 0,
+            anchorVisualRowOffset: 0, visibleStartLine: 5, visibleEndLine: 8,
+            overscanStartLine: 4, overscanEndLine: 9, contentEpoch: 42,
+            layoutGeneration: 1
+        )
+        let runtime = FrontendExtensionRuntimeMessage(
+            extensionID: "effects-test", channel: "commit", payload: Data([1])
+        )
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        // Deliberately scramble input order; prepared domains define replay order.
+        dispatcher.dispatch(.setLinkCursor(active: true))
+        dispatcher.dispatch(.guiAgentChat(
+            visible: true, status: 0, model: "model", thinkingLevel: "medium",
+            prompt: "", promptLineCount: 1, promptCursorLine: 0,
+            promptCursorCol: 0, promptVimMode: 1, promptVisibleRows: 1,
+            promptCompletion: nil, pendingToolName: nil, pendingToolSummary: "",
+            helpVisible: false, helpGroups: [], messages: []
+        ))
+        dispatcher.dispatch(.guiExtensionRuntime(runtime))
+        dispatcher.dispatch(.guiCursorAnimation(enabled: false))
+        dispatcher.dispatch(.guiLineSpacing(spacing: 1.5))
+        dispatcher.dispatch(.guiStatusBar(status()))
+        dispatcher.dispatch(.setWindowBg(r: 0x22, g: 0x33, b: 0x44))
+        dispatcher.dispatch(.setTitle("Committed"))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent(scrollPresentation: reset)))
+        dispatcher.dispatch(.setFont(family: "Menlo", size: 14, ligatures: true, weight: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        #expect(events == [
+            "font", "scroll", "cursor-animation", "spacing", "mode",
+            "background", "title", "extension", "agent-chat", "link",
+            "transaction", "first-render", "presented", "ready"
+        ])
+    }
+
     @Test("gutter and indent guide keys cannot collide across window ids")
     @MainActor func typedWindowCoalescingKeysDoNotCollide() throws {
         let (dispatcher, _) = makeDispatcher()
@@ -2323,6 +2439,41 @@ struct CommandDispatcherStagingTests {
         #expect(results == [.windowRefMiss(generation: 1, frameSeq: 1, lastAppliedFrameSeq: 0, windowId: 99)])
     }
 
+    @Test("incomplete, resource-rejected, and superseded frames replay no effects")
+    @MainActor func nonPublishedFramesReplayNoEffects() throws {
+        var effectCount = 0
+        func armEffects(_ dispatcher: CommandDispatcher) {
+            dispatcher.onTitleChanged = { _ in effectCount += 1 }
+            dispatcher.onFontChanged = { _, _, _, _ in effectCount += 1 }
+        }
+
+        let (incomplete, _) = makeDispatcher()
+        armEffects(incomplete)
+        incomplete.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        incomplete.dispatch(.setTitle("incomplete"))
+        incomplete.dispatch(.setFont(family: "Menlo", size: 14, ligatures: true, weight: 1))
+        incomplete.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        let (resourceRejected, _) = makeDispatcher()
+        armEffects(resourceRejected)
+        resourceRejected.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        resourceRejected.dispatch(.guiTheme(slots: completeThemeSlots()))
+        resourceRejected.dispatch(.setTitle("resource rejected"))
+        resourceRejected.resourcePolicyRejected()
+
+        let (superseded, _) = makeDispatcher()
+        superseded.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 2))
+        superseded.dispatch(.guiTheme(slots: completeThemeSlots()))
+        superseded.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        armEffects(superseded)
+        superseded.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
+        superseded.dispatch(.setTitle("superseded"))
+        superseded.dispatch(.setFont(family: "Menlo", size: 14, ligatures: true, weight: 1))
+        superseded.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+
+        #expect(effectCount == 0)
+    }
+
     @Test("invalid transcript operations reject without publishing sibling state")
     @MainActor func invalidTranscriptRejectsWholeTransaction() throws {
         let invalidCommands: [(RenderCommand, PreparedFrameRejection)] = [
@@ -2561,16 +2712,24 @@ struct CommandDispatcherStagingTests {
         #expect(requested.isEmpty) // out-of-band, not an invalidation
     }
 
-    @Test("set_window_bg applies immediately with no open transaction")
+    @Test("set_window_bg replays its local effect immediately after mutation")
     @MainActor func windowBgAppliesOutOfBand() throws {
         let (dispatcher, _) = makeDispatcher()
         var requested: [UInt32] = []
+        var callbackCount = 0
+        var callbackSawInstalledState = false
+        let expected: UInt32 = (0x28 << 16) | (0x2C << 8) | 0x34
         dispatcher.onRequestKeyframe = { requested.append($0) }
+        dispatcher.onWindowBgChanged = { _ in
+            callbackCount += 1
+            callbackSawInstalledState = dispatcher.frameState.defaultBg == expected
+        }
 
         dispatcher.dispatch(.setWindowBg(r: 0x28, g: 0x2C, b: 0x34))
 
-        let expected: UInt32 = (0x28 << 16) | (0x2C << 8) | 0x34
         #expect(dispatcher.frameState.defaultBg == expected)
+        #expect(callbackCount == 1)
+        #expect(callbackSawInstalledState)
         #expect(requested.isEmpty)
     }
 

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -2068,12 +2068,13 @@ defmodule MingaAgent.Providers.NativeTest do
 
   describe "concurrent prompt rejection" do
     test "rejects second prompt while streaming", %{tmp_dir: dir} do
-      {slow_stream, stream_ref} = blocking_text_stream()
+      {slow_stream, _stream_ref} = blocking_text_stream()
       client = fn _model, _messages, _opts -> build_stream_response(slow_stream) end
 
       {:ok, pid} = start_provider(tmp_dir: dir, llm_client: client)
       :ok = Native.send_prompt(pid, "First prompt")
-      assert_streaming_started(pid, stream_ref)
+      assert_receive {:agent_provider_event, %Event.AgentStart{}}
+      assert {:ok, %{is_streaming: true}} = Native.get_state(pid)
 
       assert {:error, :already_streaming} = Native.send_prompt(pid, "Second prompt")
 


### PR DESCRIPTION
# TL;DR
Validated macOS frames now install all semantic state before replaying AppKit callbacks and other external effects. This gives the Observation migration in #2899 a non-reentrant commit boundary without changing frame tokens, protocol behavior, row-fit ownership, or native interaction state.

Closes #2900

## Context
This is the first delivery unit of #2899. The current frame-version publication remains intact, but callbacks previously ran from inside `CommandDispatcher.apply(_:)` while later prepared commands had not installed their state. SwiftUI would not render during that synchronous call, but AppKit, accessibility, extension, clipboard, and renderer callbacks could observe a partial committed frame.

## Changes
- Add a typed, ordered `CommitEffect` accumulator for callback payloads, clipboard writes, extension dispatch, and deferred logging.
- Install theme, resources, windows, metadata, chrome, overlays, focus, and resync state before replaying any accumulated effect.
- Preserve canonical prepared-domain order, frame-store publication, presentation metrics, acknowledgements, first-render handling, frame-presented handling, and frame-ready rendering.
- Keep local and out-of-band commands synchronous by replaying their effects immediately after their own state mutation.
- Add focused coverage for complete-state callback observation, deterministic exactly-once replay, rejected and superseded frames, local behavior, acknowledgements, and presentation samples.

## Verification
- `make lint` on final SHA `98cbadf99`
- `mix test.llm`: 9,438 tests, 0 failures on the final SHA
- `mix swift.build`
- CI-equivalent `xcodebuild test`: 1,209 tests, 0 failures
- `scripts/check_render_performance`: combined p95 0.131083 ms on the 65,536-row resident fixture
- LSP diagnostics and `git diff --check`: clean
- Final reviewer: PASS
- CI follow-up: the concurrent prompt-rejection test now synchronizes on the provider’s public streaming state instead of waiting for an unrelated stream-consumer task; focused test and `make lint` passed

## Acceptance Criteria Addressed
- Every semantic command installs before callback or external-effect replay ✅
- Deferred effects preserve deterministic order and existing post-commit callback behavior ✅
- Rejected, superseded, incomplete, and resource-policy-failed frames execute no effects; local commands remain immediate ✅
- Font and line-spacing behavior preserves frontend-owned row fit and final rendering order ✅
- Focused and full-suite coverage proves complete-state observation, rejection, ordering, acknowledgement, and metrics behavior ✅

---
**Updated after CI:** Removed an unrelated 500 ms stream-consumer scheduling assumption exposed by CI. The prompt-rejection test now asserts the synchronous `AgentStart` event and public streaming state that define the behavior under test.
