### PR TITLE
refactor(project): centralize workspace file authorization

### DIFF
--- a/lib/minga/project/root.ex
+++ b/lib/minga/project/root.ex
@@ -31,6 +31,14 @@ defmodule Minga.Project.Root do
   @typedoc "Why a filesystem path could not be canonicalized."
   @type canonical_error :: File.posix() | :too_many_symlinks
 
+  @typedoc "Why a workspace-relative file path could not be authorized."
+  @type file_error ::
+          error()
+          | canonical_error()
+          | :absolute_path
+          | :parent_traversal
+          | :outside_workspace
+
   @doc "Builds a file-scoped root that cannot authorize recursive inventory."
   @spec file(String.t()) :: t()
   def file(path) when is_binary(path) do
@@ -82,6 +90,18 @@ defmodule Minga.Project.Root do
 
   def inventory_path(%__MODULE__{}), do: {:error, :not_a_directory_root}
 
+  @doc "Resolves an existing workspace-relative path inside an authorized directory root."
+  @spec resolve_file(t(), String.t()) :: {:ok, String.t()} | {:error, file_error()}
+  def resolve_file(%__MODULE__{} = root, relative_path) when is_binary(relative_path) do
+    with {:ok, canonical_root} <- inventory_path(root),
+         :ok <- require_relative_path(relative_path),
+         {:ok, safe_relative} <- safe_relative_path(relative_path, canonical_root),
+         {:ok, canonical_target} <- canonical_path(Path.join(canonical_root, safe_relative)),
+         :ok <- authorize_contained_target(canonical_target, canonical_root) do
+      {:ok, canonical_target}
+    end
+  end
+
   @doc "Returns the canonical target of an existing filesystem path."
   @spec canonical_path(String.t()) :: {:ok, String.t()} | {:error, canonical_error()}
   def canonical_path(path) when is_binary(path) do
@@ -119,6 +139,37 @@ defmodule Minga.Project.Root do
           {:ok, String.t()} | {:error, :enotdir}
   defp existing_directory(path, true), do: {:ok, path}
   defp existing_directory(_path, false), do: {:error, :enotdir}
+
+  @spec require_relative_path(String.t()) :: :ok | {:error, :absolute_path}
+  defp require_relative_path(path) do
+    case Path.type(path) do
+      :relative -> :ok
+      _absolute_or_volume_relative -> {:error, :absolute_path}
+    end
+  end
+
+  @spec safe_relative_path(String.t(), String.t()) ::
+          {:ok, String.t()} | {:error, :parent_traversal}
+  defp safe_relative_path(path, canonical_root) do
+    lexical_target = Path.expand(path, canonical_root)
+    relative_target = Path.relative_to(lexical_target, canonical_root)
+
+    case Path.type(relative_target) do
+      :relative -> {:ok, relative_target}
+      _outside -> {:error, :parent_traversal}
+    end
+  end
+
+  @spec authorize_contained_target(String.t(), String.t()) ::
+          :ok | {:error, :outside_workspace}
+  defp authorize_contained_target(canonical_target, canonical_root) do
+    relative_target = Path.relative_to(canonical_target, canonical_root)
+
+    case Path.safe_relative(relative_target, canonical_root) do
+      {:ok, _relative} -> :ok
+      :error -> {:error, :outside_workspace}
+    end
+  end
 
   @spec confirmation(term()) :: {:ok, boolean()} | {:error, :invalid_broad_root_confirmation}
   defp confirmation(true), do: {:ok, true}

--- a/lib/minga_agent/file_mention.ex
+++ b/lib/minga_agent/file_mention.ex
@@ -142,10 +142,10 @@ defmodule MingaAgent.FileMention do
   - `{:ok, [ContentPart.t()]}` when images are present (mixed text + image parts)
   - `{:error, message}` if any file doesn't exist or can't be read
   """
-  @spec resolve_prompt(String.t(), String.t() | nil) ::
+  @spec resolve_prompt(String.t(), Root.t() | nil) ::
           {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
-  def resolve_prompt(text, project_root) do
-    resolve_prompt(text, project_root, [])
+  def resolve_prompt(text, workspace_root) do
+    resolve_prompt(text, workspace_root, [])
   end
 
   @doc """
