### PR TITLE
refactor(editor): require shell session ownership

### DIFF
--- a/lib/minga_editor/shell.ex
+++ b/lib/minga_editor/shell.ex
@@ -80,7 +80,7 @@ defmodule MingaEditor.Shell do
   @callback on_agent_event(shell_state(), workspace(), session_pid :: pid(), event :: term()) ::
               {shell_state(), workspace()}
 
-  @doc "Returns whether shell state owns an agent session pid."
+  @doc "Returns whether this shell state owns an agent session pid. Every shell must define ownership for its own state shape."
   @callback owns_agent_session?(shell_state(), session_pid :: pid()) :: boolean()
 
   @doc "Handles an agent session going down and reports whether the shell owned it."
@@ -126,7 +126,6 @@ defmodule MingaEditor.Shell do
   @callback active_session(shell_state()) :: pid() | nil
 
   @optional_callbacks after_gui_action: 2,
-                      owns_agent_session?: 2,
                       handle_agent_session_down: 3,
                       handle_agent_session_restarted: 4,
                       handle_remote_session_disconnected: 2,

--- a/lib/minga_editor/shell/entry.ex
+++ b/lib/minga_editor/shell/entry.ex
@@ -135,27 +135,11 @@ defmodule MingaEditor.Shell.Entry do
 
   @spec required_callbacks() :: [{atom(), non_neg_integer()}]
   defp required_callbacks do
-    [
-      init: 1,
-      compute_layout: 1,
-      build_chrome: 4,
-      chrome_fingerprint: 1,
-      async_render?: 1,
-      gui_payload: 1,
-      render: 1,
-      input_handlers: 1,
-      handle_event: 3,
-      handle_gui_action: 3,
-      on_buffer_added: 5,
-      on_buffer_switched: 2,
-      on_buffer_died: 3,
-      on_agent_event: 4,
-      active_tab: 1,
-      find_tab_by_buffer: 2,
-      active_tab_kind: 1,
-      set_tab_session: 3,
-      active_session: 1
-    ]
+    optional = MingaEditor.Shell.behaviour_info(:optional_callbacks) |> MapSet.new()
+
+    MingaEditor.Shell.behaviour_info(:callbacks)
+    |> Enum.reject(&MapSet.member?(optional, &1))
+    |> Enum.sort()
   end
 
   @spec fetch_binary(map(), atom()) :: {:ok, String.t()} | {:error, term()}

--- a/lib/minga_editor/shell/identity.ex
+++ b/lib/minga_editor/shell/identity.ex
@@ -1,31 +1,40 @@
 defmodule MingaEditor.Shell.Identity do
   @moduledoc """
-  Stable registry identity for a shell registration.
+  Exact identity for one shell registration.
 
-  Shell ids are user-facing names that extension sources may unregister and later reuse. Runtime state and asynchronous renderer snapshots use this identity to prove they still belong to the currently registered shell before they are restored or written back.
+  Shell ids are user-facing names that extension sources may unregister and later reuse. Runtime state, stashes, and asynchronous renderer snapshots compare the same id, module, source, and registry generation before state is restored or written back.
   """
 
   alias MingaEditor.Shell.Entry
 
-  @enforce_keys [:module, :source, :generation]
-  defstruct [:module, :source, :generation]
+  @enforce_keys [:id, :module, :source, :generation]
+  defstruct [:id, :module, :source, :generation]
 
   @type t :: %__MODULE__{
+          id: atom(),
           module: module(),
           source: Entry.source(),
           generation: non_neg_integer()
         }
 
-  @doc "Builds an identity from a registry entry."
+  @type comparable :: t() | Entry.t()
+
+  @doc "Builds an exact identity from a registry entry."
   @spec new(Entry.t()) :: t()
   def new(%Entry{} = entry) do
-    %__MODULE__{module: entry.module, source: entry.source, generation: entry.generation}
+    %__MODULE__{
+      id: entry.id,
+      module: entry.module,
+      source: entry.source,
+      generation: entry.generation
+    }
   end
 
-  @doc "Returns true when the identity still refers to the registry entry."
-  @spec matches?(t(), Entry.t()) :: boolean()
-  def matches?(%__MODULE__{} = identity, %Entry{} = entry) do
-    identity.module == entry.module and identity.source == entry.source and
-      identity.generation == entry.generation
-  end
+  @doc "Returns true when two values describe the same exact registration."
+  @spec matches?(comparable(), comparable()) :: boolean()
+  def matches?(left, right), do: normalize(left) == normalize(right)
+
+  @spec normalize(comparable()) :: t()
+  defp normalize(%__MODULE__{} = identity), do: identity
+  defp normalize(%Entry{} = entry), do: new(entry)
 end

--- a/lib/minga_editor/shell/runtime.ex
+++ b/lib/minga_editor/shell/runtime.ex
@@ -9,10 +9,9 @@ defmodule MingaEditor.Shell.Runtime do
   alias MingaEditor.Shell.Identity
   alias MingaEditor.Shell.StateStash
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
-  alias MingaEditor.State.TabBar
 
   @type shell_state :: MingaEditor.Shell.shell_state()
-  @type stash :: %{atom() => StateStash.t()}
+  @type stash :: %{Identity.t() => StateStash.t()}
   @type persistence_change :: {Entry.t(), shell_state(), shell_state()}
 
   @enforce_keys [:entry, :state]
