### PR TITLE
fix(editor): correlate render and focus ownership

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -758,9 +758,10 @@ defmodule MingaEditor do
     {:noreply, EventDispatcher.dispatch(state, event, payload, msg)}
   end
 
-  # Debounced render timer fired — perform the actual render.
-  def handle_info(:debounced_render, state) do
-    {:noreply, RenderHandler.handle_debounced_render(state)}
+  # Debounced render timer fired — perform the actual render only for the
+  # semantic identity that still owns the scheduled window.
+  def handle_info({:debounced_render, timer_identity}, state) do
+    {:noreply, RenderHandler.handle_debounced_render(state, timer_identity)}
   end
 
   # Correlated file-tree debounce timers enter the domain workflow directly.
@@ -1455,18 +1456,18 @@ defmodule MingaEditor do
 
   defp schedule_new_render(state, delay_ms) do
     effective_delay_ms = schedule_render_delay_ms(state, delay_ms)
-    ref = Process.send_after(self(), :debounced_render, effective_delay_ms)
+    correlation = state.render.render_correlation
+    timer_identity = MingaEditor.State.RenderCorrelation.next_timer_identity(correlation)
+
+    timer =
+      Process.send_after(self(), {:debounced_render, timer_identity}, effective_delay_ms)
+
+    {:scheduled, correlation} =
+      MingaEditor.State.RenderCorrelation.schedule(correlation, timer_identity, timer)
 
     %{
       state
-      | render:
-          MingaEditor.State.Render.accept_correlation(
-            state.render,
-            elem(
-              MingaEditor.State.RenderCorrelation.schedule(state.render.render_correlation, ref),
-              1
-            )
-          )
+      | render: MingaEditor.State.Render.accept_correlation(state.render, correlation)
     }
   end
 

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -2726,7 +2726,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp find_popup_for_buffer(state, buffer_pid) do
     result =
       Enum.find(state.workspace.windows.map, fn {_id, window} ->
-        Window.popup?(window) and window.buffer == buffer_pid
+        Window.popup?(window) and match?({:buffer, ^buffer_pid}, window.content)
       end)
 
     case result do

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -737,8 +737,8 @@ defmodule MingaEditor.Commands.FileTree do
   @spec active_editing_buffer(state()) :: pid() | nil
   defp active_editing_buffer(state) do
     case State.active_window_struct(state.workspace) do
-      %{buffer: buf} when is_pid(buf) -> buf
-      _ -> state.workspace.buffers.active
+      %{content: {:buffer, buf}} when is_pid(buf) -> buf
+      _other -> state.workspace.buffers.active
     end
   end
 

--- a/lib/minga_editor/commands/folding.ex
+++ b/lib/minga_editor/commands/folding.ex
@@ -156,14 +156,19 @@ defmodule MingaEditor.Commands.Folding do
           non_neg_integer(),
           :toggle | :close | :open | :close_recursive | :open_recursive
         ) :: state()
-  defp dispatch_fold_command_at_line(state, window, buffer_line, action) do
+  defp dispatch_fold_command_at_line(
+         state,
+         %Window{content: {:buffer, buffer}} = window,
+         buffer_line,
+         action
+       ) do
     has_active_fold = FoldMap.fold_at(window.fold_map, buffer_line) != :none
     has_available_range = Enum.any?(window.fold_ranges, &FoldRange.contains?(&1, buffer_line))
 
     if has_active_fold or has_available_range do
       apply_window_fold(state, window, buffer_line, action)
     else
-      apply_decoration_fold(state, window.buffer, buffer_line, action)
+      apply_decoration_fold(state, buffer, buffer_line, action)
     end
   end
 

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -593,11 +593,11 @@ defmodule MingaEditor.Commands.Movement do
   @spec apply_split(state(), Windows.t(), WindowTree.t(), Window.id(), Window.id()) :: state()
   defp apply_split(state, ws, new_tree, active_id, new_id) do
     case Windows.fetch(ws, active_id) do
-      {:ok, active_window} ->
-        cursor = Buffer.cursor(active_window.buffer)
+      {:ok, %Window{content: {:buffer, buffer}}} ->
+        cursor = Buffer.cursor(buffer)
 
         # New window gets a copy of the current cursor position
-        new_window = Window.new(new_id, active_window.buffer, 24, 80, cursor)
+        new_window = Window.new(new_id, buffer, 24, 80, cursor)
 
         # Also snapshot the current cursor into the active window
         new_windows =

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -1919,7 +1919,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   # `record_scroll_event/3`; without one there is nothing to detach from, so only the
   # echo mark is recorded.
   @spec scroll_to_line_commit(Window.t(), Viewport.t()) :: Window.t()
-  defp scroll_to_line_commit(%Window{buffer: buf} = window, new_vp)
+  defp scroll_to_line_commit(%Window{content: {:buffer, buf}} = window, new_vp)
        when is_pid(buf) do
     now = System.monotonic_time(:millisecond)
     cursor_pos = Buffer.cursor(buf)

--- a/lib/minga_editor/handlers/highlight_handler.ex
+++ b/lib/minga_editor/handlers/highlight_handler.ex
@@ -500,13 +500,18 @@ defmodule MingaEditor.Handlers.HighlightHandler do
   defp visible_window_buffers(state) do
     state.workspace.windows.map
     |> Map.values()
-    |> Enum.map(& &1.buffer)
-    |> Enum.filter(&is_pid/1)
+    |> Enum.flat_map(fn
+      %{content: {:buffer, buffer}} -> [buffer]
+      _semantic_window -> []
+    end)
   end
 
   # Returns true if the given buffer PID is visible in any window.
   @spec buffer_visible_in_window?(EditorState.t(), pid()) :: boolean()
   defp buffer_visible_in_window?(state, buf_pid) do
-    Enum.any?(state.workspace.windows.map, fn {_id, win} -> win.buffer == buf_pid end)
+    Enum.any?(state.workspace.windows.map, fn
+      {_id, %{content: {:buffer, ^buf_pid}}} -> true
+      _entry -> false
+    end)
   end
 end

--- a/lib/minga_editor/handlers/render_handler.ex
+++ b/lib/minga_editor/handlers/render_handler.ex
@@ -11,20 +11,29 @@ defmodule MingaEditor.Handlers.RenderHandler do
 
   @type state :: EditorState.t()
 
-  @doc "Handles the debounced render timer and observes cursor movement."
-  @spec handle_debounced_render(state()) :: state()
-  def handle_debounced_render(state) do
-    state = maybe_trigger_nav_flash(state)
-    state = Renderer.render_or_async(state)
+  @doc "Handles a matching debounced render delivery and rejects stale timer identities."
+  @spec handle_debounced_render(
+          state(),
+          MingaEditor.State.RenderCorrelation.timer_identity()
+        ) :: state()
+  def handle_debounced_render(state, timer_identity) do
+    case MingaEditor.State.RenderCorrelation.deliver(
+           state.render.render_correlation,
+           timer_identity
+         ) do
+      {:current, correlation} ->
+        state = %{
+          state
+          | render: MingaEditor.State.Render.accept_correlation(state.render, correlation)
+        }
 
