### PR TITLE
fix(editor): move file-tree scans off the mailbox

### DIFF
--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -522,10 +522,6 @@ defmodule MingaEditor do
     {:noreply, FileEventHandler.dispatch(new_state, msg)}
   end
 
-  def handle_info({:file_tree_filter_walk, _root, _filter, _entries} = msg, state) do
-    {:noreply, FileEventHandler.dispatch(state, msg)}
-  end
-
   def handle_info(
         {:minga_input, {:mouse_event, row, col, button, mods, event_type, click_count}},
         state

--- a/lib/minga_editor/commands/file_tree.ex
+++ b/lib/minga_editor/commands/file_tree.ex
@@ -320,61 +320,15 @@ defmodule MingaEditor.Commands.FileTree do
 
   @doc "Starts inline file tree filtering."
   @spec filter(state()) :: state()
-  def filter(state) do
-    file_tree = FileTreeState.start_filtering(file_tree_state(state))
-    maybe_spawn_filter_walk(file_tree)
-    update_file_tree(state, fn _ -> file_tree end)
-  end
+  def filter(state), do: FileTreeFreshness.start_filtering(state)
 
   @doc "Restores unfiltered rows while keeping the filter input active."
   @spec reset_filter_query(state()) :: state()
-  def reset_filter_query(state), do: restore_unfiltered_filter(state, :keep_open)
+  def reset_filter_query(state), do: FileTreeFreshness.clear_filter(state, :keep_open)
 
   @doc "Restores unfiltered rows and dismisses filter input."
   @spec clear_filter(state()) :: state()
-  def clear_filter(state), do: restore_unfiltered_filter(state, :dismiss)
-
-  @spec restore_unfiltered_filter(state(), :keep_open | :dismiss) :: state()
-  defp restore_unfiltered_filter(state, disposition) do
-    case file_tree_state(state).tree do
-      %FileTree{} = tree ->
-        tree = tree |> FileTree.put_cached_files(nil) |> FileTree.clear_filter()
-        restore_resolved_filter(resolve_tree_entries(tree), state, disposition)
-
-      nil ->
-        state
-    end
-  end
-
-  @spec restore_resolved_filter(tree_resolution(), state(), :keep_open | :dismiss) :: state()
-  defp restore_resolved_filter({:error, reason}, state, _disposition) do
-    update_file_tree(state, &FileTreeState.refresh_failed(&1, reason))
-  end
-
-  defp restore_resolved_filter({:ok, tree}, state, disposition) do
-    tree = if disposition == :keep_open, do: FileTree.begin_filter(tree), else: tree
-    file_tree = FileTreeState.replace_tree(file_tree_state(state), tree)
-    file_tree = dismiss_filter(file_tree, disposition)
-    state = set_file_tree(state, file_tree)
-    sync_buffer(state)
-  end
-
-  @spec dismiss_filter(FileTreeState.t(), :keep_open | :dismiss) :: FileTreeState.t()
-  defp dismiss_filter(file_tree, :keep_open), do: file_tree
-  defp dismiss_filter(file_tree, :dismiss), do: FileTreeState.accept_filter(file_tree)
-
-  # Spawns the async no-cache filesystem walk when re-entering filtering carries
-  # a pre-existing filter on a root the project cache does not cover (#2377 AC4).
-  @spec maybe_spawn_filter_walk(FileTreeState.t()) :: :ok
-  defp maybe_spawn_filter_walk(%FileTreeState{tree: %FileTree{} = tree} = file_tree) do
-    if FileTreeState.needs_filter_walk?(file_tree) do
-      MingaEditor.FileTree.FilterWalk.start(tree, self())
-    end
-
-    :ok
-  end
-
-  defp maybe_spawn_filter_walk(%FileTreeState{}), do: :ok
+  def clear_filter(state), do: FileTreeFreshness.clear_filter(state, :dismiss)
 
   @doc "Toggles the file tree help overlay."
   @spec toggle_help(state()) :: state()
@@ -744,11 +698,6 @@ defmodule MingaEditor.Commands.FileTree do
 
   @spec close(state()) :: state()
   def close(state) do
-    case file_tree_state(state).tree do
-      %FileTree{} = tree -> FileTreeFreshness.unwatch_expanded_dirs(tree)
-      nil -> :ok
-    end
-
     case file_tree_state(state).buffer do
       buf when is_pid(buf) -> GenServer.stop(buf, :normal)
       _ -> :ok
@@ -767,6 +716,7 @@ defmodule MingaEditor.Commands.FileTree do
             )
       }
     end)
+    |> FileTreeFreshness.synchronize_watchers()
     |> then(fn state ->
       %{state | workspace: State.set_keymap_scope(state.workspace, scope)}
     end)
@@ -977,31 +927,7 @@ defmodule MingaEditor.Commands.FileTree do
   end
 
   @spec reroot(state(), String.t()) :: state()
-  defp reroot(state, root) do
-    case file_tree_state(state).tree do
-      %FileTree{} = tree ->
-        FileTreeFreshness.unwatch_expanded_dirs(tree)
-        new_tree = FileTree.reroot(tree, root)
-
-        case resolve_tree_entries(new_tree) do
-          {:ok, new_tree} ->
-            new_tree =
-              FileTreeRefresh.with_cached_git_status(
-                new_tree,
-                state.extension_surfaces.events_registry
-              )
-
-            FileTreeFreshness.watch_expanded_dirs(new_tree)
-            sync_and_update(state, new_tree)
-
-          {:error, reason} ->
-            install_tree_error(state, new_tree, reason)
-        end
-
-      nil ->
-        state
-    end
-  end
+  defp reroot(state, root), do: FileTreeFreshness.reroot(state, root)
 
   # Mutual exclusivity: close git status panel when opening file tree.
   # Explicitly resets keymap_scope to :editor so we don't leave orphaned
@@ -1089,8 +1015,10 @@ defmodule MingaEditor.Commands.FileTree do
           FileTreeRefresh.with_cached_git_status(tree, state.extension_surfaces.events_registry)
 
         tree = reveal_active(tree, state.workspace.buffers.active)
-        FileTreeFreshness.watch_expanded_dirs(tree)
-        install_open_tree(state, tree, nil)
+
+        state
+        |> install_open_tree(tree, nil)
+        |> FileTreeFreshness.synchronize_watchers()
 
       {:error, reason} ->
         install_open_tree(state, FileTree.put_entries(tree, []), reason)
@@ -1111,9 +1039,11 @@ defmodule MingaEditor.Commands.FileTree do
   defp sync_and_update(state, new_tree) do
     case resolve_tree_entries(new_tree) do
       {:ok, new_tree} ->
-        FileTreeFreshness.watch_expanded_dirs(new_tree)
         sync_tree_buffer(state, new_tree)
-        update_file_tree(state, &FileTreeState.set_tree(&1, new_tree))
+
+        state
+        |> update_file_tree(&FileTreeState.set_tree(&1, new_tree))
+        |> FileTreeFreshness.synchronize_watchers()
 
       {:error, reason} ->
         install_tree_error(state, new_tree, reason)

--- a/lib/minga_editor/file_tree/filter_walk.ex
+++ b/lib/minga_editor/file_tree/filter_walk.ex
@@ -1,48 +1,88 @@
 defmodule MingaEditor.FileTree.FilterWalk do
   @moduledoc """
-  Async filesystem walk for filtering a file tree whose root is NOT covered by
-  the active project cache (#2377 AC4).
+  Typed, latest-wins filter scan for one file-tree root.
 
-  The active project root filters in memory from `Minga.Project.files/0`, so this
-  fallback only runs for other roots (e.g. a tree pointed at a subdirectory or a
-  directory opened before project detection). The walk runs off the Editor
-  process and its result is keyed by `(root, filter)`; the Editor drops the
-  result if the user has since changed the filter or re-rooted the tree
-  (stale-result dropping), so a slow walk can never clobber newer state.
+  Cache reads and fallback filesystem walks execute in the bounded effect
+  scheduler. The request carries the exact root and filter identity; application
+  remains in the file-tree workflow so rerooted, repeated, closed, canceled, and
+  failed work cannot overwrite newer state.
   """
+
+  @behaviour MingaEditor.Effect
 
   alias Minga.Project.FileTree
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.Effect.Policy
+  alias MingaEditor.Effect.Request
+  alias MingaEditor.FileTree.FilterWalk.CacheOrFilesystemScanner
+  alias MingaEditor.FileTree.FilterWalk.Result
+  alias MingaEditor.FileTree.Freshness
+  alias MingaEditor.State, as: EditorState
 
-  @typedoc "An async walk result tagged with the (root, filter) it was computed for."
-  @type result ::
-          {:file_tree_filter_walk, root :: String.t(), filter :: String.t(), [FileTree.entry()]}
+  @enforce_keys [:root, :filter, :tree, :scanner, :scanner_context]
+  defstruct [
+    :root,
+    :filter,
+    :tree,
+    :scanner,
+    :scanner_context,
+    :watcher_backend,
+    :watcher_context,
+    synchronize_watchers?: true
+  ]
 
-  @doc """
-  Spawns an unlinked walk that computes the filtered entries for `tree` and
-  sends `{:file_tree_filter_walk, root, filter, entries}` back to `reply_to`.
+  @type t :: %__MODULE__{
+          root: String.t(),
+          filter: String.t(),
+          tree: FileTree.t(),
+          scanner: module(),
+          scanner_context: term(),
+          watcher_backend: module() | nil,
+          watcher_context: term(),
+          synchronize_watchers?: boolean()
+        }
 
-  Returns `:ok`. The process is unlinked so a walk crash never takes down the
-  Editor; a dropped result simply means the tree keeps its prior entries.
-  """
-  @spec start(FileTree.t(), pid()) :: :ok
-  def start(%FileTree{root: root, filter: filter} = tree, reply_to)
-      when is_binary(filter) and is_pid(reply_to) do
-    {:ok, _pid} =
-      Task.start(fn ->
-        entries = FileTree.filtered_walk_entries(tree)
-        send(reply_to, {:file_tree_filter_walk, root, filter, entries})
-      end)
+  @doc "Builds a latest-wins request for the tree's exact root and active filter."
+  @spec request(FileTree.t(), keyword()) :: Request.t()
+  def request(%FileTree{root: root, filter: filter} = tree, opts \\ [])
+      when is_binary(root) and is_binary(filter) and filter != "" do
+    expanded_root = Path.expand(root)
 
-    :ok
+    effect = %__MODULE__{
+      root: expanded_root,
+      filter: filter,
+      tree: tree,
+      scanner: Keyword.get(opts, :scanner, CacheOrFilesystemScanner),
+      scanner_context: Keyword.get(opts, :scanner_context),
+      watcher_backend: Keyword.get(opts, :watcher_backend),
+      watcher_context: Keyword.get(opts, :watcher_context),
+      synchronize_watchers?: Keyword.get(opts, :synchronize_watchers?, true)
+    }
+
+    Request.new(effect, {:file_tree_filter, expanded_root}, Policy.latest_wins())
   end
 
-  @doc """
-  Returns true when an async walk result still matches the tree's current
-  `(root, filter)`. Stale results (the user changed the filter or re-rooted)
-  return false and must be dropped.
-  """
-  @spec fresh?(FileTree.t(), String.t(), String.t()) :: boolean()
-  def fresh?(%FileTree{root: root, filter: filter}, result_root, result_filter) do
-    root == result_root and filter == result_filter
+  @impl true
+  @spec run(t()) :: {:ok, Result.t()} | {:error, term()}
+  def run(%__MODULE__{} = effect) do
+    case effect.scanner.scan(effect.tree, effect.scanner_context) do
+      %Result{} = result -> {:ok, result}
+      {:error, reason} -> {:error, reason}
+      other -> {:error, {:invalid_filter_result, other}}
+    end
   end
+
+  @impl true
+  @spec coalesce(t(), t()) :: t()
+  def coalesce(%__MODULE__{}, %__MODULE__{} = newer), do: newer
+
+  @impl true
+  @spec apply(EditorState.t(), Outcome.t()) :: {EditorState.t(), Outcome.t()}
+  def apply(%EditorState{} = state, %Outcome{} = outcome) do
+    Freshness.apply_filter_outcome(state, outcome)
+  end
+
+  @impl true
+  @spec render?(Outcome.t()) :: boolean()
+  def render?(%Outcome{}), do: false
 end

--- a/lib/minga_editor/file_tree/filter_walk/cache_or_filesystem_scanner.ex
+++ b/lib/minga_editor/file_tree/filter_walk/cache_or_filesystem_scanner.ex
@@ -1,0 +1,37 @@
+defmodule MingaEditor.FileTree.FilterWalk.CacheOrFilesystemScanner do
+  @moduledoc "Production filter scanner that prefers the project cache and otherwise walks disk."
+
+  @behaviour MingaEditor.FileTree.FilterWalk.Scanner
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.FilterWalk.Result
+  alias MingaEditor.FileTree.ProjectCache
+  alias MingaEditor.FileTree.ProjectCache.Snapshot
+
+  @impl true
+  @spec scan(FileTree.t(), Snapshot.t() | nil) :: Result.t()
+  def scan(%FileTree{root: root} = tree, nil) do
+    scan_with_snapshot(tree, ProjectCache.snapshot(root))
+  end
+
+  def scan(%FileTree{} = tree, %Snapshot{} = snapshot), do: scan_with_snapshot(tree, snapshot)
+
+  @spec scan_with_snapshot(FileTree.t(), Snapshot.t()) :: Result.t()
+  defp scan_with_snapshot(
+         %FileTree{root: root, filter: filter} = tree,
+         %Snapshot{} = snapshot
+       )
+       when is_binary(filter) do
+    if snapshot.active? and Path.expand(snapshot.root) == Path.expand(root) do
+      entries =
+        tree
+        |> FileTree.put_cached_files(snapshot.files)
+        |> FileTree.set_filter(filter)
+        |> FileTree.visible_entries()
+
+      Result.project_cache(root, filter, entries, snapshot)
+    else
+      Result.filesystem(root, filter, FileTree.filtered_walk_entries(tree))
+    end
+  end
+end

--- a/lib/minga_editor/file_tree/filter_walk/result.ex
+++ b/lib/minga_editor/file_tree/filter_walk/result.ex
@@ -1,0 +1,44 @@
+defmodule MingaEditor.FileTree.FilterWalk.Result do
+  @moduledoc "Typed immutable result of one scheduled file-tree filter scan."
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.ProjectCache.Snapshot
+
+  @enforce_keys [:root, :filter, :source, :entries]
+  defstruct [:root, :filter, :source, :entries, :project_cache]
+
+  @type source :: :filesystem | :project_cache
+
+  @type t :: %__MODULE__{
+          root: String.t(),
+          filter: String.t(),
+          source: source(),
+          entries: [FileTree.entry()],
+          project_cache: Snapshot.t() | nil
+        }
+
+  @doc "Builds a filesystem-backed filter result."
+  @spec filesystem(String.t(), String.t(), [FileTree.entry()]) :: t()
+  def filesystem(root, filter, entries)
+      when is_binary(root) and is_binary(filter) and is_list(entries) do
+    %__MODULE__{
+      root: Path.expand(root),
+      filter: filter,
+      source: :filesystem,
+      entries: entries
+    }
+  end
+
+  @doc "Builds a project-cache-backed filter result with final materialized entries."
+  @spec project_cache(String.t(), String.t(), [FileTree.entry()], Snapshot.t()) :: t()
+  def project_cache(root, filter, entries, %Snapshot{} = snapshot)
+      when is_binary(root) and is_binary(filter) and is_list(entries) do
+    %__MODULE__{
+      root: Path.expand(root),
+      filter: filter,
+      source: :project_cache,
+      entries: entries,
+      project_cache: snapshot
+    }
+  end
+end

--- a/lib/minga_editor/file_tree/filter_walk/scanner.ex
+++ b/lib/minga_editor/file_tree/filter_walk/scanner.ex
@@ -1,0 +1,8 @@
+defmodule MingaEditor.FileTree.FilterWalk.Scanner do
+  @moduledoc "Contract for controllable cache/filesystem scanners used by filter effects."
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.FilterWalk.Result
+
+  @callback scan(FileTree.t(), term()) :: Result.t() | {:error, term()}
+end

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -13,8 +13,11 @@ defmodule MingaEditor.FileTree.Freshness do
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effect.Request
   alias MingaEditor.EffectScheduler
