### PR TITLE
refactor(ui): capture project file picker identity

### DIFF
--- a/lib/minga_editor/render_model/ui/picker_builder.ex
+++ b/lib/minga_editor/render_model/ui/picker_builder.ex
@@ -6,9 +6,9 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
   alias Minga.Buffer
   alias Minga.RenderModel.UI.Picker, as: PickerModel
   alias Minga.RenderModel.UI.Picker.ActionMenu
-  alias Minga.Project.Root
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Picker.ProjectFileCandidate
 
   @max_items 100
   @preview_max_lines 50
@@ -141,10 +141,15 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
           [[PickerModel.preview_segment()]] | nil
   defp build_preview_for_item(
          ctx,
-         %Picker.Item{id: id, meta: %{workspace_root: %Root{path: root}}}
-       )
-       when is_binary(id) do
-    build_file_preview(ctx, resolve_preview_path(id, root))
+         %Picker.Item{id: %ProjectFileCandidate{} = candidate}
+       ) do
+    abs_path =
+      case ProjectFileCandidate.resolve(candidate) do
+        {:ok, path} -> path
+        {:error, _reason} -> nil
+      end
+
+    build_file_preview(ctx, abs_path)
   end
 
   defp build_preview_for_item(ctx, %Picker.Item{id: id}) when is_binary(id) do

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -17,6 +17,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   alias Minga.Language.Devicon
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.ProjectFileCandidate
   alias MingaEditor.UI.Picker.Source
 
   @impl true
@@ -48,7 +49,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
         score_map = build_score_map(frecency_map, git_status_map)
 
         paths
-        |> Enum.map(&lean_candidate(&1, git_status_map, root))
+        |> Enum.flat_map(&lean_candidate(&1, git_status_map, root))
         |> sort_by_score(score_map)
 
       {:error, msg} ->
@@ -84,14 +85,27 @@ defmodule MingaEditor.UI.Picker.FileSource do
   # and to enrich later (git status stashed in `meta`). Icon, color, two-line
   # description, and the status annotation are built in `enrich/1` for the
   # bounded winners only, so a 50k-file repo never materializes 50k rich items.
-  @spec lean_candidate(String.t(), %{String.t() => atom()}, Root.t()) :: Item.t()
+  @spec lean_candidate(String.t(), %{String.t() => atom()}, Root.t()) :: [Item.t()]
   defp lean_candidate(path, git_status_map, root) do
-    %Item{
-      id: path,
-      label: Path.basename(path),
-      search_text: path,
-      meta: %{git: Map.get(git_status_map, path), workspace_root: root}
-    }
+    case ProjectFileCandidate.new(root, path) do
+      {:ok, candidate} ->
+        [
+          %Item{
+            id: candidate,
+            label: Path.basename(candidate.path),
+            search_text: candidate.path,
+            meta: %{git: Map.get(git_status_map, candidate.path)}
+          }
+        ]
+
+      {:error, reason} ->
+        Log.warning(
+          :editor,
+          "Ignoring invalid cached project path #{inspect(path)}: #{inspect(reason)}"
+        )
+
+        []
+    end
   end
 
   @impl true
@@ -99,7 +113,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   def enrich(items), do: Enum.map(items, &enrich_item/1)
 
   @spec enrich_item(Item.t()) :: Item.t()
-  defp enrich_item(%Item{id: path, meta: meta} = item) do
+  defp enrich_item(%Item{id: %ProjectFileCandidate{path: path}, meta: meta} = item) do
     filename = Path.basename(path)
     dir = Path.dirname(path)
     ft = Language.detect_filetype(filename)
@@ -124,13 +138,19 @@ defmodule MingaEditor.UI.Picker.FileSource do
 
   @impl true
   @spec on_select(Item.t(), term()) :: term()
-  def on_select(%Item{id: rel_path} = item, state) do
-    Log.debug(:editor, "[file_picker] on_select path=#{rel_path}")
-    open_selected_file(absolute_path(item, state), state)
+  def on_select(%Item{id: %ProjectFileCandidate{} = candidate}, state) do
+    Log.debug(:editor, "[file_picker] on_select path=#{candidate.path}")
+    open_selected_file(ProjectFileCandidate.resolve(candidate), state)
   end
 