-    %{
-      state
-      | render:
-          MingaEditor.State.Render.accept_correlation(
-            state.render,
-            MingaEditor.State.RenderCorrelation.clear_timer(state.render.render_correlation)
-          )
-    }
+        state
+        |> maybe_trigger_nav_flash()
+        |> Renderer.render_or_async()
+
+      {:stale, _correlation} ->
+        state
+    end
   end
 
   @doc """

--- a/lib/minga_editor/key_dispatch.ex
+++ b/lib/minga_editor/key_dispatch.ex
@@ -179,7 +179,8 @@ defmodule MingaEditor.KeyDispatch do
        ) do
     buf =
       case Map.fetch(map, active_id) do
-        {:ok, window} -> window.buffer
+        {:ok, %{content: {:buffer, buffer}}} -> buffer
+        {:ok, _semantic_window} -> nil
         :error -> state.workspace.buffers.active
       end
 

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -134,7 +134,7 @@ defmodule MingaEditor.Mouse do
   @spec apply_scroll_intent(state(), non_neg_integer(), integer(), :down | :up) :: state()
   defp apply_scroll_intent(state, window_id, delta_lines, _direction) do
     case Map.fetch(state.workspace.windows.map, window_id) do
-      {:ok, %Window{buffer: buf} = window} when is_pid(buf) ->
+      {:ok, %Window{content: {:buffer, buf}} = window} when is_pid(buf) ->
         now = System.monotonic_time(:millisecond)
         total_lines = Buffer.line_count(buf)
         cursor_pos = Buffer.cursor(buf)
@@ -1324,7 +1324,7 @@ defmodule MingaEditor.Mouse do
     case WindowTree.window_at(state.workspace.windows.tree, screen, row, col) do
       {:ok, id, _rect} ->
         case Map.fetch(state.workspace.windows.map, id) do
-          {:ok, %Window{buffer: ^active}} -> true
+          {:ok, %Window{content: {:buffer, ^active}}} -> true
           _ -> false
         end
 
@@ -1490,27 +1490,28 @@ defmodule MingaEditor.Mouse do
          win_h,
          content_w
        ) do
-    with %Window{} = window <- MingaEditor.Session.State.active_window_struct(state.workspace),
-         buf when is_pid(buf) <- window.buffer do
-      total_lines = Buffer.line_count(buf)
-      {cursor_line, _} = window.cursor
-      scroll_top = HitTest.scroll_top(window, win_h, content_w, cursor_line, buf)
+    case MingaEditor.Session.State.active_window_struct(state.workspace) do
+      %Window{content: {:buffer, buf}} = window ->
+        total_lines = Buffer.line_count(buf)
+        {cursor_line, _} = window.cursor
+        scroll_top = HitTest.scroll_top(window, win_h, content_w, cursor_line, buf)
 
-      case fold_target_line_at_row(
-             buf,
-             window,
-             local_row,
-             scroll_top,
-             win_h,
-             content_w,
-             total_lines
-           ) do
-        nil -> nil
-        {:window_fold, buf_line} -> {:window_fold, win_id, buf_line}
-        {:decoration_fold, fold_id} -> {:decoration_fold, buf, fold_id}
-      end
-    else
-      _ -> nil
+        case fold_target_line_at_row(
+               buf,
+               window,
+               local_row,
+               scroll_top,
+               win_h,
+               content_w,
+               total_lines
+             ) do
+          nil -> nil
+          {:window_fold, buf_line} -> {:window_fold, win_id, buf_line}
+          {:decoration_fold, fold_id} -> {:decoration_fold, buf, fold_id}
+        end
+
+      _other ->
+        nil
     end
   end
 
@@ -1686,10 +1687,10 @@ defmodule MingaEditor.Mouse do
     win_id = state.workspace.mouse.drag_origin_window || state.workspace.windows.active
 
     with id when is_integer(id) <- win_id,
-         %Window{} = window <- Map.get(state.workspace.windows.map, id),
+         %Window{content: {:buffer, buf}} = window <-
+           Map.get(state.workspace.windows.map, id),
          %{content: {content_row, content_col, content_w, content_h}} <-
-           Map.get(layout.window_layouts, id),
-         buf when is_pid(buf) <- window.buffer do
+           Map.get(layout.window_layouts, id) do
       {id, window, buf, content_row, content_col, content_w, max(content_h, 1)}
     else
       _ -> nil

--- a/lib/minga_editor/mouse/hit_test.ex
+++ b/lib/minga_editor/mouse/hit_test.ex
@@ -242,7 +242,8 @@ defmodule MingaEditor.Mouse.HitTest do
   defp context_from_window(state, layout, id, row, col) do
     with %{content: content} <- Map.get(layout.window_layouts, id),
          true <- point_in_rect?(row, col, content),
-         %Window{buffer: buffer} = window <- Map.get(state.workspace.windows.map, id),
+         %Window{content: {:buffer, buffer}} = window <-
+           Map.get(state.workspace.windows.map, id),
          true <- is_pid(buffer) do
       %{id: id, window: window, buffer: buffer, content: content}
     else

--- a/lib/minga_editor/render_model/ui/completion_builder.ex
+++ b/lib/minga_editor/render_model/ui/completion_builder.ex
@@ -113,7 +113,7 @@ defmodule MingaEditor.RenderModel.UI.CompletionBuilder do
     layout = ctx.layout
 
     case {Map.get(layout.window_layouts, active), Map.get(ctx.windows.map, active)} do
-      {%{content: {row, col, _w, _h}}, %{buffer: buf, viewport: viewport} = window}
+      {%{content: {row, col, _w, _h}}, %{content: {:buffer, buf}, viewport: viewport} = window}
       when is_pid(buf) ->
         {line, column} = Buffer.cursor(buf)
         total_lines = Buffer.line_count(buf)

--- a/lib/minga_editor/render_model/ui/extension_overlay_builder.ex
+++ b/lib/minga_editor/render_model/ui/extension_overlay_builder.ex
@@ -35,7 +35,12 @@ defmodule MingaEditor.RenderModel.UI.ExtensionOverlayBuilder do
           pos_integer(),
           MingaEditor.Layout.window_layout()
         ) :: [Entry.t()]
-  defp maybe_overlay_entry(overlay, %{buffer: buf} = window, win_id, win_layout)
+  defp maybe_overlay_entry(
+         overlay,
+         %{content: {:buffer, buf}} = window,
+         win_id,
+         win_layout
+       )
        when is_pid(buf) do
     if buf == overlay.buffer do
       viewport_top = max(Map.get(window.render_cache, :last_viewport_top, window.viewport.top), 0)

--- a/lib/minga_editor/render_model/ui/float_popup_builder.ex
+++ b/lib/minga_editor/render_model/ui/float_popup_builder.ex
@@ -45,7 +45,7 @@ defmodule MingaEditor.RenderModel.UI.FloatPopupBuilder do
   end
 
   @spec build_float_popup_model(Context.t(), MingaEditor.Window.t()) :: FloatPopup.t()
-  defp build_float_popup_model(ctx, window) do
+  defp build_float_popup_model(ctx, %{content: {:buffer, buffer}} = window) do
     rule = window.popup_meta.rule
     vp = ctx.viewport
 
@@ -54,11 +54,10 @@ defmodule MingaEditor.RenderModel.UI.FloatPopupBuilder do
 
     {title, lines} =
       try do
-        name = Buffer.buffer_name(window.buffer)
-        line_count = Buffer.line_count(window.buffer)
+        name = Buffer.buffer_name(buffer)
+        line_count = Buffer.line_count(buffer)
 
-        snapshot =
-          Buffer.render_snapshot(window.buffer, 0, min(line_count, @max_native_popup_lines))
+        snapshot = Buffer.render_snapshot(buffer, 0, min(line_count, @max_native_popup_lines))
 
         {name, snapshot.lines}
       catch

--- a/lib/minga_editor/render_pipeline/buffer_prefetch.ex
+++ b/lib/minga_editor/render_pipeline/buffer_prefetch.ex
@@ -56,8 +56,8 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     |> Enum.reduce({%{}, input}, fn {win_id, win_layout}, {acc, st} ->
       window = Map.get(st.workspace.windows.map, win_id)
 
-      if window == nil or window.buffer == nil or match?({:agent_chat, _}, window.content) do
-        # Skip nil windows and agent chat windows (rendered by build_agent_chat_content)
+      if window == nil or not match?({:buffer, _}, window.content) do
+        # Skip nil and semantic windows; they have no buffer snapshot to prefetch.
         {acc, st}
       else
         scroll_and_invalidate(input, st, acc, win_id, window, win_layout)
@@ -180,9 +180,9 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     # This preserves the scroll position (viewport.top) across frames so that
     # Ctrl-e/y, zz/zt/zb, and mouse wheel scroll actually persist.
     # scroll_to_cursor only adjusts top when the cursor moves off-screen.
-    wrap_on = wrap_enabled?(window.buffer)
+    wrap_on = wrap_enabled?(buffer_pid(window))
     width_oracle = Capabilities.width_oracle(state.capabilities)
-    scroll_margin = scroll_margin(window.buffer)
+    scroll_margin = scroll_margin(buffer_pid(window))
     fold_map = window.fold_map
     %Viewport{} = win_vp = window.viewport
     viewport = %{win_vp | rows: content_height, cols: content_width, reserved: 0}
@@ -239,10 +239,10 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
 
     # Compute final gutter dimensions before building the DisplayMap.
     # Dynamic block decorations must see the same text width in scroll, content, and GUI gutter paths.
-    line_number_style = Buffer.get_option(window.buffer, :line_numbers)
+    line_number_style = Buffer.get_option(buffer_pid(window), :line_numbers)
 
     {has_sign_column, gutter_w} =
-      gutter_dimensions(state, window.buffer, line_number_style, line_count)
+      gutter_dimensions(state, buffer_pid(window), line_number_style, line_count)
 
     content_w = max(viewport.cols - gutter_w, 1)
 
@@ -250,7 +250,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     # The DisplayMap merges per-window folds, decoration folds, and virtual
     # lines into a unified mapping. Falls back to VisibleLines when there
     # are no decoration folds or virtual lines (pure window-fold case).
-    decorations = fetch_decorations(state, window.buffer)
+    decorations = fetch_decorations(state, buffer_pid(window))
 
     # Two-pass scroll: compute DisplayMap, then verify cursor is visible.
     # If decorations push the cursor off-screen, adjust first_line and recompute.
@@ -286,7 +286,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     # instead of blocking first paint. `residence_armed` resets on layout_generation
     # rebuilds (RenderCache.reset/1) so resize/font/wrap changes re-defer.
     residence_eligible? =
-      is_nil(visible_line_map) and full_residence?(window.buffer, wrap_on, line_count)
+      is_nil(visible_line_map) and full_residence?(buffer_pid(window), wrap_on, line_count)
 
     full_residence? = residence_eligible? and Window.residence_armed?(window)
 
@@ -304,7 +304,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
 
     snapshot =
       fetch_snapshot!(
-        window.buffer,
+        buffer_pid(window),
         expected_version,
         fetch_first,
         fetch_count,
@@ -316,7 +316,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     Minga.Telemetry.execute(
       [:minga, :render, :line_fetch],
       %{lines_fetched: length(lines)},
-      %{window_id: win_id, buffer: window.buffer, full_residence?: full_residence?}
+      %{window_id: win_id, buffer: buffer_pid(window), full_residence?: full_residence?}
     )
 
     # Cursor byte → display col
@@ -329,7 +329,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
         first_line: fetch_first,
         lines: lines,
         snapshot: snapshot,
-        buf: window.buffer,
+        buf: buffer_pid(window),
         cursor_line: cursor_line,
         cursor_byte_col: cursor_byte_col,
         content_w: content_w,
@@ -408,9 +408,14 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
   @spec render_observation!(Window.t()) ::
           {non_neg_integer(), RenderSnapshot.t() | nil, RenderSnapshot.t()}
   defp render_observation!(window) do
-    expected_version = Window.expected_buffer_version(window) || Buffer.version(window.buffer)
+    expected_version =
+      Window.expected_buffer_version(window) || Buffer.version(buffer_pid(window))
+
     changed_snapshot = Window.changed_snapshot(window)
-    base_snapshot = changed_snapshot || fetch_at_version!(window.buffer, expected_version, 0, 0)
+
+    base_snapshot =
+      changed_snapshot || fetch_at_version!(buffer_pid(window), expected_version, 0, 0)
+
     {expected_version, changed_snapshot, base_snapshot}
   end
 
@@ -642,7 +647,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
 
       case Window.cached_total_visual_rows(window, key) do
         nil ->
-          total = visual_rows_to_eof(window.buffer, snapshot.version, 0, content_w, oracle)
+          total = visual_rows_to_eof(buffer_pid(window), snapshot.version, 0, content_w, oracle)
           {total, Window.put_total_visual_rows(window, key, total)}
 
         total ->
@@ -688,7 +693,7 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
 
     {
       scroll.win_id,
-      scroll.window.buffer,
+      buffer_pid(scroll.window),
       scroll.win_layout.total,
       scroll.win_layout.content,
       scroll.content_w,
@@ -1159,8 +1164,11 @@ defmodule MingaEditor.RenderPipeline.BufferPrefetch do
     end
   end
 
+  @spec buffer_pid(Window.t()) :: pid()
+  defp buffer_pid(%Window{content: {:buffer, buffer}}), do: buffer
+
   @spec window_cursor(Window.t(), boolean()) :: {non_neg_integer(), non_neg_integer()}
-  defp window_cursor(window, true), do: Buffer.cursor(window.buffer)
+  defp window_cursor(window, true), do: Buffer.cursor(buffer_pid(window))
   defp window_cursor(window, false), do: window.cursor
 
   @spec scroll_horizontal(

--- a/lib/minga_editor/render_pipeline/content_helpers.ex
+++ b/lib/minga_editor/render_pipeline/content_helpers.ex
@@ -406,7 +406,8 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
 
   @doc "Returns the decorations for a window's buffer."
   @spec window_decorations(term(), window(), Decorations.t() | nil) :: Decorations.t()
-  def window_decorations(state, %{buffer: buf}, %Decorations{} = decorations) when is_pid(buf) do
+  def window_decorations(state, %{content: {:buffer, buf}}, %Decorations{} = decorations)
+      when is_pid(buf) do
     decorations
     |> InlineAskRender.merge_decorations(state, buf)
     |> InlineEditRender.merge_decorations(state, buf)
@@ -423,9 +424,9 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
 
   @doc "Returns the highlight state for a window's buffer."
   @spec window_highlight(state(), window()) :: MingaEditor.UI.Highlight.t() | nil
-  def window_highlight(state, window) do
+  def window_highlight(state, %{content: {:buffer, buffer}}) do
     hl =
-      case Map.fetch(state.highlighting.highlights, window.buffer) do
+      case Map.fetch(state.highlighting.highlights, buffer) do
         {:ok, highlight} -> highlight
         :error -> MingaEditor.UI.Highlight.from_theme(state.theme)
       end
@@ -433,7 +434,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
     if hl.capture_names == {} do
       nil
     else
-      apply_buffer_face_overrides(hl, window.buffer, state)
+      apply_buffer_face_overrides(hl, buffer, state)
     end
   end
 
@@ -451,7 +452,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
 
   @doc "Returns diff-view signs when a diff view is active, otherwise git signs for a window's buffer."
   @spec signs_for_window(state(), window()) :: %{non_neg_integer() => atom()}
-  def signs_for_window(%{diff_views: diff_views}, %{buffer: buf} = window)
+  def signs_for_window(%{diff_views: diff_views}, %{content: {:buffer, buf}} = window)
       when is_pid(buf) and is_map(diff_views) do
     case Map.get(diff_views, buf) do
       nil -> git_signs_for_window(window)
@@ -479,7 +480,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
 
   @doc "Returns git signs for a window's buffer."
   @spec git_signs_for_window(window()) :: %{non_neg_integer() => atom()}
-  def git_signs_for_window(%{buffer: buf}) when is_pid(buf) do
+  def git_signs_for_window(%{content: {:buffer, buf}}) when is_pid(buf) do
     case Git.tracking_pid(buf) do
       nil ->
         %{}
@@ -495,7 +496,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpers do
 
   @doc "Returns diagnostic signs for a window's buffer."
   @spec diagnostic_signs_for_window(window()) :: %{non_neg_integer() => atom()}
-  def diagnostic_signs_for_window(%{buffer: buf}) when is_pid(buf) do
+  def diagnostic_signs_for_window(%{content: {:buffer, buf}}) when is_pid(buf) do
     case Buffer.file_path(buf) do
       nil -> %{}
       path -> diagnostic_signs_for_path(path)

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -386,7 +386,7 @@ defmodule MingaEditor.RenderPipeline.Input do
         } = input
       ) do
     case Map.fetch(windows, id) do
-      {:ok, %{buffer: ^buf} = window} ->
+      {:ok, %{content: {:buffer, ^buf}} = window} ->
         cursor = Minga.Buffer.cursor(buf)
         new_map = Map.put(windows, id, %{window | cursor: cursor})
         %{input | workspace: %{ws | windows: %{ws.windows | map: new_map}}}

--- a/lib/minga_editor/render_pipeline/intent.ex
+++ b/lib/minga_editor/render_pipeline/intent.ex
@@ -57,14 +57,14 @@ defmodule MingaEditor.RenderPipeline.Intent do
     Enum.reduce(windows, %{}, fn
       {_id,
        %Window{
-         buffer: buffer,
+         content: {:buffer, buffer},
          render_cache: %RenderCache{buffer_version: observed_version}
        }},
       acc
       when is_pid(buffer) and is_integer(observed_version) and observed_version >= 0 ->
         Map.update(acc, buffer, observed_version, &max(&1, observed_version))
 
-      {_id, %Window{buffer: buffer}}, acc when is_pid(buffer) ->
+      {_id, %Window{content: {:buffer, buffer}}}, acc when is_pid(buffer) ->
         Map.put_new(acc, buffer, 0)
 
       _, acc ->

--- a/lib/minga_editor/render_pipeline/window_intent.ex
+++ b/lib/minga_editor/render_pipeline/window_intent.ex
@@ -7,7 +7,6 @@ defmodule MingaEditor.RenderPipeline.WindowIntent do
   @fields [
     :id,
     :content,
-    :buffer,
     :viewport,
     :cursor,
     :pinned,
@@ -21,13 +20,12 @@ defmodule MingaEditor.RenderPipeline.WindowIntent do
     :scroll_echo_top,
     :authoritative_scroll_seq
   ]
-  @enforce_keys [:id, :content, :buffer, :viewport]
+  @enforce_keys [:id, :content, :viewport]
   defstruct @fields
 
   @type t :: %__MODULE__{
           id: Window.id(),
-          content: term(),
-          buffer: pid() | nil,
+          content: MingaEditor.Window.Content.t(),
           viewport: MingaEditor.Viewport.t(),
           cursor: Minga.Buffer.position(),
           pinned: boolean(),
@@ -47,7 +45,6 @@ defmodule MingaEditor.RenderPipeline.WindowIntent do
     %__MODULE__{
       id: window.id,
       content: window.content,
-      buffer: window.buffer,
       viewport: window.viewport,
       cursor: window.cursor,
       pinned: window.pinned,

--- a/lib/minga_editor/renderer/render_window.ex
+++ b/lib/minga_editor/renderer/render_window.ex
@@ -42,7 +42,6 @@ defmodule MingaEditor.Renderer.RenderWindow do
   @type t :: %__MODULE__{
           id: id(),
           content: Content.t(),
-          buffer: pid() | nil,
           viewport: Viewport.t(),
           cursor: Buffer.position(),
           pinned: boolean(),
@@ -58,11 +57,10 @@ defmodule MingaEditor.Renderer.RenderWindow do
           authoritative_scroll_seq: non_neg_integer()
         }
 
-  @enforce_keys [:id, :content, :buffer, :viewport]
+  @enforce_keys [:id, :content, :viewport]
   defstruct [
     :id,
     :content,
-    :buffer,
     :viewport,
     cursor: {0, 0},
     pinned: false,
@@ -78,14 +76,7 @@ defmodule MingaEditor.Renderer.RenderWindow do
     authoritative_scroll_seq: 0
   ]
 
-  @doc """
-  Creates a new window with the given id, buffer, and viewport dimensions.
-
-  Sets both `content` (the polymorphic content reference) and `buffer`
-  (backward-compatible pid field). During the migration, callers access
-  `window.buffer` directly. Once all callers are updated to use
-  `Content.buffer_pid(window.content)`, the `buffer` field will be removed.
-  """
+  @doc "Creates a new window with the given id, buffer, and viewport dimensions."
   @spec new(id(), pid(), pos_integer(), pos_integer()) :: t()
   def new(id, buffer, rows, cols)
       when is_integer(id) and id > 0 and is_pid(buffer) and
@@ -93,7 +84,6 @@ defmodule MingaEditor.Renderer.RenderWindow do
     %__MODULE__{
       id: id,
       content: Content.buffer(buffer),
-      buffer: buffer,
       viewport: Viewport.new(rows, cols)
     }
   end
@@ -108,7 +98,6 @@ defmodule MingaEditor.Renderer.RenderWindow do
     %__MODULE__{
       id: id,
       content: Content.agent_chat(),
-      buffer: nil,
       viewport: Viewport.new(rows, cols),
       pinned: true,
       render_cache: RenderCache.reset()
@@ -123,7 +112,6 @@ defmodule MingaEditor.Renderer.RenderWindow do
     %__MODULE__{
       id: id,
       content: Content.empty(),
-      buffer: nil,
       viewport: Viewport.new(rows, cols),
       render_cache: RenderCache.reset()
     }
@@ -138,7 +126,7 @@ defmodule MingaEditor.Renderer.RenderWindow do
   """
   @spec show_empty_state(t()) :: t()
   def show_empty_state(%__MODULE__{} = window) do
