### PR TITLE
test(macos): enforce Observation architecture

### DIFF
--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -210,6 +210,7 @@
 		A4F18CE5271CF85A08AFB06F /* ObservatoryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B23834E6FEB75E891AAFE2 /* ObservatoryState.swift */; };
 		A4F2EB67F3AC15AD8F8DAB32 /* SearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6104336F33C41EBE21B10F6 /* SearchState.swift */; };
 		A5ABF2822747A306951D59AE /* MingaProtocol.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; };
+		A5D751F67D30FAD01858C3E5 /* GUIObservationGuardrailTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0028682767B3EA94AB2CA62 /* GUIObservationGuardrailTests.swift */; };
 		A6327C6FAB3DCFD57327FBF4 /* DecoderRobustnessTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57B35E8311966948B1BA7AEF /* DecoderRobustnessTests.swift */; };
 		A78FBA1CD5BB02EEBA8ACB45 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
 		A7D247B53DE01DC5F375E228 /* FileTreeHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51E88C12915EC4EBE96165AF /* FileTreeHeaderView.swift */; };
@@ -575,6 +576,7 @@
 		A87246A39436BB38B41100F9 /* TextHighlighting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextHighlighting.swift; sourceTree = "<group>"; };
 		A915C3108F2370C753A1931B /* ProtocolErrorState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolErrorState.swift; sourceTree = "<group>"; };
 		AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MouseInputTests.swift; sourceTree = "<group>"; };
+		B0028682767B3EA94AB2CA62 /* GUIObservationGuardrailTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIObservationGuardrailTests.swift; sourceTree = "<group>"; };
 		B0D44A3A14F416969E64AA15 /* SidebarHeaderButton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarHeaderButton.swift; sourceTree = "<group>"; };
 		B4867C8EE01AF6ACFB27DB7C /* MessagesContentStateTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessagesContentStateTests.swift; sourceTree = "<group>"; };
 		B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PowerThermalPolicy.swift; sourceTree = "<group>"; };
@@ -1062,6 +1064,7 @@
 				754C68BAFE0C4DB553BFD06A /* GUIChromeDecoderTests.swift */,
 				485DB41F09E703BBC203DBD0 /* GUIFrameRoutingAndMetricsTests.swift */,
 				510D1033E87B077777E8FD64 /* GUIFrameSwiftUIInvalidationTests.swift */,
+				B0028682767B3EA94AB2CA62 /* GUIObservationGuardrailTests.swift */,
 				F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */,
 				7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */,
 				DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */,
@@ -1648,6 +1651,7 @@
 				30E31170A79F30413D15D858 /* GUIChromeDecoderTests.swift in Sources */,
 				CD0AC714E46D3F95FE9AAE6F /* GUIFrameRoutingAndMetricsTests.swift in Sources */,
 				4D276F4F3C0C19A3E184D09B /* GUIFrameSwiftUIInvalidationTests.swift in Sources */,
+				A5D751F67D30FAD01858C3E5 /* GUIObservationGuardrailTests.swift in Sources */,
 				312DC4940992B35ED9EE7648 /* IMEComposition.swift in Sources */,
 				1631D7B76B33CD897C48F263 /* IMECompositionTests.swift in Sources */,
 				25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */,

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -156,8 +156,8 @@ final class CommandDispatcher {
     }
 
     /// Returns the committed editor frame waiting for native Metal presentation.
