### PR TITLE
refactor(project): make workspace snapshots atomic

### DIFF
--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -8,13 +8,11 @@ defmodule Minga.Project do
 
   ## State
 
-  * `current_root` — the path of the active explicit directory workspace
-  * `workspace_root` — the typed root that authorizes recursive project behavior
-  * `cached_files` — the file list for the current project (populated by a background Task)
+  * `workspace` — one atomic typed root, relative file inventory, and rebuild status
   * `known_projects` — list of all project roots the user has visited, persisted to disk
   * `recent_files` — per-project list of recently opened files, most recent first, persisted to disk
   * `command_frecency` — command execution timestamps used to rank the empty command palette
-  * `rebuilding?` — true while a background Task is rebuilding the file cache
+  * rebuild PID, monitor, and timer fields — operational discovery lifecycle state
 
   ## File cache
 
@@ -30,15 +28,13 @@ defmodule Minga.Project do
   alias Minga.Command
   alias Minga.Config
   alias Minga.Project.Root
+  alias Minga.Project.WorkspaceSnapshot
 
-  defstruct current_root: nil,
-            workspace_root: nil,
-            cached_files: [],
+  defstruct workspace: nil,
             known_projects: [],
             recent_files: %{},
             frecency_events: %{},
             command_frecency: %{},
-            rebuilding?: false,
             rebuild_pid: nil,
             rebuild_ref: nil,
             rebuild_timer_ref: nil,