-    %{window | content: Content.empty(), buffer: nil}
+    %{window | content: Content.empty()}
     |> set_document_symbols([])
     |> invalidate()
   end
@@ -146,7 +134,7 @@ defmodule MingaEditor.Renderer.RenderWindow do
   @doc "Switches the window from the launchpad back to a buffer."
   @spec show_buffer(t(), pid()) :: t()
   def show_buffer(%__MODULE__{} = window, buffer) when is_pid(buffer) do
-    %{window | content: Content.buffer(buffer), buffer: buffer}
+    %{window | content: Content.buffer(buffer)}
     |> set_document_symbols([])
     |> invalidate()
   end
@@ -160,7 +148,6 @@ defmodule MingaEditor.Renderer.RenderWindow do
     %__MODULE__{
       id: id,
       content: Content.buffer(buffer),
-      buffer: buffer,
       viewport: Viewport.new(rows, cols),
       cursor: cursor
     }
@@ -627,7 +614,10 @@ defmodule MingaEditor.Renderer.RenderWindow do
 
   @doc "Reconciles durable logical-line identities from an atomic buffer snapshot."
   @spec sync_line_identity(t(), Minga.Buffer.RenderSnapshot.t()) :: t()
-  def sync_line_identity(%__MODULE__{render_cache: cache, buffer: buffer} = window, snapshot) do
+  def sync_line_identity(
+        %__MODULE__{render_cache: cache, content: {:buffer, buffer}} = window,
+        snapshot
+      ) do
     %{window | render_cache: RenderCache.sync_line_identity(cache, buffer, snapshot)}
   end
 
@@ -638,7 +628,7 @@ defmodule MingaEditor.Renderer.RenderWindow do
           non_neg_integer()
         ) :: t()
   def put_lineage(
-        %__MODULE__{render_cache: cache, buffer: buffer} = window,
+        %__MODULE__{render_cache: cache, content: {:buffer, buffer}} = window,
         identity,
         sequence
       ) do
@@ -671,7 +661,7 @@ defmodule MingaEditor.Renderer.RenderWindow do
   @doc "Explicitly rebuilds durable content identity in a fresh epoch."
   @spec reset_content_identity(t(), Minga.Buffer.RenderSnapshot.t()) :: t()
   def reset_content_identity(
-        %__MODULE__{render_cache: cache, buffer: buffer} = window,
+        %__MODULE__{render_cache: cache, content: {:buffer, buffer}} = window,
         snapshot
       ) do
     %{window | render_cache: RenderCache.reset_content_identity(cache, buffer, snapshot)}

--- a/lib/minga_editor/renderer/state.ex
+++ b/lib/minga_editor/renderer/state.ex
@@ -205,8 +205,9 @@ defmodule MingaEditor.Renderer.State do
   @spec reconcile_windows(t(), Intent.t()) :: t()
   def reconcile_windows(%__MODULE__{} = state, %Intent{windows: windows}) do
     wanted =
-      Map.new(windows, fn {window_id, window} ->
-        {window_id, window.buffer}
+      Map.new(windows, fn
+        {window_id, %{content: {:buffer, buffer}}} -> {window_id, buffer}
+        {window_id, _semantic_window} -> {window_id, nil}
       end)
 
     resident_windows =

--- a/lib/minga_editor/renderer/window_observation.ex
+++ b/lib/minga_editor/renderer/window_observation.ex
@@ -16,7 +16,7 @@ defmodule MingaEditor.Renderer.WindowObservation do
   @doc "Captures the editor-owned fields observed while rendering one buffer window."
   @spec from_window(RenderWindow.t()) :: t() | nil
   def from_window(%RenderWindow{
-        buffer: buffer,
+        content: {:buffer, buffer},
         render_cache: cache,
         viewport: %Viewport{} = viewport
       })

--- a/lib/minga_editor/session/state.ex
+++ b/lib/minga_editor/session/state.ex
@@ -135,7 +135,8 @@ defmodule MingaEditor.Session.State do
       )
       when is_pid(buffer) and is_integer(version) and version >= 0 do
     case Windows.fetch(windows, id) do