@@ -75,7 +74,7 @@ defmodule MingaEditor.Shell.Runtime do
   @doc "Returns whether an exact-identity stashed value can restore the resolved entry."
   @spec restorable?(t(), Entry.t()) :: boolean()
   def restorable?(%__MODULE__{} = runtime, %Entry{} = entry) do
-    case Map.get(runtime.stash, entry.id) do
+    case Map.get(runtime.stash, Identity.new(entry)) do
       %StateStash{} = stashed -> StateStash.matches?(stashed, entry)
       nil -> false
     end
@@ -88,7 +87,11 @@ defmodule MingaEditor.Shell.Runtime do
       runtime
     else
       stash =
-        Map.put(runtime.stash, runtime.entry.id, StateStash.new(runtime.entry, runtime.state))
+        Map.put(
+          runtime.stash,
+          Identity.new(runtime.entry),
+          StateStash.new(runtime.entry, runtime.state)
+        )
 
       {target_state, stash} = restore_target(stash, target, initialized_state)
       %__MODULE__{entry: target, state: target_state, stash: stash}
@@ -105,7 +108,7 @@ defmodule MingaEditor.Shell.Runtime do
          runtime
          | entry: resolved,
            state: initialized_state,
-           stash: Map.delete(runtime.stash, resolved.id)
+           stash: drop_registration_id(runtime.stash, resolved.id)
        }, :reset}
     end
   end
@@ -193,16 +196,18 @@ defmodule MingaEditor.Shell.Runtime do
   @spec route_stashed_agent_event(t(), [Entry.t()], MingaEditor.Shell.workspace(), pid(), term()) ::
           {t(), MingaEditor.Shell.workspace(), [persistence_change()]}
   def route_stashed_agent_event(%__MODULE__{} = runtime, entries, workspace, session_pid, event) do
-    entries_by_id = Map.new(entries, &{&1.id, &1})
-
     {stash, workspace, changes} =
-      Enum.reduce(runtime.stash, {%{}, workspace, []}, fn {id, stashed},
-                                                          {stash_acc, workspace_acc, changes_acc} ->
-        case Map.get(entries_by_id, id) do
-          %Entry{} = entry ->
+      Enum.reduce(entries, {runtime.stash, workspace, []}, fn entry,
+                                                              {stash_acc, workspace_acc,
+                                                               changes_acc} ->
+        identity = Identity.new(entry)
+
+        case Map.get(stash_acc, identity) do
+          %StateStash{} = stashed ->
             route_stashed_agent_value(
               stash_acc,
               changes_acc,
+              identity,
               stashed,
               entry,
               workspace_acc,
@@ -211,7 +216,7 @@ defmodule MingaEditor.Shell.Runtime do
             )
 
           nil ->
-            {Map.put(stash_acc, id, stashed), workspace_acc, changes_acc}
+            {stash_acc, workspace_acc, changes_acc}
         end
       end)
 
@@ -387,7 +392,7 @@ defmodule MingaEditor.Shell.Runtime do
   @spec restore_target(stash(), Entry.t(), shell_state()) :: {shell_state(), stash()}
   defp restore_target(stash, %Entry{} = target, initialized_state) do
     target_state =
-      case Map.get(stash, target.id) do
+      case Map.get(stash, Identity.new(target)) do
         %StateStash{} = stashed ->
           case StateStash.restore(stashed, target) do
             {:ok, state} -> state
@@ -398,12 +403,13 @@ defmodule MingaEditor.Shell.Runtime do
           initialized_state
       end
 
-    {target_state, Map.delete(stash, target.id)}
+    {target_state, drop_registration_id(stash, target.id)}
   end
 
   @spec route_stashed_agent_value(
           stash(),
           [persistence_change()],
+          Identity.t(),
           StateStash.t(),
           Entry.t(),
           MingaEditor.Shell.workspace(),
@@ -413,6 +419,7 @@ defmodule MingaEditor.Shell.Runtime do
   defp route_stashed_agent_value(
          stash,
          changes,
+         %Identity{} = identity,
          %StateStash{} = stashed,
          %Entry{} = entry,
          workspace,
@@ -426,10 +433,10 @@ defmodule MingaEditor.Shell.Runtime do
 
         updated = StateStash.new(entry, new_state)
         change = persistence_change(entry, old_state, new_state)
-        {Map.put(stash, entry.id, updated), workspace, prepend_change(change, changes)}
+        {Map.put(stash, identity, updated), workspace, prepend_change(change, changes)}
 
       :mismatch ->
-        {Map.put(stash, entry.id, stashed), workspace, changes}
+        {Map.put(stash, identity, stashed), workspace, changes}
     end
   end
 
@@ -444,7 +451,7 @@ defmodule MingaEditor.Shell.Runtime do
          %Entry{} = entry,
          session_pid
        ) do
-    case Map.get(runtime.stash, entry.id) do
+    case Map.get(runtime.stash, Identity.new(entry)) do
       %StateStash{} = stashed ->
         case StateStash.restore(stashed, entry) do
           {:ok, state} -> shell_state_owns_agent_session?(entry.module, state, session_pid)
@@ -458,31 +465,8 @@ defmodule MingaEditor.Shell.Runtime do
 
   @spec shell_state_owns_agent_session?(module(), shell_state(), pid()) :: boolean()
   defp shell_state_owns_agent_session?(module, shell_state, session_pid) do
-    if function_exported?(module, :owns_agent_session?, 2) do
-      module.owns_agent_session?(shell_state, session_pid)
-    else
-      module.active_session(shell_state) == session_pid or
-        legacy_shell_state_owns_agent_session?(shell_state, session_pid)
-    end
+    module.owns_agent_session?(shell_state, session_pid)
   end
-
-  @spec legacy_shell_state_owns_agent_session?(shell_state(), pid()) :: boolean()
-  defp legacy_shell_state_owns_agent_session?(%{cards: cards} = shell_state, session_pid)
-       when is_map(cards) do
-    Enum.any?(cards, fn {_card_id, card} -> Map.get(card, :session) == session_pid end) or
-      legacy_tab_bar_owns_agent_session?(shell_state, session_pid)
-  end
-
-  defp legacy_shell_state_owns_agent_session?(shell_state, session_pid),
-    do: legacy_tab_bar_owns_agent_session?(shell_state, session_pid)
-
-  @spec legacy_tab_bar_owns_agent_session?(shell_state(), pid()) :: boolean()
-  defp legacy_tab_bar_owns_agent_session?(%{tab_bar: %TabBar{} = tab_bar}, session_pid) do
-    not is_nil(TabBar.find_by_session(tab_bar, session_pid)) or
-      not is_nil(TabBar.find_workspace_by_session(tab_bar, session_pid))
-  end
-
-  defp legacy_tab_bar_owns_agent_session?(_shell_state, _session_pid), do: false
 
   @spec route_active_boolean_callback(t(), atom(), [term()]) ::
           {t(), boolean(), persistence_change() | nil}
@@ -537,7 +521,7 @@ defmodule MingaEditor.Shell.Runtime do
          callback,
          args
        ) do
-    case Map.get(runtime.stash, entry.id) do
+    case Map.get(runtime.stash, Identity.new(entry)) do
       %StateStash{} = stashed ->
         route_matching_stashed_boolean_callback(runtime, stashed, entry, callback, args)
 
@@ -560,7 +544,12 @@ defmodule MingaEditor.Shell.Runtime do
       case apply(entry.module, callback, [old_state | args]) do
         {new_state, true} ->
           updated = StateStash.new(entry, new_state)
-          runtime = %__MODULE__{runtime | stash: Map.put(runtime.stash, entry.id, updated)}
+
+          runtime = %__MODULE__{
+            runtime
+            | stash: Map.put(runtime.stash, updated.identity, updated)
+          }
+
           change = persistence_change(entry, old_state, new_state)
           {runtime, true, change}
 
@@ -598,13 +587,13 @@ defmodule MingaEditor.Shell.Runtime do
          callback,
          args
        ) do