+  alias MingaEditor.FileTree.FilterWalk
+  alias MingaEditor.FileTree.FilterWalk.Result, as: FilterResult
   alias MingaEditor.FileTree.Refresh
-  alias MingaEditor.FileTree.Refresh.FilesystemScanner
+  alias MingaEditor.FileTree.WatcherSync
+  alias MingaEditor.FileTree.WatcherSync.Result, as: WatcherResult
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
 
@@ -128,14 +131,131 @@ defmodule MingaEditor.FileTree.Freshness do
 
   def apply_refresh_outcome(state, %Outcome{} = outcome), do: {state, outcome}
 
-  @spec schedule_refresh(state(), FileTree.t()) :: state()
-  defp schedule_refresh(%EditorState{effect_scheduler: nil} = state, _tree) do
+  @doc "Applies one typed filter outcome with request, root, and query correlation."
+  @spec apply_filter_outcome(state(), Outcome.t()) :: {state(), Outcome.t()}
+  def apply_filter_outcome(
+        state,
+        %Outcome{
+          status: :completed,
+          request: %Request{effect: %FilterWalk{} = effect} = request,
+          result: %FilterResult{} = result
+        } = outcome
+      ) do
+    case FileTreeState.accept_filter_result(
+           file_tree_state(state),
+           effect.root,
+           effect.filter,
+           request.id,
+           result
+         ) do
+      {:accepted, file_tree} ->
+        state = set_file_tree(state, file_tree)
+
+        state =
+          state
+          |> maybe_synchronize_watchers(effect)
+          |> sync_buffer(file_tree.tree)
+          |> MingaEditor.schedule_render(16)
+
+        {state, outcome}
+
+      {reason, file_tree} ->
+        {set_file_tree(state, file_tree), Outcome.stale(outcome, reason)}
+    end
+  end
+
+  def apply_filter_outcome(
+        state,
+        %Outcome{
+          status: :failed,
+          request: %Request{effect: %FilterWalk{} = effect} = request,
+          reason: reason
+        } = outcome
+      ) do
+    case FileTreeState.finish_filter(
+           file_tree_state(state),
+           effect.root,
+           effect.filter,
+           request.id
+         ) do
+      {:current, file_tree} ->
+        file_tree = FileTreeState.filter_failed(file_tree, reason)
+
+        state =
+          state
+          |> set_file_tree(file_tree)
+          |> MingaEditor.schedule_render(16)
+
+        {state, outcome}
+
+      {stale_reason, file_tree} ->
+        {set_file_tree(state, file_tree), Outcome.stale(outcome, stale_reason)}
+    end
+  end
+
+  def apply_filter_outcome(
+        state,
+        %Outcome{
+          status: status,
+          request: %Request{effect: %FilterWalk{} = effect} = request
+        } = outcome
+      )
+      when status in [:canceled, :stale] do
+    case FileTreeState.finish_filter(
+           file_tree_state(state),
+           effect.root,
+           effect.filter,
+           request.id
+         ) do
+      {:current, file_tree} -> {set_file_tree(state, file_tree), outcome}
+      {reason, file_tree} -> {set_file_tree(state, file_tree), Outcome.stale(outcome, reason)}
+    end
+  end
+
+  def apply_filter_outcome(state, %Outcome{} = outcome), do: {state, outcome}
+
+  @doc "Applies watcher synchronization outcomes without calling watcher services."
+  @spec apply_watcher_outcome(state(), Outcome.t()) :: {state(), Outcome.t()}
+  def apply_watcher_outcome(
+        state,
+        %Outcome{
+          status: :completed,
+          request: %Request{effect: %WatcherSync{}} = request,
+          result: %WatcherResult{target: target}
+        } = outcome
+      ) do
+    case FileTreeState.accept_watcher_result(file_tree_state(state), request.id, target) do
+      {:current, file_tree} -> {set_file_tree(state, file_tree), outcome}
+      {:stale, file_tree} -> {set_file_tree(state, file_tree), Outcome.stale(outcome, :stale)}
+    end
+  end
+
+  def apply_watcher_outcome(
+        state,
+        %Outcome{
+          status: status,
+          request: %Request{effect: %WatcherSync{}} = request
+        } = outcome
+      )
+      when status in [:failed, :canceled, :stale] do
+    case FileTreeState.finish_watcher_request(file_tree_state(state), request.id) do
+      {:current, file_tree} -> {set_file_tree(state, file_tree), outcome}
+      {:stale, file_tree} -> {set_file_tree(state, file_tree), Outcome.stale(outcome, :stale)}
+    end
+  end
+
+  def apply_watcher_outcome(state, %Outcome{} = outcome), do: {state, outcome}
+
+  @spec schedule_refresh(state(), FileTree.t(), keyword()) :: state()
+  defp schedule_refresh(state, tree, opts \\ [])
+
+  defp schedule_refresh(%EditorState{effect_scheduler: nil} = state, _tree, _opts) do
     Minga.Log.warning(:editor, "File tree refresh scheduler unavailable")
     state
   end
 
-  defp schedule_refresh(state, %FileTree{} = tree) do
-    request = Refresh.request(tree, state.extension_surfaces.events_registry)
+  defp schedule_refresh(state, %FileTree{} = tree, opts) do
+    request = Refresh.request(tree, state.extension_surfaces.events_registry, opts)
 
     case EffectScheduler.schedule(state.effect_scheduler, request) do
       {:ok, _request_id, _disposition} ->
@@ -179,10 +299,10 @@ defmodule MingaEditor.FileTree.Freshness do
          ) do
       {:accepted, file_tree} ->
         state = set_file_tree(state, file_tree)
-        watch_expanded_dirs(refreshed_tree)
 
         state =
           state
+          |> maybe_synchronize_watchers(effect)
           |> sync_buffer(refreshed_tree)
           |> MingaEditor.schedule_render(16)
 
@@ -207,14 +327,56 @@ defmodule MingaEditor.FileTree.Freshness do
   defp finish_failed_refresh(state, effect, request_token, reason) do
     case FileTreeState.finish_refresh(file_tree_state(state), effect.root, request_token) do
       {:current, file_tree} ->
-        state
-        |> set_file_tree(FileTreeState.refresh_failed(file_tree, reason))
-        |> MingaEditor.schedule_render(16)
+        file_tree = failed_file_tree(file_tree, effect, reason)
+        file_tree = prepare_failed_watcher_cleanup(file_tree, effect)
+        state = set_file_tree(state, file_tree)
+        state = maybe_synchronize_failed_watchers(state, effect)
+        state = maybe_sync_failed_root(state, file_tree, effect)
+        MingaEditor.schedule_render(state, 16)
 
       {_status, file_tree} ->
         set_file_tree(state, file_tree)
     end
   end
+
+  @spec maybe_synchronize_failed_watchers(state(), Refresh.t()) :: state()
+  defp maybe_synchronize_failed_watchers(
+         state,
+         %Refresh{previous_root: previous_root} = effect
+       )
+       when is_binary(previous_root),
+       do: maybe_synchronize_watchers(state, effect)
+
+  defp maybe_synchronize_failed_watchers(state, %Refresh{}), do: state
+
+  @spec prepare_failed_watcher_cleanup(FileTreeState.t(), Refresh.t()) :: FileTreeState.t()
+  defp prepare_failed_watcher_cleanup(
+         %FileTreeState{} = file_tree,
+         %Refresh{previous_root: previous_root}
+       )
+       when is_binary(previous_root),
+       do: FileTreeState.cleanup_watchers(file_tree)
+
+  defp prepare_failed_watcher_cleanup(%FileTreeState{} = file_tree, %Refresh{}), do: file_tree
+
+  @spec failed_file_tree(FileTreeState.t(), Refresh.t(), term()) :: FileTreeState.t()
+  defp failed_file_tree(file_tree, %Refresh{previous_root: previous_root}, reason)
+       when is_binary(previous_root),
+       do: FileTreeState.root_scan_failed(file_tree, reason)
+
+  defp failed_file_tree(file_tree, %Refresh{}, reason),
+    do: FileTreeState.refresh_failed(file_tree, reason)
+
+  @spec maybe_sync_failed_root(state(), FileTreeState.t(), Refresh.t()) :: state()
+  defp maybe_sync_failed_root(
+         state,
+         %FileTreeState{tree: %FileTree{} = tree},
+         %Refresh{previous_root: previous_root}
+       )
+       when is_binary(previous_root),
+       do: sync_buffer(state, tree)
+
+  defp maybe_sync_failed_root(state, %FileTreeState{}, %Refresh{}), do: state
 
   @doc "Updates tree git badges from an already-fetched git status event."
   @spec refresh_git_status(state(), Minga.Events.GitStatusEvent.t()) :: state()
@@ -257,80 +419,174 @@ defmodule MingaEditor.FileTree.Freshness do
     end
   end
 
-  @doc "Updates the remembered project root and replaces visible stale tree entries when the project changes."
-  @spec update_project_root(state(), String.t()) :: state()
-  def update_project_root(state, root) when is_binary(root) do
+  @doc "Publishes a project-root loading state and schedules its typed root scan."
+  @spec update_project_root(state(), String.t(), keyword()) :: state()
+  def update_project_root(state, root, opts \\ []) when is_binary(root) do
     expanded_root = Path.expand(root)
     file_tree = file_tree_state(state)
 
     case file_tree.tree do
       %FileTree{root: ^expanded_root} ->
-        file_tree
-        |> FileTreeState.set_project_root(expanded_root)
-        |> refilter_active_tree()
-        |> then(&set_file_tree(state, &1))
+        state = set_file_tree(state, FileTreeState.set_project_root(file_tree, expanded_root))
+        refilter_active_tree(state, opts)
 
       %FileTree{} = old_tree ->
-        unwatch_expanded_dirs(old_tree)
         new_tree = FileTree.new(expanded_root, width: old_tree.width)
+        file_tree = FileTreeState.begin_root_scan(file_tree, new_tree, :project)
 
-        case FilesystemScanner.scan(new_tree, nil) do
-          %FileTree{} = new_tree ->
-            new_tree =
-              Refresh.with_cached_git_status(new_tree, state.extension_surfaces.events_registry)
-
-            watch_expanded_dirs(new_tree)
-
-            file_tree =
-              file_tree
-              |> FileTreeState.set_project_root(expanded_root)
-              |> FileTreeState.replace_tree(new_tree)
-
-            state
-            |> set_file_tree(file_tree)
-            |> sync_buffer(new_tree)
-
-          {:error, {:root_unavailable, reason}} ->
-            failed_tree = FileTree.put_entries(new_tree, [])
-
-            file_tree =
-              file_tree
-              |> FileTreeState.set_project_root(expanded_root)
-              |> FileTreeState.replace_tree(failed_tree)
-              |> FileTreeState.refresh_failed(reason)
-
-            state
-            |> set_file_tree(file_tree)
-            |> sync_buffer(failed_tree)
-        end
+        state
+        |> set_file_tree(file_tree)
+        |> schedule_refresh(new_tree, Keyword.put(opts, :previous_root, old_tree.root))
 
       nil ->
         set_file_tree(state, FileTreeState.set_project_root(file_tree, expanded_root))
     end
   end
 
-  # Re-applies the active filter so an open filtered tree picks up the freshly
-  # rebuilt project cache (#2377 AC3). No-op when no filter is active, so normal
-  # expanded browsing keeps its lazy-walked entries untouched.
-  @spec refilter_active_tree(FileTreeState.t()) :: FileTreeState.t()
-  defp refilter_active_tree(%FileTreeState{tree: %FileTree{filter: filter}} = file_tree)
-       when is_binary(filter) and filter != "" do
-    FileTreeState.update_filter(file_tree, filter)
+  @doc "Publishes a browsing-root loading state and schedules its typed root scan."
+  @spec reroot(state(), String.t(), keyword()) :: state()
+  def reroot(state, root, opts \\ []) when is_binary(root) do
+    expanded_root = Path.expand(root)
+
+    case file_tree_state(state) do
+      %FileTreeState{tree: %FileTree{root: current_root}} when current_root == expanded_root ->
+        state
+
+      %FileTreeState{tree: %FileTree{} = old_tree} = file_tree ->
+        new_tree = FileTree.reroot(old_tree, expanded_root)
+        file_tree = FileTreeState.begin_root_scan(file_tree, new_tree, :reroot)
+
+        state
+        |> set_file_tree(file_tree)
+        |> schedule_refresh(new_tree, Keyword.put(opts, :previous_root, old_tree.root))
+
+      %FileTreeState{} ->
+        state
+    end
   end
 
-  defp refilter_active_tree(%FileTreeState{} = file_tree), do: file_tree
+  @doc "Publishes a loading filter query and schedules its typed cache/filesystem scan."
+  @spec update_filter(state(), String.t(), keyword()) :: state()
+  def update_filter(state, filter, opts \\ []) when is_binary(filter) and filter != "" do
+    file_tree = FileTreeState.update_filter(file_tree_state(state), filter)
 
-  @doc "Registers expanded tree directories with the external file watcher when it is running."
-  @spec watch_expanded_dirs(FileTree.t()) :: :ok
-  def watch_expanded_dirs(%FileTree{expanded: expanded}) do
-    Enum.each(expanded, &safe_watch_directory/1)
+    state
+    |> set_file_tree(file_tree)
+    |> schedule_filter(file_tree.tree, opts)
   end
 
-  @doc "Unregisters every watched project directory under the tree root when the file tree closes or changes root."
-  @spec unwatch_expanded_dirs(FileTree.t()) :: :ok
-  def unwatch_expanded_dirs(%FileTree{root: root}) do
-    safe_unwatch_directory_tree(root)
+  @doc "Starts filter input and reschedules any existing non-empty query."
+  @spec start_filtering(state(), keyword()) :: state()
+  def start_filtering(state, opts \\ []) do
+    file_tree = FileTreeState.start_filtering(file_tree_state(state))
+    state = set_file_tree(state, file_tree)
+
+    case file_tree.tree do
+      %FileTree{filter: filter} = tree when is_binary(filter) and filter != "" ->
+        schedule_filter(state, tree, opts)
+
+      _tree ->
+        state
+    end
   end
+
+  @doc "Publishes unfiltered loading rows and schedules their root scan."
+  @spec clear_filter(state(), :keep_open | :dismiss, keyword()) :: state()
+  def clear_filter(state, disposition, opts \\ [])
+      when disposition in [:keep_open, :dismiss] do
+    file_tree = FileTreeState.clear_filter_loading(file_tree_state(state), disposition)
+    state = set_file_tree(state, file_tree)
+
+    case file_tree.tree do
+      %FileTree{} = tree -> schedule_refresh(state, tree, opts)
+      nil -> state
+    end
+  end
+
+  @spec refilter_active_tree(state(), keyword()) :: state()
+  defp refilter_active_tree(state, opts) do
+    case file_tree_state(state).tree do
+      %FileTree{filter: filter} when is_binary(filter) and filter != "" ->
+        update_filter(state, filter, opts)
+
+      _tree ->
+        state
+    end
+  end
+
+  @spec schedule_filter(state(), FileTree.t() | nil, keyword()) :: state()
+  defp schedule_filter(state, nil, _opts), do: state
+
+  defp schedule_filter(%EditorState{effect_scheduler: nil} = state, %FileTree{}, _opts) do
+    Minga.Log.warning(:editor, "File tree filter scheduler unavailable")
+    state
+  end
+
+  defp schedule_filter(state, %FileTree{} = tree, opts) do
+    request = FilterWalk.request(tree, opts)
+
+    case EffectScheduler.schedule(state.effect_scheduler, request) do
+      {:ok, _request_id, _disposition} ->
+        file_tree =
+          state
+          |> file_tree_state()
+          |> FileTreeState.track_filter_request(tree.root, tree.filter, request.id)
+
+        set_file_tree(state, file_tree)
+
+      {:error, reason} ->
+        Minga.Log.warning(:editor, "File tree filter not scheduled: #{inspect(reason)}")
+        set_file_tree(state, FileTreeState.filter_failed(file_tree_state(state), reason))
+    end
+  end
+
+  @doc "Schedules the current file-tree watcher intent on the serialized watcher resource."
+  @spec synchronize_watchers(state(), keyword()) :: state()
+  def synchronize_watchers(state, opts \\ []) do
+    intent = FileTreeState.watcher_intent(file_tree_state(state))
+    schedule_watcher_sync(state, intent, opts)
+  end
+
+  @spec maybe_synchronize_watchers(state(), Refresh.t() | FilterWalk.t()) :: state()
+  defp maybe_synchronize_watchers(state, %Refresh{synchronize_watchers?: false}), do: state
+  defp maybe_synchronize_watchers(state, %FilterWalk{synchronize_watchers?: false}), do: state
+
+  defp maybe_synchronize_watchers(state, %Refresh{} = effect) do
+    synchronize_watchers(state, watcher_options(effect.watcher_backend, effect.watcher_context))
+  end
+
+  defp maybe_synchronize_watchers(state, %FilterWalk{} = effect) do
+    synchronize_watchers(state, watcher_options(effect.watcher_backend, effect.watcher_context))
+  end
+
+  @spec schedule_watcher_sync(state(), MingaEditor.State.FileTree.Watchers.t(), keyword()) ::
+          state()
+  defp schedule_watcher_sync(%EditorState{effect_scheduler: nil} = state, _intent, _opts) do
+    Minga.Log.warning(:editor, "File tree watcher scheduler unavailable")
+    state
+  end
+
+  defp schedule_watcher_sync(state, intent, opts) do
+    request = WatcherSync.request(intent.candidates, intent.target, intent.expanded_dirs, opts)
+
+    case EffectScheduler.schedule(state.effect_scheduler, request) do
+      {:ok, _request_id, _disposition} ->
+        file_tree =
+          state
+          |> file_tree_state()
+          |> FileTreeState.track_watcher_request(request.id)
+
+        set_file_tree(state, file_tree)
+
+      {:error, reason} ->
+        Minga.Log.warning(:editor, "File tree watcher sync not scheduled: #{inspect(reason)}")
+        state
+    end
+  end
+
+  @spec watcher_options(module() | nil, term()) :: keyword()
+  defp watcher_options(nil, context), do: [watcher_context: context]
+  defp watcher_options(backend, context), do: [watcher_backend: backend, watcher_context: context]
 
   @spec sync_buffer(state(), FileTree.t()) :: state()
   defp sync_buffer(state, tree) do