@@ -60,14 +56,11 @@ defmodule Minga.Project do
 
   @typedoc "Project GenServer state."
   @type t :: %__MODULE__{
-          current_root: String.t() | nil,
-          workspace_root: Root.t() | nil,
-          cached_files: [String.t()],
+          workspace: WorkspaceSnapshot.t() | nil,
           known_projects: [String.t()],
           recent_files: recent_files_map(),
           frecency_events: frecency_events_map(),
           command_frecency: command_frecency_map(),
-          rebuilding?: boolean(),
           rebuild_pid: pid() | nil,
           rebuild_ref: reference() | nil,
           rebuild_timer_ref: reference() | nil,
@@ -112,6 +105,12 @@ defmodule Minga.Project do
     GenServer.call(server, :workspace_root)
   end
 
+  @doc "Atomically returns the active typed workspace and its cached inventory state."
+  @spec snapshot(GenServer.server()) :: WorkspaceSnapshot.t() | nil
+  def snapshot(server \\ __MODULE__) do
+    GenServer.call(server, :snapshot)
+  end
+
   @doc """
   Replaces the home directory prefix with `~` for display.
 
@@ -139,6 +138,24 @@ defmodule Minga.Project do
   def known_projects(server \\ __MODULE__) do
     GenServer.call(server, :known_projects)
   end
+
+  @doc """
+  Synchronously installs an authorized directory workspace and starts discovery.
+
+  The returned snapshot is installed before this call returns. File discovery
+  continues asynchronously and later replaces the inventory in one atomic
+  snapshot transition.
+  """
+  @spec activate(Root.t()) :: {:ok, WorkspaceSnapshot.t()} | {:error, Root.error()}
+  def activate(%Root{} = root), do: activate(__MODULE__, root)
+
+  @spec activate(GenServer.server(), Root.t()) ::
+          {:ok, WorkspaceSnapshot.t()} | {:error, Root.error()}
+  def activate(server, %Root{kind: :directory} = root) do
+    GenServer.call(server, {:activate, root})
+  end
+
+  def activate(_server, %Root{}), do: {:error, :not_a_directory_root}
 
   @doc "Switches to an explicit directory workspace, triggering one cache rebuild."
   @spec switch(String.t() | Root.t()) :: :ok
@@ -294,37 +311,46 @@ defmodule Minga.Project do
 
   @impl true
   @spec handle_call(term(), GenServer.from(), t()) :: {:reply, term(), t()}
+  def handle_call({:activate, %Root{kind: :directory} = root}, _from, state) do
+    {reply, state} = activate_workspace(state, root)
+    {:reply, reply, state}
+  end
+
   def handle_call(:root, _from, state) do
-    {:reply, state.current_root, state}
+    {:reply, workspace_path(state.workspace), state}
   end
 
   def handle_call(:workspace_root, _from, state) do
-    {:reply, state.workspace_root, state}
+    {:reply, snapshot_root(state.workspace), state}
+  end
+
+  def handle_call(:snapshot, _from, state) do
+    {:reply, state.workspace, state}
   end
 
   def handle_call(:files, _from, state) do
-    {:reply, state.cached_files, state}
+    {:reply, workspace_files(state.workspace), state}
   end
 
   def handle_call(:known_projects, _from, state) do
     {:reply, state.known_projects, state}
   end
 
-  def handle_call(:recent_files, _from, %{current_root: nil} = state) do
+  def handle_call(:recent_files, _from, %{workspace: nil} = state) do
     {:reply, [], state}
   end
 
   def handle_call(:recent_files, _from, state) do
-    files = Map.get(state.recent_files, state.current_root, [])
+    files = Map.get(state.recent_files, workspace_path(state.workspace), [])
     {:reply, files, state}
   end
 
-  def handle_call(:frecency_scores, _from, %{current_root: nil} = state) do
+  def handle_call(:frecency_scores, _from, %{workspace: nil} = state) do
     {:reply, %{}, state}
   end
 
   def handle_call(:frecency_scores, _from, state) do
-    root = state.current_root
+    root = workspace_path(state.workspace)
     now_unix = System.system_time(:second)
 
     scores =
@@ -338,7 +364,7 @@ defmodule Minga.Project do
   end
 
   def handle_call(:rebuilding?, _from, state) do
-    {:reply, state.rebuilding?, state}
+    {:reply, workspace_rebuilding?(state.workspace), state}
   end
 
   def handle_call(:command_frecency, _from, state) do
@@ -359,14 +385,7 @@ defmodule Minga.Project do
   @impl true
   @spec handle_cast(term(), t()) :: {:noreply, t()}
   def handle_cast({:switch, %Root{kind: :directory} = root}, state) do
-    state =
-      state
-      |> cancel_rebuild()
-      |> set_project(root)
-      |> add_to_known(root.path)
-      |> start_rebuild()
-
-    {:noreply, state}
+    {:noreply, install_workspace(state, root)}
   end
 
   def handle_cast({:switch_rejected, root_path, reason}, state) do
@@ -380,12 +399,14 @@ defmodule Minga.Project do
 
   def handle_cast(:close, state) do
     state = cancel_rebuild(state)
-    {:noreply, %{state | current_root: nil, workspace_root: nil, cached_files: []}}
+    {:noreply, %{state | workspace: nil}}
   end
+
+  def handle_cast(:invalidate, %{workspace: nil} = state), do: {:noreply, state}
 
   def handle_cast(:invalidate, state) do
     state = cancel_rebuild(state)
-    state = %{state | cached_files: []}
+    state = %{state | workspace: WorkspaceSnapshot.invalidate(state.workspace)}
     {:noreply, start_rebuild(state)}
   end
 
@@ -401,7 +422,7 @@ defmodule Minga.Project do
     end
   end
 
-  def handle_cast({:record_file, _file_path}, %{current_root: nil} = state) do
+  def handle_cast({:record_file, _file_path}, %{workspace: nil} = state) do
     {:noreply, state}
   end
 
@@ -425,7 +446,8 @@ defmodule Minga.Project do
   def handle_info({:file_find_done, pid, result}, %{rebuild_pid: pid} = state) do
     state = clear_rebuild(state)
     files = discovery_files(result)
-    root = state.current_root
+    root = workspace_path(state.workspace)
+    workspace = WorkspaceSnapshot.complete_rebuild(state.workspace, files)
 
     Minga.Events.broadcast(
       :project_rebuilt,
@@ -433,7 +455,7 @@ defmodule Minga.Project do
       state.events_registry
     )
 
-    {:noreply, %{state | cached_files: files}}
+    {:noreply, %{state | workspace: workspace}}
   end
 
   def handle_info(
@@ -470,12 +492,34 @@ defmodule Minga.Project do
 
   # ── Private ─────────────────────────────────────────────────────────────────
 
+  @spec workspace_path(WorkspaceSnapshot.t() | nil) :: String.t() | nil
+  defp workspace_path(nil), do: nil
+  defp workspace_path(%WorkspaceSnapshot{root: %Root{path: path}}), do: path
+
+  @spec snapshot_root(WorkspaceSnapshot.t() | nil) :: Root.t() | nil
+  defp snapshot_root(nil), do: nil
+  defp snapshot_root(%WorkspaceSnapshot{root: root}), do: root
+
+  @spec workspace_files(WorkspaceSnapshot.t() | nil) :: [String.t()]
+  defp workspace_files(nil), do: []
+  defp workspace_files(%WorkspaceSnapshot{files: files}), do: files
+
+  @spec workspace_rebuilding?(WorkspaceSnapshot.t() | nil) :: boolean()
+  defp workspace_rebuilding?(nil), do: false
+  defp workspace_rebuilding?(%WorkspaceSnapshot{rebuilding?: rebuilding?}), do: rebuilding?
+
+  @spec stop_workspace_rebuild(WorkspaceSnapshot.t() | nil) :: WorkspaceSnapshot.t() | nil
+  defp stop_workspace_rebuild(nil), do: nil
+
+  defp stop_workspace_rebuild(%WorkspaceSnapshot{} = workspace),
+    do: WorkspaceSnapshot.stop_rebuild(workspace)
+
   @spec do_record_file(t(), String.t()) :: t()
-  defp do_record_file(%{current_root: nil} = state, _file_path), do: state
+  defp do_record_file(%{workspace: nil} = state, _file_path), do: state
 
   defp do_record_file(state, file_path) do
     expanded = Path.expand(file_path)
-    root = state.current_root
+    root = workspace_path(state.workspace)
 
     case make_relative(expanded, root) do
       nil ->
@@ -523,9 +567,26 @@ defmodule Minga.Project do
     state
   end
 
-  @spec set_project(t(), Root.t()) :: t()
-  defp set_project(state, %Root{kind: :directory} = root) do
-    %{state | current_root: root.path, workspace_root: root, cached_files: []}
+  @spec activate_workspace(t(), Root.t()) ::
+          {{:ok, WorkspaceSnapshot.t()} | {:error, Root.error()}, t()}
+  defp activate_workspace(state, %Root{kind: :directory} = root) do
+    case Root.inventory_path(root) do
+      {:ok, _path} ->
+        state = install_workspace(state, root)
+        {{:ok, state.workspace}, state}
+
+      {:error, reason} ->
+        {{:error, reason}, state}
+    end
+  end
+
+  @spec install_workspace(t(), Root.t()) :: t()
+  defp install_workspace(state, %Root{kind: :directory} = root) do
+    state
+    |> cancel_rebuild()
+    |> then(&%{&1 | workspace: WorkspaceSnapshot.activate(root)})
+    |> add_to_known(root.path)
+    |> start_rebuild()
   end
 
   @spec add_to_known(t(), String.t()) :: t()
@@ -540,17 +601,17 @@ defmodule Minga.Project do
   end
 
   @spec start_rebuild(t()) :: t()
-  defp start_rebuild(%{workspace_root: nil} = state), do: state
+  defp start_rebuild(%{workspace: nil} = state), do: state
 
   defp start_rebuild(state) do
-    case state.file_find_module.start(state.workspace_root, self()) do
+    case state.file_find_module.start(state.workspace.root, self()) do
       {:ok, pid} ->
         ref = Process.monitor(pid)
         timer_ref = Process.send_after(self(), {:rebuild_timeout, pid}, state.rebuild_timeout_ms)
 
         %{
           state
-          | rebuilding?: true,
+          | workspace: WorkspaceSnapshot.begin_rebuild(state.workspace),
             rebuild_pid: pid,
             rebuild_ref: ref,
             rebuild_timer_ref: timer_ref
@@ -591,7 +652,14 @@ defmodule Minga.Project do
   defp clear_rebuild(state) do
     if is_reference(state.rebuild_ref), do: Process.demonitor(state.rebuild_ref, [:flush])
     if is_reference(state.rebuild_timer_ref), do: Process.cancel_timer(state.rebuild_timer_ref)
-    %{state | rebuilding?: false, rebuild_pid: nil, rebuild_ref: nil, rebuild_timer_ref: nil}
+
+    %{
+      state
+      | workspace: stop_workspace_rebuild(state.workspace),
+        rebuild_pid: nil,
+        rebuild_ref: nil,
+        rebuild_timer_ref: nil
+    }
   end
 
   @spec discovery_files(Minga.Project.FileFind.result()) :: [String.t()]

--- a/lib/minga/project/workspace_snapshot.ex
+++ b/lib/minga/project/workspace_snapshot.ex
@@ -1,0 +1,51 @@
+defmodule Minga.Project.WorkspaceSnapshot do
+  @moduledoc """
+  Atomic cached state for one active directory workspace.
+
+  The root authorizes recursive project behavior, files are always relative to
+  that root, and `rebuilding?` describes discovery for that same root.
+  Operational worker, monitor, and timer state remains owned by `Minga.Project`.
+  """
+
+  alias Minga.Project.Root
+
+  @enforce_keys [:root, :files, :rebuilding?]
+  defstruct [:root, :files, :rebuilding?]
+
+  @typedoc "A coherent directory workspace and its cached inventory state."
+  @type t :: %__MODULE__{
+          root: Root.t(),
+          files: [String.t()],
+          rebuilding?: boolean()
+        }
+
+  @doc "Installs a directory root with an empty, idle inventory."
+  @spec activate(Root.t()) :: t()
+  def activate(%Root{kind: :directory} = root) do
+    %__MODULE__{root: root, files: [], rebuilding?: false}
+  end
+
+  @doc "Clears cached inventory before discovery starts."
+  @spec invalidate(t()) :: t()
+  def invalidate(%__MODULE__{} = snapshot) do
+    %{snapshot | files: [], rebuilding?: false}
+  end
+
+  @doc "Marks discovery as running for this workspace."
+  @spec begin_rebuild(t()) :: t()
+  def begin_rebuild(%__MODULE__{} = snapshot) do
+    %{snapshot | rebuilding?: true}
+  end
+
+  @doc "Installs one completed workspace-relative inventory atomically."
+  @spec complete_rebuild(t(), [String.t()]) :: t()
+  def complete_rebuild(%__MODULE__{} = snapshot, files) when is_list(files) do
+    %{snapshot | files: files, rebuilding?: false}
+  end
+
+  @doc "Marks discovery as stopped while retaining the current cached inventory."
+  @spec stop_rebuild(t()) :: t()
+  def stop_rebuild(%__MODULE__{} = snapshot) do
+    %{snapshot | rebuilding?: false}
+  end
+end

--- a/lib/minga_editor/file_tree/project_cache.ex
+++ b/lib/minga_editor/file_tree/project_cache.ex
@@ -3,62 +3,44 @@ defmodule MingaEditor.FileTree.ProjectCache do
   Bridges the editor file tree to the project's background-rebuilt file cache
   (#2377).
 
-  `Minga.Project` keeps a flat list of project-relative paths that it rebuilds in
-  the background. When a tree (or picker) root is the active project root, the
-  picker and the filtered tree read this cache instead of doing filesystem I/O on
-  the editor path. This module centralizes the "is this the active project root?"
-  decision and the cache reads, with `:exit` guards so callers work even when the
-  Project GenServer is unavailable (early startup, tests).
-
-  File-tree effects use `snapshot/1` in scheduler workers and pass the immutable
-  value into pure state transitions. The state owner never calls this service.
+  `Minga.Project` owns one atomic typed workspace snapshot. File-tree effects
+  read that value once in scheduler workers and derive an immutable tree-root
+  cache value before pure state transitions. The state owner never calls this
+  service, and no second discovery or scheduling workflow is introduced here.
   """
 
+  alias Minga.Project.Root
+  alias Minga.Project.WorkspaceSnapshot
   alias MingaEditor.FileTree.ProjectCache.Snapshot
 
-  @doc "Returns true when `root` expands to the active project root."
-  @spec active_root?(String.t()) :: boolean()
-  def active_root?(root) when is_binary(root) do
-    case active_root() do
-      active when is_binary(active) -> Path.expand(active) == Path.expand(root)
-      _ -> false
-    end
-  end
-
-  @doc "Returns the active project root, or nil when none is set or the process is down."
-  @spec active_root() :: String.t() | nil
-  def active_root do
-    Minga.Project.root()
-  catch
-    :exit, _ -> nil
-  end
-
-  @doc "Returns the project's cached relative-path list (empty while rebuilding or unavailable)."
-  @spec files() :: [String.t()]
-  def files do
-    Minga.Project.files()
-  catch
-    :exit, _ -> []
-  end
-
-  @doc "Returns true while the project's file cache is rebuilding."
-  @spec rebuilding?() :: boolean()
-  def rebuilding? do
-    Minga.Project.rebuilding?()
-  catch
-    :exit, _ -> false
-  end
-
-  @doc "Reads all project-cache inputs needed to filter one root as an immutable value."
-  @spec snapshot(String.t()) :: Snapshot.t()
-  def snapshot(root) when is_binary(root) do
+  @doc "Reads and derives all cache inputs for one tree root from one Project call."
+  @spec snapshot(String.t(), GenServer.server()) :: Snapshot.t()
+  def snapshot(root, project_server \\ Minga.Project) when is_binary(root) do
     expanded_root = Path.expand(root)
-    active? = active_root?(expanded_root)
-
-    if active? do
-      Snapshot.new(expanded_root, true, files(), rebuilding?())
-    else
-      Snapshot.new(expanded_root, false, [], false)
-    end
+    workspace = Minga.Project.snapshot(project_server)
+    tree_snapshot(expanded_root, workspace)
+  catch
+    :exit, _ -> Snapshot.new(Path.expand(root), false, [], false)
   end
+
+  @spec tree_snapshot(String.t(), WorkspaceSnapshot.t() | nil) :: Snapshot.t()
+  defp tree_snapshot(root, nil), do: Snapshot.new(root, false, [], false)
+
+  defp tree_snapshot(
+         root,
+         %WorkspaceSnapshot{
+           root: %Root{path: active_root},
+           files: files,
+           rebuilding?: rebuilding?
+         }
+       ) do
+    tree_snapshot(root, files, rebuilding?, Path.expand(active_root) == root)
+  end
+
+  @spec tree_snapshot(String.t(), [String.t()], boolean(), boolean()) :: Snapshot.t()
+  defp tree_snapshot(root, files, rebuilding?, true),
+    do: Snapshot.new(root, true, files, rebuilding?)
+
+  defp tree_snapshot(root, _files, _rebuilding?, false),
+    do: Snapshot.new(root, false, [], false)
 end

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -1534,19 +1534,21 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
 
   # ── File tree helpers ──────────────────────────────────────────────
 
-  # Project.switch/1 is a cast; the picker opens against current state while the
-  # file cache rebuilds asynchronously. BEAM message ordering from the Editor
-  # process guarantees the cast reaches Project before any subsequent call.
   @spec open_dropped_directory(state(), String.t()) :: state()
   defp open_dropped_directory(state, dir_path) do
     case Minga.Project.Root.directory(dir_path) do
-      {:ok, root} ->
-        Minga.Project.switch(root)
-        _ = Minga.Project.workspace_root()
+      {:ok, root} -> activate_dropped_directory(state, root)
+      {:error, _reason} -> state
+    end
+  end
 
+  @spec activate_dropped_directory(state(), Minga.Project.Root.t()) :: state()
+  defp activate_dropped_directory(state, root) do
+    case Minga.Project.activate(Minga.Project, root) do
+      {:ok, %Minga.Project.WorkspaceSnapshot{root: installed_root}} ->
         state
-        |> FileTreeFreshness.update_project_root(root.path)
-        |> PickerUI.open(MingaEditor.UI.Picker.FileSource, %{project_root: root})
+        |> FileTreeFreshness.update_project_root(installed_root.path)
+        |> PickerUI.open(MingaEditor.UI.Picker.FileSource, %{project_root: installed_root})
 
       {:error, _reason} ->
         state

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -2,14 +2,14 @@ defmodule MingaEditor.UI.Picker.FileSource do
   @moduledoc """
   Picker source for finding and opening files in the project.
 
-  Lists all files in the project directory using `Minga.Project.FileFind` and opens
-  the selected file in a new buffer (or switches to it if already open).
+  Reads workspace-relative files from one atomic `Minga.Project` snapshot and
+  opens the selected file in a new buffer (or switches to it if already open).
   """
 
   @behaviour MingaEditor.UI.Picker.Source
 
   alias Minga.Project.Root
-  alias MingaEditor.FileTree.ProjectCache
+  alias Minga.Project.WorkspaceSnapshot
   alias MingaEditor.State, as: EditorState
   alias Minga.Git
   alias Minga.Language
@@ -38,9 +38,10 @@ defmodule MingaEditor.UI.Picker.FileSource do
   @impl true
   @spec candidates(Context.t() | nil) :: [Item.t()]
   def candidates(ctx) do
-    root = project_root(ctx)
+    workspace = active_workspace()
+    root = project_root(ctx, workspace)
 
-    case resolve_paths(root) do
+    case resolve_paths(root, workspace) do
       {:ok, paths} ->
         frecency_map = build_frecency_map()
         git_status_map = build_git_status_map(root.path)
@@ -58,17 +59,26 @@ defmodule MingaEditor.UI.Picker.FileSource do
   # The picker reads only the Project-owned cache.
   # A managed `:project_rebuilt` event refreshes an open picker after an empty cache fills.
   # Picker tasks never start recursive inventory.
-  @spec resolve_paths(Root.t() | nil) :: {:ok, [String.t()]} | {:error, String.t()}
-  defp resolve_paths(nil),
+  @spec resolve_paths(Root.t() | nil, WorkspaceSnapshot.t() | nil) ::
+          {:ok, [String.t()]} | {:error, String.t()}
+  defp resolve_paths(nil, _workspace),
     do: {:error, "No directory workspace active. Open a folder or switch project."}
 
-  defp resolve_paths(%Root{} = root) do
-    if ProjectCache.active_root?(root.path) do
-      {:ok, ProjectCache.files()}
-    else
-      {:error, "Directory workspace is no longer active"}
-    end
+  defp resolve_paths(%Root{}, nil), do: {:error, "Directory workspace is no longer active"}
+
+  defp resolve_paths(
+         %Root{} = root,
+         %WorkspaceSnapshot{root: active_root, files: files}
+       ) do
+    resolve_matching_paths(files, Path.expand(root.path) == Path.expand(active_root.path))
   end
+
+  @spec resolve_matching_paths([String.t()], boolean()) ::
+          {:ok, [String.t()]} | {:error, String.t()}
+  defp resolve_matching_paths(files, true), do: {:ok, files}
+
+  defp resolve_matching_paths(_files, false),
+    do: {:error, "Directory workspace is no longer active"}
 
   # Lean candidate: just enough to match (filename label, full-path search text)
   # and to enrich later (git status stashed in `meta`). Icon, color, two-line
@@ -321,17 +331,31 @@ defmodule MingaEditor.UI.Picker.FileSource do
   defp git_status_annotation(:conflict), do: "!"
   defp git_status_annotation(_), do: nil
 
-  @spec project_root(Context.t() | EditorState.t() | nil) :: Root.t() | nil
-  defp project_root(%Context{picker_ui: %{context: %{project_root: nil}}}), do: nil
-  defp project_root(%Context{picker_ui: %{context: %{project_root: %Root{} = root}}}), do: root
-  defp project_root(%Context{file_tree: %{project_root: %Root{} = root}}), do: root
-  defp project_root(%EditorState{}), do: active_workspace_root()
-  defp project_root(_ctx), do: active_workspace_root()
+  @spec project_root(Context.t() | EditorState.t() | nil, WorkspaceSnapshot.t() | nil) ::
+          Root.t() | nil
+  defp project_root(%Context{picker_ui: %{context: %{project_root: nil}}}, _workspace), do: nil
 
-  @spec active_workspace_root() :: Root.t() | nil
-  defp active_workspace_root do
-    Minga.Project.workspace_root()
+  defp project_root(
+         %Context{picker_ui: %{context: %{project_root: %Root{} = root}}},
+         _workspace
+       ),
+       do: root
+
+  defp project_root(%Context{file_tree: %{project_root: %Root{} = root}}, _workspace), do: root
+  defp project_root(%EditorState{}, workspace), do: workspace_root(workspace)
+  defp project_root(_ctx, workspace), do: workspace_root(workspace)
+
+  @spec active_workspace() :: WorkspaceSnapshot.t() | nil
+  defp active_workspace do
+    Minga.Project.snapshot(Minga.Project)
   catch
     :exit, _ -> nil
   end
+
+  @spec active_workspace_root() :: Root.t() | nil
+  defp active_workspace_root, do: active_workspace() |> workspace_root()
+
+  @spec workspace_root(WorkspaceSnapshot.t() | nil) :: Root.t() | nil
+  defp workspace_root(nil), do: nil
+  defp workspace_root(%WorkspaceSnapshot{root: root}), do: root
 end

--- a/lib/minga_editor/ui/picker/project_source.ex
+++ b/lib/minga_editor/ui/picker/project_source.ex
@@ -16,6 +16,7 @@ defmodule MingaEditor.UI.Picker.ProjectSource do
 
   alias Minga.Project
   alias Minga.Project.Root
+  alias Minga.Project.WorkspaceSnapshot
 
   @impl true
   @spec title() :: String.t()
@@ -50,13 +51,16 @@ defmodule MingaEditor.UI.Picker.ProjectSource do
   end
 
   @spec activate_project(Root.t(), term()) :: term()
-  defp activate_project(%Root{path: path} = root, state) do
-    Project.switch(root)
-    _ = Project.workspace_root()
+  defp activate_project(%Root{} = root, state) do
+    case Project.activate(Project, root) do
+      {:ok, %WorkspaceSnapshot{root: installed_root}} ->
+        state
+        |> FileTreeFreshness.update_project_root(installed_root.path)
+        |> PickerUI.open(FileSource, %{project_root: installed_root})
 
-    state
-    |> FileTreeFreshness.update_project_root(path)
-    |> PickerUI.open(FileSource, %{project_root: root})
+      {:error, _reason} ->
+        state
+    end
   end
 
   @impl true

--- a/test/minga/project_test.exs
+++ b/test/minga/project_test.exs
@@ -4,6 +4,7 @@ defmodule Minga.ProjectTest do
 
   alias Minga.Project
   alias Minga.Project.Root
+  alias Minga.Project.WorkspaceSnapshot
 
   @moduletag :tmp_dir
 
@@ -75,9 +76,113 @@ defmodule Minga.ProjectTest do
 
         assert Project.root(name) == nil
         assert Project.workspace_root(name) == nil
+        assert Project.snapshot(name) == nil
         assert Project.known_projects(name) == []
-        assert state.rebuilding? == false
+        assert state.workspace == nil
       end
+    end
+  end
+
+  describe "activate/2 and snapshot/1" do
+    test "activation synchronously returns the installed typed workspace while discovery runs", %{
+      tmp_dir: tmp
+    } do
+      project = Path.join(tmp, "immediate_activation")
+      File.mkdir_p!(project)
+      {:ok, root} = Root.directory(project)
+      {_pid, name} = start_project!(file_find_module: Minga.Project.SlowFileFind)
+
+      assert {:ok, %WorkspaceSnapshot{root: ^root, files: [], rebuilding?: true} = installed} =
+               Project.activate(name, root)
+
+      assert Project.snapshot(name) == installed
+      assert Project.root(name) == project
+      assert Project.workspace_root(name) == root
+    end
+
+    test "completion atomically installs relative files and the matching rebuild status", %{
+      tmp_dir: tmp
+    } do
+      project = Path.join(tmp, "atomic_completion")
+      File.mkdir_p!(project)
+      {:ok, root} = Root.directory(project)
+      {_pid, name} = start_project!(file_find_module: Minga.Project.SlowFileFind)
+      Minga.Events.subscribe(:project_rebuilt)
+
+      assert {:ok, %WorkspaceSnapshot{rebuilding?: true}} = Project.activate(name, root)
+      worker = flush(name).rebuild_pid
+      worker_ref = Process.monitor(worker)
+
+      :ok = Minga.Project.SlowFileFind.complete(worker, {:ok, ["lib/app.ex", "README.md"]})
+
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^project}},
+                     1_000
+
+      assert_receive {:DOWN, ^worker_ref, :process, ^worker, :normal}, 1_000
+
+      assert %WorkspaceSnapshot{
+               root: ^root,
+               files: ["lib/app.ex", "README.md"],
+               rebuilding?: false
+             } = Project.snapshot(name)
+    end
+
+    test "rapid rerooting cannot install a superseded worker result", %{tmp_dir: tmp} do
+      first = Path.join(tmp, "snapshot_first")
+      second = Path.join(tmp, "snapshot_second")
+      File.mkdir_p!(first)
+      File.mkdir_p!(second)
+      {:ok, first_root} = Root.directory(first)
+      {:ok, second_root} = Root.directory(second)
+      {_pid, name} = start_project!(file_find_module: Minga.Project.SlowFileFind)
+
+      assert {:ok, %WorkspaceSnapshot{root: ^first_root, rebuilding?: true}} =
+               Project.activate(name, first_root)
+
+      first_worker = flush(name).rebuild_pid
+      first_ref = Process.monitor(first_worker)
+
+      assert {:ok, %WorkspaceSnapshot{root: ^second_root, files: [], rebuilding?: true}} =
+               Project.activate(name, second_root)
+
+      second_worker = flush(name).rebuild_pid
+      assert_receive {:DOWN, ^first_ref, :process, ^first_worker, :normal}, 1_000
+
+      send(name, {:file_find_done, first_worker, {:ok, ["stale-first.txt"]}})
+      _ = flush(name)
+
+      assert %WorkspaceSnapshot{root: ^second_root, files: [], rebuilding?: true} =
+               Project.snapshot(name)
+
+      Minga.Events.subscribe(:project_rebuilt)
+      :ok = Minga.Project.SlowFileFind.complete(second_worker, {:ok, ["second.txt"]})
+
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^second}},
+                     1_000
+
+      assert %WorkspaceSnapshot{root: ^second_root, files: ["second.txt"], rebuilding?: false} =
+               Project.snapshot(name)
+    end
+
+    test "rejects a non-directory typed root without replacing the workspace", %{tmp_dir: tmp} do
+      project = Path.join(tmp, "directory")
+      file = Path.join(tmp, "loose.txt")
+      File.mkdir_p!(project)
+      File.write!(file, "loose")
+      {:ok, root} = Root.directory(project)
+      {_pid, name} = start_project!(file_find_module: Minga.Project.SlowFileFind)
+
+      assert {:ok, installed} = Project.activate(name, root)
+      assert {:error, :not_a_directory_root} = Project.activate(name, Root.file(file))
+
+      unconfirmed_home = %Root{kind: :directory, path: Path.expand("~")}
+
+      assert {:error, :broad_root_confirmation_required} =
+               Project.activate(name, unconfirmed_home)
+
+      assert Project.snapshot(name) == installed
     end
   end
 