-    case Map.get(runtime.stash, entry.id) do
+    case Map.get(runtime.stash, Identity.new(entry)) do
       %StateStash{} = stashed ->
         with {:ok, old_state} <- StateStash.restore(stashed, entry),
              true <- function_exported?(entry.module, callback, length(args) + 1) do
           new_state = apply(entry.module, callback, [old_state | args])
           updated = StateStash.new(entry, new_state)
-          %__MODULE__{runtime | stash: Map.put(runtime.stash, entry.id, updated)}
+          %__MODULE__{runtime | stash: Map.put(runtime.stash, updated.identity, updated)}
         else
           _ -> runtime
         end
@@ -616,11 +605,11 @@ defmodule MingaEditor.Shell.Runtime do
 
   @spec accept_stashed_persisted_state(t(), Entry.t(), shell_state()) :: t()
   defp accept_stashed_persisted_state(%__MODULE__{} = runtime, %Entry{} = entry, persisted_state) do
-    case Map.get(runtime.stash, entry.id) do
+    case Map.get(runtime.stash, Identity.new(entry)) do
       %StateStash{} = stashed ->
         if StateStash.matches?(stashed, entry) do
-          stash = Map.put(runtime.stash, entry.id, StateStash.new(entry, persisted_state))
-          %__MODULE__{runtime | stash: stash}
+          updated = StateStash.new(entry, persisted_state)
+          %__MODULE__{runtime | stash: Map.put(runtime.stash, updated.identity, updated)}
         else
           runtime
         end
@@ -639,9 +628,11 @@ defmodule MingaEditor.Shell.Runtime do
   defp prepend_change(nil, changes), do: changes
   defp prepend_change(change, changes), do: [change | changes]
 
-  @spec same_entry?(Entry.t(), Entry.t()) :: boolean()
-  defp same_entry?(%Entry{} = left, %Entry{} = right) do
-    left.id == right.id and left.module == right.module and left.source == right.source and
-      left.generation == right.generation
+  @spec drop_registration_id(stash(), atom()) :: stash()
+  defp drop_registration_id(stash, id) do
+    Map.reject(stash, fn {%Identity{id: stashed_id}, _stashed} -> stashed_id == id end)
   end
+
+  @spec same_entry?(Entry.t(), Entry.t()) :: boolean()
+  defp same_entry?(%Entry{} = left, %Entry{} = right), do: Identity.matches?(left, right)
 end

--- a/lib/minga_editor/shell/state_stash.ex
+++ b/lib/minga_editor/shell/state_stash.ex
@@ -1,43 +1,34 @@
 defmodule MingaEditor.Shell.StateStash do
   @moduledoc """
-  Stashed shell state tied to the exact shell registry identity that produced it.
+  Stashed shell state tied to the exact shell registration that produced it.
 
-  Shell state is only safe to restore into the same registered shell id, module, and source. Extension shell ids can be unregistered and later reused, so the registry generation is part of the identity as well.
+  Shell state is safe to restore only into the same registered shell id, module, source, and generation. `MingaEditor.Shell.Identity` owns that comparison contract for registration, runtime, renderer, and stash paths.
   """
 
   alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Identity
 