@@ -358,28 +614,6 @@ defmodule MingaEditor.FileTree.Freshness do
   @spec set_file_tree(state(), FileTreeState.t()) :: state()
   defp set_file_tree(%EditorState{} = state, %FileTreeState{} = file_tree) do
     %{state | workspace: MingaEditor.Session.State.set_file_tree(state.workspace, file_tree)}
-  end
-
-  @spec safe_watch_directory(String.t()) :: :ok
-  defp safe_watch_directory(path) when is_binary(path) do
-    Minga.FileWatcher.watch_directory(path)
-  catch
-    :exit, reason ->
-      Minga.Log.warning(
-        :editor,
-        "File tree watch registration failed for #{path}: #{inspect(reason)}"
-      )
-
-      :ok
-  end
-
-  @spec safe_unwatch_directory_tree(String.t()) :: :ok
-  defp safe_unwatch_directory_tree(path) when is_binary(path) do
-    Minga.FileWatcher.unwatch_directory_tree(path)
-  catch
-    :exit, reason ->
-      Minga.Log.warning(:editor, "File tree watch cleanup failed for #{path}: #{inspect(reason)}")
-      :ok
   end
 
   @spec path_under_root?(String.t(), String.t()) :: boolean()

--- a/lib/minga_editor/file_tree/project_cache.ex
+++ b/lib/minga_editor/file_tree/project_cache.ex
@@ -9,7 +9,12 @@ defmodule MingaEditor.FileTree.ProjectCache do
   the editor path. This module centralizes the "is this the active project root?"
   decision and the cache reads, with `:exit` guards so callers work even when the
   Project GenServer is unavailable (early startup, tests).
+
+  File-tree effects use `snapshot/1` in scheduler workers and pass the immutable
+  value into pure state transitions. The state owner never calls this service.
   """
+
+  alias MingaEditor.FileTree.ProjectCache.Snapshot
 
   @doc "Returns true when `root` expands to the active project root."
   @spec active_root?(String.t()) :: boolean()
@@ -42,5 +47,18 @@ defmodule MingaEditor.FileTree.ProjectCache do
     Minga.Project.rebuilding?()
   catch
     :exit, _ -> false
+  end
+
+  @doc "Reads all project-cache inputs needed to filter one root as an immutable value."
+  @spec snapshot(String.t()) :: Snapshot.t()
+  def snapshot(root) when is_binary(root) do
+    expanded_root = Path.expand(root)
+    active? = active_root?(expanded_root)
+
+    if active? do
+      Snapshot.new(expanded_root, true, files(), rebuilding?())
+    else
+      Snapshot.new(expanded_root, false, [], false)
+    end
   end
 end

--- a/lib/minga_editor/file_tree/project_cache/snapshot.ex
+++ b/lib/minga_editor/file_tree/project_cache/snapshot.ex
@@ -1,0 +1,26 @@
+defmodule MingaEditor.FileTree.ProjectCache.Snapshot do
+  @moduledoc "Immutable project-cache data prepared outside file-tree value transitions."
+
+  @enforce_keys [:root, :active?, :files, :rebuilding?]
+  defstruct [:root, :active?, :files, :rebuilding?]
+
+  @type t :: %__MODULE__{
+          root: String.t(),
+          active?: boolean(),
+          files: [String.t()],
+          rebuilding?: boolean()
+        }
+
+  @doc "Builds a project-cache snapshot for one expanded tree root."
+  @spec new(String.t(), boolean(), [String.t()], boolean()) :: t()
+  def new(root, active?, files, rebuilding?)
+      when is_binary(root) and is_boolean(active?) and is_list(files) and
+             is_boolean(rebuilding?) do
+    %__MODULE__{
+      root: Path.expand(root),
+      active?: active?,
+      files: files,
+      rebuilding?: rebuilding?
+    }
+  end
+end

--- a/lib/minga_editor/file_tree/refresh.ex
+++ b/lib/minga_editor/file_tree/refresh.ex
@@ -20,7 +20,17 @@ defmodule MingaEditor.FileTree.Refresh do
   alias MingaEditor.State, as: EditorState
 
   @enforce_keys [:root, :tree, :events_registry, :scanner, :scanner_context]
-  defstruct [:root, :tree, :events_registry, :scanner, :scanner_context]
+  defstruct [
+    :root,
+    :tree,
+    :events_registry,
+    :scanner,
+    :scanner_context,
+    :previous_root,
+    :watcher_backend,
+    :watcher_context,
+    synchronize_watchers?: true
+  ]
 
   @typedoc "Scanner module input kept as data in the scheduler request."
   @type scanner_context :: term()
@@ -30,7 +40,11 @@ defmodule MingaEditor.FileTree.Refresh do
           tree: FileTree.t(),
           events_registry: Minga.Events.registry(),
           scanner: module(),
-          scanner_context: scanner_context()
+          scanner_context: scanner_context(),
+          previous_root: String.t() | nil,
+          watcher_backend: module() | nil,
+          watcher_context: term(),
+          synchronize_watchers?: boolean()
         }
 
   @doc "Builds a coalescing request keyed by the expanded file-tree root."
@@ -43,7 +57,11 @@ defmodule MingaEditor.FileTree.Refresh do
       tree: tree,
       events_registry: events_registry,
       scanner: Keyword.get(opts, :scanner, MingaEditor.FileTree.Refresh.FilesystemScanner),
-      scanner_context: Keyword.get(opts, :scanner_context)
+      scanner_context: Keyword.get(opts, :scanner_context),
+      previous_root: expanded_optional_root(Keyword.get(opts, :previous_root)),
+      watcher_backend: Keyword.get(opts, :watcher_backend),
+      watcher_context: Keyword.get(opts, :watcher_context),
+      synchronize_watchers?: Keyword.get(opts, :synchronize_watchers?, true)
     }
 
     Request.new(effect, {:file_tree_root, expanded_root}, Policy.coalescing(1))
@@ -66,7 +84,9 @@ defmodule MingaEditor.FileTree.Refresh do
 
   @impl true
   @spec coalesce(t(), t()) :: t()
-  def coalesce(%__MODULE__{}, %__MODULE__{} = newer), do: newer
+  def coalesce(%__MODULE__{previous_root: previous_root}, %__MODULE__{} = newer) do
+    %{newer | previous_root: newer.previous_root || previous_root}
+  end
 
   @impl true
   @spec apply(EditorState.t(), Outcome.t()) :: {EditorState.t(), Outcome.t()}
@@ -109,6 +129,10 @@ defmodule MingaEditor.FileTree.Refresh do
 
       :ok
   end
+
+  @spec expanded_optional_root(String.t() | nil) :: String.t() | nil
+  defp expanded_optional_root(nil), do: nil
+  defp expanded_optional_root(root) when is_binary(root), do: Path.expand(root)
 
   @spec start_repo(String.t(), String.t(), Minga.Events.registry()) :: :ok
   defp start_repo(git_root, root, events_registry) do

--- a/lib/minga_editor/file_tree/watcher_sync.ex
+++ b/lib/minga_editor/file_tree/watcher_sync.ex
@@ -1,0 +1,112 @@
+defmodule MingaEditor.FileTree.WatcherSync do
+  @moduledoc """
+  Typed, serialized synchronization of file-tree watcher ownership.
+
+  Every request carries the full cleanup lineage plus the newest desired target.
+  Coalescing unions cleanup roots while retaining that newest target, so queued
+  reroot bursts cannot leak intermediate watchers.
+  """
+
+  @behaviour MingaEditor.Effect
+
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.Effect.Policy
+  alias MingaEditor.Effect.Request
+  alias MingaEditor.FileTree.Freshness
+  alias MingaEditor.FileTree.WatcherSync.FileWatcherBackend
+  alias MingaEditor.FileTree.WatcherSync.Result
+  alias MingaEditor.State, as: EditorState
+
+  @resource :file_tree_watcher_sync
+
+  @enforce_keys [:candidates, :target, :expanded_dirs, :backend, :backend_context]
+  defstruct [:candidates, :target, :expanded_dirs, :backend, :backend_context]
+
+  @type t :: %__MODULE__{
+          candidates: MapSet.t(String.t()),
+          target: String.t() | nil,
+          expanded_dirs: MapSet.t(String.t()),
+          backend: module(),
+          backend_context: term()
+        }
+
+  @doc "Builds one coalescing request on the stable watcher resource."
+  @spec request(MapSet.t(String.t()), String.t() | nil, MapSet.t(String.t()), keyword()) ::
+          Request.t()
+  def request(candidates, target, expanded_dirs, opts \\ []) do
+    effect = %__MODULE__{
+      candidates: expand_set(candidates),
+      target: expand_optional(target),
+      expanded_dirs: expand_set(expanded_dirs),
+      backend: Keyword.get(opts, :watcher_backend, FileWatcherBackend),
+      backend_context: Keyword.get(opts, :watcher_context)
+    }
+
+    Request.new(effect, @resource, Policy.coalescing(1))
+  end
+
+  @impl true
+  @spec run(t()) :: {:ok, Result.t()} | {:error, term()}
+  def run(%__MODULE__{} = effect) do
+    with :ok <- unwatch_obsolete_roots(effect),
+         :ok <- watch_target_dirs(effect) do
+      {:ok, Result.new(effect.target)}
+    end
+  end
+
+  @impl true
+  @spec coalesce(t(), t()) :: t()
+  def coalesce(%__MODULE__{} = older, %__MODULE__{} = newer) do
+    %{newer | candidates: MapSet.union(older.candidates, newer.candidates)}
+  end
+
+  @impl true
+  @spec apply(EditorState.t(), Outcome.t()) :: {EditorState.t(), Outcome.t()}
+  def apply(%EditorState{} = state, %Outcome{} = outcome) do
+    Freshness.apply_watcher_outcome(state, outcome)
+  end
+
+  @impl true
+  @spec render?(Outcome.t()) :: boolean()
+  def render?(%Outcome{}), do: false
+
+  @spec unwatch_obsolete_roots(t()) :: :ok | {:error, term()}
+  defp unwatch_obsolete_roots(%__MODULE__{} = effect) do
+    effect.candidates
+    |> Enum.reject(&same_target?(&1, effect.target))
+    |> Enum.sort()
+    |> Enum.reduce_while(:ok, fn root, :ok ->
+      case effect.backend.unwatch_directory_tree(root, effect.backend_context) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+        other -> {:halt, {:error, {:invalid_unwatch_result, root, other}}}
+      end
+    end)
+  end
+
+  @spec watch_target_dirs(t()) :: :ok | {:error, term()}
+  defp watch_target_dirs(%__MODULE__{target: nil}), do: :ok
+
+  defp watch_target_dirs(%__MODULE__{} = effect) do
+    effect.expanded_dirs
+    |> Enum.sort()
+    |> Enum.reduce_while(:ok, fn path, :ok ->
+      case effect.backend.watch_directory(path, effect.backend_context) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+        other -> {:halt, {:error, {:invalid_watch_result, path, other}}}
+      end
+    end)
+  end
+
+  @spec same_target?(String.t(), String.t() | nil) :: boolean()
+  defp same_target?(_root, nil), do: false
+  defp same_target?(root, target), do: Path.expand(root) == Path.expand(target)
+
+  @spec expand_optional(String.t() | nil) :: String.t() | nil
+  defp expand_optional(nil), do: nil
+  defp expand_optional(path) when is_binary(path), do: Path.expand(path)
+
+  @spec expand_set(MapSet.t(String.t())) :: MapSet.t(String.t())
+  defp expand_set(%MapSet{} = paths), do: MapSet.new(paths, &Path.expand/1)
+end

--- a/lib/minga_editor/file_tree/watcher_sync/backend.ex
+++ b/lib/minga_editor/file_tree/watcher_sync/backend.ex
@@ -1,0 +1,6 @@
+defmodule MingaEditor.FileTree.WatcherSync.Backend do
+  @moduledoc "Contract for file-watcher operations executed by the watcher synchronization effect."
+
+  @callback watch_directory(String.t(), term()) :: :ok | {:error, term()}
+  @callback unwatch_directory_tree(String.t(), term()) :: :ok | {:error, term()}
+end

--- a/lib/minga_editor/file_tree/watcher_sync/file_watcher_backend.ex
+++ b/lib/minga_editor/file_tree/watcher_sync/file_watcher_backend.ex
@@ -1,0 +1,21 @@
+defmodule MingaEditor.FileTree.WatcherSync.FileWatcherBackend do
+  @moduledoc "Production watcher backend that isolates FileWatcher calls inside effect workers."
+
+  @behaviour MingaEditor.FileTree.WatcherSync.Backend
+
+  @impl true
+  @spec watch_directory(String.t(), term()) :: :ok | {:error, term()}
+  def watch_directory(path, _context) when is_binary(path) do
+    Minga.FileWatcher.watch_directory(path)
+  catch
+    :exit, reason -> {:error, {:watch_failed, path, reason}}
+  end
+
+  @impl true
+  @spec unwatch_directory_tree(String.t(), term()) :: :ok | {:error, term()}
+  def unwatch_directory_tree(path, _context) when is_binary(path) do
+    Minga.FileWatcher.unwatch_directory_tree(path)
+  catch
+    :exit, reason -> {:error, {:unwatch_failed, path, reason}}
+  end
+end

--- a/lib/minga_editor/file_tree/watcher_sync/result.ex
+++ b/lib/minga_editor/file_tree/watcher_sync/result.ex
@@ -1,0 +1,13 @@
+defmodule MingaEditor.FileTree.WatcherSync.Result do
+  @moduledoc "Typed immutable result of one successful watcher synchronization."
+
+  @enforce_keys [:target]
+  defstruct [:target]
+
+  @type t :: %__MODULE__{target: String.t() | nil}
+
+  @doc "Builds a result for the exact synchronized target."
+  @spec new(String.t() | nil) :: t()
+  def new(nil), do: %__MODULE__{target: nil}
+  def new(target) when is_binary(target), do: %__MODULE__{target: Path.expand(target)}
+end

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -98,11 +98,6 @@ defmodule MingaEditor.Handlers.FileEventHandler do
     handle_file_changed(state, path)
   end
 
-  def handle(state, {:file_tree_filter_walk, root, filter, entries})
-      when is_binary(root) and is_binary(filter) and is_list(entries) do
-    handle_filter_walk_result(state, root, filter, entries)
-  end
-
   def handle(state, {:git_remote_result, ref, result}) when is_reference(ref) do
     {state, [{:handle_git_remote_result, ref, result}]}
   end
@@ -307,16 +302,4 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   end
 
   defp maybe_refresh_file_picker(state), do: state
-
-  @spec handle_filter_walk_result(EditorState.t(), String.t(), String.t(), [
-          Minga.Project.FileTree.entry()
-        ]) :: {EditorState.t(), [file_effect()]}
-  defp handle_filter_walk_result(state, root, filter, entries) do
-    file_tree =
-      state.workspace.file_tree
-      |> MingaEditor.State.FileTree.apply_filter_walk(root, filter, entries)
-
-    {%{state | workspace: MingaEditor.Session.State.set_file_tree(state.workspace, file_tree)},
-     [{:render, 16}]}
-  end
 end

--- a/lib/minga_editor/input/file_tree_handler.ex
+++ b/lib/minga_editor/input/file_tree_handler.ex
@@ -14,7 +14,7 @@ defmodule MingaEditor.Input.FileTreeHandler do
 
   alias Minga.Buffer
   alias MingaEditor.Commands
-  alias MingaEditor.FileTree.FilterWalk
+  alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.FocusTree
   alias MingaEditor.FocusTree.Node, as: FocusNode
   alias MingaEditor.State, as: EditorState
@@ -425,30 +425,11 @@ defmodule MingaEditor.Input.FileTreeHandler do
     end
   end
 
-  # Updates the active filter, then kicks off the async no-cache filesystem walk
-  # when the tree root is not covered by the project cache (#2377 AC4). The
-  # active project root filters in memory inside update_filter/2, so the walk is
-  # only spawned for other roots. The walk result arrives as a
-  # {:file_tree_filter_walk, ...} message handled by the editor.
   @spec apply_filter_update(EditorState.t(), String.t()) :: EditorState.t()
   defp apply_filter_update(state, ""), do: Commands.FileTree.reset_filter_query(state)
 
-  defp apply_filter_update(state, filter_text) do
-    file_tree = FileTreeState.update_filter(file_tree_state(state), filter_text)
-    maybe_spawn_filter_walk(file_tree)
-    set_file_tree(state, file_tree)
-  end
-
-  @spec maybe_spawn_filter_walk(FileTreeState.t()) :: :ok
-  defp maybe_spawn_filter_walk(%FileTreeState{tree: %FileTree{} = tree} = file_tree) do
-    if FileTreeState.needs_filter_walk?(file_tree) do
-      FilterWalk.start(tree, self())
-    end
-
-    :ok
-  end
-
-  defp maybe_spawn_filter_walk(%FileTreeState{}), do: :ok
+  defp apply_filter_update(state, filter_text),
+    do: FileTreeFreshness.update_filter(state, filter_text)
 
   # ── Shared helpers ──────────────────────────────────────────────────────
 

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -8,10 +8,11 @@ defmodule MingaEditor.State.FileTree do
   """
 
   alias Minga.Project.FileTree
