### PR TITLE
refactor(editor): enforce Traditional owner boundaries

### DIFF
--- a/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
@@ -12,8 +12,10 @@ defmodule MingaGitPorcelain.Commands do
   alias Minga.Core.Face
   alias MingaEditor.BufferLifecycle
   alias MingaEditor.Commands
+  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Layout
   alias MingaEditor.PickerUI
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.GitToast
   alias MingaEditor.Shell.Traditional.GitToastWorkflow
@@ -94,7 +96,7 @@ defmodule MingaGitPorcelain.Commands do
       end)
       |> SidebarWorkflow.close_git_status()
       |> Layout.invalidate()
-      |> EditorState.invalidate_all_windows()
+      |> invalidate_all_windows()
     else
       open_git_status_panel(state)
     end
@@ -1322,10 +1324,10 @@ defmodule MingaGitPorcelain.Commands do
           }
 
         state
-        |> SidebarWorkflow.replace_git_status(panel_data)
+        |> SidebarWorkflow.replace_git_status(GitStatusPanel.new(panel_data))
         |> SidebarWorkflow.select("git_status")
         |> Layout.invalidate()
-        |> EditorState.invalidate_all_windows()
+        |> invalidate_all_windows()
     end
   end
 
@@ -1351,11 +1353,15 @@ defmodule MingaGitPorcelain.Commands do
       }
 
     state
-    |> SidebarWorkflow.replace_git_status(panel_data)
+    |> SidebarWorkflow.replace_git_status(GitStatusPanel.new(panel_data))
     |> SidebarWorkflow.select("git_status")
     |> Layout.invalidate()
-    |> EditorState.invalidate_all_windows()
+    |> invalidate_all_windows()
   end
+
+  @spec invalidate_all_windows(state()) :: state()
+  defp invalidate_all_windows(%EditorState{} = state),
+    do: %{state | workspace: SessionState.invalidate_all_windows(state.workspace)}
 
   @spec git_status_last_commit_message(state()) :: String.t()
   defp git_status_last_commit_message(state) do

--- a/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/input/git_status.ex
@@ -13,13 +13,14 @@ defmodule MingaGitPorcelain.Input.GitStatus do
 
   alias Minga.Buffer
   alias MingaEditor.Commands
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
   alias Minga.Git
   alias Minga.Log
   alias MingaEditor.Input
   alias MingaEditor.Layout
-  alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
+  alias MingaEditor.GitStatus.TUIState, as: TuiState
   alias Minga.Keymap
   alias MingaEditor.PromptUI
   alias MingaGitPorcelain.UI.Prompt.GitCommit, as: CommitPrompt
@@ -40,7 +41,7 @@ defmodule MingaGitPorcelain.Input.GitStatus do
              :git_status,
              binding_state,
              key,
-             EditorState.keymap_context(state)
+             keymap_server: state.interaction.keymap_server
            ) do
         {:command, cmd} ->
           {:handled, execute_command(state, cmd)}
@@ -267,8 +268,12 @@ defmodule MingaGitPorcelain.Input.GitStatus do
     end)
     |> SidebarWorkflow.close_git_status()
     |> Layout.invalidate()
-    |> EditorState.invalidate_all_windows()
+    |> invalidate_all_windows()
   end
+
+  @spec invalidate_all_windows(EditorState.t()) :: EditorState.t()
+  defp invalidate_all_windows(%EditorState{} = state),
+    do: %{state | workspace: SessionState.invalidate_all_windows(state.workspace)}
 
   @spec open_diff_for_entry(EditorState.t(), String.t(), Git.StatusEntry.t()) :: EditorState.t()
   defp open_diff_for_entry(state, git_root, %Git.StatusEntry{} = entry) do

--- a/extensions/git_porcelain/lib/minga_git_porcelain/shell/traditional/git_status_renderer.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/shell/traditional/git_status_renderer.ex
@@ -13,7 +13,7 @@ defmodule MingaGitPorcelain.Shell.Traditional.GitStatusRenderer do
   alias Minga.Git.StatusEntry
   alias MingaEditor.DisplayList
   alias MingaEditor.Layout
-  alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
+  alias MingaEditor.GitStatus.TUIState, as: TuiState
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.State, as: EditorState

--- a/extensions/git_porcelain/test/minga_git_porcelain/input/status_diff_open_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/input/status_diff_open_test.exs
@@ -7,6 +7,7 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
   alias Minga.Git
   alias Minga.Git.Stub, as: GitStub
   alias MingaGitPorcelain.Input.GitStatus
+  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
@@ -97,7 +98,7 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
   defp state_with_selected_entry(entry), do: state_with_panel_entries([entry])
 
   defp state_with_panel_entries(entries) do
-    alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
+    alias MingaEditor.GitStatus.TUIState, as: TuiState
 
     panel_data = %{
       repo_state: :normal,
@@ -119,7 +120,7 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
         focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
       }
     }
-    |> SidebarWorkflow.replace_git_status(panel_data)
+    |> SidebarWorkflow.replace_git_status(GitStatusPanel.new(panel_data))
     |> SidebarWorkflow.replace_git_status_tui(tui)
   end
 

--- a/extensions/git_porcelain/test/minga_git_porcelain/input/status_input_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/input/status_input_test.exs
@@ -10,7 +10,8 @@ defmodule MingaGitPorcelain.Input.GitStatusInputTest do
 
   alias Minga.Git
   alias MingaGitPorcelain.Input.GitStatus
-  alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
+  alias MingaEditor.GitStatus.TUIState, as: TuiState
+  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.State, as: ShellState
@@ -51,7 +52,7 @@ defmodule MingaGitPorcelain.Input.GitStatusInputTest do
         focus_stack: [MingaEditor.Input.Scoped, MingaEditor.Input.ModeFSM]
       }
     }
-    |> SidebarWorkflow.replace_git_status(panel_data)
+    |> SidebarWorkflow.replace_git_status(GitStatusPanel.new(panel_data))
     |> SidebarWorkflow.replace_git_status_tui(TuiState.new())
   end
 

--- a/extensions/git_porcelain/test/minga_git_porcelain/picker_branch_delete_shortcut_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/picker_branch_delete_shortcut_test.exs
@@ -82,7 +82,7 @@ defmodule MingaGitPorcelain.PickerBranchDeleteShortcutTest do
       frontend: %MingaEditor.State.Frontend{port_manager: nil},
       workspace: %SessionState{viewport: Viewport.new(24, 80), editing: VimState.new()}
     }
-    |> ModalWorkflow.transition(:picker, PickerPayload.new(picker_state))
+    |> ModalWorkflow.transition({:picker, PickerPayload.new(picker_state)})
   end
 
   defp reset_global_project! do

--- a/extensions/git_porcelain/test/minga_git_porcelain/shell/traditional/status_renderer_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/shell/traditional/status_renderer_test.exs
@@ -3,7 +3,8 @@ defmodule MingaGitPorcelain.Shell.Traditional.GitStatusRendererTest do
   use ExUnit.Case, async: true
 
   alias Minga.Git.StatusEntry
-  alias MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState
+  alias MingaEditor.GitStatus.Panel
+  alias MingaEditor.GitStatus.TUIState, as: TuiState
   alias MingaGitPorcelain.Shell.Traditional.GitStatusRenderer
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
 
@@ -27,25 +28,23 @@ defmodule MingaGitPorcelain.Shell.Traditional.GitStatusRendererTest do
         keymap_scope: :git_status
       },
       shell_state: shell_state,
-      theme: theme
+      appearance: %{theme: theme}
     }
   end
 
   defp make_panel(entries) do
-    %{
+    Panel.new(%{
       repo_state: :normal,
       branch: "main",
       ahead: 0,
       behind: 0,
       entries: entries,
       stash_count: 0
-    }
+    })
   end
 
-  defp make_tui_state(overrides) do
-    TuiState.new()
-    |> Map.merge(overrides)
-  end
+  defp make_tui_state(collapsed),
+    do: %TuiState{cursor_index: 0, collapsed: collapsed}
 
   describe "render/2" do
     test "returns empty list when no panel is active" do
@@ -141,7 +140,7 @@ defmodule MingaGitPorcelain.Shell.Traditional.GitStatusRendererTest do
       ]
 
       panel = make_panel(entries)
-      state = base_state(panel, tui_state: make_tui_state(%{collapsed: %{changes: true}}))
+      state = base_state(panel, tui_state: make_tui_state(%{changes: true}))
       draws = GitStatusRenderer.render(state, @rect)
 
       texts = Enum.map(draws, fn d -> elem(d, 2) end)

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -1210,8 +1210,7 @@ defmodule MingaEditor do
 
     state
     |> MingaEditor.Shell.Traditional.ModalWorkflow.transition(
-      :picker,
-      PickerPayload.put_picker_ui(payload, new_picker_state)
+      {:picker, PickerPayload.put_picker_ui(payload, new_picker_state)}
     )
     |> apply_fetch_status(meta)
   end
@@ -1222,8 +1221,7 @@ defmodule MingaEditor do
 
     MingaEditor.Shell.Traditional.ModalWorkflow.transition(
       state,
-      :picker,
-      PickerPayload.put_picker_ui(payload, new_picker_state)
+      {:picker, PickerPayload.put_picker_ui(payload, new_picker_state)}
     )
   end
 

--- a/lib/minga_editor/agent/compaction.ex
+++ b/lib/minga_editor/agent/compaction.ex
@@ -191,7 +191,7 @@ defmodule MingaEditor.Agent.Compaction do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tab_bar
         )

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -860,7 +860,7 @@ defmodule MingaEditor.Agent.Events do
 
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )
@@ -902,7 +902,7 @@ defmodule MingaEditor.Agent.Events do
 
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )
@@ -952,7 +952,10 @@ defmodule MingaEditor.Agent.Events do
   @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
   defp install_tab_bar(%EditorState{} = state, %TabBar{} = tab_bar) do
     shell_state =
-      MingaEditor.Shell.Traditional.State.set_tab_bar(Runtime.state(state.shell_runtime), tab_bar)
+      MingaEditor.Shell.Traditional.State.install_tab_bar(
+        MingaEditor.Shell.Runtime.state(state.shell_runtime),
+        tab_bar
+      )
 
     %{state | shell_runtime: Runtime.install_traditional_state(state.shell_runtime, shell_state)}
   end

--- a/lib/minga_editor/agent_lifecycle.ex
+++ b/lib/minga_editor/agent_lifecycle.ex
@@ -385,7 +385,7 @@ defmodule MingaEditor.AgentLifecycle do
 
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               MingaEditor.State.TabBar.update_label(tb, active_id, label)
             )

--- a/lib/minga_editor/commands/agent.ex
+++ b/lib/minga_editor/commands/agent.ex
@@ -232,7 +232,7 @@ defmodule MingaEditor.Commands.Agent do
 
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tb
             )
@@ -1020,7 +1020,7 @@ defmodule MingaEditor.Commands.Agent do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -74,7 +74,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -520,7 +520,7 @@ defmodule MingaEditor.Commands.AgentSession do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )
@@ -556,7 +556,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -600,7 +600,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tb
             )
@@ -722,7 +722,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -967,7 +967,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -1069,7 +1069,7 @@ defmodule MingaEditor.Commands.AgentSession do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -963,7 +963,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp toggle_tab_pin(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.State.TabBar.toggle_active_pin(tb)
         )
@@ -983,7 +983,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp unpin_active_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.State.TabBar.unpin_tab(tb, tb.active_id)
         )
@@ -1003,7 +1003,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp move_active_tab(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state, direction) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           move_tab_bar(tb, direction)
         )
@@ -1423,7 +1423,7 @@ defmodule MingaEditor.Commands.BufferManagement do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             MingaEditor.State.TabBar.remove_workspace(
               state.shell_runtime.state.tab_bar,
@@ -1487,7 +1487,7 @@ defmodule MingaEditor.Commands.BufferManagement do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )
@@ -1584,7 +1584,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tb
             )
@@ -1683,7 +1683,7 @@ defmodule MingaEditor.Commands.BufferManagement do
       %{id: workspace_id} ->
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               MingaEditor.State.TabBar.remove_workspace(
                 state.shell_runtime.state.tab_bar,
@@ -1727,7 +1727,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           updated_tb
         )
@@ -1759,7 +1759,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           updated_tb
         )