-  @enforce_keys [:id, :module, :source, :generation, :state]
-  defstruct [:id, :module, :source, :generation, :state]
+  @enforce_keys [:identity, :state]
+  defstruct [:identity, :state]
 
   @type t :: %__MODULE__{
-          id: atom(),
-          module: module(),
-          source: Entry.source(),
-          generation: non_neg_integer(),
+          identity: Identity.t(),
           state: MingaEditor.Shell.shell_state()
         }
 
-  @doc "Stores shell state with the registry identity that produced it."
+  @doc "Stores shell state with the exact registry identity that produced it."
   @spec new(Entry.t(), MingaEditor.Shell.shell_state()) :: t()
   def new(%Entry{} = entry, state) do
-    %__MODULE__{
-      id: entry.id,
-      module: entry.module,
-      source: entry.source,
-      generation: entry.generation,
-      state: state
-    }
+    %__MODULE__{identity: Identity.new(entry), state: state}
   end
 
-  @doc "Returns true when the stash belongs to the current registry entry."
+  @doc "Returns true when the stash belongs to the current exact registry entry."
   @spec matches?(t(), Entry.t()) :: boolean()
   def matches?(%__MODULE__{} = stash, %Entry{} = entry) do
-    stash.id == entry.id and stash.module == entry.module and stash.source == entry.source and
-      stash.generation == entry.generation
+    Identity.matches?(stash.identity, entry)
   end
 
-  @doc "Restores stored state only when the current registry entry has the same identity."
+  @doc "Restores stored state only when the current registry entry has the same exact identity."
   @spec restore(t(), Entry.t()) :: {:ok, MingaEditor.Shell.shell_state()} | :mismatch
   def restore(%__MODULE__{} = stash, %Entry{} = entry) do
     if matches?(stash, entry), do: {:ok, stash.state}, else: :mismatch

--- a/test/minga_editor/feature_state_shell_cleanup_test.exs
+++ b/test/minga_editor/feature_state_shell_cleanup_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.FeatureStateShellCleanupTest do
 
   alias MingaEditor.FeatureState
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Identity
   alias MingaEditor.Shell.Registry
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.StateStash
@@ -67,8 +68,10 @@ defmodule MingaEditor.FeatureStateShellCleanupTest do
 
     [cleaned_context] = Runtime.state(cleaned.shell_runtime).contexts
 
-    assert %StateStash{module: MingaEditor.Test.FakeShellAlt, state: stashed_shell_state} =
-             Runtime.stash(cleaned.shell_runtime).fake_shell_alt
+    assert %StateStash{
+             identity: %Identity{module: MingaEditor.Test.FakeShellAlt},
+             state: stashed_shell_state
+           } = Map.fetch!(Runtime.stash(cleaned.shell_runtime), Identity.new(stashed_entry))
 
     [cleaned_stashed_context] = stashed_shell_state.contexts
     restored = SessionState.restore_tab_context(workspace(), cleaned_context)
@@ -111,7 +114,7 @@ defmodule MingaEditor.FeatureStateShellCleanupTest do
     cleaned = EditorState.drop_feature_state_source(state, @source)
 
     %StateStash{state: %{contexts: [unchanged_context]}} =
-      Runtime.stash(cleaned.shell_runtime).fake_shell
+      Map.fetch!(Runtime.stash(cleaned.shell_runtime), Identity.new(stale_entry))
 
     restored = SessionState.restore_tab_context(workspace(), unchanged_context)
 

--- a/test/minga_editor/file_tree/freshness_test.exs
+++ b/test/minga_editor/file_tree/freshness_test.exs
@@ -21,6 +21,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
   import MingaEditor.RenderPipeline.TestHelpers
 
   @moduletag :tmp_dir
+  @timeout 1_000
 
   test "cache refresh starts a Git.Repo owner when no cache exists yet", %{tmp_dir: dir} do
     events_registry = start_events_registry()
@@ -216,7 +217,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     assert file_tree(loading).tree.entries == nil
     assert FileTreeState.status(file_tree(loading)) == :loading
     assert is_reference(request_id)
-    assert_receive {:file_tree_scan_started, :project_root, worker}
+    assert_receive {:file_tree_scan_started, :project_root, worker}, @timeout
 
     result = tree(new_root, [entry(new_root, "new.ex")])
     send(worker, {:release_file_tree_scan, :project_root, {:return, result}})
@@ -247,7 +248,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
       )
 
     first_id = file_tree(first_state).refresh.current.token
-    assert_receive {:file_tree_scan_started, :first_root, first_worker}
+    assert_receive {:file_tree_scan_started, :first_root, first_worker}, @timeout
 
     latest_state =
       Freshness.update_project_root(first_state, latest_root,
@@ -258,7 +259,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
 
     latest_id = file_tree(latest_state).refresh.current.token
     assert latest_id != first_id
-    assert_receive {:file_tree_scan_started, :latest_root, latest_worker}
+    assert_receive {:file_tree_scan_started, :latest_root, latest_worker}, @timeout
 
     first_result = tree(first_root, [entry(first_root, "first.ex")])
     send(first_worker, {:release_file_tree_scan, :first_root, {:return, first_result}})
@@ -301,7 +302,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
       )
 
     failed_id = file_tree(failing).refresh.current.token