@@ -134,7 +239,7 @@ defmodule Minga.ProjectTest do
 
       assert Project.root(name) == nil
       assert Project.workspace_root(name) == nil
-      assert state.rebuilding? == false
+      assert state.workspace == nil
     end
 
     test "adds switched project to known projects", %{tmp_dir: tmp} do
@@ -192,9 +297,8 @@ defmodule Minga.ProjectTest do
       state = flush(name)
 
       assert_receive {:DOWN, ^second_ref, :process, ^second_worker, :normal}, 1_000
-      assert state.current_root == nil
-      assert state.workspace_root == nil
-      assert state.rebuilding? == false
+      assert state.workspace == nil
+      assert Project.snapshot(name) == nil
     end
 
     test "discovery timeout cancels the worker", %{tmp_dir: tmp} do
@@ -210,7 +314,7 @@ defmodule Minga.ProjectTest do
 
       assert_receive {:DOWN, ^ref, :process, ^worker, :normal}, 1_000
       state = flush(name)
-      assert state.rebuilding? == false
+      assert %WorkspaceSnapshot{root: %Root{path: ^root}, rebuilding?: false} = state.workspace
       assert state.rebuild_pid == nil
     end
 

--- a/test/minga_editor/file_tree/project_cache_test.exs
+++ b/test/minga_editor/file_tree/project_cache_test.exs
@@ -1,0 +1,61 @@
+defmodule MingaEditor.FileTree.ProjectCacheTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Project
+  alias Minga.Project.Root
+  alias Minga.Project.WorkspaceSnapshot
+  alias MingaEditor.FileTree.ProjectCache
+  alias MingaEditor.FileTree.ProjectCache.Snapshot
+
+  @moduletag :tmp_dir
+
+  test "derives one tree cache value from the Project workspace snapshot", %{tmp_dir: tmp_dir} do
+    project = Path.join(tmp_dir, "project")
+    other = Path.join(tmp_dir, "other")
+    File.mkdir_p!(project)
+    File.mkdir_p!(other)
+    {:ok, root} = Root.directory(project)
+    server = start_project!()
+
+    assert {:ok, %WorkspaceSnapshot{root: ^root, files: [], rebuilding?: true}} =
+             Project.activate(server, root)
+
+    assert %Snapshot{root: ^project, active?: true, files: [], rebuilding?: true} =
+             ProjectCache.snapshot(project, server)
+
+    assert %Snapshot{root: ^other, active?: false, files: [], rebuilding?: false} =
+             ProjectCache.snapshot(other, server)
+
+    Minga.Events.subscribe(:project_rebuilt)
+    worker = :sys.get_state(server).rebuild_pid
+    :ok = Minga.Project.SlowFileFind.complete(worker, {:ok, ["lib/app.ex"]})
+
+    assert_receive {:minga_event, :project_rebuilt,
+                    %Minga.Events.ProjectRebuiltEvent{root: ^project}},
+                   1_000
+
+    assert %Snapshot{
+             root: ^project,
+             active?: true,
+             files: ["lib/app.ex"],
+             rebuilding?: false
+           } = ProjectCache.snapshot(project, server)
+  end
+
+  defp start_project! do
+    name = :"project_cache_#{System.unique_integer([:positive])}"
+
+    start_supervised!(
+      Supervisor.child_spec(
+        {Project,
+         name: name,
+         subscribe: false,
+         command_frecency: %{},
+         file_find_module: Minga.Project.SlowFileFind},
+        id: make_ref()
+      )
+    )
+
+    name
+  end
+end