-  alias MingaEditor.FileTree.FilterWalk
-  alias MingaEditor.FileTree.ProjectCache
+  alias MingaEditor.FileTree.FilterWalk.Result, as: FilterResult
+  alias MingaEditor.FileTree.ProjectCache.Snapshot, as: ProjectCacheSnapshot
   alias MingaEditor.State.FileTree.ClipboardMark
   alias MingaEditor.State.FileTree.Refresh
+  alias MingaEditor.State.FileTree.Watchers
 
   @typedoc """
   Inline editing state for creating files/folders or renaming entries.
@@ -33,6 +34,13 @@ defmodule MingaEditor.State.FileTree do
   @type clipboard_operation :: ClipboardMark.operation()
   @type clipboard_mark :: ClipboardMark.t()
 
+  @typedoc "Identity of the latest admitted filter request."
+  @type filter_request :: %{
+          root: String.t(),
+          filter: String.t(),
+          token: reference()
+        }
+
   @typedoc "Explicit presentation state for the file tree sidebar."
   @type tree_status :: :hidden | :loading | :empty | :ready | {:error, String.t()}
 
@@ -50,6 +58,8 @@ defmodule MingaEditor.State.FileTree do
           refresh: Refresh.t(),
           clipboard_mark: clipboard_mark() | nil,
           filtering: boolean(),
+          filter_request: filter_request() | nil,
+          watchers: Watchers.t(),
           help_visible: boolean()
         }
 
@@ -65,6 +75,8 @@ defmodule MingaEditor.State.FileTree do
             refresh: %Refresh{},
             clipboard_mark: nil,
             filtering: false,
+            filter_request: nil,
+            watchers: %Watchers{},
             help_visible: false
 
   @doc """
@@ -147,6 +159,8 @@ defmodule MingaEditor.State.FileTree do
   @doc "Opens the tree with the given data, buffer, and focused state."
   @spec open(t(), FileTree.t(), pid() | nil) :: t()
   def open(%__MODULE__{} = ft, tree, buffer) do
+    watchers = Watchers.retarget(ft.watchers, current_tree_roots(ft), tree)
+
     %{
       ft
       | tree: tree,
@@ -157,7 +171,9 @@ defmodule MingaEditor.State.FileTree do
         original_root: ft.original_root || tree.root,
         tree_status: classify_tree(tree),
         tree_width: tree.width,
-        refresh: refresh_for_tree(ft, tree.root)
+        refresh: refresh_for_tree(ft, tree.root),
+        filter_request: nil,
+        watchers: watchers
     }
   end
 
@@ -165,6 +181,7 @@ defmodule MingaEditor.State.FileTree do
   @spec replace_tree(t(), FileTree.t()) :: t()
   def replace_tree(%__MODULE__{} = ft, %FileTree{} = tree) do
     refresh = refresh_for_tree(ft, tree.root)
+    watchers = Watchers.retarget(ft.watchers, current_tree_roots(ft), tree)
 
     %{
       ft
@@ -172,7 +189,9 @@ defmodule MingaEditor.State.FileTree do
         project_root: tree.root,
         tree_status: replacement_status(ft, tree),
         tree_width: tree.width,
-        refresh: refresh
+        refresh: refresh,
+        filter_request: nil,
+        watchers: watchers
     }
   end
 
@@ -188,6 +207,7 @@ defmodule MingaEditor.State.FileTree do
       | focused: false,
         editing: nil,
         filtering: false,
+        filter_request: nil,
         help_visible: false,
         tree_status: :loading
     }
@@ -200,6 +220,62 @@ defmodule MingaEditor.State.FileTree do
   def set_project_root(%__MODULE__{} = ft, root) when is_binary(root) do
     expanded = Path.expand(root)
     %{ft | project_root: expanded, original_root: expanded}
+  end
+
+  @doc "Publishes an immediate loading tree for a root scan without resolving entries."
+  @spec begin_root_scan(t(), FileTree.t(), :project | :reroot) :: t()
+  def begin_root_scan(%__MODULE__{} = ft, %FileTree{} = tree, kind)
+      when kind in [:project, :reroot] do
+    expanded_root = Path.expand(tree.root)
+    original_root = if kind == :project, do: expanded_root, else: ft.original_root
+    watchers = Watchers.retarget(ft.watchers, current_tree_roots(ft), tree)
+
+    %{
+      ft
+      | tree: tree,
+        project_root: expanded_root,
+        original_root: original_root,
+        tree_status: :loading,
+        tree_width: tree.width,
+        editing: nil,
+        filtering: false,
+        filter_request: nil,
+        help_visible: false,
+        refresh: Refresh.invalidate(ft.refresh),
+        watchers: watchers
+    }
+  end
+
+  @doc "Returns the immutable watcher intent owned by this file tree."
+  @spec watcher_intent(t()) :: Watchers.t()
+  def watcher_intent(%__MODULE__{} = ft), do: ft.watchers
+
+  @doc "Correlates the latest admitted watcher synchronization request."
+  @spec track_watcher_request(t(), reference()) :: t()
+  def track_watcher_request(%__MODULE__{} = ft, token) when is_reference(token) do
+    %{ft | watchers: Watchers.request_admitted(ft.watchers, token)}
+  end
+
+  @doc "Collapses watcher lineage only for the latest exact successful request."
+  @spec accept_watcher_result(t(), reference(), String.t() | nil) :: {:current | :stale, t()}
+  def accept_watcher_result(%__MODULE__{} = ft, token, target) when is_reference(token) do
+    case Watchers.synchronized(ft.watchers, token, target) do
+      {status, watchers} -> {status, %{ft | watchers: watchers}}
+    end
+  end
+
+  @doc "Finishes watcher work without discarding cleanup candidates."
+  @spec finish_watcher_request(t(), reference()) :: {:current | :stale, t()}
+  def finish_watcher_request(%__MODULE__{} = ft, token) when is_reference(token) do
+    case Watchers.request_finished(ft.watchers, token) do
+      {status, watchers} -> {status, %{ft | watchers: watchers}}
+    end
+  end
+
+  @doc "Changes the watcher target to cleanup-only while retaining all known roots."
+  @spec cleanup_watchers(t()) :: t()
+  def cleanup_watchers(%__MODULE__{} = ft) do
+    %{ft | watchers: Watchers.cleanup(ft.watchers, current_tree_roots(ft))}
   end
 
   @doc "Records one debounced request to refresh the open tree."
@@ -274,9 +350,21 @@ defmodule MingaEditor.State.FileTree do
     %{ft | tree_status: {:error, format_error_reason(reason)}}
   end
 
+  @doc "Installs an empty failed root scan while retaining the requested root."
+  @spec root_scan_failed(t(), term()) :: t()
+  def root_scan_failed(%__MODULE__{tree: %FileTree{} = tree} = ft, reason) do
+    ft
+    |> replace_tree(FileTree.put_entries(tree, []))
+    |> refresh_failed(reason)
+  end
+
+  def root_scan_failed(%__MODULE__{} = ft, reason), do: refresh_failed(ft, reason)
+
   @doc "Closes the tree and clears the buffer."
   @spec close(t()) :: t()
   def close(%__MODULE__{} = ft) do
+    watchers = Watchers.cleanup(ft.watchers, current_tree_roots(ft))
+
     %{
       ft
       | tree: nil,
@@ -287,6 +375,8 @@ defmodule MingaEditor.State.FileTree do
         tree_status: :hidden,
         clipboard_mark: nil,
         filtering: false,
+        filter_request: nil,
+        watchers: watchers,
         help_visible: false,
         refresh: Refresh.invalidate(ft.refresh)
     }
@@ -332,117 +422,87 @@ defmodule MingaEditor.State.FileTree do
   @spec clear_clipboard(t()) :: t()
   def clear_clipboard(%__MODULE__{} = ft), do: %{ft | clipboard_mark: nil}
 
-  @doc "Starts inline file tree filtering."
+  @doc "Starts inline file tree filtering without resolving any rows."
   @spec start_filtering(t()) :: t()
   def start_filtering(%__MODULE__{tree: %FileTree{filter: filter} = tree} = ft)
       when filter in [nil, ""] do
     %{ft | tree: FileTree.begin_filter(tree), filtering: true, editing: nil, help_visible: false}
   end
 
-  def start_filtering(%__MODULE__{tree: %FileTree{} = tree} = ft) do
-    {tree, status} = filtered_tree(tree, tree.filter)
-
-    %{
-      ft
-      | tree: tree,
-        tree_status: status,
-        filtering: true,
-        editing: nil,
-        help_visible: false
-    }
+  def start_filtering(%__MODULE__{tree: %FileTree{filter: filter}} = ft)
+      when is_binary(filter) and filter != "" do
+    ft
+    |> update_filter(filter)
+    |> then(&%{&1 | filtering: true, editing: nil, help_visible: false})
   end
 
   def start_filtering(%__MODULE__{} = ft), do: ft
 
-  @doc """
-  Updates the active file tree filter.
-
-  When the tree root matches the active project root, the matching entries are
-  filtered in memory from the project's cached file list (`Minga.Project.files/0`)
-  rather than walking the filesystem. Roots not covered by the active cache fall
-  back to the filesystem walk.
-
-  While the active project's cache is still rebuilding (empty list), the tree
-  reports a `:loading` pending state instead of silently re-shelling out.
-  """
+  @doc "Publishes a loading filter transition without cache or filesystem calls."
   @spec update_filter(t(), String.t()) :: t()
   def update_filter(%__MODULE__{tree: %FileTree{} = tree} = ft, filter)
       when is_binary(filter) and filter != "" do
-    {tree, status} = filtered_tree(tree, filter)
-    %{ft | tree: tree, tree_status: status}
+    tree = tree |> FileTree.put_cached_files(nil) |> FileTree.set_filter(filter)
+    %{ft | tree: tree, tree_status: :loading, filter_request: nil}
   end
 
   def update_filter(%__MODULE__{} = ft, _filter), do: ft
 
-  @doc """
-  Returns true when filtering the tree requires the async no-cache filesystem
-  walk (#2377 AC4): a filter is active and the tree root is not the active
-  project root, so in-memory cache filtering does not cover it.
-  """
-  @spec needs_filter_walk?(t()) :: boolean()
-  def needs_filter_walk?(%__MODULE__{tree: %FileTree{filter: filter, root: root}})
-      when is_binary(filter) and filter != "" do
-    not ProjectCache.active_root?(root)
-  end
+  @doc "Publishes an unfiltered loading tree while preserving filter-input disposition."
+  @spec clear_filter_loading(t(), :keep_open | :dismiss) :: t()
+  def clear_filter_loading(%__MODULE__{tree: %FileTree{} = tree} = ft, disposition) do
+    tree = tree |> FileTree.put_cached_files(nil) |> FileTree.clear_filter()
 
-  def needs_filter_walk?(%__MODULE__{}), do: false
-
-  @doc """
-  Applies an async no-cache filter walk result, dropping it if stale.
-
-  The result is keyed by the `(root, filter)` it was computed for; if the user
-  has since changed the filter or re-rooted the tree it is discarded so a slow
-  walk never clobbers newer state (#2377 AC4 stale-result dropping).
-  """
-  @spec apply_filter_walk(t(), String.t(), String.t(), [FileTree.entry()]) :: t()
-  def apply_filter_walk(%__MODULE__{tree: %FileTree{} = tree} = ft, root, filter, entries) do
-    if FilterWalk.fresh?(tree, root, filter) do
-      tree = FileTree.put_entries(tree, entries)
-      %{ft | tree: tree, tree_status: classify_entries(entries)}
-    else
+    %{
       ft
+      | tree: tree,
+        tree_status: :loading,
+        filtering: disposition == :keep_open,
+        filter_request: nil
+    }
+  end
+
+  def clear_filter_loading(%__MODULE__{} = ft, _disposition), do: ft
+
+  @doc "Correlates the latest admitted filter request with its exact root and query."
+  @spec track_filter_request(t(), String.t(), String.t(), reference()) :: t()
+  def track_filter_request(%__MODULE__{} = ft, root, filter, token)
+      when is_binary(root) and is_binary(filter) and is_reference(token) do
+    request = %{root: Path.expand(root), filter: filter, token: token}
+    %{ft | filter_request: request, refresh: Refresh.invalidate(ft.refresh)}
+  end
+
+  @doc "Installs a current filter result prepared by a scheduler worker."
+  @spec accept_filter_result(t(), String.t(), String.t(), reference(), FilterResult.t()) ::
+          {:accepted | :closed | :rerooted | :stale, t()}
+  def accept_filter_result(
+        %__MODULE__{} = ft,
+        root,
+        filter,
+        token,
+        %FilterResult{} = result
+      )
+      when is_binary(root) and is_binary(filter) and is_reference(token) do
+    case classify_filter_request(ft, root, filter, token) do
+      :current -> install_filter_result(%{ft | filter_request: nil}, result)
+      reason -> {reason, ft}
     end
   end
 