-    assert_receive {:file_tree_scan_started, :failed_root, _worker}
+    assert_receive {:file_tree_scan_started, :failed_root, _worker}, @timeout
     failed_outcome = receive_outcome(scheduler, failed_id, :failed)
     assert :ok = EffectScheduler.claim(scheduler, failed_outcome)
 
@@ -324,7 +325,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
       )
 
     recovered_id = file_tree(recovering).refresh.current.token
-    assert_receive {:file_tree_scan_started, :recovered_root, _worker}
+    assert_receive {:file_tree_scan_started, :recovered_root, _worker}, @timeout
     recovered_outcome = receive_outcome(scheduler, recovered_id, :completed)
     assert :ok = EffectScheduler.claim(scheduler, recovered_outcome)
 

--- a/test/minga_editor/shell/identity_test.exs
+++ b/test/minga_editor/shell/identity_test.exs
@@ -1,0 +1,48 @@
+defmodule MingaEditor.Shell.IdentityTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Identity
+
+  test "id, module, source, and generation define one exact registration identity" do
+    entry = entry()
+    identity = Identity.new(entry)
+
+    assert Identity.matches?(entry, entry)
+    assert Identity.matches?(identity, entry)
+    assert Identity.matches?(entry, identity)
+
+    refute Identity.matches?(identity, %{entry | id: :replacement})
+    refute Identity.matches?(identity, %{entry | module: String})
+    refute Identity.matches?(identity, %{entry | source: {:extension, :replacement}})
+    refute Identity.matches?(identity, %{entry | generation: entry.generation + 1})
+  end
+
+  test "presentation metadata does not change registration identity" do
+    entry = entry()
+
+    changed_metadata = %Entry{
+      entry
+      | display_name: "Renamed",
+        description: "Updated description",
+        capabilities: [:gui, :tui],
+        default?: true
+    }
+
+    assert Identity.matches?(entry, changed_metadata)
+    assert Identity.new(entry) == Identity.new(changed_metadata)
+  end
+
+  @spec entry() :: Entry.t()
+  defp entry do
+    %Entry{
+      id: :fake,
+      source: {:extension, :fake},
+      module: MingaEditor.Test.FakeShell,
+      display_name: "Fake",
+      description: "Fake shell",
+      capabilities: [:tui],
+      generation: 7
+    }
+  end
+end

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -27,6 +27,7 @@ defmodule MingaEditor.Shell.RegistryTest do
   alias Minga.Test.RecordingFrontend
   alias MingaEditor.Test.FakeShell
   alias MingaEditor.Test.FakeShellAlt
+  alias MingaEditor.Test.UnknownGuiPayloadShell
 
   setup do
     Registry.reset_for_test()
@@ -56,6 +57,17 @@ defmodule MingaEditor.Shell.RegistryTest do
     snapshot = Registry.snapshot()
     assert Registry.resolve(:fake) == snapshot.entries.fake
     assert Registry.resolve(FakeShell) == snapshot.entries.fake
+  end
+
+  test "registration reports a missing session-ownership callback with its required arity" do
+    assert {:error,
+            {:invalid_entry, {:missing_callbacks, UnknownGuiPayloadShell, missing_callbacks}}} =
+             Registry.register(
+               {:extension, :incomplete},
+               shell_attrs(:incomplete, UnknownGuiPayloadShell, "Incomplete")
+             )
+
+    assert {:owns_agent_session?, 2} in missing_callbacks
   end
 
   test "input dispatch uses the active extension shell contract" do
@@ -432,12 +444,14 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
+    fake_entry = Registry.get(:fake)
+
     state =
       TestHelpers.base_state()
       |> Workflow.switch(:fake)
       |> Workflow.switch(:traditional)
 
-    assert Runtime.stash(state.shell_runtime).fake.state == %{name: :fake, events: []}
+    assert stashed(state.shell_runtime, fake_entry).state == %{name: :fake, events: []}
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -610,7 +624,7 @@ defmodule MingaEditor.Shell.RegistryTest do
     assert Runtime.module(result.shell_runtime) == default.module
     assert Runtime.identity(result.shell_runtime) == Identity.new(default)
     refute Map.has_key?(result.shell_runtime.state, :obsolete)
-    refute Map.has_key?(Runtime.stash(result.shell_runtime), :fake)
+    assert Runtime.stash(result.shell_runtime) == %{}
     assert result.render.layout == nil
     assert result.render.focus_tree == nil
   end
@@ -636,6 +650,8 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
+    fake_entry = Registry.get(:fake)
+
     state =
       TestHelpers.base_state()
       |> Workflow.switch(:fake)
@@ -645,7 +661,7 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     event = {:status_changed, :error}
     {:noreply, matching} = MingaEditor.handle_info({:agent_event, self(), event}, state)
-    assert Runtime.stash(matching.shell_runtime).fake.state.events == [event]
+    assert stashed(matching.shell_runtime, fake_entry).state.events == [event]
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -661,7 +677,7 @@ defmodule MingaEditor.Shell.RegistryTest do
     {:noreply, stale} =
       MingaEditor.handle_info({:agent_event, self(), {:status_changed, :idle}}, matching)
 
-    assert Runtime.stash(stale.shell_runtime).fake.state.events == [event]
+    assert stashed(stale.shell_runtime, fake_entry).state.events == [event]
     Process.cancel_timer(stale.render.render_correlation.timer)
   end
 
@@ -718,7 +734,7 @@ defmodule MingaEditor.Shell.RegistryTest do
       |> stash_shell_state(fake_entry, %{session: session})
 
     {matching, _effects} = Events.handle(state, {:status_changed, :thinking})
