### PR TITLE
chore(macos): calibrate thread CPU render baseline

### DIFF
--- a/docs/PERFORMANCE.md
+++ b/docs/PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Rendering performance gates
 
-Minga uses deterministic production work gates first and an optimized native process-CPU-time gate second. Stable operation counts catch algorithmic regressions without runner noise; Release percentiles diagnose the shipping Swift preparation path. Neither substitutes for the other.
+Minga uses deterministic production work gates first and an optimized native calling-thread-CPU-time gate second. Stable operation counts catch algorithmic regressions without runner noise; Release percentiles diagnose the shipping Swift preparation path. Neither substitutes for the other.
 
 ## Production conformance fixture
 
@@ -77,7 +77,7 @@ The harness prints raw JSON percentiles and environment metadata. `performance/b
 
 CI never generates a baseline. A change requires an explicit JSON diff and PR rationale naming the fixture/toolchain change and measured p95 values. Never change the 4 ms, 8 ms, 1.20x, or 0.05 ms policies merely to make a run pass. Measurements above the hybrid limit must be investigated instead of increasing the allowance.
 
-`resident-ordinary-edit-v2` replaces #2791's synthetic dictionary/tuple work with the production resident decode/apply and shared CoreText command preparation paths. Process-CPU runs `29360855703` and `29362531315` measured 0.185 ms and 0.547 ms combined p95 on unchanged renderer code while combined p50 stayed at 0.145 ms and 0.152 ms. Schema v3 therefore measures calling-thread CPU, which matches the synchronous work under test and excludes unrelated Foundation or runtime threads. The baseline file records the thread-clock calibration runs, exact macOS version, Swift version, and conservative checked reference. The hard 4 ms stage, 8 ms combined, 1.20x regression ratio, and 0.05 ms sub-millisecond measurement allowance remain code-owned policy.
+`resident-ordinary-edit-v2` replaces #2791's synthetic dictionary/tuple work with the production resident decode/apply and shared CoreText command preparation paths. Process-CPU runs `29360855703` and `29362531315` measured 0.185 ms and 0.547 ms combined p95 on unchanged renderer code while combined p50 stayed at 0.145 ms and 0.152 ms. Schema v3 therefore measures calling-thread CPU, which matches the synchronous work under test and excludes unrelated Foundation or runtime threads. Two thread-CPU calibrations in CI run `29363711962` (jobs `87189922733` and `87192352431`) measured 0.071/0.386/0.460 ms and 0.015/0.138/0.157 ms p95 for decode/apply, command preparation, and combined work. The checked references use the conservative first run, rounded upward to three decimals. The hard 4 ms stage, 8 ms combined, 1.20x regression ratio, and 0.05 ms sub-millisecond measurement allowance remain code-owned policy.
 
 ## Native latency milestones
 

--- a/performance/baselines/macos_render_release.json
+++ b/performance/baselines/macos_render_release.json
@@ -2,13 +2,13 @@
   "version": 3,
   "fixtureVersion": "resident-ordinary-edit-v2",
   "measurementClock": "thread_cpu",
-  "decodeApplyP95Ms": 0.040,
-  "commandPreparationP95Ms": 0.360,
-  "combinedP95Ms": 0.415,
+  "decodeApplyP95Ms": 0.071,
+  "commandPreparationP95Ms": 0.387,
+  "combinedP95Ms": 0.460,
   "provenance": {
     "measuredAt": "2026-07-14",
     "environment": "GitHub-hosted macos-15 arm64 runner, macOS 15.7.7 (24G720)",
     "toolchain": "Apple Swift 6.1.2 (swiftlang-6.1.2.1.2 clang-1700.0.13.5), swiftc -O",
-    "rationale": "Switched the synchronous single-thread harness from process CPU to calling-thread CPU after unchanged renderer code produced 0.185 ms and 0.547 ms combined p95 in consecutive runs while p50 stayed stable, demonstrating contamination from unrelated process threads. Thread-CPU calibration is recorded in the final PR validation. The five-batch median, 1.20x regression ratio, 0.05 ms noise allowance, and hard-coded 4 ms stage and 8 ms combined ceilings remain authoritative."
+    "rationale": "Switched the synchronous single-thread harness from process CPU to calling-thread CPU after unchanged renderer code produced 0.185 ms and 0.547 ms combined p95 in consecutive process-clock runs while p50 stayed stable. Thread-CPU calibrations from CI run 29363711962 jobs 87189922733 and 87192352431 aggregated to 0.071/0.386/0.460 ms and 0.015/0.138/0.157 ms p95 for decode/apply, command preparation, and combined work. The conservative first run is checked in, rounded upward to three decimals. The five-batch median, 1.20x regression ratio, 0.05 ms noise allowance, and hard-coded 4 ms stage and 8 ms combined ceilings remain authoritative."
   }
 }

--- a/test/minga/editing/formatter_test.exs
+++ b/test/minga/editing/formatter_test.exs
@@ -17,6 +17,11 @@ defmodule Minga.Editing.FormatterTest do
         Options.set(:clipboard, :none)
     end
 
+    on_exit(fn ->
+      Options.reset()
+      Options.set(:clipboard, :none)
+    end)
+
     :ok
   end
 

--- a/test/minga_editor/commands/formatting_scheduler_test.exs
+++ b/test/minga_editor/commands/formatting_scheduler_test.exs
@@ -1,10 +1,11 @@
 defmodule MingaEditor.Commands.FormattingSchedulerTest do
   @moduledoc "Integrated scheduler ownership regressions for external formatting."
 
-  # External formatting launches a real shell process, which must not run concurrently in ExUnit.
+  # External formatting launches a real shell process and this test sets global formatter options.
   use ExUnit.Case, async: false
 
   alias Minga.Buffer
+  alias Minga.Config.Options
   alias MingaEditor.Commands.Formatting
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effect.Request
@@ -17,6 +18,13 @@ defmodule MingaEditor.Commands.FormattingSchedulerTest do
   @effect_timeout 2_000
 
   test "origin creates feedback before scheduling and correlates the running lifecycle" do
+    Options.set_for_filetype(:elixir, :formatter, "cat")
+
+    on_exit(fn ->
+      Options.reset()
+      Options.set(:clipboard, :none)
+    end)
+
     task_supervisor = start_supervised!({Task.Supervisor, []})
 
     scheduler =


### PR DESCRIPTION
# TL;DR
Check in the conservative calling-thread CPU calibration collected while validating #2931, and correct the remaining top-level performance documentation wording.

Follow-up to #2931.

## Changes
- Calibrate schema-v3 `thread_cpu` references to 0.071/0.387/0.460 ms p95 for decode/apply, command preparation, and combined work.
- Record both independent macOS CI calibration jobs and the conservative-selection rationale.
- Describe the optimized gate consistently as calling-thread CPU time.

## Calibration
CI run [29363711962](https://github.com/jsmestad/minga/actions/runs/29363711962) produced two independent macOS measurements:

- Job `87189922733`: 0.071/0.386/0.460 ms p95.
- Job `87192352431`: 0.015/0.138/0.157 ms p95.

The checked references use the conservative first run, rounded upward to three decimals. The five-batch median, workload, fixture, 4 ms stage ceiling, 8 ms combined ceiling, 1.20x ratio, and 0.05 ms allowance are unchanged.

## Verification
- Both calibration attempts passed the optimized native gate, macOS build, packaged-helper integration, and Swift tests.
- The full 10-check CI matrix passed twice at the functional #2931 SHA.
- Final reviewer approved the clock contract and calibration after one documentation wording correction.


## CI flake root cause
- Reproduced the CI seed with `Minga.Editing.FormatterTest` ordered before `FormattingSchedulerTest`.
- The former leaked a global `:elixir` formatter override (`custom-fmt`) into the Options server.
- The latter then could not find that executable, correctly entered the missing-tool prompt path, and never created the operation feedback its assertion expected.
- The mutating test now restores global Options state, and the scheduler test declares a deterministic `cat` formatter fixture and restores it after the test.
- Validation: exact two-module reproduction passes; exact CI suite at seed `904667` passes 10,005 tests with 0 failures.