-  def apply_filter_walk(%__MODULE__{} = ft, _root, _filter, _entries), do: ft
-
-  # Resolves the filtered tree plus its presentation status. An empty filter is
-  # the full unfiltered tree (always classified from the walk). With an active
-  # filter, the active project root filters in memory from the cache; a
-  # rebuilding (empty) cache reports `:loading`; other roots defer to an async
-  # filesystem walk (`:loading` until the walk result arrives).
-  @spec filtered_tree(FileTree.t(), String.t()) :: {FileTree.t(), tree_status()}
-  defp filtered_tree(%FileTree{root: root} = tree, filter) do
-    if ProjectCache.active_root?(root) do
-      filtered_from_cache(tree, filter, ProjectCache.files())
-    else
-      # No-cache root: clear the cache and mark loading; the editor spawns an
-      # async walk (see needs_filter_walk?/1) and applies the result later.
-      tree = tree |> FileTree.put_cached_files(nil) |> FileTree.set_filter(filter)
-      {tree, :loading}
+  @doc "Finishes a current failed or canceled filter request without installing rows."
+  @spec finish_filter(t(), String.t(), String.t(), reference()) ::
+          {:current | :closed | :rerooted | :stale, t()}
+  def finish_filter(%__MODULE__{} = ft, root, filter, token)
+      when is_binary(root) and is_binary(filter) and is_reference(token) do
+    case classify_filter_request(ft, root, filter, token) do
+      :current -> {:current, %{ft | filter_request: nil}}
+      reason -> {reason, ft}
     end
   end
 
-  @spec filtered_from_cache(FileTree.t(), String.t(), [String.t()]) ::
-          {FileTree.t(), tree_status()}
-  defp filtered_from_cache(tree, filter, []) do
-    # Active root but the cache is empty: a rebuild is in progress (or the
-    # project has no files). Show a pending state rather than re-shelling out.
-    tree = tree |> FileTree.put_cached_files([]) |> FileTree.set_filter(filter)
-    {tree, cache_pending_status(tree)}
-  end
-
-  defp filtered_from_cache(tree, filter, files) do
-    tree = tree |> FileTree.put_cached_files(files) |> FileTree.set_filter(filter)
-    {tree, classify_entries(FileTree.visible_entries(tree))}
-  end
-
-  @spec cache_pending_status(FileTree.t()) :: tree_status()
-  defp cache_pending_status(tree) do
-    if ProjectCache.rebuilding?(),
-      do: :loading,
-      else: classify_entries(FileTree.visible_entries(tree))
-  end
+  @doc "Reports a current filter failure while preserving recovery on the next query."
+  @spec filter_failed(t(), term()) :: t()
+  def filter_failed(%__MODULE__{} = ft, reason), do: refresh_failed(ft, reason)
 
   @doc "Accepts the current filter and leaves the narrowed tree visible."
   @spec accept_filter(t()) :: t()
@@ -466,7 +526,14 @@ defmodule MingaEditor.State.FileTree do
   @doc "Replaces the tree data."
   @spec set_tree(t(), FileTree.t() | nil) :: t()
   def set_tree(%__MODULE__{} = ft, nil) do
-    %{ft | tree: nil, tree_status: :hidden, refresh: Refresh.invalidate(ft.refresh)}
+    %{
+      ft
+      | tree: nil,
+        tree_status: :hidden,
+        refresh: Refresh.invalidate(ft.refresh),
+        filter_request: nil,
+        watchers: Watchers.cleanup(ft.watchers, current_tree_roots(ft))
+    }
   end
 
   def set_tree(%__MODULE__{} = ft, %FileTree{} = tree), do: replace_tree(ft, tree)
@@ -480,24 +547,121 @@ defmodule MingaEditor.State.FileTree do
   defp accept_current_refresh(%__MODULE__{tree: nil} = ft, _root, _tree), do: {:closed, ft}
 
   defp accept_current_refresh(
-         %__MODULE__{tree: %FileTree{root: live_root}} = ft,
+         %__MODULE__{
+           tree: %FileTree{root: live_root},
+           project_root: project_root,
+           filter_request: filter_request
+         } = ft,
          root,
          %FileTree{root: result_root} = refreshed_tree
        ) do
-    case {Path.expand(live_root) == Path.expand(root),
-          Path.expand(result_root) == Path.expand(root)} do
-      {false, _result_matches?} -> {:rerooted, ft}
-      {true, false} -> {:stale, ft}
-      {true, true} -> {:accepted, replace_tree(ft, refreshed_tree)}
+    expanded_root = Path.expand(root)
+
+    case {Path.expand(live_root) == expanded_root,
+          is_binary(project_root) and Path.expand(project_root) == expanded_root,
+          Path.expand(result_root) == expanded_root, is_nil(filter_request)} do
+      {false, _project_matches?, _result_matches?, _filter_idle?} -> {:rerooted, ft}
+      {true, false, _result_matches?, _filter_idle?} -> {:rerooted, ft}
+      {true, true, false, _filter_idle?} -> {:stale, ft}
+      {true, true, true, false} -> {:stale, ft}
+      {true, true, true, true} -> {:accepted, replace_tree(ft, refreshed_tree)}
     end
   end
 
   @spec classify_current_tree(t(), String.t()) :: {:current | :closed | :rerooted, t()}
   defp classify_current_tree(%__MODULE__{tree: nil} = ft, _root), do: {:closed, ft}
 
-  defp classify_current_tree(%__MODULE__{tree: %FileTree{root: live_root}} = ft, root) do
-    if Path.expand(live_root) == Path.expand(root), do: {:current, ft}, else: {:rerooted, ft}
+  defp classify_current_tree(
+         %__MODULE__{tree: %FileTree{root: live_root}, project_root: project_root} = ft,
+         root
+       ) do
+    expanded_root = Path.expand(root)
+
+    if Path.expand(live_root) == expanded_root and is_binary(project_root) and
+         Path.expand(project_root) == expanded_root do
+      {:current, ft}
+    else
+      {:rerooted, ft}
+    end
   end
