### PR TITLE
refactor(macos): publish presentation state through Observation

### DIFF
--- a/macos/Sources/Extensions/FrontendExtensionRuntime.swift
+++ b/macos/Sources/Extensions/FrontendExtensionRuntime.swift
@@ -14,12 +14,13 @@ public struct FrontendExtensionViewContext {
 }
 
 @MainActor
+@Observable
 public final class FrontendExtensionRuntimeRegistry {
     public typealias Decoder = (FrontendExtensionRuntimeMessage) -> Void
     public typealias ViewBuilder = (FrontendExtensionViewContext) -> AnyView
 
-    private var decoders: [String: Decoder] = [:]
-    private var viewBuilders: [String: ViewBuilder] = [:]
+    @ObservationIgnored private var decoders: [String: Decoder] = [:]
+    @ObservationIgnored private var viewBuilders: [String: ViewBuilder] = [:]
     public private(set) var activeExtensionIDs: [String] = []
 
     public init() {}

--- a/macos/Sources/Views/Agent/AgentChatState.swift
+++ b/macos/Sources/Views/Agent/AgentChatState.swift
@@ -98,6 +98,7 @@ public enum AgentTranscriptPreparationFailure: Error, Equatable {
 }
 
 @MainActor
+@Observable
 public final class AgentChatState {
     public init(visible: Bool = false, status: UInt8 = 0, model: String = "", thinkingLevel: String = "medium", prompt: String = "", messages: [ChatMessageEntry] = [], helpVisible: Bool = false, helpGroups: [HelpGroup] = [], promptVersion: Int = 0, promptLineCount: UInt8 = 1, promptCursorLine: UInt16 = 0, promptCursorCol: UInt16 = 0, promptVimMode: UInt8 = 0, promptVisibleRows: UInt8 = 1, promptCompletion: Wire.PromptCompletion? = nil) {
         self.visible = visible
@@ -139,7 +140,7 @@ public final class AgentChatState {
 
     /// Whether a `full_replace` has seeded the resident transcript. Appends before
     /// the first full_replace are dropped until a full_replace arrives.
-    private var hasTranscript: Bool = false
+    @ObservationIgnored private var hasTranscript: Bool = false
 
     /// True when older messages sit outside the resident byte-cap window (0x86
     /// `truncated` flag). A UI hint that the visible history is not the full session.

--- a/macos/Sources/Views/Agent/AgentContextBarState.swift
+++ b/macos/Sources/Views/Agent/AgentContextBarState.swift
@@ -10,6 +10,7 @@ import MingaProtocol
 ///
 /// Updated by the BEAM via the `gui_agent_context` opcode (0x88).
 @MainActor
+@Observable
 public final class AgentContextBarState {
     public init(visible: Bool = false, task: String = "", dispatchTimestamp: Date = Date(), status: CardStatus = .idle, canApprove: Bool = false, progress: Wire.AgentProgress = .init(activeAction: "", toolCount: 0, fileCount: 0, reviewHint: ""), todos: [Wire.AgentTodo] = []) {
         self.visible = visible

--- a/macos/Sources/Views/EditorChrome/BottomPanelState.swift
+++ b/macos/Sources/Views/EditorChrome/BottomPanelState.swift
@@ -19,6 +19,7 @@ public struct BottomPanelTab: Identifiable, Equatable {
 }
 
 @MainActor
+@Observable
 public final class BottomPanelState {
     public init(visible: Bool = false, activeTabIndex: Int = 0, heightPercent: Int = 30, filterPreset: UInt8 = 0, tabs: [BottomPanelTab] = []) {
         self.visible = visible
@@ -26,6 +27,7 @@ public final class BottomPanelState {
         self.heightPercent = heightPercent
         self.filterPreset = filterPreset
         self.tabs = tabs
+        self.userHeight = UserDefaults.standard.double(forKey: "bottomPanelHeight").clamped(to: 100...800, fallback: 200)
     }
     public var visible: Bool = false
     public var activeTabIndex: Int = 0
@@ -40,8 +42,7 @@ public final class BottomPanelState {
     /// This is the user's drag-resized height; the BEAM's heightPercent is
     /// the initial/default value.
     public var userHeight: CGFloat {
-        get { UserDefaults.standard.double(forKey: "bottomPanelHeight").clamped(to: 100...800, fallback: 200) }
-        set { UserDefaults.standard.set(newValue, forKey: "bottomPanelHeight") }
+        didSet { UserDefaults.standard.set(userHeight, forKey: "bottomPanelHeight") }
     }
 
     public func update(visible: Bool, activeTabIndex: Int, heightPercent: Int,

--- a/macos/Sources/Views/EditorChrome/BreadcrumbBar.swift
+++ b/macos/Sources/Views/EditorChrome/BreadcrumbBar.swift
@@ -6,6 +6,7 @@
 import SwiftUI
 
 @MainActor
+@Observable
 public final class BreadcrumbState {
     public init(segments: [String] = []) {
         self.segments = segments

--- a/macos/Sources/Views/EditorChrome/EmptyStateState.swift
+++ b/macos/Sources/Views/EditorChrome/EmptyStateState.swift
@@ -79,6 +79,7 @@ public struct EmptyStateSectionModel: Identifiable, Equatable {
 
 /// Observable state for the launchpad, driven by BEAM protocol messages.
 @MainActor
+@Observable
 public final class EmptyStateState {
     public init(visible: Bool = false, crashed: Bool = false, version: String = "", focusedId: String = "", sections: [EmptyStateSectionModel] = []) {
         self.visible = visible

--- a/macos/Sources/Views/EditorChrome/FeedbackState.swift
+++ b/macos/Sources/Views/EditorChrome/FeedbackState.swift
@@ -8,12 +8,8 @@ public final class FeedbackState {
         self.holdTask = holdTask
         self.spinnerOnTime = spinnerOnTime
     }
-    @ObservationIgnored public private(set) var isPending = false
-    @ObservationIgnored public private(set) var showingSpinner = false
-
-    /// GUIState installs this to republish delayed local presentation changes
-    /// through its aggregate out-of-band token.
-    @ObservationIgnored public var onPresentationChanged: (() -> Void)?
+    public private(set) var isPending = false
+    public private(set) var showingSpinner = false
 
     @ObservationIgnored private var showTask: Task<Void, Never>?
     @ObservationIgnored private var holdTask: Task<Void, Never>?
@@ -40,7 +36,6 @@ public final class FeedbackState {
                 guard !Task.isCancelled, isPending else { return }
                 showingSpinner = true
                 spinnerOnTime = .now
-                notifyPresentationChanged()
             }
         } else {
             let wasSpinning = showingSpinner
@@ -58,12 +53,10 @@ public final class FeedbackState {
                         guard !Task.isCancelled else { return }
                         showingSpinner = false
                         spinnerOnTime = nil
-                        notifyPresentationChanged()
                     }
                 } else {
                     showingSpinner = false
                     spinnerOnTime = nil
-                    notifyPresentationChanged()
                 }
             }
         }
@@ -78,12 +71,6 @@ public final class FeedbackState {
         holdTask = nil
         spinnerOnTime = nil
         lastMessage = ""
-    }
-
-    private func notifyPresentationChanged() {
-        Task { @MainActor [weak self] in
-            self?.onPresentationChanged?()
-        }
     }
 
     nonisolated static func isInflight(_ message: String) -> Bool {

--- a/macos/Sources/Views/EditorChrome/SearchState.swift
+++ b/macos/Sources/Views/EditorChrome/SearchState.swift
@@ -14,6 +14,7 @@ public enum SearchFlags {
 }
 
 @MainActor
+@Observable
 public final class SearchState {
     public init(visible: Bool = false, matchCount: UInt16 = 0, currentIndex: UInt16 = 0, replaceMode: Bool = false, caseSensitive: Bool = false, wholeWord: Bool = false, regex: Bool = false) {
         self.visible = visible

--- a/macos/Sources/Views/EditorChrome/StatusBarState.swift
+++ b/macos/Sources/Views/EditorChrome/StatusBarState.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import MingaProtocol
 
 @MainActor
+@Observable
 public final class StatusBarState {
     public init(contentKind: UInt8 = 0, mode: UInt8 = 0, cursorLine: UInt32 = 1, cursorCol: UInt32 = 1, lineCount: UInt32 = 1, flags: UInt8 = 0, safeMode: Bool = false, lspStatus: UInt8 = 0, gitBranch: String = "", message: String = "", filetype: String = "", errorCount: UInt16 = 0, warningCount: UInt16 = 0, modelName: String = "", messageCount: UInt32 = 0, sessionStatus: UInt8 = 0, infoCount: UInt16 = 0, hintCount: UInt16 = 0, macroRecording: UInt8 = 0, parserStatus: UInt8 = 0, agentStatus: UInt8 = 0, activeToolName: String = "", gitAdded: UInt16 = 0, gitModified: UInt16 = 0, gitDeleted: UInt16 = 0, icon: String = "", iconColorR: UInt8 = 0, iconColorG: UInt8 = 0, iconColorB: UInt8 = 0, filename: String = "", diagnosticHint: String = "", backgroundSubagentCount: UInt16 = 0, backgroundSubagentLabel: String = "", indent: StatusBarUpdate.IndentInfo = .init(kind: 0, size: 2), modelineSegmentsPresent: Bool = false, modelineLeftSegments: [Wire.StatusBarSegment] = [], modelineRightSegments: [Wire.StatusBarSegment] = [], selection: StatusBarUpdate.SelectionInfo = .init(mode: 0, size: 0), pendingKeys: String = "") {
         self.contentKind = contentKind

--- a/macos/Sources/Views/EditorChrome/WorkspaceState.swift
+++ b/macos/Sources/Views/EditorChrome/WorkspaceState.swift
@@ -64,6 +64,7 @@ public struct WorkspaceFileTabEntry: Identifiable {
 
 /// Observable state for the workspace header and active-workspace file tabs.
 @MainActor
+@Observable
 public final class WorkspaceState {
     public init(workspaces: [WorkspaceSummaryEntry] = [], visibleTabs: [WorkspaceFileTabEntry] = [], activeWorkspaceId: UInt16 = 0, viewMode: UInt8 = 0, flags: UInt8 = 0, hasCanonicalPayload: Bool = false) {
         self.workspaces = workspaces

--- a/macos/Sources/Views/Extensions/ExtensionOverlayState.swift
+++ b/macos/Sources/Views/Extensions/ExtensionOverlayState.swift
@@ -6,6 +6,7 @@ import MingaProtocol
 /// Updated by `CommandDispatcher` from `gui_extension_overlay` (0x9C) opcode.
 /// Read by `ExtensionOverlayView` to render positioned overlays.
 @MainActor
+@Observable
 public final class ExtensionOverlayState {
     public init() {}
     /// Active overlay entries from all extensions.

--- a/macos/Sources/Views/Extensions/ExtensionPanelState.swift
+++ b/macos/Sources/Views/Extensions/ExtensionPanelState.swift
@@ -6,6 +6,7 @@ import MingaProtocol
 /// Updated by `CommandDispatcher` from `gui_extension_panel` (0x9D) opcode.
 /// Read by `ExtensionPanelView` to render structured content with native widgets.
 @MainActor
+@Observable
 public final class ExtensionPanelState {
     public init() {}
     /// Active panel entries from all extensions.

--- a/macos/Sources/Views/Extensions/ToolManagerState.swift
+++ b/macos/Sources/Views/Extensions/ToolManagerState.swift
@@ -129,6 +129,7 @@ public struct ToolEntry: Identifiable {
 // MARK: - Observable state
 
 @MainActor
+@Observable
 public final class ToolManagerState {
     public init(visible: Bool = false, filter: ToolFilter = .all, selectedIndex: Int = 0, tools: [ToolEntry] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/CompletionState.swift
+++ b/macos/Sources/Views/Overlays/CompletionState.swift
@@ -17,6 +17,7 @@ public struct CompletionItem: Identifiable {
 }
 
 @MainActor
+@Observable
 public final class CompletionState {
     public init(visible: Bool = false, anchorRow: Int = 0, anchorCol: Int = 0, selectedIndex: Int = 0, previewSelectedIndex: Int? = nil, items: [CompletionItem] = [], documentation: String = "") {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/FloatPopupState.swift
+++ b/macos/Sources/Views/Overlays/FloatPopupState.swift
@@ -8,6 +8,7 @@
 import SwiftUI
 
 @MainActor
+@Observable
 public final class FloatPopupState {
     public init(visible: Bool = false, title: String = "", width: Int = 0, height: Int = 0, lines: [String] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/HoverPopupState.swift
+++ b/macos/Sources/Views/Overlays/HoverPopupState.swift
@@ -32,6 +32,7 @@ public struct HoverLine: Identifiable {
 }
 
 @MainActor
+@Observable
 public final class HoverPopupState {
     public init(visible: Bool = false, anchorRow: Int = 0, anchorCol: Int = 0, focused: Bool = false, scrollOffset: Int = 0, lines: [HoverLine] = [], openActionName: String? = nil) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/MessagesContentState.swift
+++ b/macos/Sources/Views/Overlays/MessagesContentState.swift
@@ -150,11 +150,11 @@ public final class MessagesContentState {
         self.activeSubsystems = activeSubsystems
         self.searchText = searchText
     }
-    @ObservationIgnored public var entries: [MessageEntry] = []
+    public var entries: [MessageEntry] = []
     /// Whether the view should auto-scroll to the latest entry.
-    @ObservationIgnored public var isAutoScrolling: Bool = true
+    public var isAutoScrolling: Bool = true
     /// Set to true when new entries arrive while scrolled up (shows "jump to latest").
-    @ObservationIgnored public var hasNewEntries: Bool = false
+    public var hasNewEntries: Bool = false
 
     // MARK: - Filters
 

--- a/macos/Sources/Views/Overlays/MinibufferState.swift
+++ b/macos/Sources/Views/Overlays/MinibufferState.swift
@@ -42,6 +42,7 @@ public enum MinibufferMode: UInt8 {
 }
 
 @MainActor
+@Observable
 public final class MinibufferState {
     public init(visible: Bool = false, mode: UInt8 = 0, cursorPos: UInt16 = 0xFFFF, prompt: String = "", input: String = "", context: String = "", selectedIndex: UInt16 = 0, candidates: [MinibufferCandidate] = [], totalCandidates: UInt16 = 0, inputVersion: Int = 0) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/NotificationCenterState.swift
+++ b/macos/Sources/Views/Overlays/NotificationCenterState.swift
@@ -42,6 +42,7 @@ public struct EditorNotification: Identifiable, Equatable {
 
 /// Stores the current notification stack sent by the BEAM.
 @MainActor
+@Observable
 public final class NotificationCenterState {
     public init(notifications: [EditorNotification] = []) {
         self.notifications = notifications

--- a/macos/Sources/Views/Overlays/PickerState.swift
+++ b/macos/Sources/Views/Overlays/PickerState.swift
@@ -94,6 +94,7 @@ public struct PreviewSegment: Identifiable {
 }
 
 @MainActor
+@Observable
 public final class PickerState {
     public init(visible: Bool = false, selectedIndex: Int = 0, previewSelectedIndex: Int? = nil, filteredCount: Int = 0, totalCount: Int = 0, markedCount: Int = 0, title: String = "", query: String = "", modePrefix: String = "", hasPreview: Bool = false, loadStatus: Wire.PickerLoadStatus = .ready, items: [PickerItem] = [], previewLines: [PreviewLine] = [], actionMenu: PickerActionMenu? = nil) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/ProtocolErrorState.swift
+++ b/macos/Sources/Views/Overlays/ProtocolErrorState.swift
@@ -10,6 +10,7 @@
 import SwiftUI
 
 @MainActor
+@Observable
 public final class ProtocolErrorState {
     public init() {}
     /// The BEAM-supplied reason, or nil when no protocol_error has arrived.

--- a/macos/Sources/Views/Overlays/ResyncState.swift
+++ b/macos/Sources/Views/Overlays/ResyncState.swift
@@ -15,6 +15,7 @@
 import SwiftUI
 
 @MainActor
+@Observable
 public final class ResyncState {
     public init() {}
     /// True between an invalidation and the next clean commit. Drives a small

--- a/macos/Sources/Views/Overlays/SignatureHelpState.swift
+++ b/macos/Sources/Views/Overlays/SignatureHelpState.swift
@@ -30,6 +30,7 @@ public struct SignatureInfo: Identifiable {
 }
 
 @MainActor
+@Observable
 public final class SignatureHelpState {
     public init(visible: Bool = false, anchorRow: Int = 0, anchorCol: Int = 0, activeSignature: Int = 0, activeParameter: Int = 0, signatures: [SignatureInfo] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Overlays/WhichKeyState.swift
+++ b/macos/Sources/Views/Overlays/WhichKeyState.swift
@@ -19,6 +19,7 @@ public struct WhichKeyBinding: Identifiable {
 }
 
 @MainActor
+@Observable
 public final class WhichKeyState {
     public init(visible: Bool = false, prefix: String = "", page: Int = 0, pageCount: Int = 0, bindings: [WhichKeyBinding] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Shared/EditTimelineState.swift
+++ b/macos/Sources/Views/Shared/EditTimelineState.swift
@@ -1,7 +1,9 @@
 import Foundation
 import MingaProtocol
+import Observation
 
 @MainActor
+@Observable
 public final class EditTimelineState {
     public init(visible: Bool = false, viewingIndex: Int = -1, entries: [TimelineEntry] = [], files: [TimelineFile] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Shared/GUIState.swift
+++ b/macos/Sources/Views/Shared/GUIState.swift
@@ -27,9 +27,6 @@ public final class GUIState {
 
     public init(windowContents: [UInt16: GUIWindowContent] = [:]) {
         windowContentBacking = GUIWindowContentBacking(windowContents)
-        feedbackState.onPresentationChanged = { [weak frameStore] in
-            frameStore?.publishLocal(impact: .shell) {}
-        }
     }
 
     /// Stable shell-scoped input created and owned by this GUI state.

--- a/macos/Sources/Views/Sidebar/ChangeSummaryState.swift
+++ b/macos/Sources/Views/Sidebar/ChangeSummaryState.swift
@@ -7,6 +7,7 @@ import MingaProtocol
 /// stats. Drives `ChangeSummaryView` which renders a list of changed files
 /// with their status and line counts.
 @MainActor
+@Observable
 public final class ChangeSummaryState {
     public init(visible: Bool = false, entries: [ChangeSummaryEntry] = [], selectedIndex: Int = 0) {
         self.visible = visible

--- a/macos/Sources/Views/Sidebar/GitStatusState.swift
+++ b/macos/Sources/Views/Sidebar/GitStatusState.swift
@@ -105,41 +105,41 @@ public final class GitStatusState {
         self.amendMode = amendMode
         self.entriesRevision = entriesRevision
     }
-    @ObservationIgnored public var visible: Bool = false
-    @ObservationIgnored public var repoState: GitRepoState = .notARepo
-    @ObservationIgnored public var syncing: Bool = false
+    public var visible: Bool = false
+    public var repoState: GitRepoState = .notARepo
+    public var syncing: Bool = false
 
     // Branch info
-    @ObservationIgnored public var branchName: String = ""
-    @ObservationIgnored public var ahead: UInt16 = 0
-    @ObservationIgnored public var behind: UInt16 = 0
-    @ObservationIgnored public var entryBasePath: String = ""
-    @ObservationIgnored public var stashCount: UInt16 = 0
+    public var branchName: String = ""
+    public var ahead: UInt16 = 0
+    public var behind: UInt16 = 0
+    public var entryBasePath: String = ""
+    public var stashCount: UInt16 = 0
 
     // Toast notification (shown after remote operations)
-    @ObservationIgnored public var toastMessage: String? = nil
-    @ObservationIgnored public var toastLevel: ToastLevel = .success
-    @ObservationIgnored public var toastAction: ToastAction = .none
+    public var toastMessage: String? = nil
+    public var toastLevel: ToastLevel = .success
+    public var toastAction: ToastAction = .none
 
     // File entries grouped by section
-    @ObservationIgnored public var stagedEntries: [GitStatusEntry] = []
-    @ObservationIgnored public var changedEntries: [GitStatusEntry] = []
-    @ObservationIgnored public var untrackedEntries: [GitStatusEntry] = []
-    @ObservationIgnored public var conflictedEntries: [GitStatusEntry] = []
-    @ObservationIgnored public var duplicatePathHashes: Set<UInt32> = []
+    public var stagedEntries: [GitStatusEntry] = []
+    public var changedEntries: [GitStatusEntry] = []
+    public var untrackedEntries: [GitStatusEntry] = []
+    public var conflictedEntries: [GitStatusEntry] = []
+    public var duplicatePathHashes: Set<UInt32> = []
 
     // Section collapsed state (local UI state, not sent by BEAM)
     public var collapsedSections: Set<GitStatusSection> = []
 
     // Commit message (local UI state, typed by the user)
     public var commitMessage: String = ""
-    @ObservationIgnored public var previousCommitMessage: String = ""
+    public var previousCommitMessage: String = ""
 
     // Amend mode (local UI state, toggled by the user)
     public var amendMode: Bool = false
 
     // Changes whenever BEAM-provided entries update. Views use this to animate moves between sections.
-    @ObservationIgnored public var entriesRevision: UInt64 = 0
+    public var entriesRevision: UInt64 = 0
 
     /// Total number of entries across all sections.
     public var totalCount: Int {

--- a/macos/Sources/Views/Sidebar/ObservatoryState.swift
+++ b/macos/Sources/Views/Sidebar/ObservatoryState.swift
@@ -4,6 +4,7 @@ import MingaProtocol
 
 /// Observable state for the BEAM Observatory sidebar.
 @MainActor
+@Observable
 public final class ObservatoryState {
     public init(visible: Bool = false, nodes: [ObservatoryNode] = []) {
         self.visible = visible

--- a/macos/Sources/Views/Sidebar/SidebarHostState.swift
+++ b/macos/Sources/Views/Sidebar/SidebarHostState.swift
@@ -30,13 +30,14 @@ public struct SidebarItem: Identifiable, Equatable {
 
 /// Stores the BEAM-selected sidebar identities and validates semantic kinds against the native registry.
 @MainActor
+@Observable
 public final class SidebarHostState {
     public init(warnedUnknownKinds: Set<String> = []) {
         self.warnedUnknownKinds = warnedUnknownKinds
     }
     public private(set) var sidebars: [SidebarItem] = SidebarHostState.defaultSidebars
     public private(set) var activeId: String = "file_tree"
-    private var warnedUnknownKinds: Set<String> = []
+    @ObservationIgnored private var warnedUnknownKinds: Set<String> = []
 
     public var visibleSidebars: [SidebarItem] {
         sidebars.sorted { lhs, rhs in lhs.order < rhs.order }

--- a/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
@@ -143,6 +143,138 @@ private struct ProductionFrameProbe: View {
     }
 }
 
+private enum ObservationOwnerProbePoint: CaseIterable {
+    case shellChrome
+    case bottomPanel
+    case sidebar
+    case editorOverlay
+    case windowOverlay
+    case agent
+    case extensionOverlay
+    case extensionRuntime
+    case gitStatus
+    case messages
+    case feedbackPending
+    case feedbackSpinner
+}
+
+@MainActor
+private final class ObservationOwnerProbeRecorder {
+    private struct Entry {
+        weak var view: FrameProbeNSView?
+        var updateCount: Int
+    }
+
+    private var entries: [ObservationOwnerProbePoint: Entry] = [:]
+    private let updates: AsyncStream<ObservationOwnerProbePoint>
+    private let continuation: AsyncStream<ObservationOwnerProbePoint>.Continuation
+
+    init() {
+        let stream = AsyncStream.makeStream(
+            of: ObservationOwnerProbePoint.self,
+            bufferingPolicy: .bufferingNewest(64)
+        )
+        updates = stream.stream
+        continuation = stream.continuation
+    }
+
+    func record(point: ObservationOwnerProbePoint, value: String, view: FrameProbeNSView) {
+        view.publishedValue = value
+        entries[point] = Entry(
+            view: view,
+            updateCount: (entries[point]?.updateCount ?? 0) + 1
+        )
+        continuation.yield(point)
+    }
+
+    func value(for point: ObservationOwnerProbePoint) -> String? {
+        entries[point]?.view?.publishedValue
+    }
+
+    func updateCounts() -> [ObservationOwnerProbePoint: Int] {
+        Dictionary(uniqueKeysWithValues: ObservationOwnerProbePoint.allCases.map { point in
+            (point, entries[point]?.updateCount ?? 0)
+        })
+    }
+
+    func waitForValue(_ value: String, point: ObservationOwnerProbePoint) async {
+        if self.value(for: point) == value {
+            return
+        }
+
+        for await updatedPoint in updates where updatedPoint == point {
+            if self.value(for: point) == value {
+                return
+            }
+        }
+    }
+}
+
+private struct ObservationOwnerProbeRepresentable: NSViewRepresentable {
+    let point: ObservationOwnerProbePoint
+    let value: String
+    let recorder: ObservationOwnerProbeRecorder
+
+    func makeNSView(context: Context) -> FrameProbeNSView {
+        let view = FrameProbeNSView(frame: .zero)
+        recorder.record(point: point, value: value, view: view)
+        return view
+    }
+
+    func updateNSView(_ nsView: FrameProbeNSView, context: Context) {
+        recorder.record(point: point, value: value, view: nsView)
+    }
+}
+
+private struct ObservationOwnerProbe<Owner: AnyObject>: View {
+    let point: ObservationOwnerProbePoint
+    let owner: Owner
+    let materialize: (Owner) -> String
+    let recorder: ObservationOwnerProbeRecorder
+
+    var body: some View {
+        ObservationOwnerProbeRepresentable(
+            point: point,
+            value: materialize(owner),
+            recorder: recorder
+        )
+    }
+}
+
+private struct ObservationOwnerProbeMatrix: View {
+    let statusBar: StatusBarState
+    let bottomPanel: BottomPanelState
+    let sidebar: SidebarHostState
+    let completion: CompletionState
+    let picker: PickerState
+    let agentContext: AgentContextBarState
+    let extensionOverlay: ExtensionOverlayState
+    let extensionRuntime: FrontendExtensionRuntimeRegistry
+    let gitStatus: GitStatusState
+    let messages: MessagesContentState
+    let feedback: FeedbackState
+    let recorder: ObservationOwnerProbeRecorder
+
+    var body: some View {
+        VStack {
+            ObservationOwnerProbe(point: .shellChrome, owner: statusBar, materialize: { $0.message }, recorder: recorder)
+            ObservationOwnerProbe(point: .bottomPanel, owner: bottomPanel, materialize: { "\($0.userHeight)" }, recorder: recorder)
+            ObservationOwnerProbe(point: .sidebar, owner: sidebar, materialize: { $0.activeId }, recorder: recorder)
+            ObservationOwnerProbe(point: .editorOverlay, owner: completion, materialize: { $0.items.first?.label ?? "" }, recorder: recorder)
+            ObservationOwnerProbe(point: .windowOverlay, owner: picker, materialize: { $0.items.first?.label ?? "" }, recorder: recorder)
+            ObservationOwnerProbe(point: .agent, owner: agentContext, materialize: { $0.task }, recorder: recorder)
+            ObservationOwnerProbe(point: .extensionOverlay, owner: extensionOverlay, materialize: { $0.entries.first?.content ?? "" }, recorder: recorder)
+            ObservationOwnerProbe(point: .extensionRuntime, owner: extensionRuntime, materialize: { $0.activeExtensionIDs.joined(separator: ",") }, recorder: recorder)
+            ObservationOwnerProbe(point: .gitStatus, owner: gitStatus, materialize: { "\($0.branchName)|\($0.totalCount)" }, recorder: recorder)
+            ObservationOwnerProbe(point: .messages, owner: messages, materialize: {
+                "\($0.filteredEntries.last?.text ?? "")|\($0.isAutoScrolling)|\($0.hasNewEntries)"
+            }, recorder: recorder)
+            ObservationOwnerProbe(point: .feedbackPending, owner: feedback, materialize: { String($0.isPending) }, recorder: recorder)
+            ObservationOwnerProbe(point: .feedbackSpinner, owner: feedback, materialize: { String($0.showingSpinner) }, recorder: recorder)
+        }
+    }
+}
+
 @Suite("Persistent SwiftUI GUI frame invalidation")
 @MainActor
 struct GUIFrameSwiftUIInvalidationTests {
@@ -439,6 +571,164 @@ struct GUIFrameSwiftUIInvalidationTests {
     }
 
     @Test(
+        "direct owner updates render representative presentation leaves without frame publication",
+        .timeLimit(.minutes(1))
+    )
+    func directObservationUpdatesPresentationOwnerMatrix() async throws {
+        let bottomPanelHeightKey = "bottomPanelHeight"
+        let persistedBottomPanelHeight = UserDefaults.standard.object(forKey: bottomPanelHeightKey)
+        defer {
+            if let persistedBottomPanelHeight {
+                UserDefaults.standard.set(persistedBottomPanelHeight, forKey: bottomPanelHeightKey)
+            } else {
+                UserDefaults.standard.removeObject(forKey: bottomPanelHeightKey)
+            }
+        }
+
+        let statusBar = StatusBarState()
+        let bottomPanel = BottomPanelState()
+        let sidebar = SidebarHostState()
+        let completion = CompletionState()
+        let picker = PickerState()
+        let agentContext = AgentContextBarState()
+        let extensionOverlay = ExtensionOverlayState()
+        let extensionRuntime = FrontendExtensionRuntimeRegistry()
+        let gitStatus = GitStatusState()
+        let messages = MessagesContentState()
+        let feedback = FeedbackState()
+        defer { feedback.cancel() }
+
+        let recorder = ObservationOwnerProbeRecorder()
+        let root = ObservationOwnerProbeMatrix(
+            statusBar: statusBar,
+            bottomPanel: bottomPanel,
+            sidebar: sidebar,
+            completion: completion,
+            picker: picker,
+            agentContext: agentContext,
+            extensionOverlay: extensionOverlay,
+            extensionRuntime: extensionRuntime,
+            gitStatus: gitStatus,
+            messages: messages,
+            feedback: feedback,
+            recorder: recorder
+        )
+        let (hostingView, window) = mount(root)
+        defer { window.contentView = nil }
+        hostingView.layoutSubtreeIfNeeded()
+
+        let initialValues: [ObservationOwnerProbePoint: String] = [
+            .shellChrome: "",
+            .bottomPanel: "\(bottomPanel.userHeight)",
+            .sidebar: "file_tree",
+            .editorOverlay: "",
+            .windowOverlay: "",
+            .agent: "",
+            .extensionOverlay: "",
+            .extensionRuntime: "",
+            .gitStatus: "|0",
+            .messages: "|true|false",
+            .feedbackPending: "false",
+            .feedbackSpinner: "false",
+        ]
+        for point in ObservationOwnerProbePoint.allCases {
+            await recorder.waitForValue(try #require(initialValues[point]), point: point)
+        }
+
+        await expectOnlyOwnerProbeUpdate(.shellChrome, value: "Formatting…", recorder: recorder) {
+            statusBar.update(from: Self.statusBarUpdate(message: "Formatting…"))
+        }
+        let nextBottomPanelHeight: CGFloat = bottomPanel.userHeight == 321 ? 322 : 321
+        await expectOnlyOwnerProbeUpdate(.bottomPanel, value: "\(nextBottomPanelHeight)", recorder: recorder) {
+            bottomPanel.userHeight = nextBottomPanelHeight
+        }
+        await expectOnlyOwnerProbeUpdate(.sidebar, value: "git_status", recorder: recorder) {
+            sidebar.update(activeId: "git_status", sidebars: [Self.sidebarMetadata(id: "git_status", kind: "git_status")])
+        }
+        await expectOnlyOwnerProbeUpdate(.editorOverlay, value: "complete-me", recorder: recorder) {
+            completion.update(
+                visible: true,
+                anchorRow: 0,
+                anchorCol: 0,
+                selectedIndex: 0,
+                rawItems: [Wire.CompletionItem(kind: 1, label: "complete-me", detail: "")],
+                documentation: ""
+            )
+        }
+        await expectOnlyOwnerProbeUpdate(.windowOverlay, value: "pick-me", recorder: recorder) {
+            picker.update(
+                visible: true,
+                selectedIndex: 0,
+                filteredCount: 1,
+                totalCount: 1,
+                markedCount: 0,
+                title: "Files",
+                query: "",
+                hasPreview: false,
+                rawItems: [Self.pickerItem(label: "pick-me")],
+                actionMenu: nil
+            )
+        }
+        await expectOnlyOwnerProbeUpdate(.agent, value: "review the diff", recorder: recorder) {
+            agentContext.update(
+                visible: true,
+                task: "review the diff",
+                dispatchTimestamp: Date(),
+                status: .idle,
+                canApprove: false,
+                progress: .init(activeAction: "", toolCount: 0, fileCount: 0, reviewHint: ""),
+                todos: []
+            )
+        }
+        await expectOnlyOwnerProbeUpdate(.extensionOverlay, value: "extension-content", recorder: recorder) {
+            extensionOverlay.update([Self.extensionOverlay(content: "extension-content")])
+        }
+        await expectOnlyOwnerProbeUpdate(.extensionRuntime, value: "mounted-extension", recorder: recorder) {
+            extensionRuntime.register(extensionID: "mounted-extension", decoder: { _ in }) { _ in
+                AnyView(EmptyView())
+            }
+        }
+        await expectOnlyOwnerProbeUpdate(.gitStatus, value: "feature/observation|1", recorder: recorder) {
+            gitStatus.update(
+                repoState: .normal,
+                branchName: "feature/observation",
+                ahead: 0,
+                behind: 0,
+                syncing: false,
+                entries: [GitStatusEntry(pathHash: 1, section: .changed, status: .modified, path: "lib/minga.ex")],
+                toast: nil,
+                entryBasePath: "/repo",
+                lastCommitMessage: "prior",
+                stashCount: 0
+            )
+        }
+        await expectOnlyOwnerProbeUpdate(.messages, value: "message-entry|false|true", recorder: recorder) {
+            messages.scrolledUp()
+            messages.appendEntries([
+                Wire.MessageEntry(
+                    streamInstance: 1,
+                    id: 1,
+                    level: 1,
+                    subsystem: 0,
+                    timestampSecs: 0,
+                    filePath: "",
+                    text: "message-entry"
+                ),
+            ])
+        }
+        let feedbackBaseline = recorder.updateCounts()
+        feedback.update(message: "Formatting…")
+        await recorder.waitForValue("true", point: .feedbackPending)
+        await recorder.waitForValue("true", point: .feedbackSpinner)
+        let feedbackCounts = recorder.updateCounts()
+        #expect(feedbackCounts[.feedbackPending, default: 0] > feedbackBaseline[.feedbackPending, default: 0])
+        #expect(feedbackCounts[.feedbackSpinner, default: 0] > feedbackBaseline[.feedbackSpinner, default: 0])
+        for point in ObservationOwnerProbePoint.allCases where point != .feedbackPending && point != .feedbackSpinner {
+            #expect(feedbackCounts[point, default: 0] == feedbackBaseline[point, default: 0])
+        }
+    }
+
+    @Test(
         "1,000 dispatcher commits mount only coherent tab and FileTree pairs",
         .timeLimit(.minutes(2))
     )
@@ -547,36 +837,108 @@ struct GUIFrameSwiftUIInvalidationTests {
         #expect(recorder.stateObjectIDs(for: .fileTree) == [ObjectIdentifier(gui.fileTreeState)])
     }
 
-    @Test("tab and FileTree leaves use Observation without token or replacement hooks")
+    @Test("protocol presentation owner inventory uses Observation with only allowlisted infrastructure ignored")
     func observationLeafSourceGuard() throws {
         let macosRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()
             .deletingLastPathComponent()
             .deletingLastPathComponent()
-        let relativePaths = [
-            "Sources/Views/EditorChrome/TabBarState.swift",
-            "Sources/Views/EditorChrome/TabBarView.swift",
-            "Sources/Views/Sidebar/FileTreeState.swift",
-            "Sources/Views/Sidebar/FileTreeView.swift",
+        let owners: [(name: String, path: String, ignored: Set<String>)] = [
+            ("AgentChatState", "Sources/Views/Agent/AgentChatState.swift", [
+                "@ObservationIgnored private var hasTranscript: Bool = false",
+            ]),
+            ("AgentContextBarState", "Sources/Views/Agent/AgentContextBarState.swift", []),
+            ("BottomPanelState", "Sources/Views/EditorChrome/BottomPanelState.swift", []),
+            ("EmptyStateState", "Sources/Views/EditorChrome/EmptyStateState.swift", []),
+            ("SearchState", "Sources/Views/EditorChrome/SearchState.swift", []),
+            ("StatusBarState", "Sources/Views/EditorChrome/StatusBarState.swift", []),
+            ("TabBarState", "Sources/Views/EditorChrome/TabBarState.swift", []),
+            ("WorkspaceState", "Sources/Views/EditorChrome/WorkspaceState.swift", []),
+            ("BreadcrumbState", "Sources/Views/EditorChrome/BreadcrumbBar.swift", []),
+            ("FileTreeState", "Sources/Views/Sidebar/FileTreeState.swift", []),
+            ("SidebarHostState", "Sources/Views/Sidebar/SidebarHostState.swift", [
+                "@ObservationIgnored private var warnedUnknownKinds: Set<String> = []",
+            ]),
+            ("ObservatoryState", "Sources/Views/Sidebar/ObservatoryState.swift", []),
+            ("ChangeSummaryState", "Sources/Views/Sidebar/ChangeSummaryState.swift", []),
+            ("GitStatusState", "Sources/Views/Sidebar/GitStatusState.swift", []),
+            ("EditTimelineState", "Sources/Views/Shared/EditTimelineState.swift", []),
+            ("CompletionState", "Sources/Views/Overlays/CompletionState.swift", []),
+            ("HoverPopupState", "Sources/Views/Overlays/HoverPopupState.swift", []),
+            ("SignatureHelpState", "Sources/Views/Overlays/SignatureHelpState.swift", []),
+            ("MinibufferState", "Sources/Views/Overlays/MinibufferState.swift", []),
+            ("PickerState", "Sources/Views/Overlays/PickerState.swift", []),
+            ("WhichKeyState", "Sources/Views/Overlays/WhichKeyState.swift", []),
+            ("FloatPopupState", "Sources/Views/Overlays/FloatPopupState.swift", []),
+            ("NotificationCenterState", "Sources/Views/Overlays/NotificationCenterState.swift", []),
+            ("ProtocolErrorState", "Sources/Views/Overlays/ProtocolErrorState.swift", []),
+            ("ResyncState", "Sources/Views/Overlays/ResyncState.swift", []),
+            ("MessagesContentState", "Sources/Views/Overlays/MessagesContentState.swift", []),
+            ("ToolManagerState", "Sources/Views/Extensions/ToolManagerState.swift", []),
+            ("ExtensionOverlayState", "Sources/Views/Extensions/ExtensionOverlayState.swift", []),
+            ("ExtensionPanelState", "Sources/Views/Extensions/ExtensionPanelState.swift", []),
+            ("FeedbackState", "Sources/Views/EditorChrome/FeedbackState.swift", [
+                "@ObservationIgnored private var showTask: Task<Void, Never>?",
+                "@ObservationIgnored private var holdTask: Task<Void, Never>?",
+                "@ObservationIgnored private var spinnerOnTime: ContinuousClock.Instant?",
+                "@ObservationIgnored private var lastMessage = \"\"",
+            ]),
+            ("FrontendExtensionRuntimeRegistry", "Sources/Extensions/FrontendExtensionRuntime.swift", [
+                "@ObservationIgnored private var decoders: [String: Decoder] = [:]",
+                "@ObservationIgnored private var viewBuilders: [String: ViewBuilder] = [:]",
+            ]),
         ]
-        let sources = try Dictionary(uniqueKeysWithValues: relativePaths.map { path in
+        let ignoredReasons = [
+            "@ObservationIgnored private var hasTranscript: Bool = false": "cache",
+            "@ObservationIgnored private var warnedUnknownKinds: Set<String> = []": "cache",
+            "@ObservationIgnored private var showTask: Task<Void, Never>?": "task",
+            "@ObservationIgnored private var holdTask: Task<Void, Never>?": "task",
+            "@ObservationIgnored private var spinnerOnTime: ContinuousClock.Instant?": "clock",
+            "@ObservationIgnored private var lastMessage = \"\"": "cache",
+            "@ObservationIgnored private var decoders: [String: Decoder] = [:]": "decoder",
+            "@ObservationIgnored private var viewBuilders: [String: ViewBuilder] = [:]": "builder",
+        ]
+        let allowedIgnoredReasons: Set<String> = ["task", "callback", "clock", "cache", "decoder", "builder", "metrics"]
+        #expect(Set(owners.flatMap(\.ignored)) == Set(ignoredReasons.keys))
+        #expect(Set(ignoredReasons.values).isSubset(of: allowedIgnoredReasons))
+
+        let sourcePaths = Set(owners.map(\.path)).union([
+            "Sources/Views/EditorChrome/TabBarView.swift",
+            "Sources/Views/Sidebar/FileTreeView.swift",
+            "Sources/Views/Shared/GUIState.swift",
+        ])
+        let sources = try Dictionary(uniqueKeysWithValues: sourcePaths.map { path in
             (path, try String(contentsOf: macosRoot.appendingPathComponent(path), encoding: .utf8))
         })
-        let tabState = try #require(sources[relativePaths[0]])
-        let tabView = try #require(sources[relativePaths[1]])
-        let treeState = try #require(sources[relativePaths[2]])
-        let treeView = try #require(sources[relativePaths[3]])
 
+        for owner in owners {
+            let source = try #require(sources[owner.path])
+            #expect(source.contains("@MainActor\n@Observable\npublic final class \(owner.name)"))
+            let ignoredLines = Set(source.split(separator: "\n").compactMap { line -> String? in
+                let trimmed = line.trimmingCharacters(in: .whitespaces)
+                return trimmed.contains("@ObservationIgnored") ? trimmed : nil
+            })
+            #expect(ignoredLines == owner.ignored)
+            #expect(!source.contains("ObservableObject"))
+            #expect(!source.contains("objectWillChange"))
+            #expect(!source.contains("ObservationRegistrar"))
+        }
+
+        let feedbackState = try #require(sources["Sources/Views/EditorChrome/FeedbackState.swift"])
+        let guiState = try #require(sources["Sources/Views/Shared/GUIState.swift"])
+        #expect(!feedbackState.contains("onPresentationChanged"))
+        #expect(!feedbackState.contains("notifyPresentationChanged"))
+        #expect(!guiState.contains("feedbackState.onPresentationChanged"))
+
+        let tabState = try #require(sources["Sources/Views/EditorChrome/TabBarState.swift"])
+        let tabView = try #require(sources["Sources/Views/EditorChrome/TabBarView.swift"])
+        let treeState = try #require(sources["Sources/Views/Sidebar/FileTreeState.swift"])
+        let treeView = try #require(sources["Sources/Views/Sidebar/FileTreeView.swift"])
         #expect(tabState.contains("@MainActor\n@Observable\npublic final class TabBarState"))
         #expect(treeState.contains("@MainActor\n@Observable\npublic final class FileTreeState"))
         for leafView in [tabView, treeView] {
             #expect(!leafView.contains("@Environment(\\.guiFrameVersion)"))
             #expect(!leafView.contains("let _ = frameVersion"))
-        }
-        for owner in [tabState, treeState] {
-            #expect(!owner.contains("ObservableObject"))
-            #expect(!owner.contains("objectWillChange"))
-            #expect(!owner.contains("ObservationRegistrar"))
         }
         #expect(!tabView.contains(".id(tabBarState"))
         #expect(!treeView.contains(".id(fileTreeState"))
@@ -614,6 +976,22 @@ struct GUIFrameSwiftUIInvalidationTests {
         )
         window.contentView = hostingView
         return (hostingView, window)
+    }
+
+    private func expectOnlyOwnerProbeUpdate(
+        _ point: ObservationOwnerProbePoint,
+        value: String,
+        recorder: ObservationOwnerProbeRecorder,
+        mutation: @MainActor () -> Void
+    ) async {
+        let baseline = recorder.updateCounts()
+        mutation()
+        await recorder.waitForValue(value, point: point)
+        let updated = recorder.updateCounts()
+        #expect(updated[point, default: 0] > baseline[point, default: 0])
+        for unrelatedPoint in ObservationOwnerProbePoint.allCases where unrelatedPoint != point {
+            #expect(updated[unrelatedPoint, default: 0] == baseline[unrelatedPoint, default: 0])
+        }
     }
 
     private func stageCanonicalShellFrame(
@@ -781,6 +1159,56 @@ struct GUIFrameSwiftUIInvalidationTests {
         CommandDispatcher.requiredThemeSlots.map { slot in
             (slot, slot, slot, slot)
         }
+    }
+
+    private static func statusBarUpdate(message: String) -> StatusBarUpdate {
+        StatusBarUpdate(
+            contentKind: 0,
+            mode: 0,
+            cursorLine: 1,
+            cursorCol: 1,
+            lineCount: 1,
+            flags: 0,
+            lspStatus: 0,
+            gitBranch: "",
+            message: message,
+            filetype: "",
+            errorCount: 0,
+            warningCount: 0,
+            modelName: "",
+            messageCount: 0,
+            sessionStatus: 0,
+            infoCount: 0,
+            hintCount: 0,
+            macroRecording: 0,
+            parserStatus: 0,
+            agentStatus: 0,
+            gitAdded: 0,
+            gitModified: 0,
+            gitDeleted: 0,
+            icon: "",
+            iconColorR: 0,
+            iconColorG: 0,
+            iconColorB: 0,
+            filename: "",
+            diagnosticHint: "",
+            backgroundSubagentCount: 0,
+            backgroundSubagentLabel: ""
+        )
+    }
+
+    private static func sidebarMetadata(id: String, kind: String) -> Wire.SidebarMetadata {
+        Wire.SidebarMetadata(
+            id: id,
+            displayName: id,
+            semanticKind: kind,
+            icon: "",
+            order: 0,
+            visible: true,
+            focused: true,
+            preferredWidth: 30,
+            badgeCount: nil
+        )
     }
 
     private static func updateEmptyState(_ gui: GUIState, label: String) {


### PR DESCRIPTION
# TL;DR
All remaining protocol-backed macOS presentation state now publishes through first-party Swift Observation. Direct state mutations update only the mounted leaves that read them, while the existing committed-frame token path remains intact for the later removal slice.

Closes #2907

## Context
#2904 proved the Observation approach on TabBar and FileTree. This PR applies that established owner pattern to the rest of the protocol presentation inventory without consuming later epic scope for theme backing, resident window content, or frame-token removal.

This is the third delivery unit in #2899. Existing State owners remain the single writers, and BEAM-owned frame staging, rejection, supersession, resource policy, typed effect replay, acknowledgements, metrics, and atomic publication remain unchanged.

## Changes
- Added `@Observable` to the remaining 24 protocol-backed presentation State owners across agent, shell chrome, sidebars, editor overlays, window overlays, shared state, and extensions.
- Restored Observation for rendered fields in `GitStatusState`, `MessagesContentState`, and `FeedbackState`.
- Removed Feedback's invalidation-only callback path now that pending and spinner changes publish directly.
- Made frontend extension active IDs observable while keeping decoder and view-builder registries outside dependency tracking.
- Added an explicit 31-owner source inventory with narrow, reasoned `@ObservationIgnored` allowlists.
- Added mounted direct-update probes for shell chrome, bottom-panel height, sidebar, editor overlay, window overlay, agent, extension, Git status, messages, and feedback. Each mutation proves that its own leaf updates while unrelated probes remain unchanged.

## Compatibility
- Frame channels, `GUIFrameVersion`, Environment keys, host plumbing, and compatibility token reads remain unchanged.
- Theme and resident window-content backing remain unchanged for the next delivery unit.
- No protocol, opcode, generated source, renderer ownership, native interaction ownership, Metal identity, or row-fit behavior changed.

## Verification
- `make lint`
- `mix swift.harness && mix test.llm`: 9,463 tests, 0 failures, 1 skipped
- `mix swift.build`
- `xcodebuild test -scheme Minga -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO`: 1,223 tests passed
- `scripts/check_render_performance`: 5/5 batches passed; aggregate combined p50 0.126 ms and p95 0.131 ms
- `git diff --check`

## Acceptance Criteria Addressed
- Every remaining protocol-backed presentation State is a first-party Observation owner ✅
- Rendered fields on existing observable owners participate in Observation, with only justified infrastructure ignored ✅
- Local State changes update mounted leaves without frame-token publication or unrelated invalidation ✅
- Committed-frame staging, rejection, effects, acknowledgements, metrics, and compatibility publication remain unchanged ✅
- Native and local interaction ownership remains intact ✅
- Theme/window backing and frame-token removal remain reserved for later epic slices ✅
- Source inventory, ignored-field allowlists, and mounted-view tests guard the complete migrated surface ✅