--- a/test/minga_editor/handlers/session_restore_test.exs
+++ b/test/minga_editor/handlers/session_restore_test.exs
@@ -93,7 +93,7 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
 
     assert Minga.Project.root() == nil
     assert Minga.Project.workspace_root() == nil
-    assert project_state.rebuilding? == false
+    assert project_state.workspace == nil
     assert Minga.Project.files() == []
     assert Minga.Project.known_projects() == known_before
     refute fake_home in Minga.Project.known_projects()

--- a/test/support/minga/project/slow_file_find.ex
+++ b/test/support/minga/project/slow_file_find.ex
@@ -3,7 +3,14 @@ defmodule Minga.Project.SlowFileFind do
 
   @spec start(Minga.Project.Root.t(), pid()) :: {:ok, pid()}
   def start(_root, owner) do
-    {:ok, spawn(fn -> wait_for_cancel(owner, Process.monitor(owner)) end)}
+    {:ok, spawn(fn -> wait_for_control(owner, Process.monitor(owner)) end)}
+  end
+
+  @doc "Completes a controlled discovery with the exact result."
+  @spec complete(pid(), Minga.Project.FileFind.result()) :: :ok
+  def complete(pid, result) when is_pid(pid) do
+    send(pid, {:complete, result})
+    :ok
   end
 
   @spec cancel(pid()) :: :ok