+
+  @spec classify_filter_request(t(), String.t(), String.t(), reference()) ::
+          :current | :closed | :rerooted | :stale
+  defp classify_filter_request(%__MODULE__{tree: nil}, _root, _filter, _token), do: :closed
+
+  defp classify_filter_request(
+         %__MODULE__{
+           tree: %FileTree{root: live_root, filter: live_filter},
+           project_root: project_root,
+           filter_request: request
+         },
+         root,
+         filter,
+         token
+       ) do
+    expanded_root = Path.expand(root)
+
+    case request do
+      %{root: ^expanded_root, filter: ^filter, token: ^token} ->
+        if Path.expand(live_root) == expanded_root and live_filter == filter and
+             is_binary(project_root) and Path.expand(project_root) == expanded_root do
+          :current
+        else
+          :rerooted
+        end
+
+      _request ->
+        :stale
+    end
+  end
+
+  @spec install_filter_result(t(), FilterResult.t()) ::
+          {:accepted | :stale, t()}
+  defp install_filter_result(
+         %__MODULE__{tree: %FileTree{} = tree} = ft,
+         %FilterResult{root: root, filter: filter, source: :filesystem, entries: entries}
+       )
+       when is_list(entries) do
+    if Path.expand(tree.root) == Path.expand(root) and tree.filter == filter do
+      tree = FileTree.put_entries(tree, entries)
+      watchers = Watchers.retarget(ft.watchers, [tree.root], tree)
+      {:accepted, %{ft | tree: tree, tree_status: classify_entries(entries), watchers: watchers}}
+    else
+      {:stale, ft}
+    end
+  end
+
+  defp install_filter_result(
+         %__MODULE__{tree: %FileTree{} = tree} = ft,
+         %FilterResult{
+           root: root,
+           filter: filter,
+           source: :project_cache,
+           entries: entries,
+           project_cache: %ProjectCacheSnapshot{} = snapshot
+         }
+       )
+       when is_list(entries) do
+    if Path.expand(tree.root) == Path.expand(root) and tree.filter == filter and
+         snapshot.active? and Path.expand(snapshot.root) == Path.expand(root) do
+      tree = tree |> FileTree.put_cached_files(snapshot.files) |> FileTree.put_entries(entries)
+      status = cache_result_status(entries, snapshot)
+      watchers = Watchers.retarget(ft.watchers, [tree.root], tree)
+      {:accepted, %{ft | tree: tree, tree_status: status, watchers: watchers}}
+    else
+      {:stale, ft}
+    end
+  end
+
+  @spec cache_result_status([FileTree.entry()], ProjectCacheSnapshot.t()) :: tree_status()
+  defp cache_result_status(_entries, %ProjectCacheSnapshot{files: [], rebuilding?: true}),
+    do: :loading
+
+  defp cache_result_status(entries, %ProjectCacheSnapshot{}), do: classify_entries(entries)
+
+  @spec current_tree_roots(t()) :: [String.t()]
+  defp current_tree_roots(%__MODULE__{tree: %FileTree{root: root}}), do: [root]
+  defp current_tree_roots(%__MODULE__{}), do: []
 
   @spec refresh_for_tree(t(), String.t()) :: Refresh.t()
   defp refresh_for_tree(

--- a/lib/minga_editor/state/file_tree/watchers.ex
+++ b/lib/minga_editor/state/file_tree/watchers.ex
@@ -1,0 +1,83 @@
+defmodule MingaEditor.State.FileTree.Watchers do
+  @moduledoc """
+  File-tree-owned watcher intent and cleanup lineage.
+
+  Candidates are retained until the latest exact synchronization succeeds.
+  Failed, canceled, and stale work can therefore be recovered by the next exact
+  request without relying on an effect queue's bounded history.
+  """
+
+  alias Minga.Project.FileTree
+
+  @type request :: %{token: reference(), target: String.t() | nil}
+
+  @type t :: %__MODULE__{
+          candidates: MapSet.t(String.t()),
+          target: String.t() | nil,
+          expanded_dirs: MapSet.t(String.t()),
+          request: request() | nil
+        }
+
+  defstruct candidates: MapSet.new(), target: nil, expanded_dirs: MapSet.new(), request: nil
+
+  @doc "Records a desired tree while retaining every known cleanup root."
+  @spec retarget(t(), [String.t()], FileTree.t()) :: t()
+  def retarget(%__MODULE__{} = watchers, roots, %FileTree{} = tree) when is_list(roots) do
+    target = Path.expand(tree.root)
+
+    %{
+      watchers
+      | candidates: add_roots(watchers.candidates, [target | roots]),
+        target: target,
+        expanded_dirs: expand_set(tree.expanded)
+    }
+  end
+
+  @doc "Records cleanup of all known roots with no replacement target."
+  @spec cleanup(t(), [String.t()]) :: t()
+  def cleanup(%__MODULE__{} = watchers, roots) when is_list(roots) do
+    %{
+      watchers
+      | candidates: add_roots(watchers.candidates, roots),
+        target: nil,
+        expanded_dirs: MapSet.new()
+    }
+  end
+
+  @doc "Correlates the latest admitted watcher request with its exact target."
+  @spec request_admitted(t(), reference()) :: t()
+  def request_admitted(%__MODULE__{} = watchers, token) when is_reference(token) do
+    %{watchers | request: %{token: token, target: watchers.target}}
+  end
+
+  @doc "Collapses ownership only after the latest exact request succeeds."
+  @spec synchronized(t(), reference(), String.t() | nil) :: {:current | :stale, t()}
+  def synchronized(
+        %__MODULE__{request: %{token: token, target: target}} = watchers,
+        token,
+        target
+      ) do
+    candidates = if is_binary(target), do: MapSet.new([target]), else: MapSet.new()
+    {:current, %{watchers | candidates: candidates, request: nil}}
+  end
+
+  def synchronized(%__MODULE__{} = watchers, _token, _target), do: {:stale, watchers}
+
+  @doc "Finishes a failed or canceled exact request without dropping cleanup lineage."
+  @spec request_finished(t(), reference()) :: {:current | :stale, t()}
+  def request_finished(%__MODULE__{request: %{token: token}} = watchers, token) do
+    {:current, %{watchers | request: nil}}
+  end
+
+  def request_finished(%__MODULE__{} = watchers, _token), do: {:stale, watchers}
+
+  @spec add_roots(MapSet.t(String.t()), [String.t()]) :: MapSet.t(String.t())
+  defp add_roots(candidates, roots) do
+    Enum.reduce(roots, candidates, fn root, acc ->
+      if is_binary(root), do: MapSet.put(acc, Path.expand(root)), else: acc
+    end)
+  end
+
+  @spec expand_set(MapSet.t(String.t())) :: MapSet.t(String.t())
+  defp expand_set(%MapSet{} = paths), do: MapSet.new(paths, &Path.expand/1)
+end

--- a/test/minga_editor/file_tree/filter_walk_test.exs
+++ b/test/minga_editor/file_tree/filter_walk_test.exs
@@ -1,45 +1,208 @@
 defmodule MingaEditor.FileTree.FilterWalkTest do
+  @moduledoc "Deterministic typed filter-effect and workflow tests."
+
   use ExUnit.Case, async: true
 
   alias Minga.Project.FileTree
+  alias Minga.Test.FileTreeFilterScanner
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.EffectScheduler
   alias MingaEditor.FileTree.FilterWalk
+  alias MingaEditor.FileTree.FilterWalk.CacheOrFilesystemScanner
+  alias MingaEditor.FileTree.FilterWalk.Result
+  alias MingaEditor.FileTree.Freshness
+  alias MingaEditor.FileTree.ProjectCache.Snapshot
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
 
-  describe "fresh?/3" do
-    test "a result for the current root and filter is fresh" do
-      tree = "/root" |> FileTree.new() |> FileTree.set_filter("needle")
+  import MingaEditor.RenderPipeline.TestHelpers
 
-      assert FilterWalk.fresh?(tree, "/root", "needle")
-    end
+  @moduletag :tmp_dir
+  @timeout 2_000
 
-    test "a result for a superseded filter is stale" do
-      tree = "/root" |> FileTree.new() |> FileTree.set_filter("newer")
+  test "request is latest-wins and keyed by the expanded tree root", %{tmp_dir: root} do
+    tree = root |> FileTree.new() |> FileTree.set_filter("needle")
+    request = FilterWalk.request(tree)
 
-      refute FilterWalk.fresh?(tree, "/root", "older")
-    end
-
-    test "a result for a different root is stale" do
-      tree = "/current" |> FileTree.new() |> FileTree.set_filter("needle")
-
-      refute FilterWalk.fresh?(tree, "/previous", "needle")
-    end
+    assert request.resource == {:file_tree_filter, Path.expand(root)}
+    assert request.policy.mode == :latest_wins
+    assert request.policy.max_queued == 0
+    assert request.effect.root == Path.expand(root)
+    assert request.effect.filter == "needle"
   end
 
-  describe "start/2 async walk" do
-    @tag :tmp_dir
-    test "walks off-process and replies with entries keyed by root and filter",
-         %{tmp_dir: tmp_dir} do
-      mkdir = fn p -> File.mkdir_p!(p) end
-      mkdir.(Path.join(tmp_dir, "lib"))
-      File.write!(Path.join([tmp_dir, "lib", "target.ex"]), "")
-      File.write!(Path.join(tmp_dir, "other.txt"), "")
+  test "run uses a controllable scanner and preserves exact failures", %{tmp_dir: root} do
+    tree = root |> FileTree.new() |> FileTree.set_filter("needle")
+    result = Result.filesystem(root, "needle", [entry(root, "needle.ex")])
 
-      tree = tmp_dir |> FileTree.new() |> FileTree.set_filter("target")
+    completed = request(tree, :completed, {:return, result})
+    assert FilterWalk.run(completed.effect) == {:ok, result}
+    assert_receive {:file_tree_filter_scan_started, :completed, _worker}, @timeout
 
-      assert :ok = FilterWalk.start(tree, self())
+    failed = request(tree, :failed, {:error, :unreadable})
+    assert FilterWalk.run(failed.effect) == {:error, :unreadable}
+    assert_receive {:file_tree_filter_scan_started, :failed, _worker}, @timeout
+  end
 
-      root = tree.root
-      assert_receive {:file_tree_filter_walk, ^root, "target", entries}, 5_000
-      assert Enum.map(entries, & &1.name) == ["target.ex"]
-    end
+  test "cache scanner returns sorted final materialized entries", %{tmp_dir: root} do
+    tree = root |> FileTree.new() |> FileTree.set_filter("needle")
+
+    snapshot =
+      Snapshot.new(
+        root,
+        true,
+        ["z/needle.ex", "lib/other.ex", "a/needle.ex", ".hidden/needle.ex"],
+        false
+      )
+
+    assert %Result{source: :project_cache, entries: entries, project_cache: ^snapshot} =
+             CacheOrFilesystemScanner.scan(tree, snapshot)
+
+    assert Enum.map(entries, &Path.relative_to(&1.path, root)) == [
+             "a/needle.ex",
+             "z/needle.ex"
+           ]
+  end
+
+  test "repeated filters cancel old work and install only the exact latest outcome", %{
+    tmp_dir: root
+  } do
+    scheduler = start_scheduler()
+    state = state_with_tree(root, scheduler)
+
+    state =
+      Freshness.update_filter(state, "older",
+        scanner: FileTreeFilterScanner,
+        scanner_context: {self(), :older, :wait}
+      )
+
+    older_id = file_tree(state).filter_request.token
+    assert_receive {:file_tree_filter_scan_started, :older, older_worker}, @timeout
+    older_monitor = Process.monitor(older_worker)
+
+    latest_result = Result.filesystem(root, "newer", [entry(root, "newer.ex")])
+
+    state =
+      Freshness.update_filter(state, "newer",
+        scanner: FileTreeFilterScanner,
+        scanner_context: {self(), :newer, :wait}
+      )
+
+    newer_id = file_tree(state).filter_request.token
+    assert newer_id != older_id
+    assert_receive {:DOWN, ^older_monitor, :process, ^older_worker, _reason}, @timeout
+
+    assert_receive {:effect_lifecycle,
+                    %Outcome{request: %{id: ^older_id}, status: :canceled} = canceled},
+                   @timeout
+
+    assert {state, %Outcome{status: :stale}} = FilterWalk.apply(state, canceled)
+    assert_receive {:file_tree_filter_scan_started, :newer, newer_worker}, @timeout
+
+    send(newer_worker, {:release_file_tree_filter_scan, :newer, {:return, latest_result}})
+    outcome = receive_outcome(scheduler, newer_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, outcome)
+    assert {state, %Outcome{status: :completed} = applied} = FilterWalk.apply(state, outcome)
+    EffectScheduler.finalize(scheduler, applied)
+
+    assert Enum.map(FileTree.visible_entries(file_tree(state).tree), & &1.name) == ["newer.ex"]
+    assert file_tree(state).tree_status == :ready
+    Process.cancel_timer(state.render.render_correlation.timer)
+  end
+
+  test "a failed filter exposes an error and the next exact request recovers", %{tmp_dir: root} do
+    scheduler = start_scheduler()
+    state = state_with_tree(root, scheduler)
+
+    state =
+      Freshness.update_filter(state, "broken",
+        scanner: FileTreeFilterScanner,
+        scanner_context: {self(), :broken, {:error, :unreadable}}
+      )
+
+    broken_id = file_tree(state).filter_request.token
+    assert_receive {:file_tree_filter_scan_started, :broken, _worker}, @timeout
+    broken = receive_outcome(scheduler, broken_id, :failed)
+    assert broken.reason == :unreadable
+    assert :ok = EffectScheduler.claim(scheduler, broken)
+    assert {state, %Outcome{status: :failed} = failed} = FilterWalk.apply(state, broken)
+    EffectScheduler.finalize(scheduler, failed)
+    assert {:error, _reason} = FileTreeState.status(file_tree(state))
+    Process.cancel_timer(state.render.render_correlation.timer)
+
+    recovered_result = Result.filesystem(root, "fixed", [entry(root, "fixed.ex")])
+
+    state =
+      Freshness.update_filter(state, "fixed",
+        scanner: FileTreeFilterScanner,
+        scanner_context: {self(), :fixed, {:return, recovered_result}}
+      )
+
+    fixed_id = file_tree(state).filter_request.token
+    assert_receive {:file_tree_filter_scan_started, :fixed, _worker}, @timeout
+    fixed = receive_outcome(scheduler, fixed_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, fixed)
+    assert {state, %Outcome{status: :completed} = applied} = FilterWalk.apply(state, fixed)
+    EffectScheduler.finalize(scheduler, applied)
+
+    assert FileTreeState.status(file_tree(state)) == :ready
+    assert Enum.map(FileTree.visible_entries(file_tree(state).tree), & &1.name) == ["fixed.ex"]
+    Process.cancel_timer(state.render.render_correlation.timer)
+  end
+
+  defp request(tree, label, action) do
+    FilterWalk.request(tree,
+      scanner: FileTreeFilterScanner,
+      scanner_context: {self(), label, action}
+    )
+  end
+
+  defp state_with_tree(root, scheduler) do
+    tree = root |> FileTree.new() |> FileTree.put_entries([])
+    file_tree = FileTreeState.open(%FileTreeState{}, tree, nil)
+    state = base_state(backend: :tui)
+    state = %{state | effect_scheduler: scheduler}
+
+    %{
+      state
+      | workspace: MingaEditor.Session.State.set_file_tree(state.workspace, file_tree)
+    }
+  end
+
+  defp start_scheduler do
+    task_supervisor =
+      start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
+
+    scheduler =
+      start_supervised!(
+        Supervisor.child_spec(
+          {EffectScheduler, task_supervisor: task_supervisor, observer: self()},
+          id: make_ref()
+        )
+      )
+
+    :ok = EffectScheduler.attach(scheduler, self())
+    scheduler
+  end
+
+  defp receive_outcome(scheduler, request_id, status) do
+    assert_receive {:effect_result, ^scheduler,
+                    %Outcome{request: %{id: ^request_id}, status: ^status} = outcome},
+                   @timeout
+
+    outcome
+  end
+
+  defp file_tree(state), do: EditorState.file_tree_state(state)
+
+  defp entry(root, name) do
+    %{
+      path: Path.join(root, name),
+      name: name,
+      dir?: false,
+      depth: 0,
+      last_child?: true,
+      guides: []
+    }
   end
 end

--- a/test/minga_editor/file_tree/freshness_test.exs
+++ b/test/minga_editor/file_tree/freshness_test.exs
@@ -195,16 +195,146 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     assert rerooted_state.render.render_correlation.timer == nil
   end
 
-  test "project-root replacement exposes unavailable roots as errors", %{tmp_dir: root} do
+  test "project-root replacement immediately publishes loading before its scan finishes", %{
+    tmp_dir: root
+  } do
     old_root = Path.join(root, "old")
-    missing_root = Path.join(root, "missing")
-    File.mkdir_p!(old_root)
+    new_root = Path.join(root, "new")
+    Enum.each([old_root, new_root], &File.mkdir_p!/1)
+    scheduler = start_scheduler()
+    state = tui_state_with_tree(old_root, scheduler)
 
-    updated = old_root |> state_with_tree() |> Freshness.update_project_root(missing_root)
+    loading =
+      Freshness.update_project_root(state, new_root,
+        scanner: FileTreeRefreshScanner,
+        scanner_context: {self(), :project_root, :wait},
+        synchronize_watchers?: false
+      )
 
-    assert file_tree(updated).tree.root == Path.expand(missing_root)
-    assert {:error, reason} = FileTreeState.status(file_tree(updated))
+    request_id = file_tree(loading).refresh.current.token
+    assert file_tree(loading).tree.root == Path.expand(new_root)
+    assert file_tree(loading).tree.entries == nil
+    assert FileTreeState.status(file_tree(loading)) == :loading
+    assert is_reference(request_id)
+    assert_receive {:file_tree_scan_started, :project_root, worker}
+
+    result = tree(new_root, [entry(new_root, "new.ex")])
+    send(worker, {:release_file_tree_scan, :project_root, {:return, result}})
+    outcome = receive_outcome(scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, outcome)
+    assert {loaded, %Outcome{status: :completed} = applied} = Refresh.apply(loading, outcome)
+    EffectScheduler.finalize(scheduler, applied)
+
+    assert file_tree(loaded).tree == result
+    Process.cancel_timer(loaded.render.render_correlation.timer)
+  end
+
+  test "rerooted project results are stale and only the exact latest root installs", %{
+    tmp_dir: root
+  } do
+    old_root = Path.join(root, "old")
+    first_root = Path.join(root, "first")
+    latest_root = Path.join(root, "latest")
+    Enum.each([old_root, first_root, latest_root], &File.mkdir_p!/1)
+    scheduler = start_scheduler()
+    state = tui_state_with_tree(old_root, scheduler)
+
+    first_state =
+      Freshness.update_project_root(state, first_root,
+        scanner: FileTreeRefreshScanner,
+        scanner_context: {self(), :first_root, :wait},
+        synchronize_watchers?: false
+      )
+
+    first_id = file_tree(first_state).refresh.current.token
+    assert_receive {:file_tree_scan_started, :first_root, first_worker}
+
+    latest_state =
+      Freshness.update_project_root(first_state, latest_root,
+        scanner: FileTreeRefreshScanner,
+        scanner_context: {self(), :latest_root, :wait},
+        synchronize_watchers?: false
+      )
+
+    latest_id = file_tree(latest_state).refresh.current.token
+    assert latest_id != first_id
+    assert_receive {:file_tree_scan_started, :latest_root, latest_worker}
+
+    first_result = tree(first_root, [entry(first_root, "first.ex")])
+    send(first_worker, {:release_file_tree_scan, :first_root, {:return, first_result}})
+    first_outcome = receive_outcome(scheduler, first_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, first_outcome)
+
+    assert {latest_state, %Outcome{status: :stale, reason: :stale} = stale} =
+             Refresh.apply(latest_state, first_outcome)
+
+    EffectScheduler.finalize(scheduler, stale)
+
+    latest_result = tree(latest_root, [entry(latest_root, "latest.ex")])
+    send(latest_worker, {:release_file_tree_scan, :latest_root, {:return, latest_result}})
+    latest_outcome = receive_outcome(scheduler, latest_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, latest_outcome)
+
+    assert {loaded, %Outcome{status: :completed} = applied} =
+             Refresh.apply(latest_state, latest_outcome)
+
+    EffectScheduler.finalize(scheduler, applied)
+    assert file_tree(loaded).tree == latest_result
+    Process.cancel_timer(loaded.render.render_correlation.timer)
+  end
+
+  test "project-root scan failure installs the requested root error and a later scan recovers", %{
+    tmp_dir: root
+  } do
+    old_root = Path.join(root, "old")
+    failed_root = Path.join(root, "failed")
+    recovered_root = Path.join(root, "recovered")
+    Enum.each([old_root, recovered_root], &File.mkdir_p!/1)
+    scheduler = start_scheduler()
+    state = tui_state_with_tree(old_root, scheduler)
+
+    failing =
+      Freshness.update_project_root(state, failed_root,
+        scanner: FileTreeRefreshScanner,
+        scanner_context: {self(), :failed_root, {:error, {:root_unavailable, :enoent}}},
+        synchronize_watchers?: false
+      )
+
+    failed_id = file_tree(failing).refresh.current.token
+    assert_receive {:file_tree_scan_started, :failed_root, _worker}
+    failed_outcome = receive_outcome(scheduler, failed_id, :failed)
+    assert :ok = EffectScheduler.claim(scheduler, failed_outcome)
+
+    assert {failed, %Outcome{status: :failed} = finalized_failure} =
+             Refresh.apply(failing, failed_outcome)
+
+    EffectScheduler.finalize(scheduler, finalized_failure)
+    assert file_tree(failed).tree.root == Path.expand(failed_root)
+    assert {:error, reason} = FileTreeState.status(file_tree(failed))
     assert reason != ""
+    Process.cancel_timer(failed.render.render_correlation.timer)
+
+    recovered_result = tree(recovered_root, [entry(recovered_root, "ok.ex")])
+
+    recovering =
+      Freshness.update_project_root(failed, recovered_root,
+        scanner: FileTreeRefreshScanner,
+        scanner_context: {self(), :recovered_root, {:return, recovered_result}},
+        synchronize_watchers?: false
+      )
+
+    recovered_id = file_tree(recovering).refresh.current.token
+    assert_receive {:file_tree_scan_started, :recovered_root, _worker}
+    recovered_outcome = receive_outcome(scheduler, recovered_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, recovered_outcome)
+
+    assert {recovered, %Outcome{status: :completed} = finalized_recovery} =
+             Refresh.apply(recovering, recovered_outcome)
+
+    EffectScheduler.finalize(scheduler, finalized_recovery)
+    assert file_tree(recovered).tree == recovered_result
+    assert FileTreeState.status(file_tree(recovered)) == :ready
+    Process.cancel_timer(recovered.render.render_correlation.timer)
   end
 
   test "git metadata updates preserve an unavailable-root error", %{tmp_dir: root} do
@@ -253,6 +383,12 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     assert file_tree(failed).refresh.current == nil
     assert is_reference(failed.render.render_correlation.timer)
     Process.cancel_timer(failed.render.render_correlation.timer)
+  end
+
+  defp tui_state_with_tree(root, scheduler) do
+    state = state_with_tree(root, scheduler)
+    %Frontend{} = frontend = state.frontend
+    %{state | frontend: %Frontend{frontend | backend: :tui}}
   end
 
   defp state_with_tree(root, scheduler \\ nil, buffer \\ nil) do
@@ -318,6 +454,14 @@ defmodule MingaEditor.FileTree.FreshnessTest do
               end)
         }
       end)
+
+  defp receive_outcome(scheduler, request_id, status) do
+    assert_receive {:effect_result, ^scheduler,
+                    %Outcome{request: %{id: ^request_id}, status: ^status} = outcome},
+                   2_000
+
+    outcome
+  end
 
   defp file_tree(state), do: EditorState.file_tree_state(state)
 

--- a/test/minga_editor/file_tree/refresh_test.exs
+++ b/test/minga_editor/file_tree/refresh_test.exs
@@ -216,7 +216,8 @@ defmodule MingaEditor.FileTree.RefreshTest do
   defp request(tree, label, action) do
     Refresh.request(tree, Minga.Events.default_registry(),
       scanner: FileTreeRefreshScanner,
-      scanner_context: {self(), label, action}
+      scanner_context: {self(), label, action},
+      synchronize_watchers?: false
     )
   end
 

