### PR TITLE
refactor(ui): preserve TODO workspace authorization

### DIFF
--- a/lib/minga_editor/effects/todo_search.ex
+++ b/lib/minga_editor/effects/todo_search.ex
@@ -4,34 +4,35 @@ defmodule MingaEditor.Effects.TodoSearch do
 
   Repository probing and grep execution run in the generation-owned effect
   scheduler. The editor only applies the correlated picker result when its
-  source and fetch revision are still live.
+  source, workspace root, and fetch revision are still live.
   """
 
   @behaviour MingaEditor.Effect
 
+  alias Minga.Project.Root
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effect.Policy
   alias MingaEditor.Effect.Request
+  alias MingaEditor.Effects.TodoSearch.Port, as: TodoSearchPort
+  alias MingaEditor.Effects.TodoSearch.Result
+  alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.UI.Picker.Candidate
   alias MingaEditor.UI.Picker.TodoSearchSource
-  alias MingaEditor.PickerUI
 
   @keyword_pattern "(^|[[:space:]])(#|//|/\\*|%|--)[[:space:]]*(TODO|FIXME|HACK|NOTE|REVIEW|DEPRECATED)([^[:alnum:]_]|$)"
-  @command_timeout_ms 5_000
 
   @enforce_keys [:root, :revision]
-  defstruct [:root, :revision]
+  defstruct [:root, :revision, impl: TodoSearchPort]
 
-  @type t :: %__MODULE__{root: String.t(), revision: reference()}
-
-  alias MingaEditor.Effects.TodoSearch.Result
+  @type impl :: module()
+  @type t :: %__MODULE__{root: Root.t(), revision: reference(), impl: impl()}
 
   @doc "Builds a latest-wins TODO search request for one project root."
-  @spec request(String.t(), reference()) :: Request.t()
-  def request(root, revision) when is_binary(root) and is_reference(revision) do
+  @spec request(Root.t(), reference()) :: Request.t()
+  def request(%Root{} = root, revision) when is_reference(revision) do
     Request.new(
-      %__MODULE__{root: root, revision: revision},
+      %__MODULE__{root: root, revision: revision, impl: impl()},
       {:todo_search, root},
       Policy.latest_wins()
     )
@@ -39,21 +40,10 @@ defmodule MingaEditor.Effects.TodoSearch do
 
   @impl true
   @spec run(t()) :: {:ok, Result.t()} | {:error, String.t()}
-  def run(%__MODULE__{root: root, revision: revision}) do
-    with {:ok, output} <- search_output(root) do
-      items =
-        output
-        |> TodoSearchSource.parse_output()
-        |> TodoSearchSource.build_candidates(root)
-
-      {:ok,
-       %Result{
-         root: root,
-         revision: revision,
-         items: items,
-         candidates: Candidate.from_items(items),
-         meta: %{}
-       }}
+  def run(%__MODULE__{root: root} = effect) do
+    case Root.inventory_path(root) do
+      {:ok, canonical_root} -> run_authorized(effect, canonical_root)
+      {:error, reason} -> {:error, authorization_failure(reason)}
     end
   end
 
@@ -69,21 +59,22 @@ defmodule MingaEditor.Effects.TodoSearch do
           status: :completed,
           request: %Request{effect: effect},
           result: %Result{} = result
-        } =
-          outcome
+        } = outcome
       ) do
-    if result.revision == effect.revision do
-      apply_completed_result(state, effect, result, outcome)
-    else
-      {state, Outcome.stale(outcome, :revision_mismatch)}
-    end
+    apply_matching_revision(state, effect, result, outcome, result.revision == effect.revision)
   end
 
   def apply(
         state,
         %Outcome{status: :failed, request: %Request{effect: effect}, reason: reason} = outcome
       ) do
-    apply_failed_result(state, effect, failure_message(reason), outcome)
+    apply_failed_for_workspace(
+      state,
+      effect,
+      failure_message(reason),
+      outcome,
+      active_workspace_root()
+    )
   end
 
   def apply(state, %Outcome{} = outcome), do: {state, outcome}
@@ -91,6 +82,70 @@ defmodule MingaEditor.Effects.TodoSearch do
   @impl true
   @spec render?(Outcome.t()) :: boolean()
   def render?(%Outcome{}), do: true
+
+  @spec run_authorized(t(), String.t()) :: {:ok, Result.t()} | {:error, String.t()}
+  defp run_authorized(%__MODULE__{revision: revision, impl: impl}, canonical_root) do
+    with {:ok, output} <- search_output(canonical_root, impl) do
+      items =
+        output
+        |> TodoSearchSource.parse_output()
+        |> TodoSearchSource.build_candidates(canonical_root)
+
+      {:ok,
+       %Result{
+         revision: revision,
+         items: items,
+         candidates: Candidate.from_items(items),
+         meta: %{}
+       }}
+    end
+  end
+
+  @spec apply_matching_revision(EditorState.t(), t(), Result.t(), Outcome.t(), boolean()) ::
+          {EditorState.t(), Outcome.t()}
+  defp apply_matching_revision(state, effect, result, outcome, true) do
+    apply_completed_for_workspace(state, effect, result, outcome, active_workspace_root())
+  end
+
+  defp apply_matching_revision(state, _effect, _result, outcome, false) do
+    {state, Outcome.stale(outcome, :revision_mismatch)}
+  end
+
+  @spec apply_completed_for_workspace(
+          EditorState.t(),
+          t(),
+          Result.t(),
+          Outcome.t(),
+          Root.t() | nil
+        ) :: {EditorState.t(), Outcome.t()}
+  defp apply_completed_for_workspace(
+         state,
+         %__MODULE__{root: root} = effect,
+         result,
+         outcome,
+         root
+       ) do
+    apply_completed_result(state, effect, result, outcome)
+  end
+
+  defp apply_completed_for_workspace(state, _effect, _result, outcome, _active_root) do
+    {state, Outcome.stale(outcome, :workspace_rerooted)}
+  end
+
+  @spec apply_failed_for_workspace(
+          EditorState.t(),
+          t(),
+          String.t(),
+          Outcome.t(),
+          Root.t() | nil
+        ) :: {EditorState.t(), Outcome.t()}
+  defp apply_failed_for_workspace(state, %__MODULE__{root: root} = effect, reason, outcome, root) do
+    apply_failed_result(state, effect, reason, outcome)
+  end
+
+  defp apply_failed_for_workspace(state, _effect, _reason, outcome, _active_root) do
+    {state, Outcome.stale(outcome, :workspace_rerooted)}
+  end
 
   @spec apply_completed_result(EditorState.t(), t(), Result.t(), Outcome.t()) ::
           {EditorState.t(), Outcome.t()}
@@ -115,74 +170,58 @@ defmodule MingaEditor.Effects.TodoSearch do
     end
   end
 
-  defp search_output(root) do
-    if git_repo?(root) do
-      run_search_command("git", [
-        "-C",
-        root,
-        "grep",
-        "-n",
-        "-I",
-        "-E",
-        @keyword_pattern,
-        "--",
-        "."
-      ])
+  @spec active_workspace_root() :: Root.t() | nil
+  defp active_workspace_root do
+    Minga.Project.workspace_root()
+  catch
+    :exit, _reason -> nil
+  end
+
+  @spec impl() :: impl()
+  defp impl do
+    Application.get_env(:minga, :todo_search_port_module, TodoSearchPort)
+  end
+
+  @spec search_output(String.t(), impl()) :: {:ok, String.t()} | {:error, String.t()}
+  defp search_output(canonical_root, port_backend) do
+    if git_repo?(canonical_root, port_backend) do
+      run_search_command(
+        port_backend,
+        "git",
+        ["-C", canonical_root, "grep", "-n", "-I", "-E", @keyword_pattern, "--", "."]
+      )
     else
-      run_search_command("grep", ["-rnEI", "--exclude-dir=.git", @keyword_pattern, root])
+      run_search_command(port_backend, "grep", [
+        "-rnEI",
+        "--exclude-dir=.git",
+        @keyword_pattern,
+        canonical_root
+      ])
     end
   end
 
-  defp git_repo?(root) do
-    case run_port("git", ["-C", root, "rev-parse", "--is-inside-work-tree"]) do
+  @spec git_repo?(String.t(), impl()) :: boolean()
+  defp git_repo?(canonical_root, port_backend) do
+    case port_backend.run("git", ["-C", canonical_root, "rev-parse", "--is-inside-work-tree"]) do
       {output, 0} -> String.trim(output) == "true"
       _ -> false
     end
   end
 
-  defp run_search_command(command, args) do
-    case run_port(command, args) do
+  @spec run_search_command(impl(), String.t(), [String.t()]) ::
+          {:ok, String.t()} | {:error, String.t()}
+  defp run_search_command(port_backend, command, args) do
+    case port_backend.run(command, args) do
       {output, 0} -> {:ok, output}
       {_output, 1} -> {:ok, ""}
       {output, status} -> {:error, "#{command} exited with status #{status}: #{output}"}
     end
   end
 
-  defp run_port(command, args) do
-    case System.find_executable(command) do
-      nil -> {"#{command} executable not found", 127}
-      executable -> open_port(executable, args)
-    end
-  rescue
-    error -> {Exception.message(error), 1}
-  end
+  @spec authorization_failure(Root.error()) :: String.t()
+  defp authorization_failure(reason), do: "TODO search root rejected: #{reason}"
 
-  defp open_port(executable, args) do
-    port =
-      Port.open({:spawn_executable, executable}, [
-        :binary,
-        :exit_status,
-        :hide,
-        :stderr_to_stdout,
-        {:args, args},
-        {:line, 65_536}
-      ])
-
-    collect_port_output(port, [])
-  end
-
-  defp collect_port_output(port, acc) do
-    receive do
-      {^port, {:data, {:eol, chunk}}} -> collect_port_output(port, ["\n", chunk | acc])
-      {^port, {:data, {:noeol, chunk}}} -> collect_port_output(port, [chunk | acc])
-      {^port, {:exit_status, status}} -> {acc |> Enum.reverse() |> IO.iodata_to_binary(), status}
-    after
-      @command_timeout_ms ->
-        Port.close(port)
-        {"command timed out", 124}
-    end
-  end
-
+  @spec failure_message(term()) :: String.t()
   defp failure_message({:worker_exit, reason}),
     do: "TODO search worker failed: #{inspect(reason)}"
 

--- a/lib/minga_editor/effects/todo_search_port.ex
+++ b/lib/minga_editor/effects/todo_search_port.ex
@@ -1,0 +1,55 @@
+defmodule MingaEditor.Effects.TodoSearch.Port do
+  @moduledoc """
+  Executes the bounded git and grep Ports used by TODO search.
+
+  This is a focused execution seam for TODO search. Workspace authorization
+  remains in `MingaEditor.Effects.TodoSearch` and must complete before this
+  module is called.
+  """
+
+  @command_timeout_ms 5_000
+
+  @typedoc "A completed TODO-search command result."
+  @type result :: {String.t(), non_neg_integer()}
+
+  @doc "Runs one TODO-search command through a Port with a bounded timeout."
+  @callback run(String.t(), [String.t()]) :: result()
+
+  @spec run(String.t(), [String.t()]) :: result()
+  def run(command, args) when is_binary(command) and is_list(args) do
+    case System.find_executable(command) do
+      nil -> {"#{command} executable not found", 127}
+      executable -> open_port(executable, args)
+    end
+  rescue
+    error -> {Exception.message(error), 1}
+  end
+
+  @spec open_port(String.t(), [String.t()]) :: result()
+  defp open_port(executable, args) do
+    port =
+      Port.open({:spawn_executable, executable}, [
+        :binary,
+        :exit_status,
+        :hide,
+        :stderr_to_stdout,
+        {:args, args},
+        {:line, 65_536}
+      ])
+
+    collect_port_output(port, [])
+  end
+
+  @spec collect_port_output(port(), iodata()) :: result()
+  defp collect_port_output(port, acc) do
+    receive do
+      {^port, {:data, {:eol, chunk}}} -> collect_port_output(port, ["\n", chunk | acc])
+      {^port, {:data, {:noeol, chunk}}} -> collect_port_output(port, [chunk | acc])
+      {^port, {:exit_status, status}} -> {acc |> Enum.reverse() |> IO.iodata_to_binary(), status}
+    after
+      @command_timeout_ms ->
+        Port.close(port)
+        {"command timed out", 124}
+    end
+  end
+end

--- a/lib/minga_editor/effects/todo_search_result.ex
+++ b/lib/minga_editor/effects/todo_search_result.ex
@@ -3,11 +3,10 @@ defmodule MingaEditor.Effects.TodoSearch.Result do
 
   alias MingaEditor.UI.Picker.Candidate
 
-  @enforce_keys [:root, :revision, :items, :candidates, :meta]
-  defstruct [:root, :revision, :items, :candidates, :meta]
+  @enforce_keys [:revision, :items, :candidates, :meta]
+  defstruct [:revision, :items, :candidates, :meta]
 
   @type t :: %__MODULE__{
-          root: String.t(),
           revision: reference(),
           items: [MingaEditor.UI.Picker.Item.t()],
           candidates: [Candidate.t()],

--- a/lib/minga_editor/shell/traditional/todo_search_workflow.ex
+++ b/lib/minga_editor/shell/traditional/todo_search_workflow.ex
@@ -13,9 +13,10 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
   @spec open(MingaEditor.State.t()) :: MingaEditor.State.t()
   def open(state) do
     {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
-    schedule(state, workspace_root(state), revision)
+    schedule(state, active_workspace_root(), revision)
   end
 
+  @spec schedule(MingaEditor.State.t(), Root.t() | nil, reference()) :: MingaEditor.State.t()
   defp schedule(state, nil, revision) do
     apply_failure(state, revision, "No directory workspace active")
   end
@@ -24,7 +25,7 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
     apply_failure(state, revision, "TODO search scheduler unavailable")
   end
 
-  defp schedule(state, root, revision) do
+  defp schedule(state, %Root{} = root, revision) do
     case EffectScheduler.schedule(state.effect_scheduler, TodoSearch.request(root, revision)) do
       {:ok, _request_id, _disposition} ->
         state
@@ -37,24 +38,6 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
       apply_failure(state, revision, "TODO search scheduler unavailable: #{inspect(reason)}")
   end
 
-  @spec workspace_root(MingaEditor.State.t()) :: String.t() | nil
-  defp workspace_root(%{workspace: %{file_tree: %{project_root: file_tree_root}}}) do
-    resolve_workspace_root(file_tree_root, active_workspace_root())
-  end
-
-  @spec resolve_workspace_root(String.t() | nil, Root.t() | nil) :: String.t() | nil
-  defp resolve_workspace_root(path, %Root{path: path} = root), do: authorized_path(root)
-
-  defp resolve_workspace_root(path, _active_root) when is_binary(path) do
-    case Root.directory(path) do
-      {:ok, root} -> authorized_path(root)
-      {:error, _reason} -> nil
-    end
-  end
-
-  defp resolve_workspace_root(nil, %Root{} = root), do: authorized_path(root)
-  defp resolve_workspace_root(nil, nil), do: nil
-
   @spec active_workspace_root() :: Root.t() | nil
   defp active_workspace_root do
     Minga.Project.workspace_root()
@@ -62,14 +45,7 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
     :exit, _reason -> nil
   end
 
-  @spec authorized_path(Root.t()) :: String.t() | nil
-  defp authorized_path(root) do
-    case Root.inventory_path(root) do
-      {:ok, path} -> path
-      {:error, _reason} -> nil
-    end
-  end
-
+  @spec apply_failure(MingaEditor.State.t(), reference(), String.t()) :: MingaEditor.State.t()
   defp apply_failure(state, revision, message) do
     {:ok, state} =
       PickerUI.apply_fetch_result(state, TodoSearchSource, revision, {:error, message})

--- a/lib/minga_editor/ui/picker/todo_search_source.ex
+++ b/lib/minga_editor/ui/picker/todo_search_source.ex
@@ -49,19 +49,19 @@ defmodule MingaEditor.UI.Picker.TodoSearchSource do
     |> Enum.flat_map(&parse_line/1)
   end
 
-  @doc "Builds picker items from parsed marker maps."
+  @doc "Builds picker items using the canonical root authorized by TODO search."
   @spec build_candidates([marker()] | {:ok, String.t()} | {:error, String.t()}, String.t()) :: [
           Item.t()
         ]
-  def build_candidates({:ok, output}, root),
-    do: output |> parse_output() |> build_candidates(root)
+  def build_candidates({:ok, output}, canonical_root),
+    do: output |> parse_output() |> build_candidates(canonical_root)
 
-  def build_candidates({:error, _message}, _root), do: []
+  def build_candidates({:error, _message}, _canonical_root), do: []
 
-  def build_candidates(markers, root) when is_list(markers) do
+  def build_candidates(markers, canonical_root) when is_list(markers) do
     markers
     |> Enum.with_index()
-    |> Enum.map(fn {marker, idx} -> marker_item(marker, idx, root) end)
+    |> Enum.map(fn {marker, idx} -> marker_item(marker, idx, canonical_root) end)
   end
 
   @impl true
@@ -93,9 +93,9 @@ defmodule MingaEditor.UI.Picker.TodoSearchSource do
   end
 
   @spec marker_item(marker(), non_neg_integer(), String.t()) :: Item.t()
-  defp marker_item(marker, idx, root) do
-    path = Path.expand(marker.path, root)
-    rel_path = Path.relative_to(path, root)
+  defp marker_item(marker, idx, canonical_root) do
+    path = Path.expand(marker.path, canonical_root)
+    rel_path = Path.relative_to(path, canonical_root)
     filename = Path.basename(path)
     filetype = Language.detect_filetype(filename)
     {icon, color} = Devicon.icon_and_color(filetype)

--- a/test/minga_editor/effect_scheduler_test.exs
+++ b/test/minga_editor/effect_scheduler_test.exs
@@ -3,15 +3,34 @@ defmodule MingaEditor.EffectSchedulerTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Project.Root
   alias Minga.Test.EffectOwner
   alias Minga.Test.EffectProbe
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effect.Policy
   alias MingaEditor.Effect.Request
   alias MingaEditor.EffectScheduler
+  alias MingaEditor.Effects.TodoSearch
   alias MingaEditor.GenerationSupervisor
 
   @effect_timeout 15_000
+
+  test "TODO requests retain their typed Root through scheduler failure outcomes" do
+    root = %Root{kind: :directory, path: "/missing/todo-search-root"}
+    request = TodoSearch.request(root, make_ref())
+    scheduler = start_scheduler()
+
+    assert request.resource == {:todo_search, root}
+    assert request.effect.root == root
+    assert EffectScheduler.schedule(scheduler, request) == {:ok, request.id, :running}
+
+    outcome = receive_candidate(scheduler, request.id, :failed)
+
+    assert outcome.request.resource == {:todo_search, root}
+    assert outcome.request.effect.root == root
+    assert outcome.reason == "TODO search root rejected: not_a_directory"
+    finalize_once(scheduler, outcome)
+  end
 
   test "normal completion produces exactly one completed terminal outcome" do
     scheduler = start_scheduler()

--- a/test/minga_editor/picker_async_stale_test.exs
+++ b/test/minga_editor/picker_async_stale_test.exs
@@ -12,8 +12,13 @@ defmodule MingaEditor.PickerAsyncStaleTest do
   never appear, regardless of whether the real fetch has landed.
   """
 