-      {:ok, %Window{buffer: ^buffer, render_cache: %{buffer_version: current}} = window}
+      {:ok,
+       %Window{content: {:buffer, ^buffer}, render_cache: %{buffer_version: current}} = window}
       when current <= version ->
         replace_window(workspace, id, Window.observe_render(window, viewport, version))
 
@@ -275,7 +276,7 @@ defmodule MingaEditor.Session.State do
       )
       when is_pid(buffer) do
     case Windows.fetch(windows, windows.active) do
-      {:ok, %Window{buffer: ^buffer}} ->
+      {:ok, %Window{content: {:buffer, ^buffer}}} ->
         %{
           workspace
           | windows:
@@ -302,7 +303,7 @@ defmodule MingaEditor.Session.State do
          replace?
        ) do
     case Windows.fetch(windows, windows.active) do
-      {:ok, %Window{buffer: ^buffer, content: {:buffer, ^buffer}}} ->
+      {:ok, %Window{content: {:buffer, ^buffer}}} ->
         normalize_buffer_surface(workspace, buffer)
 
       {:ok, %Window{content: {:buffer, _}}} ->

--- a/lib/minga_editor/shell.ex
+++ b/lib/minga_editor/shell.ex
@@ -46,6 +46,9 @@ defmodule MingaEditor.Shell do
   @doc "Returns the input handler stack for this shell."
   @callback input_handlers(editor_state :: term()) :: %{overlay: [module()], surface: [module()]}
 
+  @doc "Blurs shell-owned bottom-panel presentation during a window focus transition."
+  @callback blur_bottom_panel(shell_state()) :: shell_state()
+
   @doc "Handles a shell-specific event."
   @callback handle_event(shell_state(), workspace(), event :: term()) ::
               {shell_state(), workspace()}

--- a/lib/minga_editor/shell/runtime.ex
+++ b/lib/minga_editor/shell/runtime.ex
@@ -151,6 +151,13 @@ defmodule MingaEditor.Shell.Runtime do
     end
   end
 
+  @doc "Routes bottom-panel blur through the active shell contract."
+  @spec blur_bottom_panel(t()) :: t()
+  def blur_bottom_panel(%__MODULE__{} = runtime) do
+    shell_state = runtime.entry.module.blur_bottom_panel(runtime.state)
+    %__MODULE__{runtime | state: shell_state}
+  end
+
   @doc "Routes a shell event through the active entry's contract."
   @spec route_event(t(), MingaEditor.Shell.workspace(), term()) ::
           {t(), MingaEditor.Shell.workspace()}

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -258,6 +258,11 @@ defmodule MingaEditor.Shell.Traditional do
     }
   end
 
+  @impl true
+  @spec blur_bottom_panel(ShellState.t()) :: ShellState.t()
+  def blur_bottom_panel(%ShellState{} = shell_state),
+    do: ShellState.blur_bottom_panel(shell_state)
+
   # -------------------------------------------------------------------
   # Buffer lifecycle callbacks
   # -------------------------------------------------------------------

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -279,6 +279,11 @@ defmodule MingaEditor.Shell.Traditional.State do
   @spec bottom_panel(t()) :: BottomPanel.t()
   def bottom_panel(%{bottom_panel: panel}), do: panel
 
+  @doc "Blurs the shell-owned bottom panel."
+  @spec blur_bottom_panel(t()) :: t()
+  def blur_bottom_panel(%__MODULE__{} = state),
+    do: %{state | bottom_panel: BottomPanel.blur(state.bottom_panel)}
+
   @doc "Replaces the bottom panel state."
   @spec set_bottom_panel(t(), BottomPanel.t()) :: t()
   def set_bottom_panel(%{} = ss, panel) do

--- a/lib/minga_editor/state/buffers.ex
+++ b/lib/minga_editor/state/buffers.ex
@@ -34,17 +34,15 @@ defmodule MingaEditor.State.Buffers do
     %{bs | list: bs.list ++ [pid]}
   end
 
-  @doc "Switches to the buffer at `idx`, wrapping around."
-  @spec switch_to(t(), non_neg_integer()) :: t()
-  def switch_to(%__MODULE__{list: [_ | _] = buffers} = bs, idx) do
-    len = Enum.count(buffers)
-    idx = rem(idx, len)
-    idx = if idx < 0, do: idx + len, else: idx
-    pid = Enum.at(buffers, idx)
-    %{bs | active_index: idx, active: pid}
+  @doc "Switches to the buffer at `idx`, wrapping negative and positive indexes."
+  @spec switch_to(t(), integer()) :: t()
+  def switch_to(%__MODULE__{list: [_ | _] = buffers} = bs, idx) when is_integer(idx) do
+    wrapped_index = Integer.mod(idx, Enum.count(buffers))
+    pid = Enum.at(buffers, wrapped_index)
+    %{bs | active_index: wrapped_index, active: pid}
   end
 
-  def switch_to(%__MODULE__{} = bs, _idx), do: bs
+  def switch_to(%__MODULE__{} = bs, idx) when is_integer(idx), do: bs
 
   @doc "Switches to the buffer with the given pid, if it exists in the list."
   @spec switch_to_pid(t(), pid()) :: t()