-    func pendingPresentationFrameSeq() -> UInt32? {
-        guiState.presentationMetrics.pendingEditorFrameSeq()
+    func pendingPresentationFrame() -> GUICommittedFrame? {
+        guiState.presentationMetrics.pendingEditorFrame()
     }
 
     /// Discards an applied frame that cannot acquire a drawable/presentation path.

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -348,7 +348,7 @@ final class CoreTextMetalRenderer {
                 contentScale: Float, scrollOffset: SIMD2<Float> = .zero,
                 presentationWindowId: UInt16? = nil,
                 presentationInputSeq: UInt32 = 0,
-                presentationFrameSeq: UInt32? = nil,
+                presentationFrame: GUICommittedFrame? = nil,
                 latencyRecorder: LatencyRecorder? = nil) {
         let renderSignpostID = OSSignpostID(log: renderLog)
         os_signpost(.begin, log: renderLog, name: "Frame", signpostID: renderSignpostID)
@@ -445,7 +445,7 @@ final class CoreTextMetalRenderer {
             recordNativeFailure(NativePresentationFailure(
                 phase: .atlas, dimension: .texture,
                 frameSequence: presentationInputSeq, reason: .unavailable
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
         let candidateConfigurationEpoch = configurationEpoch
@@ -462,7 +462,7 @@ final class CoreTextMetalRenderer {
         case .success:
             break
         case .failure(let failure):
-            recordNativeFailure(failure, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            recordNativeFailure(failure, latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
 
@@ -849,7 +849,7 @@ final class CoreTextMetalRenderer {
 
         if let failure = windowContentRenderer?.nativePresentationFailure ?? candidateAtlas.nativePresentationFailure {
             recordNativeFailure(failure, frameSequence: presentationInputSeq,
-                                latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                                latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
 
@@ -883,13 +883,13 @@ final class CoreTextMetalRenderer {
                 frameSequence: presentationInputSeq
             )
         } catch let failure as NativePresentationFailure {
-            recordNativeFailure(failure, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            recordNativeFailure(failure, latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         } catch {
             recordNativeFailure(NativePresentationFailure(
                 phase: .buffers, dimension: .arithmetic,
                 frameSequence: presentationInputSeq, reason: .overflow
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
         let candidateInstanceBuffer: MTLBuffer?
@@ -899,7 +899,7 @@ final class CoreTextMetalRenderer {
                     phase: .buffers, dimension: .lineBuffer,
                     requested: bufferDemand.lineBytes,
                     frameSequence: presentationInputSeq, reason: .allocation
-                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                 return
             }
             candidateInstanceBuffer = buffer
@@ -916,7 +916,7 @@ final class CoreTextMetalRenderer {
                         phase: .buffers, dimension: dimensions[index],
                         requested: bufferDemand.quadBytesPerBuffer,
                         frameSequence: presentationInputSeq, reason: .allocation
-                    ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                    ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                     return
                 }
                 candidateQuadBuffers.append(buffer)
@@ -930,7 +930,7 @@ final class CoreTextMetalRenderer {
             recordNativeFailure(NativePresentationFailure(
                 phase: .drawable, dimension: .renderTarget,
                 frameSequence: presentationInputSeq, reason: .overflow
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
         let deviceDimensionLimit = nativeDeviceTextureDimensionLimit(device)
@@ -943,7 +943,7 @@ final class CoreTextMetalRenderer {
                 phase: .drawable, dimension: .textureWidth,
                 requested: requested, limit: targetWidthLimit,
                 frameSequence: presentationInputSeq, reason: .limit
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
         guard viewportSize.height <= CGFloat(targetHeightLimit) else {
@@ -953,7 +953,7 @@ final class CoreTextMetalRenderer {
                 phase: .drawable, dimension: .textureHeight,
                 requested: requested, limit: targetHeightLimit,
                 frameSequence: presentationInputSeq, reason: .limit
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
         let targetWidth = Int(viewportSize.width.rounded(.up))
@@ -967,13 +967,13 @@ final class CoreTextMetalRenderer {
                 frameSequence: presentationInputSeq
             )
         } catch let failure as NativePresentationFailure {
-            recordNativeFailure(failure, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            recordNativeFailure(failure, latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         } catch {
             recordNativeFailure(NativePresentationFailure(
                 phase: .drawable, dimension: .arithmetic,
                 frameSequence: presentationInputSeq, reason: .overflow
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
         let targetDescriptor = MTLTextureDescriptor.texture2DDescriptor(
@@ -989,7 +989,7 @@ final class CoreTextMetalRenderer {
                 phase: .drawable, dimension: .renderTarget,
                 requested: targetDemand.byteCount, limit: resourcePolicy.renderTargetBytes,
                 frameSequence: presentationInputSeq, reason: .allocation
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
 
@@ -1004,14 +1004,14 @@ final class CoreTextMetalRenderer {
             recordNativeFailure(NativePresentationFailure(
                 phase: .command, dimension: .commandBuffer,
                 frameSequence: presentationInputSeq, reason: .unavailable
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
         guard let encoder = factories.makeEncoder(cmdBuf, renderDesc) else {
             recordNativeFailure(NativePresentationFailure(
                 phase: .command, dimension: .encoder,
                 frameSequence: presentationInputSeq, reason: .unavailable
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
 
@@ -1456,7 +1456,7 @@ final class CoreTextMetalRenderer {
         if let failure = windowContentRenderer?.nativePresentationFailure ?? candidateAtlas.nativePresentationFailure {
             encoder.endEncoding()
             recordNativeFailure(failure, frameSequence: presentationInputSeq,
-                                latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                                latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
 
@@ -1469,7 +1469,7 @@ final class CoreTextMetalRenderer {
             recordNativeFailure(NativePresentationFailure(
                 phase: .submission, dimension: .submission,
                 frameSequence: presentationInputSeq, reason: .submission
-            ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
 
@@ -1486,7 +1486,7 @@ final class CoreTextMetalRenderer {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .completion, dimension: .completion,
                     frameSequence: presentationInputSeq, reason: .completion
-                ), discardLatency: false, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                ), discardLatency: false, latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                 latencyRecorder?.discard(seq: presentationInputSeq, reason: .gpuFailure)
                 os_signpost(.event, log: renderLog, name: "PresentationDropped", signpostID: renderSignpostID,
                             "input=%{public}u status=%{public}d", presentationInputSeq, status)
@@ -1494,9 +1494,9 @@ final class CoreTextMetalRenderer {
             }
             guard self.configurationEpoch == candidateConfigurationEpoch else {
                 latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
-                if let presentationFrameSeq {
+                if let presentationFrame {
                     self.presentationMetrics?.discard(
-                        domain: .editor, outcome: .superseded, frameSeq: presentationFrameSeq
+                        domain: .editor, outcome: .superseded, frame: presentationFrame
                     )
                 }
                 return
@@ -1505,7 +1505,7 @@ final class CoreTextMetalRenderer {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .drawable, dimension: .drawable,
                     frameSequence: presentationInputSeq, reason: .unavailable
-                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                 return
             }
             guard drawable.texture.width == candidateRenderTarget.width else {
@@ -1513,7 +1513,7 @@ final class CoreTextMetalRenderer {
                     phase: .drawable, dimension: .textureWidth,
                     requested: drawable.texture.width, limit: candidateRenderTarget.width,
                     frameSequence: presentationInputSeq, reason: .mismatch
-                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                 return
             }
             guard drawable.texture.height == candidateRenderTarget.height else {
@@ -1521,28 +1521,28 @@ final class CoreTextMetalRenderer {
                     phase: .drawable, dimension: .textureHeight,
                     requested: drawable.texture.height, limit: candidateRenderTarget.height,
                     frameSequence: presentationInputSeq, reason: .mismatch
-                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                 return
             }
             guard drawable.texture.pixelFormat == candidateRenderTarget.pixelFormat else {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .drawable, dimension: .renderTarget,
                     frameSequence: presentationInputSeq, reason: .mismatch
-                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                 return
             }
             guard let presentationBuffer = self.factories.makeCommandBuffer(self.commandQueue) else {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .command, dimension: .presentationCommandBuffer,
                     frameSequence: presentationInputSeq, reason: .unavailable
-                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                 return
             }
             guard let blit = self.factories.makeBlitEncoder(presentationBuffer) else {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .command, dimension: .presentationEncoder,
                     frameSequence: presentationInputSeq, reason: .unavailable
-                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                 return
             }
             blit.copy(
@@ -1562,7 +1562,7 @@ final class CoreTextMetalRenderer {
                 self.recordNativeFailure(NativePresentationFailure(
                     phase: .submission, dimension: .presentationCopy,
                     frameSequence: presentationInputSeq, reason: .submission
-                ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                 return
             }
 
@@ -1572,16 +1572,16 @@ final class CoreTextMetalRenderer {
                     self.recordNativeFailure(NativePresentationFailure(
                         phase: .completion, dimension: .presentationCopy,
                         frameSequence: presentationInputSeq, reason: .completion
-                    ), discardLatency: false, latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                    ), discardLatency: false, latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                     latencyRecorder?.discard(seq: presentationInputSeq, reason: .gpuFailure)
                     return
                 }
                 guard self.configurationEpoch == candidateConfigurationEpoch,
                       generation > self.presentationGeneration.completed else {
                     latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
-                    if let presentationFrameSeq {
+                    if let presentationFrame {
                         self.presentationMetrics?.discard(
-                            domain: .editor, outcome: .superseded, frameSeq: presentationFrameSeq
+                            domain: .editor, outcome: .superseded, frame: presentationFrame
                         )
                     }
                     return
@@ -1592,14 +1592,14 @@ final class CoreTextMetalRenderer {
                     self.recordNativeFailure(NativePresentationFailure(
                         phase: .submission, dimension: .drawable,
                         frameSequence: presentationInputSeq, reason: .submission
-                    ), latencyRecorder: latencyRecorder, presentationFrameSeq: presentationFrameSeq)
+                    ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
                     return
                 }
                 guard self.presentationGeneration.complete(generation) else {
                     latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
-                    if let presentationFrameSeq {
+                    if let presentationFrame {
                         self.presentationMetrics?.discard(
-                            domain: .editor, outcome: .superseded, frameSeq: presentationFrameSeq
+                            domain: .editor, outcome: .superseded, frame: presentationFrame
                         )
                     }
                     return
@@ -1614,20 +1614,20 @@ final class CoreTextMetalRenderer {
                 self.quadBufferCapacity = candidateQuadCapacity
                 self.lastCompletedPresentationGeneration = generation
                 latencyRecorder?.markPresented(seq: presentationInputSeq)
-                if let presentationFrameSeq {
-                    self.presentationMetrics?.recordMetalPresented(frameSeq: presentationFrameSeq)
+                if let presentationFrame {
+                    self.presentationMetrics?.recordMetalPresented(presentationFrame: presentationFrame)
                 }
                 os_signpost(.event, log: renderLog, name: "PresentationComplete",
                             signpostID: renderSignpostID,
                             "input=%{public}u", presentationInputSeq)
             }
             presentationBuffer.commit()
-            if let presentationFrameSeq {
-                self.presentationMetrics?.recordMetalSubmission(frameSeq: presentationFrameSeq)
+            if let presentationFrame {
+                self.presentationMetrics?.recordMetalSubmission(presentationFrame: presentationFrame)
             }
             os_signpost(.event, log: renderLog, name: "MetalPresentationSubmit", signpostID: renderSignpostID,
                         "input=%{public}u frame=%{public}u", presentationInputSeq,
-                        presentationFrameSeq ?? 0)
+                        presentationFrame?.frameSeq ?? 0)
         }
         cmdBuf.commit()
         latencyRecorder?.markSubmitted(seq: presentationInputSeq)
@@ -1653,7 +1653,7 @@ final class CoreTextMetalRenderer {
         frameSequence: UInt32? = nil,
         discardLatency: Bool = true,
         latencyRecorder: LatencyRecorder?,
-        presentationFrameSeq: UInt32? = nil
+        presentationFrame: GUICommittedFrame? = nil
     ) {
         let recorded = NativePresentationFailure(
             phase: failure.phase,
@@ -1668,11 +1668,11 @@ final class CoreTextMetalRenderer {
         if discardLatency {
             latencyRecorder?.discard(seq: recorded.frameSequence, reason: .nativeResourceFailure)
         }
-        if let presentationFrameSeq {
+        if let presentationFrame {
             let outcome: GUIFramePresentationMetrics.Outcome =
                 recorded.reason == .unavailable ? .unavailable : .failed
             presentationMetrics?.discard(
-                domain: .editor, outcome: outcome, frameSeq: presentationFrameSeq
+                domain: .editor, outcome: outcome, frame: presentationFrame
             )
         }
     }

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -574,7 +574,7 @@ final class EditorNSView: MTKView {
         let validMouseInGutter = isMouseInGutter && validGutterHoverWindowId != nil
         let cursorAnimationGeneration = coreTextRenderer.cursorAnimationGeneration
         let presentationInputSeq = dispatcher.takePresentationInputSeq()
-        let presentationFrameSeq = dispatcher.pendingPresentationFrameSeq()
+        let presentationFrame = dispatcher.pendingPresentationFrame()
         let localScrollPresentation = localScrollPresentation
         coreTextRenderer.render(frameState: fs, fontManager: fontManager,
                                 cursorBlinkVisible: cursorBlinkVisible,
@@ -598,7 +598,7 @@ final class EditorNSView: MTKView {
                                 ),
                                 presentationWindowId: localScrollPresentation?.windowId,
                                 presentationInputSeq: presentationInputSeq,
-                                presentationFrameSeq: presentationFrameSeq,
+                                presentationFrame: presentationFrame,
                                 latencyRecorder: dispatcher.latency)
         if coreTextRenderer.cursorAnimationGeneration != cursorAnimationGeneration {
             resetCursorBlink()

--- a/macos/Sources/Views/Overlays/MessagesContentView.swift
+++ b/macos/Sources/Views/Overlays/MessagesContentView.swift
@@ -17,7 +17,7 @@ public struct MessagesContentView: View {
         self.encoder = encoder
         self.usesPreviewEagerLayout = usesPreviewEagerLayout
     }
-    @Bindable public var state: MessagesContentState
+    public let state: MessagesContentState
     @Environment(\.themeColors) private var theme
 
     public let encoder: InputEncoder?

--- a/macos/Sources/Views/Shared/GUIFramePresentationMetrics.swift
+++ b/macos/Sources/Views/Shared/GUIFramePresentationMetrics.swift
@@ -48,8 +48,8 @@ public final class GUIFramePresentationMetrics {
     }
 
     /// Returns the committed editor frame currently waiting for Metal submission.
-    public func pendingEditorFrameSeq() -> UInt32? {
-        pending[.editor]?.frame.frameSeq
+    public func pendingEditorFrame() -> GUICommittedFrame? {
+        pending[.editor]?.frame
     }
 
     /// Returns the committed identity currently awaiting presentation in one domain.
@@ -78,8 +78,8 @@ public final class GUIFramePresentationMetrics {
 
     /// Records native submission only after `MTLCommandBuffer.commit()` returned.
     /// The ticket stays pending until drawable presentation succeeds or is discarded.
-    public func recordMetalSubmission(frameSeq: UInt32) {
-        guard var ticket = pending[.editor], ticket.frame.frameSeq == frameSeq,
+    public func recordMetalSubmission(presentationFrame: GUICommittedFrame) {
+        guard var ticket = pending[.editor], ticket.frame == presentationFrame,
               !ticket.submitted else { return }
         ticket.submitted = true
         pending[.editor] = ticket
@@ -87,8 +87,8 @@ public final class GUIFramePresentationMetrics {
     }
 
     /// Resolves the resident editor after its drawable was presented successfully.
-    public func recordMetalPresented(frameSeq: UInt32) {
-        guard let ticket = pending[.editor], ticket.frame.frameSeq == frameSeq else { return }
+    public func recordMetalPresented(presentationFrame: GUICommittedFrame) {
+        guard let ticket = pending[.editor], ticket.frame == presentationFrame else { return }
         pending.removeValue(forKey: .editor)
         record(frame: ticket.frame, domain: .editor, outcome: .presented, started: ticket.started)
     }
@@ -97,12 +97,6 @@ public final class GUIFramePresentationMetrics {
     public func discard(domain: GUIFrameImpact, outcome: Outcome, frame: GUICommittedFrame? = nil) {
         guard outcome == .superseded || outcome == .hidden || outcome == .unavailable || outcome == .failed,
               let ticket = pending[domain], frame == nil || ticket.frame == frame else { return }
-        resolveDiscard(domain: domain, ticket: ticket, outcome: outcome)
-    }
-
-    /// Resolves an editor ticket from renderer code that carries the committed frame sequence.
-    public func discard(domain: GUIFrameImpact, outcome: Outcome, frameSeq: UInt32) {
-        guard let ticket = pending[domain], ticket.frame.frameSeq == frameSeq else { return }
         resolveDiscard(domain: domain, ticket: ticket, outcome: outcome)
     }
 

--- a/macos/Tests/MingaTests/GUIFrameRoutingAndMetricsTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameRoutingAndMetricsTests.swift
@@ -171,8 +171,66 @@ struct GUIFramePresentationMetricsTests {
         ])
     }
 
+    @Test("reused frame sequences cannot resolve across BEAM generations")
+    @MainActor func reusedFrameSequencesStayGenerationCorrelated() throws {
+        let metrics = GUIFramePresentationMetrics()
+        let stale = GUICommittedFrame(generation: 1, frameSeq: 30)
+        let current = GUICommittedFrame(generation: 2, frameSeq: 30)
+
+        metrics.beginCommitted(frame: stale, impact: .editor)
+        let capturedStale = try #require(metrics.pendingEditorFrame())
+        metrics.beginCommitted(frame: current, impact: .editor)
+        let capturedCurrent = try #require(metrics.pendingEditorFrame())
+
+        metrics.recordMetalSubmission(presentationFrame: capturedStale)
+        metrics.recordMetalPresented(presentationFrame: capturedStale)
+        metrics.discard(domain: .editor, outcome: .failed, frame: capturedStale)
+        #expect(metrics.snapshot() == [
+            .init(frame: stale, domain: .editor, outcome: .superseded)
+        ])
+
+        metrics.recordMetalSubmission(presentationFrame: capturedCurrent)
+        metrics.recordMetalPresented(presentationFrame: capturedCurrent)
+        #expect(metrics.snapshot() == [
+            .init(frame: stale, domain: .editor, outcome: .superseded),
+            .init(frame: current, domain: .editor, outcome: .submitted),
+            .init(frame: current, domain: .editor, outcome: .presented)
+        ])
+    }
+
     @Test("successful native draw and Metal milestones keep committed frame identity")
     @MainActor func successfulOutcomes() throws {
+        let frame = GUICommittedFrame(generation: 2, frameSeq: 8)
+        #expect(try successfulOutcomeSamples() == [
+            .init(frame: frame, domain: .shell, outcome: .nativeDraw),
+            .init(frame: frame, domain: .editorOverlay, outcome: .nativeDraw),
+            .init(frame: frame, domain: .windowOverlay, outcome: .nativeDraw),
+            .init(frame: frame, domain: .editor, outcome: .submitted),
+            .init(frame: frame, domain: .editor, outcome: .presented)
+        ])
+    }
+
+    @Test("superseded hidden unavailable and failed samples remain distinct")
+    @MainActor func discardedOutcomes() {
+        let first = GUICommittedFrame(generation: 1, frameSeq: 1)
+        let second = GUICommittedFrame(generation: 1, frameSeq: 2)
+        #expect(discardedOutcomeSamples() == [
+            .init(frame: first, domain: .shell, outcome: .superseded),
+            .init(frame: second, domain: .shell, outcome: .hidden),
+            .init(frame: first, domain: .editor, outcome: .unavailable),
+            .init(frame: first, domain: .editorOverlay, outcome: .failed),
+            .init(frame: first, domain: .windowOverlay, outcome: .superseded)
+        ])
+    }
+
+    @Test("exercised metrics outcomes exactly match the declared outcome cases")
+    @MainActor func outcomeCoverageIsExhaustive() throws {
+        let exercised = Set((try successfulOutcomeSamples() + discardedOutcomeSamples()).map(\.outcome))
+        #expect(exercised == Set(GUIFramePresentationMetrics.Outcome.allCases))
+    }
+
+    @MainActor
+    private func successfulOutcomeSamples() throws -> [GUIFramePresentationMetrics.Sample] {
         let metrics = GUIFramePresentationMetrics()
         let frame = GUICommittedFrame(generation: 2, frameSeq: 8)
 
@@ -185,40 +243,28 @@ struct GUIFramePresentationMetricsTests {
         metrics.recordNativeDraw(domain: .shell, expectedFrame: shell)
         metrics.recordNativeDraw(domain: .editorOverlay, expectedFrame: editorOverlay)
         metrics.recordNativeDraw(domain: .windowOverlay, expectedFrame: windowOverlay)
-        metrics.recordMetalSubmission(frameSeq: 7)
+        metrics.recordMetalSubmission(
+            presentationFrame: GUICommittedFrame(generation: 1, frameSeq: frame.frameSeq)
+        )
         #expect(metrics.snapshot().count == 3)
 
-        metrics.recordMetalSubmission(frameSeq: 8)
-        metrics.recordMetalPresented(frameSeq: 8)
-
-        #expect(metrics.snapshot() == [
-            .init(frame: frame, domain: .shell, outcome: .nativeDraw),
-            .init(frame: frame, domain: .editorOverlay, outcome: .nativeDraw),
-            .init(frame: frame, domain: .windowOverlay, outcome: .nativeDraw),
-            .init(frame: frame, domain: .editor, outcome: .submitted),
-            .init(frame: frame, domain: .editor, outcome: .presented)
-        ])
+        metrics.recordMetalSubmission(presentationFrame: frame)
+        metrics.recordMetalPresented(presentationFrame: frame)
+        return metrics.snapshot()
     }
 
-    @Test("superseded hidden unavailable and failed samples remain distinct")
-    @MainActor func discardedOutcomes() {
+    @MainActor
+    private func discardedOutcomeSamples() -> [GUIFramePresentationMetrics.Sample] {
         let metrics = GUIFramePresentationMetrics()
         let first = GUICommittedFrame(generation: 1, frameSeq: 1)
         let second = GUICommittedFrame(generation: 1, frameSeq: 2)
 
         metrics.beginCommitted(frame: first, impact: .all)
         metrics.beginCommitted(frame: second, impact: .shell)
-        metrics.discard(domain: .shell, outcome: .hidden, frameSeq: 2)
-        metrics.discard(domain: .editor, outcome: .unavailable, frameSeq: 1)
-        metrics.discard(domain: .editorOverlay, outcome: .failed, frameSeq: 1)
-        metrics.discard(domain: .windowOverlay, outcome: .superseded, frameSeq: 1)
-
-        #expect(metrics.snapshot() == [
-            .init(frame: first, domain: .shell, outcome: .superseded),
-            .init(frame: second, domain: .shell, outcome: .hidden),
-            .init(frame: first, domain: .editor, outcome: .unavailable),
-            .init(frame: first, domain: .editorOverlay, outcome: .failed),
-            .init(frame: first, domain: .windowOverlay, outcome: .superseded)
-        ])
+        metrics.discard(domain: .shell, outcome: .hidden, frame: second)
+        metrics.discard(domain: .editor, outcome: .unavailable, frame: first)
+        metrics.discard(domain: .editorOverlay, outcome: .failed, frame: first)
+        metrics.discard(domain: .windowOverlay, outcome: .superseded, frame: first)
+        return metrics.snapshot()
     }
 }

--- a/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
@@ -980,7 +980,8 @@ struct GUIFrameSwiftUIInvalidationTests {
             "@ObservationIgnored private var decoders: [String: Decoder] = [:]": "decoder",
             "@ObservationIgnored private var viewBuilders: [String: ViewBuilder] = [:]": "builder",
         ]
-        let allowedIgnoredReasons: Set<String> = ["task", "callback", "clock", "cache", "decoder", "builder", "metrics"]
+        let allowedIgnoredReasons: Set<String> = ["task", "callback", "clock", "cache", "decoder", "builder"]
+        #expect(owners.count == 31)
         #expect(Set(owners.flatMap(\.ignored)) == Set(ignoredReasons.keys))
         #expect(Set(ignoredReasons.values).isSubset(of: allowedIgnoredReasons))
 
@@ -1016,6 +1017,8 @@ struct GUIFrameSwiftUIInvalidationTests {
         let guiStateStart = try #require(guiState.range(of: guiStateDeclaration))
         let themeBackingSource = guiState[themeBackingStart.lowerBound..<windowBackingStart.lowerBound]
         let windowBackingSource = guiState[windowBackingStart.lowerBound..<guiStateStart.lowerBound]
+        #expect(themeBackingSource.contains("var current = ThemeColors()"))
+        #expect(windowBackingSource.contains("var current: [UInt16: GUIWindowContent]"))
         #expect(!themeBackingSource.contains("@ObservationIgnored"))
         #expect(!windowBackingSource.contains("@ObservationIgnored"))
         #expect(!feedbackState.contains("onPresentationChanged"))

--- a/macos/Tests/MingaTests/GUIObservationGuardrailTests.swift
+++ b/macos/Tests/MingaTests/GUIObservationGuardrailTests.swift
@@ -1,0 +1,653 @@
+import Foundation
+import Testing
+
+@Suite("GUI Observation source guardrails")
+struct GUIObservationGuardrailTests {
+    private struct ProductionSource {
+        let path: String
+        let contents: String
+        let sanitized: String
+    }
+
+    private static let bannedTerms: Set<String> = [
+        "GUIFrameVersion",
+        "GUIFrameVersions",
+        "GUIFrameChannel",
+        "GUIFrameStore",
+        "guiFrameVersion",
+        "frameStore",
+        "publishLocalIfChanged",
+        "ObservableObject",
+        "objectWillChange",
+        "ObservationRegistrar",
+    ]
+
+    /// Every production `@Observable` type is classified here.
+    private static let observationTypeAllowlist: [String: String] = [
+        "Sources/AppState.swift#AppState": "application-owned observable state",
+        "Sources/Extensions/FrontendExtensionRuntime.swift#FrontendExtensionRuntimeRegistry": "extension registry observable state",
+        "Sources/Views/Agent/AgentChatState.swift#AgentChatState": "protocol presentation owner",
+        "Sources/Views/Agent/AgentContextBarState.swift#AgentContextBarState": "protocol presentation owner",
+        "Sources/Views/EditorChrome/BottomPanelState.swift#BottomPanelState": "protocol presentation owner",
+        "Sources/Views/EditorChrome/BreadcrumbBar.swift#BreadcrumbState": "protocol presentation owner",
+        "Sources/Views/EditorChrome/EmptyStateState.swift#EmptyStateState": "protocol presentation owner",
+        "Sources/Views/EditorChrome/FeedbackState.swift#FeedbackState": "protocol presentation owner",
+        "Sources/Views/EditorChrome/SearchState.swift#SearchState": "protocol presentation owner",
+        "Sources/Views/EditorChrome/StatusBarState.swift#StatusBarState": "protocol presentation owner",
+        "Sources/Views/EditorChrome/TabBarState.swift#TabBarState": "protocol presentation owner",
+        "Sources/Views/EditorChrome/WorkspaceState.swift#WorkspaceState": "protocol presentation owner",
+        "Sources/Views/Extensions/ExtensionOverlayState.swift#ExtensionOverlayState": "protocol presentation owner",
+        "Sources/Views/Extensions/ExtensionPanelState.swift#ExtensionPanelState": "protocol presentation owner",
+        "Sources/Views/Extensions/ToolManagerState.swift#ToolManagerState": "protocol presentation owner",
+        "Sources/Views/Overlays/CompletionState.swift#CompletionState": "protocol presentation owner",
+        "Sources/Views/Overlays/FloatPopupState.swift#FloatPopupState": "protocol presentation owner",
+        "Sources/Views/Overlays/HoverPopupState.swift#HoverPopupState": "protocol presentation owner",
+        "Sources/Views/Overlays/LatencyHUDState.swift#LatencyHUDState": "local diagnostics observable state",
+        "Sources/Views/Overlays/MessagesContentState.swift#MessagesContentState": "protocol presentation owner",
+        "Sources/Views/Overlays/MinibufferState.swift#MinibufferState": "protocol presentation owner",
+        "Sources/Views/Overlays/NotificationCenterState.swift#NotificationCenterState": "protocol presentation owner",
+        "Sources/Views/Overlays/PickerState.swift#PickerState": "protocol presentation owner",
+        "Sources/Views/Overlays/ProtocolErrorState.swift#ProtocolErrorState": "protocol presentation owner",
+        "Sources/Views/Overlays/ResyncState.swift#ResyncState": "protocol presentation owner",
+        "Sources/Views/Overlays/SignatureHelpState.swift#SignatureHelpState": "protocol presentation owner",
+        "Sources/Views/Overlays/WhichKeyState.swift#WhichKeyState": "protocol presentation owner",
+        "Sources/Views/Settings/SettingsState.swift#SettingsState": "settings observable state",
+        "Sources/Views/Shared/EditTimelineState.swift#EditTimelineState": "protocol presentation owner",
+        "Sources/Views/Shared/GUIFramePresentationMetrics.swift#GUIFramePresentationMetrics": "observable native correlation tickets",
+        "Sources/Views/Shared/GUIState.swift#GUIThemeBacking": "observable theme backing",
+        "Sources/Views/Shared/GUIState.swift#GUIWindowContentBacking": "observable resident-window backing",
+        "Sources/Views/Shared/GUIState.swift#GUIState": "aggregate observable state",
+        "Sources/Views/Shared/ThemeColors.swift#ThemeColors": "observable theme slots",
+        "Sources/Views/Sidebar/ChangeSummaryState.swift#ChangeSummaryState": "protocol presentation owner",
+        "Sources/Views/Sidebar/FileTreeState.swift#FileTreeState": "protocol presentation owner",
+        "Sources/Views/Sidebar/GitStatusState.swift#GitStatusState": "protocol presentation owner",
+        "Sources/Views/Sidebar/ObservatoryState.swift#ObservatoryState": "protocol presentation owner",
+        "Sources/Views/Sidebar/SidebarHostState.swift#SidebarHostState": "protocol presentation owner",
+    ]
+
+    /// Path-qualified declarations make both a new ignored owner and a new ignored rendered field fail.
+    private static let ignoredDeclarationAllowlist: [String: String] = [
+        "Sources/Extensions/FrontendExtensionRuntime.swift: @ObservationIgnored private var decoders: [String: Decoder] = [:]": "decoder registry storage, not rendered state",
+        "Sources/Extensions/FrontendExtensionRuntime.swift: @ObservationIgnored private var viewBuilders: [String: ViewBuilder] = [:]": "view-builder registry storage, not rendered state",
+        "Sources/Views/Agent/AgentChatState.swift: @ObservationIgnored private var hasTranscript: Bool = false": "protocol readiness cache, not rendered state",
+        "Sources/Views/EditorChrome/FeedbackState.swift: @ObservationIgnored private var holdTask: Task<Void, Never>?": "task lifecycle handle, not rendered state",
+        "Sources/Views/EditorChrome/FeedbackState.swift: @ObservationIgnored private var lastMessage = \"\"": "feedback timing cache; rendered fields remain observed",
+        "Sources/Views/EditorChrome/FeedbackState.swift: @ObservationIgnored private var showTask: Task<Void, Never>?": "task lifecycle handle, not rendered state",
+        "Sources/Views/EditorChrome/FeedbackState.swift: @ObservationIgnored private var spinnerOnTime: ContinuousClock.Instant?": "timing bookkeeping, not rendered state",
+        "Sources/Views/Shared/GUIFramePresentationMetrics.swift: @ObservationIgnored private let log = OSLog(subsystem: \"com.minga.editor\", category: \"GUIFramePresentation\")": "telemetry logging handle, not rendered state",
+        "Sources/Views/Shared/GUIFramePresentationMetrics.swift: @ObservationIgnored private var samples: [Sample] = []": "debug telemetry sample buffer, not rendered state",
+        "Sources/Views/Shared/GUIState.swift: @ObservationIgnored private let themeBacking = GUIThemeBacking()": "stable dependency reference; backing fields are observed",
+        "Sources/Views/Shared/GUIState.swift: @ObservationIgnored private let windowContentBacking: GUIWindowContentBacking": "stable dependency reference; backing fields are observed",
+        "Sources/Views/Shared/GUIState.swift: @ObservationIgnored public lazy private(set) var editorInput = EditorHostInput(": "stable host dependency bundle, not rendered state",
+        "Sources/Views/Shared/GUIState.swift: @ObservationIgnored public lazy private(set) var editorOverlayInput = EditorOverlayHostInput(": "stable host dependency bundle, not rendered state",
+        "Sources/Views/Shared/GUIState.swift: @ObservationIgnored public lazy private(set) var shellInput = ShellHostInput(": "stable host dependency bundle, not rendered state",
+        "Sources/Views/Shared/GUIState.swift: @ObservationIgnored public lazy private(set) var windowOverlayInput = WindowOverlayHostInput(": "stable host dependency bundle, not rendered state",
+        "Sources/Views/Sidebar/SidebarHostState.swift: @ObservationIgnored private var warnedUnknownKinds: Set<String> = []": "diagnostic de-duplication cache, not rendered state",
+    ]
+
+    @Test("production Swift stays free of synthetic invalidation")
+    func productionSwiftRejectsSyntheticInvalidation() throws {
+        var violations: [String] = []
+
+        for source in try productionSources() {
+            let identifiers = Set(identifierTokens(in: source.sanitized))
+            for term in Self.bannedTerms.intersection(identifiers).sorted() {
+                violations.append("\(source.path): banned identifier `\(term)`")
+            }
+            for read in try discardedCorrelationReads(in: source.sanitized) {
+                violations.append("\(source.path): invalidation-only discarded read `\(read)`")
+            }
+            for call in try revisionDrivenIdentityCalls(in: source.sanitized, original: source.contents) {
+                violations.append("\(source.path): revision/frame-token identity `\(call)`")
+            }
+        }
+
+        record(violations)
+    }
+
+    @Test("every production Observation type and ignored declaration is classified")
+    func globalObservationInventoryIsExact() throws {
+        let sources = try productionSources()
+        let actualObservable = try Set(sources.flatMap(observableDeclarations(in:)))
+        #expect(actualObservable == Set(Self.observationTypeAllowlist.keys))
+        #expect(Self.observationTypeAllowlist.count == 39)
+
+        let actualIgnored = occurrenceCounts(sources.flatMap(ignoredDeclarations(in:)))
+        let expectedIgnored = Dictionary(uniqueKeysWithValues: Self.ignoredDeclarationAllowlist.keys.map { ($0, 1) })
+        #expect(actualIgnored == expectedIgnored)
+
+        let attributeFixture = ProductionSource(
+            path: "Fixture.swift",
+            contents: "@Observable @MainActor final class InlineOwner {}\n@Observable\n@MainActor\nfinal class StackedOwner {}",
+            sanitized: "@Observable @MainActor final class InlineOwner {}\n@Observable\n@MainActor\nfinal class StackedOwner {}"
+        )
+        #expect(try observableDeclarations(in: attributeFixture) == [
+            "Fixture.swift#InlineOwner", "Fixture.swift#StackedOwner"
+        ])
+
+        let duplicateIgnored = ProductionSource(
+            path: "Fixture.swift",
+            contents: "@ObservationIgnored private var cache = 0\n@ObservationIgnored private var cache = 0",
+            sanitized: "@ObservationIgnored private var cache = 0\n@ObservationIgnored private var cache = 0"
+        )
+        #expect(occurrenceCounts(ignoredDeclarations(in: duplicateIgnored)).values.first == 2)
+    }
+
+    @Test("committed correlation types and accessors stay inside owned boundaries")
+    func committedCorrelationBoundaries() throws {
+        let allowedPaths: [String: Set<String>] = [
+            "GUICommittedFrame": [
+                "Sources/Views/Shared/GUIFrameCorrelation.swift",
+                "Sources/Views/Shared/GUIFramePresentationMetrics.swift",
+                "Sources/Renderer/CommandDispatcher.swift",
+                "Sources/Renderer/CoreTextMetalRenderer.swift",
+                "Sources/Views/Editor/EditorNSView.swift",
+            ],
+            "GUIFrameImpact": [
+                "Sources/Views/Shared/GUIFrameCorrelation.swift",
+                "Sources/Views/Shared/GUIFramePresentationMetrics.swift",
+                "Sources/Renderer/CommandDispatcher.swift",
+                "Sources/Renderer/PreparedFrameTransaction.swift",
+            ],
+            "pendingFrame": [
+                "Sources/Views/Shared/GUIFramePresentationMetrics.swift",
+            ],
+            "pendingEditorFrame": [
+                "Sources/Views/Shared/GUIFramePresentationMetrics.swift",
+                "Sources/Renderer/CommandDispatcher.swift",
+            ],
+            "pendingPresentationFrame": [
+                "Sources/Renderer/CommandDispatcher.swift",
+                "Sources/Views/Editor/EditorNSView.swift",
+            ],
+            "presentationFrame": [
+                "Sources/Views/Shared/GUIFramePresentationMetrics.swift",
+                "Sources/Renderer/CoreTextMetalRenderer.swift",
+                "Sources/Views/Editor/EditorNSView.swift",
+            ],
+        ]
+        var violations: [String] = []
+
+        let sources = try productionSources()
+        for source in sources {
+            let identifiers = Set(identifierTokens(in: source.sanitized))
+            for term in allowedPaths.keys.sorted()
+            where identifiers.contains(term) && !allowedPaths[term, default: []].contains(source.path) {
+                violations.append("\(source.path): `\(term)` is outside its correlation boundary")
+            }
+        }
+
+        let exactAccessorOccurrences: [String: [String: Int]] = [
+            "pendingFrame": ["Sources/Views/Shared/GUIFramePresentationMetrics.swift": 2],
+            "pendingEditorFrame": [
+                "Sources/Views/Shared/GUIFramePresentationMetrics.swift": 1,
+                "Sources/Renderer/CommandDispatcher.swift": 1,
+            ],
+            "pendingPresentationFrame": [
+                "Sources/Renderer/CommandDispatcher.swift": 1,
+                "Sources/Views/Editor/EditorNSView.swift": 1,
+            ],
+        ]
+        for (accessor, expected) in exactAccessorOccurrences {
+            let actual = Dictionary(uniqueKeysWithValues: sources.compactMap { source in
+                let count = identifierTokens(in: source.sanitized).count { $0 == accessor }
+                return count == 0 ? nil : (source.path, count)
+            })
+            if actual != expected {
+                violations.append("`\(accessor)` occurrences changed: \(actual)")
+            }
+        }
+
+        record(violations)
+    }
+
+    @Test("stable semantic identity remains allowed while formatting cannot bypass the policy")
+    func stableIdentityAllowances() throws {
+        let allowed = ##"""
+        // view.id(frameID)
+        /* view.id(frameSequence); ObservableObject */
+        let ordinary = "view.id(frameSequence)"
+        let raw = #"view.id(currentGeneration)"#
+        let multiline = """
+        view.id(renderGeneration)
+        """
+        let rawMultiline = #"""
+        view.id(frameToken)
+        """#
+        rows.id(item.id)
+        rows.id(entry.id)
+        rows.id(index)
+        rows.id("bottom-anchor")
+        rows.id(item.generation)
+        rows.id(model.generation)
+        let MyObservableObjectFactory = 1
+        """##
+        let sanitizedAllowed = sanitizeSwiftSource(allowed)
+        #expect(try revisionDrivenIdentityCalls(in: sanitizedAllowed).isEmpty)
+        #expect(!Set(identifierTokens(in: sanitizedAllowed)).contains("ObservableObject"))
+
+        let rejected = """
+        view.id(revision)
+        view.id(state.presentationRevision)
+        view.id(frameToken)
+        view.id(committed.frameSeq)
+        view.id(generation)
+        view.id(generation + 1)
+        view.id(
+            state.presentationRevision
+        )
+        view
+            .id(
+                frameID
+            )
+        view.id(
+            frameSequence
+        )
+        view.id(currentGeneration)
+        view.id(renderGeneration)
+        view.`id`(frameToken)
+        let identity = state.presentationRevision
+        view.id(identity)
+        view.id("\\(frameToken)")
+        view.id(#"\\#(revision)"#)
+        view.id("\\(revision /* ( */)")
+        """
+        #expect(try revisionDrivenIdentityCalls(in: sanitizeSwiftSource(rejected), original: rejected).count == 16)
+
+        let discarded = """
+        let _ = frameToken
+        _ = generation
+        let _ =
+            frameSequence
+        _ =
+            currentGeneration
+        // _ = renderGeneration
+        let example = "_ = frameID"
+        """
+        #expect(try discardedCorrelationReads(in: sanitizeSwiftSource(discarded)).count == 4)
+        #expect(try discardedCorrelationReads(in: sanitizeSwiftSource("_ = item.id")).isEmpty)
+    }
+
+    @Test("presentation metrics observe pending correlation and ignore only classified telemetry infrastructure")
+    func metricsSourcePolicy() throws {
+        let source = try source(at: "Sources/Views/Shared/GUIFramePresentationMetrics.swift")
+        #expect(source.sanitized.contains("@MainActor\n@Observable\npublic final class GUIFramePresentationMetrics"))
+        #expect(source.sanitized.contains("private var pending: [GUIFrameImpact: Pending] = [:]"))
+        #expect(source.sanitized.contains("expectedFrame: metrics.pendingFrame(domain: domain)"))
+        #expect(source.sanitized.contains("func frameNativeDrawProbe("))
+        #expect(identifierTokens(in: source.sanitized).count { $0 == "pending" } == 13)
+    }
+
+    private func productionSources() throws -> [ProductionSource] {
+        let sourcesRoot = Self.macosRoot.appendingPathComponent("Sources", isDirectory: true)
+        guard let enumerator = FileManager.default.enumerator(
+            at: sourcesRoot,
+            includingPropertiesForKeys: [.isRegularFileKey],
+            options: [.skipsHiddenFiles]
+        ) else {
+            Issue.record("Unable to enumerate production Swift sources at \(sourcesRoot.path)")
+            return []
+        }
+
+        var urls: [URL] = []
+        for case let url as URL in enumerator where url.pathExtension == "swift" {
+            let values = try url.resourceValues(forKeys: [.isRegularFileKey])
+            if values.isRegularFile == true { urls.append(url) }
+        }
+        let sortedURLs = urls.sorted { $0.path < $1.path }
+        #expect(!sortedURLs.isEmpty)
+        return try sortedURLs.map { url in
+            let relativePath = String(url.path.dropFirst(Self.macosRoot.path.count + 1))
+            let contents = try String(contentsOf: url, encoding: .utf8)
+            return ProductionSource(
+                path: relativePath,
+                contents: contents,
+                sanitized: sanitizeSwiftSource(contents)
+            )
+        }
+    }
+
+    private func source(at path: String) throws -> ProductionSource {
+        let url = Self.macosRoot.appendingPathComponent(path)
+        let contents = try String(contentsOf: url, encoding: .utf8)
+        return ProductionSource(path: path, contents: contents, sanitized: sanitizeSwiftSource(contents))
+    }
+
+    private func observableDeclarations(in source: ProductionSource) throws -> [String] {
+        let regex = try NSRegularExpression(
+            pattern: #"@Observable(?:(?:\s+@[A-Za-z_][A-Za-z0-9_]*(?:\([^)]*\))?)|(?:\s+(?:public|private|fileprivate|internal|package|final)))*\s+(?:class|struct|actor)\s+([A-Za-z_][A-Za-z0-9_]*)"#
+        )
+        let range = NSRange(source.sanitized.startIndex..<source.sanitized.endIndex, in: source.sanitized)
+        return regex.matches(in: source.sanitized, range: range).compactMap { match in
+            guard let nameRange = Range(match.range(at: 1), in: source.sanitized) else { return nil }
+            return "\(source.path)#\(source.sanitized[nameRange])"
+        }
+    }
+
+    private func ignoredDeclarations(in source: ProductionSource) -> [String] {
+        let originalLines = source.contents.split(separator: "\n", omittingEmptySubsequences: false)
+        let sanitizedLines = source.sanitized.split(separator: "\n", omittingEmptySubsequences: false)
+        return zip(originalLines, sanitizedLines).compactMap { original, sanitized in
+            guard identifierTokens(in: String(sanitized)).contains("ObservationIgnored") else { return nil }
+            return "\(source.path): \(original.trimmingCharacters(in: .whitespaces))"
+        }
+    }
+
+    private func discardedCorrelationReads(in source: String) throws -> [String] {
+        let regex = try NSRegularExpression(
+            pattern: #"\b(?:let\s+)?_\s*=\s*([A-Za-z_][A-Za-z0-9_]*(?:\s*\.\s*[A-Za-z_][A-Za-z0-9_]*)*)"#
+        )
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        return regex.matches(in: source, range: range).compactMap { match in
+            guard let expressionRange = Range(match.range(at: 1), in: source),
+                  containsCorrelationIdentity(in: String(source[expressionRange])),
+                  let readRange = Range(match.range, in: source) else { return nil }
+            return source[readRange].split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        }
+    }
+
+    private func revisionDrivenIdentityCalls(in source: String, original: String? = nil) throws -> [String] {
+        let aliases = try correlationAliases(in: source)
+        let regex = try NSRegularExpression(pattern: #"\.\s*`?id`?\s*\("#)
+        let fullRange = NSRange(source.startIndex..<source.endIndex, in: source)
+        return regex.matches(in: source, range: fullRange).compactMap { match in
+            guard let matchRange = Range(match.range, in: source) else { return nil }
+            let open = source.index(before: matchRange.upperBound)
+            let argumentStart = source.index(after: open)
+            var cursor = argumentStart
+            var depth = 1
+            while cursor < source.endIndex, depth > 0 {
+                if source[cursor] == "(" { depth += 1 }
+                if source[cursor] == ")" { depth -= 1 }
+                cursor = source.index(after: cursor)
+            }
+            guard depth == 0 else { return nil }
+            let close = source.index(before: cursor)
+            let argumentRange = argumentStart..<close
+            let argument = String(source[argumentRange])
+            let interpolationViolation = original.flatMap { correspondingSlice(argumentRange, from: source, in: $0) }
+                .map { interpolationBodies(in: String($0)) }
+                .map { bodies in
+                    bodies.contains { body in
+                        let sanitizedBody = sanitizeSwiftSource(body)
+                        return containsCorrelationIdentity(in: sanitizedBody)
+                            || identifierTokens(in: sanitizedBody).contains(where: aliases.contains)
+                    }
+                } ?? false
+            guard containsCorrelationIdentity(in: argument)
+                    || identifierTokens(in: argument).contains(where: aliases.contains)
+                    || interpolationViolation else { return nil }
+            let callRange = matchRange.lowerBound..<cursor
+            let reported = original.flatMap { correspondingSlice(callRange, from: source, in: $0) }
+                .map(String.init) ?? String(source[callRange])
+            return reported.split(whereSeparator: { $0.isWhitespace }).joined(separator: " ")
+        }
+    }
+
+    private func correspondingSlice(
+        _ range: Range<String.Index>,
+        from sanitized: String,
+        in original: String
+    ) -> Substring? {
+        guard let lowerUTF8 = range.lowerBound.samePosition(in: sanitized.utf8),
+              let upperUTF8 = range.upperBound.samePosition(in: sanitized.utf8) else { return nil }
+        let lowerOffset = sanitized.utf8.distance(from: sanitized.utf8.startIndex, to: lowerUTF8)
+        let upperOffset = sanitized.utf8.distance(from: sanitized.utf8.startIndex, to: upperUTF8)
+        guard let originalLower = String.Index(
+            original.utf8.index(original.utf8.startIndex, offsetBy: lowerOffset),
+            within: original
+        ), let originalUpper = String.Index(
+            original.utf8.index(original.utf8.startIndex, offsetBy: upperOffset),
+            within: original
+        ) else { return nil }
+        return original[originalLower..<originalUpper]
+    }
+
+    private func interpolationBodies(in source: String) -> [String] {
+        let bytes = Array(source.utf8)
+        var bodies: [String] = []
+        var index = 0
+        while index < bytes.count {
+            guard bytes[index] == 92 else {
+                index += 1
+                continue
+            }
+            var markerEnd = index + 1
+            while markerEnd < bytes.count, bytes[markerEnd] == 35 { markerEnd += 1 }
+            guard markerEnd < bytes.count, bytes[markerEnd] == 40 else {
+                index += 1
+                continue
+            }
+            let bodyStart = markerEnd + 1
+            guard let bodyEnd = interpolationBodyEnd(in: bytes, startingAt: bodyStart) else { break }
+            let body = String(decoding: bytes[bodyStart..<bodyEnd], as: UTF8.self)
+            bodies.append(body)
+            bodies.append(contentsOf: interpolationBodies(in: body))
+            index = bodyEnd + 1
+        }
+        return bodies
+    }
+
+    private func interpolationBodyEnd(in bytes: [UInt8], startingAt start: Int) -> Int? {
+        var cursor = start
+        var depth = 1
+        while cursor < bytes.count {
+            if cursor + 1 < bytes.count, bytes[cursor] == 47, bytes[cursor + 1] == 47 {
+                cursor += 2
+                while cursor < bytes.count, bytes[cursor] != 10, bytes[cursor] != 13 { cursor += 1 }
+                continue
+            }
+            if cursor + 1 < bytes.count, bytes[cursor] == 47, bytes[cursor + 1] == 42 {
+                cursor = blockCommentEnd(in: bytes, startingAt: cursor + 2)
+                continue
+            }
+            if let end = stringLiteralEnd(in: bytes, startingAt: cursor) {
+                cursor = end
+                continue
+            }
+            if bytes[cursor] == 40 { depth += 1 }
+            if bytes[cursor] == 41 {
+                depth -= 1
+                if depth == 0 { return cursor }
+            }
+            cursor += 1
+        }
+        return nil
+    }
+
+    private func blockCommentEnd(in bytes: [UInt8], startingAt start: Int) -> Int {
+        var cursor = start
+        var depth = 1
+        while cursor < bytes.count, depth > 0 {
+            if cursor + 1 < bytes.count, bytes[cursor] == 47, bytes[cursor + 1] == 42 {
+                depth += 1
+                cursor += 2
+            } else if cursor + 1 < bytes.count, bytes[cursor] == 42, bytes[cursor + 1] == 47 {
+                depth -= 1
+                cursor += 2
+            } else {
+                cursor += 1
+            }
+        }
+        return cursor
+    }
+
+    private func stringLiteralEnd(in bytes: [UInt8], startingAt start: Int) -> Int? {
+        var hashCount = 0
+        while start + hashCount < bytes.count, bytes[start + hashCount] == 35 { hashCount += 1 }
+        let quoteIndex = start + hashCount
+        guard quoteIndex < bytes.count, bytes[quoteIndex] == 34 else { return nil }
+        let multiline = quoteIndex + 2 < bytes.count
+            && bytes[quoteIndex + 1] == 34
+            && bytes[quoteIndex + 2] == 34
+        let quoteCount = multiline ? 3 : 1
+        var cursor = quoteIndex + quoteCount
+        while cursor < bytes.count {
+            let hasQuotes = cursor + quoteCount <= bytes.count
+                && bytes[cursor..<(cursor + quoteCount)].allSatisfy { $0 == 34 }
+            let hashesStart = cursor + quoteCount
+            let hasHashes = hashesStart + hashCount <= bytes.count
+                && bytes[hashesStart..<(hashesStart + hashCount)].allSatisfy { $0 == 35 }
+            if hasQuotes, hasHashes {
+                if hashCount > 0 || !quoteIsEscaped(in: bytes, at: cursor) {
+                    return hashesStart + hashCount
+                }
+            }
+            cursor += 1
+        }
+        return bytes.count
+    }
+
+    private func quoteIsEscaped(in bytes: [UInt8], at offset: Int) -> Bool {
+        var cursor = offset
+        var slashCount = 0
+        while cursor > 0, bytes[cursor - 1] == 92 {
+            slashCount += 1
+            cursor -= 1
+        }
+        return !slashCount.isMultiple(of: 2)
+    }
+
+    private func correlationAliases(in source: String) throws -> Set<String> {
+        let regex = try NSRegularExpression(
+            pattern: #"\b(?:let|var)\s+([A-Za-z_][A-Za-z0-9_]*)\s*=\s*([^;\n]+)"#
+        )
+        let range = NSRange(source.startIndex..<source.endIndex, in: source)
+        var aliases: Set<String> = []
+        var changed = true
+        while changed {
+            changed = false
+            for match in regex.matches(in: source, range: range) {
+                guard let nameRange = Range(match.range(at: 1), in: source),
+                      let valueRange = Range(match.range(at: 2), in: source) else { continue }
+                let name = String(source[nameRange])
+                let value = String(source[valueRange])
+                let aliasesCorrelation = identifierTokens(in: value).contains(where: aliases.contains)
+                if containsCorrelationIdentity(in: value) || aliasesCorrelation {
+                    changed = aliases.insert(name).inserted || changed
+                }
+            }
+        }
+        return aliases
+    }
+
+    private func occurrenceCounts(_ values: [String]) -> [String: Int] {
+        values.reduce(into: [:]) { counts, value in counts[value, default: 0] += 1 }
+    }
+
+    private func containsCorrelationIdentity(in expression: String) -> Bool {
+        let identifiers = identifierTokens(in: expression).map { $0.lowercased() }
+        guard !identifiers.isEmpty else { return false }
+        if identifiers.contains(where: {
+            $0 == "frameid"
+                || $0 == "framesequence"
+                || $0 == "frameseq"
+                || $0 == "currentgeneration"
+                || $0 == "rendergeneration"
+                || $0 == "committedframe"
+                || $0 == "revision"
+                || $0.hasSuffix("revision")
+                || $0.hasSuffix("frameversion")
+                || $0.hasSuffix("frametoken")
+        }) {
+            return true
+        }
+        let compact = expression.filter { !$0.isWhitespace }
+        return compact.range(of: #"(?:^|[^.A-Za-z0-9_])generation\b"#, options: .regularExpression) != nil
+    }
+
+    private func identifierTokens(in source: String) -> [String] {
+        source.split { !$0.isLetter && !$0.isNumber && $0 != "_" }.map(String.init)
+    }
+
+    /// Blanks comments and all Swift string forms while retaining byte positions and newlines.
+    private func sanitizeSwiftSource(_ source: String) -> String {
+        let bytes = Array(source.utf8)
+        var result = bytes
+        var index = 0
+
+        func blank(_ range: Range<Int>) {
+            for offset in range where result[offset] != 10 && result[offset] != 13 {
+                result[offset] = 32
+            }
+        }
+
+        func isEscapedQuote(at offset: Int) -> Bool {
+            var cursor = offset
+            var slashCount = 0
+            while cursor > 0, bytes[cursor - 1] == 92 {
+                slashCount += 1
+                cursor -= 1
+            }
+            return !slashCount.isMultiple(of: 2)
+        }
+
+        while index < bytes.count {
+            if index + 1 < bytes.count, bytes[index] == 47, bytes[index + 1] == 47 {
+                let start = index
+                index += 2
+                while index < bytes.count, bytes[index] != 10, bytes[index] != 13 { index += 1 }
+                blank(start..<index)
+                continue
+            }
+            if index + 1 < bytes.count, bytes[index] == 47, bytes[index + 1] == 42 {
+                let start = index
+                var depth = 1
+                index += 2
+                while index < bytes.count, depth > 0 {
+                    if index + 1 < bytes.count, bytes[index] == 47, bytes[index + 1] == 42 {
+                        depth += 1
+                        index += 2
+                    } else if index + 1 < bytes.count, bytes[index] == 42, bytes[index + 1] == 47 {
+                        depth -= 1
+                        index += 2
+                    } else {
+                        index += 1
+                    }
+                }
+                blank(start..<index)
+                continue
+            }
+
+            var hashCount = 0
+            while index + hashCount < bytes.count, bytes[index + hashCount] == 35 { hashCount += 1 }
+            let quoteIndex = index + hashCount
+            guard quoteIndex < bytes.count, bytes[quoteIndex] == 34 else {
+                index += 1
+                continue
+            }
+
+            let start = index
+            let isMultiline = quoteIndex + 2 < bytes.count
+                && bytes[quoteIndex + 1] == 34
+                && bytes[quoteIndex + 2] == 34
+            let quoteCount = isMultiline ? 3 : 1
+            index = quoteIndex + quoteCount
+            while index < bytes.count {
+                let hasQuotes = index + quoteCount <= bytes.count
+                    && bytes[index..<(index + quoteCount)].allSatisfy { $0 == 34 }
+                let hashesStart = index + quoteCount
+                let hasHashes = hashesStart + hashCount <= bytes.count
+                    && bytes[hashesStart..<(hashesStart + hashCount)].allSatisfy { $0 == 35 }
+                if hasQuotes, hasHashes, hashCount > 0 || !isEscapedQuote(at: index) {
+                    index = hashesStart + hashCount
+                    break
+                }
+                index += 1
+            }
+            blank(start..<index)
+        }
+
+        return String(decoding: result, as: UTF8.self)
+    }
+
+    private func record(_ violations: [String]) {
+        guard !violations.isEmpty else { return }
+        Issue.record(Comment(rawValue: violations.sorted().joined(separator: "\n")))
+    }
+
+    private static let macosRoot = URL(fileURLWithPath: #filePath)
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+        .deletingLastPathComponent()
+}

--- a/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
+++ b/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
@@ -688,7 +688,7 @@ struct NativeRenderResourcesTests {
             frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
             drawableProvider: { NativeTestDrawable(texture: texture) },
             viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
-            presentationInputSeq: 302, presentationFrameSeq: 42
+            presentationInputSeq: 302, presentationFrame: committedFrame
         )
         #expect(completions.count == 1)
         #expect(presentCalls == 0)


### PR DESCRIPTION
## Summary

- scan every macOS production Swift source in CI and reject removed frame-token infrastructure, custom invalidation frameworks, discarded token reads, and revision-driven `.id(...)` workarounds, including aliases and string interpolation
- classify all 39 production Observation types and all 16 path-qualified `@ObservationIgnored` declarations so new owners and hidden rendered fields require explicit review
- keep committed identity inside prepared-transaction, dispatcher, renderer-correlation, and presentation-metrics boundaries, with exact accessor call-site policies and exhaustive outcome coverage
- carry the full committed frame through Metal callbacks so a stale callback cannot resolve a newer generation that reused the same frame sequence

Protocol, generated source, row-store algorithms, renderer drawing behavior, native interaction ownership, and `FrameState.cols/rows` are unchanged.

## Why

The Observation migration removed synthetic frame invalidation, but the architecture needed permanent guardrails against reintroducing token-driven redraws or unreviewed observation owners. While adding those guards, an adversarial test exposed a real metrics-only bug: frame sequences can be reused after a BEAM generation change, so sequence-only Metal callbacks could resolve the wrong pending frame.

The production correction preserves the full `GUICommittedFrame` identity through submission and presentation metrics. It does not affect rendering semantics or view identity.

## Validation

- `make lint`
- `mix swift.build`
- `mix swift.harness && mix test.llm`: 9,463 tests, 0 failures, 1 skipped
- full `xcodebuild test`: 1,227 tests, 0 failures
- `scripts/check_render_performance`: 5/5 batches, aggregate combined p50 0.126 ms, p95 0.132 ms
- LSP diagnostics on all eight changed Swift files: 0
- `git diff --check`
- targeted reviewer re-check: PASS

Closes #2923