-  use Minga.Test.EditorCase, async: true, rendering: :disabled
+  # TODO fetches spawn git/grep Ports and read the process-global Project workspace.
+  use Minga.Test.EditorCase, async: false, rendering: :disabled
 
+  alias Minga.Project
+  alias Minga.Project.Root
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.Effects.TodoSearch
   alias MingaEditor.UI.Picker.Candidate
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.TodoSearchSource
@@ -21,12 +26,23 @@ defmodule MingaEditor.PickerAsyncStaleTest do
   @sync_timeout 15_000
 
   setup do
-    root =
-      Path.join(System.tmp_dir!(), "minga-async-picker-#{System.unique_integer([:positive])}")
+    original_workspace = Project.snapshot()
+    id = System.unique_integer([:positive])
+    root = Path.join(System.tmp_dir!(), "minga-async-picker-#{id}")
+    reroot = Path.join(System.tmp_dir!(), "minga-async-picker-reroot-#{id}")
 
     File.mkdir_p!(root)
-    on_exit(fn -> File.rm_rf(root) end)
-    %{project_root: root}
+    File.mkdir_p!(reroot)
+    {:ok, active_root} = Root.directory(root)
+    activate_project!(active_root)
+
+    on_exit(fn ->
+      restore_project(original_workspace)
+      File.rm_rf(root)
+      File.rm_rf(reroot)
+    end)
+
+    %{project_root: root, reroot: reroot}
   end
 
   defp picker_payload(ctx) do