-  @spec open_selected_file({:ok, String.t()} | :error, term()) :: term()
-  defp open_selected_file(:error, state), do: state
+  @spec open_selected_file(
+          {:ok, String.t()} | {:error, ProjectFileCandidate.error()},
+          term()
+        ) :: term()
+  defp open_selected_file({:error, reason}, state) do
+    Log.error(:editor, "Failed to resolve project file candidate: #{inspect(reason)}")
+    state
+  end
 
   defp open_selected_file({:ok, abs_path}, state) do
     case MingaEditor.Handlers.BufferRegistry.find_buffer_by_path(state, abs_path) do
@@ -183,6 +203,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   end
 
   @impl true
+  @spec on_cancel(term()) :: term()
   def on_cancel(state), do: Source.restore_or_keep(state)
 
   @impl true
@@ -195,14 +216,24 @@ defmodule MingaEditor.UI.Picker.FileSource do
   @spec on_action(term(), Item.t(), term()) :: term()
   def on_action(:open, item, state), do: on_select(item, state)
 
-  def on_action(:delete, %Item{} = item, state) do
-    delete_selected_file(absolute_path(item, state), state)
+  def on_action(
+        :delete,
+        %Item{id: %ProjectFileCandidate{} = candidate},
+        state
+      ) do
+    delete_selected_file(ProjectFileCandidate.resolve(candidate), state)
   end
 
   def on_action(_action, _item, state), do: state
 
-  @spec delete_selected_file({:ok, String.t()} | :error, term()) :: term()
-  defp delete_selected_file(:error, state), do: state
+  @spec delete_selected_file(
+          {:ok, String.t()} | {:error, ProjectFileCandidate.error()},
+          term()
+        ) :: term()
+  defp delete_selected_file({:error, reason}, state) do
+    Log.error(:editor, "Failed to resolve project file candidate: #{inspect(reason)}")
+    state
+  end
 
   defp delete_selected_file({:ok, abs_path}, state) do
     case File.rm(abs_path) do
@@ -235,31 +266,6 @@ defmodule MingaEditor.UI.Picker.FileSource do
   defp open_items(items, state) do
     Enum.reduce(items, state, fn item, acc -> on_select(item, acc) end)
   end
-
-  @spec absolute_path(Item.t(), term()) :: {:ok, String.t()} | :error
-  defp absolute_path(%Item{id: rel_path, meta: %{workspace_root: %Root{path: path}}}, _state),
-    do: {:ok, Path.expand(rel_path, path)}
-
-  defp absolute_path(%Item{id: rel_path}, state) do
-    case selection_root(state) do
-      path when is_binary(path) -> {:ok, Path.expand(rel_path, path)}
-      nil -> :error
-    end
-  end
-
-  @spec selection_root(term()) :: String.t() | nil
-  defp selection_root(%EditorState{} = state) do
-    case EditorState.file_tree_state(state).project_root do
-      path when is_binary(path) -> path
-      _other -> root_path(active_workspace_root())
-    end
-  end
-
-  defp selection_root(_state), do: root_path(active_workspace_root())
-
-  @spec root_path(Root.t() | nil) :: String.t() | nil
-  defp root_path(%Root{path: path}), do: path
-  defp root_path(nil), do: nil
 
   @spec record_selection(String.t(), term()) :: :ok
   defp record_selection(_abs_path, %{buffer_lifecycle: %{buffer_add_context: :preview}}),
@@ -313,7 +319,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
   defp sort_by_score(items, score_map) when map_size(score_map) == 0, do: items
 
   defp sort_by_score(items, score_map) do