-    assert Runtime.stash(matching.shell_runtime).fake.state.synced_agent_status == :thinking
+    assert stashed(matching.shell_runtime, fake_entry).state.synced_agent_status == :thinking
 
     assert :ok = Registry.unregister_source({:extension, :fake})
 
@@ -732,7 +748,7 @@ defmodule MingaEditor.Shell.RegistryTest do
              })
 
     {stale, _effects} = Events.handle(matching, {:status_changed, :idle})
-    assert Runtime.stash(stale.shell_runtime).fake.state.synced_agent_status == :thinking
+    assert stashed(stale.shell_runtime, fake_entry).state.synced_agent_status == :thinking
   end
 
   test "buffer session restart updates a matching stash but not a replaced registration" do
@@ -765,7 +781,7 @@ defmodule MingaEditor.Shell.RegistryTest do
         :restarted
       )
 
-    assert Runtime.stash(matching.shell_runtime).fake.state.session == new_pid
+    assert stashed(matching.shell_runtime, entry).state.session == new_pid
 
     stale_state = state
 
@@ -789,7 +805,7 @@ defmodule MingaEditor.Shell.RegistryTest do
         :restarted
       )
 
-    assert Runtime.stash(stale.shell_runtime).fake.state.session == old_pid
+    assert stashed(stale.shell_runtime, entry).state.session == old_pid
     assert {:stale, _normalized} = BufferManagement.prepare_agent_session_restart(stale, old_pid)
   end
 
@@ -919,7 +935,7 @@ defmodule MingaEditor.Shell.RegistryTest do
 
     assert Runtime.identity(normalized.shell_runtime) == Identity.new(current_entry)
     refute Map.has_key?(normalized.shell_runtime.state, :session)
-    assert Runtime.stash(normalized.shell_runtime).valid.state.session == old_pid
+    assert stashed(normalized.shell_runtime, valid_entry).state.session == old_pid
   end
 
   test "session down and disconnect reset obsolete active shell state before callbacks" do
@@ -1063,8 +1079,8 @@ defmodule MingaEditor.Shell.RegistryTest do
         :restarted
       )
 
-    assert Runtime.stash(restarted.shell_runtime).a_stale.state.session == old_pid
-    assert Runtime.stash(restarted.shell_runtime).z_valid.state.session == new_pid
+    assert stashed(restarted.shell_runtime, stale_entry).state.session == old_pid
+    assert stashed(restarted.shell_runtime, valid_entry).state.session == new_pid
   end
 
   test "agent status synchronization updates every exact-identity stash" do
@@ -1089,18 +1105,20 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
+    first = Registry.get(:first)
+    second = Registry.get(:second)
+
     state =
       TestHelpers.base_state()
       |> stash_shell_states([
-        {Registry.get(:first), %{session: session}},
-        {Registry.get(:second), %{session: session}}
+        {first, %{session: session}},
+        {second, %{session: session}}
       ])
 
     runtime = Runtime.sync_agent_status(state.shell_runtime, Registry.list(), session, :thinking)
-    stash = Runtime.stash(runtime)
 
-    assert stash.first.state.synced_agent_status == :thinking
-    assert stash.second.state.synced_agent_status == :thinking
+    assert stashed(runtime, first).state.synced_agent_status == :thinking
+    assert stashed(runtime, second).state.synced_agent_status == :thinking
   end
 
   test "active shell callbacks normalize a stale registration before dispatch" do
@@ -1286,6 +1304,11 @@ defmodule MingaEditor.Shell.RegistryTest do
       |> Runtime.activate(active_entry, active_state)
 
     %{state | shell_runtime: runtime}
+  end
+
+  @spec stashed(Runtime.t(), Entry.t()) :: MingaEditor.Shell.StateStash.t()
+  defp stashed(%Runtime{} = runtime, %Entry{} = entry) do
+    Map.fetch!(Runtime.stash(runtime), Identity.new(entry))
   end
 
   @spec with_frontend_backend(EditorState.t(), Frontend.backend()) :: EditorState.t()

--- a/test/minga_editor/shell/runtime_test.exs
+++ b/test/minga_editor/shell/runtime_test.exs
@@ -3,9 +3,8 @@ defmodule MingaEditor.Shell.RuntimeTest do
 
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Identity
   alias MingaEditor.Shell.Runtime
-  alias MingaEditor.State.Tab
-  alias MingaEditor.State.TabBar
   alias MingaEditor.Test.FakeShell
   alias MingaEditor.Test.FakeShellAlt
   alias MingaEditor.Viewport
@@ -40,12 +39,12 @@ defmodule MingaEditor.Shell.RuntimeTest do
       |> Runtime.activate(alternate, %{marker: :alternate})
 
     assert Runtime.state(runtime) == %{marker: :alternate}
-    assert Runtime.stash(runtime).fake.state == %{marker: :fake}
+    assert stashed(runtime, fake).state == %{marker: :fake}
 
     restored = Runtime.activate(runtime, fake, %{marker: :new_default})
     assert Runtime.state(restored) == %{marker: :fake}
-    refute Map.has_key?(Runtime.stash(restored), :fake)
-    assert Runtime.stash(restored).alternate.state == %{marker: :alternate}
+    refute stashed_id?(restored, :fake)
+    assert stashed(restored, alternate).state == %{marker: :alternate}
   end
 
   test "reused ids with stale module, source, or generation never restore old state" do