@@ -1830,7 +1830,7 @@ defmodule MingaEditor.Commands.BufferManagement do
           :ok ->
             then(state, fn root ->
               shell_state =
-                MingaEditor.Shell.Traditional.State.set_tab_bar(
+                MingaEditor.Shell.Traditional.State.install_tab_bar(
                   MingaEditor.Shell.Runtime.state(root.shell_runtime),
                   MingaEditor.State.TabBar.remove_workspace(tb, workspace.id)
                 )
@@ -2043,7 +2043,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -2081,7 +2081,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
           then(state, fn root ->
             shell_state =
-              MingaEditor.Shell.Traditional.State.set_tab_bar(
+              MingaEditor.Shell.Traditional.State.install_tab_bar(
                 MingaEditor.Shell.Runtime.state(root.shell_runtime),
                 tb
               )
@@ -2266,8 +2266,8 @@ defmodule MingaEditor.Commands.BufferManagement do
         tab_bar = maybe_switch_to_replacement(new_tb, replacement_id)
 
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
-            Runtime.state(state.shell_runtime),
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
+            MingaEditor.Shell.Runtime.state(state.shell_runtime),
             tab_bar
           )
 
@@ -2807,7 +2807,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           new_panel
         )
@@ -2826,7 +2826,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           new_panel
         )

--- a/lib/minga_editor/commands/inline_ask.ex
+++ b/lib/minga_editor/commands/inline_ask.ex
@@ -110,7 +110,7 @@ defmodule MingaEditor.Commands.InlineAsk do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -165,7 +165,7 @@ defmodule MingaEditor.Commands.InlineAsk do
   @spec install_tab_bar(state(), TabBar.t()) :: state()
   defp install_tab_bar(state, tab_bar) do
     shell_state =
-      MingaEditor.Shell.Traditional.State.set_tab_bar(
+      MingaEditor.Shell.Traditional.State.install_tab_bar(
         MingaEditor.Shell.Runtime.state(state.shell_runtime),
         tab_bar
       )

--- a/lib/minga_editor/commands/movement.ex
+++ b/lib/minga_editor/commands/movement.ex
@@ -651,7 +651,7 @@ defmodule MingaEditor.Commands.Movement do
 
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_bottom_panel(
+          MingaEditor.Shell.Traditional.State.install_bottom_panel(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             panel
           )
@@ -719,7 +719,7 @@ defmodule MingaEditor.Commands.Movement do
     if panel.visible do
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_bottom_panel(
+          MingaEditor.Shell.Traditional.State.install_bottom_panel(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             MingaEditor.BottomPanel.focus(panel)
           )

--- a/lib/minga_editor/commands/ui.ex
+++ b/lib/minga_editor/commands/ui.ex
@@ -84,7 +84,7 @@ defmodule MingaEditor.Commands.UI do
   defp toggle_bottom_panel(state) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.BottomPanel.toggle(state.shell_runtime.state.bottom_panel)
         )
@@ -101,7 +101,7 @@ defmodule MingaEditor.Commands.UI do
   defp bottom_panel_next_tab(state) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.BottomPanel.next_tab(state.shell_runtime.state.bottom_panel)
         )
@@ -118,7 +118,7 @@ defmodule MingaEditor.Commands.UI do
   defp bottom_panel_prev_tab(state) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.BottomPanel.prev_tab(state.shell_runtime.state.bottom_panel)
         )

--- a/lib/minga_editor/commands/workspace.ex
+++ b/lib/minga_editor/commands/workspace.ex
@@ -91,7 +91,7 @@ defmodule MingaEditor.Commands.Workspace do
             state =
               then(state, fn root ->
                 shell_state =
-                  MingaEditor.Shell.Traditional.State.set_tab_bar(
+                  MingaEditor.Shell.Traditional.State.install_tab_bar(
                     MingaEditor.Shell.Runtime.state(root.shell_runtime),
                     MingaEditor.State.TabBar.update_workspace(tb, workspace_id, fn _ ->
                       updated
@@ -161,7 +161,7 @@ defmodule MingaEditor.Commands.Workspace do
               state =
                 then(state, fn root ->
                   shell_state =
-                    MingaEditor.Shell.Traditional.State.set_tab_bar(
+                    MingaEditor.Shell.Traditional.State.install_tab_bar(
                       MingaEditor.Shell.Runtime.state(root.shell_runtime),
                       MingaEditor.State.TabBar.update_workspace(tb, workspace_id, fn _ ->
                         updated
@@ -407,7 +407,7 @@ defmodule MingaEditor.Commands.Workspace do
   defp remove_workspace_and_sync_agent_ui(state, tb, workspace_id) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.State.TabBar.remove_workspace(tb, workspace_id)
         )
@@ -479,7 +479,7 @@ defmodule MingaEditor.Commands.Workspace do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.State.TabBar.update_workspace(tb, workspace.id, fn _ ->
             updated_workspace
@@ -546,7 +546,7 @@ defmodule MingaEditor.Commands.Workspace do
   defp put_workspace_review_result({:ok, updated}, state, tb, workspace_id) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.State.TabBar.update_workspace(tb, workspace_id, fn _ -> updated end)
         )

--- a/lib/minga_editor/completion_handling.ex
+++ b/lib/minga_editor/completion_handling.ex
@@ -12,12 +12,14 @@ defmodule MingaEditor.CompletionHandling do
   alias Minga.Config
   alias Minga.Editing.Completion
   alias MingaEditor.CompletionTrigger
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.ModalWorkflow
   alias MingaEditor.Shell.Traditional.SignatureHelpWorkflow
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.SignatureHelp
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.Tab
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
 
@@ -463,12 +465,16 @@ defmodule MingaEditor.CompletionHandling do
         trigger: ModalWorkflow.completion_trigger(state)
       )
 
-    ModalWorkflow.open(state, :completion, payload)
+    ModalWorkflow.open(state, {:completion, payload})
   end
 
-  @spec active_tab_id(EditorState.t()) :: term() | nil
-  defp active_tab_id(%{shell_runtime: %{state: %{tab_bar: %{active_id: id}}}}), do: id
-  defp active_tab_id(_), do: nil
+  @spec active_tab_id(EditorState.t()) :: Tab.id() | nil
+  defp active_tab_id(%EditorState{shell_runtime: %Runtime{} = runtime}) do
+    case Runtime.active_tab(runtime) do
+      %Tab{id: id} -> id
+      nil -> nil
+    end
+  end
 
   @typedoc "Config contexts that produce completion items (excludes :none)."
   @type active_config_context :: :option_name | {:option_value, atom()} | :filetype

--- a/lib/minga_editor/file_watcher_helpers.ex
+++ b/lib/minga_editor/file_watcher_helpers.ex
@@ -132,8 +132,7 @@ defmodule MingaEditor.FileWatcherHelpers do
     state =
       MingaEditor.Shell.Traditional.ModalWorkflow.open(
         state,
-        :conflict,
-        ConflictPayload.new(buf, path)
+        {:conflict, ConflictPayload.new(buf, path)}
       )
 
     MingaEditor.Shell.Traditional.NoticeWorkflow.publish(

--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -21,6 +21,9 @@ defmodule MingaEditor.FocusTree do
   alias MingaEditor.Layout.OverlayBand
   alias MingaEditor.SignatureHelp
   alias MingaEditor.SignatureHelp.Presenter, as: SignatureHelpPresenter
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Frontend, as: FrontendState
+  alias MingaEditor.RenderPipeline.Input, as: RenderInput
   alias MingaEditor.Renderer.Gutter
   alias MingaEditor.UI.Picker, as: PickerData
   alias MingaEditor.Viewport
@@ -608,17 +611,25 @@ defmodule MingaEditor.FocusTree do
     {first_row, 0, cols, height}
   end
 
-  @spec completion_render_opts(map(), Layout.t()) :: CompletionUI.render_opts()
+  @spec completion_render_opts(EditorState.t() | RenderInput.t(), Layout.t()) ::
+          CompletionUI.render_opts()
   defp completion_render_opts(state, layout) do
     {cursor_row, cursor_col} = cursor_screen_pos(state, layout)
+    viewport = terminal_viewport(state)
 
     %{
       cursor_row: cursor_row,
       cursor_col: cursor_col,
-      viewport_rows: state.frontend.terminal_viewport.rows,
-      viewport_cols: state.frontend.terminal_viewport.cols
+      viewport_rows: viewport.rows,
+      viewport_cols: viewport.cols
     }
   end
+
+  @spec terminal_viewport(EditorState.t() | RenderInput.t()) :: Viewport.t()
+  defp terminal_viewport(%EditorState{frontend: %FrontendState{terminal_viewport: viewport}}),
+    do: viewport
+
+  defp terminal_viewport(%RenderInput{terminal_viewport: viewport}), do: viewport
 
   @spec cursor_screen_pos(map(), Layout.t()) :: {non_neg_integer(), non_neg_integer()}
   defp cursor_screen_pos(%{workspace: %{buffers: %{active: buf}}} = state, layout)
@@ -638,14 +649,16 @@ defmodule MingaEditor.FocusTree do
 
   defp cursor_screen_pos(_state, _layout), do: {0, 0}
 
-  @spec cursor_origin(map(), Layout.t()) ::
+  @spec cursor_origin(EditorState.t() | RenderInput.t(), Layout.t()) ::
           {integer(), integer(), non_neg_integer(), non_neg_integer()}
   defp cursor_origin(state, layout) do
     with %{content: {row, col, _width, _height}} <- active_window_layout(layout, state),
          %{viewport: viewport} <- active_window(state) do
       {row, col, viewport.top, viewport.left}
     else
-      _ -> {0, 0, state.frontend.terminal_viewport.top, state.frontend.terminal_viewport.left}
+      _ ->
+        viewport = terminal_viewport(state)
+        {0, 0, viewport.top, viewport.left}
     end
   end
 

--- a/lib/minga_editor/git_status/tui_state.ex
+++ b/lib/minga_editor/git_status/tui_state.ex
@@ -1,6 +1,6 @@
-defmodule MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState do
+defmodule MingaEditor.GitStatus.TUIState do
   @moduledoc """
-  TUI-only view state for the traditional git status sidebar.
+  TUI-only value owner for the Traditional Git-status sidebar.
 
   The shared git status panel data stays frontend-neutral. This struct tracks
   terminal presentation concerns such as cursor position, collapsed sections,

--- a/lib/minga_editor/handlers/event_dispatcher.ex
+++ b/lib/minga_editor/handlers/event_dispatcher.ex
@@ -558,7 +558,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )
@@ -635,7 +635,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
   @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
   defp install_tab_bar(%EditorState{} = state, %TabBar{} = tab_bar) do
     shell_state =
-      MingaEditor.Shell.Traditional.State.set_tab_bar(
+      MingaEditor.Shell.Traditional.State.install_tab_bar(
         MingaEditor.Shell.Runtime.state(state.shell_runtime),
         tab_bar
       )
@@ -655,7 +655,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
        ) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.State.TabBar.set_remote_connection_status(tb, server_name, status)
         )
@@ -687,7 +687,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
        ) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           set_workspace_remote_state(tb, workspace, workspace.session, status)
         )
@@ -714,7 +714,7 @@ defmodule MingaEditor.Handlers.EventDispatcher do
        ) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           set_workspace_remote_state(tb, workspace, nil, status)
         )

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -440,7 +440,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   defp dispatch_action(state, {:toggle_panel, 1}) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.BottomPanel.toggle(state.shell_runtime.state.bottom_panel)
         )
@@ -490,7 +490,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   defp dispatch_action(state, {:panel_switch_tab, tab_index}) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.BottomPanel.switch_tab(
             state.shell_runtime.state.bottom_panel,
@@ -509,7 +509,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   defp dispatch_action(state, :panel_dismiss) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.BottomPanel.dismiss(state.shell_runtime.state.bottom_panel)
         )
@@ -525,7 +525,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   defp dispatch_action(state, {:panel_resize, height_percent}) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.BottomPanel.resize(
             state.shell_runtime.state.bottom_panel,
@@ -1700,7 +1700,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
       %TabBar{} = tb ->
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               fun.(tb)
             )

--- a/lib/minga_editor/inline_edit/events.ex
+++ b/lib/minga_editor/inline_edit/events.ex
@@ -61,7 +61,7 @@ defmodule MingaEditor.InlineEdit.Events do
          {:tool_ended, "produce_rewrite", replacement, :done}
        )
        when is_binary(replacement),
-       do: InlineEdit.set_proposal(edit, replacement)
+       do: InlineEdit.install_proposal(edit, replacement)
 
   defp apply_event(%InlineEdit{} = edit, _session_pid, {:text_delta, text}),
     do: InlineEdit.append_proposal(edit, text)

--- a/lib/minga_editor/input/bottom_panel.ex
+++ b/lib/minga_editor/input/bottom_panel.ex
@@ -66,7 +66,7 @@ defmodule MingaEditor.Input.BottomPanel do
   defp close_panel(state, panel) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_bottom_panel(
+        MingaEditor.Shell.Traditional.State.install_bottom_panel(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           MingaEditor.BottomPanel.hide(panel)
         )
@@ -115,7 +115,7 @@ defmodule MingaEditor.Input.BottomPanel do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_bottom_panel(
+          MingaEditor.Shell.Traditional.State.install_bottom_panel(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             panel
           )

--- a/lib/minga_editor/key_dispatch.ex
+++ b/lib/minga_editor/key_dispatch.ex
@@ -262,7 +262,7 @@ defmodule MingaEditor.KeyDispatch do
         total: total
       )
 
-    MingaEditor.Shell.Traditional.ModalWorkflow.open(state, :command_completion, payload)
+    MingaEditor.Shell.Traditional.ModalWorkflow.open(state, {:command_completion, payload})
   end
 
   defp sync_command_completion_overlay(state, :command, new_mode) when new_mode != :command do

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -131,8 +131,7 @@ defmodule MingaEditor.PickerUI do
     new_state =
       MingaEditor.Shell.Traditional.ModalWorkflow.open(
         new_state,
-        :picker,
-        PickerPayload.new(picker_state)
+        {:picker, PickerPayload.new(picker_state)}
       )
 
     {new_state, revision}
@@ -151,8 +150,7 @@ defmodule MingaEditor.PickerUI do
         new_state =
           state
           |> MingaEditor.Shell.Traditional.ModalWorkflow.transition(
-            :picker,
-            PickerPayload.put_picker_ui(payload, new_picker_state)
+            {:picker, PickerPayload.put_picker_ui(payload, new_picker_state)}
           )
           |> apply_fetch_status(meta)
 
@@ -172,8 +170,7 @@ defmodule MingaEditor.PickerUI do
         {:ok,
          MingaEditor.Shell.Traditional.ModalWorkflow.transition(
            state,
-           :picker,
-           PickerPayload.put_picker_ui(payload, new_picker_state)
+           {:picker, PickerPayload.put_picker_ui(payload, new_picker_state)}
          )}
 
       :stale ->
@@ -216,8 +213,7 @@ defmodule MingaEditor.PickerUI do
 
     MingaEditor.Shell.Traditional.ModalWorkflow.open(
       new_state,
-      :picker,
-      PickerPayload.new(picker_state)
+      {:picker, PickerPayload.new(picker_state)}
     )
   end
 
@@ -754,8 +750,7 @@ defmodule MingaEditor.PickerUI do
 
     MingaEditor.Shell.Traditional.ModalWorkflow.transition(
       state,
-      :picker,
-      PickerPayload.put_picker_ui(payload, new_pui)
+      {:picker, PickerPayload.put_picker_ui(payload, new_pui)}
     )
   end
 

--- a/lib/minga_editor/prompt_ui.ex
+++ b/lib/minga_editor/prompt_ui.ex
@@ -8,7 +8,7 @@ defmodule MingaEditor.PromptUI do
 
   Prompts and pickers are mutually exclusive: opening a prompt closes any
   active picker. The replacement is handled automatically by
-  `MingaEditor.Shell.Traditional.ModalWorkflow.open/3`.
+  `MingaEditor.Shell.Traditional.ModalWorkflow.open/2`.
 
   ## Usage
 
@@ -71,8 +71,7 @@ defmodule MingaEditor.PromptUI do
 
     MingaEditor.Shell.Traditional.ModalWorkflow.open(
       state,
-      :prompt,
-      PromptPayload.new(prompt_state)
+      {:prompt, PromptPayload.new(prompt_state)}
     )
   end
 
@@ -156,8 +155,7 @@ defmodule MingaEditor.PromptUI do
 
     MingaEditor.Shell.Traditional.ModalWorkflow.transition(
       state,
-      :prompt,
-      PromptPayload.put_prompt_ui(payload, new_pui)
+      {:prompt, PromptPayload.put_prompt_ui(payload, new_pui)}
     )
   end
 

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -23,6 +23,7 @@ defmodule MingaEditor.Shell.Traditional do
 
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Commands.AgentSession
+  alias MingaEditor.GitStatus.TUIState
   alias Minga.Buffer
   alias Minga.Project.FileRef
   alias MingaEditor.State.Agent, as: AgentState
@@ -82,7 +83,7 @@ defmodule MingaEditor.Shell.Traditional do
 
       context = background_agent_context(workspace)
       tb = TabBar.update_context(tb, tab.id, context)
-      {ShellState.set_tab_bar(shell_state, tb), workspace}
+      {ShellState.install_tab_bar(shell_state, tb), workspace}
     end
   end
 
@@ -90,52 +91,16 @@ defmodule MingaEditor.Shell.Traditional do
     {shell_state, workspace}
   end
 
-  @git_status_tui_state_module :"Elixir.MingaGitPorcelain.Shell.Traditional.GitStatus.TuiState"
-
   @spec refresh_git_status_tui_state(ShellState.t(), [Minga.Git.StatusEntry.t()]) ::
           ShellState.t()
   defp refresh_git_status_tui_state(%ShellState{} = shell_state, entries) do
     case ShellState.git_status_tui_state(shell_state) do
-      nil -> shell_state
-      tui -> maybe_refresh_git_status_tui_state(shell_state, tui, entries)
-    end
-  end
+      %TUIState{} = tui ->
+        ShellState.replace_git_status_tui_state(shell_state, TUIState.refresh(tui, entries))
 
-  @spec maybe_refresh_git_status_tui_state(ShellState.t(), struct(), [Minga.Git.StatusEntry.t()]) ::
-          ShellState.t()
-  defp maybe_refresh_git_status_tui_state(shell_state, tui, entries) do
-    if git_status_tui_refresh_available?() do
-      refreshed = :erlang.apply(@git_status_tui_state_module, :refresh, [tui, entries])
-      install_refreshed_git_status_tui_state(shell_state, refreshed)
-    else
-      shell_state
-    end
-  end
-
-  @spec install_refreshed_git_status_tui_state(ShellState.t(), term()) :: ShellState.t()
-  defp install_refreshed_git_status_tui_state(shell_state, refreshed) do
-    if is_struct(refreshed, @git_status_tui_state_module),
-      do: ShellState.replace_git_status_tui_state(shell_state, refreshed),
-      else: shell_state
-  end
-
-  @spec git_status_tui_refresh_available?() :: boolean()
-  defp git_status_tui_refresh_available? do
-    git_porcelain_running?() and Code.ensure_loaded?(@git_status_tui_state_module) and
-      function_exported?(@git_status_tui_state_module, :refresh, 2)
-  end
-
-  @spec git_porcelain_running?() :: boolean()
-  defp git_porcelain_running? do
-    case Process.whereis(Minga.Extension.Registry) do
       nil ->
-        false
-
-      _pid ->
-        match?({:ok, %{status: :running}}, Minga.Extension.Registry.get(:minga_git_porcelain))
+        shell_state
     end
-  catch
-    :exit, _reason -> false
   end
 
   @impl true
@@ -169,7 +134,7 @@ defmodule MingaEditor.Shell.Traditional do
       ) do
     stop_workspace_session(TabBar.get_workspace(tb, ws_id))
     tab_bar = TabBar.remove_workspace(tb, ws_id)
-    shell_state = ShellState.set_tab_bar(shell_state, tab_bar)
+    shell_state = ShellState.install_tab_bar(shell_state, tab_bar)
     workspace = sync_workspace_agent_ui(tab_bar, workspace)
     {shell_state, workspace}
   end
@@ -180,7 +145,7 @@ defmodule MingaEditor.Shell.Traditional do
         {:workspace_rename, ws_id, name}
       ) do
     tb = TabBar.update_workspace(tb, ws_id, &Workspace.rename(&1, name))
-    {ShellState.set_tab_bar(shell_state, tb), workspace}
+    {ShellState.install_tab_bar(shell_state, tb), workspace}
   end
 
   def handle_gui_action(
@@ -189,7 +154,7 @@ defmodule MingaEditor.Shell.Traditional do
         {:workspace_set_icon, ws_id, icon}
       ) do
     tb = TabBar.update_workspace(tb, ws_id, &Workspace.set_icon(&1, icon))
-    {ShellState.set_tab_bar(shell_state, tb), workspace}
+    {ShellState.install_tab_bar(shell_state, tb), workspace}
   end
 
   def handle_gui_action(shell_state, workspace, _action) do
@@ -367,7 +332,7 @@ defmodule MingaEditor.Shell.Traditional do
     {tb, tab} = TabBar.add(tb, :file, label)
     tb = TabBar.switch_to(tb, tab.id)
     workspace = SessionState.activate_buffer(workspace, workspace.buffers)
-    {ShellState.set_tab_bar(shell_state, tb), workspace}
+    {ShellState.install_tab_bar(shell_state, tb), workspace}
   end
 
   @impl true
@@ -388,11 +353,11 @@ defmodule MingaEditor.Shell.Traditional do
           |> sync_file_tab_ref(tb.active_id, workspace.buffers.active, workspace)
           |> TabBar.update_context(tb.active_id, SessionState.to_tab_context(workspace))
 
-        {ShellState.set_tab_bar(shell_state, tb), workspace}
+        {ShellState.install_tab_bar(shell_state, tb), workspace}
 
       %Tab{} ->
         tb = TabBar.update_context(tb, tb.active_id, SessionState.to_tab_context(workspace))
-        {ShellState.set_tab_bar(shell_state, tb), workspace}
+        {ShellState.install_tab_bar(shell_state, tb), workspace}
 
       nil ->
         {shell_state, workspace}
@@ -448,7 +413,7 @@ defmodule MingaEditor.Shell.Traditional do
         tb
       end
 
-    {ShellState.set_tab_bar(shell_state, tb), workspace}
+    {ShellState.install_tab_bar(shell_state, tb), workspace}
   end
 
   def on_agent_event(
@@ -458,7 +423,7 @@ defmodule MingaEditor.Shell.Traditional do
         {:approval_pending, _}
       ) do
     tb = TabBar.set_attention_by_session(tb, session_pid, true)
-    {ShellState.set_tab_bar(shell_state, tb), workspace}
+    {ShellState.install_tab_bar(shell_state, tb), workspace}
   end
 
   # A direct :error event raises attention so a background tab whose session
@@ -472,7 +437,7 @@ defmodule MingaEditor.Shell.Traditional do
         {:error, _message}
       ) do
     tb = TabBar.set_attention_by_session(tb, session_pid, true)
-    {ShellState.set_tab_bar(shell_state, tb), workspace}
+    {ShellState.install_tab_bar(shell_state, tb), workspace}
   end
 
   def on_agent_event(shell_state, workspace, _session_pid, _event) do
@@ -508,7 +473,7 @@ defmodule MingaEditor.Shell.Traditional do
       ) do
     status = restarted_session_status(new_pid)
     updated_tb = update_restarted_session_tab_bar(tb, old_pid, new_pid, status)
-    {ShellState.set_tab_bar(shell_state, updated_tb), updated_tb != tb}
+    {ShellState.install_tab_bar(shell_state, updated_tb), updated_tb != tb}
   end
 
   @spec update_restarted_session_tab_bar(TabBar.t(), pid(), pid(), Tab.agent_status()) ::
@@ -630,9 +595,13 @@ defmodule MingaEditor.Shell.Traditional do
           tb
       end
 
-    ShellState.set_tab_bar(
+    ShellState.install_tab_bar(
       shell_state,
-      TabBar.update_tab(tb, tab_id, &Tab.set_session(&1, session_pid))
+      MingaEditor.State.TabBar.update_tab(
+        tb,
+        tab_id,
+        &MingaEditor.State.Tab.set_session(&1, session_pid)
+      )
     )
   end
 
@@ -735,7 +704,7 @@ defmodule MingaEditor.Shell.Traditional do
       tb = TabBar.update_tab(tb, target_id, &Tab.set_attention(&1, false))
 
       workspace = SessionState.invalidate_all_windows(workspace)
-      {ShellState.set_tab_bar(shell_state, tb), workspace}
+      {ShellState.install_tab_bar(shell_state, tb), workspace}
     end
   end
 
@@ -784,8 +753,7 @@ defmodule MingaEditor.Shell.Traditional do
     Log.debug(:editor, fn -> "[tab] on_buffer_added new tab=#{new_tab.id} label=#{label}" end)
 
     shell_state =
-      shell_state
-      |> ShellState.set_tab_bar(tb)
+      ShellState.install_tab_bar(shell_state, tb)
       |> then(fn current ->
         ShellState.replace_agent(
           current,
@@ -830,7 +798,7 @@ defmodule MingaEditor.Shell.Traditional do
       |> sync_file_tab_ref(new_tab.id, workspace.buffers.active, workspace)
       |> TabBar.update_context(new_tab.id, new_context)
 
-    {ShellState.set_tab_bar(shell_state, tb), workspace}
+    {ShellState.install_tab_bar(shell_state, tb), workspace}
   end
 
   @spec sync_file_tab_ref(TabBar.t(), Tab.id(), pid() | nil, SessionState.t()) :: TabBar.t()

--- a/lib/minga_editor/shell/traditional/agent_surfaces.ex
+++ b/lib/minga_editor/shell/traditional/agent_surfaces.ex
@@ -98,12 +98,6 @@ defmodule MingaEditor.Shell.Traditional.AgentSurfaces do
       when is_pid(session_pid) and is_binary(delta),
       do: update_edit_session(surfaces, session_pid, &InlineEdit.append_proposal(&1, delta))
 
-  @doc "Installs a tool-produced proposal only on the matching inline edit session."
-  @spec set_edit_proposal(t(), pid(), String.t()) :: t()
-  def set_edit_proposal(%__MODULE__{} = surfaces, session_pid, proposal)
-      when is_pid(session_pid) and is_binary(proposal),
-      do: update_edit_session(surfaces, session_pid, &InlineEdit.set_proposal(&1, proposal))
-
   @doc "Cancels the inline edit for a buffer and returns its session pid."
   @spec cancel_edit(t(), pid() | nil) :: {t(), pid() | nil}
   def cancel_edit(%__MODULE__{} = surfaces, buffer_pid) do
@@ -113,23 +107,36 @@ defmodule MingaEditor.Shell.Traditional.AgentSurfaces do
 
   @spec update_ask_session(t(), pid(), (InlineAsk.t() -> InlineAsk.t())) :: t()
   defp update_ask_session(%__MODULE__{} = surfaces, session_pid, update) do
-    asks =
-      Map.new(surfaces.asks, fn
-        {buffer_pid, %InlineAsk{session_pid: ^session_pid} = ask} -> {buffer_pid, update.(ask)}
-        entry -> entry
-      end)
-
-    %{surfaces | asks: asks}
+    case matching_ask(surfaces.asks, session_pid) do
+      {buffer_pid, ask} -> %{surfaces | asks: Map.put(surfaces.asks, buffer_pid, update.(ask))}
+      nil -> surfaces
+    end
   end
 
   @spec update_edit_session(t(), pid(), (InlineEdit.t() -> InlineEdit.t())) :: t()
   defp update_edit_session(%__MODULE__{} = surfaces, session_pid, update) do
-    edits =
-      Map.new(surfaces.edits, fn
-        {buffer_pid, %InlineEdit{session_pid: ^session_pid} = edit} -> {buffer_pid, update.(edit)}
-        entry -> entry
-      end)
+    case matching_edit(surfaces.edits, session_pid) do
+      {buffer_pid, edit} ->
+        %{surfaces | edits: Map.put(surfaces.edits, buffer_pid, update.(edit))}
 
-    %{surfaces | edits: edits}
+      nil ->
+        surfaces
+    end
+  end
+
+  @spec matching_ask(InlineAsk.store(), pid()) :: {pid(), InlineAsk.t()} | nil
+  defp matching_ask(asks, session_pid) do
+    Enum.find(asks, fn
+      {_buffer_pid, %InlineAsk{session_pid: ^session_pid}} -> true
+      _entry -> false
+    end)
+  end
+
+  @spec matching_edit(InlineEdit.store(), pid()) :: {pid(), InlineEdit.t()} | nil
+  defp matching_edit(edits, session_pid) do
+    Enum.find(edits, fn
+      {_buffer_pid, %InlineEdit{session_pid: ^session_pid}} -> true
+      _entry -> false
+    end)
   end
 end

--- a/lib/minga_editor/shell/traditional/modal_workflow.ex
+++ b/lib/minga_editor/shell/traditional/modal_workflow.ex
@@ -2,16 +2,23 @@ defmodule MingaEditor.Shell.Traditional.ModalWorkflow do
   @moduledoc "Editor-state workflow around the pure `ModalOverlay` value owner."
 
   alias MingaEditor.CompletionTrigger
+  alias MingaEditor.RenderPipeline.Input
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.Shell.Traditional.WhichKeyWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.Tab
 
-  @doc "Opens a modal, preserving conflict stickiness and suppressing lower transients."
-  @spec open(EditorState.t(), ModalOverlay.variant(), ModalOverlay.payload()) :: EditorState.t()
-  def open(%{shell_runtime: %{state: %ShellState{}}} = state, variant, payload) do
+  @doc "Opens an exact modal value, preserving conflict stickiness and suppressing lower transients."
+  @spec open(EditorState.t(), ModalOverlay.active()) :: EditorState.t()
+  def open(
+        %EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state,
+        modal
+      ) do
     previous = state.shell_runtime.state.modal
-    next = ModalOverlay.open(previous, variant, payload)
+    next = ModalOverlay.open(previous, modal)
+    variant = ModalOverlay.tag(modal)
 
     if next == previous and ModalOverlay.match(previous, :conflict) and variant != :conflict do
       Minga.Log.info(
@@ -23,68 +30,84 @@ defmodule MingaEditor.Shell.Traditional.ModalWorkflow do
     else
       state
       |> suppress_lower_surfaces()
-      |> update_shell_state(&ShellState.open_modal(&1, variant, payload))
+      |> update_shell_state(&ShellState.open_modal(&1, modal))
     end
   end
 
-  def open(state, _variant, _payload), do: state
+  def open(%EditorState{} = state, _modal), do: state
 
-  @doc "Transitions the active modal unconditionally and suppresses lower transients."
-  @spec transition(EditorState.t(), ModalOverlay.variant(), ModalOverlay.payload()) ::
-          EditorState.t()
-  def transition(%{shell_runtime: %{state: %ShellState{}}} = state, variant, payload) do
+  @doc "Transitions to an exact modal value unconditionally and suppresses lower transients."
+  @spec transition(EditorState.t(), ModalOverlay.active()) :: EditorState.t()
+  def transition(
+        %EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state,
+        modal
+      ) do
     state
     |> suppress_lower_surfaces()
-    |> update_shell_state(&ShellState.transition_modal(&1, variant, payload))
+    |> update_shell_state(&ShellState.transition_modal(&1, modal))
   end
 
-  def transition(state, _variant, _payload), do: state
+  def transition(%EditorState{} = state, _modal), do: state
 
   @doc "Closes a completed modal."
   @spec close(EditorState.t()) :: EditorState.t()
-  def close(%{shell_runtime: %{state: %ShellState{}}} = state),
+  def close(%EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state),
     do: update_shell_state(state, &ShellState.close_modal/1)
 
-  def close(state), do: state
+  def close(%EditorState{} = state), do: state
 
   @doc "Dismisses a canceled modal and cancels only its local completion timers."
   @spec dismiss(EditorState.t()) :: EditorState.t()
-  def dismiss(%{shell_runtime: %{state: %ShellState{modal: modal}}} = state) do
+  def dismiss(%EditorState{shell_runtime: %Runtime{state: %ShellState{modal: modal}}} = state) do
     cancel_completion_timers(modal)
     update_shell_state(state, &ShellState.dismiss_modal/1)
   end
 
-  def dismiss(state), do: state
+  def dismiss(%EditorState{} = state), do: state
 
   @doc "Returns the active inner completion value."
-  @spec completion(EditorState.t() | map()) :: Minga.Editing.Completion.t() | nil
-  def completion(%{shell_runtime: %{state: %{modal: modal}}}), do: ModalOverlay.completion(modal)
-  def completion(%{shell_state: %{modal: modal}}), do: ModalOverlay.completion(modal)
-  def completion(_state), do: nil
+  @spec completion(EditorState.t() | Input.t()) :: Minga.Editing.Completion.t() | nil
+  def completion(%EditorState{shell_runtime: %Runtime{state: %ShellState{} = shell_state}}),
+    do: shell_state |> ShellState.modal() |> ModalOverlay.completion()
+
+  def completion(%Input{shell_state: %ShellState{} = shell_state}),
+    do: shell_state |> ShellState.modal() |> ModalOverlay.completion()
+
+  def completion(%EditorState{}), do: nil
+  def completion(%Input{}), do: nil
 
   @doc "Returns the active completion trigger or a fresh trigger."
-  @spec completion_trigger(EditorState.t() | map()) :: MingaEditor.CompletionTrigger.t()
-  def completion_trigger(%{shell_runtime: %{state: %{modal: modal}}}),
-    do: ModalOverlay.completion_trigger(modal)
+  @spec completion_trigger(EditorState.t() | Input.t()) :: MingaEditor.CompletionTrigger.t()
+  def completion_trigger(%EditorState{
+        shell_runtime: %Runtime{state: %ShellState{} = shell_state}
+      }),
+      do: shell_state |> ShellState.modal() |> ModalOverlay.completion_trigger()
 
-  def completion_trigger(%{shell_state: %{modal: modal}}),
-    do: ModalOverlay.completion_trigger(modal)
+  def completion_trigger(%Input{shell_state: %ShellState{} = shell_state}),
+    do: shell_state |> ShellState.modal() |> ModalOverlay.completion_trigger()
 
-  def completion_trigger(_state), do: MingaEditor.CompletionTrigger.new()
+  def completion_trigger(%EditorState{}), do: MingaEditor.CompletionTrigger.new()
+  def completion_trigger(%Input{}), do: MingaEditor.CompletionTrigger.new()
 
   @doc "Updates the active completion value."
   @spec update_completion(EditorState.t(), (Minga.Editing.Completion.t() ->
                                               Minga.Editing.Completion.t())) ::
           EditorState.t()
-  def update_completion(%{shell_runtime: %{state: %ShellState{}}} = state, update),
-    do: update_shell_state(state, &ShellState.update_modal_completion(&1, update))
+  def update_completion(
+        %EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state,
+        update
+      ),
+      do: update_shell_state(state, &ShellState.update_modal_completion(&1, update))
 
-  def update_completion(state, _update), do: state
+  def update_completion(%EditorState{} = state, _update), do: state
 
   @doc "Records completion-trigger lifecycle with current tab context."
   @spec put_completion_trigger(EditorState.t(), MingaEditor.CompletionTrigger.t()) ::
           EditorState.t()
-  def put_completion_trigger(%{shell_runtime: %{state: %ShellState{}}} = state, trigger) do
+  def put_completion_trigger(
+        %EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state,
+        trigger
+      ) do
     active_tab_id = active_tab_id(state)
 
     update_shell_state(
@@ -93,22 +116,25 @@ defmodule MingaEditor.Shell.Traditional.ModalWorkflow do
     )
   end
 
-  def put_completion_trigger(state, _trigger), do: state
+  def put_completion_trigger(%EditorState{} = state, _trigger), do: state
 
   @doc "Returns the active command-completion payload."
-  @spec command_completion(EditorState.t() | map()) ::
+  @spec command_completion(EditorState.t() | Input.t()) ::
           MingaEditor.State.ModalOverlay.CommandCompletion.t() | nil
-  def command_completion(%{shell_runtime: %{state: %{modal: modal}}}),
-    do: ModalOverlay.command_completion(modal)
+  def command_completion(%EditorState{
+        shell_runtime: %Runtime{state: %ShellState{} = shell_state}
+      }),
+      do: shell_state |> ShellState.modal() |> ModalOverlay.command_completion()
 
-  def command_completion(%{shell_state: %{modal: modal}}),
-    do: ModalOverlay.command_completion(modal)
+  def command_completion(%Input{shell_state: %ShellState{} = shell_state}),
+    do: shell_state |> ShellState.modal() |> ModalOverlay.command_completion()
 
-  def command_completion(_state), do: nil
+  def command_completion(%EditorState{}), do: nil
+  def command_completion(%Input{}), do: nil
 
   @doc "Dismisses completion owned by a different active tab."
   @spec dismiss_if_stale(EditorState.t()) :: EditorState.t()
-  def dismiss_if_stale(%{shell_runtime: %{state: %ShellState{}}} = state) do
+  def dismiss_if_stale(%EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state) do
     active_tab_id = active_tab_id(state)
 
     update_shell_state(
@@ -117,7 +143,7 @@ defmodule MingaEditor.Shell.Traditional.ModalWorkflow do
     )
   end
 
-  def dismiss_if_stale(state), do: state
+  def dismiss_if_stale(%EditorState{} = state), do: state
 
   @spec suppress_lower_surfaces(EditorState.t()) :: EditorState.t()
   defp suppress_lower_surfaces(state) do
@@ -137,9 +163,13 @@ defmodule MingaEditor.Shell.Traditional.ModalWorkflow do
     :ok
   end
 
-  @spec active_tab_id(EditorState.t()) :: term() | nil
-  defp active_tab_id(%{shell_runtime: %{state: %{tab_bar: %{active_id: id}}}}), do: id
-  defp active_tab_id(_state), do: nil
+  @spec active_tab_id(EditorState.t()) :: Tab.id() | nil
+  defp active_tab_id(%EditorState{shell_runtime: %Runtime{} = runtime}) do
+    case Runtime.active_tab(runtime) do
+      %Tab{id: id} -> id
+      nil -> nil
+    end
+  end
 
   @spec update_shell_state(EditorState.t(), (MingaEditor.Shell.Traditional.State.t() ->
                                                MingaEditor.Shell.Traditional.State.t())) ::

--- a/lib/minga_editor/shell/traditional/nav_flash.ex
+++ b/lib/minga_editor/shell/traditional/nav_flash.ex
@@ -20,7 +20,7 @@ defmodule MingaEditor.Shell.Traditional.NavFlash do
 
   @doc "Replaces the active flash and advances its monotonic generation."
   @spec replace(t(), non_neg_integer()) :: t()
-  def replace(%__MODULE__{} = flash, line) do
+  def replace(%__MODULE__{} = flash, line) when is_integer(line) and line >= 0 do
     %__MODULE__{generation: flash.generation + 1, line: line}
   end
 

--- a/lib/minga_editor/shell/traditional/notice_workflow.ex
+++ b/lib/minga_editor/shell/traditional/notice_workflow.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Shell.Traditional.NoticeWorkflow do
 
   alias Minga.Events
   alias MingaEditor.MessageLog
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.Notice
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.State, as: EditorState
@@ -18,8 +19,11 @@ defmodule MingaEditor.Shell.Traditional.NoticeWorkflow do
   @timeout_ms 2_000
 
   @doc "Publishes an ordinary notice under the status-lane arbitration contract."
-  @spec publish(EditorState.t() | map(), String.t()) :: EditorState.t() | map()
-  def publish(%{shell_runtime: %{state: %MingaEditor.Shell.Traditional.State{}}} = state, message)
+  @spec publish(EditorState.t(), String.t()) :: EditorState.t()
+  def publish(
+        %EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state,
+        message
+      )
       when is_binary(message) do
     state = cancel_current_timer(state)
 
@@ -36,51 +40,44 @@ defmodule MingaEditor.Shell.Traditional.NoticeWorkflow do
     MessageLog.append_to_store(state, message, :info)
   end
 
-  def publish(state, message) when is_binary(message) do
-    Minga.Log.info(:editor, message)
-    state
-  end
-
   @doc "Acknowledges a notice before keyboard dispatch."
-  @spec acknowledge(EditorState.t() | map()) :: EditorState.t() | map()
-  def acknowledge(%{shell_runtime: %{state: %MingaEditor.Shell.Traditional.State{}}} = state) do
+  @spec acknowledge(EditorState.t()) :: EditorState.t()
+  def acknowledge(%EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state) do
     state
     |> cancel_current_timer()
     |> update_shell_state(&ShellState.acknowledge_notice/1)
   end
 
-  def acknowledge(state), do: state
+  def acknowledge(%EditorState{} = state), do: state
 
   @doc "Dismisses a notice explicitly, such as from Ctrl-G."
-  @spec dismiss(EditorState.t() | map()) :: EditorState.t() | map()
-  def dismiss(%{shell_runtime: %{state: %MingaEditor.Shell.Traditional.State{}}} = state) do
+  @spec dismiss(EditorState.t()) :: EditorState.t()
+  def dismiss(%EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state) do
     state
     |> cancel_current_timer()
     |> update_shell_state(&ShellState.dismiss_notice/1)
   end
 
-  def dismiss(state), do: state
+  def dismiss(%EditorState{} = state), do: state
 
   @doc "Handles one identity-tagged timeout; stale delivery is a no-op."
-  @spec timeout(EditorState.t() | map(), Notice.id()) :: EditorState.t() | map()
-  def timeout(%{shell_runtime: %{state: %MingaEditor.Shell.Traditional.State{}}} = state, id) do
+  @spec timeout(EditorState.t(), Notice.id()) :: EditorState.t()
+  def timeout(%EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state, id) do
     update_shell_state(state, &ShellState.timeout_notice(&1, id))
   end
 
-  def timeout(state, _id), do: state
+  def timeout(%EditorState{} = state, _id), do: state
 
   @doc "Returns the currently visible ordinary notice message."
-  @spec message(EditorState.t() | map()) :: String.t() | nil
-  def message(%{
-        shell_runtime: %{
-          state: %{notice: %MingaEditor.Shell.Traditional.Notice{message: message}}
-        }
+  @spec message(EditorState.t()) :: String.t() | nil
+  def message(%EditorState{
+        shell_runtime: %Runtime{state: %ShellState{notice: %Notice{message: message}}}
       }),
       do: message
 
-  def message(_state), do: nil
+  def message(%EditorState{}), do: nil
 
-  @spec publish_visible(EditorState.t() | map(), String.t()) :: EditorState.t() | map()
+  @spec publish_visible(EditorState.t(), String.t()) :: EditorState.t()
   defp publish_visible(state, message) do
     state = update_shell_state(state, &ShellState.publish_notice(&1, message))
     %Notice{id: id} = state.shell_runtime.state.notice
@@ -93,7 +90,7 @@ defmodule MingaEditor.Shell.Traditional.NoticeWorkflow do
     end
   end
 
-  @spec log_hidden(EditorState.t() | map(), String.t()) :: EditorState.t() | map()
+  @spec log_hidden(EditorState.t(), String.t()) :: EditorState.t()
   defp log_hidden(state, message) do
     state = update_shell_state(state, &ShellState.dismiss_notice/1)
 
@@ -106,17 +103,16 @@ defmodule MingaEditor.Shell.Traditional.NoticeWorkflow do
     state
   end
 
-  @spec cancel_current_timer(EditorState.t() | map()) :: EditorState.t() | map()
+  @spec cancel_current_timer(EditorState.t()) :: EditorState.t()
   defp cancel_current_timer(
-         %{
-           shell_runtime: %{state: %{notice: %MingaEditor.Shell.Traditional.Notice{timer: timer}}}
-         } = state
+         %EditorState{shell_runtime: %Runtime{state: %ShellState{notice: %Notice{timer: timer}}}} =
+           state
        ) do
     cancel_timer(timer)
     state
   end
 
-  defp cancel_current_timer(state), do: state
+  defp cancel_current_timer(%EditorState{} = state), do: state
 
   @spec cancel_timer(reference() | nil) :: :ok
   defp cancel_timer(nil), do: :ok
@@ -130,12 +126,7 @@ defmodule MingaEditor.Shell.Traditional.NoticeWorkflow do
                                                MingaEditor.Shell.Traditional.State.t())) ::
           EditorState.t()
   defp update_shell_state(%EditorState{} = state, transition) when is_function(transition, 1) do
-    shell_state = state.shell_runtime |> MingaEditor.Shell.Runtime.state() |> transition.()
-
-    %{
-      state
-      | shell_runtime:
-          MingaEditor.Shell.Runtime.install_traditional_state(state.shell_runtime, shell_state)
-    }
+    shell_state = state.shell_runtime |> Runtime.state() |> transition.()
+    %{state | shell_runtime: Runtime.install_traditional_state(state.shell_runtime, shell_state)}
   end
 end

--- a/lib/minga_editor/shell/traditional/sidebar_workflow.ex
+++ b/lib/minga_editor/shell/traditional/sidebar_workflow.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.Shell.Traditional.SidebarWorkflow do
 
   alias Minga.Log
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
+  alias MingaEditor.GitStatus.TUIState
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.Observatory
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
@@ -39,16 +40,20 @@ defmodule MingaEditor.Shell.Traditional.SidebarWorkflow do
 
   def git_status_panel(%EditorState{}), do: nil
 
-  @doc "Replaces Git status and synchronizes its registered surface."
-  @spec replace_git_status(state(), GitStatusPanel.t() | map() | nil) :: state()
-  def replace_git_status(%EditorState{} = state, panel) do
-    panel = if is_nil(panel), do: nil, else: GitStatusPanel.new(panel)
+  @doc "Replaces Git status with an exact panel value and synchronizes its registered surface."
+  @spec replace_git_status(state(), GitStatusPanel.t() | nil) :: state()
+  def replace_git_status(%EditorState{} = state, nil) do
+    sync_git_status_sidebar(state, nil)
+    update(state, &TraditionalState.replace_git_status_panel(&1, nil))
+  end
+
+  def replace_git_status(%EditorState{} = state, %GitStatusPanel{} = panel) do
     sync_git_status_sidebar(state, panel)
     update(state, &TraditionalState.replace_git_status_panel(&1, panel))
   end
 
   @doc "Returns the TUI-specific Git status presentation value."
-  @spec git_status_tui_state(state()) :: struct() | nil
+  @spec git_status_tui_state(state()) :: TUIState.t() | nil
   def git_status_tui_state(%EditorState{
         shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}
       }),
@@ -57,8 +62,11 @@ defmodule MingaEditor.Shell.Traditional.SidebarWorkflow do
   def git_status_tui_state(%EditorState{}), do: nil
 
   @doc "Replaces the TUI-specific Git status presentation value."
-  @spec replace_git_status_tui(state(), struct() | nil) :: state()
-  def replace_git_status_tui(%EditorState{} = state, tui),
+  @spec replace_git_status_tui(state(), TUIState.t() | nil) :: state()
+  def replace_git_status_tui(%EditorState{} = state, nil),
+    do: update(state, &TraditionalState.replace_git_status_tui_state(&1, nil))
+
+  def replace_git_status_tui(%EditorState{} = state, %TUIState{} = tui),
     do: update(state, &TraditionalState.replace_git_status_tui_state(&1, tui))
 
   @doc "Closes Git status and synchronizes its registered surface."

--- a/lib/minga_editor/shell/traditional/sidebars.ex
+++ b/lib/minga_editor/shell/traditional/sidebars.ex
@@ -8,9 +8,10 @@ defmodule MingaEditor.Shell.Traditional.Sidebars do
   """
 
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
+  alias MingaEditor.GitStatus.TUIState
   alias MingaEditor.Shell.Traditional.Observatory
 
-  @type git_status_tui_state :: struct()
+  @type git_status_tui_state :: TUIState.t()
   @type t :: %__MODULE__{
           active_id: String.t() | nil,
           git_status_panel: GitStatusPanel.t() | nil,
@@ -41,19 +42,19 @@ defmodule MingaEditor.Shell.Traditional.Sidebars do
   def git_status_tui_state(%__MODULE__{git_status_tui_state: state}), do: state
 
   @doc "Replaces the Git status panel while retaining its TUI view state."
-  @spec replace_git_status(t(), GitStatusPanel.t() | map() | nil) :: t()
+  @spec replace_git_status(t(), GitStatusPanel.t() | nil) :: t()
   def replace_git_status(%__MODULE__{} = sidebars, nil),
     do: %{sidebars | git_status_panel: nil}
 
   def replace_git_status(%__MODULE__{} = sidebars, %GitStatusPanel{} = panel),
     do: %{sidebars | git_status_panel: panel}
 
-  def replace_git_status(%__MODULE__{} = sidebars, %{} = panel),
-    do: %{sidebars | git_status_panel: GitStatusPanel.new(panel)}
-
   @doc "Replaces the TUI-specific Git status view state."
   @spec replace_git_status_tui(t(), git_status_tui_state() | nil) :: t()
-  def replace_git_status_tui(%__MODULE__{} = sidebars, state),
+  def replace_git_status_tui(%__MODULE__{} = sidebars, nil),
+    do: %{sidebars | git_status_tui_state: nil}
+
+  def replace_git_status_tui(%__MODULE__{} = sidebars, %TUIState{} = state),
     do: %{sidebars | git_status_tui_state: state}
 
   @doc "Closes Git status and clears both shared and TUI-specific state."

--- a/lib/minga_editor/shell/traditional/signature_help_workflow.ex
+++ b/lib/minga_editor/shell/traditional/signature_help_workflow.ex
@@ -1,59 +1,73 @@
 defmodule MingaEditor.Shell.Traditional.SignatureHelpWorkflow do
   @moduledoc "Editor-state workflow for value-owned signature-help transitions."
 
+  alias MingaEditor.HoverPopup
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: ShellState
   alias MingaEditor.SignatureHelp
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.WhichKey
 
   @doc "Shows signature help unless a higher interactive surface owns input."
   @spec show(EditorState.t(), SignatureHelp.t()) :: EditorState.t()
-  def show(%{shell_runtime: %{state: %{modal: modal}}} = state, _signature_help)
+  def show(
+        %EditorState{shell_runtime: %Runtime{state: %ShellState{modal: modal}}} = state,
+        %SignatureHelp{}
+      )
       when modal != :none,
       do: state
 
-  def show(%{shell_runtime: %{state: %{whichkey: %{node: node}}}} = state, _signature_help)
+  def show(
+        %EditorState{
+          shell_runtime: %Runtime{state: %ShellState{whichkey: %WhichKey{node: node}}}
+        } = state,
+        %SignatureHelp{}
+      )
       when node != nil,
       do: state
 
-  def show(%{shell_runtime: %{state: %{hover_popup: %{focused: true}}}} = state, _signature_help),
-    do: state
+  def show(
+        %EditorState{
+          shell_runtime: %Runtime{state: %ShellState{hover_popup: %HoverPopup{focused: true}}}
+        } = state,
+        %SignatureHelp{}
+      ),
+      do: state
 
-  def show(%{shell_runtime: %{state: %ShellState{}}} = state, signature_help),
-    do: update_shell_state(state, &ShellState.show_signature_help(&1, signature_help))
+  def show(
+        %EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state,
+        %SignatureHelp{} = signature_help
+      ),
+      do: update_shell_state(state, &ShellState.show_signature_help(&1, signature_help))
 
-  def show(state, _signature_help), do: state
+  def show(%EditorState{} = state, %SignatureHelp{}), do: state
 
   @doc "Cycles to the next signature overload."
   @spec next(EditorState.t()) :: EditorState.t()
-  def next(%{shell_runtime: %{state: %ShellState{}}} = state),
+  def next(%EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state),
     do: update_shell_state(state, &ShellState.next_signature_help/1)
 
-  def next(state), do: state
+  def next(%EditorState{} = state), do: state
 
   @doc "Cycles to the previous signature overload."
   @spec previous(EditorState.t()) :: EditorState.t()
-  def previous(%{shell_runtime: %{state: %ShellState{}}} = state),
+  def previous(%EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state),
     do: update_shell_state(state, &ShellState.previous_signature_help/1)
 
-  def previous(state), do: state
+  def previous(%EditorState{} = state), do: state
 
   @doc "Dismisses signature help."
   @spec dismiss(EditorState.t()) :: EditorState.t()
-  def dismiss(%{shell_runtime: %{state: %ShellState{}}} = state),
+  def dismiss(%EditorState{shell_runtime: %Runtime{state: %ShellState{}}} = state),
     do: update_shell_state(state, &ShellState.dismiss_signature_help/1)
 
-  def dismiss(state), do: state
+  def dismiss(%EditorState{} = state), do: state
 
   @spec update_shell_state(EditorState.t(), (MingaEditor.Shell.Traditional.State.t() ->
                                                MingaEditor.Shell.Traditional.State.t())) ::
           EditorState.t()
   defp update_shell_state(%EditorState{} = state, transition) when is_function(transition, 1) do
-    shell_state = state.shell_runtime |> MingaEditor.Shell.Runtime.state() |> transition.()
-
-    %{
-      state
-      | shell_runtime:
-          MingaEditor.Shell.Runtime.install_traditional_state(state.shell_runtime, shell_state)
-    }
+    shell_state = state.shell_runtime |> Runtime.state() |> transition.()
+    %{state | shell_runtime: Runtime.install_traditional_state(state.shell_runtime, shell_state)}
   end
 end

--- a/lib/minga_editor/shell/traditional/state.ex
+++ b/lib/minga_editor/shell/traditional/state.ex
@@ -9,6 +9,7 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   alias MingaEditor.BottomPanel
   alias MingaEditor.HoverPopup
+  alias MingaEditor.SignatureHelp
   alias MingaEditor.Shell.Traditional.AgentSurfaces
   alias MingaEditor.Shell.Traditional.ClickRegions
   alias MingaEditor.Shell.Traditional.Flashes
@@ -19,13 +20,16 @@ defmodule MingaEditor.Shell.Traditional.State do
   alias MingaEditor.Shell.Traditional.Sidebars
   alias MingaEditor.Shell.Traditional.SpaceLeader
   alias MingaEditor.Shell.Traditional.ToolPrompts
+  alias MingaEditor.Shell.Traditional.YankFlash
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.InlineAsk
   alias MingaEditor.State.InlineEdit
   alias MingaEditor.State.ModalOverlay
+  alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.WhichKey
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
+  alias MingaEditor.GitStatus.TUIState
 
   @type git_status_panel :: GitStatusPanel.t()
   @type git_status_tui_state :: Sidebars.git_status_tui_state()
@@ -44,7 +48,7 @@ defmodule MingaEditor.Shell.Traditional.State do
           agent_surfaces: AgentSurfaces.t(),
           modal: ModalOverlay.t(),
           input: InputState.t(),
-          signature_help: MingaEditor.SignatureHelp.t() | nil,
+          signature_help: SignatureHelp.t() | nil,
           tool_prompts: ToolPrompts.t()
         }
 
@@ -62,9 +66,10 @@ defmodule MingaEditor.Shell.Traditional.State do
             signature_help: nil,
             tool_prompts: %ToolPrompts{}
 
-  @doc "Controls whether missing-tool prompts are suppressed."
-  @spec set_suppress_tool_prompts(t(), boolean()) :: t()
-  def set_suppress_tool_prompts(%__MODULE__{} = state, suppress?) when is_boolean(suppress?) do
+  @doc "Installs the configured missing-tool prompt suppression policy."
+  @spec install_tool_prompt_suppression(t(), boolean()) :: t()
+  def install_tool_prompt_suppression(%__MODULE__{} = state, suppress?)
+      when is_boolean(suppress?) do
     %{state | tool_prompts: ToolPrompts.suppress(state.tool_prompts, suppress?)}
   end
 
@@ -118,7 +123,13 @@ defmodule MingaEditor.Shell.Traditional.State do
     do: %{state | flashes: Flashes.cancel_nav(state.flashes)}
 
   @doc "Replaces only the yank flash."
-  @spec replace_yank_flash(t(), pid(), tuple(), tuple(), atom()) :: t()
+  @spec replace_yank_flash(
+          t(),
+          pid(),
+          YankFlash.position(),
+          YankFlash.position(),
+          YankFlash.range_type()
+        ) :: t()
   def replace_yank_flash(%__MODULE__{} = state, buf, start_pos, end_pos, range_type),
     do: %{
       state
@@ -172,7 +183,7 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Returns the hover popup state, or nil when not showing."
   @spec hover_popup(t()) :: HoverPopup.t() | nil
-  def hover_popup(%{hover_popup: popup}), do: popup
+  def hover_popup(%__MODULE__{hover_popup: popup}), do: popup
 
   @doc "Shows newly produced hover content, replacing prior content."
   @spec show_hover_popup(t(), HoverPopup.t()) :: t()
@@ -185,44 +196,30 @@ defmodule MingaEditor.Shell.Traditional.State do
     do: %{state | hover_popup: HoverPopup.dismiss(state.hover_popup)}
 
   @doc "Shows newly produced signature-help content."
-  @spec show_signature_help(t(), MingaEditor.SignatureHelp.t()) :: t()
-  def show_signature_help(%__MODULE__{} = state, signature_help),
-    do: %{
-      state
-      | signature_help: MingaEditor.SignatureHelp.replace(state.signature_help, signature_help)
-    }
+  @spec show_signature_help(t(), SignatureHelp.t()) :: t()
+  def show_signature_help(%__MODULE__{} = state, %SignatureHelp{} = signature_help),
+    do: %{state | signature_help: SignatureHelp.replace(state.signature_help, signature_help)}
 
   @doc "Cycles to the next signature through its value owner."
   @spec next_signature_help(t()) :: t()
-  def next_signature_help(
-        %__MODULE__{signature_help: %MingaEditor.SignatureHelp{} = signature_help} = state
-      ),
-      do: %{
-        state
-        | signature_help: MingaEditor.SignatureHelp.next_signature(signature_help)
-      }
+  def next_signature_help(%__MODULE__{signature_help: %SignatureHelp{} = signature_help} = state),
+    do: %{state | signature_help: SignatureHelp.next_signature(signature_help)}
 
   def next_signature_help(%__MODULE__{} = state), do: state
 
   @doc "Cycles to the previous signature through its value owner."
   @spec previous_signature_help(t()) :: t()
   def previous_signature_help(
-        %__MODULE__{signature_help: %MingaEditor.SignatureHelp{} = signature_help} = state
+        %__MODULE__{signature_help: %SignatureHelp{} = signature_help} = state
       ),
-      do: %{
-        state
-        | signature_help: MingaEditor.SignatureHelp.prev_signature(signature_help)
-      }
+      do: %{state | signature_help: SignatureHelp.prev_signature(signature_help)}
 
   def previous_signature_help(%__MODULE__{} = state), do: state
 
   @doc "Dismisses signature help through its value owner."
   @spec dismiss_signature_help(t()) :: t()
   def dismiss_signature_help(%__MODULE__{} = state),
-    do: %{
-      state
-      | signature_help: MingaEditor.SignatureHelp.dismiss(state.signature_help)
-    }
+    do: %{state | signature_help: SignatureHelp.dismiss(state.signature_help)}
 
   @doc "Suppresses hover and signature help below a higher interactive surface."
   @spec suppress_lower_transients(t()) :: t()
@@ -236,7 +233,7 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Returns the which-key popup state."
   @spec whichkey(t()) :: WhichKey.t()
-  def whichkey(%{whichkey: wk}), do: wk
+  def whichkey(%__MODULE__{whichkey: whichkey}), do: whichkey
 
   @doc "Begins a hidden which-key lifecycle generation."
   @spec begin_whichkey(t(), Minga.Keymap.Bindings.node_t(), [String.t()]) :: t()
@@ -277,18 +274,17 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Returns the bottom panel state."
   @spec bottom_panel(t()) :: BottomPanel.t()
-  def bottom_panel(%{bottom_panel: panel}), do: panel
+  def bottom_panel(%__MODULE__{bottom_panel: panel}), do: panel
 
   @doc "Blurs the shell-owned bottom panel."
   @spec blur_bottom_panel(t()) :: t()
   def blur_bottom_panel(%__MODULE__{} = state),
     do: %{state | bottom_panel: BottomPanel.blur(state.bottom_panel)}
 
-  @doc "Replaces the bottom panel state."
-  @spec set_bottom_panel(t(), BottomPanel.t()) :: t()
-  def set_bottom_panel(%{} = ss, panel) do
-    %{ss | bottom_panel: panel}
-  end
+  @doc "Installs an exact bottom-panel value."
+  @spec install_bottom_panel(t(), BottomPanel.t()) :: t()
+  def install_bottom_panel(%__MODULE__{} = state, %BottomPanel{} = panel),
+    do: %{state | bottom_panel: panel}
 
   # ── Sidebar and Observatory lifecycle ─────────────────────────────────────
 
@@ -301,8 +297,11 @@ defmodule MingaEditor.Shell.Traditional.State do
   def git_status_panel(%__MODULE__{sidebars: sidebars}), do: Sidebars.git_status_panel(sidebars)
 
   @doc "Replaces the Git status panel through the sidebar owner."
-  @spec replace_git_status_panel(t(), git_status_panel() | map() | nil) :: t()
-  def replace_git_status_panel(%__MODULE__{} = state, panel),
+  @spec replace_git_status_panel(t(), git_status_panel() | nil) :: t()
+  def replace_git_status_panel(%__MODULE__{} = state, nil),
+    do: %{state | sidebars: Sidebars.replace_git_status(state.sidebars, nil)}
+
+  def replace_git_status_panel(%__MODULE__{} = state, %GitStatusPanel{} = panel),
     do: %{state | sidebars: Sidebars.replace_git_status(state.sidebars, panel)}
 
   @doc "Returns the TUI-only git status view state, or nil."
@@ -312,7 +311,10 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Replaces the TUI-only Git status view state."
   @spec replace_git_status_tui_state(t(), git_status_tui_state() | nil) :: t()
-  def replace_git_status_tui_state(%__MODULE__{} = state, tui),
+  def replace_git_status_tui_state(%__MODULE__{} = state, nil),
+    do: %{state | sidebars: Sidebars.replace_git_status_tui(state.sidebars, nil)}
+
+  def replace_git_status_tui_state(%__MODULE__{} = state, %TUIState{} = tui),
     do: %{state | sidebars: Sidebars.replace_git_status_tui(state.sidebars, tui)}
 
   @doc "Closes the Git status sidebar and its paired TUI state."
@@ -383,13 +385,14 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Returns the tab bar state, or nil."
   @spec tab_bar(t()) :: TabBar.t() | nil
-  def tab_bar(%{tab_bar: tb}), do: tb
+  def tab_bar(%__MODULE__{tab_bar: tab_bar}), do: tab_bar
 
-  @doc "Replaces the tab bar state."
-  @spec set_tab_bar(t(), TabBar.t() | nil) :: t()
-  def set_tab_bar(%{} = ss, tb) do
-    %{ss | tab_bar: tb}
-  end
+  @doc "Installs an exact tab-bar value or clears it with nil."
+  @spec install_tab_bar(t(), TabBar.t() | nil) :: t()
+  def install_tab_bar(%__MODULE__{} = state, nil), do: %{state | tab_bar: nil}
+
+  def install_tab_bar(%__MODULE__{} = state, %TabBar{} = tab_bar),
+    do: %{state | tab_bar: tab_bar}
 
   # ── Agent presentation and inline surfaces ────────────────────────────────
 
@@ -404,24 +407,24 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Replaces the agent presentation cache."
   @spec replace_agent(t(), AgentState.t()) :: t()
-  def replace_agent(%__MODULE__{} = state, agent),
+  def replace_agent(%__MODULE__{} = state, %AgentState{} = agent),
     do: %{state | agent_surfaces: AgentSurfaces.replace_presentation(state.agent_surfaces, agent)}
 
   # ── Modal overlay ──────────────────────────────────────────────────────────
 
   @doc "Returns the active modal overlay value (`:none` when no modal is open)."
   @spec modal(t()) :: ModalOverlay.t()
-  def modal(%{modal: m}), do: m
+  def modal(%__MODULE__{modal: modal}), do: modal
 
-  @doc "Opens a modal through the conflict-sticky value transition."
-  @spec open_modal(t(), ModalOverlay.variant(), ModalOverlay.payload()) :: t()
-  def open_modal(%__MODULE__{} = state, variant, payload),
-    do: %{state | modal: ModalOverlay.open(state.modal, variant, payload)}
+  @doc "Opens an exact modal value through the conflict-sticky transition."
+  @spec open_modal(t(), ModalOverlay.active()) :: t()
+  def open_modal(%__MODULE__{} = state, modal),
+    do: %{state | modal: ModalOverlay.open(state.modal, modal)}
 
-  @doc "Transitions the modal value unconditionally."
-  @spec transition_modal(t(), ModalOverlay.variant(), ModalOverlay.payload()) :: t()
-  def transition_modal(%__MODULE__{} = state, variant, payload),
-    do: %{state | modal: ModalOverlay.transition(state.modal, variant, payload)}
+  @doc "Transitions to an exact modal value unconditionally."
+  @spec transition_modal(t(), ModalOverlay.active()) :: t()
+  def transition_modal(%__MODULE__{} = state, modal),
+    do: %{state | modal: ModalOverlay.transition(state.modal, modal)}
 
   @doc "Closes a completed modal."
   @spec close_modal(t()) :: t()
@@ -440,7 +443,8 @@ defmodule MingaEditor.Shell.Traditional.State do
     do: %{state | modal: ModalOverlay.update_completion(state.modal, update)}
 
   @doc "Records completion trigger lifecycle with explicit active-tab context."
-  @spec put_modal_completion_trigger(t(), MingaEditor.CompletionTrigger.t(), term() | nil) :: t()
+  @spec put_modal_completion_trigger(t(), MingaEditor.CompletionTrigger.t(), Tab.id() | nil) ::
+          t()
   def put_modal_completion_trigger(%__MODULE__{} = state, trigger, active_tab_id),
     do: %{
       state
@@ -448,7 +452,7 @@ defmodule MingaEditor.Shell.Traditional.State do
     }
 
   @doc "Dismisses stale completion using the now-active tab id."
-  @spec dismiss_stale_modal_completion(t(), term() | nil) :: t()
+  @spec dismiss_stale_modal_completion(t(), Tab.id() | nil) :: t()
   def dismiss_stale_modal_completion(%__MODULE__{} = state, active_tab_id),
     do: %{state | modal: ModalOverlay.dismiss_if_stale(state.modal, active_tab_id)}
 
@@ -460,12 +464,12 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Activates or replaces an inline ask."
   @spec activate_inline_ask(t(), InlineAsk.t()) :: t()
-  def activate_inline_ask(%__MODULE__{} = state, ask),
+  def activate_inline_ask(%__MODULE__{} = state, %InlineAsk{} = ask),
     do: %{state | agent_surfaces: AgentSurfaces.activate_ask(state.agent_surfaces, ask)}
 
   @doc "Replaces an inline ask after a leaf transition."
   @spec replace_inline_ask(t(), InlineAsk.t()) :: t()
-  def replace_inline_ask(%__MODULE__{} = state, ask),
+  def replace_inline_ask(%__MODULE__{} = state, %InlineAsk{} = ask),
     do: %{state | agent_surfaces: AgentSurfaces.replace_ask(state.agent_surfaces, ask)}
 
   @doc "Cancels an inline ask and returns its session pid."
@@ -481,12 +485,12 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Activates or replaces an inline edit."
   @spec activate_inline_edit(t(), InlineEdit.t()) :: t()
-  def activate_inline_edit(%__MODULE__{} = state, edit),
+  def activate_inline_edit(%__MODULE__{} = state, %InlineEdit{} = edit),
     do: %{state | agent_surfaces: AgentSurfaces.activate_edit(state.agent_surfaces, edit)}
 
   @doc "Replaces an inline edit after a leaf transition."
   @spec replace_inline_edit(t(), InlineEdit.t()) :: t()
-  def replace_inline_edit(%__MODULE__{} = state, edit),
+  def replace_inline_edit(%__MODULE__{} = state, %InlineEdit{} = edit),
     do: %{state | agent_surfaces: AgentSurfaces.replace_edit(state.agent_surfaces, edit)}
 
   @doc "Cancels an inline edit and returns its session pid."
@@ -514,8 +518,9 @@ defmodule MingaEditor.Shell.Traditional.State do
 
   @doc "Replaces tool-prompt decisions and pending queue atomically."
   @spec replace_tool_prompts(t(), [atom()], MapSet.t(atom())) :: t()
-  def replace_tool_prompts(%__MODULE__{} = state, queue, declined),
-    do: %{state | tool_prompts: ToolPrompts.replace(state.tool_prompts, queue, declined)}
+  def replace_tool_prompts(%__MODULE__{} = state, queue, %MapSet{} = declined)
+      when is_list(queue),
+      do: %{state | tool_prompts: ToolPrompts.replace(state.tool_prompts, queue, declined)}
 
   @doc "Advances to the next missing-tool prompt."
   @spec advance_tool_prompt(t()) :: t()

--- a/lib/minga_editor/shell/traditional/tool_prompt_workflow.ex
+++ b/lib/minga_editor/shell/traditional/tool_prompt_workflow.ex
@@ -37,7 +37,7 @@ defmodule MingaEditor.Shell.Traditional.ToolPromptWorkflow do
   @doc "Controls whether missing-tool prompts are suppressed."
   @spec suppress(state(), boolean()) :: state()
   def suppress(%EditorState{} = state, suppressed?) when is_boolean(suppressed?),
-    do: update(state, &TraditionalState.set_suppress_tool_prompts(&1, suppressed?))
+    do: update(state, &TraditionalState.install_tool_prompt_suppression(&1, suppressed?))
 
   @doc "Queues a missing tool once."
   @spec enqueue(state(), atom()) :: state()

--- a/lib/minga_editor/shell/traditional/tool_prompts.ex
+++ b/lib/minga_editor/shell/traditional/tool_prompts.ex
@@ -41,7 +41,9 @@ defmodule MingaEditor.Shell.Traditional.ToolPrompts do
   def enqueue(%__MODULE__{} = prompts, tool_name) when is_atom(tool_name) do
     if decided?(prompts, tool_name),
       do: prompts,
-      else: %{prompts | queue: List.insert_at(prompts.queue, -1, tool_name)}
+      # Small human-facing prompt queues preserve order directly.
+      # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
+      else: %{prompts | queue: prompts.queue ++ [tool_name]}
   end
 
   @doc "Replaces prompt decisions and queue atomically."

--- a/lib/minga_editor/shell/traditional/workflow.ex
+++ b/lib/minga_editor/shell/traditional/workflow.ex
@@ -50,7 +50,7 @@ defmodule MingaEditor.Shell.Traditional.Workflow do
                 tab_bar
             end
 
-          TraditionalState.set_tab_bar(shell_state, tab_bar)
+          TraditionalState.install_tab_bar(shell_state, tab_bar)
 
         _ ->
           shell_state

--- a/lib/minga_editor/shell/traditional/yank_flash.ex
+++ b/lib/minga_editor/shell/traditional/yank_flash.ex
@@ -42,7 +42,16 @@ defmodule MingaEditor.Shell.Traditional.YankFlash do
 
   @doc "Replaces the active yank flash and advances its monotonic generation."
   @spec replace(t(), pid(), position(), position(), range_type()) :: t()
-  def replace(%__MODULE__{} = flash, buf, start_pos, end_pos, range_type) do
+  def replace(
+        %__MODULE__{} = flash,
+        buf,
+        {start_line, start_col} = start_pos,
+        {end_line, end_col} = end_pos,
+        range_type
+      )
+      when is_pid(buf) and is_integer(start_line) and start_line >= 0 and is_integer(start_col) and
+             start_col >= 0 and is_integer(end_line) and end_line >= 0 and is_integer(end_col) and
+             end_col >= 0 and range_type in [:charwise, :linewise] do
     %__MODULE__{
       generation: flash.generation + 1,
       buf: buf,

--- a/lib/minga_editor/shell/workflow.ex
+++ b/lib/minga_editor/shell/workflow.ex
@@ -139,7 +139,7 @@ defmodule MingaEditor.Shell.Workflow do
           false
       end
 
-    TraditionalState.set_suppress_tool_prompts(%TraditionalState{}, suppressed?)
+    TraditionalState.install_tool_prompt_suppression(%TraditionalState{}, suppressed?)
   end
 
   defp initialize_shell_state(module, _previous_state), do: module.init([])

--- a/lib/minga_editor/signature_help.ex
+++ b/lib/minga_editor/signature_help.ex
@@ -56,11 +56,15 @@ defmodule MingaEditor.SignatureHelp do
 
   @doc "Replaces any prior signature-help value with a fresh response value."
   @spec replace(t() | nil, t()) :: t()
-  def replace(_current, %__MODULE__{} = signature_help), do: signature_help
+  def replace(nil, %__MODULE__{} = signature_help), do: signature_help
+
+  def replace(%__MODULE__{}, %__MODULE__{} = signature_help),
+    do: signature_help
 
   @doc "Dismisses signature help."
   @spec dismiss(t() | nil) :: nil
-  def dismiss(_signature_help), do: nil
+  def dismiss(nil), do: nil
+  def dismiss(%__MODULE__{}), do: nil
 
   @doc "Cycles to the next signature overload."
   @spec next_signature(t()) :: t()

--- a/lib/minga_editor/startup.ex
+++ b/lib/minga_editor/startup.ex
@@ -221,7 +221,7 @@ defmodule MingaEditor.Startup do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             initial_tab_bar(active_buf, keymap_scope, project_root)
           )
@@ -251,7 +251,7 @@ defmodule MingaEditor.Startup do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -662,7 +662,7 @@ defmodule MingaEditor.Startup do
 
   @spec init_shell_state(module(), keyword()) :: term()
   defp init_shell_state(MingaEditor.Shell.Traditional, opts) do
-    MingaEditor.Shell.Traditional.State.set_suppress_tool_prompts(
+    MingaEditor.Shell.Traditional.State.install_tool_prompt_suppression(
       %MingaEditor.Shell.Traditional.State{},
       Keyword.get(opts, :suppress_tool_prompts, false)
     )

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -299,9 +299,9 @@ defmodule MingaEditor.State do
           | shell_runtime:
               ShellRuntime.install_traditional_state(
                 state.shell_runtime,
-                ShellState.set_tab_bar(
-                  ShellRuntime.state(state.shell_runtime),
-                  TabBar.drop_feature_state_source(tb, source)
+                ShellState.install_tab_bar(
+                  MingaEditor.Shell.Runtime.state(state.shell_runtime),
+                  MingaEditor.State.TabBar.drop_feature_state_source(tb, source)
                 )
               )
         }
@@ -324,9 +324,9 @@ defmodule MingaEditor.State do
           | shell_runtime:
               ShellRuntime.install_traditional_state(
                 state.shell_runtime,
-                ShellState.set_tab_bar(
-                  ShellRuntime.state(state.shell_runtime),
-                  TabBar.drop_extension_feature_state_sources(tb)
+                ShellState.install_tab_bar(
+                  MingaEditor.Shell.Runtime.state(state.shell_runtime),
+                  MingaEditor.State.TabBar.drop_extension_feature_state_sources(tb)
                 )
               )
         }
@@ -479,9 +479,9 @@ defmodule MingaEditor.State do
           | shell_runtime:
               ShellRuntime.install_traditional_state(
                 state.shell_runtime,
-                ShellState.set_tab_bar(
-                  ShellRuntime.state(state.shell_runtime),
-                  TabBar.scrub_dead_buffer(tb, pid)
+                ShellState.install_tab_bar(
+                  MingaEditor.Shell.Runtime.state(state.shell_runtime),
+                  MingaEditor.State.TabBar.scrub_dead_buffer(tb, pid)
                 )
               )
         }
@@ -643,8 +643,8 @@ defmodule MingaEditor.State do
           | shell_runtime:
               ShellRuntime.install_traditional_state(
                 state.shell_runtime,
-                ShellState.set_tab_bar(
-                  ShellRuntime.state(state.shell_runtime),
+                ShellState.install_tab_bar(
+                  MingaEditor.Shell.Runtime.state(state.shell_runtime),
                   rebind_tabs_to_file_ref(tab_bar, tabs, file_ref)
                 )
               )
@@ -822,9 +822,9 @@ defmodule MingaEditor.State do
       | shell_runtime:
           ShellRuntime.install_traditional_state(
             state.shell_runtime,
-            ShellState.set_tab_bar(
-              ShellRuntime.state(state.shell_runtime),
-              TabBar.remove_file_tabs(tb)
+            ShellState.install_tab_bar(
+              MingaEditor.Shell.Runtime.state(state.shell_runtime),
+              MingaEditor.State.TabBar.remove_file_tabs(tb)
             )
           )
     }
@@ -886,9 +886,9 @@ defmodule MingaEditor.State do
                 | shell_runtime:
                     ShellRuntime.install_traditional_state(
                       state.shell_runtime,
-                      ShellState.set_tab_bar(
-                        ShellRuntime.state(state.shell_runtime),
-                        TabBar.update_context(tb, id, synthesized)
+                      ShellState.install_tab_bar(
+                        MingaEditor.Shell.Runtime.state(state.shell_runtime),
+                        MingaEditor.State.TabBar.update_context(tb, id, synthesized)
                       )
                     )
               }
@@ -1121,7 +1121,8 @@ defmodule MingaEditor.State do
 
   @spec install_tab_bar(t(), TabBar.t()) :: t()
   defp install_tab_bar(%__MODULE__{} = state, %TabBar{} = tab_bar) do
-    shell_state = ShellState.set_tab_bar(ShellRuntime.state(state.shell_runtime), tab_bar)
+    shell_state =
+      ShellState.install_tab_bar(MingaEditor.Shell.Runtime.state(state.shell_runtime), tab_bar)
 
     %{
       state
@@ -1251,7 +1252,10 @@ defmodule MingaEditor.State do
           | shell_runtime:
               ShellRuntime.install_traditional_state(
                 state.shell_runtime,
-                ShellState.set_tab_bar(ShellRuntime.state(state.shell_runtime), tb)
+                ShellState.install_tab_bar(
+                  MingaEditor.Shell.Runtime.state(state.shell_runtime),
+                  tb
+                )
               )
         }
 

--- a/lib/minga_editor/state/inline_edit.ex
+++ b/lib/minga_editor/state/inline_edit.ex
@@ -135,9 +135,9 @@ defmodule MingaEditor.State.InlineEdit do
       when is_binary(delta),
       do: %{edit | proposed_rewrite: proposed <> delta, proposal_source: :stream}
 
-  @doc "Replaces the proposed replacement text from the constrained rewrite tool."
-  @spec set_proposal(t(), String.t()) :: t()
-  def set_proposal(%__MODULE__{} = edit, proposed) when is_binary(proposed),
+  @doc "Installs proposed replacement text from the constrained rewrite tool."
+  @spec install_proposal(t(), String.t()) :: t()
+  def install_proposal(%__MODULE__{} = edit, proposed) when is_binary(proposed),
     do: %{edit | proposed_rewrite: proposed, proposal_source: :tool}
 
   @doc "Marks the edit as proposed."

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -2,7 +2,7 @@ defmodule MingaEditor.State.ModalOverlay do
   @moduledoc """
   Pure tagged-union lifecycle owner for exclusive input-capturing modals.
 
-  Conflict modals are sticky under `open/3`; `transition/3` is unconditional.
+  Conflict modals are sticky under `open/2`; `transition/2` is unconditional.
   Completion trigger bookkeeping and stale-tab dismissal receive the required
   active-tab context as values rather than reaching into Editor state.
   """
@@ -14,21 +14,16 @@ defmodule MingaEditor.State.ModalOverlay do
   alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
   alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
   alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
+  alias MingaEditor.State.Tab
 
   @type variant :: :picker | :prompt | :completion | :command_completion | :conflict
-  @type payload ::
-          PickerPayload.t()
-          | PromptPayload.t()
-          | CompletionPayload.t()
-          | CommandCompletionPayload.t()
-          | ConflictPayload.t()
-  @type t ::
-          :none
-          | {:picker, PickerPayload.t()}
+  @type active ::
+          {:picker, PickerPayload.t()}
           | {:prompt, PromptPayload.t()}
           | {:completion, CompletionPayload.t()}
           | {:command_completion, CommandCompletionPayload.t()}
           | {:conflict, ConflictPayload.t()}
+  @type t :: :none | active()
 
   @variants [:picker, :prompt, :completion, :command_completion, :conflict]
 
@@ -39,48 +34,89 @@ defmodule MingaEditor.State.ModalOverlay do
   @doc "Returns the active tag, or `:none`."
   @spec tag(t()) :: :none | variant()
   def tag(:none), do: :none
-  def tag({tag, _payload}) when tag in @variants, do: tag
+  def tag({:picker, %PickerPayload{}}), do: :picker
+  def tag({:prompt, %PromptPayload{}}), do: :prompt
+  def tag({:completion, %CompletionPayload{}}), do: :completion
+  def tag({:command_completion, %CommandCompletionPayload{}}), do: :command_completion
+  def tag({:conflict, %ConflictPayload{}}), do: :conflict
 
   @doc "Returns whether a modal is active."
   @spec active?(t()) :: boolean()
-  def active?(:none), do: false
-  def active?({tag, _payload}) when tag in @variants, do: true
+  def active?(modal), do: tag(modal) != :none
 
   @doc "Returns whether the modal has the expected tag."
   @spec match(t(), :none | variant()) :: boolean()
-  def match(:none, :none), do: true
-  def match({tag, _payload}, tag) when tag in @variants, do: true
-  def match(_modal, _tag), do: false
+  def match(modal, expected) when expected == :none or expected in @variants,
+    do: tag(modal) == expected
 
-  @doc "Opens a modal, preserving an active conflict against other variants."
-  @spec open(t(), variant(), payload()) :: t()
-  def open({:conflict, _payload} = modal, variant, _next) when variant != :conflict, do: modal
-  def open(_modal, variant, payload) when variant in @variants, do: {variant, payload}
+  @doc "Opens an exact modal value, preserving an active conflict against other variants."
+  @spec open(t(), active()) :: t()
+  def open({:conflict, %ConflictPayload{}} = modal, {:picker, %PickerPayload{}}), do: modal
+  def open({:conflict, %ConflictPayload{}} = modal, {:prompt, %PromptPayload{}}), do: modal
 
-  @doc "Transitions to a modal unconditionally, bypassing conflict stickiness."
-  @spec transition(t(), variant(), payload()) :: t()
-  def transition(_modal, variant, payload) when variant in @variants, do: {variant, payload}
+  def open({:conflict, %ConflictPayload{}} = modal, {:completion, %CompletionPayload{}}),
+    do: modal
+
+  def open(
+        {:conflict, %ConflictPayload{}} = modal,
+        {:command_completion, %CommandCompletionPayload{}}
+      ),
+      do: modal
+
+  def open(_modal, {:picker, %PickerPayload{}} = next), do: next
+  def open(_modal, {:prompt, %PromptPayload{}} = next), do: next
+  def open(_modal, {:completion, %CompletionPayload{}} = next), do: next
+  def open(_modal, {:command_completion, %CommandCompletionPayload{}} = next), do: next
+  def open(_modal, {:conflict, %ConflictPayload{}} = next), do: next
+
+  @doc "Transitions to an exact modal value unconditionally, bypassing conflict stickiness."
+  @spec transition(t(), active()) :: active()
+  def transition(_modal, {:picker, %PickerPayload{}} = next), do: next
+  def transition(_modal, {:prompt, %PromptPayload{}} = next), do: next
+  def transition(_modal, {:completion, %CompletionPayload{}} = next), do: next
+  def transition(_modal, {:command_completion, %CommandCompletionPayload{}} = next), do: next
+  def transition(_modal, {:conflict, %ConflictPayload{}} = next), do: next
 
   @doc "Closes a completed modal."
-  @spec close(t()) :: t()
+  @spec close(t()) :: :none
   def close(:none), do: :none
-  def close({_variant, _payload}), do: :none
+  def close({:picker, %PickerPayload{}}), do: :none
+  def close({:prompt, %PromptPayload{}}), do: :none
+  def close({:completion, %CompletionPayload{}}), do: :none
+  def close({:command_completion, %CommandCompletionPayload{}}), do: :none
+  def close({:conflict, %ConflictPayload{}}), do: :none
 
   @doc "Dismisses a canceled modal."
-  @spec dismiss(t()) :: t()
-  def dismiss(modal), do: close(modal)
+  @spec dismiss(t()) :: :none
+  def dismiss(:none), do: :none
+  def dismiss({:picker, %PickerPayload{}}), do: :none
+  def dismiss({:prompt, %PromptPayload{}}), do: :none
+  def dismiss({:completion, %CompletionPayload{}}), do: :none
+  def dismiss({:command_completion, %CommandCompletionPayload{}}), do: :none
+  def dismiss({:conflict, %ConflictPayload{}}), do: :none
 
   @doc "Returns the inner completion value when completion is active."
   @spec completion(t()) :: Completion.t() | nil
   def completion({:completion, %CompletionPayload{completion: completion}}), do: completion
-  def completion(_modal), do: nil
+  def completion(:none), do: nil
+  def completion({:picker, %PickerPayload{}}), do: nil
+  def completion({:prompt, %PromptPayload{}}), do: nil
+  def completion({:command_completion, %CommandCompletionPayload{}}), do: nil
+  def completion({:conflict, %ConflictPayload{}}), do: nil
 
   @doc "Returns the active completion trigger or a fresh trigger."
   @spec completion_trigger(t()) :: CompletionTrigger.t()
   def completion_trigger({:completion, %CompletionPayload{trigger: trigger}}),
     do: trigger || CompletionTrigger.new()
 
-  def completion_trigger(_modal), do: CompletionTrigger.new()
+  def completion_trigger(:none), do: CompletionTrigger.new()
+  def completion_trigger({:picker, %PickerPayload{}}), do: CompletionTrigger.new()
+  def completion_trigger({:prompt, %PromptPayload{}}), do: CompletionTrigger.new()
+
+  def completion_trigger({:command_completion, %CommandCompletionPayload{}}),
+    do: CompletionTrigger.new()
+
+  def completion_trigger({:conflict, %ConflictPayload{}}), do: CompletionTrigger.new()
 
   @doc "Updates the active inner completion value."
   @spec update_completion(t(), (Completion.t() -> Completion.t())) :: t()
@@ -89,19 +125,46 @@ defmodule MingaEditor.State.ModalOverlay do
     {:completion, CompletionPayload.put_completion(payload, fun.(completion))}
   end
 
-  def update_completion(modal, _fun), do: modal
+  def update_completion(:none, fun) when is_function(fun, 1), do: :none
+
+  def update_completion({:picker, %PickerPayload{}} = modal, fun) when is_function(fun, 1),
+    do: modal
+
+  def update_completion({:prompt, %PromptPayload{}} = modal, fun) when is_function(fun, 1),
+    do: modal
+
+  def update_completion({:command_completion, %CommandCompletionPayload{}} = modal, fun)
+      when is_function(fun, 1),
+      do: modal
+
+  def update_completion({:conflict, %ConflictPayload{}} = modal, fun) when is_function(fun, 1),
+    do: modal
 
   @doc "Records completion-trigger lifecycle using explicit active-tab context."
-  @spec put_completion_trigger(t(), CompletionTrigger.t(), term() | nil) :: t()
+  @spec put_completion_trigger(t(), CompletionTrigger.t(), Tab.id() | nil) :: t()
   def put_completion_trigger(
-        {:completion, %CompletionPayload{} = payload},
-        trigger,
-        _active_tab_id
-      ) do
-    {:completion, CompletionPayload.put_trigger(payload, trigger)}
-  end
+        modal,
+        %{
+          pending_ref: _pending_ref,
+          pending_refs: %MapSet{},
+          debounce_timer: _timer,
+          trigger_position: _position,
+          gen: _generation
+        } = trigger,
+        active_tab_id
+      )
+      when (is_integer(active_tab_id) and active_tab_id > 0) or is_nil(active_tab_id),
+      do: do_put_completion_trigger(modal, trigger, active_tab_id)
 
-  def put_completion_trigger(:none, trigger, active_tab_id) do
+  @spec do_put_completion_trigger(t(), CompletionTrigger.t(), Tab.id() | nil) :: t()
+  defp do_put_completion_trigger(
+         {:completion, %CompletionPayload{} = payload},
+         trigger,
+         _active_tab_id
+       ),
+       do: {:completion, CompletionPayload.put_trigger(payload, trigger)}
+
+  defp do_put_completion_trigger(:none, trigger, active_tab_id) do
     if trigger_active?(trigger) do
       {:completion, CompletionPayload.new(active_tab_id, trigger: trigger)}
     else
@@ -109,27 +172,66 @@ defmodule MingaEditor.State.ModalOverlay do
     end
   end
 
-  def put_completion_trigger(modal, _trigger, _active_tab_id), do: modal
+  defp do_put_completion_trigger({:picker, %PickerPayload{}} = modal, _trigger, _active_tab_id),
+    do: modal
+
+  defp do_put_completion_trigger({:prompt, %PromptPayload{}} = modal, _trigger, _active_tab_id),
+    do: modal
+
+  defp do_put_completion_trigger(
+         {:command_completion, %CommandCompletionPayload{}} = modal,
+         _trigger,
+         _active_tab_id
+       ),
+       do: modal
+
+  defp do_put_completion_trigger(
+         {:conflict, %ConflictPayload{}} = modal,
+         _trigger,
+         _active_tab_id
+       ),
+       do: modal
 
   @doc "Returns the active command-completion payload."
   @spec command_completion(t()) :: CommandCompletionPayload.t() | nil
   def command_completion({:command_completion, %CommandCompletionPayload{} = payload}),
     do: payload
 
-  def command_completion(_modal), do: nil
+  def command_completion(:none), do: nil
+  def command_completion({:picker, %PickerPayload{}}), do: nil
+  def command_completion({:prompt, %PromptPayload{}}), do: nil
+  def command_completion({:completion, %CompletionPayload{}}), do: nil
+  def command_completion({:conflict, %ConflictPayload{}}), do: nil
 
   @doc "Dismisses completion whose owner does not match the active tab id."
-  @spec dismiss_if_stale(t(), term() | nil) :: t()
-  def dismiss_if_stale({:completion, %CompletionPayload{owner: owner}} = modal, active_tab_id) do
+  @spec dismiss_if_stale(t(), Tab.id() | nil) :: t()
+  def dismiss_if_stale({:completion, %CompletionPayload{owner: owner}} = modal, active_tab_id)
+      when (is_integer(active_tab_id) and active_tab_id > 0) or is_nil(active_tab_id) do
     if owner == active_tab_id, do: modal, else: :none
   end
 
-  def dismiss_if_stale(modal, _active_tab_id), do: modal
+  def dismiss_if_stale(:none, active_tab_id)
+      when (is_integer(active_tab_id) and active_tab_id > 0) or is_nil(active_tab_id),
+      do: :none
+
+  def dismiss_if_stale({:picker, %PickerPayload{}} = modal, active_tab_id)
+      when (is_integer(active_tab_id) and active_tab_id > 0) or is_nil(active_tab_id),
+      do: modal
+
+  def dismiss_if_stale({:prompt, %PromptPayload{}} = modal, active_tab_id)
+      when (is_integer(active_tab_id) and active_tab_id > 0) or is_nil(active_tab_id),
+      do: modal
+
+  def dismiss_if_stale({:command_completion, %CommandCompletionPayload{}} = modal, active_tab_id)
+      when (is_integer(active_tab_id) and active_tab_id > 0) or is_nil(active_tab_id),
+      do: modal
+
+  def dismiss_if_stale({:conflict, %ConflictPayload{}} = modal, active_tab_id)
+      when (is_integer(active_tab_id) and active_tab_id > 0) or is_nil(active_tab_id),
+      do: modal
 
   @spec trigger_active?(CompletionTrigger.t()) :: boolean()
   defp trigger_active?(%{debounce_timer: timer, pending_ref: ref, pending_refs: refs}) do
     timer != nil or ref != nil or MapSet.size(refs) > 0
   end
-
-  defp trigger_active?(_trigger), do: false
 end

--- a/lib/minga_editor/state/modal_overlay/completion.ex
+++ b/lib/minga_editor/state/modal_overlay/completion.ex
@@ -19,14 +19,14 @@ defmodule MingaEditor.State.ModalOverlay.Completion do
 
   alias Minga.Editing.Completion
   alias MingaEditor.CompletionTrigger
+  alias MingaEditor.State.Tab
 
   @typedoc """
   Identifier of the tab that triggered completion.
 
-  Tab IDs are the keys of `MingaEditor.State.TabBar`'s tab map. We accept
-  any term so callers do not need to depend on TabBar's id type directly.
+  Tab IDs are the positive integer keys of `MingaEditor.State.TabBar`'s tab map. `nil` is valid while completion-trigger work starts before a tab is available.
   """
-  @type owner :: term()
+  @type owner :: Tab.id() | nil
 
   @typedoc """
   The user-visible completion menu, or `nil` while a request is pending.
@@ -61,7 +61,7 @@ defmodule MingaEditor.State.ModalOverlay.Completion do
   an LSP request is in flight.
   """
   @spec new(owner(), keyword()) :: t()
-  def new(owner, opts \\ []) do
+  def new(owner, opts \\ []) when (is_integer(owner) and owner > 0) or is_nil(owner) do
     %__MODULE__{
       completion: Keyword.get(opts, :completion),
       trigger: Keyword.get(opts, :trigger, CompletionTrigger.new()),

--- a/lib/minga_editor/ui/picker/pending_reviews_source.ex
+++ b/lib/minga_editor/ui/picker/pending_reviews_source.ex
@@ -72,7 +72,7 @@ defmodule MingaEditor.UI.Picker.PendingReviewsSource do
 
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tab_bar
             )

--- a/lib/minga_editor/ui/picker/workspace_icon_source.ex
+++ b/lib/minga_editor/ui/picker/workspace_icon_source.ex
@@ -102,7 +102,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceIconSource do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )

--- a/lib/minga_editor/ui/picker/workspace_target_source.ex
+++ b/lib/minga_editor/ui/picker/workspace_target_source.ex
@@ -166,7 +166,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSource do
 
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -198,7 +198,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSource do
         refreshed_state =
           then(state, fn root ->
             shell_state =
-              MingaEditor.Shell.Traditional.State.set_tab_bar(
+              MingaEditor.Shell.Traditional.State.install_tab_bar(
                 MingaEditor.Shell.Runtime.state(root.shell_runtime),
                 refreshed_tab_bar
               )
@@ -260,7 +260,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSource do
 
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -303,7 +303,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSource do
       |> do_move(
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tab_bar
             )
@@ -346,7 +346,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSource do
 
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )

--- a/lib/minga_editor/ui/prompt/workspace_rename.ex
+++ b/lib/minga_editor/ui/prompt/workspace_rename.ex
@@ -31,7 +31,7 @@ defmodule MingaEditor.UI.Prompt.WorkspaceRename do
 
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )

--- a/test/minga_editor/agent/compaction_test.exs
+++ b/test/minga_editor/agent/compaction_test.exs
@@ -74,7 +74,7 @@ defmodule MingaEditor.Agent.CompactionTest do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -130,7 +130,7 @@ defmodule MingaEditor.Agent.CompactionTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          TraditionalState.set_tab_bar(%TraditionalState{}, tab_bar)
+          TraditionalState.install_tab_bar(%TraditionalState{}, tab_bar)
         )
     }
   end

--- a/test/minga_editor/agent/concurrent_sessions_test.exs
+++ b/test/minga_editor/agent/concurrent_sessions_test.exs
@@ -40,7 +40,7 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
       shell_runtime:
         Runtime.new(
           Registry.get(:traditional),
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Traditional.State.replace_agent(
               %MingaEditor.Shell.Traditional.State{},
               %AgentState{}
@@ -132,7 +132,7 @@ defmodule MingaEditor.Agent.ConcurrentSessionsTest do
       switched =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               %{
                 state.shell_runtime.state.tab_bar

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -87,7 +87,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       ]
 
       shell_state =
-        TraditionalState.set_tab_bar(
+        TraditionalState.install_tab_bar(
           TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
           tab_bar(tabs, 1)
         )
@@ -186,7 +186,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            TraditionalState.set_tab_bar(
+            TraditionalState.install_tab_bar(
               TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
               tab_bar
             )
@@ -306,7 +306,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            TraditionalState.set_tab_bar(
+            TraditionalState.install_tab_bar(
               TraditionalState.replace_agent(%TraditionalState{}, agent),
               tab_bar
             )
@@ -352,7 +352,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            TraditionalState.set_tab_bar(
+            TraditionalState.install_tab_bar(
               TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
               tb
             )
@@ -406,7 +406,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            TraditionalState.set_tab_bar(
+            TraditionalState.install_tab_bar(
               TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
               tb
             )
@@ -456,7 +456,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            TraditionalState.set_tab_bar(
+            TraditionalState.install_tab_bar(
               TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
               tb
             )
@@ -492,7 +492,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         shell_runtime:
           Runtime.new(
             Runtime.default_entry(),
-            TraditionalState.set_tab_bar(
+            TraditionalState.install_tab_bar(
               TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
               tb
             )

--- a/test/minga_editor/agent/ingest_approval_regression_test.exs
+++ b/test/minga_editor/agent/ingest_approval_regression_test.exs
@@ -178,7 +178,7 @@ defmodule MingaEditor.Agent.IngestApprovalRegressionTest do
           Runtime.default_entry(),
           %TraditionalState{}
           |> TraditionalState.replace_agent(agent)
-          |> TraditionalState.set_tab_bar(tb)
+          |> TraditionalState.install_tab_bar(tb)
         )
     }
   end

--- a/test/minga_editor/agent/slash_command_test.exs
+++ b/test/minga_editor/agent/slash_command_test.exs
@@ -233,7 +233,7 @@ defmodule MingaEditor.Agent.SlashCommandTest do
       }
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )

--- a/test/minga_editor/commands/agent_commands_test.exs
+++ b/test/minga_editor/commands/agent_commands_test.exs
@@ -117,7 +117,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Traditional.State.replace_agent(
               %MingaEditor.Shell.Traditional.State{},
               agent
@@ -149,7 +149,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tab_bar
         )
@@ -168,7 +168,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tab_bar
         )
@@ -1059,7 +1059,7 @@ defmodule MingaEditor.Commands.AgentCommandsTest do
         new_state
         |> then(fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tab_bar
             )

--- a/test/minga_editor/commands/agent_session_down_test.exs
+++ b/test/minga_editor/commands/agent_session_down_test.exs
@@ -32,7 +32,7 @@ defmodule MingaEditor.Commands.AgentSessionDownTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tab_bar
         )

--- a/test/minga_editor/commands/agent_split_test.exs
+++ b/test/minga_editor/commands/agent_split_test.exs
@@ -79,7 +79,7 @@ defmodule MingaEditor.Commands.AgentSplitTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Traditional.State.replace_agent(
               %MingaEditor.Shell.Traditional.State{},
               agent

--- a/test/minga_editor/commands/agent_split_toggle_test.exs
+++ b/test/minga_editor/commands/agent_split_toggle_test.exs
@@ -80,7 +80,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          TraditionalState.set_tab_bar(
+          TraditionalState.install_tab_bar(
             TraditionalState.replace_agent(
               %MingaEditor.Shell.Traditional.State{},
               agent
@@ -119,7 +119,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
       state =
         then(state, fn root ->
           shell_state =
-            TraditionalState.set_tab_bar(
+            TraditionalState.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tb
             )
@@ -162,7 +162,7 @@ defmodule MingaEditor.Commands.AgentSplitToggleTest do
 
       then(state, fn root ->
         shell_state =
-          TraditionalState.set_tab_bar(
+          TraditionalState.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )

--- a/test/minga_editor/commands/buffer_management_frontend_test.exs
+++ b/test/minga_editor/commands/buffer_management_frontend_test.exs
@@ -41,7 +41,7 @@ defmodule MingaEditor.Commands.BufferManagement.FrontendTest do
       state =
         then(base_state(@gui), fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_bottom_panel(
+            MingaEditor.Shell.Traditional.State.install_bottom_panel(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               %BottomPanel{
                 dismissed: true

--- a/test/minga_editor/commands/file_tree_neo_bindings_test.exs
+++ b/test/minga_editor/commands/file_tree_neo_bindings_test.exs
@@ -170,7 +170,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
         |> build_state(Buffers.add(%Buffers{}, active_buffer))
         |> then(fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tab_bar
             )
@@ -484,7 +484,7 @@ defmodule MingaEditor.Commands.FileTreeNeoBindingsTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tab_bar
         )

--- a/test/minga_editor/commands/inline_ask_test.exs
+++ b/test/minga_editor/commands/inline_ask_test.exs
@@ -241,7 +241,7 @@ defmodule MingaEditor.Commands.InlineAskTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )

--- a/test/minga_editor/commands/ui_frontend_test.exs
+++ b/test/minga_editor/commands/ui_frontend_test.exs
@@ -59,7 +59,7 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
         state =
           then(base_state(unquote(Macro.escape(caps))), fn root ->
             shell_state =
-              MingaEditor.Shell.Traditional.State.set_bottom_panel(
+              MingaEditor.Shell.Traditional.State.install_bottom_panel(
                 MingaEditor.Shell.Runtime.state(root.shell_runtime),
                 %BottomPanel{visible: true}
               )
@@ -82,7 +82,7 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
         state =
           then(base_state(unquote(Macro.escape(caps))), fn root ->
             shell_state =
-              MingaEditor.Shell.Traditional.State.set_bottom_panel(
+              MingaEditor.Shell.Traditional.State.install_bottom_panel(
                 MingaEditor.Shell.Runtime.state(root.shell_runtime),
                 %BottomPanel{tabs: [:messages, :diagnostics], active_tab: :messages}
               )
@@ -105,7 +105,7 @@ defmodule MingaEditor.Commands.UI.FrontendTest do
         state =
           then(base_state(unquote(Macro.escape(caps))), fn root ->
             shell_state =
-              MingaEditor.Shell.Traditional.State.set_bottom_panel(
+              MingaEditor.Shell.Traditional.State.install_bottom_panel(
                 MingaEditor.Shell.Runtime.state(root.shell_runtime),
                 %BottomPanel{tabs: [:messages, :diagnostics], active_tab: :diagnostics}
               )

--- a/test/minga_editor/commands/workspace_test.exs
+++ b/test/minga_editor/commands/workspace_test.exs
@@ -105,7 +105,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           TabBar.update_workspace(
             tb,
@@ -128,7 +128,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           TabBar.update_workspace(tb, workspace_id, &WorkspaceModel.set_session(&1, session_pid))
         )
@@ -147,7 +147,7 @@ defmodule MingaEditor.Commands.WorkspaceTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           TabBar.update_workspace(tb, workspace_id, &WorkspaceModel.set_review(&1, review))
         )

--- a/test/minga_editor/completion_async_test.exs
+++ b/test/minga_editor/completion_async_test.exs
@@ -47,7 +47,7 @@ defmodule MingaEditor.CompletionAsyncTest do
     owner = EditorState.tab_bar(state).active_id
     trigger = %{CompletionTrigger.new() | gen: gen}
     payload = CompletionPayload.new(owner, completion: completion, trigger: trigger)
-    ModalWorkflow.open(state, :completion, payload)
+    ModalWorkflow.open(state, {:completion, payload})
   end
 
   defp labels(%Completion{filtered: filtered}), do: Enum.map(filtered, & &1.label)
@@ -204,7 +204,7 @@ defmodule MingaEditor.CompletionAsyncTest do
         }
 
         payload = CompletionPayload.new(owner, trigger: trigger)
-        ModalWorkflow.open(state, :completion, payload)
+        ModalWorkflow.open(state, {:completion, payload})
       end)
     end
 

--- a/test/minga_editor/completion_doc_preview_test.exs
+++ b/test/minga_editor/completion_doc_preview_test.exs
@@ -21,7 +21,7 @@ defmodule MingaEditor.CompletionDocPreviewTest do
     modal =
       case completion do
         nil -> :none
-        %Completion{} -> {:completion, CompletionPayload.new(:tab1, completion: completion)}
+        %Completion{} -> {:completion, CompletionPayload.new(1, completion: completion)}
       end
 
     %EditorState{

--- a/test/minga_editor/feature_state_cleanup_test.exs
+++ b/test/minga_editor/feature_state_cleanup_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.FeatureStateCleanupTest do
   alias MingaEditor.FeatureState
 
   @source {:extension, :cleanup_sync}
+  @receive_timeout 1_000
 
   test "source cleanup waits for editor feature-state cleanup before returning" do
     pid = start_fake_editor()
@@ -22,7 +23,7 @@ defmodule MingaEditor.FeatureStateCleanupTest do
     try do
       send(pid, {:run_self_cleanup, self(), @source})
 
-      assert_receive {:self_cleanup_result, :ok}
+      assert_receive {:self_cleanup_result, :ok}, @receive_timeout
       refute_receive {:cleanup_finished, @source}
     after
       stop_fake_editor(pid)
@@ -35,7 +36,7 @@ defmodule MingaEditor.FeatureStateCleanupTest do
     try do
       send(pid, {:run_self_cleanup, self(), :config})
 
-      assert_receive {:self_cleanup_result, :ok}
+      assert_receive {:self_cleanup_result, :ok}, @receive_timeout
       refute_receive {:cleanup_finished, :config}
     after
       stop_fake_editor(pid)
@@ -46,7 +47,7 @@ defmodule MingaEditor.FeatureStateCleanupTest do
   defp start_fake_editor do
     test_pid = self()
     pid = spawn_link(fn -> fake_editor_loop(test_pid) end)
-    assert_receive :fake_editor_ready
+    assert_receive :fake_editor_ready, @receive_timeout
     pid
   end
 
@@ -54,7 +55,7 @@ defmodule MingaEditor.FeatureStateCleanupTest do
   defp stop_fake_editor(pid) do
     ref = Process.monitor(pid)
     send(pid, :stop)
-    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}
+    assert_receive {:DOWN, ^ref, :process, ^pid, _reason}, @receive_timeout
     :ok
   end
 

--- a/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
+++ b/test/minga_editor/frontend/emit/gui_chrome_cache_test.exs
@@ -93,7 +93,7 @@ defmodule MingaEditor.Frontend.Emit.AdapterGUIChromeCacheTest do
       state =
         then(gui_state(), fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               TabBar.new(Tab.new_file(1, "test.ex"))
             )
@@ -137,7 +137,7 @@ defmodule MingaEditor.Frontend.Emit.AdapterGUIChromeCacheTest do
       state_with_agents =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tab_bar
             )

--- a/test/minga_editor/frontend/emit_test.exs
+++ b/test/minga_editor/frontend/emit_test.exs
@@ -8,6 +8,7 @@ defmodule MingaEditor.Frontend.EmitTest do
   use ExUnit.Case, async: true
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Editing.Completion
   alias Minga.RenderModel.Cursor
   alias MingaEditor.RenderPipeline.ComposedFrame
   alias MingaEditor.Layout
@@ -22,6 +23,10 @@ defmodule MingaEditor.Frontend.EmitTest do
   alias Minga.RenderModel.Window.Span, as: RenderSpan
   alias Minga.Test.RecordingFrontend
   alias MingaEditor.Renderer.Caches
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Traditional.ModalWorkflow
+  alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
+  alias MingaEditor.State.Windows
   alias MingaEditor.UI.FontRegistry
 
   import MingaEditor.RenderPipeline.TestHelpers
@@ -37,6 +42,26 @@ defmodule MingaEditor.Frontend.EmitTest do
 
     Process.put(:emit_test_frontend, frontend)
     :ok
+  end
+
+  describe "context projection" do
+    test "active completion survives the typed render-input projection" do
+      completion = Completion.new([], {0, 0})
+
+      state =
+        ModalWorkflow.open(
+          emit_state(),
+          {:completion, CompletionPayload.new(1, completion: completion)}
+        )
+
+      assert Context.from_editor_state(state).completion == completion
+
+      windows = Windows.set_active(state.workspace.windows, 999)
+      workspace = SessionState.set_windows(state.workspace, windows)
+      state = %{state | workspace: workspace}
+
+      assert Context.from_editor_state(state).completion == completion
+    end
   end
 
   describe "emit/2 dispatching" do

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -14,6 +14,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
   alias Minga.Git.StatusEntry
   alias Minga.Project.FileRef
   alias Minga.Project.FileTree
+  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Handlers.FileEventHandler
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
@@ -34,13 +35,16 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       state = base_state()
 
       state =
-        SidebarWorkflow.replace_git_status(state, %{
-          repo_state: :normal,
-          branch: "main",
-          ahead: 0,
-          behind: 0,
-          entries: []
-        })
+        SidebarWorkflow.replace_git_status(
+          state,
+          GitStatusPanel.new(%{
+            repo_state: :normal,
+            branch: "main",
+            ahead: 0,
+            behind: 0,
+            entries: []
+          })
+        )
 
       event =
         {:minga_event, :git_status_changed,
@@ -67,13 +71,15 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
     test "does not create tui state during generic panel refresh" do
       state =
         base_state()
-        |> SidebarWorkflow.replace_git_status(%{
-          repo_state: :normal,
-          branch: "main",
-          ahead: 0,
-          behind: 0,
-          entries: []
-        })
+        |> SidebarWorkflow.replace_git_status(
+          GitStatusPanel.new(%{
+            repo_state: :normal,
+            branch: "main",
+            ahead: 0,
+            behind: 0,
+            entries: []
+          })
+        )
 
       event =
         {:minga_event, :git_status_changed,
@@ -323,7 +329,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tab_bar
             )
@@ -426,7 +432,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tab_bar
             )

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -15,6 +15,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Handlers.GuiActionHandler
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Shell.Entry
@@ -99,7 +100,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
       base_state(table)
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -146,7 +147,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
       base_state(table)
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -177,7 +178,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
     assert file_tree_active.workspace.keymap_scope == :file_tree
     assert SidebarWorkflow.active_id(file_tree_active) == "file_tree"
 
-    git_state = SidebarWorkflow.replace_git_status(state, %{entries: []})
+    git_state = SidebarWorkflow.replace_git_status(state, GitStatusPanel.new(%{entries: []}))
 
     git_active =
       GuiActionHandler.dispatch(

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -221,8 +221,8 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       client = start_fake_lsp_client()
       timer = make_ref()
       trigger = %{CompletionTrigger.new() | debounce_timer: timer}
-      payload = CompletionPayload.new(:tab1, trigger: trigger)
-      state = ModalWorkflow.transition(state, :completion, payload)
+      payload = CompletionPayload.new(1, trigger: trigger)
+      state = ModalWorkflow.transition(state, {:completion, payload})
       buffer = state.workspace.buffers.active
 
       {new_state, effects} =
@@ -253,8 +253,8 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       completion = Completion.new(Completion.parse_response(%{"items" => [item]}), {0, 0})
       trigger = %{CompletionTrigger.new() | pending_ref: make_ref(), pending_refs: MapSet.new()}
-      payload = CompletionPayload.new(:tab1, completion: completion, trigger: trigger)
-      state = ModalWorkflow.transition(state, :completion, payload)
+      payload = CompletionPayload.new(1, completion: completion, trigger: trigger)
+      state = ModalWorkflow.transition(state, {:completion, payload})
 
       {new_state, effects} = LspEventHandler.handle(state, {:completion_resolve, 0})
 
@@ -344,11 +344,11 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
     test "delayed completion response does not spawn processing or replay after a shell switch" do
       ref = make_ref()
       trigger = %{CompletionTrigger.new() | pending_ref: ref, pending_refs: MapSet.new([ref])}
-      payload = CompletionPayload.new(:tab1, trigger: trigger)
+      payload = CompletionPayload.new(1, trigger: trigger)
 
       state =
         base_state()
-        |> ModalWorkflow.transition(:completion, payload)
+        |> ModalWorkflow.transition({:completion, payload})
         |> ShellWorkflow.switch(:fake)
 
       foreign_shell_state = Runtime.state(state.shell_runtime)
@@ -376,11 +376,11 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       ref = make_ref()
       item = %{"label" => "resolved", "documentation" => "old", "sortText" => "resolved"}
       completion = Completion.new(Completion.parse_response(%{"items" => [item]}), {0, 0})
-      payload = CompletionPayload.new(:tab1, completion: completion)
+      payload = CompletionPayload.new(1, completion: completion)
 
       state =
         base_state()
-        |> ModalWorkflow.transition(:completion, payload)
+        |> ModalWorkflow.transition({:completion, payload})
         |> put_lsp_pending(ref, :completion_resolve)
         |> ShellWorkflow.switch(:fake)
 
@@ -399,11 +399,11 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
     test "delayed processed completion does not touch or replay a foreign shell" do
       trigger = %{CompletionTrigger.new() | gen: 7}
-      payload = CompletionPayload.new(:tab1, trigger: trigger)
+      payload = CompletionPayload.new(1, trigger: trigger)
 
       state =
         base_state()
-        |> ModalWorkflow.transition(:completion, payload)
+        |> ModalWorkflow.transition({:completion, payload})
         |> ShellWorkflow.switch(:fake)
 
       processed =
@@ -458,8 +458,8 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       state = buffer_state("hello\n")
       ref = make_ref()
       trigger = %{CompletionTrigger.new() | pending_ref: ref, pending_refs: MapSet.new([ref])}
-      payload = CompletionPayload.new(:tab1, trigger: trigger)
-      state = ModalWorkflow.transition(state, :completion, payload)
+      payload = CompletionPayload.new(1, trigger: trigger)
+      state = ModalWorkflow.transition(state, {:completion, payload})
 
       completion_result = %{
         "items" => [

--- a/test/minga_editor/input/agent_mouse_test.exs
+++ b/test/minga_editor/input/agent_mouse_test.exs
@@ -64,7 +64,7 @@ defmodule MingaEditor.Input.AgentMouseTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Traditional.State.replace_agent(
               %MingaEditor.Shell.Traditional.State{},
               agent

--- a/test/minga_editor/input/completion_key_test.exs
+++ b/test/minga_editor/input/completion_key_test.exs
@@ -21,7 +21,7 @@ defmodule MingaEditor.Input.CompletionKeyTest do
 
   defp completion_state do
     completion = Completion.new(sample_items(), {0, 0})
-    payload = CompletionPayload.new(:tab1, completion: completion)
+    payload = CompletionPayload.new(1, completion: completion)
 
     %EditorState{
       frontend: %MingaEditor.State.Frontend{port_manager: nil, backend: :headless},

--- a/test/minga_editor/input/completion_mouse_test.exs
+++ b/test/minga_editor/input/completion_mouse_test.exs
@@ -15,7 +15,7 @@ defmodule MingaEditor.Input.CompletionMouseTest do
   defp completion_state(items, opts \\ []) do
     mode = Keyword.get(opts, :mode, :insert)
     completion = Completion.new(items, max_visible: 10)
-    payload = CompletionPayload.new(:tab1, completion: completion)
+    payload = CompletionPayload.new(1, completion: completion)
 
     %EditorState{
       frontend: %MingaEditor.State.Frontend{port_manager: nil},

--- a/test/minga_editor/input/handler_test.exs
+++ b/test/minga_editor/input/handler_test.exs
@@ -47,7 +47,7 @@ defmodule MingaEditor.Input.HandlerTest do
     test "handles 'r' key during conflict by reloading" do
       state = base_state()
       buf = state.workspace.buffers.active
-      state = ModalWorkflow.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
+      state = ModalWorkflow.open(state, {:conflict, ConflictPayload.new(buf, "/tmp/test.txt")})
 
       assert {:handled, new_state} = ConflictPrompt.handle_key(state, ?r, 0)
       refute ModalOverlay.match(new_state.shell_runtime.state.modal, :conflict)
@@ -59,7 +59,7 @@ defmodule MingaEditor.Input.HandlerTest do
       File.write!(path, "hello\nworld")
       state = base_state(buffer_opts: [file_path: path])
       buf = state.workspace.buffers.active
-      state = ModalWorkflow.open(state, :conflict, ConflictPayload.new(buf, path))
+      state = ModalWorkflow.open(state, {:conflict, ConflictPayload.new(buf, path)})
 
       assert {:handled, new_state} = ConflictPrompt.handle_key(state, ?k, 0)
 
@@ -72,7 +72,7 @@ defmodule MingaEditor.Input.HandlerTest do
     test "swallows unrecognized keys during conflict" do
       state = base_state()
       buf = state.workspace.buffers.active
-      state = ModalWorkflow.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
+      state = ModalWorkflow.open(state, {:conflict, ConflictPayload.new(buf, "/tmp/test.txt")})
 
       assert {:handled, new_state} = ConflictPrompt.handle_key(state, ?x, 0)
       # State unchanged except for swallowing the key

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -53,24 +53,23 @@ defmodule MingaEditor.Input.InterruptTest do
   @spec open_modal_variant(EditorState.t(), ModalOverlay.variant()) :: EditorState.t()
   defp open_modal_variant(state, :picker) do
     picker = MingaEditor.UI.Picker.new([%MingaEditor.UI.Picker.Item{id: "x", label: "x"}])
-    ModalWorkflow.open(state, :picker, PickerPayload.new(%Picker{picker: picker}))
+    ModalWorkflow.open(state, {:picker, PickerPayload.new(%Picker{picker: picker})})
   end
 
   defp open_modal_variant(state, :prompt) do
     prompt = %PromptState{handler: __MODULE__, text: "query", cursor: 5, label: "Find"}
-    ModalWorkflow.open(state, :prompt, PromptPayload.new(prompt))
+    ModalWorkflow.open(state, {:prompt, PromptPayload.new(prompt)})
   end
 
   defp open_modal_variant(state, :completion) do
     completion = %Completion{items: [], trigger_position: {0, 0}}
-    ModalWorkflow.open(state, :completion, CompletionPayload.new(:tab1, completion: completion))
+    ModalWorkflow.open(state, {:completion, CompletionPayload.new(1, completion: completion)})
   end
 
   defp open_modal_variant(state, :conflict) do
     ModalWorkflow.open(
       state,
-      :conflict,
-      ConflictPayload.new(state.workspace.buffers.active, "/tmp/test.txt")
+      {:conflict, ConflictPayload.new(state.workspace.buffers.active, "/tmp/test.txt")}
     )
   end
 
@@ -268,8 +267,7 @@ defmodule MingaEditor.Input.InterruptTest do
       state =
         ModalWorkflow.open(
           state,
-          :picker,
-          PickerPayload.new(%Picker{picker: picker, source: nil})
+          {:picker, PickerPayload.new(%Picker{picker: picker, source: nil})}
         )
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
@@ -288,7 +286,7 @@ defmodule MingaEditor.Input.InterruptTest do
     test "dismisses conflict prompt" do
       state = base_state()
       buf = state.workspace.buffers.active
-      state = ModalWorkflow.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
+      state = ModalWorkflow.open(state, {:conflict, ConflictPayload.new(buf, "/tmp/test.txt")})
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
       refute ModalOverlay.match(Runtime.state(new_state.shell_runtime).modal, :conflict)
@@ -299,9 +297,9 @@ defmodule MingaEditor.Input.InterruptTest do
       completion = %Completion{items: [], trigger_position: {0, 0}}
 
       payload =
-        MingaEditor.State.ModalOverlay.Completion.new(:tab1, completion: completion)
+        MingaEditor.State.ModalOverlay.Completion.new(1, completion: completion)
 
-      state = ModalWorkflow.open(state, :completion, payload)
+      state = ModalWorkflow.open(state, {:completion, payload})
 
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
       assert MingaEditor.Shell.Traditional.ModalWorkflow.completion(new_state) == nil

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -181,7 +181,7 @@ defmodule MingaEditor.Input.RouterTest do
 
       state = base_state()
       buf = state.workspace.buffers.active
-      state = ModalWorkflow.open(state, :conflict, ConflictPayload.new(buf, "/tmp/test.txt"))
+      state = ModalWorkflow.open(state, {:conflict, ConflictPayload.new(buf, "/tmp/test.txt")})
 
       # 'j' is swallowed by conflict prompt, not forwarded to mode
       new_state = Router.dispatch(state, ?j, 0)
@@ -234,7 +234,7 @@ defmodule MingaEditor.Input.RouterTest do
       state =
         then(base_state(), fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_bottom_panel(
+            MingaEditor.Shell.Traditional.State.install_bottom_panel(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               %BottomPanel{
                 visible: true,
@@ -261,7 +261,7 @@ defmodule MingaEditor.Input.RouterTest do
       state =
         then(base_state(editing_model: :cua), fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_bottom_panel(
+            MingaEditor.Shell.Traditional.State.install_bottom_panel(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               %BottomPanel{
                 visible: true,
@@ -288,7 +288,7 @@ defmodule MingaEditor.Input.RouterTest do
       state =
         then(base_state(editing_model: :cua), fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_bottom_panel(
+            MingaEditor.Shell.Traditional.State.install_bottom_panel(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               %BottomPanel{
                 visible: true,
@@ -426,7 +426,7 @@ defmodule MingaEditor.Input.RouterTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_bottom_panel(
+            MingaEditor.Shell.Traditional.State.install_bottom_panel(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               %BottomPanel{
                 visible: true
@@ -464,7 +464,7 @@ defmodule MingaEditor.Input.RouterTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_bottom_panel(
+            MingaEditor.Shell.Traditional.State.install_bottom_panel(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               %BottomPanel{
                 visible: true

--- a/test/minga_editor/input/scoped_editor_agent_test.exs
+++ b/test/minga_editor/input/scoped_editor_agent_test.exs
@@ -163,7 +163,7 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tb
             )
@@ -192,7 +192,7 @@ defmodule MingaEditor.Input.ScopedEditorAgentTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tb
             )

--- a/test/minga_editor/input/signature_help_test.exs
+++ b/test/minga_editor/input/signature_help_test.exs
@@ -3,6 +3,9 @@ defmodule MingaEditor.Input.SignatureHelpTest do
 
   alias MingaEditor.SignatureHelp, as: SigHelp
   alias MingaEditor.Input.SignatureHelp, as: SigHelpInput
+  alias MingaEditor.Shell.Traditional.ModalWorkflow
+  alias MingaEditor.Shell.Traditional.SignatureHelpWorkflow
+  alias MingaEditor.State.ModalOverlay.Conflict, as: ConflictPayload
 
   import MingaEditor.RenderPipeline.TestHelpers
 
@@ -28,6 +31,18 @@ defmodule MingaEditor.Input.SignatureHelpTest do
     test "passes through" do
       state = base_state()
       assert {:passthrough, ^state} = SigHelpInput.handle_key(state, ?a, 0)
+    end
+  end
+
+  describe "exact workflow values" do
+    test "suppressed signature help rejects a legacy map" do
+      state = base_state()
+      buffer = state.workspace.buffers.active
+      state = ModalWorkflow.open(state, {:conflict, ConflictPayload.new(buffer, "/tmp/test.ex")})
+
+      assert_raise FunctionClauseError, fn ->
+        invoke(SignatureHelpWorkflow, :show, [state, %{signatures: []}])
+      end
     end
   end
 
@@ -58,4 +73,8 @@ defmodule MingaEditor.Input.SignatureHelpTest do
       assert new_state.shell_runtime.state.signature_help != nil
     end
   end
+
+  # The indirection lets runtime boundary tests pass intentionally invalid typed values.
+  # credo:disable-for-next-line Credo.Check.Refactor.Apply
+  defp invoke(module, function, arguments), do: apply(module, function, arguments)
 end

--- a/test/minga_editor/input/sub_state_handlers_test.exs
+++ b/test/minga_editor/input/sub_state_handlers_test.exs
@@ -77,7 +77,7 @@ defmodule MingaEditor.Input.SubStateHandlersTest do
       shell_runtime:
         Runtime.new(
           Runtime.default_entry(),
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Traditional.State.replace_agent(
               %MingaEditor.Shell.Traditional.State{},
               agent

--- a/test/minga_editor/layout/footer_band_overlays_test.exs
+++ b/test/minga_editor/layout/footer_band_overlays_test.exs
@@ -28,6 +28,7 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
   alias MingaEditor.Layout.OverlayBand
   alias MingaEditor.Layout.SurfaceRegistry
   alias MingaEditor.Observatory.Data, as: ObservatoryData
+  alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.State.Feedback
@@ -184,14 +185,9 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
       assert height == 4
       assert row + height == 24
 
-      transfer_state =
-        state
-        |> Map.from_struct()
-        |> Map.delete(:shell_runtime)
-        |> Map.put(:shell, state.shell_runtime.entry.module)
-        |> Map.put(:shell_state, state.shell_runtime.state)
+      render_input = Input.from_editor_state(state)
 
-      assert SurfaceRegistry.rect_for(transfer_state, :observatory) == {row, 0, 80, height}
+      assert SurfaceRegistry.rect_for(render_input, :observatory) == {row, 0, 80, height}
     end
 
     test "the edit timeline band height is one header plus one row per entry" do

--- a/test/minga_editor/layout_test.exs
+++ b/test/minga_editor/layout_test.exs
@@ -116,7 +116,7 @@ defmodule MingaEditor.LayoutTest do
     end)
     |> then(fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -62,7 +62,7 @@ defmodule MingaEditor.PickerUITest do
             end)
       }
     end)
-    |> ModalWorkflow.open(:picker, PickerPayload.new(picker_state))
+    |> ModalWorkflow.open({:picker, PickerPayload.new(picker_state)})
   end
 
   defp preview_promotion_state do
@@ -178,7 +178,7 @@ defmodule MingaEditor.PickerUITest do
       restore: state.workspace.buffers.active_index
     }
 
-    ModalWorkflow.open(state, :picker, PickerPayload.new(picker_state))
+    ModalWorkflow.open(state, {:picker, PickerPayload.new(picker_state)})
   end
 
   defp mark_all_picker(%Picker{items: []} = picker), do: picker
@@ -336,7 +336,7 @@ defmodule MingaEditor.PickerUITest do
       source = :"Elixir.MingaEditor.PickerUITest.GitLogSource"
       picker = Picker.new([%Item{id: "abc123", label: "abc123"}], title: "Git Log")
       picker_state = %PickerState{picker: picker, source: source}
-      state = ModalWorkflow.open(state, :picker, PickerPayload.new(picker_state))
+      state = ModalWorkflow.open(state, {:picker, PickerPayload.new(picker_state)})
 
       state = Enum.reduce(~c"fix", state, fn cp, acc -> PickerUI.handle_key(acc, cp, 0) end)
       {:picker, %{picker_ui: pui}} = state.shell_runtime.state.modal
@@ -365,7 +365,7 @@ defmodule MingaEditor.PickerUITest do
         restore: state.workspace.buffers.active_index
       }
 
-      ModalWorkflow.open(state, :picker, PickerPayload.new(picker_state))
+      ModalWorkflow.open(state, {:picker, PickerPayload.new(picker_state)})
     end
 
     defp type_string(state, string) do
@@ -486,7 +486,7 @@ defmodule MingaEditor.PickerUITest do
         restore: state.workspace.buffers.active_index
       }
 
-      ModalWorkflow.open(state, :picker, PickerPayload.new(picker_state))
+      ModalWorkflow.open(state, {:picker, PickerPayload.new(picker_state)})
     end
   end
 end

--- a/test/minga_editor/prompt_ui_test.exs
+++ b/test/minga_editor/prompt_ui_test.exs
@@ -110,7 +110,7 @@ defmodule MingaEditor.PromptUITest do
 
       state =
         base_state()
-        |> ModalWorkflow.open(:picker, PickerPayload.new(picker_struct))
+        |> ModalWorkflow.open({:picker, PickerPayload.new(picker_struct)})
         |> PromptUI.open(TestHandler)
 
       assert prompt_state(state).handler == TestHandler

--- a/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_chat_builder_test.exs
@@ -399,7 +399,7 @@ defmodule MingaEditor.RenderModel.UI.AgentChatBuilderTest do
       layout: nil,
       shell: Traditional,
       shell_state:
-        TraditionalState.set_tab_bar(
+        TraditionalState.install_tab_bar(
           TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
           tab_bar
         ),

--- a/test/minga_editor/render_pipeline/chrome_dirty_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_dirty_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Test.RecordingFrontend
   alias MingaEditor.Extension.Sidebar
+  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Session.State, as: SessionState
@@ -183,13 +184,16 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
       fp1 = Input.chrome_fingerprint(input)
 
       state =
-        SidebarWorkflow.replace_git_status(state, %{
-          repo_state: :normal,
-          branch: "main",
-          ahead: 0,
-          behind: 0,
-          entries: []
-        })
+        SidebarWorkflow.replace_git_status(
+          state,
+          GitStatusPanel.new(%{
+            repo_state: :normal,
+            branch: "main",
+            ahead: 0,
+            behind: 0,
+            entries: []
+          })
+        )
 
       input2 = Input.from_editor_state(state)
       fp2 = Input.chrome_fingerprint(input2)

--- a/test/minga_editor/shell/traditional/agent_surfaces_test.exs
+++ b/test/minga_editor/shell/traditional/agent_surfaces_test.exs
@@ -35,6 +35,34 @@ defmodule MingaEditor.Shell.Traditional.AgentSurfacesTest do
     assert InlineAsk.active(AgentSurfaces.asks(canceled), buffer) == nil
   end
 
+  test "session updates replace only the matching ask entry and ignore missing sessions" do
+    first_buffer = self()
+    second_buffer = spawn_session()
+    first_session = spawn_session()
+    second_session = spawn_session()
+    missing_session = spawn_session()
+
+    on_exit(fn ->
+      Enum.each([second_buffer, first_session, second_session, missing_session], fn pid ->
+        Process.exit(pid, :kill)
+      end)
+    end)
+
+    first_ask = first_buffer |> ask() |> InlineAsk.thinking(first_session)
+    second_ask = second_buffer |> ask() |> InlineAsk.thinking(second_session)
+
+    surfaces =
+      %AgentSurfaces{}
+      |> AgentSurfaces.activate_ask(first_ask)
+      |> AgentSurfaces.activate_ask(second_ask)
+
+    updated = AgentSurfaces.append_ask_response(surfaces, first_session, "first")
+
+    assert InlineAsk.active(AgentSurfaces.asks(updated), first_buffer).response == "first"
+    assert InlineAsk.active(AgentSurfaces.asks(updated), second_buffer) == second_ask
+    assert AgentSurfaces.append_ask_response(updated, missing_session, "missing") == updated
+  end
+
   test "replacement inline edit ignores stale completion and completes the current session" do
     buffer = self()
     old_session = spawn_session()
@@ -60,6 +88,36 @@ defmodule MingaEditor.Shell.Traditional.AgentSurfacesTest do
 
     assert %InlineEdit{status: :proposed, session_pid: nil} =
              InlineEdit.active(AgentSurfaces.edits(completed), buffer)
+  end
+
+  test "session updates replace only the matching edit entry and ignore missing sessions" do
+    first_buffer = self()
+    second_buffer = spawn_session()
+    first_session = spawn_session()
+    second_session = spawn_session()
+    missing_session = spawn_session()
+
+    on_exit(fn ->
+      Enum.each([second_buffer, first_session, second_session, missing_session], fn pid ->
+        Process.exit(pid, :kill)
+      end)
+    end)
+
+    first_edit = first_buffer |> edit() |> InlineEdit.thinking(first_session)
+    second_edit = second_buffer |> edit() |> InlineEdit.thinking(second_session)
+
+    surfaces =
+      %AgentSurfaces{}
+      |> AgentSurfaces.activate_edit(first_edit)
+      |> AgentSurfaces.activate_edit(second_edit)
+
+    updated = AgentSurfaces.append_edit_proposal(surfaces, first_session, "first")
+
+    assert InlineEdit.active(AgentSurfaces.edits(updated), first_buffer).proposed_rewrite ==
+             "first"
+
+    assert InlineEdit.active(AgentSurfaces.edits(updated), second_buffer) == second_edit
+    assert AgentSurfaces.append_edit_proposal(updated, missing_session, "missing") == updated
   end
 
   defp ask(buffer) do

--- a/test/minga_editor/shell/traditional/nav_flash_test.exs
+++ b/test/minga_editor/shell/traditional/nav_flash_test.exs
@@ -14,6 +14,14 @@ defmodule MingaEditor.Shell.Traditional.NavFlashTest do
     assert %NavFlash{generation: 2, line: 9, step: 0, timer: nil} = second
   end
 
+  test "replacement rejects negative and legacy line values" do
+    assert_raise FunctionClauseError, fn -> invoke(NavFlash, :replace, [%NavFlash{}, -1]) end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(NavFlash, :replace, [%NavFlash{}, %{line: 1}])
+    end
+  end
+
   test "timer handles record only for the matching active generation" do
     flash = NavFlash.replace(%NavFlash{}, 10)
     timer = make_ref()
@@ -50,4 +58,8 @@ defmodule MingaEditor.Shell.Traditional.NavFlashTest do
     assert NavFlash.color_for_step(%NavFlash{step: 2, max_steps: 3}, 0xFF0000, 0x0000FF) ==
              0x0000FF
   end
+
+  # The indirection lets runtime boundary tests pass intentionally invalid typed values.
+  # credo:disable-for-next-line Credo.Check.Refactor.Apply
+  defp invoke(module, function, arguments), do: apply(module, function, arguments)
 end

--- a/test/minga_editor/shell/traditional/notice_workflow_test.exs
+++ b/test/minga_editor/shell/traditional/notice_workflow_test.exs
@@ -7,6 +7,14 @@ defmodule MingaEditor.Shell.Traditional.NoticeWorkflowTest do
 
   import MingaEditor.RenderPipeline.TestHelpers
 
+  test "public notice workflows reject legacy map-shaped editor state" do
+    assert_raise FunctionClauseError, fn -> invoke(NoticeWorkflow, :publish, [%{}, "notice"]) end
+    assert_raise FunctionClauseError, fn -> invoke(NoticeWorkflow, :acknowledge, [%{}]) end
+    assert_raise FunctionClauseError, fn -> invoke(NoticeWorkflow, :dismiss, [%{}]) end
+    assert_raise FunctionClauseError, fn -> invoke(NoticeWorkflow, :timeout, [%{}, 1]) end
+    assert_raise FunctionClauseError, fn -> invoke(NoticeWorkflow, :message, [%{}]) end
+  end
+
   test "publishes, replaces, acknowledges, and rejects stale timeout delivery" do
     state = base_state()
     first = NoticeWorkflow.publish(state, "first")
@@ -121,4 +129,8 @@ defmodule MingaEditor.Shell.Traditional.NoticeWorkflowTest do
 
     assert retained_operation.message == "Formatting"
   end
+
+  # The indirection lets runtime boundary tests pass intentionally invalid typed values.
+  # credo:disable-for-next-line Credo.Check.Refactor.Apply
+  defp invoke(module, function, arguments), do: apply(module, function, arguments)
 end

--- a/test/minga_editor/shell/traditional/sidebars_test.exs
+++ b/test/minga_editor/shell/traditional/sidebars_test.exs
@@ -1,16 +1,20 @@
 defmodule MingaEditor.Shell.Traditional.SidebarsTest do
   use ExUnit.Case, async: true
 
+  alias MingaEditor.GitStatus.Panel
+  alias MingaEditor.GitStatus.TUIState
   alias MingaEditor.Observatory.Data
   alias MingaEditor.Observatory.Inspection
   alias MingaEditor.Shell.Traditional.Observatory
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.Shell.Traditional.Sidebars
+  alias MingaEditor.State, as: EditorState
 
   test "Git status close clears its selected surface and paired TUI state" do
     sidebars =
       %Sidebars{}
-      |> Sidebars.replace_git_status(%{entries: []})
-      |> Sidebars.replace_git_status_tui(%URI{path: "/status"})
+      |> Sidebars.replace_git_status(Panel.new(%{entries: []}))
+      |> Sidebars.replace_git_status_tui(TUIState.new())
       |> Sidebars.select("git_status")
 
     closed = Sidebars.close_git_status(sidebars)
@@ -18,6 +22,36 @@ defmodule MingaEditor.Shell.Traditional.SidebarsTest do
     assert Sidebars.active_id(closed) == nil
     assert Sidebars.git_status_panel(closed) == nil
     assert Sidebars.git_status_tui_state(closed) == nil
+  end
+
+  test "Git status replacement rejects legacy map-shaped panel and TUI state" do
+    editor_state = %EditorState{
+      workspace: %MingaEditor.Session.State{viewport: MingaEditor.Viewport.new(24, 80)}
+    }
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(Sidebars, :replace_git_status, [%Sidebars{}, %{entries: []}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(Sidebars, :replace_git_status_tui, [%Sidebars{}, %{cursor_index: 0}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(Sidebars, :replace_git_status_tui, [%Sidebars{}, %URI{path: "/foreign"}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(SidebarWorkflow, :replace_git_status, [editor_state, %{entries: []}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(SidebarWorkflow, :replace_git_status_tui, [editor_state, %{cursor_index: 0}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(SidebarWorkflow, :replace_git_status_tui, [editor_state, %URI{path: "/foreign"}])
+    end
   end
 
   test "closing Observatory clears every surface value and invalidates delayed work" do
@@ -84,4 +118,8 @@ defmodule MingaEditor.Shell.Traditional.SidebarsTest do
     assert Observatory.timer(observatory) == next_timer
     assert observatory.token == next_token
   end
+
+  # The indirection lets runtime boundary tests pass intentionally invalid typed values.
+  # credo:disable-for-next-line Credo.Check.Refactor.Apply
+  defp invoke(module, function, arguments), do: apply(module, function, arguments)
 end

--- a/test/minga_editor/shell/traditional/state_test.exs
+++ b/test/minga_editor/shell/traditional/state_test.exs
@@ -1,0 +1,120 @@
+defmodule MingaEditor.Shell.Traditional.StateTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.BottomPanel
+  alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
+  alias MingaEditor.Shell.Traditional.Notice
+  alias MingaEditor.Shell.Traditional.State
+  alias MingaEditor.SignatureHelp
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+
+  test "exact child installers replace only their owned Traditional fields" do
+    original_notice = Notice.publish(%Notice{}, "keep")
+    state = %State{notice: original_notice}
+    panel = %BottomPanel{visible: true}
+    tab_bar = TabBar.new(Tab.new_file(1, "one.ex"))
+
+    state = State.install_bottom_panel(state, panel)
+    assert State.bottom_panel(state) == panel
+    assert state.notice == original_notice
+
+    state = State.install_tab_bar(state, tab_bar)
+    assert State.tab_bar(state) == tab_bar
+    assert state.bottom_panel == panel
+
+    cleared = State.install_tab_bar(state, nil)
+    assert State.tab_bar(cleared) == nil
+    assert cleared.notice == original_notice
+  end
+
+  test "child installers reject foreign roots and legacy map-shaped values" do
+    panel = %BottomPanel{}
+    tab_bar = TabBar.new(Tab.new_file(1, "one.ex"))
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :install_bottom_panel, [%{}, panel])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :install_bottom_panel, [%State{}, %{}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :install_tab_bar, [%{}, tab_bar])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :install_tab_bar, [%State{}, %{tabs: []}])
+    end
+
+    refute function_exported?(State, :set_bottom_panel, 2)
+    refute function_exported?(State, :set_tab_bar, 2)
+  end
+
+  test "signature help and Git status accept only concrete owner values" do
+    signature_help = %SignatureHelp{
+      signatures: [],
+      active_signature: 0,
+      active_parameter: 0,
+      anchor_row: 0,
+      anchor_col: 0
+    }
+
+    state = State.show_signature_help(%State{}, signature_help)
+    assert state.signature_help == signature_help
+
+    panel = GitStatusPanel.new(%{entries: []})
+    state = State.replace_git_status_panel(state, panel)
+    assert State.git_status_panel(state) == panel
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :show_signature_help, [state, %{}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :replace_git_status_panel, [state, %{entries: []}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :replace_git_status_tui_state, [state, %{cursor_index: 0}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :replace_git_status_tui_state, [state, %URI{path: "/foreign"}])
+    end
+  end
+
+  test "agent and inline installers reject legacy map-shaped values" do
+    state = %State{}
+
+    assert_raise FunctionClauseError, fn -> invoke(State, :replace_agent, [state, %{}]) end
+    assert_raise FunctionClauseError, fn -> invoke(State, :activate_inline_ask, [state, %{}]) end
+    assert_raise FunctionClauseError, fn -> invoke(State, :replace_inline_ask, [state, %{}]) end
+    assert_raise FunctionClauseError, fn -> invoke(State, :activate_inline_edit, [state, %{}]) end
+    assert_raise FunctionClauseError, fn -> invoke(State, :replace_inline_edit, [state, %{}]) end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :replace_tool_prompts, [state, [], []])
+    end
+  end
+
+  test "flash replacement rejects broad positions and range atoms" do
+    state = State.replace_yank_flash(%State{}, self(), {1, 2}, {3, 4}, :charwise)
+    assert state.flashes.yank.start_pos == {1, 2}
+    assert state.flashes.yank.end_pos == {3, 4}
+    assert state.flashes.yank.range_type == :charwise
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :replace_yank_flash, [state, self(), %{line: 1}, {3, 4}, :charwise])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(State, :replace_yank_flash, [state, self(), {1, 2}, {3, 4}, :legacy_range])
+    end
+  end
+
+  # The indirection lets runtime boundary tests pass intentionally invalid typed values.
+  # credo:disable-for-next-line Credo.Check.Refactor.Apply
+  defp invoke(module, function, arguments), do: apply(module, function, arguments)
+end

--- a/test/minga_editor/signature_help_test.exs
+++ b/test/minga_editor/signature_help_test.exs
@@ -82,6 +82,24 @@ defmodule MingaEditor.SignatureHelpTest do
     end
   end
 
+  describe "exact lifecycle values" do
+    test "replacement and dismissal reject legacy values" do
+      signature_help = SignatureHelp.from_response(@sample_response, 10, 20)
+      assert SignatureHelp.replace(nil, signature_help) == signature_help
+      assert SignatureHelp.dismiss(signature_help) == nil
+
+      assert_raise FunctionClauseError, fn ->
+        invoke(SignatureHelp, :replace, [%{}, signature_help])
+      end
+
+      assert_raise FunctionClauseError, fn ->
+        invoke(SignatureHelp, :replace, [nil, %{}])
+      end
+
+      assert_raise FunctionClauseError, fn -> invoke(SignatureHelp, :dismiss, [%{}]) end
+    end
+  end
+
   describe "next_signature/1 and prev_signature/1" do
     test "cycles forward through signatures" do
       sh = SignatureHelp.from_response(@sample_response, 10, 20)
@@ -132,4 +150,8 @@ defmodule MingaEditor.SignatureHelpTest do
       assert row + h <= 15
     end
   end
+
+  # The indirection lets runtime boundary tests pass intentionally invalid typed values.
+  # credo:disable-for-next-line Credo.Check.Refactor.Apply
+  defp invoke(module, function, arguments), do: apply(module, function, arguments)
 end

--- a/test/minga_editor/state/agent_workspace_lifecycle_test.exs
+++ b/test/minga_editor/state/agent_workspace_lifecycle_test.exs
@@ -56,7 +56,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
       state
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -97,7 +97,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
       state
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -145,7 +145,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -217,7 +217,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
       state
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -479,7 +479,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tab_bar
         )
@@ -516,7 +516,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
       state
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )
@@ -555,7 +555,7 @@ defmodule MingaEditor.State.AgentWorkspaceLifecycleTest do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -33,7 +33,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -55,7 +55,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
 
     {then(state, fn root ->
        shell_state =
-         MingaEditor.Shell.Traditional.State.set_tab_bar(
+         MingaEditor.Shell.Traditional.State.install_tab_bar(
            MingaEditor.Shell.Runtime.state(root.shell_runtime),
            tb
          )
@@ -95,7 +95,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -458,7 +458,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
     state_with_tb =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )
@@ -474,7 +474,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
 
     {then(state, fn root ->
        shell_state =
-         MingaEditor.Shell.Traditional.State.set_tab_bar(
+         MingaEditor.Shell.Traditional.State.install_tab_bar(
            MingaEditor.Shell.Runtime.state(root.shell_runtime),
            tb
          )

--- a/test/minga_editor/state/event_routing_test.exs
+++ b/test/minga_editor/state/event_routing_test.exs
@@ -29,7 +29,7 @@ defmodule MingaEditor.State.EventRoutingTest do
           |> TraditionalState.replace_agent(%AgentState{
             runtime: %RuntimeState{status: :idle}
           })
-          |> TraditionalState.set_tab_bar(tb)
+          |> TraditionalState.install_tab_bar(tb)
         )
     }
 
@@ -329,7 +329,7 @@ defmodule MingaEditor.State.EventRoutingTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tb
             )
@@ -363,7 +363,7 @@ defmodule MingaEditor.State.EventRoutingTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               tb
             )

--- a/test/minga_editor/state/modal_overlay_test.exs
+++ b/test/minga_editor/state/modal_overlay_test.exs
@@ -53,21 +53,59 @@ defmodule MingaEditor.State.ModalOverlayTest do
   end
 
   test "open replaces ordinary modals but preserves an active conflict" do
-    picker = ModalOverlay.open(:none, :picker, picker_payload())
+    picker = ModalOverlay.open(:none, {:picker, picker_payload()})
     prompt = prompt_payload("hello")
-    assert ModalOverlay.open(picker, :prompt, prompt) == {:prompt, prompt}
+    assert ModalOverlay.open(picker, {:prompt, prompt}) == {:prompt, prompt}
 
     conflict = {:conflict, conflict_payload()}
-    assert ModalOverlay.open(conflict, :picker, picker_payload()) == conflict
+    assert ModalOverlay.open(conflict, {:picker, picker_payload()}) == conflict
 
     next_conflict = conflict_payload(self())
-    assert ModalOverlay.open(conflict, :conflict, next_conflict) == {:conflict, next_conflict}
+    assert ModalOverlay.open(conflict, {:conflict, next_conflict}) == {:conflict, next_conflict}
+  end
+
+  test "modal transitions reject mismatched payload and legacy split arguments" do
+    assert_raise FunctionClauseError, fn ->
+      invoke(ModalOverlay, :open, [:none, {:picker, prompt_payload()}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(ModalOverlay, :open, [{:conflict, conflict_payload()}, {:picker, prompt_payload()}])
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(ModalOverlay, :transition, [:none, {:prompt, picker_payload()}])
+    end
+
+    assert_raise UndefinedFunctionError, fn ->
+      invoke(ModalOverlay, :open, [:none, :picker, picker_payload()])
+    end
+
+    malformed = {:picker, prompt_payload()}
+
+    for function <- [
+          :tag,
+          :active?,
+          :close,
+          :dismiss,
+          :completion,
+          :completion_trigger,
+          :command_completion
+        ] do
+      assert_raise FunctionClauseError, fn -> invoke(ModalOverlay, function, [malformed]) end
+    end
+
+    assert_raise FunctionClauseError, fn -> invoke(ModalOverlay, :match, [malformed, :picker]) end
+
+    assert_raise FunctionClauseError, fn ->
+      invoke(CompletionPayload, :new, [:legacy_owner, []])
+    end
   end
 
   test "transition bypasses conflict stickiness and close or dismiss returns none" do
     conflict = {:conflict, conflict_payload()}
     picker = picker_payload()
-    assert ModalOverlay.transition(conflict, :picker, picker) == {:picker, picker}
+    assert ModalOverlay.transition(conflict, {:picker, picker}) == {:picker, picker}
     assert ModalOverlay.close({:picker, picker}) == :none
     assert ModalOverlay.dismiss(conflict) == :none
     assert ModalOverlay.close(:none) == :none
@@ -104,4 +142,8 @@ defmodule MingaEditor.State.ModalOverlayTest do
     picker = {:picker, picker_payload()}
     assert ModalOverlay.dismiss_if_stale(picker, 8) == picker
   end
+
+  # The indirection lets runtime boundary tests pass intentionally invalid typed values.
+  # credo:disable-for-next-line Credo.Check.Refactor.Apply
+  defp invoke(module, function, arguments), do: apply(module, function, arguments)
 end

--- a/test/minga_editor/state/shell_callbacks_test.exs
+++ b/test/minga_editor/state/shell_callbacks_test.exs
@@ -48,7 +48,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -116,7 +116,7 @@ defmodule MingaEditor.State.ShellCallbacksTest do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )

--- a/test/minga_editor/state/tab_switch_test.exs
+++ b/test/minga_editor/state/tab_switch_test.exs
@@ -98,7 +98,7 @@ defmodule MingaEditor.State.TabSwitchTest do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )
@@ -172,7 +172,7 @@ defmodule MingaEditor.State.TabSwitchTest do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tb
           )
@@ -412,7 +412,7 @@ defmodule MingaEditor.State.TabSwitchTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               TabBar.update_context(tb, target_id, tab2_context)
             )
@@ -636,7 +636,7 @@ defmodule MingaEditor.State.TabSwitchTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               TabBar.update_context(tb, target_id, target_context)
             )
@@ -686,7 +686,7 @@ defmodule MingaEditor.State.TabSwitchTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               TabBar.update_context(tb, target_id, target_context)
             )

--- a/test/minga_editor/state_test.exs
+++ b/test/minga_editor/state_test.exs
@@ -190,7 +190,7 @@ defmodule MingaEditor.StateTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               TabBar.new(tab)
             )
@@ -571,7 +571,7 @@ defmodule MingaEditor.StateTest do
       end)
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             TabBar.new(Tab.new_agent(1, "Agent"))
           )

--- a/test/minga_editor/system_wake_test.exs
+++ b/test/minga_editor/system_wake_test.exs
@@ -51,7 +51,7 @@ defmodule MingaEditor.SystemWakeTest do
 
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )

--- a/test/minga_editor/ui/picker/theme_source_test.exs
+++ b/test/minga_editor/ui/picker/theme_source_test.exs
@@ -87,10 +87,7 @@ defmodule MingaEditor.UI.Picker.ThemeSourceTest do
       state =
         base_state()
         |> EditorState.apply_theme(Theme.get!(:one_dark))
-        |> ModalWorkflow.open(
-          :picker,
-          PickerPayload.new(%PickerState{restore_theme: original})
-        )
+        |> ModalWorkflow.open({:picker, PickerPayload.new(%PickerState{restore_theme: original})})
 
       restored = ThemeSource.on_cancel(state)
       assert restored.appearance.theme.name == :doom_one
@@ -104,8 +101,7 @@ defmodule MingaEditor.UI.Picker.ThemeSourceTest do
       state =
         ModalWorkflow.open(
           state,
-          :picker,
-          PickerPayload.new(%PickerState{restore_theme: original})
+          {:picker, PickerPayload.new(%PickerState{restore_theme: original})}
         )
 
       restored = ThemeSource.on_cancel(state)

--- a/test/minga_editor/ui/picker/workspace_target_source_test.exs
+++ b/test/minga_editor/ui/picker/workspace_target_source_test.exs
@@ -124,7 +124,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               TabBar.update_workspace(
                 state.shell_runtime.state.tab_bar,
@@ -172,7 +172,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
       state =
         then(state, fn root ->
           shell_state =
-            MingaEditor.Shell.Traditional.State.set_tab_bar(
+            MingaEditor.Shell.Traditional.State.install_tab_bar(
               MingaEditor.Shell.Runtime.state(root.shell_runtime),
               TabBar.update_workspace(
                 state.shell_runtime.state.tab_bar,
@@ -611,7 +611,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
 
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           tb
         )
@@ -627,7 +627,7 @@ defmodule MingaEditor.UI.Picker.WorkspaceTargetSourceTest do
   defp update_workspace(state, workspace_id, fun) do
     then(state, fn root ->
       shell_state =
-        MingaEditor.Shell.Traditional.State.set_tab_bar(
+        MingaEditor.Shell.Traditional.State.install_tab_bar(
           MingaEditor.Shell.Runtime.state(root.shell_runtime),
           TabBar.update_workspace(state.shell_runtime.state.tab_bar, workspace_id, fun)
         )

--- a/test/minga_editor/window_focus_test.exs
+++ b/test/minga_editor/window_focus_test.exs
@@ -24,7 +24,7 @@ defmodule MingaEditor.WindowFocusTest do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_bottom_panel(
+          MingaEditor.Shell.Traditional.State.install_bottom_panel(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             panel
           )
@@ -55,7 +55,7 @@ defmodule MingaEditor.WindowFocusTest do
       state
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_bottom_panel(
+          MingaEditor.Shell.Traditional.State.install_bottom_panel(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             panel
           )
@@ -123,7 +123,7 @@ defmodule MingaEditor.WindowFocusTest do
     state =
       then(state, fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_bottom_panel(
+          MingaEditor.Shell.Traditional.State.install_bottom_panel(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             panel
           )

--- a/test/support/scoped_input_helpers.ex
+++ b/test/support/scoped_input_helpers.ex
@@ -79,7 +79,7 @@ defmodule Minga.Test.ScopedInputHelpers do
           Runtime.default_entry(),
           %TraditionalState{}
           |> TraditionalState.replace_agent(agent)
-          |> TraditionalState.set_tab_bar(tab_bar)
+          |> TraditionalState.install_tab_bar(tab_bar)
         )
     }
   end
@@ -125,7 +125,7 @@ defmodule Minga.Test.ScopedInputHelpers do
       state
       |> then(fn root ->
         shell_state =
-          MingaEditor.Shell.Traditional.State.set_tab_bar(
+          MingaEditor.Shell.Traditional.State.install_tab_bar(
             MingaEditor.Shell.Runtime.state(root.shell_runtime),
             tab_bar
           )


### PR DESCRIPTION
# TL;DR

Traditional shell transitions now accept only their owned domain values. Invalid modal payloads, legacy maps, foreign structs, and broad setter calls fail at the ownership boundary instead of leaking into rendering, input, or extension state.

Closes #2918

## Context

This is the Traditional owner-API slice of #2914. It builds on the explicit shell session contract from #2917 while preserving one Editor GenServer and the existing shell workflows.

## Changes

- Replace broad touched setters with exact `install_*` and domain transition APIs on `MingaEditor.Shell.Traditional.State`.
- Require concrete `BottomPanel`, `TabBar`, agent, inline, signature-help, Git panel, Git TUI, flash, and tagged modal values throughout the owner and workflow layers.
- Move the existing Git-status TUI value owner into `MingaEditor.GitStatus.TUIState`, allowing the core Traditional owner to enforce one concrete type without depending on bundled extension modules.
- Validate modal tag and payload pairs before conflict stickiness, close, dismissal, rendering queries, and completion bookkeeping.
- Restrict notice and signature-help workflows to exact `EditorState` and Traditional runtime shapes.
- Update inline ask and edit sessions with a focused `Map.put` on the matching entry, preserving unrelated sessions and missing-session no-ops.
- Preserve direct ordered append for the small tool-prompt queue.
- Keep typed `RenderPipeline.Input` completion projection working, including the missing-active-layout viewport fallback.
- Update bundled Git porcelain callers, keymap context, window invalidation, renderer fixtures, and exact modal calls to the narrowed contracts.

## Verification

Validated final commit `8886dfe3bb1769fbde97fd5de11899b0f7e8f222`:

- `make lint`: passed with Credo clean, compilation clean, and incremental Dialyzer at 0 errors.
- `mix test.llm`: 9,518 tests, 97 properties, and 58 doctests passed with 0 failures; 1 test skipped.
- Focused owner, notice, signature-help, modal, Git, and render-input suites: 77 tests passed.
- Focused bundled `git_porcelain` suites: 19 tests passed.
- `bash scripts/bench_keystroke_latency_ab origin/main HEAD`: all blocking latency budgets stayed within limits across four base and HEAD rounds.
- `git diff origin/main...HEAD --check`: passed.
- Final acceptance review and targeted blocker re-review: PASS.
- Frontend-specific Swift, Go, and Zig checks are not applicable because those sources did not change.

## Acceptance Criteria Addressed

- Traditional child values install only into `MingaEditor.Shell.Traditional.State` through concrete public types. ✅
- Notice, modal, sidebar, signature-help, flash, Git-status, and related transitions reject arbitrary maps and legacy shapes. ✅
- Broad touched `set_*` operations use intent-revealing installation or domain transition names. ✅
- Yank flash, signature help, modal, completion owner, and aggregate APIs use concrete domain types. ✅
- Inline updates replace only the matching entry, and tool prompts preserve direct queue order. ✅
- Traditional rendering, input, shell switching, timers, agent surfaces, and Git presentation remain compatible. ✅
- Focused tests cover exact installation, replacement, rejection, missing entries, and queue order. ✅