@@ -154,7 +154,7 @@ defmodule MingaAgent.FileMention do
   Options:
     - `:model` — the model string for vision capability checking
   """
-  @spec resolve_prompt(String.t(), String.t() | nil, keyword()) ::
+  @spec resolve_prompt(String.t(), Root.t() | nil, keyword()) ::
           {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
   def resolve_prompt(text, nil, _opts) do
     case extract_mentions(text) do
@@ -163,19 +163,19 @@ defmodule MingaAgent.FileMention do
     end
   end
 
-  def resolve_prompt(text, project_root, opts) when is_binary(project_root) do
+  def resolve_prompt(text, %Root{} = workspace_root, opts) do
     mentions = extract_mentions(text)
 
     if mentions == [] do
       {:ok, text}
     else
-      maybe_check_vision(mentions, text, project_root, opts)
+      maybe_check_vision(mentions, text, workspace_root, opts)
     end
   end
 
-  @spec maybe_check_vision([mention()], String.t(), String.t(), keyword()) ::
+  @spec maybe_check_vision([mention()], String.t(), Root.t(), keyword()) ::
           {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
-  defp maybe_check_vision(mentions, text, project_root, opts) do
+  defp maybe_check_vision(mentions, text, workspace_root, opts) do
     has_images = Enum.any?(mentions, fn %{path: path} -> image_path?(path) end)
     model = Keyword.get(opts, :model)
 
@@ -185,7 +185,7 @@ defmodule MingaAgent.FileMention do
       {:error,
        "Model #{model} does not support image input. Use a vision-capable model (Claude, GPT-4o, Gemini)."}
     else
-      resolve_all(mentions, text, project_root)
+      resolve_all(mentions, text, workspace_root)
     end
   end
 
@@ -196,7 +196,7 @@ defmodule MingaAgent.FileMention do
     ext in @image_extensions
   end
 
-  @spec resolve_all([mention()], String.t(), String.t()) ::
+  @spec resolve_all([mention()], String.t(), Root.t()) ::
           {:ok, String.t()} | {:ok, [ContentPart.t()]} | {:error, String.t()}
   defp resolve_all(mentions, text, root) do
     results = Enum.map(mentions, &resolve_mention(&1, root))
@@ -220,15 +220,15 @@ defmodule MingaAgent.FileMention do
     end
   end
 
-  @spec resolve_mention(mention(), String.t()) ::
+  @spec resolve_mention(mention(), Root.t()) ::
           {String.t(),
            {:ok, String.t()}
            | {:ok, {:image, binary(), String.t(), non_neg_integer()}}
            | {:error, String.t()}}
   defp resolve_mention(%{path: path}, root) do
-    case contained_path(path, root) do
+    case Root.resolve_file(root, path) do
       {:ok, abs_path} -> {path, read_mention(path, abs_path)}
-      {:error, reason} -> {path, {:error, reason}}
+      {:error, reason} -> {path, {:error, resolution_error(reason)}}
     end
   end
 
@@ -240,34 +240,31 @@ defmodule MingaAgent.FileMention do
     if image_path?(path), do: read_image_safe(abs_path), else: read_file_safe(abs_path)
   end
 
-  @spec contained_path(String.t(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  defp contained_path(path, root) do
-    contained_path(Path.type(path), path, root)
-  end
+  @spec resolution_error(Root.file_error()) :: String.t()
+  defp resolution_error(:absolute_path),
+    do: "absolute paths are outside the active workspace"
 
-  @spec contained_path(:absolute | :relative | :volumerelative, String.t(), String.t()) ::
-          {:ok, String.t()} | {:error, String.t()}
-  defp contained_path(:absolute, _path, _root),
-    do: {:error, "absolute paths are outside the active workspace"}
+  defp resolution_error(:parent_traversal),
+    do: "path is outside the active workspace (parent traversal is not allowed)"
 
-  defp contained_path(_path_type, path, root) do
-    with {:ok, canonical_root} <- Root.canonical_path(root),
-         {:ok, canonical_target} <- Root.canonical_path(Path.expand(path, canonical_root)),
-         true <- path_within_root?(canonical_target, canonical_root) do
-      {:ok, canonical_target}
-    else
-      false -> {:error, "path is outside the active workspace"}
-      {:error, :enoent} -> {:error, "file not found"}
-      {:error, reason} -> {:error, "cannot resolve path (#{reason})"}
-    end
-  end
+  defp resolution_error(:outside_workspace),
+    do: "path is outside the active workspace"
 
-  @spec path_within_root?(String.t(), String.t()) :: boolean()
-  defp path_within_root?(_path, "/"), do: true
+  defp resolution_error(:enoent), do: "file not found"
 
-  defp path_within_root?(path, root) do
-    path == root or String.starts_with?(path, root <> "/")
-  end
+  defp resolution_error(:not_a_directory_root),
+    do: "active workspace root is not an authorized directory"
+
+  defp resolution_error(:broad_root_confirmation_required),
+    do: "active workspace root requires broad-root confirmation"
+
+  defp resolution_error(:invalid_broad_root_confirmation),
+    do: "active workspace root has invalid broad-root confirmation"
+
+  defp resolution_error(:root_changed),
+    do: "active workspace root changed after authorization"
+
+  defp resolution_error(reason), do: "cannot resolve path (#{reason})"
 
   @spec build_text_prompt([{String.t(), {:ok, String.t()}}], String.t()) :: {:ok, String.t()}
   defp build_text_prompt(results, body) do

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -816,8 +816,7 @@ defmodule MingaEditor.Commands.Agent do
   @spec resolve_mentions(String.t(), keyword()) ::
           {:ok, String.t()} | {:ok, [ReqLLM.Message.ContentPart.t()]} | {:error, String.t()}
   defp resolve_mentions(text, opts) do
-    root = project_root()
-    FileMention.resolve_prompt(text, root, opts)
+    FileMention.resolve_prompt(text, Minga.Project.workspace_root(), opts)
   end
 
   @spec project_root() :: String.t() | nil

--- a/test/minga/project/file_find_test.exs
+++ b/test/minga/project/file_find_test.exs
@@ -1,5 +1,6 @@
 defmodule Minga.Project.FileFindTest do
-  use ExUnit.Case, async: true
+  # This suite spawns git and file-discovery OS processes, which cannot run concurrently safely.
+  use ExUnit.Case, async: false
 
   alias Minga.Project.FileFind
   alias Minga.Project.Root
@@ -179,6 +180,104 @@ defmodule Minga.Project.FileFindTest do
       refute ".DS_Store" in files
       refute "lib/.DS_Store" in files
       assert "README.md" in files
+    end
+  end
+
+  describe "Root.resolve_file/2" do
+    setup do
+      tmp_dir = make_tmp_dir("minga_root_resolve_file")
+      File.write!(Path.join(tmp_dir, "inside.txt"), "inside")
+      on_exit(fn -> File.rm_rf!(tmp_dir) end)
+
+      %{tmp_dir: tmp_dir, root: directory_root!(tmp_dir)}
+    end
+
+    test "returns the canonical target for an authorized workspace-relative file", %{
+      tmp_dir: tmp_dir,
+      root: root
+    } do
+      assert Root.resolve_file(root, "inside.txt") ==
+               {:ok, Path.join(tmp_dir, "inside.txt")}
+    end
+
+    test "returns the canonical target of an in-workspace symlink", %{
+      tmp_dir: tmp_dir,
+      root: root
+    } do
+      File.ln_s!("inside.txt", Path.join(tmp_dir, "inside-link.txt"))
+
+      assert Root.resolve_file(root, "inside-link.txt") ==
+               {:ok, Path.join(tmp_dir, "inside.txt")}
+    end
+
+    test "returns the filesystem error when the target is missing", %{root: root} do
+      assert Root.resolve_file(root, "missing.txt") == {:error, :enoent}
+    end
+
+    test "accepts an existing file beneath a literally confirmed broad root", %{tmp_dir: tmp_dir} do
+      {:ok, root} = Root.directory("/", broad_root_confirmed: true)
+      relative_path = Path.relative_to(tmp_dir, "/") |> Path.join("inside.txt")
+      {:ok, canonical_target} = Root.canonical_path(Path.join(tmp_dir, "inside.txt"))
+
+      assert Root.resolve_file(root, relative_path) == {:ok, canonical_target}
+    end
+
+    test "rejects absolute paths and parent traversal before joining", %{
+      tmp_dir: tmp_dir,
+      root: root
+    } do
+      assert Root.resolve_file(root, Path.join(tmp_dir, "inside.txt")) ==
+               {:error, :absolute_path}
+
+      assert Root.resolve_file(root, "../outside.txt") == {:error, :parent_traversal}
+    end
+
+    test "rejects a symlink whose canonical target escapes the workspace", %{
+      tmp_dir: tmp_dir,
+      root: root
+    } do
+      outside = Path.join(Path.dirname(tmp_dir), "outside-#{System.unique_integer([:positive])}")
+      File.write!(outside, "outside")
+      File.ln_s!(outside, Path.join(tmp_dir, "escape.txt"))
+      on_exit(fn -> File.rm(outside) end)
+
+      assert Root.resolve_file(root, "escape.txt") == {:error, :outside_workspace}
+    end
+
+    test "reuses inventory authorization for broad and non-directory roots", %{tmp_dir: tmp_dir} do
+      {:ok, confirmed_home} = Root.directory(Path.expand("~"), broad_root_confirmed: true)
+
+      unauthorized_home = %Root{
+        kind: :directory,
+        path: confirmed_home.path,
+        broad_root_confirmed?: false
+      }
+
+      assert Root.resolve_file(unauthorized_home, "anything") ==
+               {:error, :broad_root_confirmation_required}
+
+      assert Root.resolve_file(Root.file(Path.join(tmp_dir, "inside.txt")), "inside.txt") ==
+               {:error, :not_a_directory_root}
+    end
+
+    test "rejects a root whose canonical target changed after authorization", %{
+      tmp_dir: tmp_dir,
+      root: root
+    } do
+      original_workspace = Path.join(Path.dirname(tmp_dir), "original-#{Path.basename(tmp_dir)}")
+      replacement = Path.join(Path.dirname(tmp_dir), "replacement-#{Path.basename(tmp_dir)}")
+
+      File.rename!(tmp_dir, original_workspace)
+      File.mkdir_p!(replacement)
+      File.ln_s!(replacement, tmp_dir)
+
+      on_exit(fn ->
+        File.rm(tmp_dir)
+        File.rm_rf!(original_workspace)
+        File.rm_rf!(replacement)
+      end)
+
+      assert Root.resolve_file(root, "inside.txt") == {:error, :root_changed}
     end
   end
 

--- a/test/minga_agent/file_mention_test.exs
+++ b/test/minga_agent/file_mention_test.exs
@@ -1,9 +1,15 @@
 defmodule MingaAgent.FileMentionTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Project.Root
   alias MingaAgent.FileMention
 
   @moduletag :tmp_dir
+
+  setup %{tmp_dir: dir} do
+    {:ok, root} = Root.directory(dir)
+    %{root: root}
+  end
 
   describe "resolve_prompt/3 without a workspace" do
     test "keeps prompts without file mentions unchanged" do
@@ -84,25 +90,25 @@ defmodule MingaAgent.FileMentionTest do
   # ── Resolution ──────────────────────────────────────────────────────────────
 
   describe "resolve_prompt/2" do
-    test "returns text unchanged when no mentions", %{tmp_dir: dir} do
-      assert {:ok, "hello world"} = FileMention.resolve_prompt("hello world", dir)
+    test "returns text unchanged when no mentions", %{root: root} do
+      assert {:ok, "hello world"} = FileMention.resolve_prompt("hello world", root)
     end
 
-    test "prepends file content for a valid mention", %{tmp_dir: dir} do
+    test "prepends file content for a valid mention", %{tmp_dir: dir, root: root} do
       path = Path.join(dir, "test.ex")
       File.write!(path, "defmodule Test do\nend")
 
-      {:ok, result} = FileMention.resolve_prompt("@test.ex explain this", dir)
+      {:ok, result} = FileMention.resolve_prompt("@test.ex explain this", root)
       assert result =~ "Contents of test.ex:"
       assert result =~ "defmodule Test do"
       assert result =~ "explain this"
     end
 
-    test "handles multiple mentions", %{tmp_dir: dir} do
+    test "handles multiple mentions", %{tmp_dir: dir, root: root} do
       File.write!(Path.join(dir, "a.ex"), "module_a")
       File.write!(Path.join(dir, "b.ex"), "module_b")
 
-      {:ok, result} = FileMention.resolve_prompt("@a.ex @b.ex compare these", dir)
+      {:ok, result} = FileMention.resolve_prompt("@a.ex @b.ex compare these", root)
       assert result =~ "Contents of a.ex:"
       assert result =~ "Contents of b.ex:"
       assert result =~ "module_a"
@@ -110,64 +116,67 @@ defmodule MingaAgent.FileMentionTest do
       assert result =~ "compare these"
     end
 
-    test "returns error for missing file", %{tmp_dir: dir} do
-      assert {:error, msg} = FileMention.resolve_prompt("@nonexistent.ex read this", dir)
+    test "returns error for missing file", %{root: root} do
+      assert {:error, msg} = FileMention.resolve_prompt("@nonexistent.ex read this", root)
       assert msg =~ "nonexistent.ex"
       assert msg =~ "file not found"
     end
 
-    test "rejects absolute paths even when the file exists", %{tmp_dir: dir} do
+    test "rejects absolute paths even when the file exists", %{tmp_dir: dir, root: root} do
       path = Path.join(dir, "absolute.ex")
       File.write!(path, "secret")
 
-      assert {:error, msg} = FileMention.resolve_prompt("@#{path} read this", dir)
+      assert {:error, msg} = FileMention.resolve_prompt("@#{path} read this", root)
       assert msg =~ "absolute paths are outside the active workspace"
     end
 
-    test "rejects traversal outside the workspace", %{tmp_dir: dir} do
+    test "rejects traversal outside the workspace", %{tmp_dir: dir, root: root} do
       outside = Path.join(Path.dirname(dir), "outside-#{System.unique_integer([:positive])}.txt")
       File.write!(outside, "secret")
       on_exit(fn -> File.rm(outside) end)
 
       assert {:error, msg} =
-               FileMention.resolve_prompt("@../#{Path.basename(outside)} read this", dir)
+               FileMention.resolve_prompt("@../#{Path.basename(outside)} read this", root)
 
       assert msg =~ "path is outside the active workspace"
     end
 
-    test "rejects symlinks whose canonical target escapes the workspace", %{tmp_dir: dir} do
+    test "rejects symlinks whose canonical target escapes the workspace", %{
+      tmp_dir: dir,
+      root: root
+    } do
       outside = Path.join(Path.dirname(dir), "secret-#{System.unique_integer([:positive])}.txt")
       link = Path.join(dir, "linked-secret.txt")
       File.write!(outside, "secret")
       File.ln_s!(outside, link)
       on_exit(fn -> File.rm(outside) end)
 
-      assert {:error, msg} = FileMention.resolve_prompt("@linked-secret.txt read this", dir)
+      assert {:error, msg} = FileMention.resolve_prompt("@linked-secret.txt read this", root)
       assert msg =~ "path is outside the active workspace"
     end
 
-    test "returns error for binary file", %{tmp_dir: dir} do
+    test "returns error for binary file", %{tmp_dir: dir, root: root} do
       path = Path.join(dir, "binary.bin")
       File.write!(path, <<0, 1, 2, 255, 254, 253>>)
 
-      assert {:error, msg} = FileMention.resolve_prompt("@binary.bin read this", dir)
+      assert {:error, msg} = FileMention.resolve_prompt("@binary.bin read this", root)
       assert msg =~ "binary file"
     end
 
-    test "removes @mention from body text", %{tmp_dir: dir} do
+    test "removes @mention from body text", %{tmp_dir: dir, root: root} do
       File.write!(Path.join(dir, "x.ex"), "content")
 
-      {:ok, result} = FileMention.resolve_prompt("@x.ex explain", dir)
+      {:ok, result} = FileMention.resolve_prompt("@x.ex explain", root)
       # The body should just say "explain", not "@x.ex explain"
       lines = String.split(result, "\n")
       last_line = Enum.at(lines, -1)
       assert last_line == "explain"
     end
 
-    test "uses file extension for code fence language", %{tmp_dir: dir} do
+    test "uses file extension for code fence language", %{tmp_dir: dir, root: root} do
       File.write!(Path.join(dir, "app.py"), "print('hello')")
 
-      {:ok, result} = FileMention.resolve_prompt("@app.py what does this do?", dir)
+      {:ok, result} = FileMention.resolve_prompt("@app.py what does this do?", root)
       assert result =~ "```py"
     end
   end
@@ -196,13 +205,13 @@ defmodule MingaAgent.FileMentionTest do
   end
 
   describe "resolve_prompt/2 with images" do
-    test "returns ContentPart list when image is mentioned", %{tmp_dir: dir} do
+    test "returns ContentPart list when image is mentioned", %{tmp_dir: dir, root: root} do
       # Create a minimal 1x1 red PNG (67 bytes)
       png_data = create_minimal_png()
       path = Path.join(dir, "screenshot.png")
       File.write!(path, png_data)
 
-      {:ok, parts} = FileMention.resolve_prompt("@screenshot.png what is this?", dir)
+      {:ok, parts} = FileMention.resolve_prompt("@screenshot.png what is this?", root)
 
       assert is_list(parts)
       assert Enum.count(parts) == 2
@@ -216,11 +225,11 @@ defmodule MingaAgent.FileMentionTest do
       assert is_binary(image_part.data)
     end
 
-    test "mixes text files and images as content parts", %{tmp_dir: dir} do
+    test "mixes text files and images as content parts", %{tmp_dir: dir, root: root} do
       File.write!(Path.join(dir, "code.ex"), "defmodule Foo do\nend")
       File.write!(Path.join(dir, "design.png"), create_minimal_png())
 
-      {:ok, parts} = FileMention.resolve_prompt("@code.ex @design.png compare", dir)
+      {:ok, parts} = FileMention.resolve_prompt("@code.ex @design.png compare", root)
 
       assert is_list(parts)
       text_parts = Enum.filter(parts, &(&1.type == :text))
@@ -233,24 +242,24 @@ defmodule MingaAgent.FileMentionTest do
       assert hd(text_parts).text =~ "compare"
     end
 
-    test "rejects oversized images", %{tmp_dir: dir} do
+    test "rejects oversized images", %{tmp_dir: dir, root: root} do
       # Create a file that exceeds the 5MB limit
       path = Path.join(dir, "huge.png")
       File.write!(path, :binary.copy(<<0>>, 6 * 1024 * 1024))
 
-      assert {:error, msg} = FileMention.resolve_prompt("@huge.png look", dir)
+      assert {:error, msg} = FileMention.resolve_prompt("@huge.png look", root)
       assert msg =~ "image too large"
     end
 
-    test "returns error for missing image file", %{tmp_dir: dir} do
-      assert {:error, msg} = FileMention.resolve_prompt("@missing.png look", dir)
+    test "returns error for missing image file", %{root: root} do
+      assert {:error, msg} = FileMention.resolve_prompt("@missing.png look", root)
       assert msg =~ "file not found"
     end
 
-    test "text-only mentions still return a string", %{tmp_dir: dir} do
+    test "text-only mentions still return a string", %{tmp_dir: dir, root: root} do
       File.write!(Path.join(dir, "test.ex"), "code")
 
-      {:ok, result} = FileMention.resolve_prompt("@test.ex explain", dir)
+      {:ok, result} = FileMention.resolve_prompt("@test.ex explain", root)
       assert is_binary(result)
     end
   end


### PR DESCRIPTION
# TL;DR
Workspace-relative file mentions now use the same typed authorization boundary as project inventory, so absolute paths, traversal, stale roots, and escaping symlinks are rejected without feature-specific containment logic.

Closes #2940

## Context
This is the first delivery slice of #2939. File mentions previously accepted a root string and reconstructed workspace authorization locally, which duplicated privacy-sensitive canonicalization and containment rules already owned by `Minga.Project.Root`.

## Changes
- Add `Minga.Project.Root.resolve_file/2` as the single operation for resolving an existing workspace-relative file under an authorized directory root.
- Reuse `inventory_path/1` so literal broad-root confirmation and canonical root-change detection apply before file resolution.
- Canonicalize targets and reject absolute paths, parent traversal, missing files, and symlink escapes with tagged errors.
- Pass `Minga.Project.workspace_root/0` into file mention resolution and remove the local string-root containment implementation.
- Preserve existing text-file prompt expansion and image attachment behavior.
- Serialize the existing file discovery test module because it spawns OS processes.

## Verification
- `mix test.debug test/minga/project/file_find_test.exs test/minga_agent/file_mention_test.exs` (65 tests, 0 failures)
- `make lint` (Credo clean, compilation clean, Dialyzer 0 errors)
- `mix test.llm` (9,512 tests, 97 properties, 58 doctests, 0 failures)
- Final reviewer and targeted blocker re-review: PASS

## Acceptance Criteria Addressed
- Workspace-relative resolution requires an authorized directory root and a canonically contained target ✅
- Absolute paths, traversal, and escaping symlinks return explicit errors ✅
- Broad-root confirmation and root-change detection match project inventory ✅
- Missing workspaces reject file mentions without cwd fallback ✅
- Valid text and image mentions preserve their existing output ✅
- File authorization has one implementation in `Minga.Project.Root` ✅