@@ -64,7 +63,7 @@ defmodule MingaEditor.Shell.RuntimeTest do
         |> Runtime.activate(replacement, %{marker: :fresh})
 
       assert Runtime.state(runtime) == %{marker: :fresh}
-      refute Map.has_key?(Runtime.stash(runtime), :fake)
+      refute stashed_id?(runtime, :fake)
     end
   end
 
@@ -97,8 +96,8 @@ defmodule MingaEditor.Shell.RuntimeTest do
     fallback = Runtime.fallback_from_removed(runtime, default, %{marker: :new_default})
     assert Runtime.entry(fallback) == default
     assert Runtime.state(fallback) == %{marker: :default}
-    refute Map.has_key?(Runtime.stash(fallback), :traditional)
-    refute Map.has_key?(Runtime.stash(fallback), :fake)
+    refute stashed_id?(fallback, :traditional)
+    refute stashed_id?(fallback, :fake)
   end
 
   test "active events route through the active entry contract" do
@@ -136,7 +135,7 @@ defmodule MingaEditor.Shell.RuntimeTest do
 
     assert Runtime.entry(updated) == alternate
     assert Runtime.state(updated) == %{events: []}
-    assert Runtime.stash(updated).fake.state.events == [:background]
+    assert stashed(updated, fake).state.events == [:background]
     assert [{%Entry{module: FakeShell}, _old_state, _new_state}] = changes
 
     {unchanged, @workspace, []} =
@@ -159,30 +158,33 @@ defmodule MingaEditor.Shell.RuntimeTest do
     stashed = Runtime.activate(active, alternate, %{marker: :alternate})
     stashed = Runtime.accept_persisted_state(stashed, fake, %{marker: :persisted_stash})
     assert Runtime.state(stashed) == %{marker: :alternate}
-    assert Runtime.stash(stashed).fake.state == %{marker: :persisted_stash}
+    assert stashed(stashed, fake).state == %{marker: :persisted_stash}
   end
 
-  test "legacy shells without an ownership callback retain restart ownership" do
+  test "extension ownership uses its contract without Traditional state fields" do
     session = self()
-    legacy = entry(:legacy, FakeShellAlt, 1)
+    extension = entry(:extension, FakeShellAlt, 1)
+    shell_state = %{owned_sessions: [session], extension_only: :state}
+    runtime = Runtime.new(extension, shell_state)
 
-    tab_bar =
-      1
-      |> Tab.new_agent("Agent")
-      |> Tab.set_session(session)
-      |> TabBar.new()
+    assert Runtime.owns_agent_session?(runtime, [extension], session)
 
-    for shell_state <- [
-          %{session: session},
-          %{cards: %{one: %{session: session}}},
-          %{tab_bar: tab_bar}
-        ] do
-      runtime = Runtime.new(legacy, shell_state)
-      assert Runtime.owns_agent_session?(runtime, [legacy], session)
+    stashed_runtime = Runtime.activate(runtime, entry(:active, FakeShell, 2), %{})
+    assert Runtime.owns_agent_session?(stashed_runtime, [extension], session)
+    refute Runtime.owns_agent_session?(stashed_runtime, [extension], spawn(fn -> :ok end))
+  end
 
-      stashed = Runtime.activate(runtime, entry(:active, FakeShell, 2), %{})
-      assert Runtime.owns_agent_session?(stashed, [legacy], session)
-    end
+  test "session extraction and installation use an extension shell's state shape" do
+    extension = entry(:extension, FakeShellAlt, 1)
+    runtime = Runtime.new(extension, %{extension_only: :state})
+
+    assert Runtime.active_session(runtime) == nil
+
+    installed = Runtime.set_tab_session(runtime, :extension_slot, self())
+
+    assert Runtime.active_session(installed) == self()
+    assert Runtime.state(installed) == %{extension_only: :state, session_slot: self()}
+    assert Runtime.owns_agent_session?(installed, [extension], self())
   end
 
   test "rejected stashed callbacks leave runtime state unchanged" do
@@ -196,7 +198,7 @@ defmodule MingaEditor.Shell.RuntimeTest do
     assert {^runtime, false, []} =
              Runtime.route_stashed_session_down(runtime, [stashed_entry], self(), :foreign)
 
-    refute Map.has_key?(Runtime.stash(runtime).fake.state, :foreign_mutation)
+    refute Map.has_key?(stashed(runtime, stashed_entry).state, :foreign_mutation)
   end
 
   test "active and stashed session lifecycle routes through exact entry contracts" do
@@ -227,7 +229,7 @@ defmodule MingaEditor.Shell.RuntimeTest do
              Runtime.route_session_restarted(runtime, [fake], old_pid, new_pid, :restart)
 
     assert Runtime.state(restarted).session == new_pid
-    assert Runtime.stash(restarted).fake.state.session == new_pid
+    assert stashed(restarted, fake).state.session == new_pid
     assert [_, _] = changes
 
     stashed_runtime =
@@ -238,12 +240,24 @@ defmodule MingaEditor.Shell.RuntimeTest do
     assert {stashed_down, true, [_change]} =
              Runtime.route_stashed_session_down(stashed_runtime, [fake], old_pid, :boom)
 
-    assert Runtime.stash(stashed_down).fake.state.session_down?
+    assert stashed(stashed_down, fake).state.session_down?
 
     assert {disconnected, true, [_change]} =
              Runtime.route_stashed_remote_session_disconnected(stashed_runtime, [fake], old_pid)
 