@@ -83,6 +99,31 @@ defmodule MingaEditor.PickerAsyncStaleTest do
     refute "stale-sentinel" in labels
   end
 
+  test "rejects a live-revision result captured before workspace rerooting",
+       %{project_root: root_path, reroot: reroot_path} do
+    ctx = start_editor("scratch", project_root: root_path)
+    :ok = GenServer.call(ctx.editor, {:api_execute_command, :search_todos}, @sync_timeout)
+
+    revision = picker_payload(ctx).picker_ui.fetch_revision
+    state = :sys.get_state(ctx.editor, @sync_timeout)
+    {:ok, captured_root} = Root.directory(root_path)
+    {:ok, reroot} = Root.directory(reroot_path)
+    assert Project.workspace_root() == captured_root
+    assert {:ok, _snapshot} = Project.activate(reroot)
+
+    request = TodoSearch.request(captured_root, revision)
+
+    result = %TodoSearch.Result{
+      revision: revision,
+      items: [],
+      candidates: [],
+      meta: %{}
+    }
+
+    assert {^state, %Outcome{status: :stale, reason: :workspace_rerooted}} =
+             TodoSearch.apply(state, Outcome.completed(request, result))
+  end
+
   test "applies a live-revision result carrying candidates pre-built off the editor",
        %{project_root: root} do
     ctx = start_editor("scratch", project_root: root)