--- a/test/minga_editor/file_tree/watcher_sync_test.exs
+++ b/test/minga_editor/file_tree/watcher_sync_test.exs
@@ -1,0 +1,363 @@
+defmodule MingaEditor.FileTree.WatcherSyncTest do
+  @moduledoc "Deterministic watcher serialization, lineage, and workflow tests."
+
+  use ExUnit.Case, async: true
+
+  alias Minga.Project.FileTree
+  alias Minga.Test.FileTreeFilterScanner
+  alias Minga.Test.FileTreeRefreshScanner
+  alias Minga.Test.FileTreeWatcherBackend
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.EffectScheduler
+  alias MingaEditor.FileTree.FilterWalk
+  alias MingaEditor.FileTree.FilterWalk.Result, as: FilterResult
+  alias MingaEditor.FileTree.Freshness
+  alias MingaEditor.FileTree.Refresh
+  alias MingaEditor.FileTree.WatcherSync
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
+
+  import MingaEditor.RenderPipeline.TestHelpers
+
+  @moduletag :tmp_dir
+  @timeout 2_000
+
+  test "watcher calls execute in the worker and outcome application is service-free", %{
+    tmp_dir: root
+  } do
+    scheduler = start_scheduler()
+    state = state_with_tree(root, scheduler)
+
+    state =
+      Freshness.synchronize_watchers(state,
+        watcher_backend: FileTreeWatcherBackend,
+        watcher_context: {self(), :initial, :immediate}
+      )
+
+    request_id = file_tree(state).watchers.request.token
+
+    assert_receive {:file_tree_watcher_call, :initial, :watch, ^root, worker}, @timeout
+    assert worker != self()
+
+    outcome = receive_outcome(scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, outcome)
+    assert {state, %Outcome{status: :completed} = applied} = WatcherSync.apply(state, outcome)
+    refute_receive {:file_tree_watcher_call, :initial, _, _, _}
+    EffectScheduler.finalize(scheduler, applied)
+
+    assert file_tree(state).watchers.candidates == MapSet.new([root])
+    assert file_tree(state).watchers.target == root
+  end
+
+  test "queued watcher intents coalesce full cleanup lineage and retain newest target", %{
+    tmp_dir: root
+  } do
+    a = Path.join(root, "a")
+    b = Path.join(root, "b")
+    c = Path.join(root, "c")
+    scheduler = start_scheduler()
+
+    blocker =
+      watcher_request([a], nil, [], :blocker, :wait)
+
+    b_request =
+      watcher_request([a, b], b, [b], :b, :immediate)
+
+    c_request =
+      watcher_request([a, b, c], c, [c], :c, :immediate)
+
+    assert EffectScheduler.schedule(scheduler, blocker) == {:ok, blocker.id, :running}
+    assert_receive {:file_tree_watcher_call, :blocker, :unwatch, ^a, blocker_worker}, @timeout
+    assert EffectScheduler.schedule(scheduler, b_request) == {:ok, b_request.id, :queued}
+    assert EffectScheduler.schedule(scheduler, c_request) == {:ok, c_request.id, :queued}
+
+    send(blocker_worker, {:release_file_tree_watcher_call, :blocker, :unwatch, a, :ok})
+    blocker_outcome = receive_outcome(scheduler, blocker.id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, blocker_outcome)
+    EffectScheduler.finalize(scheduler, blocker_outcome)
+
+    assert_receive {:file_tree_watcher_call, :c, :unwatch, ^a, c_worker}, @timeout
+    assert_receive {:file_tree_watcher_call, :c, :unwatch, ^b, ^c_worker}, @timeout
+    assert_receive {:file_tree_watcher_call, :c, :watch, ^c, ^c_worker}, @timeout
+
+    c_outcome = receive_outcome(scheduler, c_request.id, :completed)
+    assert c_outcome.request.effect.candidates == MapSet.new([a, b, c])
+    assert c_outcome.request.effect.target == c
+  end
+
+  test "failed watcher sync retains lineage and the next exact request recovers", %{
+    tmp_dir: root
+  } do
+    a = Path.join(root, "a")
+    b = Path.join(root, "b")
+    scheduler = start_scheduler()
+    state = state_with_tree(a, scheduler) |> establish_owned_root(a, scheduler)
+    state = retarget_state(state, b)
+
+    state =
+      Freshness.synchronize_watchers(state,
+        watcher_backend: FileTreeWatcherBackend,
+        watcher_context: {self(), :failed, {:fail, :unwatch, a, :unavailable}}
+      )
+
+    failed_id = file_tree(state).watchers.request.token
+    assert_receive {:file_tree_watcher_call, :failed, :unwatch, ^a, _worker}, @timeout
+    failed = receive_outcome(scheduler, failed_id, :failed)
+    assert :ok = EffectScheduler.claim(scheduler, failed)
+    assert {state, %Outcome{status: :failed} = applied_failure} = WatcherSync.apply(state, failed)
+    EffectScheduler.finalize(scheduler, applied_failure)
+
+    assert file_tree(state).watchers.candidates == MapSet.new([a, b])
+    assert file_tree(state).watchers.target == b
+    assert file_tree(state).watchers.request == nil
+
+    state =
+      Freshness.synchronize_watchers(state,
+        watcher_backend: FileTreeWatcherBackend,
+        watcher_context: {self(), :recovered, :immediate}
+      )
+
+    recovered_id = file_tree(state).watchers.request.token
+    assert_receive {:file_tree_watcher_call, :recovered, :unwatch, ^a, worker}, @timeout
+    assert_receive {:file_tree_watcher_call, :recovered, :watch, ^b, ^worker}, @timeout
+    recovered = receive_outcome(scheduler, recovered_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, recovered)
+
+    assert {state, %Outcome{status: :completed} = applied_recovery} =
+             WatcherSync.apply(state, recovered)
+
+    EffectScheduler.finalize(scheduler, applied_recovery)
+    assert file_tree(state).watchers.candidates == MapSet.new([b])
+  end
+
+  test "A to B filter-winning reroot followed by C leaves only C owned", %{tmp_dir: root} do
+    a = Path.join(root, "a")
+    b = Path.join(root, "b")
+    c = Path.join(root, "c")
+    Enum.each([a, b, c], &File.mkdir_p!/1)
+
+    scheduler = start_scheduler()
+    state = state_with_tree(a, scheduler) |> establish_owned_root(a, scheduler)
+
+    state =
+      Freshness.reroot(state, b,
+        scanner: FileTreeRefreshScanner,
+        scanner_context: {self(), :b_refresh, :wait},
+        watcher_backend: FileTreeWatcherBackend,
+        watcher_context: {self(), :unused_b_refresh, :immediate}
+      )
+
+    b_refresh_id = file_tree(state).refresh.current.token
+    assert_receive {:file_tree_scan_started, :b_refresh, b_refresh_worker}, @timeout
+
+    b_filter_result = FilterResult.filesystem(b, "needle", [entry(b, "needle.ex")])
+
+    state =
+      Freshness.update_filter(state, "needle",
+        scanner: FileTreeFilterScanner,
+        scanner_context: {self(), :b_filter, {:return, b_filter_result}},
+        watcher_backend: FileTreeWatcherBackend,
+        watcher_context: {self(), :b_watchers, :wait}
+      )
+
+    b_filter_id = file_tree(state).filter_request.token
+    assert_receive {:file_tree_filter_scan_started, :b_filter, _worker}, @timeout
+    b_filter = receive_outcome(scheduler, b_filter_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, b_filter)
+
+    assert {state, %Outcome{status: :completed} = applied_filter} =
+             FilterWalk.apply(state, b_filter)
+
+    EffectScheduler.finalize(scheduler, applied_filter)
+    assert_receive {:file_tree_watcher_call, :b_watchers, :unwatch, ^a, b_watcher}, @timeout
+
+    send(b_refresh_worker, {:release_file_tree_scan, :b_refresh, {:return, tree(b)}})
+    stale_refresh = receive_outcome(scheduler, b_refresh_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, stale_refresh)
+
+    assert {state, %Outcome{status: :stale} = applied_stale_refresh} =
+             Refresh.apply(state, stale_refresh)
+
+    EffectScheduler.finalize(scheduler, applied_stale_refresh)
+
+    state =
+      Freshness.reroot(state, c,
+        scanner: FileTreeRefreshScanner,
+        scanner_context: {self(), :c_refresh, {:return, tree(c)}},
+        watcher_backend: FileTreeWatcherBackend,
+        watcher_context: {self(), :c_watchers, :immediate}
+      )
+
+    c_refresh_id = file_tree(state).refresh.current.token
+    assert file_tree(state).watchers.candidates == MapSet.new([a, b, c])
+    assert_receive {:file_tree_scan_started, :c_refresh, _worker}, @timeout
+    c_refresh = receive_outcome(scheduler, c_refresh_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, c_refresh)
+
+    assert {state, %Outcome{status: :completed} = applied_c_refresh} =
+             Refresh.apply(state, c_refresh)
+
+    EffectScheduler.finalize(scheduler, applied_c_refresh)
+
+    send(b_watcher, {:release_file_tree_watcher_call, :b_watchers, :unwatch, a, :ok})
+    assert_receive {:file_tree_watcher_call, :b_watchers, :watch, ^b, ^b_watcher}, @timeout
+    send(b_watcher, {:release_file_tree_watcher_call, :b_watchers, :watch, b, :ok})
+
+    b_watchers = receive_outcome_by_handler(scheduler, WatcherSync, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, b_watchers)
+
+    assert {state, %Outcome{status: :stale} = stale_b_watchers} =
+             WatcherSync.apply(state, b_watchers)
+
+    EffectScheduler.finalize(scheduler, stale_b_watchers)
+
+    assert_receive {:file_tree_watcher_call, :c_watchers, :unwatch, ^a, c_watcher}, @timeout
+    assert_receive {:file_tree_watcher_call, :c_watchers, :unwatch, ^b, ^c_watcher}, @timeout
+    assert_receive {:file_tree_watcher_call, :c_watchers, :watch, ^c, ^c_watcher}, @timeout
+
+    c_watchers = receive_outcome_by_handler(scheduler, WatcherSync, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, c_watchers)
+
+    assert {state, %Outcome{status: :completed} = applied_c_watchers} =
+             WatcherSync.apply(state, c_watchers)
+
+    EffectScheduler.finalize(scheduler, applied_c_watchers)
+    assert file_tree(state).watchers.candidates == MapSet.new([c])
+    assert file_tree(state).watchers.target == c
+    cancel_render_timer(state)
+  end
+
+  test "root-scan failure keeps the visible error and schedules cleanup in a worker", %{
+    tmp_dir: root
+  } do
+    a = Path.join(root, "a")
+    missing = Path.join(root, "missing")
+    File.mkdir_p!(a)
+    scheduler = start_scheduler()
+    state = state_with_tree(a, scheduler) |> establish_owned_root(a, scheduler)
+
+    state =
+      Freshness.update_project_root(state, missing,
+        scanner: FileTreeRefreshScanner,
+        scanner_context: {self(), :missing, {:error, {:root_unavailable, :enoent}}},
+        watcher_backend: FileTreeWatcherBackend,
+        watcher_context: {self(), :cleanup, :immediate}
+      )
+
+    refresh_id = file_tree(state).refresh.current.token
+    assert_receive {:file_tree_scan_started, :missing, _worker}, @timeout
+    failed = receive_outcome(scheduler, refresh_id, :failed)
+    assert :ok = EffectScheduler.claim(scheduler, failed)
+    assert {state, %Outcome{status: :failed} = applied_failure} = Refresh.apply(state, failed)
+    EffectScheduler.finalize(scheduler, applied_failure)
+
+    assert {:error, _reason} = FileTreeState.status(file_tree(state))
+    assert file_tree(state).tree.root == missing
+    assert_receive {:file_tree_watcher_call, :cleanup, :unwatch, ^a, worker}, @timeout
+    assert worker != self()
+    assert_receive {:file_tree_watcher_call, :cleanup, :unwatch, ^missing, ^worker}, @timeout
+
+    cleanup = receive_outcome_by_handler(scheduler, WatcherSync, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, cleanup)
+
+    assert {state, %Outcome{status: :completed} = applied_cleanup} =
+             WatcherSync.apply(state, cleanup)
+
+    EffectScheduler.finalize(scheduler, applied_cleanup)
+    assert file_tree(state).watchers.candidates == MapSet.new()
+    cancel_render_timer(state)
+  end
+
+  defp establish_owned_root(state, root, scheduler) do
+    state =
+      Freshness.synchronize_watchers(state,
+        watcher_backend: FileTreeWatcherBackend,
+        watcher_context: {self(), {:establish, root}, :immediate}
+      )
+
+    request_id = file_tree(state).watchers.request.token
+
+    assert_receive {:file_tree_watcher_call, {:establish, ^root}, :watch, ^root, _worker},
+                   @timeout
+
+    outcome = receive_outcome(scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, outcome)
+    assert {state, %Outcome{status: :completed} = applied} = WatcherSync.apply(state, outcome)
+    EffectScheduler.finalize(scheduler, applied)
+    state
+  end
+
+  defp retarget_state(state, root) do
+    file_tree = FileTreeState.begin_root_scan(file_tree(state), tree(root), :reroot)
+    put_file_tree(state, file_tree)
+  end
+
+  defp watcher_request(candidates, target, expanded_dirs, label, mode) do
+    WatcherSync.request(MapSet.new(candidates), target, MapSet.new(expanded_dirs),
+      watcher_backend: FileTreeWatcherBackend,
+      watcher_context: {self(), label, mode}
+    )
+  end
+
+  defp state_with_tree(root, scheduler) do
+    file_tree = FileTreeState.open(%FileTreeState{}, tree(root), nil)
+    state = base_state(backend: :tui)
+    state = %{state | effect_scheduler: scheduler}
+    put_file_tree(state, file_tree)
+  end
+
+  defp put_file_tree(state, file_tree) do
+    %{state | workspace: MingaEditor.Session.State.set_file_tree(state.workspace, file_tree)}
+  end
+
+  defp tree(root), do: root |> FileTree.new() |> FileTree.put_entries([])
+
+  defp entry(root, name) do
+    %{
+      path: Path.join(root, name),
+      name: name,
+      dir?: false,
+      depth: 0,
+      last_child?: true,
+      guides: []
+    }
+  end
+
+  defp receive_outcome(scheduler, request_id, status) do
+    assert_receive {:effect_result, ^scheduler,
+                    %Outcome{request: %{id: ^request_id}, status: ^status} = outcome},
+                   @timeout
+
+    outcome
+  end
+
+  defp receive_outcome_by_handler(scheduler, handler, status) do
+    assert_receive {:effect_result, ^scheduler,
+                    %Outcome{request: %{handler: ^handler}, status: ^status} = outcome},
+                   @timeout
+
+    outcome
+  end
+
+  defp file_tree(state), do: EditorState.file_tree_state(state)
+
+  defp cancel_render_timer(state) do
+    case state.render.render_correlation.timer do
+      timer when is_reference(timer) -> Process.cancel_timer(timer)
+      nil -> :ok
+    end
+  end
+
+  defp start_scheduler do
+    task_supervisor =
+      start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
+
+    scheduler =
+      start_supervised!(
+        Supervisor.child_spec({EffectScheduler, task_supervisor: task_supervisor}, id: make_ref())
+      )
+
+    :ok = EffectScheduler.attach(scheduler, self())
+    scheduler
+  end
+end

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -258,13 +258,11 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       assert effects == []
     end
 
-    test "project rebuild changes the visible tree root", %{tmp_dir: tmp_dir} do
+    test "project rebuild immediately publishes the new root loading state", %{tmp_dir: tmp_dir} do
       old_root = Path.join(tmp_dir, "old")
       new_root = Path.join(tmp_dir, "new")
       File.mkdir_p!(old_root)
       File.mkdir_p!(new_root)
-      File.write!(Path.join(old_root, "old.ex"), "")
-      File.write!(Path.join(new_root, "new.ex"), "")
 
       state = state_with_tree(old_root)
 
@@ -275,12 +273,10 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
           %Minga.Events.ProjectRebuiltEvent{root: new_root}
         })
 
-      names =
-        ft(new_state).tree |> FileTree.visible_entries() |> Enum.map(& &1.name)
-
       assert ft(new_state).project_root == Path.expand(new_root)
-      assert "new.ex" in names
-      refute "old.ex" in names
+      assert ft(new_state).tree.root == Path.expand(new_root)
+      assert ft(new_state).tree.entries == nil
+      assert FileTreeState.status(ft(new_state)) == :loading
       assert {:render, 16} in effects
     end
   end

--- a/test/minga_editor/input/file_tree_editing_input_test.exs
+++ b/test/minga_editor/input/file_tree_editing_input_test.exs
@@ -14,6 +14,10 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
   @moduletag :tmp_dir
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.EffectScheduler
+  alias MingaEditor.FileTree.FilterWalk
+  alias MingaEditor.FileTree.Refresh
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -32,9 +36,11 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
 
     tree = FileTree.new(tmp_dir)
     buf = BufferSync.start_buffer(tree)