--- a/lib/minga_editor/state/render.ex
+++ b/lib/minga_editor/state/render.ex
@@ -14,7 +14,7 @@ defmodule MingaEditor.State.Render do
 
   @type t :: %__MODULE__{
           renderer: pid() | nil,
-          render_correlation: RenderCorrelation.t(),
+          render_correlation: term(),
           message_store: MessageStore.t(),
           layout: Layout.t() | nil,
           focus_tree: FocusTree.t() | nil,
@@ -40,7 +40,7 @@ defmodule MingaEditor.State.Render do
 
   @doc "Commits correlation state produced by a render scheduling transition."
   @spec accept_correlation(t(), RenderCorrelation.t()) :: t()
-  def accept_correlation(%__MODULE__{} = render, %RenderCorrelation{} = correlation),
+  def accept_correlation(%__MODULE__{} = render, correlation),
     do: %{render | render_correlation: correlation}
 
   @doc "Appends a structured editor log message to the semantic message store."

--- a/lib/minga_editor/state/render_correlation.ex
+++ b/lib/minga_editor/state/render_correlation.ex
@@ -2,41 +2,88 @@ defmodule MingaEditor.State.RenderCorrelation do
   @moduledoc "Immutable Editor-owned render scheduling, keyframe, and receipt-ordering state."
 
   defstruct timer: nil,
+            timer_identity: nil,
+            timer_sequence: 0,
             keyframe_pending?: false,
             latest_intent_revision: 0,
             last_receipt_revision: 0,
             last_receipt_seq: 0
 
-  @type t :: %__MODULE__{
-          timer: reference() | nil,
-          keyframe_pending?: boolean(),
-          latest_intent_revision: non_neg_integer(),
-          last_receipt_revision: non_neg_integer(),
-          last_receipt_seq: non_neg_integer()
-        }
+  @opaque timer_identity :: {:render_window, pos_integer()}
+
+  @opaque t :: %__MODULE__{
+            timer: reference() | nil,
+            timer_identity: timer_identity() | nil,
+            timer_sequence: non_neg_integer(),
+            keyframe_pending?: boolean(),
+            latest_intent_revision: non_neg_integer(),
+            last_receipt_revision: non_neg_integer(),
+            last_receipt_seq: non_neg_integer()
+          }
 
   @type freshness_reason :: :superseded_intent | :stale_receipt_revision | :stale_sequence
   @type freshness :: {:fresh, non_neg_integer()} | {:stale, freshness_reason()}
+  @type timer_delivery :: {:current, t()} | {:stale, t()}
 
   @doc "Returns initial render correlation state."
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
-  @doc "Admits one render timer or coalesces into the already scheduled timer."
-  @spec schedule(t(), reference()) :: {:scheduled | :coalesced, t()}
-  def schedule(%__MODULE__{timer: nil} = correlation, timer) when is_reference(timer),
-    do: {:scheduled, %{correlation | timer: timer}}
+  @doc "Returns the semantic identity for the next render window."
+  @spec next_timer_identity(t()) :: timer_identity()
+  def next_timer_identity(%__MODULE__{timer_sequence: sequence}),
+    do: {:render_window, sequence + 1}
 
-  def schedule(%__MODULE__{} = correlation, timer) when is_reference(timer),
-    do: {:coalesced, correlation}
+  @doc "Admits one render timer or coalesces into the already scheduled timer."
+  @spec schedule(t(), timer_identity(), reference()) :: {:scheduled | :coalesced, t()}
+  def schedule(
+        %__MODULE__{timer: nil, timer_sequence: sequence} = correlation,
+        {:render_window, next_sequence} = identity,
+        timer
+      )
+      when next_sequence == sequence + 1 and is_reference(timer) do
+    {:scheduled,
+     %{
+       correlation
+       | timer: timer,
+         timer_identity: identity,
+         timer_sequence: next_sequence
+     }}
+  end
+
+  def schedule(%__MODULE__{} = correlation, {:render_window, sequence}, timer)
+      when is_integer(sequence) and sequence > 0 and is_reference(timer),
+      do: {:coalesced, correlation}
 
   @doc "Returns whether a render timer currently owns the throttle window."
   @spec scheduled?(t()) :: boolean()
-  def scheduled?(%__MODULE__{timer: timer}), do: is_reference(timer)
+  def scheduled?(%__MODULE__{timer: timer, timer_identity: identity}),
+    do: is_reference(timer) and not is_nil(identity)
 
-  @doc "Clears the render timer after synchronous rendering or timer delivery."
+  @doc "Returns the current timer reference for cancellation at the Editor boundary."
+  @spec timer_reference(t()) :: reference() | nil
+  def timer_reference(%__MODULE__{timer: timer}), do: timer
+
+  @doc "Returns the identity of the currently scheduled render window."
+  @spec scheduled_identity(t()) :: timer_identity() | nil
+  def scheduled_identity(%__MODULE__{timer_identity: identity}), do: identity
+
+  @doc "Clears the scheduled render window while preserving its monotonic identity sequence."
   @spec clear_timer(t()) :: t()
-  def clear_timer(%__MODULE__{} = correlation), do: %{correlation | timer: nil}
+  def clear_timer(%__MODULE__{} = correlation),
+    do: %{correlation | timer: nil, timer_identity: nil}
+
+  @doc "Accepts only delivery for the currently scheduled render window."
+  @spec deliver(t(), timer_identity()) :: timer_delivery()
+  def deliver(
+        %__MODULE__{timer_identity: {:render_window, sequence}} = correlation,
+        {:render_window, sequence}
+      ),
+      do: {:current, clear_timer(correlation)}
+
+  def deliver(%__MODULE__{} = correlation, {:render_window, sequence})
+      when is_integer(sequence) and sequence > 0,
+      do: {:stale, correlation}
 
   @doc "Marks the next completed render as requiring a keyframe."
   @spec request_keyframe(t()) :: t()
@@ -61,6 +108,18 @@ defmodule MingaEditor.State.RenderCorrelation do
     revision = correlation.latest_intent_revision + 1
     {%{correlation | latest_intent_revision: revision}, revision}
   end
+
+  @doc "Returns the latest submitted render intent revision."
+  @spec latest_intent_revision(t()) :: non_neg_integer()
+  def latest_intent_revision(%__MODULE__{latest_intent_revision: revision}), do: revision
+
+  @doc "Returns the last accepted render receipt revision."
+  @spec last_receipt_revision(t()) :: non_neg_integer()
+  def last_receipt_revision(%__MODULE__{last_receipt_revision: revision}), do: revision
+
+  @doc "Returns the last accepted renderer frame sequence."
+  @spec last_receipt_sequence(t()) :: non_neg_integer()
+  def last_receipt_sequence(%__MODULE__{last_receipt_seq: sequence}), do: sequence
 
   @doc "Classifies asynchronous receipt ordering and normalizes legacy revision zero."
   @spec classify_receipt(t(), non_neg_integer(), non_neg_integer()) :: freshness()

--- a/lib/minga_editor/state/windows.ex
+++ b/lib/minga_editor/state/windows.ex
@@ -106,7 +106,7 @@ defmodule MingaEditor.State.Windows do
       when is_pid(buffer) and is_map(replacements) do
     map =
       Enum.reduce(windows, windows, fn
-        {id, %Window{buffer: ^buffer}}, acc ->
+        {id, %Window{content: {:buffer, ^buffer}}}, acc ->
           case Map.fetch(replacements, id) do
             {:ok, %Window{} = window} -> Map.put(acc, id, window)
             :error -> acc
@@ -256,7 +256,7 @@ defmodule MingaEditor.State.Windows do
       when is_pid(buffer) and is_list(symbols) do
     replacements =
       Map.new(state.map, fn
-        {id, %Window{buffer: ^buffer} = window} ->
+        {id, %Window{content: {:buffer, ^buffer}} = window} ->
           {id, Window.set_document_symbols(window, symbols)}
 
         {id, window} ->
@@ -269,7 +269,10 @@ defmodule MingaEditor.State.Windows do
   @doc "Finds the first window showing a buffer."
   @spec find_by_buffer(t(), pid()) :: {Window.id(), Window.t()} | nil
   def find_by_buffer(%__MODULE__{map: map}, buffer) when is_pid(buffer) do
-    Enum.find(map, fn {_id, %Window{buffer: window_buffer}} -> window_buffer == buffer end)
+    Enum.find(map, fn
+      {_id, %Window{content: {:buffer, ^buffer}}} -> true
+      _entry -> false
+    end)
   end
 
   @doc "Finds the first agent chat window."

--- a/lib/minga_editor/window.ex
+++ b/lib/minga_editor/window.ex
@@ -26,7 +26,6 @@ defmodule MingaEditor.Window do
   @type t :: %__MODULE__{
           id: id(),
           content: Content.t(),
-          buffer: pid() | nil,
           viewport: Viewport.t(),
           cursor: Buffer.position(),
           pinned: boolean(),
@@ -42,11 +41,10 @@ defmodule MingaEditor.Window do
           authoritative_scroll_seq: non_neg_integer()
         }
 
-  @enforce_keys [:id, :content, :buffer, :viewport]
+  @enforce_keys [:id, :content, :viewport]
   defstruct [
     :id,
     :content,
-    :buffer,
     :viewport,
     cursor: {0, 0},
     pinned: false,
@@ -68,14 +66,7 @@ defmodule MingaEditor.Window do
     authoritative_scroll_seq: 0
   ]
 
-  @doc """
-  Creates a new window with the given id, buffer, and viewport dimensions.
-
-  Sets both `content` (the polymorphic content reference) and `buffer`
-  (backward-compatible pid field). During the migration, callers access
-  `window.buffer` directly. Once all callers are updated to use
-  `Content.buffer_pid(window.content)`, the `buffer` field will be removed.
-  """
+  @doc "Creates a new window with the given id, buffer, and viewport dimensions."
   @spec new(id(), pid(), pos_integer(), pos_integer()) :: t()
   def new(id, buffer, rows, cols)
       when is_integer(id) and id > 0 and is_pid(buffer) and
@@ -83,7 +74,6 @@ defmodule MingaEditor.Window do
     %__MODULE__{
       id: id,
       content: Content.buffer(buffer),
-      buffer: buffer,
       viewport: Viewport.new(rows, cols)
     }
   end
@@ -98,7 +88,6 @@ defmodule MingaEditor.Window do
     %__MODULE__{
       id: id,
       content: Content.agent_chat(),
-      buffer: nil,
       viewport: Viewport.new(rows, cols),
       pinned: true
     }
@@ -112,7 +101,6 @@ defmodule MingaEditor.Window do
     %__MODULE__{
       id: id,
       content: Content.empty(),
-      buffer: nil,
       viewport: Viewport.new(rows, cols)
     }
   end
@@ -126,14 +114,14 @@ defmodule MingaEditor.Window do
   """
   @spec show_empty_state(t()) :: t()
   def show_empty_state(%__MODULE__{} = window) do
-    %{window | content: Content.empty(), buffer: nil}
+    %{window | content: Content.empty()}
     |> set_document_symbols([])
   end
 
   @doc "Switches the window from the launchpad back to a buffer."
   @spec show_buffer(t(), pid()) :: t()
   def show_buffer(%__MODULE__{} = window, buffer) when is_pid(buffer) do
-    %{window | content: Content.buffer(buffer), buffer: buffer}
+    %{window | content: Content.buffer(buffer)}
     |> set_document_symbols([])
   end
 
@@ -146,7 +134,6 @@ defmodule MingaEditor.Window do
     %__MODULE__{
       id: id,
       content: Content.buffer(buffer),
-      buffer: buffer,
       viewport: Viewport.new(rows, cols),
       cursor: cursor
     }

--- a/lib/minga_editor/window/content.ex
+++ b/lib/minga_editor/window/content.ex
@@ -3,8 +3,8 @@ defmodule MingaEditor.Window.Content do
   Polymorphic content reference for window panes.
 
   A window can host any content type: a file buffer, an agent chat session,
-  a terminal, etc. This module defines the tagged union that replaces the
-  old `buffer: pid()` field on `Window.t()`.
+  a terminal, etc. This module defines the authoritative tagged union for
+  window content identity.
 
   ## Why a tagged tuple instead of a protocol?
 

--- a/lib/minga_editor/window_focus.ex
+++ b/lib/minga_editor/window_focus.ex
@@ -4,41 +4,52 @@ defmodule MingaEditor.WindowFocus do
   alias Minga.Buffer
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Runtime
-  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Windows
-  alias MingaEditor.BottomPanel
   alias MingaEditor.Window
 
   @type state :: EditorState.t()
+  @type focus_failure :: :window_not_found | :cursor_source_mismatch | :buffer_unavailable
+  @type focus_result :: {:ok, state()} | {:error, focus_failure()}
 
   @doc "Focuses a window after saving and restoring its buffer cursor state."
   @spec focus(state(), Window.id()) :: state()
-  def focus(%EditorState{workspace: %{windows: %{active: active}}} = state, target_id)
-      when target_id == active,
-      do: blur_bottom_panel(state)
-
   def focus(%EditorState{} = state, target_id) do
+    case focus_result(state, target_id) do
+      {:ok, focused} -> focused
+      {:error, _reason} -> state
+    end
+  end
+
+  @doc "Focuses a window and reports why an ownership-safe transition was rejected."
+  @spec focus_result(state(), Window.id()) :: focus_result()
+  def focus_result(
+        %EditorState{workspace: %{windows: %{active: active}}} = state,
+        target_id
+      )
+      when target_id == active,
+      do: {:ok, blur_bottom_panel(state)}
+
+  def focus_result(%EditorState{} = state, target_id) do
     windows = state.workspace.windows
 
-    with {:ok, old_window} <- Windows.fetch(windows, windows.active),
-         {:ok, target_window} <- Windows.fetch(windows, target_id),
+    with {:ok, old_window} <- fetch_window(windows, windows.active),
+         {:ok, target_window} <- fetch_window(windows, target_id),
          {:ok, outgoing_cursor} <- outgoing_cursor(old_window, state.workspace.buffers.active),
          :ok <- restore_target_cursor(target_window) do
-      state
-      |> then(fn state ->
-        %{
-          state
-          | workspace: SessionState.focus_window(state.workspace, target_id, outgoing_cursor)
-        }
-      end)
-      |> blur_bottom_panel()
-    else
-      :error -> state
+      focused =
+        state
+        |> then(fn state ->
+          %{
+            state
+            | workspace: SessionState.focus_window(state.workspace, target_id, outgoing_cursor)
+          }
+        end)
+        |> blur_bottom_panel()
+
+      {:ok, focused}
     end
-  catch
-    :exit, _reason -> state
   end
 
   @doc "Restores focus without reading the outgoing window's buffer, for popup dismissal."
@@ -54,6 +65,8 @@ defmodule MingaEditor.WindowFocus do
         |> blur_bottom_panel()
 
       {:ok, restored}
+    else
+      _failure -> :error
     end
   catch
     :exit, _reason -> :error
@@ -82,34 +95,71 @@ defmodule MingaEditor.WindowFocus do
       end)
       |> blur_bottom_panel()
     else
-      :error -> state
+      _failure -> state
     end
   catch
     :exit, _reason -> state
   end
 
-  @doc "Snapshots the active buffer cursor into its matching window."
+  @doc "Snapshots the active cursor only when the active window owns its buffer source."
   @spec remember_active_cursor(state()) :: state()
-  def remember_active_cursor(%EditorState{workspace: %{buffers: %{active: buffer}}} = state)
-      when is_pid(buffer) do
-    cursor = Buffer.cursor(buffer)
-    %{state | workspace: SessionState.remember_active_window_cursor(state.workspace, cursor)}
-  catch
-    :exit, _reason -> state
+  def remember_active_cursor(%EditorState{} = state) do
+    case remember_active_cursor_result(state) do
+      {:ok, remembered} -> remembered
+      {:error, _reason} -> state
+    end
   end
 
-  def remember_active_cursor(%EditorState{} = state), do: state
+  @doc "Snapshots the active cursor and reports ownership failures without changing state."
+  @spec remember_active_cursor_result(state()) :: focus_result()
+  def remember_active_cursor_result(%EditorState{} = state) do
+    windows = state.workspace.windows
 
-  @spec outgoing_cursor(Window.t(), pid() | nil) :: {:ok, SessionState.position() | nil}
-  defp outgoing_cursor(%Window{content: {:buffer, _}}, active_buffer) when is_pid(active_buffer),
-    do: {:ok, Buffer.cursor(active_buffer)}
+    with {:ok, outgoing_window} <- fetch_window(windows, windows.active),
+         {:ok, cursor} <- outgoing_cursor(outgoing_window, state.workspace.buffers.active) do
+      remember_cursor_result(state, cursor)
+    end
+  end
 
-  defp outgoing_cursor(%Window{}, _active_buffer), do: {:ok, nil}
+  @spec remember_cursor_result(state(), SessionState.position() | nil) :: {:ok, state()}
+  defp remember_cursor_result(state, {_, _} = cursor) do
+    {:ok,
+     %{
+       state
+       | workspace: SessionState.remember_active_window_cursor(state.workspace, cursor)
+     }}
+  end
 
-  @spec restore_target_cursor(Window.t()) :: :ok
+  defp remember_cursor_result(state, nil), do: {:ok, state}
+
+  @spec fetch_window(Windows.t(), Window.id()) :: {:ok, Window.t()} | {:error, :window_not_found}
+  defp fetch_window(windows, id) do
+    case Windows.fetch(windows, id) do
+      {:ok, window} -> {:ok, window}
+      :error -> {:error, :window_not_found}
+    end
+  end
+
+  @spec outgoing_cursor(Window.t(), pid() | nil) ::
+          {:ok, SessionState.position() | nil} | {:error, focus_failure()}
+  defp outgoing_cursor(%Window{content: {:buffer, buffer}}, buffer) when is_pid(buffer) do
+    {:ok, Buffer.cursor(buffer)}
+  catch
+    :exit, _reason -> {:error, :buffer_unavailable}
+  end
+
+  defp outgoing_cursor(%Window{content: {:buffer, _buffer}}, _active_buffer),
+    do: {:error, :cursor_source_mismatch}
+
+  defp outgoing_cursor(%Window{}, nil), do: {:ok, nil}
+  defp outgoing_cursor(%Window{}, _active_buffer), do: {:error, :cursor_source_mismatch}
+
+  @spec restore_target_cursor(Window.t()) :: :ok | {:error, :buffer_unavailable}
   defp restore_target_cursor(%Window{content: {:buffer, buffer}, cursor: cursor})
        when is_pid(buffer) do
     Buffer.move_to(buffer, cursor)
+  catch
+    :exit, _reason -> {:error, :buffer_unavailable}
   end
 
   defp restore_target_cursor(%Window{}), do: :ok
@@ -172,15 +222,6 @@ defmodule MingaEditor.WindowFocus do
   end
 
   @spec blur_bottom_panel(state()) :: state()
-  defp blur_bottom_panel(%EditorState{} = state) do
-    shell_state = Runtime.state(state.shell_runtime)
-    panel = shell_state |> TraditionalState.bottom_panel() |> BottomPanel.blur()
-    shell_state = TraditionalState.set_bottom_panel(shell_state, panel)
-
-    %{
-      state
-      | shell_runtime:
-          MingaEditor.Shell.Runtime.install_traditional_state(state.shell_runtime, shell_state)
-    }
-  end
+  defp blur_bottom_panel(%EditorState{} = state),
+    do: %{state | shell_runtime: Runtime.blur_bottom_panel(state.shell_runtime)}
 end

--- a/test/minga/extension/editor_api_test.exs
+++ b/test/minga/extension/editor_api_test.exs
@@ -68,11 +68,9 @@ defmodule MingaEditor.Extension.EditorAPITest do
       MingaEditor.State.Windows.replace_window(
         state.workspace.windows,
         new_window_id,
-        %{
-          Map.fetch!(state.workspace.windows.map, new_window_id)
-          | buffer: second_buffer,
-            content: {:buffer, second_buffer}
-        }
+        state.workspace.windows.map
+        |> Map.fetch!(new_window_id)
+        |> MingaEditor.Window.show_buffer(second_buffer)
       )
 
     state =

--- a/test/minga_editor/agent/ingest_test.exs
+++ b/test/minga_editor/agent/ingest_test.exs
@@ -260,6 +260,7 @@ defmodule MingaEditor.Agent.IngestTest do
       session = fake_session()
 
       send(ingest, {:agent_event, session, {:text_delta, "lead"}})
+      sync(ingest)
       assert_receive {:agent_stream_batch, ^session, [{:text_delta, "lead"}]}
 
       # Each delta is 6 bytes ("chunk1", "chunk2", "chunk3"). Cap is 10 bytes,

--- a/test/minga_editor/layout_preset_test.exs
+++ b/test/minga_editor/layout_preset_test.exs
@@ -40,7 +40,7 @@ defmodule MingaEditor.LayoutPresetTest do
       # New window should have agent_chat content
       agent_win = new_state.workspace.windows.map[2]
       assert Content.agent_chat?(agent_win.content)
-      assert agent_win.buffer == nil
+      assert Content.buffer_pid(agent_win.content) == nil
 
       # Original window unchanged
       assert Content.buffer?(new_state.workspace.windows.map[1].content)

--- a/test/minga_editor/layout_test.exs
+++ b/test/minga_editor/layout_test.exs
@@ -58,7 +58,6 @@ defmodule MingaEditor.LayoutTest do
     window = %Window{
       id: win_id,
       content: {:buffer, self()},
-      buffer: self(),
       viewport: Viewport.new(24, 80)
     }
 
@@ -135,14 +134,12 @@ defmodule MingaEditor.LayoutTest do
     win1 = %Window{
       id: 1,
       content: {:buffer, self()},
-      buffer: self(),
       viewport: Viewport.new(24, 40)
     }
 
     win2 = %Window{
       id: 2,
       content: {:buffer, self()},
-      buffer: self(),
       viewport: Viewport.new(24, 40)
     }
 
@@ -162,14 +159,12 @@ defmodule MingaEditor.LayoutTest do
     win1 = %Window{
       id: 1,
       content: {:buffer, self()},
-      buffer: self(),
       viewport: Viewport.new(12, 80)
     }
 
     win2 = %Window{
       id: 2,
       content: {:buffer, self()},
-      buffer: self(),
       viewport: Viewport.new(12, 80)
     }
 

--- a/test/minga_editor/mouse/hit_test_test.exs
+++ b/test/minga_editor/mouse/hit_test_test.exs
@@ -16,6 +16,7 @@ defmodule MingaEditor.Mouse.HitTestTest do
   alias MingaEditor.Mouse.Target.Buffer, as: BufferTarget
   alias MingaEditor.Startup
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Window.Content
   alias MingaEditor.Window
 
   describe "resolve_buffer/3" do
@@ -74,10 +75,12 @@ defmodule MingaEditor.Mouse.HitTestTest do
       {target_id, %{content: {row, col, _width, _height}}} = rightmost_window_layout(layout)
       target_window = Map.fetch!(state.workspace.windows.map, target_id)
 
+      target_buffer = Content.buffer_pid(target_window.content)
+
       gutter_width =
         HitTest.buffer_gutter_width(
-          target_window.buffer,
-          BufferProcess.line_count(target_window.buffer)
+          target_buffer,
+          BufferProcess.line_count(target_buffer)
         )
 
       assert target_id != active_id
@@ -86,7 +89,7 @@ defmodule MingaEditor.Mouse.HitTestTest do
                HitTest.resolve_buffer(state, row + 2, col + gutter_width + 1)
 
       assert target.window_id == target_id
-      assert target.buffer == target_window.buffer
+      assert target.buffer == target_buffer
       assert BufferTarget.position(target) == {2, 1}
       assert state.workspace.windows.active == active_id
     end

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -70,7 +70,7 @@ defmodule MingaEditor.PickerUITest do
     {:ok, preview_buf} = BufferProcess.start_link(content: "preview")
     win_id = 1
     original_window = Window.new(win_id, original_buf, 24, 80)
-    preview_window = %{original_window | buffer: preview_buf, content: {:buffer, preview_buf}}
+    preview_window = Window.show_buffer(original_window, preview_buf)
 
     original_workspace = %SessionState{
       viewport: Viewport.new(24, 80),

--- a/test/minga_editor/render_model/window/builder_test.exs
+++ b/test/minga_editor/render_model/window/builder_test.exs
@@ -73,7 +73,11 @@ defmodule MingaEditor.RenderModel.Window.BuilderTest do
     end
   end
 
-  defp update_renderer_window({id, %{buffer: buffer} = window}, buffer, consumed) do
+  defp update_renderer_window(
+         {id, %{content: {:buffer, buffer}} = window},
+         buffer,
+         consumed
+       ) do
     cache = update_renderer_cache(window.render_cache, buffer, consumed)
     {id, %{window | render_cache: cache}}
   end

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -342,7 +342,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       synced = Input.sync_active_window_cursor(input)
 
       window = Map.fetch!(synced.workspace.windows.map, synced.workspace.windows.active)
-      assert window.buffer == original_window.buffer
+      assert window.content == original_window.content
       assert window.cursor == original_cursor
     end
 

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -1024,7 +1024,8 @@ defmodule MingaEditor.Renderer.ServerTest do
     input_sequence = window.render_cache.applied_change_sequence
 
     expected_version = Window.expected_buffer_version(window)
-    {:ok, snapshot} = Minga.Buffer.render_lines(window.buffer, expected_version, 0, 0)
+    {:buffer, buffer} = window.content
+    {:ok, snapshot} = Minga.Buffer.render_lines(buffer, expected_version, 0, 0)
     updated_window = Window.sync_line_identity(window, snapshot)
     output_identity = Window.line_identity(updated_window)
 

--- a/test/minga_editor/session/state_test.exs
+++ b/test/minga_editor/session/state_test.exs
@@ -35,14 +35,14 @@ defmodule MingaEditor.Session.StateTest do
 
       # Confirm the window still points at the old buffer
       window = Map.get(ws.windows.map, win_id)
-      assert window.buffer == original_buf
+      assert Content.buffer_pid(window.content) == original_buf
       assert window.content == {:buffer, original_buf}
 
       # sync should update the window to point at the new buffer
       ws = SessionState.activate_buffer(ws, ws.buffers)
 
       updated_window = Map.get(ws.windows.map, win_id)
-      assert updated_window.buffer == new_buf
+      assert Content.buffer_pid(updated_window.content) == new_buf
       assert updated_window.content == {:buffer, new_buf}
     end
 
@@ -52,7 +52,7 @@ defmodule MingaEditor.Session.StateTest do
       win_id = ws.windows.active
 
       window = Map.get(ws.windows.map, win_id)
-      agent_window = %{window | content: Content.agent_chat(), buffer: nil}
+      agent_window = %{window | content: Content.agent_chat()}
       ws = %{ws | windows: %{ws.windows | map: Map.put(ws.windows.map, win_id, agent_window)}}
 
       # Change the active buffer to something different
@@ -64,7 +64,7 @@ defmodule MingaEditor.Session.StateTest do
 
       result_window = Map.get(ws.windows.map, win_id)
       assert result_window.content == {:agent_chat, :semantic}
-      assert result_window.buffer == nil
+      assert Content.buffer_pid(result_window.content) == nil
     end
 
     test "clears document symbols when the active window switches buffers" do

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -258,7 +258,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
       assert file_buf in new_state.workspace.buffers.list
       assert new_state.workspace.buffers.active == file_buf
       assert Content.agent_chat?(window.content)
-      assert window.buffer == nil
+      assert Content.buffer_pid(window.content) == nil
     end
   end
 

--- a/test/minga_editor/state/buffers_test.exs
+++ b/test/minga_editor/state/buffers_test.exs
@@ -3,6 +3,34 @@ defmodule MingaEditor.State.BuffersTest do
 
   alias MingaEditor.State.Buffers
 
+  describe "switch_to/2" do
+    test "wraps negative, zero, in-range, and positive indexes" do
+      buffers = %Buffers{list: [:a, :b, :c], active: :a, active_index: 0}
+
+      cases = [
+        {-1, 2, :c},
+        {0, 0, :a},
+        {1, 1, :b},
+        {3, 0, :a},
+        {4, 1, :b}
+      ]
+
+      for {requested, expected_index, expected_buffer} <- cases do
+        switched = Buffers.switch_to(buffers, requested)
+        assert switched.active_index == expected_index
+        assert switched.active == expected_buffer
+      end
+    end
+
+    test "keeps empty buffer state unchanged for any integer index" do
+      buffers = %Buffers{}
+
+      assert Buffers.switch_to(buffers, -1) == buffers
+      assert Buffers.switch_to(buffers, 0) == buffers
+      assert Buffers.switch_to(buffers, 1) == buffers
+    end
+  end
+
   describe "remove/2" do
     test "removes pid from list and selects neighbor" do
       bs = %Buffers{list: [:a, :b, :c], active: :b, active_index: 1}

--- a/test/minga_editor/state/render_correlation_test.exs
+++ b/test/minga_editor/state/render_correlation_test.exs
@@ -1,21 +1,94 @@
 defmodule MingaEditor.State.RenderCorrelationTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.State.Render
   alias MingaEditor.State.RenderCorrelation
+
+  import MingaEditor.RenderPipeline.TestHelpers
 
   test "render timer admission coalesces until the timer is cleared" do
     first = make_ref()
     second = make_ref()
+    correlation = RenderCorrelation.new()
+    first_identity = RenderCorrelation.next_timer_identity(correlation)
 
-    assert {:scheduled, correlation} = RenderCorrelation.schedule(RenderCorrelation.new(), first)
+    assert {:scheduled, correlation} =
+             RenderCorrelation.schedule(correlation, first_identity, first)
+
     assert RenderCorrelation.scheduled?(correlation)
-    assert correlation.timer == first
-    assert {:coalesced, unchanged} = RenderCorrelation.schedule(correlation, second)
+    assert RenderCorrelation.timer_reference(correlation) == first
+    assert RenderCorrelation.scheduled_identity(correlation) == first_identity
+
+    second_identity = RenderCorrelation.next_timer_identity(correlation)
+
+    assert {:coalesced, unchanged} =
+             RenderCorrelation.schedule(correlation, second_identity, second)
+
     assert unchanged == correlation
 
     cleared = RenderCorrelation.clear_timer(correlation)
     refute RenderCorrelation.scheduled?(cleared)
-    assert cleared.timer == nil
+    assert RenderCorrelation.timer_reference(cleared) == nil
+    assert RenderCorrelation.scheduled_identity(cleared) == nil
+  end
+
+  test "timer replacement gives the new window a distinct identity and rejects stale delivery" do
+    correlation = RenderCorrelation.new()
+    old_identity = RenderCorrelation.next_timer_identity(correlation)
+    {:scheduled, correlation} = RenderCorrelation.schedule(correlation, old_identity, make_ref())
+
+    cleared = RenderCorrelation.clear_timer(correlation)
+    new_identity = RenderCorrelation.next_timer_identity(cleared)
+    refute new_identity == old_identity
+
+    {:scheduled, replacement} =
+      RenderCorrelation.schedule(cleared, new_identity, make_ref())
+
+    assert {:stale, unchanged} = RenderCorrelation.deliver(replacement, old_identity)
+    assert unchanged == replacement
+    assert RenderCorrelation.scheduled?(unchanged)
+
+    assert {:current, delivered} = RenderCorrelation.deliver(replacement, new_identity)
+    refute RenderCorrelation.scheduled?(delivered)
+  end
+
+  test "Editor callback changes state only for the current timer identity" do
+    state = base_state(backend: :tui, rendering: :disabled)
+    first = MingaEditor.schedule_render(state, 60_000)
+    first_correlation = first.render.render_correlation
+    first_identity = RenderCorrelation.scheduled_identity(first_correlation)
+    first_timer = RenderCorrelation.timer_reference(first_correlation)
+
+    cleared = %{
+      first
+      | render:
+          Render.accept_correlation(
+            first.render,
+            RenderCorrelation.clear_timer(first_correlation)
+          )
+    }
+
+    replacement = MingaEditor.schedule_render(cleared, 60_000)
+    replacement_correlation = replacement.render.render_correlation
+    replacement_identity = RenderCorrelation.scheduled_identity(replacement_correlation)
+    replacement_timer = RenderCorrelation.timer_reference(replacement_correlation)
+
+    on_exit(fn ->
+      Process.cancel_timer(first_timer)
+      Process.cancel_timer(replacement_timer)
+    end)
+
+    stale_message = {:debounced_render, first_identity}
+    send(self(), stale_message)
+    assert_receive ^stale_message
+    assert {:noreply, unchanged} = MingaEditor.handle_info(stale_message, replacement)
+    assert unchanged == replacement
+
+    current_message = {:debounced_render, replacement_identity}
+    send(self(), current_message)
+    assert_receive ^current_message
+    assert {:noreply, delivered} = MingaEditor.handle_info(current_message, replacement)
+    refute RenderCorrelation.scheduled?(delivered.render.render_correlation)
   end
 
   test "frontend readiness and reset require a keyframe without resetting ordering evidence" do
@@ -27,9 +100,9 @@ defmodule MingaEditor.State.RenderCorrelationTest do
 
     ready = RenderCorrelation.frontend_ready(correlation)
     assert RenderCorrelation.force_keyframe?(ready)
-    assert ready.latest_intent_revision == 8
-    assert ready.last_receipt_revision == 7
-    assert ready.last_receipt_seq == 41
+    assert RenderCorrelation.latest_intent_revision(ready) == 8
+    assert RenderCorrelation.last_receipt_revision(ready) == 7
+    assert RenderCorrelation.last_receipt_sequence(ready) == 41
 
     reset = RenderCorrelation.reset(correlation)
     assert reset == ready
@@ -41,8 +114,8 @@ defmodule MingaEditor.State.RenderCorrelationTest do
 
     assert first == 1
     assert second == 2
-    assert correlation.latest_intent_revision == 2
-    assert correlation.last_receipt_revision == 0
+    assert RenderCorrelation.latest_intent_revision(correlation) == 2
+    assert RenderCorrelation.last_receipt_revision(correlation) == 0
   end
 
   test "receipt freshness rejects superseded, duplicate, and out-of-order evidence" do
@@ -94,7 +167,7 @@ defmodule MingaEditor.State.RenderCorrelationTest do
     correlation = %RenderCorrelation{last_receipt_revision: 10, last_receipt_seq: 20}
     correlation = RenderCorrelation.accept_synchronous_receipt(correlation, 8, 19, false)
 
-    assert correlation.last_receipt_revision == 10
-    assert correlation.last_receipt_seq == 20
+    assert RenderCorrelation.last_receipt_revision(correlation) == 10
+    assert RenderCorrelation.last_receipt_sequence(correlation) == 20
   end
 end

--- a/test/minga_editor/state/shell_callbacks_test.exs
+++ b/test/minga_editor/state/shell_callbacks_test.exs
@@ -286,7 +286,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
       # Window should be synced to show buf1 (via on_buffer_died callback)
       win_id = new_state.workspace.windows.active
       window = Map.fetch!(new_state.workspace.windows.map, win_id)
-      assert window.buffer == buf1
+      assert window.content == {:buffer, buf1}
     end
 
     test "tab-less extension shell: preserves agent_chat window content on buffer death" do

--- a/test/minga_editor/state_test.exs
+++ b/test/minga_editor/state_test.exs
@@ -103,25 +103,29 @@ defmodule MingaEditor.StateTest do
       assert added.workspace.buffers.active == buf2
       assert added.workspace.buffers.active_index == 1
       assert added.workspace.buffers.list == [buf1, buf2]
-      assert active_window(added).buffer == buf2
+      assert Content.buffer_pid(active_window(added).content) == buf2
 
       switched = MingaEditor.BufferActivation.activate(added, 0)
       assert switched.workspace.buffers.active == buf1
       assert switched.workspace.buffers.active_index == 0
-      assert active_window(switched).buffer == buf1
+      assert Content.buffer_pid(active_window(switched).content) == buf1
 
       split_state = added |> with_split_window(2, buf2)
       split_switched = MingaEditor.BufferActivation.activate(split_state, 0)
-      assert Map.fetch!(split_switched.workspace.windows.map, 1).buffer == buf1
-      assert Map.fetch!(split_switched.workspace.windows.map, 2).buffer == buf2
+
+      assert Content.buffer_pid(Map.fetch!(split_switched.workspace.windows.map, 1).content) ==
+               buf1
+
+      assert Content.buffer_pid(Map.fetch!(split_switched.workspace.windows.map, 2).content) ==
+               buf2
 
       split_added =
         MingaEditor.Handlers.BufferRegistry.add_buffer(split_state, start_buffer("new file"))
 
-      assert Map.fetch!(split_added.workspace.windows.map, 1).buffer ==
+      assert Content.buffer_pid(Map.fetch!(split_added.workspace.windows.map, 1).content) ==
                split_added.workspace.buffers.active
 
-      assert Map.fetch!(split_added.workspace.windows.map, 2).buffer == buf2
+      assert Content.buffer_pid(Map.fetch!(split_added.workspace.windows.map, 2).content) == buf2
 
       no_window =
         MingaEditor.Handlers.BufferRegistry.add_buffer(new_state(), start_buffer("no window"))
@@ -164,7 +168,7 @@ defmodule MingaEditor.StateTest do
 
       synced = MingaEditor.WindowFocus.remember_active_cursor(state)
 
-      assert active_window(synced).buffer == files_buf
+      assert Content.buffer_pid(active_window(synced).content) == files_buf
       assert active_window(synced).cursor == active_window(state).cursor
     end
   end
@@ -204,7 +208,7 @@ defmodule MingaEditor.StateTest do
       restored = EditorState.restore_tab_context(state, context)
 
       assert restored.workspace.buffers.active == file_buf
-      assert active_window(restored).buffer == file_buf
+      assert Content.buffer_pid(active_window(restored).content) == file_buf
       assert Content.buffer_pid(active_window(restored).content) == file_buf
     end
   end
@@ -219,7 +223,7 @@ defmodule MingaEditor.StateTest do
           notify_shell?: false
         )
 
-      assert active_window(unchanged).buffer == buf1
+      assert Content.buffer_pid(active_window(unchanged).content) == buf1
       assert active_window(unchanged).content == active_window(state).content
 
       buf2 = start_buffer("world")
@@ -235,7 +239,7 @@ defmodule MingaEditor.StateTest do
           notify_shell?: false
         )
 
-      assert active_window(synced).buffer == buf2
+      assert Content.buffer_pid(active_window(synced).content) == buf2
       assert Content.buffer?(active_window(synced).content)
       assert Content.buffer_pid(active_window(synced).content) == buf2
 
@@ -256,7 +260,7 @@ defmodule MingaEditor.StateTest do
           notify_shell?: false
         )
 
-      assert active_window(synced_agent).buffer == nil
+      assert Content.buffer_pid(active_window(synced_agent).content) == nil
       assert Content.agent_chat?(active_window(synced_agent).content)
     end
 
@@ -270,7 +274,7 @@ defmodule MingaEditor.StateTest do
 
       assert active_tab.kind == :file
       assert new_state.workspace.keymap_scope == :editor
-      assert active_window.buffer == file_buf
+      assert Content.buffer_pid(active_window.content) == file_buf
       assert Content.buffer?(active_window.content)
       refute Content.agent_chat?(active_window.content)
       assert Content.buffer?(tab_window.content)

--- a/test/minga_editor/window/content_test.exs
+++ b/test/minga_editor/window/content_test.exs
@@ -76,26 +76,26 @@ defmodule MingaEditor.Window.ContentTest do
     end
   end
 
-  describe "Window.new sets content field" do
-    test "new/4 sets both content and buffer" do
+  describe "Window content identity" do
+    test "new/4 stores the buffer only in content" do
       pid = self()
       window = Window.new(1, pid, 24, 80)
       assert window.content == {:buffer, pid}
-      assert window.buffer == pid
+      refute Map.has_key?(window, :buffer)
     end
 
-    test "new/5 sets both content and buffer" do
+    test "new/5 stores the buffer only in content" do
       pid = self()
       window = Window.new(1, pid, 24, 80, {5, 10})
       assert window.content == {:buffer, pid}
-      assert window.buffer == pid
+      refute Map.has_key?(window, :buffer)
       assert window.cursor == {5, 10}
     end
 
-    test "new_agent_chat/3 sets semantic agent chat content without a buffer" do
+    test "new_agent_chat/3 stores semantic agent chat content without a buffer field" do
       window = Window.new_agent_chat(1, 24, 80)
       assert window.content == {:agent_chat, :semantic}
-      assert window.buffer == nil
+      refute Map.has_key?(window, :buffer)
       assert Content.agent_chat?(window.content)
       refute Content.buffer?(window.content)
     end

--- a/test/minga_editor/window_focus_test.exs
+++ b/test/minga_editor/window_focus_test.exs
@@ -4,6 +4,8 @@ defmodule MingaEditor.WindowFocusTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.BottomPanel
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Windows
@@ -95,6 +97,25 @@ defmodule MingaEditor.WindowFocusTest do
     refute BottomPanel.focused?(EditorState.bottom_panel(focused))
   end
 
+  test "active-shell blur dispatches through an alternate shell contract" do
+    state = base_state()
+
+    entry =
+      Entry.builtin!(
+        :fake,
+        MingaEditor.Test.FakeShell,
+        "Fake",
+        "Focus contract test shell",
+        false
+      )
+
+    state = %{state | shell_runtime: Runtime.new(entry, %{events: []})}
+    focused = WindowFocus.focus(state, state.workspace.windows.active)
+
+    assert Runtime.state(focused.shell_runtime).events == [:bottom_panel_blurred]
+    assert focused.workspace == state.workspace
+  end
+
   test "focusing the active window only blurs Traditional bottom-panel presentation" do
     state = base_state()
     panel = %BottomPanel{} |> BottomPanel.show() |> BottomPanel.focus()
@@ -136,6 +157,26 @@ defmodule MingaEditor.WindowFocusTest do
     assert_receive {:DOWN, ^monitor, :process, ^first_buffer, :normal}
 
     assert WindowFocus.focus(state, 2) == state
+  end
+
+  test "cursor-source mismatch returns a focused failure and leaves state unchanged" do
+    {state, _first_buffer, second_buffer} = split_state()
+
+    mismatched = %{
+      state
+      | workspace:
+          SessionState.set_buffers(state.workspace, Buffers.switch_to(state.workspace.buffers, 1))
+    }
+
+    assert WindowFocus.focus_result(mismatched, 2) ==
+             {:error, :cursor_source_mismatch}
+
+    assert WindowFocus.focus(mismatched, 2) == mismatched
+
+    assert WindowFocus.remember_active_cursor_result(mismatched) ==
+             {:error, :cursor_source_mismatch}
+
+    assert BufferProcess.cursor(second_buffer) == {0, 1}
   end
 
   test "active cursor snapshots require a matching live buffer window" do

--- a/test/minga_editor/window_test.exs
+++ b/test/minga_editor/window_test.exs
@@ -46,7 +46,7 @@ defmodule MingaEditor.WindowTest do
 
       assert observed.viewport == viewport
       assert observed.render_cache == RenderCache.new(5, 3, 7, 11, 42)
-      assert observed.buffer == window.buffer
+      assert observed.content == window.content
       assert observed.fold_map == window.fold_map
     end
   end

--- a/test/minga_editor/window_textobject_test.exs
+++ b/test/minga_editor/window_textobject_test.exs
@@ -14,7 +14,6 @@ defmodule MingaEditor.WindowTextobjectTest do
     %Window{
       id: 1,
       content: Content.buffer(pid),
-      buffer: pid,
       viewport: Viewport.new(24, 80),
       textobject_positions: positions
     }

--- a/test/support/conformance_case.ex
+++ b/test/support/conformance_case.ex
@@ -459,16 +459,16 @@ defmodule Minga.Test.ConformanceCase do
           MingaEditor.Window.id(),
           {non_neg_integer(), non_neg_integer()} | WindowTree.rect()
         ) :: minga_window_info()
-  defp window_to_info(win, active_id, position) do
+  defp window_to_info(%{content: {:buffer, buffer}} = win, active_id, position) do
     first_line =
-      win.buffer
+      buffer
       |> BufferProcess.content()
       |> String.split("\n", parts: 2)
       |> hd()
 
     cursor =
       if win.id == active_id do
-        BufferProcess.cursor(win.buffer)
+        BufferProcess.cursor(buffer)
       else
         win.cursor
       end

--- a/test/support/fake_shell.ex
+++ b/test/support/fake_shell.ex
@@ -46,6 +46,12 @@ defmodule MingaEditor.Test.FakeShell do
     do: %{overlay: [], surface: [MingaEditor.Test.FakeShellInput]}
 
   @impl true
+  @spec blur_bottom_panel(map()) :: map()
+  def blur_bottom_panel(shell_state) do
+    Map.update(shell_state, :events, [:bottom_panel_blurred], &[:bottom_panel_blurred | &1])
+  end
+
+  @impl true
   @spec handle_event(map(), MingaEditor.Session.State.t(), term()) ::
           {map(), MingaEditor.Session.State.t()}
   def handle_event(_shell_state, workspace, {:replace_test_state, replacement})

--- a/test/support/fake_shell_alt.ex
+++ b/test/support/fake_shell_alt.ex
@@ -47,6 +47,12 @@ defmodule MingaEditor.Test.FakeShellAlt do
   def input_handlers(_editor_state), do: %{overlay: [], surface: []}
 
   @impl true
+  @spec blur_bottom_panel(map()) :: map()
+  def blur_bottom_panel(shell_state) do
+    Map.update(shell_state, :events, [:bottom_panel_blurred], &[:bottom_panel_blurred | &1])
+  end
+
+  @impl true
   @spec handle_event(map(), MingaEditor.Session.State.t(), term()) ::
           {map(), MingaEditor.Session.State.t()}
   def handle_event(_shell_state, workspace, {:replace_test_state, replacement})


### PR DESCRIPTION
# TL;DR

Render debounce delivery is now correlated to the timer window that owns it, and focus transitions reject stale or mismatched buffer ownership. Window state now has one buffer identity, shell-owned panel blur stays behind the shell contract, and buffer indexes wrap accurately in both directions.

Closes #2915

## Context

This is the ready-now timer and focus ownership slice of #2914. It preserves one Editor GenServer and the 16-value root while making stale timer delivery harmless and removing the duplicate buffer identity that could drift between a window and its semantic content.

## Changes

- Add monotonic semantic render-window identities, carry them in debounce messages, and reject delivery that no longer owns the scheduled window.
- Expose render-correlation values as opaque state with owner APIs and accessors that remain clean under Dialyzer.
- Return focused window-transition failures for missing windows, dead buffers, and outgoing-window/active-buffer mismatches without mutating state.
- Route bottom-panel blur through the active shell implementation instead of coupling generic focus workflow code to Traditional state.
- Remove duplicate `buffer` fields from Editor windows, render windows, and render intents; derive the authoritative buffer from tagged window content across input, rendering, mouse, layout, and test helpers.
- Accept every integer in `Buffers.switch_to/2` and use modulo wraparound for negative and positive indexes.
- Add deterministic timer replacement, stale delivery, cursor mismatch, alternate-shell blur, content identity, and index-boundary coverage without sleeps.

## Verification

Validated commit `6e57a5dd6704f654b2fda12f2f80bff445dcadae`:

- `make lint`: passed with Credo clean, compilation clean, and incremental Dialyzer at 0 errors.
- `mix test.llm`: 9,441 tests, 97 properties, and 58 doctests passed with 0 failures; 1 test skipped.
- Focused changed-area suite: 203 tests and 1 property passed.
- Focused migration regressions: renderer/mouse 38 tests, picker/extension/ingest 36 tests, and window builder 33 tests passed.
- `bash scripts/bench_keystroke_latency_ab origin/main HEAD`: all blocking latency budgets within limits across four base and HEAD rounds.
- `git diff --check`: passed.
- Final acceptance reviewer: PASS.
- Frontend-specific checks are not applicable because no Swift, Go, or Zig files changed.

## Acceptance Criteria Addressed

- Only the current render debounce identity can trigger and clear its scheduled render window. ✅
- Render-correlation identity and state are explicit and opaque. ✅
- Focus snapshots only the outgoing window's owned buffer and reports mismatches without mutation. ✅
- Bottom-panel blur dispatches through the active shell contract. ✅
- Window buffer identity is singular, and buffer index wraparound contracts are accurate. ✅
- Editing, rendering, shells, popup and split focus, and frontend behavior remain compatible. ✅
- Deterministic tests cover stale timers, replacement, mismatches, alternate shells, and index boundaries. ✅