@@ -113,5 +154,33 @@ defmodule MingaEditor.PickerAsyncStaleTest do
     # The same candidates flow straight through; the picker keeps the pre-built set.
     assert payload.picker_ui.picker.candidates == candidates
     assert payload.picker_ui.load_status == :ready
+  end
+
+  @spec activate_project!(Root.t()) :: :ok
+  defp activate_project!(%Root{path: path} = root) do
+    Minga.Events.subscribe(:project_rebuilt)
+    assert {:ok, snapshot} = Project.activate(root)
+
+    if snapshot.rebuilding? do
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^path}},
+                     @sync_timeout
+    end
+
+    :ok
+  end
+
+  @spec restore_project(Minga.Project.WorkspaceSnapshot.t() | nil) :: :ok
+  defp restore_project(nil) do
+    Project.close()
+    _ = :sys.get_state(Project)
+    :ok
+  end
+
+  defp restore_project(%Minga.Project.WorkspaceSnapshot{root: root}) do
+    Project.close()
+    _ = :sys.get_state(Project)
+    _ = Project.activate(root)
+    :ok
   end
 end

--- a/test/minga_editor/shell/traditional/todo_search_workflow_test.exs
+++ b/test/minga_editor/shell/traditional/todo_search_workflow_test.exs
@@ -1,0 +1,138 @@
+defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflowTest do
+  # The workflow reads and mutates the process-global Project workspace.
+  use ExUnit.Case, async: false
+
+  alias Minga.Project
+  alias Minga.Project.Root
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.Effect.Request
+  alias MingaEditor.EffectScheduler
+  alias MingaEditor.Effects.TodoSearch
+  alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.TodoSearchWorkflow
+  alias MingaEditor.State.FileTree
+
+  setup do
+    original_workspace = Project.snapshot()
+
+    on_exit(fn ->
+      restore_project(original_workspace)
+    end)
+
+    :ok
+  end
+
+  test "schedules only the active typed Root and ignores the file-tree path" do
+    active_path = temporary_root("active")
+    stale_file_tree_path = temporary_root("stale-file-tree")
+    {:ok, active_root} = Root.directory(active_path)
+    activate_project!(active_root)
+    scheduler = start_scheduler()
+
+    state =
+      TestHelpers.base_state(effect_scheduler: scheduler)
+      |> put_file_tree_root(stale_file_tree_path)
+      |> TodoSearchWorkflow.open()
+
+    assert {:picker, %{picker_ui: %{load_status: :loading}}} =
+             Runtime.state(state.shell_runtime).modal
+
+    assert_receive {:effect_lifecycle,
+                    %Outcome{
+                      status: :running,
+                      request: %Request{
+                        resource: {:todo_search, ^active_root},
+                        effect: %TodoSearch{root: ^active_root}
+                      }
+                    }}
+  end
+
+  test "does not reconstruct a Root from the file-tree path when no workspace is active" do
+    Project.close()
+    _ = :sys.get_state(Project)
+    file_tree_path = temporary_root("file-tree-only")
+    scheduler = start_scheduler()
+
+    state =
+      TestHelpers.base_state(effect_scheduler: scheduler)
+      |> put_file_tree_root(file_tree_path)
+      |> TodoSearchWorkflow.open()
+
+    assert {:picker, %{picker_ui: %{load_status: {:error, "No directory workspace active"}}}} =
+             Runtime.state(state.shell_runtime).modal
+
+    refute_received {:effect_lifecycle, %Outcome{request: %Request{handler: TodoSearch}}}
+  end
+
+  @spec activate_project!(Root.t()) :: :ok
+  defp activate_project!(%Root{path: path} = root) do
+    Minga.Events.subscribe(:project_rebuilt)
+    assert {:ok, snapshot} = Project.activate(root)
+
+    if snapshot.rebuilding? do
+      assert_receive {:minga_event, :project_rebuilt,
+                      %Minga.Events.ProjectRebuiltEvent{root: ^path}},
+                     5_000
+    end
+
+    :ok
+  end
+
+  @spec start_scheduler() :: pid()
+  defp start_scheduler do
+    task_supervisor =
+      start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
+
+    scheduler =
+      start_supervised!(
+        Supervisor.child_spec(
+          {EffectScheduler, task_supervisor: task_supervisor, observer: self()},
+          id: make_ref()
+        )
+      )
+
+    :ok = EffectScheduler.attach(scheduler, self())
+    scheduler
+  end
+
+  @spec put_file_tree_root(MingaEditor.State.t(), String.t()) :: MingaEditor.State.t()
+  defp put_file_tree_root(state, root_path) do
+    file_tree = FileTree.set_project_root(state.workspace.file_tree, root_path)
+    %{state | workspace: SessionState.set_file_tree(state.workspace, file_tree)}
+  end
+
+  @spec temporary_root(String.t()) :: String.t()
+  defp temporary_root(label) do
+    path =
+      Path.join(
+        System.tmp_dir!(),
+        "minga-todo-workflow-#{label}-#{System.unique_integer([:positive])}"
+      )
+
+    File.mkdir_p!(path)
+
+    on_exit(fn ->
+      Project.remove(path)
+      _ = :sys.get_state(Project)
+      File.rm_rf(path)
+    end)
+
+    path
+  end
+
+  @spec restore_project(Minga.Project.WorkspaceSnapshot.t() | nil) :: :ok
+  defp restore_project(nil) do
+    Project.close()
+    _ = :sys.get_state(Project)
+    :ok
+  end
+
+  defp restore_project(%Minga.Project.WorkspaceSnapshot{root: root}) do
+    Project.close()
+    _ = :sys.get_state(Project)
+    _ = Project.activate(root)
+    :ok
+  end
+end