+    scheduler = start_scheduler()
 
     %EditorState{
-      frontend: %MingaEditor.State.Frontend{port_manager: self()},
+      frontend: %MingaEditor.State.Frontend{port_manager: self(), backend: :tui},
+      effect_scheduler: scheduler,
       workspace:
         %SessionState{viewport: Viewport.new(24, 80), keymap_scope: :file_tree}
         |> SessionState.set_file_tree(%FileTreeState{} |> FileTreeState.open(tree, buf)),
@@ -45,6 +51,57 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
   end
 
   defp ft(state), do: EditorState.file_tree_state(state)
+
+  defp complete_current_filter(state) do
+    request_id = ft(state).filter_request.token
+    outcome = receive_outcome(state.effect_scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(state.effect_scheduler, outcome)
+    assert {state, %Outcome{status: :completed} = applied} = FilterWalk.apply(state, outcome)
+    EffectScheduler.finalize(state.effect_scheduler, applied)
+    cancel_render_timer(state)
+  end
+
+  defp complete_current_refresh(state) do
+    request_id = ft(state).refresh.current.token
+    outcome = receive_outcome(state.effect_scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(state.effect_scheduler, outcome)
+    assert {state, %Outcome{status: :completed} = applied} = Refresh.apply(state, outcome)
+    EffectScheduler.finalize(state.effect_scheduler, applied)
+    cancel_render_timer(state)
+  end
+
+  defp receive_outcome(scheduler, request_id, status) do
+    assert_receive {:effect_result, ^scheduler,
+                    %Outcome{request: %{id: ^request_id}, status: ^status} = outcome},
+                   2_000
+
+    outcome
+  end
+
+  defp cancel_render_timer(state) do
+    case state.render.render_correlation.timer do
+      timer when is_reference(timer) -> Process.cancel_timer(timer)
+      nil -> :ok
+    end
+
+    state
+  end
+
+  defp start_scheduler do
+    task_supervisor =
+      start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
+
+    scheduler =
+      start_supervised!(
+        Supervisor.child_spec(
+          {EffectScheduler, task_supervisor: task_supervisor},
+          id: make_ref()
+        )
+      )
+
+    :ok = EffectScheduler.attach(scheduler, self())
+    scheduler
+  end
 
   defp make_editing_state(tmp_dir, opts \\ []) do
     state = make_state(tmp_dir)
@@ -178,6 +235,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?a, 0)
       {:handled, state} = FileTreeHandler.handle_key(state, ?l, 0)
+      state = complete_current_filter(state)
       assert ft(state).tree.filter == "al"
       assert BufferProcess.content(ft(state).buffer) =~ "alpha.txt"
       refute BufferProcess.content(ft(state).buffer) =~ "beta.txt"
@@ -207,6 +265,7 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
         end)
 
       {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
+      state = complete_current_refresh(state)
       assert ft(state).filtering == false
       assert ft(state).tree.filter == nil
     end
@@ -232,23 +291,12 @@ defmodule MingaEditor.Input.FileTreeEditingInputTest do
 
       {:handled, state} = FileTreeHandler.handle_key(state, ?/, 0)
       {:handled, state} = FileTreeHandler.handle_key(state, ?z, 0)
-
-      no_matches = FileTreeState.apply_filter_walk(ft(state), tree.root, "z", [])
-
-      state =
-        then(state, fn state ->
-          %{
-            state
-            | workspace:
-                then(state.workspace, fn workspace ->
-                  MingaEditor.Session.State.set_file_tree(workspace, no_matches)
-                end)
-          }
-        end)
+      state = complete_current_filter(state)
 
       assert FileTreeState.status(ft(state)) == :empty
 
       {:handled, state} = FileTreeHandler.handle_key(state, @escape, 0)
+      state = complete_current_refresh(state)
 
       assert ft(state).filtering == false
       assert ft(state).tree.filter == nil

--- a/test/minga_editor/state/file_tree_filter_test.exs
+++ b/test/minga_editor/state/file_tree_filter_test.exs
@@ -1,78 +1,126 @@
 defmodule MingaEditor.State.FileTreeFilterTest do
-  @moduledoc """
-  Covers the cache-vs-walk filtering decision and async no-cache stale-drop in
-  MingaEditor.State.FileTree (#2377).
-  """
+  @moduledoc "Pure filter loading, correlation, and cache-value installation tests."
 
   use ExUnit.Case, async: true
 
   alias Minga.Project.FileTree
+  alias Minga.Project.FileTree.BufferSync
+  alias MingaEditor.FileTree.FilterWalk.Result
+  alias MingaEditor.FileTree.ProjectCache.Snapshot
   alias MingaEditor.State.FileTree, as: FileTreeState
 
-  # These tests run without the Minga.Project GenServer, so ProjectCache treats
-  # every root as "not the active project" (the :exit guard returns false). That
-  # is exactly the no-cache fallback path we want to exercise here.
-
   defp open_tree(root) do
-    %FileTreeState{}
-    |> FileTreeState.open(FileTree.new(root), nil)
+    tree = root |> FileTree.new() |> FileTree.put_entries([])
+    FileTreeState.open(%FileTreeState{}, tree, nil)
   end
 
-  test "filtering a no-cache root marks the tree loading pending the async walk" do
+  test "filter transition immediately publishes loading without resolving rows" do
     ft = open_tree("/nonexistent_root") |> FileTreeState.update_filter("needle")
 
     assert ft.tree.filter == "needle"
+    assert ft.tree.entries == nil
     assert ft.tree_status == :loading
-    assert FileTreeState.needs_filter_walk?(ft)
+    assert ft.filter_request == nil
   end
 
-  test "an empty filter never needs an async walk" do
-    ft = open_tree("/nonexistent_root") |> FileTreeState.start_filtering()
+  test "cache data is injected as a value and installed only for the current request" do
+    ft = open_tree("/project") |> FileTreeState.update_filter("needle")
+    token = make_ref()
+    ft = FileTreeState.track_filter_request(ft, ft.tree.root, "needle", token)
 
-    assert ft.tree.filter == ""
-    refute FileTreeState.needs_filter_walk?(ft)
-  end
+    snapshot = Snapshot.new(ft.tree.root, true, ["lib/recomputed-would-differ.ex"], false)
+    entries = [entry(ft.tree.root, "worker-materialized.ex")]
+    result = Result.project_cache(ft.tree.root, "needle", entries, snapshot)
 
-  test "apply_filter_walk installs entries for the current root and filter" do
-    ft = open_tree("/nonexistent_root") |> FileTreeState.update_filter("needle")
-    root = ft.tree.root
+    assert {:accepted, updated} =
+             FileTreeState.accept_filter_result(ft, ft.tree.root, "needle", token, result)
 
-    entries = [
-      %{
-        path: "/nonexistent_root/needle.ex",
-        name: "needle.ex",
-        dir?: false,
-        depth: 0,
-        last_child?: true,
-        guides: []
-      }
-    ]
-
-    updated = FileTreeState.apply_filter_walk(ft, root, "needle", entries)
-
-    assert FileTree.visible_entries(updated.tree) == entries
+    assert updated.tree.entries == entries
+    assert updated.tree.cached_files == snapshot.files
     assert updated.tree_status == :ready
+    assert updated.filter_request == nil
+
+    buffer = BufferSync.start_buffer(updated.tree)
+    assert Minga.Buffer.content(buffer) =~ "worker-materialized.ex"
+    refute Minga.Buffer.content(buffer) =~ "recomputed-would-differ.ex"
   end
 
-  test "apply_filter_walk drops a stale result for a superseded filter" do
-    ft = open_tree("/nonexistent_root") |> FileTreeState.update_filter("newer")
-    root = ft.tree.root
-    before = ft.tree.entries
+  test "rebuilding empty cache remains loading without a filesystem fallback" do
+    ft = open_tree("/project") |> FileTreeState.update_filter("needle")
+    token = make_ref()
+    ft = FileTreeState.track_filter_request(ft, ft.tree.root, "needle", token)
+    snapshot = Snapshot.new(ft.tree.root, true, [], true)
+    result = Result.project_cache(ft.tree.root, "needle", [], snapshot)
 
-    stale = [
-      %{
-        path: "/nonexistent_root/old.ex",
-        name: "old.ex",
-        dir?: false,
-        depth: 0,
-        last_child?: true,
-        guides: []
-      }
-    ]
+    assert {:accepted, updated} =
+             FileTreeState.accept_filter_result(ft, ft.tree.root, "needle", token, result)
 
-    updated = FileTreeState.apply_filter_walk(ft, root, "older", stale)
+    assert updated.tree.cached_files == []
+    assert updated.tree_status == :loading
+  end
 
-    # The stale walk result is discarded; the tree keeps its prior entries.
-    assert updated.tree.entries == before
+  test "filesystem rows install for the exact request and stale repeated filters are dropped" do
+    root = "/nonexistent_root"
+    old_token = make_ref()
+
+    old =
+      root
+      |> open_tree()
+      |> FileTreeState.update_filter("older")
+      |> FileTreeState.track_filter_request(root, "older", old_token)
+
+    newer_token = make_ref()
+
+    newer =
+      old
+      |> FileTreeState.update_filter("newer")
+      |> FileTreeState.track_filter_request(root, "newer", newer_token)
+
+    old_result = Result.filesystem(root, "older", [entry(root, "older.ex")])
+    new_result = Result.filesystem(root, "newer", [entry(root, "newer.ex")])
+
+    assert {:stale, unchanged} =
+             FileTreeState.accept_filter_result(newer, root, "older", old_token, old_result)
+
+    assert unchanged == newer
+
+    assert {:accepted, updated} =
+             FileTreeState.accept_filter_result(newer, root, "newer", newer_token, new_result)
+
+    assert Enum.map(FileTree.visible_entries(updated.tree), & &1.name) == ["newer.ex"]
+  end
+
+  test "closed and rerooted filter results remain harmless" do
+    root = "/filter-root"
+    token = make_ref()
+
+    current =
+      root
+      |> open_tree()
+      |> FileTreeState.update_filter("needle")
+      |> FileTreeState.track_filter_request(root, "needle", token)
+
+    result = Result.filesystem(root, "needle", [entry(root, "needle.ex")])
+    closed = FileTreeState.close(current)
+
+    assert {:closed, ^closed} =
+             FileTreeState.accept_filter_result(closed, root, "needle", token, result)
+
+    rerooted =
+      FileTreeState.begin_root_scan(current, FileTree.reroot(current.tree, "/new-root"), :reroot)
+
+    assert {:stale, ^rerooted} =
+             FileTreeState.accept_filter_result(rerooted, root, "needle", token, result)
+  end
+
+  defp entry(root, name) do
+    %{
+      path: Path.join(root, name),
+      name: name,
+      dir?: false,
+      depth: 0,
+      last_child?: true,
+      guides: []
+    }
   end
 end

--- a/test/minga_editor/state/file_tree_refresh_test.exs
+++ b/test/minga_editor/state/file_tree_refresh_test.exs
@@ -88,6 +88,26 @@ defmodule MingaEditor.State.FileTree.RefreshTest do
     assert accepted.tree == refreshed
   end
 
+  test "a matching request and tree root still require the current project root" do
+    root = "/tmp/minga-refresh-project-root"
+    other_root = "/tmp/minga-refresh-other-project"
+    request = make_ref()
+
+    file_tree =
+      root
+      |> open_tree()
+      |> FileTreeState.track_refresh_request(root, request)
+      |> FileTreeState.set_project_root(other_root)
+
+    result = tree(root, [entry(root, "stale.ex")])
+
+    assert {:rerooted, unchanged} =
+             FileTreeState.accept_refresh_result(file_tree, root, request, result)
+
+    assert unchanged.tree == file_tree.tree
+    assert unchanged.project_root == Path.expand(other_root)
+  end
+
   test "closing and reopening the same root invalidates the old result" do
     root = "/tmp/minga-refresh-closed"
     request = make_ref()

--- a/test/support/file_tree_filter_scanner.ex
+++ b/test/support/file_tree_filter_scanner.ex
@@ -1,0 +1,30 @@
+defmodule Minga.Test.FileTreeFilterScanner do
+  @moduledoc "Deterministic scanner used by typed file-tree filter scheduler tests."
+
+  @behaviour MingaEditor.FileTree.FilterWalk.Scanner
+
+  alias Minga.Project.FileTree
+  alias MingaEditor.FileTree.FilterWalk.Result
+
+  @type action :: :wait | {:return, Result.t()} | {:error, term()} | {:raise, String.t()}
+  @type context :: {pid(), term(), action()}
+
+  @doc "Notifies the test and performs or waits for its data-only instruction."
+  @impl true
+  @spec scan(FileTree.t(), context()) :: Result.t() | {:error, term()}
+  def scan(%FileTree{} = tree, {test_pid, label, action}) when is_pid(test_pid) do
+    send(test_pid, {:file_tree_filter_scan_started, label, self()})
+    perform(tree, label, action)
+  end
+
+  @spec perform(FileTree.t(), term(), action()) :: Result.t() | {:error, term()}
+  defp perform(tree, label, :wait) do
+    receive do
+      {:release_file_tree_filter_scan, ^label, action} -> perform(tree, label, action)
+    end
+  end
+
+  defp perform(_tree, _label, {:return, %Result{} = result}), do: result
+  defp perform(_tree, _label, {:error, reason}), do: {:error, reason}
+  defp perform(_tree, _label, {:raise, message}), do: raise(message)
+end

--- a/test/support/file_tree_watcher_backend.ex
+++ b/test/support/file_tree_watcher_backend.ex
@@ -1,0 +1,42 @@
+defmodule Minga.Test.FileTreeWatcherBackend do
+  @moduledoc "Deterministic watcher backend for serialized file-tree watcher effect tests."
+
+  @behaviour MingaEditor.FileTree.WatcherSync.Backend
+
+  @type operation :: :watch | :unwatch
+  @type mode :: :immediate | :wait | {:fail, operation(), String.t(), term()}
+  @type context :: {pid(), term(), mode()}
+
+  @impl true
+  @spec watch_directory(String.t(), context()) :: :ok | {:error, term()}
+  def watch_directory(path, context), do: perform(:watch, path, context)
+
+  @impl true
+  @spec unwatch_directory_tree(String.t(), context()) :: :ok | {:error, term()}
+  def unwatch_directory_tree(path, context), do: perform(:unwatch, path, context)
+
+  @spec perform(operation(), String.t(), context()) :: :ok | {:error, term()}
+  defp perform(operation, path, {test_pid, label, mode}) do
+    send(test_pid, {:file_tree_watcher_call, label, operation, path, self()})
+    complete(operation, path, label, mode)
+  end
+
+  @spec complete(operation(), String.t(), term(), mode()) :: :ok | {:error, term()}
+  defp complete(_operation, _path, _label, :immediate), do: :ok
+
+  defp complete(operation, path, _label, {:fail, operation, path, reason}),
+    do: {:error, reason}
+
+  defp complete(_operation, _path, _label, {:fail, _other_operation, _other_path, _reason}),
+    do: :ok
+
+  defp complete(operation, path, label, :wait) do
+    receive do
+      {:release_file_tree_watcher_call, ^label, ^operation, ^path, :ok} ->
+        :ok
+
+      {:release_file_tree_watcher_call, ^label, ^operation, ^path, {:error, reason}} ->
+        {:error, reason}
+    end
+  end
+end


### PR DESCRIPTION
# TL;DR

Project rerooting and file-tree filtering now publish loading state immediately and perform cache, filesystem, and watcher work through typed bounded effects. Exact request/root/filter correlation and retained watcher lineage keep stale scans and rapid reroots from replacing current state or leaking old watcher registrations.

Closes #2916

## Context

This is the file-tree responsiveness slice of #2914. It builds on the existing `EffectScheduler` and #2862 refresh lifecycle rather than adding another scheduler or action interpreter, while preserving one Editor GenServer and the 16-value root.

## Changes

- Replace synchronous project reroot scans with typed `Refresh` requests and immediate FileTree loading transitions.
- Replace ad-hoc filter tasks and mailbox tuples with latest-wins `FilterWalk` requests and typed outcomes.
- Move project-cache reads plus cache filtering, sorting, and entry materialization into scheduler workers; pure FileTree transitions only validate and install immutable results.
- Correlate filter results to the exact request identity, tree root, project root, and query so repeated, closed, rerooted, failed, canceled, and stale outcomes remain harmless.
- Add a serialized `WatcherSync` effect with one stable resource identity; its worker is the only file-tree path that calls `Minga.FileWatcher`.
- Retain every known watched or intended root until the latest exact watcher sync succeeds, so A→B→C reroot bursts and filter-winning races clean both A and B before owning C.
- Preserve current-main file-picker refresh behavior while removing the obsolete raw filter-result handler during rebase.
- Add controllable filter scanners and watcher backends with deterministic scheduler, staleness, coalescing, and failure-recovery coverage.

## Verification

Validated commit `06195c55ed8361193ff72a2668f81adc29ea502f`:

- `make lint`: passed with Credo clean, compilation clean, and incremental Dialyzer at 0 errors.
- `mix test.llm`: 9,466 tests, 97 properties, and 58 doctests passed with 0 failures; 1 test skipped.
- Focused file-tree and original-blocker suite: 129 tests passed.
- `bash scripts/bench_keystroke_latency_ab origin/main HEAD`: all blocking latency budgets within limits across four base and HEAD rounds.
- `git diff --check`: passed.
- Final targeted acceptance review: PASS after rebase, worker-side cache materialization, serialized watcher execution, and rapid-reroot lineage fixes.
- Frontend-specific checks are not applicable because no Swift, Go, or Zig files changed.

## Acceptance Criteria Addressed

- Project-root changes publish typed loading state immediately without filesystem or cache work in pure transitions. ✅
- Root and filter scans use existing typed EffectScheduler requests and outcomes. ✅
- Only exact current request/root/filter/project-root results install; stale terminal paths are harmless. ✅
- Pure FileTree transitions receive immutable cache and scan values rather than calling services. ✅
- File-tree focus, filtering, Git status, watcher synchronization, rendered rows, and root-error behavior remain compatible. ✅
- Deterministic tests cover rerooting, repeated filters, failure recovery, cache injection, watcher coalescing, and A→B→C cleanup without sleeps. ✅