-    Enum.sort_by(items, fn %Item{id: path} ->
+    Enum.sort_by(items, fn %Item{id: %ProjectFileCandidate{path: path}} ->
       score = Map.get(score_map, path, 0)
       depth = Enum.count(Path.split(path)) - 1
       {-score, depth, path}
@@ -351,9 +357,6 @@ defmodule MingaEditor.UI.Picker.FileSource do
   catch
     :exit, _ -> nil
   end
-
-  @spec active_workspace_root() :: Root.t() | nil
-  defp active_workspace_root, do: active_workspace() |> workspace_root()
 
   @spec workspace_root(WorkspaceSnapshot.t() | nil) :: Root.t() | nil
   defp workspace_root(nil), do: nil

--- a/lib/minga_editor/ui/picker/project_file_candidate.ex
+++ b/lib/minga_editor/ui/picker/project_file_candidate.ex
@@ -1,0 +1,44 @@
+defmodule MingaEditor.UI.Picker.ProjectFileCandidate do
+  @moduledoc """
+  Captured identity for one project file picker choice.
+
+  The authorized project root and workspace-relative cached path travel together
+  from candidate production through preview and selection. Resolving the value
+  always re-enters the `Minga.Project.Root` authorization boundary and never
+  consults the active Project or file tree.
+  """
+
+  alias Minga.Project.Root
+
+  @enforce_keys [:root, :path]
+  defstruct [:root, :path]
+
+  @typedoc "A project file choice tied to the workspace that produced it."
+  @type t :: %__MODULE__{root: Root.t(), path: String.t()}
+
+  @typedoc "Why a project file candidate could not be constructed or resolved."
+  @type error :: Root.file_error() | :empty_path
+
+  @doc "Builds a candidate from an authorized directory root and a workspace-relative path."
+  @spec new(Root.t(), String.t()) :: {:ok, t()} | {:error, error()}
+  def new(%Root{kind: :directory} = root, path) when is_binary(path) do
+    case Path.type(path) do
+      :relative -> safe_candidate(root, Path.safe_relative(path))
+      _absolute_or_volume_relative -> {:error, :absolute_path}
+    end
+  end
+
+  def new(%Root{}, path) when is_binary(path), do: {:error, :not_a_directory_root}
+
+  @doc "Resolves the candidate through its captured authorized root."
+  @spec resolve(t()) :: {:ok, String.t()} | {:error, error()}
+  def resolve(%__MODULE__{root: %Root{} = root, path: path}) do
+    Root.resolve_file(root, path)
+  end
+
+  @spec safe_candidate(Root.t(), {:ok, String.t()} | :error) ::
+          {:ok, t()} | {:error, :empty_path | :parent_traversal}
+  defp safe_candidate(_root, {:ok, ""}), do: {:error, :empty_path}
+  defp safe_candidate(root, {:ok, path}), do: {:ok, %__MODULE__{root: root, path: path}}
+  defp safe_candidate(_root, :error), do: {:error, :parent_traversal}
+end

--- a/test/minga_editor/render_model/ui/picker_builder_test.exs
+++ b/test/minga_editor/render_model/ui/picker_builder_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilderTest do
   alias MingaEditor.State.Buffers
   alias MingaEditor.UI.Picker, as: PickerState
   alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.ProjectFileCandidate
 
   describe "build/1" do
     test "returns hidden picker when modal is not a picker" do
@@ -116,7 +117,7 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilderTest do
       path = temp_file!("alpha\nbeta")
       item = %Item{id: path, label: Path.basename(path)}
       picker = %PickerState{items: [item], filtered: [item], title: "Files", selected: 0}
-      modal = picker_modal(picker, MingaEditor.UI.Picker.FileSource, nil, "", :ready)
+      modal = picker_modal(picker, MingaEditor.UI.Picker.RecentFileSource, nil, "", :ready)
 
       model = PickerBuilder.build(build_context(modal))
 
@@ -133,11 +134,8 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilderTest do
       on_exit(fn -> File.rm_rf!(root_path) end)
       {:ok, root} = Root.directory(root_path)
 
-      item = %Item{
-        id: "relative.txt",
-        label: "relative.txt",
-        meta: %{workspace_root: root}
-      }
+      {:ok, candidate} = ProjectFileCandidate.new(root, "relative.txt")
+      item = %Item{id: candidate, label: "relative.txt"}
 
       picker = %PickerState{items: [item], filtered: [item], title: "Files", selected: 0}
       modal = picker_modal(picker, MingaEditor.UI.Picker.FileSource, nil, "", :ready)
@@ -151,7 +149,7 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilderTest do
       path = temp_file!(<<0, 1, 2, "BEAM">>)
       item = %Item{id: path, label: Path.basename(path)}
       picker = %PickerState{items: [item], filtered: [item], title: "Files", selected: 0}
-      modal = picker_modal(picker, MingaEditor.UI.Picker.FileSource, nil, "", :ready)
+      modal = picker_modal(picker, MingaEditor.UI.Picker.RecentFileSource, nil, "", :ready)
 
       model = PickerBuilder.build(build_context(modal))
 

--- a/test/minga_editor/ui/picker/file_source_async_test.exs
+++ b/test/minga_editor/ui/picker/file_source_async_test.exs
@@ -10,6 +10,7 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.FileSource
   alias MingaEditor.UI.Picker.Item
+  alias MingaEditor.UI.Picker.ProjectFileCandidate
 
   @moduletag :tmp_dir
 
@@ -20,6 +21,8 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
     File.write!(Path.join(lib, "one.ex"), "one")
     File.write!(Path.join(lib, "two.ex"), "two")
 
+    {:ok, root} = Root.directory(project)
+
     state =
       TestHelpers.base_state(content: "initial")
       |> set_file_tree(%FileTree{project_root: project})
@@ -28,7 +31,10 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
 
     state =
       FileSource.on_bulk_select(
-        [%Item{id: "lib/one.ex", label: "one.ex"}, %Item{id: "lib/two.ex", label: "two.ex"}],
+        [
+          %Item{id: candidate!(root, "lib/one.ex"), label: "one.ex"},
+          %Item{id: candidate!(root, "lib/two.ex"), label: "two.ex"}
+        ],
         state
       )
 
@@ -76,7 +82,7 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
       |> set_file_tree(%FileTree{project_root: current_tree_root})
 
     initial_pids = state.workspace.buffers.list
-    item = %Item{id: "same.txt", label: "same.txt", meta: %{workspace_root: root}}
+    item = %Item{id: candidate!(root, "same.txt"), label: "same.txt"}
     state = FileSource.on_select(item, state)
     new_pids = Enum.reject(state.workspace.buffers.list, &Enum.member?(initial_pids, &1))
     on_exit(fn -> Enum.each(new_pids, &stop_pid/1) end)
@@ -85,15 +91,24 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
              Path.join(original_root, "same.txt")
   end
 
-  test "bulk actions expose open all marked" do
-    assert FileSource.bulk_actions([%Item{id: "lib/one.ex", label: "one.ex"}]) ==
-             [{"Open all marked", :open_marked}]
+  test "bulk actions expose open all marked", %{tmp_dir: tmp_dir} do
+    File.mkdir_p!(tmp_dir)
+    {:ok, root} = Root.directory(tmp_dir)
+
+    assert FileSource.bulk_actions([
+             %Item{id: candidate!(root, "lib/one.ex"), label: "one.ex"}
+           ]) == [{"Open all marked", :open_marked}]
   end
 
   describe "enrich/1" do
-    test "builds icon, color, two-line description, and git annotation for winners" do
+    test "builds icon, color, two-line description, and git annotation for winners", %{
+      tmp_dir: tmp_dir
+    } do
+      {:ok, root} = Root.directory(tmp_dir)
+      candidate = candidate!(root, "lib/foo/bar.ex")
+
       lean = %Item{
-        id: "lib/foo/bar.ex",
+        id: candidate,
         label: "bar.ex",
         search_text: "lib/foo/bar.ex",
         meta: %{git: :modified}
@@ -101,7 +116,7 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
 
       [enriched] = FileSource.enrich([lean])
 
-      assert enriched.id == "lib/foo/bar.ex"
+      assert enriched.id == candidate
       assert String.ends_with?(enriched.label, " bar.ex")
       assert String.first(enriched.label) != "b"
       assert enriched.description == "lib/foo"
@@ -110,12 +125,28 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
       assert is_integer(enriched.icon_color)
     end
 
-    test "uses an empty description for root-level files and no git annotation" do
-      lean = %Item{id: "mix.exs", label: "mix.exs", search_text: "mix.exs", meta: %{git: nil}}
+    test "uses an empty description for root-level files and no git annotation", %{
+      tmp_dir: tmp_dir
+    } do
+      {:ok, root} = Root.directory(tmp_dir)
+
+      lean = %Item{
+        id: candidate!(root, "mix.exs"),
+        label: "mix.exs",
+        search_text: "mix.exs",
+        meta: %{git: nil}
+      }
+
       [enriched] = FileSource.enrich([lean])
       assert enriched.description == ""
       assert enriched.annotation == nil
     end
+  end
+
+  @spec candidate!(Root.t(), String.t()) :: ProjectFileCandidate.t()
+  defp candidate!(root, path) do
+    {:ok, candidate} = ProjectFileCandidate.new(root, path)
+    candidate
   end
 
   @spec set_file_tree(MingaEditor.State.t(), FileTree.t()) :: MingaEditor.State.t()

--- a/test/minga_editor/ui/picker/file_source_project_switch_test.exs
+++ b/test/minga_editor/ui/picker/file_source_project_switch_test.exs
@@ -1,0 +1,269 @@
+defmodule MingaEditor.UI.Picker.FileSourceProjectSwitchTest do
+  @moduledoc "Tests delayed project-file choices against the globally registered Project."
+
+  # Candidate production must reroot the globally registered Project between workspaces.
+  use ExUnit.Case, async: false
+
+  alias Minga.Project
+  alias Minga.Project.Root
+  alias Minga.RenderModel.UI.Picker, as: PickerModel
+  alias MingaEditor.PickerUI
+  alias MingaEditor.RenderModel.UI.PickerBuilder
+  alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Traditional.ModalWorkflow
+  alias MingaEditor.State.FileTree
+  alias MingaEditor.State.ModalOverlay.Picker, as: PickerPayload
+  alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.FileSource
+  alias MingaEditor.UI.Picker.ProjectFileCandidate
+
+  @moduletag :tmp_dir
+
+  setup do
+    original_workspace = Project.snapshot()
+
+    on_exit(fn -> restore_project(original_workspace) end)
+  end
+
+  test "all delayed action paths stay tied to Project A after Project and file tree switch to B",
+       %{
+         tmp_dir: tmp_dir
+       } do
+    project_a = Path.join(tmp_dir, "project_a")
+    project_b = Path.join(tmp_dir, "project_b")
+
+    relative_paths = [
+      "single.txt",
+      "preview.txt",
+      "delete.txt",
+      "marked/one.txt",
+      "marked/two.txt",
+      "bulk/one.txt",
+      "bulk/two.txt"
+    ]
+
+    write_workspace(project_a, relative_paths, "A")
+    write_workspace(project_b, relative_paths, "B")
+    {:ok, root_a} = Root.directory(project_a)
+    {:ok, root_b} = Root.directory(project_b)
+
+    activate_project!(root_a)
+
+    production_state =
+      TestHelpers.base_state(content: "initial")
+      |> set_file_tree(%FileTree{project_root: project_a})
+
+    items =
+      production_state
+      |> Context.from_editor_state()
+      |> FileSource.candidates()
+
+    items_by_path = Map.new(items, fn item -> {item.id.path, item} end)
+
+    assert Enum.sort(Map.keys(items_by_path)) == Enum.sort(relative_paths)
+
+    assert Enum.all?(items, fn item ->
+             match?(%ProjectFileCandidate{root: ^root_a}, item.id) and
+               item.meta == %{git: nil}
+           end)
+
+    activate_project!(root_b)
+
+    rerooted_state =
+      TestHelpers.base_state(content: "initial")
+      |> set_file_tree(%FileTree{project_root: project_b})
+
+    single_picker_state = open_single_picker(rerooted_state, items_by_path["single.txt"])
+    single_state = PickerUI.handle_key(single_picker_state, 13, 0)
+    on_exit(fn -> stop_added_buffers(single_state, rerooted_state) end)
+
+    assert Minga.Buffer.file_path(single_state.workspace.buffers.active) ==
+             Path.join(project_a, "single.txt")
+
+    assert File.read!(Path.join(project_b, "single.txt")) == "B:single.txt"
+
+    preview_model =
+      items_by_path["preview.txt"]
+      |> picker_modal()
+      |> build_preview_context(rerooted_state)
+      |> PickerBuilder.build()
+
+    assert %PickerModel{preview_lines: [[{"A:preview.txt", 0xCCCCCC, false}]]} = preview_model
+
+    FileSource.on_action(:delete, items_by_path["delete.txt"], rerooted_state)
+    refute File.exists?(Path.join(project_a, "delete.txt"))
+    assert File.read!(Path.join(project_b, "delete.txt")) == "B:delete.txt"
+
+    marked_items = [items_by_path["marked/one.txt"], items_by_path["marked/two.txt"]]
+    marked_state = open_marked_picker(rerooted_state, marked_items)
+    entered_state = PickerUI.handle_key(marked_state, 13, 0)
+    on_exit(fn -> stop_added_buffers(entered_state, rerooted_state) end)
+
+    assert opened_paths(entered_state, rerooted_state) == [
+             Path.join(project_a, "marked/one.txt"),
+             Path.join(project_a, "marked/two.txt")
+           ]
+
+    assert Minga.Buffer.file_path(entered_state.workspace.buffers.active) ==
+             Path.join(project_a, "marked/two.txt")
+
+    bulk_items = [items_by_path["bulk/one.txt"], items_by_path["bulk/two.txt"]]
+    bulk_state = open_marked_picker(rerooted_state, bulk_items)
+    menu_state = PickerUI.handle_key(bulk_state, ?o, MingaEditor.Input.mod_ctrl())
+    bulk_opened_state = PickerUI.handle_key(menu_state, 13, 0)
+    on_exit(fn -> stop_added_buffers(bulk_opened_state, rerooted_state) end)
+
+    assert opened_paths(bulk_opened_state, rerooted_state) == [
+             Path.join(project_a, "bulk/one.txt"),
+             Path.join(project_a, "bulk/two.txt")
+           ]
+
+    assert Minga.Buffer.file_path(bulk_opened_state.workspace.buffers.active) ==
+             Path.join(project_a, "bulk/two.txt")
+
+    assert %Minga.Project.WorkspaceSnapshot{
+             root: ^root_b,
+             files: project_b_files,
+             rebuilding?: false
+           } = Project.snapshot()
+
+    assert Enum.sort(project_b_files) == Enum.sort(relative_paths)
+  end
+
+  @spec activate_project!(Root.t()) :: :ok
+  defp activate_project!(%Root{path: path} = root) do
+    Minga.Events.subscribe(:project_rebuilt)
+    assert {:ok, snapshot} = Project.activate(root)
+
+    if snapshot.rebuilding? do
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^path}},
+                     5_000
+    end
+
+    _ = :sys.get_state(Project)
+    :ok
+  end
+
+  @spec restore_project(Minga.Project.WorkspaceSnapshot.t() | nil) :: :ok
+  defp restore_project(nil) do
+    Project.close()
+    _ = :sys.get_state(Project)
+    :ok
+  end
+
+  defp restore_project(%Minga.Project.WorkspaceSnapshot{root: root}) do
+    Project.close()
+    _ = :sys.get_state(Project)
+    _ = Project.activate(root)
+    :ok
+  end
+
+  @spec write_workspace(String.t(), [String.t()], String.t()) :: :ok
+  defp write_workspace(root, relative_paths, prefix) do
+    Enum.each(relative_paths, fn relative_path ->
+      absolute_path = Path.join(root, relative_path)
+      File.mkdir_p!(Path.dirname(absolute_path))
+      File.write!(absolute_path, "#{prefix}:#{relative_path}")
+    end)
+  end
+
+  @spec set_file_tree(MingaEditor.State.t(), FileTree.t()) :: MingaEditor.State.t()
+  defp set_file_tree(state, file_tree) do
+    %{state | workspace: SessionState.set_file_tree(state.workspace, file_tree)}
+  end
+
+  @spec picker_modal(MingaEditor.UI.Picker.Item.t()) :: term()
+  defp picker_modal(item) do
+    picker = Picker.new([item], title: "Files")
+
+    {:picker,
+     %{
+       picker_ui: %PickerState{
+         picker: picker,
+         source: FileSource
+       }
+     }}
+  end
+
+  @spec build_preview_context(term(), MingaEditor.State.t()) ::
+          MingaEditor.Frontend.Emit.Context.t()
+  defp build_preview_context(modal, state) do
+    %MingaEditor.Frontend.Emit.Context{
+      port_manager: self(),
+      capabilities: MingaEditor.Frontend.Capabilities.default(),
+      theme: %{fg: 0xCCCCCC},
+      font_registry: MingaEditor.UI.FontRegistry.new(),
+      windows: state.workspace.windows,
+      layout: %MingaEditor.Layout{
+        terminal: {0, 0, 80, 24},
+        editor_area: {0, 0, 80, 24},
+        minibuffer: {23, 0, 80, 1},
+        window_layouts: %{}
+      },
+      shell: MingaEditor.Shell.Traditional,
+      shell_state: %{modal: modal},
+      buffers: state.workspace.buffers,
+      highlight: %{highlights: %{}}
+    }
+  end
+
+  @spec open_single_picker(MingaEditor.State.t(), MingaEditor.UI.Picker.Item.t()) ::
+          MingaEditor.State.t()
+  defp open_single_picker(state, item) do
+    picker_state = %PickerState{
+      picker: Picker.new([item], title: "Files"),
+      source: FileSource,
+      restore: state.workspace.buffers.active_index
+    }
+
+    ModalWorkflow.open(state, {:picker, PickerPayload.new(picker_state)})
+  end
+
+  @spec open_marked_picker(MingaEditor.State.t(), [MingaEditor.UI.Picker.Item.t()]) ::
+          MingaEditor.State.t()
+  defp open_marked_picker(state, items) do
+    picker =
+      items
+      |> Picker.new(title: "Files")
+      |> Picker.toggle_mark()
+      |> Picker.move_down()
+      |> Picker.toggle_mark()
+
+    picker_state = %PickerState{
+      picker: picker,
+      source: FileSource,
+      restore: state.workspace.buffers.active_index
+    }
+
+    ModalWorkflow.open(state, {:picker, PickerPayload.new(picker_state)})
+  end
+
+  @spec opened_paths(MingaEditor.State.t(), MingaEditor.State.t()) :: [String.t()]
+  defp opened_paths(result_state, initial_state) do
+    initial_buffers = MapSet.new(initial_state.workspace.buffers.list)
+
+    result_state.workspace.buffers.list
+    |> Enum.reject(&MapSet.member?(initial_buffers, &1))
+    |> Enum.map(&Minga.Buffer.file_path/1)
+  end
+
+  @spec stop_added_buffers(MingaEditor.State.t(), MingaEditor.State.t()) :: :ok
+  defp stop_added_buffers(result_state, initial_state) do
+    initial_buffers = MapSet.new(initial_state.workspace.buffers.list)
+
+    result_state.workspace.buffers.list
+    |> Enum.reject(&MapSet.member?(initial_buffers, &1))
+    |> Enum.each(&stop_pid/1)
+  end
+
+  @spec stop_pid(pid()) :: :ok
+  defp stop_pid(pid) do
+    GenServer.stop(pid)
+  catch
+    :exit, _ -> :ok
+  end
+end

--- a/test/minga_editor/ui/picker/project_file_candidate_test.exs
+++ b/test/minga_editor/ui/picker/project_file_candidate_test.exs
@@ -1,0 +1,51 @@
+defmodule MingaEditor.UI.Picker.ProjectFileCandidateTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Project.Root
+  alias MingaEditor.UI.Picker.ProjectFileCandidate
+
+  @moduletag :tmp_dir
+
+  test "captures an authorized root with a normalized workspace-relative path", %{
+    tmp_dir: tmp_dir
+  } do
+    {:ok, root} = Root.directory(tmp_dir)
+
+    assert {:ok, %ProjectFileCandidate{root: ^root, path: "lib/file.ex"}} =
+             ProjectFileCandidate.new(root, "lib/./file.ex")
+  end
+
+  test "construction rejects absolute and parent-traversing paths", %{tmp_dir: tmp_dir} do
+    {:ok, root} = Root.directory(tmp_dir)
+
+    assert {:error, :absolute_path} = ProjectFileCandidate.new(root, Path.join(tmp_dir, "file"))
+    assert {:error, :parent_traversal} = ProjectFileCandidate.new(root, "../file")
+    assert {:error, :empty_path} = ProjectFileCandidate.new(root, ".")
+  end
+
+  test "resolution rejects invalid or missing paths through the captured Root", %{
+    tmp_dir: tmp_dir
+  } do
+    {:ok, root} = Root.directory(tmp_dir)
+
+    absolute = %ProjectFileCandidate{root: root, path: Path.join(tmp_dir, "file")}
+    traversal = %ProjectFileCandidate{root: root, path: "../file"}
+    missing = %ProjectFileCandidate{root: root, path: "missing.txt"}
+
+    assert {:error, :absolute_path} = ProjectFileCandidate.resolve(absolute)
+    assert {:error, :parent_traversal} = ProjectFileCandidate.resolve(traversal)
+    assert {:error, :enoent} = ProjectFileCandidate.resolve(missing)
+  end
+
+  test "resolution rejects a symlink escaping the captured Root", %{tmp_dir: tmp_dir} do
+    workspace = Path.join(tmp_dir, "workspace")
+    outside = Path.join(tmp_dir, "outside.txt")
+    File.mkdir_p!(workspace)
+    File.write!(outside, "outside")
+    File.ln_s!(outside, Path.join(workspace, "escape.txt"))
+    {:ok, root} = Root.directory(workspace)
+    {:ok, candidate} = ProjectFileCandidate.new(root, "escape.txt")
+
+    assert {:error, :outside_workspace} = ProjectFileCandidate.resolve(candidate)
+  end
+end


### PR DESCRIPTION
# TL;DR
Project file picker choices now carry their authorized workspace Root and relative path as one typed identity, so delayed open, preview, delete, and bulk actions cannot be redirected by a later workspace switch.

Closes #2946

## Context
This is the third delivery slice of #2939. FileSource previously split identity between a relative binary ID and optional metadata, then fell back to the live file-tree or Project root when metadata was missing. That made a stale candidate capable of referring to a different file after rerooting.

## Changes
- Add `MingaEditor.UI.Picker.ProjectFileCandidate` with an enforced typed Root and normalized workspace-relative path.
- Store the typed value in FileSource `Item.id` from candidate production through filtering, marking, display enrichment, preview, and selection.
- Resolve all project file actions through `Minga.Project.Root.resolve_file/2` using the captured Root.
- Delete FileSource's live Project and file-tree root fallbacks and remove workspace identity from display metadata.
- Update PickerBuilder to preview typed project file candidates while retaining generic binary and integer IDs for unrelated picker sources.
- Add a controlled Project A to B test covering single open, preview, delete, marked Enter, and Open All Marked after both Project and file-tree rerooting.

## Compatibility

Ranking, Git annotations, frecency recording, marking, source-order bulk actions, and the atomic Project snapshot read are unchanged. Recent files and unrelated picker sources keep their existing binary and integer identities.

## Verification
- Focused FileSource, ProjectFileCandidate, PickerBuilder, PickerUI, and ProjectCache suites (35 tests, 0 failures)
- `make lint` (Credo clean, compilation clean, Dialyzer 0 errors)
- `mix test.llm` (9,536 tests, 97 properties, 58 doctests, 0 failures)
- Final reviewer and targeted blocker re-review: PASS

## Acceptance Criteria Addressed
- Every FileSource item carries one typed captured workspace identity ✅
- All single, preview, delete, and bulk action paths avoid live roots ✅
- Project and file-tree rerooting cannot redirect existing candidates ✅
- Candidate resolution uses the Root authorization boundary without discovery ✅
- Picker ranking, enrichment, marking, bulk order, frecency, and unrelated IDs remain compatible ✅