--- a/test/minga_editor/ui/picker/todo_search_source_test.exs
+++ b/test/minga_editor/ui/picker/todo_search_source_test.exs
@@ -1,15 +1,26 @@
 defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
-  use ExUnit.Case, async: true
+  # This suite spawns git/grep OS Ports and mutates the process-global Project workspace.
+  use ExUnit.Case, async: false
 
   import MingaEditor.RenderPipeline.TestHelpers, only: [base_state: 1]
 
   alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Project
+  alias Minga.Project.Root
+  alias Minga.Test.TodoSearchPortProbe
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effects.TodoSearch
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.UI.Picker.FileSource
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.TodoSearchSource
+
+  setup do
+    original_workspace = Project.snapshot()
+    on_exit(fn -> restore_project(original_workspace) end)
+    :ok
+  end
 
   describe "parse_output/1" do
     test "parses grep path, line, and match text" do
@@ -50,62 +61,171 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
 
   describe "scheduled search" do
     test "finds TODOs in a git repository" do
-      root = temporary_root()
-      File.mkdir_p!(Path.join(root, "lib"))
-      file = Path.join(root, "lib/example.ex")
+      root_path = temporary_root()
+      File.mkdir_p!(Path.join(root_path, "lib"))
+      file = Path.join(root_path, "lib/example.ex")
       File.write!(file, "# TODO ship it\n")