-    assert Runtime.stash(disconnected).fake.state.remote_disconnected?
+    assert stashed(disconnected, fake).state.remote_disconnected?
+  end
+
+  @spec stashed(Runtime.t(), Entry.t()) :: MingaEditor.Shell.StateStash.t()
+  defp stashed(%Runtime{} = runtime, %Entry{} = entry) do
+    Map.fetch!(Runtime.stash(runtime), Identity.new(entry))
+  end
+
+  @spec stashed_id?(Runtime.t(), atom()) :: boolean()
+  defp stashed_id?(%Runtime{} = runtime, id) do
+    Enum.any?(Runtime.stash(runtime), fn {%Identity{id: stashed_id}, _state} ->
+      stashed_id == id
+    end)
   end
 
   defp entry(id, module, generation, source \\ {:extension, :runtime_test}) do

--- a/test/support/fake_shell_alt.ex
+++ b/test/support/fake_shell_alt.ex
@@ -95,6 +95,17 @@ defmodule MingaEditor.Test.FakeShellAlt do
   def on_agent_event(shell_state, workspace, _session, _event), do: {shell_state, workspace}
 
   @impl true
+  @spec owns_agent_session?(map(), pid()) :: boolean()
+  def owns_agent_session?(%{owned_sessions: sessions}, session_pid)
+      when is_list(sessions) do
+    session_pid in sessions
+  end
+
+  def owns_agent_session?(%{session_slot: session_pid}, session_pid), do: true
+  def owns_agent_session?(%{session: session_pid}, session_pid), do: true
+  def owns_agent_session?(_shell_state, _session_pid), do: false
+
+  @impl true
   @spec handle_agent_session_restarted(map(), pid(), pid(), term()) :: {map(), boolean()}
   def handle_agent_session_restarted(%{session: old_pid} = shell_state, old_pid, new_pid, _reason) do
     {Map.put(shell_state, :session, new_pid), true}
@@ -147,10 +158,12 @@ defmodule MingaEditor.Test.FakeShellAlt do
 
   @impl true
   @spec set_tab_session(map(), term(), pid() | nil) :: map()
-  def set_tab_session(shell_state, _tab_id, _session_pid), do: shell_state
+  def set_tab_session(shell_state, _tab_id, session_pid),
+    do: Map.put(shell_state, :session_slot, session_pid)
 
   @impl true
   @spec active_session(map()) :: pid() | nil
+  def active_session(%{session_slot: session}) when is_pid(session), do: session
   def active_session(%{session: session}) when is_pid(session), do: session
   def active_session(_shell_state), do: nil
 


### PR DESCRIPTION
# TL;DR

Shell session ownership is now a required runtime contract instead of a structural guess. Registrations validate the live behavior callback set, runtime and stash paths share one exact identity value, and extension shells can own, install, extract, route, persist, and restore sessions without exposing Traditional fields.

Closes #2917

## Context

This is the shell-contract slice of #2914. It preserves one Editor GenServer and the current shell lifecycle while removing the last runtime fallback that inspected `cards` and `tab_bar` values from foreign shell implementations.

## Changes

- Make `owns_agent_session?/2` mandatory for every `MingaEditor.Shell` implementation.
- Derive registration requirements directly from behavior metadata instead of maintaining a second callback list that can drift.
- Return an actionable missing-callback error with the exact callback name and arity.
- Remove all `cards`, `tab_bar`, `TabBar`, and `active_session/1` fallback probing from `Shell.Runtime`; ownership dispatches only through the registered shell module.
- Extend `Shell.Identity` to the full registration identity: id, module, source, and generation.
- Key runtime stashes by exact `Shell.Identity` values and store the same identity in `StateStash`.
- Route active equality, activation, restoration, registration validation, rendered writeback, persistence, and stashed event handling through that single identity contract.
- Drop stale same-id stash registrations when a shell id is reused, preventing stale restoration or identity accumulation.
- Add extension-shaped session ownership and session installation/extraction coverage without Traditional fields.
- Give #2916’s async scanner-start assertions the same explicit receive budget already used by their refresh and watcher companions; no production file-tree code changed.

## Verification

Validated rebased commit `4d4a3762577f05dc9f902c81ade3f463b35ac0bf`:

- `make lint`: passed with Credo clean, compilation clean, and incremental Dialyzer at 0 errors.
- `mix test.llm`: 9,504 tests, 97 properties, and 58 doctests passed with 0 failures; 1 test skipped.
- Focused shell, registry, persistence, routing, and fallback suite: 182 tests passed.
- Focused file-tree freshness suite: 11 tests passed.
- `bash scripts/bench_keystroke_latency_ab origin/main HEAD`: all blocking latency budgets within limits across four base and HEAD rounds.
- `git diff origin/main...HEAD --check`: passed.
- Final acceptance review: PASS.
- Frontend-specific checks are not applicable because no Swift, Go, or Zig files changed.

## Acceptance Criteria Addressed

- Every registered shell must implement explicit session ownership. ✅
- Runtime session ownership and routing no longer inspect implementation-specific state shapes. ✅
- Registration, active equality, stash keys, restoration, persistence, and async writeback share one exact identity contract. ✅
- Missing or incompatible ownership callback arity produces an actionable registration error. ✅
- Activation, stashing, restoration, event routing, persistence, and fallback behavior remain compatible. ✅
- Focused tests cover registration validation, exact equality, session extraction/installation, stash restoration, and unrelated extension state shapes. ✅