@@ -12,11 +19,18 @@ defmodule Minga.Project.SlowFileFind do
     :ok
   end
 
-  @spec wait_for_cancel(pid(), reference()) :: :ok
-  defp wait_for_cancel(owner, owner_ref) do
+  @spec wait_for_control(pid(), reference()) :: :ok
+  defp wait_for_control(owner, owner_ref) do
     receive do
-      :cancel -> :ok
-      {:DOWN, ^owner_ref, :process, ^owner, _reason} -> :ok
+      {:complete, result} ->
+        send(owner, {:file_find_done, self(), result})
+        :ok
+
+      :cancel ->
+        :ok
+
+      {:DOWN, ^owner_ref, :process, ^owner, _reason} ->
+        :ok
     end
   end
 end


### PR DESCRIPTION
# TL;DR
Project activation and cached inventory now share one typed workspace snapshot, so callers cannot combine one authorized root with another root's files or rebuild status. Activation is synchronous while existing bounded discovery remains asynchronous.

Closes #2943

## Context
This is the second delivery slice of #2939. `Minga.Project` previously mirrored the active workspace as both a string and a typed Root, and callers assembled root, files, and rebuilding state through separate GenServer calls. Project switching also used a cast followed by a call solely as a mailbox barrier.

## Changes
- Add `Minga.Project.WorkspaceSnapshot` as the owner of typed root, workspace-relative files, and rebuilding status.
- Store one workspace snapshot in the Project GenServer and keep worker PID, monitor, and timer lifecycle state separate.
- Add synchronous `Project.activate/2` and atomic `Project.snapshot/1`, both with explicit server identity for future multi-workspace ownership.
- Preserve `switch`, `root`, `workspace_root`, `files`, and `rebuilding?` as compatibility projections from the same snapshot.
- Move project picker and dropped-directory activation off cast-plus-barrier synchronization.
- Make ProjectCache and file picker inventory reads consume one atomic Project snapshot.
- Preserve the existing monitored, bounded, cancellable discovery worker and #2916 file-tree effect scheduling.

## Compatibility

The globally named `Minga.Project` process remains the default owner for existing callers. New activation and snapshot APIs accept an explicit server, so future #28 work can assign Project ownership per workspace without changing this contract. This PR does not add multi-workspace routing, persistence, or tab identity.

## Verification
- Focused Project, ProjectCache, picker, native-open, command, file-tree, and restore suites (56 tests, 0 failures)
- `make lint` (Credo clean, compilation clean, Dialyzer 0 errors)
- `mix test.llm` (9,517 tests, 97 properties, 58 doctests, 0 failures)
- Final reviewer: PASS

## Acceptance Criteria Addressed
- Activation returns installed typed state synchronously while discovery completes asynchronously ✅
- Cached root, files, and rebuilding status come from one atomic snapshot ✅
- Rapid switches cancel prior discovery and reject stale results ✅
- Broad-root, canonicalization, relative-path, no-cwd, and bounded discovery safety remains intact ✅
- Existing file-tree scheduler and stale-result behavior remains unchanged ✅
- Required compatibility APIs project from the typed snapshot and support explicit server identity ✅