-      {"", 0} = System.cmd("git", ["-C", root, "init", "-q"])
-      {"", 0} = System.cmd("git", ["-C", root, "add", "."])
+      {"", 0} = System.cmd("git", ["-C", root_path, "init", "-q"])
+      {"", 0} = System.cmd("git", ["-C", root_path, "add", "."])
 
-      assert {:ok, %TodoSearch.Result{items: [item]}} = TodoSearch.run(effect(root))
+      assert {:ok, %TodoSearch.Result{items: [item]}} = TodoSearch.run(effect(root_path))
       assert item.description == "# TODO ship it"
     end
 
     test "falls back to grep outside a git repository" do
-      root = temporary_root()
-      file = Path.join(root, "example.ex")
+      root_path = temporary_root()
+      file = Path.join(root_path, "example.ex")
       File.write!(file, "# FIXME outside git\n")
 
-      assert {:ok, %TodoSearch.Result{items: [item]}} = TodoSearch.run(effect(root))
+      assert {:ok, %TodoSearch.Result{items: [item]}} = TodoSearch.run(effect(root_path))
       assert item.description == "# FIXME outside git"
     end
 
-    test "reports a command failure" do
-      root =
-        Path.join(System.tmp_dir!(), "minga-missing-todo-#{System.unique_integer([:positive])}")
+    test "preserves command failure presentation" do
+      root_path = temporary_root()
+      :ok = TodoSearchPortProbe.configure(:failure)
 
-      assert {:error, message} = TodoSearch.run(effect(root))
-      assert message =~ "exited with status"
+      assert {:error, message} = TodoSearch.run(effect(root_path, impl: TodoSearchPortProbe))
+
+      assert message == "grep exited with status 2: probe failure"
     end
 
-    test "marks a result stale after the picker revision changes" do
+    test "marks a result stale when its revision differs from the request" do
+      root = directory_root!(temporary_root())
+      assert {:ok, _snapshot} = Project.activate(root)
       state = base_state(content: "scratch")
