### PR TITLE
refactor(macos): prove direct Observation for tabs and FileTree

### DIFF
--- a/macos/Sources/ContentView.swift
+++ b/macos/Sources/ContentView.swift
@@ -99,6 +99,7 @@ private struct PaneWidthKey: PreferenceKey {
 
 enum ContentViewFrameProbePoint: Hashable {
     case shell
+    case fileTree
     case editor
     case editorOverlay
     case extensionOverlay
@@ -106,7 +107,7 @@ enum ContentViewFrameProbePoint: Hashable {
 }
 
 struct ContentViewFrameProbe {
-    let makeView: (ContentViewFrameProbePoint, AnyObject) -> AnyView
+    let makeView: (ContentViewFrameProbePoint, String, AnyObject) -> AnyView
 }
 
 private struct ShellFramePresentationHost<Content: View>: View {
@@ -235,7 +236,11 @@ private struct EditorOverlayHost<ExtensionContent: View>: View {
                 anchoredOverlay(row: input.completionState.anchorRow, col: input.completionState.anchorCol, preferredSide: .below, maxHeight: 420, gap: 2) { _ in
                     CompletionOverlay(state: input.completionState, encoder: encoder)
                         .background {
-                            probe(.editorOverlay, stateObject: input.completionState)
+                            probe(
+                                .editorOverlay,
+                                value: input.completionState.items.map(\.label).joined(separator: ","),
+                                stateObject: input.completionState
+                            )
                         }
                 }
                 .zIndex(30)
@@ -249,9 +254,9 @@ private struct EditorOverlayHost<ExtensionContent: View>: View {
     }
 
     @ViewBuilder
-    private func probe(_ point: ContentViewFrameProbePoint, stateObject: AnyObject) -> some View {
+    private func probe(_ point: ContentViewFrameProbePoint, value: String, stateObject: AnyObject) -> some View {
         if let frameProbe {
-            frameProbe.makeView(point, stateObject)
+            frameProbe.makeView(point, value, stateObject)
         }
     }
 
@@ -563,9 +568,9 @@ public struct ContentView<EditorSurface: View>: View {
     }
 
     @ViewBuilder
-    private func frameProbeView(_ point: ContentViewFrameProbePoint, stateObject: AnyObject) -> some View {
+    private func frameProbeView(_ point: ContentViewFrameProbePoint, value: String, stateObject: AnyObject) -> some View {
         if let frameProbe {
-            frameProbe.makeView(point, stateObject)
+            frameProbe.makeView(point, value, stateObject)
         }
     }
 
@@ -710,7 +715,11 @@ public struct ContentView<EditorSurface: View>: View {
                             encoder: encoder
                         )
                         .background {
-                            frameProbeView(.shell, stateObject: input.tabBarState)
+                            frameProbeView(
+                                .shell,
+                                value: input.tabBarState.displayTabs.map(\.label).joined(separator: ","),
+                                stateObject: input.tabBarState
+                            )
                         }
                         .accessibilityIdentifier("workspace-tabbar")
                     } else {
@@ -806,7 +815,8 @@ public struct ContentView<EditorSurface: View>: View {
                     projectName: projectName(input),
                     gitBranch: input.statusBarState.gitBranch,
                     leadingPadding: titleBarLeadingPadding,
-                    sidebarWidth: $sidebarWidth
+                    sidebarWidth: $sidebarWidth,
+                    frameProbe: frameProbe
                 )
             }
         }
@@ -954,7 +964,11 @@ public struct ContentView<EditorSurface: View>: View {
                     encoder: encoder
                 )
                 .background {
-                    frameProbeView(.editor, stateObject: input.emptyStateState)
+                    frameProbeView(
+                        .editor,
+                        value: input.emptyStateState.sections.flatMap(\.items).map(\.label).joined(separator: ","),
+                        stateObject: input.emptyStateState
+                    )
                 }
             }
 
@@ -1031,7 +1045,11 @@ public struct ContentView<EditorSurface: View>: View {
                     rowCount: geometry?.textRect.height ?? 0
                 )
                 .background {
-                    frameProbeView(.extensionOverlay, stateObject: input.extensionOverlayState)
+                    frameProbeView(
+                        .extensionOverlay,
+                        value: input.extensionOverlayState.entries.map(\.content).joined(separator: ","),
+                        stateObject: input.extensionOverlayState
+                    )
                 }
             }
         }
@@ -1212,7 +1230,11 @@ public struct ContentView<EditorSurface: View>: View {
             encoder: encoder
         )
         .background {
-            frameProbeView(.windowOverlay, stateObject: input.pickerState)
+            frameProbeView(
+                .windowOverlay,
+                value: input.pickerState.items.map(\.label).joined(separator: ","),
+                stateObject: input.pickerState
+            )
         }
 
         ToolManagerView(

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -730,9 +730,7 @@ final class CommandDispatcher {
         default:
             return false
         }
-        return guiState.frameStore.publishLocalIfChanged(impact: .shell) {
-            guiState.fileTreeState.previewNavigation(delta: delta)
-        }
+        return guiState.fileTreeState.previewNavigation(delta: delta)
     }
 
     @discardableResult

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -1988,6 +1988,33 @@ final class EditorNSView: MTKView {
         hasMouseDownPoint && !isDividerDragActive && !isDraggingScrollIndicator
     }
 
+#if DEBUG
+    struct InteractionSnapshot {
+        let hasMarkedText: Bool
+        let markedRange: NSRange
+        let hoverRow: Int16
+        let hoverCol: Int16
+        let selectionDragActive: Bool
+        let selectionDragStarted: Bool
+        let scrollWindowId: UInt16?
+        let scrollOffset: CGPoint
+    }
+
+    /// Read-only test seam for native interaction ownership across SwiftUI publication.
+    var interactionSnapshot: InteractionSnapshot {
+        InteractionSnapshot(
+            hasMarkedText: imeComposition.hasMarkedText,
+            markedRange: imeComposition.markedRange,
+            hoverRow: lastMoveRow,
+            hoverCol: lastMoveCol,
+            selectionDragActive: isSelectionDragActive,
+            selectionDragStarted: leftMouseDragStarted,
+            scrollWindowId: localScrollPresentation?.windowId,
+            scrollOffset: localScrollPresentation?.offset ?? .zero
+        )
+    }
+#endif
+
     private func handleTrackpadScroll(event: NSEvent, row: Int16, col: Int16, mods: UInt8) {
         if event.phase == .began {
             cancelScrollAnimations()

--- a/macos/Sources/Views/EditorChrome/TabBarState.swift
+++ b/macos/Sources/Views/EditorChrome/TabBarState.swift
@@ -98,6 +98,7 @@ public struct WorkspaceTabEntry: Identifiable {
 
 /// Observable state for the tab bar, driven by BEAM protocol messages.
 @MainActor
+@Observable
 public final class TabBarState {
     public init(tabs: [TabEntry] = [], activeIndex: UInt8 = 0, workspaces: [WorkspaceEntry] = [], workspaceTabs: [WorkspaceTabEntry] = [], activeWorkspaceId: UInt16 = 0, workspaceMode: UInt8 = 0, workspaceFlags: UInt8 = 0, hasCanonicalWorkspaceTabs: Bool = false) {
         self.tabs = tabs

--- a/macos/Sources/Views/EditorChrome/TabBarView.swift
+++ b/macos/Sources/Views/EditorChrome/TabBarView.swift
@@ -40,7 +40,6 @@ public struct TabBarView: View {
     }
     public let tabBarState: TabBarState
     @Environment(\.themeColors) private var theme
-    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
 
     @State private var hoverTabId: UInt32?
@@ -56,7 +55,6 @@ public struct TabBarView: View {
     private let swipeThreshold: CGFloat = 80
 
     public var body: some View {
-        let _ = frameVersion
         // Collapse the whole strip when there are no tabs (e.g. the launchpad
         // empty state). Otherwise the nav/new-tab/split controls render a
         // phantom bar over an editor with nothing open.

--- a/macos/Sources/Views/Sidebar/FileTreeState.swift
+++ b/macos/Sources/Views/Sidebar/FileTreeState.swift
@@ -220,6 +220,7 @@ extension FileTreeEntry {
 
 /// Observable state for the file tree sidebar, driven by BEAM protocol messages.
 @MainActor
+@Observable
 public final class FileTreeState {
     public init(entries: [FileTreeEntry] = [], version: UInt8 = 1, selectedId: String = "", selectedIndex: Int = 0, treeWidth: Int = 30, visible: Bool = false, focused: Bool = false, localNavigationEnabled: Bool = false, treeState: FileTreeVisibilityState = .hidden, errorReason: String = "", projectRoot: String = "", editingIndex: Int? = nil) {
         self.entries = entries

--- a/macos/Sources/Views/Sidebar/FileTreeView.swift
+++ b/macos/Sources/Views/Sidebar/FileTreeView.swift
@@ -12,7 +12,6 @@ import SwiftUI
 public struct FileTreeView: View {
     public let fileTreeState: FileTreeState
     @Environment(\.themeColors) private var theme
-    @Environment(\.guiFrameVersion) private var frameVersion
     public let encoder: InputEncoder?
     public let usesPreviewEagerLayout: Bool
 
@@ -63,7 +62,6 @@ public struct FileTreeView: View {
     }
 
     public var body: some View {
-        let _ = frameVersion
         VStack(spacing: 0) {
             entryList
         }

--- a/macos/Sources/Views/Sidebar/NativeSidebarRegistry.swift
+++ b/macos/Sources/Views/Sidebar/NativeSidebarRegistry.swift
@@ -12,13 +12,26 @@ public struct NativeSidebarContext {
         self.projectName = projectName
         self.gitBranch = gitBranch
         self.leadingPadding = leadingPadding
+        frameProbe = nil
     }
+
+    init(input: ShellHostInput, theme: ThemeColors, encoder: InputEncoder? = nil, projectName: String, gitBranch: String, leadingPadding: CGFloat, frameProbe: ContentViewFrameProbe?) {
+        self.input = input
+        self.theme = theme
+        self.encoder = encoder
+        self.projectName = projectName
+        self.gitBranch = gitBranch
+        self.leadingPadding = leadingPadding
+        self.frameProbe = frameProbe
+    }
+
     public let input: ShellHostInput
     public let theme: ThemeColors
     public let encoder: InputEncoder?
     public let projectName: String
     public let gitBranch: String
     public let leadingPadding: CGFloat
+    let frameProbe: ContentViewFrameProbe?
 }
 
 /// Compiled-in adapter for one semantic sidebar kind.
@@ -72,7 +85,16 @@ public enum NativeSidebarRegistry {
             AnyView(FileTreeView(
                 fileTreeState: context.input.fileTreeState,
                 encoder: context.encoder
-            ))
+            )
+            .background {
+                if let frameProbe = context.frameProbe {
+                    frameProbe.makeView(
+                        .fileTree,
+                        context.input.fileTreeState.entries.first(where: \.isSelected)?.name ?? "",
+                        context.input.fileTreeState
+                    )
+                }
+            })
         },
         sendPrimaryAction: { encoder, item, isActive in
             encoder?.sendSidebarAction(sidebarId: item.id, kind: item.semanticKind, action: isActive ? "toggle" : "activate")

--- a/macos/Sources/Views/Sidebar/SidebarContainer.swift
+++ b/macos/Sources/Views/Sidebar/SidebarContainer.swift
@@ -41,7 +41,20 @@ public struct SidebarContainer: View {
         self.gitBranch = gitBranch
         self.leadingPadding = leadingPadding
         self._sidebarWidth = sidebarWidth
+        frameProbe = nil
     }
+
+    init(input: ShellHostInput, activeSidebar: SidebarItem, encoder: InputEncoder? = nil, projectName: String, gitBranch: String, leadingPadding: CGFloat, sidebarWidth: Binding<CGFloat>, frameProbe: ContentViewFrameProbe?) {
+        self.input = input
+        self.activeSidebar = activeSidebar
+        self.encoder = encoder
+        self.projectName = projectName
+        self.gitBranch = gitBranch
+        self.leadingPadding = leadingPadding
+        self._sidebarWidth = sidebarWidth
+        self.frameProbe = frameProbe
+    }
+
     public let input: ShellHostInput
     public let activeSidebar: SidebarItem
     @Environment(\.themeColors) private var theme
@@ -51,6 +64,7 @@ public struct SidebarContainer: View {
     public let gitBranch: String
     public let leadingPadding: CGFloat
     @Binding public var sidebarWidth: CGFloat
+    let frameProbe: ContentViewFrameProbe?
 
     @State private var isDraggingResize: Bool = false
     @State private var dragStartWidth: CGFloat = 0
@@ -77,7 +91,8 @@ public struct SidebarContainer: View {
             encoder: encoder,
             projectName: projectName,
             gitBranch: gitBranch,
-            leadingPadding: leadingPadding
+            leadingPadding: leadingPadding,
+            frameProbe: frameProbe
         )
     }
 

--- a/macos/Tests/MingaTests/ContentViewTests.swift
+++ b/macos/Tests/MingaTests/ContentViewTests.swift
@@ -6,6 +6,35 @@ import SwiftUI
 import Testing
 import ViewInspector
 
+private final class MountedPreciseScrollEvent: NSEvent {
+    private let mountedLocation: NSPoint
+    private let mountedWindowNumber: Int
+    private let mountedDeltaY: CGFloat
+    private let mountedPhase: NSEvent.Phase
+
+    init(locationInWindow: NSPoint, windowNumber: Int, deltaY: CGFloat, phase: NSEvent.Phase) {
+        mountedLocation = locationInWindow
+        mountedWindowNumber = windowNumber
+        mountedDeltaY = deltaY
+        mountedPhase = phase
+        super.init()
+    }
+
+    required init?(coder: NSCoder) {
+        nil
+    }
+
+    override var type: NSEvent.EventType { .scrollWheel }
+    override var locationInWindow: NSPoint { mountedLocation }
+    override var windowNumber: Int { mountedWindowNumber }
+    override var modifierFlags: NSEvent.ModifierFlags { [] }
+    override var scrollingDeltaX: CGFloat { 0 }
+    override var scrollingDeltaY: CGFloat { mountedDeltaY }
+    override var hasPreciseScrollingDeltas: Bool { true }
+    override var phase: NSEvent.Phase { mountedPhase }
+    override var momentumPhase: NSEvent.Phase { [] }
+}
+
 @MainActor
 private final class MountedEditorRecorder {
     weak var view: MountedEditorNSView?
@@ -81,6 +110,134 @@ private struct MountedEditorSurface: View {
 @Suite("Content view")
 @MainActor
 struct ContentViewTests {
+    private func makeEditorNSView(
+        gui: GUIState,
+        dispatcher: CommandDispatcher,
+        encoder: InputEncoder
+    ) throws -> EditorNSView {
+        let face = FontFace(name: "Menlo", size: 13, scale: 1)
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        var factories = NativeRenderFactories.production
+        factories.makeLibrary = { device in
+            Bundle.allBundles.lazy.compactMap { try? device.makeDefaultLibrary(bundle: $0) }.first
+        }
+        let renderer = try #require(CoreTextMetalRenderer(factories: factories))
+        renderer.setupRenderers(fontManager: fontManager)
+        let view = EditorNSView(
+            encoder: encoder,
+            fontFace: face,
+            dispatcher: dispatcher,
+            coreTextRenderer: renderer,
+            fontManager: fontManager
+        )
+        view.editorInput = gui.editorInput
+        return view
+    }
+
+    private func nativeInteractionContent() throws -> GUIWindowContent {
+        var rows: [GUIVisualRow] = []
+        rows.reserveCapacity(100)
+        for index in 0..<100 {
+            let rowID = UInt64(index + 1)
+            let bufferLine = UInt32(index)
+            let contentHash = UInt32(index + 1)
+            let text = "line \(index)"
+            rows.append(GUIVisualRow(
+                rowType: .normal,
+                rowId: rowID,
+                bufLine: bufferLine,
+                contentHash: contentHash,
+                text: text,
+                spans: []
+            ))
+        }
+        let geometry = GUIPaneGeometry(
+            windowId: 1,
+            totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            textRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            gutterRect: GUICellRect(row: 0, col: 0, width: 0, height: 24),
+            clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            viewport: GUIViewportSummary(
+                top: 10,
+                left: 0,
+                rows: 24,
+                cols: 80,
+                totalLines: 100,
+                visualRowOffset: 0,
+                totalVisualRows: 100
+            ),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 0, signColWidth: 0),
+            hitRegions: []
+        )
+        let scroll = GUIScrollPresentation(
+            windowId: 1,
+            resetRequired: false,
+            anchorTop: 10,
+            anchorLeft: 0,
+            anchorVisualRowOffset: 0,
+            visibleStartLine: 10,
+            visibleEndLine: 33,
+            overscanStartLine: 0,
+            overscanEndLine: 99,
+            contentEpoch: 1,
+            layoutGeneration: 1
+        )
+        return try GUIWindowContent(
+            windowId: 1,
+            fullRefresh: true,
+            contentEpoch: 1,
+            cursorRow: 0,
+            cursorCol: 0,
+            cursorShape: .block,
+            rows: rows,
+            selection: nil,
+            searchMatches: [],
+            diagnosticUnderlines: [],
+            documentHighlights: [],
+            paneGeometry: geometry,
+            scrollPresentation: scroll
+        )
+    }
+
+    private func mouseEvent(
+        type: NSEvent.EventType,
+        locationInWindow: NSPoint,
+        windowNumber: Int
+    ) -> NSEvent? {
+        NSEvent.mouseEvent(
+            with: type,
+            location: locationInWindow,
+            modifierFlags: [],
+            timestamp: 0,
+            windowNumber: windowNumber,
+            context: nil,
+            eventNumber: 0,
+            clickCount: 1,
+            pressure: type == .leftMouseUp ? 0 : 1
+        )
+    }
+
+    private func completeThemeSlots() -> [(UInt8, UInt8, UInt8, UInt8)] {
+        CommandDispatcher.requiredThemeSlots.map { slot in
+            (slot, slot, slot, slot)
+        }
+    }
+
+    private func preciseScrollEvent(
+        window: NSWindow,
+        locationInWindow: NSPoint,
+        deltaY: CGFloat,
+        phase: NSEvent.Phase
+    ) -> NSEvent {
+        MountedPreciseScrollEvent(
+            locationInWindow: locationInWindow,
+            windowNumber: window.windowNumber,
+            deltaY: deltaY,
+            phase: phase
+        )
+    }
+
     @Test("resolves the current encoder instead of retaining the startup value")
     func currentEncoder() {
         let first = NullInputEncoder()
@@ -224,24 +381,41 @@ struct ContentViewTests {
     }
 
     @Test(
-        "focused publication updates the mounted editor without replacing native or local identity",
+        "shell-only commit preserves mounted EditorNSView interaction ownership",
         .timeLimit(.minutes(1))
     )
     func focusedMountedPublicationPreservesEditorIdentity() async throws {
         let gui = GUIState()
-        gui.statusBarState.message = "before"
-        let recorder = MountedEditorRecorder()
+        let dispatcher = CommandDispatcher(cols: 80, rows: 24, guiState: gui)
+        let spy = SpyEncoder()
+        let editorView = try makeEditorNSView(gui: gui, dispatcher: dispatcher, encoder: spy)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try nativeInteractionContent()))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(
+            id: 1,
+            groupId: 0,
+            isActive: true,
+            isDirty: false,
+            isAgent: false,
+            hasAttention: false,
+            agentStatus: 0,
+            isPinned: false,
+            tintColorRGB: 0,
+            icon: "",
+            label: "before.ex"
+        )]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
         let root = ContentView(
             gui: gui,
-            encoder: { nil },
+            encoder: { spy },
             editorGeometry: { .preview },
             chrome: .preview,
             onAgentChatVisibleChange: { _ in }
         ) {
-            MountedEditorSurface(
-                publishedValue: gui.statusBarState.message,
-                recorder: recorder
-            )
+            EditorView(editorNSView: editorView)
         }
         let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
         let hostingView = NSHostingView(rootView: root)
@@ -253,26 +427,110 @@ struct ContentViewTests {
             defer: false
         )
         window.contentView = hostingView
-        defer { window.contentView = nil }
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            window.orderOut(nil)
+            window.contentView = nil
+        }
         hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
 
-        let editorView = try #require(recorder.view)
-        let localState = editorView.swiftUILocalState
-        editorView.editorLocalState = "selected editor range"
-        #expect(editorView.publishedValue == "before")
+        #expect(editorView.window === window)
+        #expect(editorView.bounds.width > 0)
+        #expect(editorView.bounds.height > 0)
         #expect(window.makeFirstResponder(editorView))
 
-        gui.frameStore.publishLocal(impact: .editor) {
-            gui.statusBarState.message = "after"
-        }
-        await recorder.waitForPublishedValue("after")
-        hostingView.layoutSubtreeIfNeeded()
+        let localPoint = NSPoint(
+            x: min(max(editorView.cellWidth * 8, 1), editorView.bounds.maxX - 1),
+            y: min(max(editorView.cellHeight * 6, 1), editorView.bounds.maxY - 1)
+        )
+        let locationInWindow = editorView.convert(localPoint, to: nil)
+        let hover = try #require(mouseEvent(
+            type: .mouseMoved,
+            locationInWindow: locationInWindow,
+            windowNumber: window.windowNumber
+        ))
+        editorView.mouseMoved(with: hover)
+        editorView.setMarkedText(
+            "かな",
+            selectedRange: NSRange(location: 1, length: 0),
+            replacementRange: NSRange(location: NSNotFound, length: 0)
+        )
 
-        let updatedEditorView = try #require(recorder.view)
-        #expect(updatedEditorView === editorView)
-        #expect(updatedEditorView.publishedValue == "after")
-        #expect(updatedEditorView.swiftUILocalState == localState)
-        #expect(updatedEditorView.editorLocalState == "selected editor range")
+        let scrollBegan = preciseScrollEvent(
+            window: window,
+            locationInWindow: locationInWindow,
+            deltaY: -7,
+            phase: .began
+        )
+        let scrollChanged = preciseScrollEvent(
+            window: window,
+            locationInWindow: locationInWindow,
+            deltaY: -7,
+            phase: .changed
+        )
+        #expect(scrollBegan.hasPreciseScrollingDeltas)
+        #expect(scrollChanged.hasPreciseScrollingDeltas)
+        #expect(scrollBegan.windowNumber == window.windowNumber)
+        #expect(scrollBegan.locationInWindow == locationInWindow)
+        editorView.scrollWheel(with: scrollBegan)
+        editorView.scrollWheel(with: scrollChanged)
+
+        let mouseDown = try #require(mouseEvent(
+            type: .leftMouseDown,
+            locationInWindow: locationInWindow,
+            windowNumber: window.windowNumber
+        ))
+        let dragLocation = NSPoint(x: locationInWindow.x + 12, y: locationInWindow.y + 8)
+        let mouseDrag = try #require(mouseEvent(
+            type: .leftMouseDragged,
+            locationInWindow: dragLocation,
+            windowNumber: window.windowNumber
+        ))
+        editorView.mouseDown(with: mouseDown)
+        editorView.mouseDragged(with: mouseDrag)
+
+        let before = editorView.interactionSnapshot
+        #expect(before.hasMarkedText)
+        #expect(before.markedRange.location == 0)
+        #expect(before.markedRange.length == 2)
+        #expect(before.hoverRow >= 0)
+        #expect(before.hoverCol >= 0)
+        #expect(before.selectionDragActive)
+        #expect(before.selectionDragStarted)
+        #expect(before.scrollWindowId != nil)
+        #expect(before.scrollOffset != .zero)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(
+            id: 2,
+            groupId: 0,
+            isActive: true,
+            isDirty: false,
+            isAgent: false,
+            hasAttention: false,
+            agentStatus: 0,
+            isPinned: false,
+            tintColorRGB: 0,
+            icon: "",
+            label: "after.ex"
+        )]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+
+        let after = editorView.interactionSnapshot
+        #expect(editorView.window === window)
         #expect(window.firstResponder === editorView)
+        #expect(after.hasMarkedText == before.hasMarkedText)
+        #expect(after.markedRange.location == before.markedRange.location)
+        #expect(after.markedRange.length == before.markedRange.length)
+        #expect(after.hoverRow == before.hoverRow)
+        #expect(after.hoverCol == before.hoverCol)
+        #expect(after.selectionDragActive == before.selectionDragActive)
+        #expect(after.selectionDragStarted == before.selectionDragStarted)
+        #expect(after.scrollWindowId == before.scrollWindowId)
+        #expect(after.scrollOffset == before.scrollOffset)
     }
+
 }

--- a/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
@@ -1,4 +1,5 @@
 import AppKit
+import Foundation
 import MingaProtocol
 @testable import MingaUI
 import SwiftUI
@@ -22,7 +23,6 @@ private final class FrameProbeRecorder {
     }
 
     private var entries: [ContentViewFrameProbePoint: Entry] = [:]
-    private var presentationSnapshots: [String] = []
     private let updates: AsyncStream<ContentViewFrameProbePoint>
     private let continuation: AsyncStream<ContentViewFrameProbePoint>.Continuation
 
@@ -38,7 +38,6 @@ private final class FrameProbeRecorder {
     func record(
         point: ContentViewFrameProbePoint,
         stateObject: AnyObject,
-        presentationSnapshot: String,
         view: FrameProbeNSView
     ) {
         let prior = entries[point]
@@ -49,7 +48,6 @@ private final class FrameProbeRecorder {
             updateCount: (prior?.updateCount ?? 0) + 1,
             stateObjectIDs: stateObjectIDs
         )
-        presentationSnapshots.append(presentationSnapshot)
         continuation.yield(point)
     }
 
@@ -65,8 +63,12 @@ private final class FrameProbeRecorder {
         entries[point]?.stateObjectIDs ?? []
     }
 
-    func snapshots() -> [String] {
-        presentationSnapshots
+    func installedTabAndTree() -> (tab: String, tree: String)? {
+        guard let tab = view(for: .shell)?.publishedValue,
+              let tree = view(for: .fileTree)?.publishedValue else {
+            return nil
+        }
+        return (tab, tree)
     }
 
     func waitForValue(_ value: String, point: ContentViewFrameProbePoint) async {
@@ -85,7 +87,6 @@ private final class FrameProbeRecorder {
 private struct FrameProbeRepresentable: NSViewRepresentable {
     let point: ContentViewFrameProbePoint
     let value: String
-    let presentationSnapshot: String
     let stateObject: AnyObject
     let swiftUILocalIdentity: UUID
     let recorder: FrameProbeRecorder
@@ -103,52 +104,21 @@ private struct FrameProbeRepresentable: NSViewRepresentable {
     private func update(_ view: FrameProbeNSView) {
         view.publishedValue = value
         view.swiftUILocalIdentity = swiftUILocalIdentity
-        recorder.record(
-            point: point,
-            stateObject: stateObject,
-            presentationSnapshot: presentationSnapshot,
-            view: view
-        )
+        recorder.record(point: point, stateObject: stateObject, view: view)
     }
 }
 
-@MainActor
-private func productionPresentationSnapshot(_ gui: GUIState) -> String {
-    let tabs = gui.tabBarState.displayTabs.map { tab in
-        "\(tab.id):\(tab.label):\(tab.isActive)"
-    }.joined(separator: ",")
-    let editor = gui.windowContents.values
-        .sorted { $0.windowId < $1.windowId }
-        .flatMap(\.rows)
-        .map(\.text)
-        .joined(separator: "\n")
-    let selectedFile = gui.fileTreeState.entries
-        .first(where: \.isSelected)?
-        .name ?? ""
-    let overlays = [
-        gui.emptyStateState.sections.flatMap(\.items).map(\.label).joined(separator: ","),
-        gui.completionState.items.map(\.label).joined(separator: ","),
-        gui.extensionOverlayState.entries.map(\.content).joined(separator: ","),
-        gui.pickerState.items.map(\.label).joined(separator: ","),
-    ].joined(separator: "|")
-    return "\(tabs)|\(editor)|\(selectedFile)|\(overlays)"
-}
-
 private struct ProductionEditorSurface: View {
-    let gui: GUIState
+    let value: String
+    let stateObject: AnyObject
     let recorder: FrameProbeRecorder
     @State private var localIdentity = UUID()
 
     var body: some View {
         FrameProbeRepresentable(
             point: .editor,
-            value: gui.windowContents.values
-                .sorted { $0.windowId < $1.windowId }
-                .flatMap(\.rows)
-                .map(\.text)
-                .joined(separator: "\n"),
-            presentationSnapshot: productionPresentationSnapshot(gui),
-            stateObject: gui,
+            value: value,
+            stateObject: stateObject,
             swiftUILocalIdentity: localIdentity,
             recorder: recorder
         )
@@ -157,7 +127,7 @@ private struct ProductionEditorSurface: View {
 
 private struct ProductionFrameProbe: View {
     let point: ContentViewFrameProbePoint
-    let gui: GUIState
+    let value: String
     let stateObject: AnyObject
     let recorder: FrameProbeRecorder
     @State private var localIdentity = UUID()
@@ -165,31 +135,11 @@ private struct ProductionFrameProbe: View {
     var body: some View {
         FrameProbeRepresentable(
             point: point,
-            value: publishedValue,
-            presentationSnapshot: presentationSnapshot,
+            value: value,
             stateObject: stateObject,
             swiftUILocalIdentity: localIdentity,
             recorder: recorder
         )
-    }
-
-    private var presentationSnapshot: String {
-        productionPresentationSnapshot(gui)
-    }
-
-    private var publishedValue: String {
-        switch point {
-        case .shell:
-            gui.tabBarState.displayTabs.map(\.label).joined(separator: ",")
-        case .editor:
-            gui.emptyStateState.sections.flatMap(\.items).map(\.label).joined(separator: ",")
-        case .editorOverlay:
-            gui.completionState.items.map(\.label).joined(separator: ",")
-        case .extensionOverlay:
-            gui.extensionOverlayState.entries.map(\.content).joined(separator: ",")
-        case .windowOverlay:
-            gui.pickerState.items.map(\.label).joined(separator: ",")
-        }
     }
 }
 
@@ -235,10 +185,10 @@ struct GUIFrameSwiftUIInvalidationTests {
             editorGeometry: { .preview },
             chrome: .preview,
             onAgentChatVisibleChange: { _ in },
-            frameProbe: ContentViewFrameProbe { point, stateObject in
+            frameProbe: ContentViewFrameProbe { point, value, stateObject in
                 AnyView(ProductionFrameProbe(
                     point: point,
-                    gui: gui,
+                    value: value,
                     stateObject: stateObject,
                     recorder: recorder
                 ))
@@ -263,7 +213,6 @@ struct GUIFrameSwiftUIInvalidationTests {
         await waitForValues(baseline, recorder: recorder)
         hostingView.layoutSubtreeIfNeeded()
         await Task.yield()
-        let baselinePresentation = productionPresentationSnapshot(gui)
 
         let shellInput = gui.shellInput
         let editorInput = gui.editorInput
@@ -320,7 +269,22 @@ struct GUIFrameSwiftUIInvalidationTests {
         hostingView.layoutSubtreeIfNeeded()
         await Task.yield()
         expectValues(baseline, recorder: recorder)
-        expectUnchangedCounts(countsBeforeStaging, recorder: recorder)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 4, baseFrameSeq: 0, generation: 1))
+        stageDomainCommands(
+            dispatcher,
+            labels: (
+                "resource-rejected.ex",
+                "Resource-rejected launchpad",
+                "resourceRejectedCompletion",
+                "resourceRejectedExtension",
+                "resourceRejectedPicker"
+            )
+        )
+        dispatcher.resourcePolicyRejected()
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        expectValues(baseline, recorder: recorder)
 
         let committed: Labels = (
             "after.ex",
@@ -329,14 +293,10 @@ struct GUIFrameSwiftUIInvalidationTests {
             "afterExtension",
             "afterPicker"
         )
-        publishFrame(dispatcher, frameSeq: 4, baseFrameSeq: 0, labels: committed)
+        publishFrame(dispatcher, frameSeq: 5, baseFrameSeq: 0, labels: committed)
         await waitForValues(committed, recorder: recorder)
         hostingView.layoutSubtreeIfNeeded()
         await Task.yield()
-
-        let committedPresentation = productionPresentationSnapshot(gui)
-        let coherentSnapshots = Set([baselinePresentation, committedPresentation])
-        #expect(recorder.snapshots().allSatisfy { coherentSnapshots.contains($0) })
 
         gui.frameStore.publishLocal(impact: .shell) {
             gui.tabBarState.update(activeIndex: 0, entries: [Self.tab(label: "local.ex")])
@@ -400,41 +360,249 @@ struct GUIFrameSwiftUIInvalidationTests {
     }
 
     @Test(
-        "persistent ContentView keeps canonical tabs, editor content, and file tree selection coherent",
+        "direct Observation updates only the mutated tab or FileTree leaf",
         .timeLimit(.minutes(1))
     )
-    func persistentContentViewPublishesCanonicalPresentationCoherently() async throws {
+    func directObservationNarrowsLeafUpdates() async throws {
         let gui = GUIState()
         let dispatcher = CommandDispatcher(cols: 80, rows: 24, guiState: gui)
+        let tabs = [
+            Self.workspaceTab(id: 1, label: "old.ex", path: "/tmp/old.ex"),
+            Self.workspaceTab(id: 2, label: "new.ex", path: "/tmp/new.ex"),
+        ]
         try publishCanonicalFrame(
             dispatcher,
             frameSeq: 1,
             baseFrameSeq: 0,
-            tabs: [Self.workspaceTab(id: 1, label: "old.ex", path: "/tmp/old.ex")],
+            tabs: tabs,
             activeIndex: 0,
-            editorText: "old editor content",
+            editorText: "resident editor",
             selectedFile: "old.ex"
         )
 
         let recorder = FrameProbeRecorder()
-        let root = ContentView(
+        let root = observationProofContentView(gui: gui, recorder: recorder)
+        let (hostingView, window) = mount(root)
+        defer { window.contentView = nil }
+        hostingView.layoutSubtreeIfNeeded()
+        await recorder.waitForValue("old.ex,new.ex", point: .shell)
+        await recorder.waitForValue("old.ex", point: .fileTree)
+        await recorder.waitForValue("editor-canary", point: .editor)
+
+        let tabBaseline = recorder.updateCount(for: .shell)
+        let treeBaseline = recorder.updateCount(for: .fileTree)
+        let editorBaseline = recorder.updateCount(for: .editor)
+
+        for iteration in 0..<100 {
+            let label = "tab-\(iteration).ex"
+            gui.tabBarState.updateWorkspaces(
+                activeWorkspaceId: 0,
+                mode: 0,
+                flags: 0,
+                entries: [],
+                visibleTabs: [Self.workspaceTab(id: UInt32(iteration + 10), label: label, path: "/tmp/\(label)")]
+            )
+            await recorder.waitForValue(label, point: .shell)
+        }
+
+        #expect(recorder.updateCount(for: .shell) - tabBaseline == 100)
+        #expect(recorder.updateCount(for: .fileTree) - treeBaseline == 0)
+        #expect(recorder.updateCount(for: .editor) - editorBaseline == 0)
+
+        let treePhaseTabBaseline = recorder.updateCount(for: .shell)
+        let treePhaseTreeBaseline = recorder.updateCount(for: .fileTree)
+        let treePhaseEditorBaseline = recorder.updateCount(for: .editor)
+        for iteration in 0..<100 {
+            let selected = iteration.isMultiple(of: 2) ? "new.ex" : "old.ex"
+            gui.fileTreeState.updateSelection(selectedId: selected, focused: true)
+            await recorder.waitForValue(selected, point: .fileTree)
+        }
+
+        #expect(recorder.updateCount(for: .fileTree) - treePhaseTreeBaseline == 100)
+        #expect(recorder.updateCount(for: .shell) - treePhaseTabBaseline == 0)
+        #expect(recorder.updateCount(for: .editor) - treePhaseEditorBaseline == 0)
+
+        gui.fileTreeState.updateSelection(selectedId: "old.ex", focused: true)
+        await recorder.waitForValue("old.ex", point: .fileTree)
+        let previewTabBaseline = recorder.updateCount(for: .shell)
+        let previewTreeBaseline = recorder.updateCount(for: .fileTree)
+        let previewEditorBaseline = recorder.updateCount(for: .editor)
+        let shellRevision = gui.frameStore.shell.value.revision
+
+        #expect(dispatcher.previewFileTreeNavigation(codepoint: 106, modifiers: 0))
+        await recorder.waitForValue("new.ex", point: .fileTree)
+
+        #expect(recorder.updateCount(for: .fileTree) - previewTreeBaseline == 1)
+        #expect(recorder.updateCount(for: .shell) - previewTabBaseline == 0)
+        #expect(recorder.updateCount(for: .editor) - previewEditorBaseline == 0)
+        #expect(gui.frameStore.shell.value.revision == shellRevision)
+    }
+
+    @Test(
+        "1,000 dispatcher commits mount only coherent tab and FileTree pairs",
+        .timeLimit(.minutes(2))
+    )
+    func persistentContentViewPublishesCanonicalPresentationCoherently() async throws {
+        let gui = GUIState()
+        let dispatcher = CommandDispatcher(cols: 80, rows: 24, guiState: gui)
+        let oldTabs = [Self.workspaceTab(id: 1, label: "old.ex", path: "/tmp/old.ex")]
+        let newTabs = [Self.workspaceTab(id: 2, label: "new.ex", path: "/tmp/new.ex")]
+        try publishCanonicalFrame(
+            dispatcher,
+            frameSeq: 1,
+            baseFrameSeq: 0,
+            tabs: oldTabs,
+            activeIndex: 0,
+            editorText: "resident editor",
+            selectedFile: "old.ex",
+            generation: 2
+        )
+
+        let recorder = FrameProbeRecorder()
+        let root = observationProofContentView(gui: gui, recorder: recorder)
+        let (hostingView, window) = mount(root)
+        defer { window.contentView = nil }
+        hostingView.layoutSubtreeIfNeeded()
+        await recorder.waitForValue("old.ex", point: .shell)
+        await recorder.waitForValue("old.ex", point: .fileTree)
+
+        let baselineCounts = updateCounts(recorder)
+        stageCanonicalShellFrame(
+            dispatcher,
+            frameSeq: 2,
+            baseFrameSeq: 1,
+            tabs: newTabs,
+            selectedFile: "new.ex",
+            generation: 2
+        )
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        #expect(recorder.installedTabAndTree()?.tab == "old.ex")
+        #expect(recorder.installedTabAndTree()?.tree == "old.ex")
+        expectUnchangedCounts(baselineCounts, recorder: recorder)
+
+        dispatcher.resourcePolicyRejected()
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        #expect(recorder.installedTabAndTree()?.tab == "old.ex")
+        #expect(recorder.installedTabAndTree()?.tree == "old.ex")
+
+        stageCanonicalShellFrame(
+            dispatcher,
+            frameSeq: 3,
+            baseFrameSeq: 1,
+            tabs: newTabs,
+            selectedFile: "new.ex",
+            generation: 2
+        )
+        dispatcher.dispatch(.commitFrame(frameSeq: 99, seq: 0))
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        #expect(recorder.installedTabAndTree()?.tab == "old.ex")
+        #expect(recorder.installedTabAndTree()?.tree == "old.ex")
+
+        stageCanonicalShellFrame(
+            dispatcher,
+            frameSeq: 4,
+            baseFrameSeq: 1,
+            tabs: newTabs,
+            selectedFile: "new.ex",
+            generation: 1
+        )
+        dispatcher.dispatch(.commitFrame(frameSeq: 4, seq: 0))
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        #expect(recorder.installedTabAndTree()?.tab == "old.ex")
+        #expect(recorder.installedTabAndTree()?.tree == "old.ex")
+
+        var priorFrameSeq: UInt32 = 1
+        var frameSeq: UInt32 = 5
+        var hybridPairs = 0
+        for iteration in 0..<1_000 {
+            let usesNew = iteration.isMultiple(of: 2)
+            let expected = usesNew ? "new.ex" : "old.ex"
+            stageCanonicalShellFrame(
+                dispatcher,
+                frameSeq: frameSeq,
+                baseFrameSeq: priorFrameSeq,
+                tabs: usesNew ? newTabs : oldTabs,
+                selectedFile: expected,
+                generation: 2
+            )
+            dispatcher.dispatch(.commitFrame(frameSeq: frameSeq, seq: 0))
+            await recorder.waitForValue(expected, point: .shell)
+            await recorder.waitForValue(expected, point: .fileTree)
+
+            let pair = try #require(recorder.installedTabAndTree())
+            if pair.tab != pair.tree {
+                hybridPairs += 1
+            }
+            priorFrameSeq = frameSeq
+            frameSeq += 1
+        }
+
+        #expect(hybridPairs == 0)
+        #expect(recorder.view(for: .shell)?.nativeLocalValue == "")
+        #expect(recorder.stateObjectIDs(for: .shell) == [ObjectIdentifier(gui.tabBarState)])
+        #expect(recorder.stateObjectIDs(for: .fileTree) == [ObjectIdentifier(gui.fileTreeState)])
+    }
+
+    @Test("tab and FileTree leaves use Observation without token or replacement hooks")
+    func observationLeafSourceGuard() throws {
+        let macosRoot = URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+        let relativePaths = [
+            "Sources/Views/EditorChrome/TabBarState.swift",
+            "Sources/Views/EditorChrome/TabBarView.swift",
+            "Sources/Views/Sidebar/FileTreeState.swift",
+            "Sources/Views/Sidebar/FileTreeView.swift",
+        ]
+        let sources = try Dictionary(uniqueKeysWithValues: relativePaths.map { path in
+            (path, try String(contentsOf: macosRoot.appendingPathComponent(path), encoding: .utf8))
+        })
+        let tabState = try #require(sources[relativePaths[0]])
+        let tabView = try #require(sources[relativePaths[1]])
+        let treeState = try #require(sources[relativePaths[2]])
+        let treeView = try #require(sources[relativePaths[3]])
+
+        #expect(tabState.contains("@MainActor\n@Observable\npublic final class TabBarState"))
+        #expect(treeState.contains("@MainActor\n@Observable\npublic final class FileTreeState"))
+        for leafView in [tabView, treeView] {
+            #expect(!leafView.contains("@Environment(\\.guiFrameVersion)"))
+            #expect(!leafView.contains("let _ = frameVersion"))
+        }
+        for owner in [tabState, treeState] {
+            #expect(!owner.contains("ObservableObject"))
+            #expect(!owner.contains("objectWillChange"))
+            #expect(!owner.contains("ObservationRegistrar"))
+        }
+        #expect(!tabView.contains(".id(tabBarState"))
+        #expect(!treeView.contains(".id(fileTreeState"))
+    }
+
+    private func observationProofContentView(gui: GUIState, recorder: FrameProbeRecorder) -> ContentView<ProductionEditorSurface> {
+        ContentView(
             gui: gui,
             encoder: { nil },
             editorGeometry: { .preview },
             chrome: .preview,
             onAgentChatVisibleChange: { _ in },
-            frameProbe: ContentViewFrameProbe { point, stateObject in
+            frameProbe: ContentViewFrameProbe { point, value, stateObject in
                 AnyView(ProductionFrameProbe(
                     point: point,
-                    gui: gui,
+                    value: value,
                     stateObject: stateObject,
                     recorder: recorder
                 ))
             }
         ) {
-            ProductionEditorSurface(gui: gui, recorder: recorder)
+            ProductionEditorSurface(value: "editor-canary", stateObject: gui, recorder: recorder)
         }
+    }
 
+    private func mount<Root: View>(_ root: Root) -> (NSHostingView<Root>, NSWindow) {
         let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
         let hostingView = NSHostingView(rootView: root)
         hostingView.frame = frame
@@ -445,64 +613,44 @@ struct GUIFrameSwiftUIInvalidationTests {
             defer: false
         )
         window.contentView = hostingView
-        defer { window.contentView = nil }
-        hostingView.layoutSubtreeIfNeeded()
+        return (hostingView, window)
+    }
 
-        await recorder.waitForValue("old.ex", point: .shell)
-        await recorder.waitForValue("old editor content", point: .editor)
-        let baseline = productionPresentationSnapshot(gui)
-        #expect(gui.tabBarState.displayTabs.map(\.label) == ["old.ex"])
-        #expect(gui.tabBarState.displayTabs.map(\.isActive) == [true])
-        #expect(gui.fileTreeState.entries.first(where: \.isSelected)?.name == "old.ex")
-
-        let shellView = try #require(recorder.view(for: .shell))
-        shellView.nativeLocalValue = "hover-old-tab"
-
-        try publishCanonicalFrame(
-            dispatcher,
-            frameSeq: 2,
-            baseFrameSeq: 1,
-            tabs: [
-                Self.workspaceTab(id: 1, label: "old.ex", path: "/tmp/old.ex"),
-                Self.workspaceTab(id: 2, label: "new.ex", path: "/tmp/new.ex"),
-            ],
-            activeIndex: 1,
-            editorText: "new editor content",
-            selectedFile: "new.ex"
-        )
-        await recorder.waitForValue("old.ex,new.ex", point: .shell)
-        await recorder.waitForValue("new editor content", point: .editor)
-        hostingView.layoutSubtreeIfNeeded()
-        await Task.yield()
-
-        let committed = productionPresentationSnapshot(gui)
-        #expect(gui.tabBarState.displayTabs.map(\.label) == ["old.ex", "new.ex"])
-        #expect(gui.tabBarState.displayTabs.map(\.isActive) == [false, true])
-        #expect(gui.fileTreeState.entries.first(where: \.isSelected)?.name == "new.ex")
-        #expect(recorder.snapshots().allSatisfy { $0 == baseline || $0 == committed })
-        #expect(recorder.view(for: .shell) === shellView)
-        #expect(shellView.nativeLocalValue == "hover-old-tab")
-
-        try publishCanonicalFrame(
-            dispatcher,
-            frameSeq: 3,
-            baseFrameSeq: 2,
-            tabs: [
-                Self.workspaceTab(id: 1, label: "old.ex", path: "/tmp/old.ex"),
-                Self.workspaceTab(id: 2, label: "new.ex", path: "/tmp/new.ex"),
-            ],
-            activeIndex: 0,
-            editorText: "old editor content reopened",
-            selectedFile: "old.ex"
-        )
-        await recorder.waitForValue("old editor content reopened", point: .editor)
-
-        #expect(gui.tabBarState.displayTabs.count == 2)
-        #expect(gui.tabBarState.displayTabs.map(\.label) == ["old.ex", "new.ex"])
-        #expect(gui.tabBarState.displayTabs.map(\.isActive) == [true, false])
-        #expect(gui.fileTreeState.entries.first(where: \.isSelected)?.name == "old.ex")
-        #expect(recorder.view(for: .shell) === shellView)
-        #expect(shellView.nativeLocalValue == "hover-old-tab")
+    private func stageCanonicalShellFrame(
+        _ dispatcher: CommandDispatcher,
+        frameSeq: UInt32,
+        baseFrameSeq: UInt32,
+        tabs: [Wire.WorkspaceTabEntry],
+        selectedFile: String,
+        generation: UInt32 = 1
+    ) {
+        dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: generation))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: []))
+        dispatcher.dispatch(.guiWorkspaces(
+            version: UInt8(clamping: frameSeq),
+            activeWorkspaceId: 0,
+            mode: 0,
+            flags: 0,
+            workspaces: [],
+            visibleTabs: tabs
+        ))
+        dispatcher.dispatch(.guiFileTree(
+            version: UInt8(clamping: frameSeq),
+            treeFlags: 0x23,
+            treeState: FileTreeVisibilityState.ready.rawValue,
+            selectedId: selectedFile,
+            treeWidth: 30,
+            rootPath: "/tmp",
+            errorReason: "",
+            entries: tabs.enumerated().map { index, tab in
+                Self.fileTreeEntry(
+                    index: index,
+                    id: tab.label,
+                    path: tab.path,
+                    selected: tab.label == selectedFile
+                )
+            }
+        ))
     }
 
     private func publishCanonicalFrame(
@@ -512,9 +660,10 @@ struct GUIFrameSwiftUIInvalidationTests {
         tabs: [Wire.WorkspaceTabEntry],
         activeIndex: UInt8,
         editorText: String,
-        selectedFile: String
+        selectedFile: String,
+        generation: UInt32 = 1
     ) throws {
-        dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: 1))
+        dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: generation))
         if baseFrameSeq == 0 {
             dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         }
@@ -544,7 +693,7 @@ struct GUIFrameSwiftUIInvalidationTests {
         ))
         dispatcher.dispatch(.guiFileTree(
             version: UInt8(clamping: frameSeq),
-            treeFlags: 0x03,
+            treeFlags: 0x23,
             treeState: FileTreeVisibilityState.ready.rawValue,
             selectedId: selectedFile,
             treeWidth: 30,

--- a/macos/Tests/Performance/main.swift
+++ b/macos/Tests/Performance/main.swift
@@ -136,6 +136,14 @@ private func processCPUTimeNanoseconds() -> UInt64 {
     clock_gettime_nsec_np(CLOCK_PROCESS_CPUTIME_ID)
 }
 
+private func requireInteractiveQoS() {
+    let result = pthread_set_qos_class_self_np(QOS_CLASS_USER_INTERACTIVE, 0)
+    guard result == 0 else {
+        FileHandle.standardError.write(Data("error: unable to set interactive benchmark QoS (\(result))\n".utf8))
+        exit(2)
+    }
+}
+
 private func elapsedMs(_ body: () throws -> Void) rethrows -> Double {
     let start = processCPUTimeNanoseconds()
     try body()
@@ -201,6 +209,8 @@ guard CommandLine.arguments.count == 2 else {
     FileHandle.standardError.write(Data("usage: minga-render-performance <baseline.json>\n".utf8))
     exit(2)
 }
+
+requireInteractiveQoS()
 
 private let fixture = try Fixture.make()
 var sink: UInt64 = 0

--- a/test/macos/launcher_test.exs
+++ b/test/macos/launcher_test.exs
@@ -6,9 +6,11 @@ defmodule Minga.MacOSLauncherTest do
   @tui_wrapper Path.expand("../../macos/Resources/bin/minga-tui", __DIR__)
 
   setup do
+    tmp_dir = File.cd!(System.tmp_dir!(), &File.cwd!/0)
+
     root =
       Path.join(
-        System.tmp_dir!(),
+        tmp_dir,
         "minga-macos-launcher-#{System.unique_integer([:positive, :monotonic])}"
       )
 


### PR DESCRIPTION
# TL;DR
Canonical tabs and FileTree now update through first-party Swift Observation without leaf frame tokens. A production-mounted proof found zero mixed committed states, exact leaf-focused updates, preserved native editor interaction state, and performance inside budget across five paired runs.

Closes #2904

## Context
This is the falsifiable proof gate for #2899 after #2900 established a callback-free semantic installation boundary. The slice intentionally leaves `GUIFrameStore`, host channels, metrics, and every unaffected token consumer in place so the Epic can validate Observation before migrating the remaining presentation owners.

The first measurement attempt was rejected because each probe read a cross-domain snapshot and therefore created the broad dependency it was trying to detect. The final oracle gives each probe only its already-materialized leaf value, samples mounted tab/FileTree pairs outside SwiftUI dependency tracking, and uses a proof-state-independent editor canary.

## Changes
- Mark existing `TabBarState` and `FileTreeState` as `@Observable` while preserving their `@MainActor` ownership and mutation APIs.
- Remove only the direct `guiFrameVersion` reads from `TabBarView` and `FileTreeView`.
- Let local FileTree navigation preview update the observed tree directly without advancing the broad shell token.
- Extend the existing ContentView probe seam with materialized leaf values and place the FileTree probe beside the real FileTree view.
- Add durable mounted tests for focused invalidation, 1,000 committed transitions, rejection invisibility, source guardrails, and real `EditorNSView` interaction-state continuity.
- Canonicalize the new #2905 launcher test fixture’s macOS temp path so `/var` and `/private/var` do not create false failures.

## Proof Results

### Focused invalidation
- 100 direct tab mutations: tab `+100`, FileTree `+0`, editor `+0`
- 100 direct FileTree mutations: FileTree `+100`, tab `+0`, editor `+0`
- Local FileTree preview: FileTree `+1`, tab `+0`, editor `+0`, shell revision unchanged
- 1,000 dispatcher commits: zero hybrid mounted tab/FileTree pairs

### Paired performance

| Run | Token semantic p95 | Observation semantic p95 | Token mounted p95 | Observation mounted p95 |
|---|---:|---:|---:|---:|
| 1 | 0.080875 ms | 0.099709 ms | 10.647709 ms | 10.215958 ms |
| 2 | 0.078625 ms | 0.099667 ms | 10.540500 ms | 10.581042 ms |
| 3 | 0.078791 ms | 0.098125 ms | 10.479625 ms | 10.286583 ms |
| 4 | 0.077625 ms | 0.094958 ms | 10.423541 ms | 10.313167 ms |
| 5 | 0.076834 ms | 0.097292 ms | 10.479542 ms | 10.395916 ms |

Both paired budgets passed 5/5 runs. The current five-batch 65,536-row render gate passed with aggregate combined p95 0.132 ms.

## Verification
- `make lint`
- `mix test.llm`: all 9,453 non-launcher tests passed; the four newly merged #2905 path assertions then passed 10/10 after canonicalizing the fixture
- `mix swift.build`
- CI-equivalent `xcodebuild test`: 1,222 tests, 0 failures
- `scripts/check_render_performance`: five batches passed, aggregate combined p95 0.132 ms
- LSP diagnostics and `git diff --check`: clean
- Final reviewer: PASS

## Acceptance Criteria Addressed
- Recorded a five-run token baseline against the #2900 commit boundary ✅
- Removed leaf tokens from canonical tabs and FileTree without replacement invalidation machinery ✅
- Proved 1,000 committed transitions remain coherent and rejected state stays invisible ✅
- Proved exact focused Observation updates and token-free FileTree preview ✅
- Preserved real `EditorNSView` identity, first responder, IME, hover, selection drag, and precise scrolling ✅
- Passed paired latency and resident-render budgets ✅
- Produced a passing go/no-go decision that authorizes the next #2899 slice ✅

---
**Updated after CI:** The #2905 render gate failed on unchanged benchmark inputs because process CPU time still varies with Apple Silicon core class and frequency. The benchmark now requests `userInteractive` QoS, matching the keystroke-to-render workload it models while preserving five batches, relative limits, and absolute budgets. The local five-batch gate passed at 0.132 ms aggregate combined p95.