-      {state, old_revision} = PickerUI.open_loading(state, TodoSearchSource)
-      {state, _new_revision} = PickerUI.open_loading(state, TodoSearchSource)
-      request = TodoSearch.request(System.tmp_dir!(), old_revision)
+      {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
+      request = TodoSearch.request(root, revision)
 
       result = %TodoSearch.Result{
-        root: System.tmp_dir!(),
-        revision: old_revision,
+        revision: make_ref(),
         items: [],
         candidates: [],
         meta: %{}
       }
 
-      {new_state, outcome} = TodoSearch.apply(state, Outcome.completed(request, result))
+      assert {^state, %Outcome{status: :stale, reason: :revision_mismatch}} =
+               TodoSearch.apply(state, Outcome.completed(request, result))
+    end
 
-      assert outcome.status == :stale
-      assert new_state == state
+    test "marks a result stale after another picker source replaces TODO search" do
+      root = directory_root!(temporary_root())
+      assert {:ok, _snapshot} = Project.activate(root)
+      state = base_state(content: "scratch")
+      {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
+      {state, _replacement_revision} = PickerUI.open_loading(state, FileSource)
+      request = TodoSearch.request(root, revision)
+
+      result = %TodoSearch.Result{
+        revision: revision,
+        items: [],
+        candidates: [],
+        meta: %{}
+      }
+
+      assert {^state, %Outcome{status: :stale, reason: :picker_closed_or_replaced}} =
+               TodoSearch.apply(state, Outcome.completed(request, result))
+    end
+
+    test "rejects a result after the active workspace reroots" do
+      root_a = directory_root!(temporary_root())
+      root_b = directory_root!(temporary_root())
+      assert {:ok, _snapshot} = Project.activate(root_a)
+
+      state = base_state(content: "scratch")
+      {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
+      request = TodoSearch.request(root_a, revision)
+      assert {:ok, _snapshot} = Project.activate(root_b)
+
+      result = %TodoSearch.Result{
+        revision: revision,
+        items: [],
+        candidates: [],
+        meta: %{}
+      }
+
+      assert {^state, %Outcome{status: :stale, reason: :workspace_rerooted}} =
+               TodoSearch.apply(state, Outcome.completed(request, result))
     end
   end
 
-  defp effect(root), do: %TodoSearch{root: root, revision: make_ref()}
+  describe "root authorization boundary" do
+    test "passes only the canonical path into Port arguments and candidate expansion" do
+      container = temporary_root()
+      canonical = Path.join(container, "canonical")
+      alias_path = Path.join(container, "alias")
+      File.mkdir_p!(canonical)
+      File.ln_s!(canonical, alias_path)
+      root = directory_root!(alias_path)
 
-  defp temporary_root do
-    root = Path.join(System.tmp_dir!(), "minga-todo-effect-#{System.unique_integer([:positive])}")
-    File.mkdir_p!(root)
-    on_exit(fn -> File.rm_rf(root) end)
-    root
+      assert {:ok, %TodoSearch.Result{items: [item]}} =
+               TodoSearch.run(%TodoSearch{
+                 root: root,
+                 revision: make_ref(),
+                 impl: TodoSearchPortProbe
+               })
+
+      assert_received {:todo_search_port_opened, "git",
+                       ["-C", ^canonical, "rev-parse", "--is-inside-work-tree"]}
+
+      assert item.id.path == Path.join(canonical, "lib/example.ex")
+    end
+
+    test "accepts a confirmed broad root before opening the probe Port" do
+      root = %Root{kind: :directory, path: "/", broad_root_confirmed?: true}
+
+      assert {:ok, %TodoSearch.Result{}} =
+               TodoSearch.run(%TodoSearch{
+                 root: root,
+                 revision: make_ref(),
+                 impl: TodoSearchPortProbe
+               })
+
+      assert_received {:todo_search_port_opened, "git",
+                       ["-C", "/", "rev-parse", "--is-inside-work-tree"]}
+    end
+
+    test "rejects broad roots without confirmation before a Port opens" do
+      root = %Root{kind: :directory, path: "/", broad_root_confirmed?: false}
+
+      assert_rejected_before_port(root, :broad_root_confirmation_required)
+    end
+
+    test "rejects invalid broad-root confirmation before a Port opens" do
+      root_path = temporary_root()
+      root = %Root{kind: :directory, path: root_path, broad_root_confirmed?: :invalid}
+
+      assert_rejected_before_port(root, :invalid_broad_root_confirmation)
+    end
+
+    test "rejects file-scoped roots before a Port opens" do
+      file = Path.join(temporary_root(), "file.ex")
+      File.write!(file, "# TODO not recursive\n")
+
+      assert_rejected_before_port(Root.file(file), :not_a_directory_root)
+    end
+
+    test "rejects roots that stop being directories before a Port opens" do
+      root_path = temporary_root()
+      root = directory_root!(root_path)
+      File.rm_rf!(root_path)
+      File.write!(root_path, "not a directory")
+
+      assert_rejected_before_port(root, :not_a_directory)
+    end
+
+    test "rejects roots whose canonical target changed before a Port opens" do
+      container = temporary_root()
+      root_path = Path.join(container, "captured")
+      replacement = Path.join(container, "replacement")
+      File.mkdir_p!(root_path)
+      File.mkdir_p!(replacement)
+      root = directory_root!(root_path)
+      File.rm_rf!(root_path)
+      File.ln_s!(replacement, root_path)
+
+      assert_rejected_before_port(root, :root_changed)
+    end
   end
 
   describe "on_select/2" do
@@ -127,5 +247,56 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
       assert EditorState.active_buffer(new_state) == 1
       assert BufferProcess.cursor(path_buffer) == {2, 0}
     end
+  end
+
+  @spec effect(String.t(), keyword()) :: TodoSearch.t()
+  defp effect(root_path, opts \\ []) do
+    %TodoSearch{
+      root: directory_root!(root_path),
+      revision: make_ref(),
+      impl: Keyword.get(opts, :impl, MingaEditor.Effects.TodoSearch.Port)
+    }
+  end
+
+  @spec directory_root!(String.t()) :: Root.t()
+  defp directory_root!(path) do
+    {:ok, root} = Root.directory(path)
+    root
+  end
+
+  @spec assert_rejected_before_port(Root.t(), Root.error()) :: :ok
+  defp assert_rejected_before_port(root, reason) do
+    assert TodoSearch.run(%TodoSearch{
+             root: root,
+             revision: make_ref(),
+             impl: TodoSearchPortProbe
+           }) == {:error, "TODO search root rejected: #{reason}"}
+
+    refute_received {:todo_search_port_opened, _command, _args}
+    :ok
+  end
+
+  @spec temporary_root() :: String.t()
+  defp temporary_root do
+    root_path =
+      Path.join(System.tmp_dir!(), "minga-todo-effect-#{System.unique_integer([:positive])}")
+
+    File.mkdir_p!(root_path)
+    on_exit(fn -> File.rm_rf(root_path) end)
+    root_path
+  end
+
+  @spec restore_project(Minga.Project.WorkspaceSnapshot.t() | nil) :: :ok
+  defp restore_project(nil) do
+    Project.close()
+    _ = :sys.get_state(Project)
+    :ok
+  end
+
+  defp restore_project(%Minga.Project.WorkspaceSnapshot{root: root}) do
+    Project.close()
+    _ = :sys.get_state(Project)
+    _ = Project.activate(root)
+    :ok
   end
 end

--- a/test/support/todo_search_port_probe.ex
+++ b/test/support/todo_search_port_probe.ex
@@ -1,0 +1,30 @@
+defmodule Minga.Test.TodoSearchPortProbe do
+  @moduledoc "A process-local TODO Port probe for authorization-boundary tests."
+
+  @behaviour MingaEditor.Effects.TodoSearch.Port
+
+  @mode_key {__MODULE__, :mode}
+
+  @doc "Configures the probe response mode for the calling test process."
+  @spec configure(:success | :failure) :: :ok
+  def configure(mode) when mode in [:success, :failure] do
+    Process.put(@mode_key, mode)
+    :ok
+  end
+
+  @doc "Records an attempted Port operation and returns a deterministic command result."
+  @impl true
+  @spec run(String.t(), [String.t()]) :: MingaEditor.Effects.TodoSearch.Port.result()
+  def run(command, args) do
+    send(self(), {:todo_search_port_opened, command, args})
+    response(Process.get(@mode_key, :success), command, args)
+  end
+
+  @spec response(:success | :failure, String.t(), [String.t()]) ::
+          {String.t(), non_neg_integer()}
+  defp response(:success, "git", [_flag, _root, "rev-parse" | _rest]), do: {"true\n", 0}
+  defp response(:success, "git", _args), do: {"lib/example.ex:1:# TODO probe\n", 0}
+  defp response(:success, _command, _args), do: {"example.ex:1:# TODO probe\n", 0}
+  defp response(:failure, "git", [_flag, _root, "rev-parse" | _rest]), do: {"", 1}
+  defp response(:failure, _command, _args), do: {"probe failure", 2}
+end


### PR DESCRIPTION
# TL;DR
Recursive TODO search now carries the authorized typed workspace Root through its workflow, effect request, scheduler, and worker, then canonically revalidates it immediately before opening git or grep Ports.

Closes #2948

## Context
This is the final delivery slice of #2939. TODO search previously downgraded the active Root to a string before scheduling and could reconstruct authorization from the file tree's untyped path. That created a second workspace authorization path despite the bounded asynchronous search architecture already delivered by #2376.

## Changes
- Remove file-tree root fallback and Root reconstruction from `TodoSearchWorkflow`; only the active typed Project Root can start search.
- Carry `Root.t()` in the TODO effect, request resource, scheduler worker, and failure outcomes.
- Call `Root.inventory_path/1` immediately before the first repository-probe Port and pass only the canonical string into git, grep, and candidate expansion.
- Extract the existing five-second Port runner behind a typed behavior and flat `:todo_search_port_module` implementation key.
- Remove the unused string root from `TodoSearch.Result`.
- Reject completed and failed outcomes after revision mismatch, picker replacement, or workspace rerooting.
- Preserve existing git and non-git search output, labels, selection behavior, loading/error presentation, and generation-owned EffectScheduler lifecycle.

## Compatibility

TODO search still uses its existing `git grep` or recursive `grep` behavior and five-second timeout. This PR does not migrate to `Minga.ProjectSearch`, change search limits, add a scheduler, or change picker UX.

## Verification
- Focused TODO effect, workflow, source, picker staleness, and scheduler suites (50 tests, 0 failures)
- `make lint` (Credo clean, compilation clean, Dialyzer 0 errors)
- `mix test.llm` (9,548 tests, 97 properties, 58 doctests, 0 failures)
- Final review blockers resolved: direct revision/source staleness tests, Port behavior, and project-standard flat DI naming

## Acceptance Criteria Addressed
- TODO search starts only from the active typed directory Root ✅
- Request and worker retain Root until canonical Port-boundary authorization ✅
- Unsafe, broad, invalid, non-directory, and changed roots fail before Port creation ✅
- Git and non-git results and picker UX remain compatible ✅
- Existing bounded scheduler, cancellation, monitoring, and timeout behavior remains ✅
- Revision, picker replacement, and workspace reroot results remain stale-safe ✅
