### PR TITLE
refactor(agent): keep workflows focused and bounded

### DIFF
--- a/bench/operation_feedback_selector_bench.exs
+++ b/bench/operation_feedback_selector_bench.exs
@@ -1,0 +1,55 @@
+# Benchmark: bounded operation-feedback selection.
+#
+# Measures selection across the full retained collection for both precedence
+# paths: newest active operation and newest terminal fallback.
+#
+# Run: mix run bench/operation_feedback_selector_bench.exs
+
+alias MingaEditor.State.OperationFeedback
+
+limit = 32
+
+full_active =
+  Enum.reduce(1..limit, OperationFeedback.new(limit), fn index, feedback ->
+    {feedback, operation} =
+      OperationFeedback.start(
+        feedback,
+        :lsp_references,
+        "resource-#{index}",
+        "Operation #{index}",
+        replace?: false
+      )
+
+    case rem(index, 4) do
+      0 -> feedback
+      _remainder -> OperationFeedback.finish(feedback, operation.id, :success, "Done")
+    end
+  end)
+
+full_terminal =
+  Enum.reduce(1..limit, OperationFeedback.new(limit), fn index, feedback ->
+    {feedback, operation} =
+      OperationFeedback.start(
+        feedback,
+        :lsp_references,
+        "resource-#{index}",
+        "Operation #{index}",
+        replace?: false
+      )
+
+    OperationFeedback.finish(feedback, operation.id, :success, "Done")
+  end)
+
+Benchee.run(
+  %{"selected/1" => fn feedback -> OperationFeedback.selected(feedback) end},
+  inputs: %{
+    "full retained, active precedence" => full_active,
+    "full retained, terminal fallback" => full_terminal
+  },
+  warmup: 2,
+  time: 5,
+  memory_time: 2,
+  reduction_time: 2,
+  formatters: [Benchee.Formatters.Console],
+  print: [benchmarking: true, configuration: true, fast_warning: true]
+)

--- a/lib/minga_editor/agent/events.ex
+++ b/lib/minga_editor/agent/events.ex
@@ -1,1201 +1,104 @@
 defmodule MingaEditor.Agent.Events do
   @moduledoc """
-  Handles agent session events and owns their external actions.
+  Routes foreground agent events to focused, process-free workflows.
 
-  Live events and durable replay both enter `dispatch/2`; coalesced live
-  streaming enters `dispatch_batch/2`. State transitions happen first and the
-  resulting focused actions are interpreted in list order by the Editor
-  process. Rendering, transcript synchronization, tab labels, styled caches,
-  logging, and compaction therefore share one workflow.
-
-  The caller correlates events to the active session before dispatch. Durable
-  replay is already ordered and bounded; stale live sessions are routed to the
-  background shell instead. Compaction is admitted to its session-keyed typed
-  effect, whose scheduler-supervised outcome applies transcript/toast state
-  only while that session remains current. Render and log failures retain their
-  existing subsystem policy.
+  Live events and durable replay enter the same domain-family dispatch. The Editor remains the only mailbox owner, and each workflow directly composes owner transitions with rendering, synchronization, logging, or compaction.
   """
 
-  alias Minga.Distribution.ConnectionManager
-  alias Minga.Project.FileRef
-  alias MingaEditor.Agent.Activity
-  alias MingaEditor.Agent.Compaction
-  alias MingaEditor.Agent.DiffReview
+  alias MingaEditor.Agent.FileEventWorkflow
+  alias MingaEditor.Agent.SessionEventWorkflow
+  alias MingaEditor.Agent.StatusEventWorkflow
+  alias MingaEditor.Agent.StreamEventWorkflow
+  alias MingaEditor.Agent.ToolEventWorkflow
   alias MingaEditor.Agent.EditTimeline
-  alias MingaEditor.Agent.UIState
-  alias MingaEditor.Agent.UIState.Panel
-  alias MingaEditor.Agent.View.Preview
-  alias MingaEditor.AgentLifecycle
-  alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.State.Agent, as: AgentState
-  alias MingaAgent.Session
-  alias Minga.Buffer
-  alias MingaEditor.State.Buffers
-  alias MingaEditor.State.Workspace
-  alias MingaEditor.State.Remote
-  alias MingaEditor.State.Tab
-  alias MingaEditor.State.Tab.Context, as: TabContext
-  alias MingaEditor.State.TabBar
-  alias MingaEditor.Shell.Runtime
-  alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
-  alias MingaEditor.Shell.Workflow
 
-  @type effect ::
-          :render
-          | {:render, pos_integer()}
-          | {:log_message, String.t()}
-          | {:log_warning, String.t()}
-          | {:log, atom(), :debug | :info | :warning | :error, String.t()}
-          | :sync_agent_transcript
-          | {:update_tab_label, String.t()}
-          | {:compact_session, pid()}
-
-  @doc "Applies one agent event and its focused actions, returning final editor state."
+  @doc "Applies one foreground agent event through its focused workflow."
   @spec dispatch(EditorState.t(), term()) :: EditorState.t()
-  def dispatch(%EditorState{} = state, event) do
-    {state, effects} = handle(state, event)
-    apply_effects(state, effects)
+  def dispatch(%EditorState{} = state, {:status_changed, status}),
+    do: StatusEventWorkflow.status_changed(state, status)
+
+  def dispatch(%EditorState{} = state, {:text_delta, _delta} = event),
+    do: StreamEventWorkflow.delta(state, event)
+
+  def dispatch(%EditorState{} = state, {:thinking_delta, _delta} = event),
+    do: StreamEventWorkflow.delta(state, event)
+
+  def dispatch(%EditorState{} = state, :messages_changed),
+    do: StreamEventWorkflow.messages_changed(state)
+
+  def dispatch(%EditorState{} = state, {:tool_started, tool_call_id, name, args}),
+    do: ToolEventWorkflow.started(state, tool_call_id, name, args)
+
+  def dispatch(%EditorState{} = state, {:tool_started, name, args}),
+    do: ToolEventWorkflow.started(state, name, args)
+
+  def dispatch(%EditorState{} = state, {:tool_update, tool_call_id, name, partial}),
+    do: ToolEventWorkflow.updated(state, tool_call_id, name, partial)
+
+  def dispatch(%EditorState{} = state, {:tool_ended, tool_call_id, name, result, status}),
+    do: ToolEventWorkflow.ended(state, tool_call_id, name, result, status)
+
+  def dispatch(%EditorState{} = state, {:tool_ended, name, result, status}),
+    do: ToolEventWorkflow.ended(state, name, result, status)
+
+  def dispatch(%EditorState{} = state, {:tool_interrupted, tool_call_id}),
+    do: ToolEventWorkflow.interrupted(state, tool_call_id)
+
+  def dispatch(
+        %EditorState{} = state,
+        {:file_changed, path, before_content, after_content, tool_call_id, tool_name}
+      ) do
+    FileEventWorkflow.changed(
+      state,
+      path,
+      before_content,
+      after_content,
+      tool_call_id,
+      tool_name
+    )
   end
 
-  @doc "Applies one coalesced agent stream batch and its focused actions."
+  def dispatch(%EditorState{} = state, {:approval_pending, approval}),
+    do: SessionEventWorkflow.approval_pending(state, approval)
+
+  def dispatch(%EditorState{} = state, {:approval_resolved, decision}),
+    do: SessionEventWorkflow.approval_resolved(state, decision)
+
+  def dispatch(%EditorState{} = state, {:error, message}),
+    do: SessionEventWorkflow.error(state, message)
+
+  def dispatch(%EditorState{} = state, {:credentials_status, configured?}),
+    do: SessionEventWorkflow.credentials_status(state, configured?)
+
+  def dispatch(%EditorState{} = state, {:todo_plan_updated, todos}),
+    do: ToolEventWorkflow.todo_plan_updated(state, todos)
+
+  def dispatch(%EditorState{} = state, :spinner_tick),
+    do: SessionEventWorkflow.spinner_tick(state)
+
+  def dispatch(%EditorState{} = state, :dismiss_toast),
+    do: SessionEventWorkflow.dismiss_toast(state)
+
+  def dispatch(%EditorState{} = state, {:context_usage, estimated_tokens, context_limit}),
+    do: StatusEventWorkflow.context_usage(state, estimated_tokens, context_limit)
+
+  def dispatch(%EditorState{} = state, {:prompt_queued, content, queue_type}),
+    do: SessionEventWorkflow.prompt_queued(state, content, queue_type)
+
+  def dispatch(%EditorState{} = state, :queues_recalled),
+    do: SessionEventWorkflow.queues_recalled(state)
+
+  def dispatch(%EditorState{} = state, _unknown), do: state
+
+  @doc "Applies one coalesced agent stream batch without changing mailbox ownership."
   @spec dispatch_batch(EditorState.t(), [term()]) :: EditorState.t()
-  def dispatch_batch(%EditorState{} = state, batch) when is_list(batch) do
-    {state, effects} = handle_batch(state, batch)
-    apply_effects(state, effects)
-  end
-
-  @spec handle(EditorState.t(), term()) :: {EditorState.t(), [effect()]}
-
-  def handle(state, {:status_changed, status}) do
-    state = TraditionalWorkflow.install_agent_status(state, status)
-
-    {state, effects} =
-      case status do
-        :error ->
-          {state, [{:log_message, "Agent: error"}]}
-
-        :thinking ->
-          {TraditionalWorkflow.engage_agent_scroll(state), []}
-
-        _ ->
-          {state, []}
-      end
-
-    state =
-      case status do
-        s when s in [:thinking, :tool_executing] ->
-          update_activity(state, &Activity.start_turn/1)
-
-        s when s in [:idle, :error, :plan] ->
-          update_activity(state, &Activity.finish_turn/1)
-
-        _ ->
-          state
-      end
-
-    state =
-      case status do
-        s when s in [:thinking, :tool_executing] ->
-          TraditionalWorkflow.install_agent_spinner_start(state)
-
-        _ ->
-          TraditionalWorkflow.install_agent_spinner_stop(state)
-      end
-
-    state =
-      case status do
-        :idle -> reset_compact_state(state)
-        _ -> state
-      end
-
-    # Sync the tab's agent_status for tab bar rendering
-    state = sync_tab_agent_status(state, status)
-
-    # Let the active shell mirror foreground agent status if it owns an agent surface.
-    state = sync_active_shell_agent_status(state, status)
-
-    {state, effects} = maybe_apply_pending_auto_compact(state, status, effects)
-
-    {state, [:render | effects]}
-  end
-
-  # Single-delta entry points. The live streaming path coalesces deltas through
-  # `MingaEditor.Agent.Ingest` and applies them via `handle_batch/2`; these
-  # clauses remain for the durable remote event-replay path
-  # (`MingaEditor.Remote.EventReplay`), which feeds individual records and is a
-  # bounded one-shot, not a hot streaming loop. They delegate to the batch path
-  # so the state transitions stay in one place.
-  def handle(state, {:text_delta, _delta} = delta), do: handle_batch(state, [delta])
-
-  def handle(state, {:thinking_delta, _delta} = delta), do: handle_batch(state, [delta])
-
-  def handle(state, :messages_changed) do
-    state = TraditionalWorkflow.maybe_agent_auto_scroll(state)
-
-    state =
-      TraditionalWorkflow.install_agent_panel(
-        state,
-        (&Panel.bump_message_version/1).(state.workspace.agent_ui.panel)
-      )
-
-    state = maybe_rename_workspace_from_assistant(state)
-    {state, [{:render, 16}, :sync_agent_transcript, {:update_tab_label, ""}]}
-  end
-
-  def handle(state, {:tool_started, _tool_call_id, name, args}),
-    do: handle(state, {:tool_started, name, args})
-
-  def handle(state, {:tool_started, "shell", args}) do
-    command = Map.get(args, "command", "")
-    state = update_activity(state, &Activity.start_tool(&1, "shell"))
-    state = sync_active_tool_name(state, "shell")
-    state = update_preview(state, &Preview.set_shell(&1, command))
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, {:tool_update, _id, "shell", partial}) do
-    state = TraditionalWorkflow.maybe_agent_auto_scroll(state)
-    state = update_preview(state, &Preview.update_shell_output(&1, partial))
-    {state, [{:render, 50}]}
-  end
-
-  def handle(state, {:tool_update, _id, _name, _partial}) do
-    state = TraditionalWorkflow.maybe_agent_auto_scroll(state)
-    {state, [{:render, 50}]}
-  end
-
-  def handle(state, {:tool_ended, _tool_call_id, name, result, status}),
-    do: handle(state, {:tool_ended, name, result, status})
-
-  def handle(state, {:tool_interrupted, _tool_call_id}) do
-    state = update_activity(state, &Activity.finish_tool/1)
-    state = sync_active_tool_name(state, nil)
-    state = update_preview(state, &Preview.clear/1)
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, {:tool_ended, "shell", result, status}) do
-    shell_status = if status == :error, do: :error, else: :done
-    state = update_activity(state, &Activity.finish_tool/1)
-    state = sync_active_tool_name(state, nil)
-    state = update_preview(state, &Preview.finish_shell(&1, result, shell_status))
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, {:tool_started, "read_file", args}) do
-    path = Map.get(args, "path", "")
-    state = update_activity(state, &Activity.start_tool(&1, "read_file"))
-    state = sync_active_tool_name(state, "read_file")
-    state = update_preview(state, &Preview.set_file(&1, path, ""))
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, {:tool_ended, "read_file", result, _status}) do
-    state = update_activity(state, &Activity.finish_tool/1)
-    state = sync_active_tool_name(state, nil)
-
-    case state.workspace.agent_ui.view.preview.content do
-      {:file, path, _} ->
-        state = update_preview(state, &Preview.set_file(&1, path, result))
-        {state, [{:render, 16}]}
-
-      _ ->
-        {state, []}
-    end
-  end
-
-  def handle(state, {:tool_started, "list_directory", args}) do
-    path = Map.get(args, "path", ".")
-
-    state =
-      update_activity(state, &Activity.start_tool(&1, "list_directory"))
-
-    state = sync_active_tool_name(state, "list_directory")
-    state = update_preview(state, &Preview.set_directory(&1, path, []))
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, {:tool_ended, "list_directory", result, _status}) do
-    entries = result |> String.split("\n") |> Enum.reject(&(&1 == ""))
-    state = update_activity(state, &Activity.finish_tool/1)
-    state = sync_active_tool_name(state, nil)
-
-    case state.workspace.agent_ui.view.preview.content do
-      {:directory, path, _} ->
-        state = update_preview(state, &Preview.set_directory(&1, path, entries))
-        {state, [{:render, 16}]}
-
-      _ ->
-        {state, []}
-    end
-  end
-
-  def handle(state, {:tool_started, name, _args}) do
-    state = update_activity(state, &Activity.start_tool(&1, name))
-    state = sync_active_tool_name(state, name)
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, {:tool_ended, _name, _result, _status}) do
-    state = update_activity(state, &Activity.finish_tool/1)
-    state = sync_active_tool_name(state, nil)
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, {:file_changed, path, before_content, after_content, tool_call_id, tool_name}) do
-    {state, remote_effects} = reload_remote_buffer_if_open(state, path, after_content)
-
-    state =
-      TraditionalWorkflow.install_agent_ui(
-        state,
-        (&UIState.record_baseline(&1, path, before_content)).(state.workspace.agent_ui)
-      )
-
-    state =
-      update_activity(state, &Activity.record_file(&1, path))
-
-    state =
-      TraditionalWorkflow.install_agent_ui(
-        state,
-        (fn ui ->
-           timeline =
-             EditTimeline.record_edit(
-               ui.view.edit_timeline,
-               path,
-               tool_call_id,
-               tool_name,
-               before_content,
-               after_content
-             )
-
-           UIState.replace_edit_timeline(ui, timeline)
-         end).(state.workspace.agent_ui)
-      )
-
-    # Let the active shell track touched files for any shell-owned agent surface.
-    state = track_active_shell_agent_file(state, path)
-
-    # Associate the file's tab with the agent's workspace
-    state = associate_file_with_agent_workspace(state, path)
-
-    # Add a chat-visible system message so the transcript records what was modified
-    state = add_file_changed_message(state, path, tool_name)
-
-    baseline = UIState.get_baseline(state.workspace.agent_ui, path)
-    existing_review = existing_diff_for_path(state, path)
-
-    review =
-      case existing_review do
-        nil -> DiffReview.new(path, baseline, after_content)
-        existing -> DiffReview.update_after(existing, after_content)
-      end
-
-    case review do
-      nil ->
-        {state, [{:render, 16} | remote_effects]}
-
-      _ ->
-        state = update_preview(state, &Preview.set_diff(&1, review))
-
-        state =
-          TraditionalWorkflow.install_agent_ui(
-            state,
-            UIState.set_focus(state.workspace.agent_ui, :file_viewer)
-          )
-
-        {state, [:render | remote_effects]}
-    end
-  end
-
-  def handle(state, {:approval_pending, approval}) do
-    cached = Map.take(approval, [:tool_call_id, :name, :args, :preview])
-    state = TraditionalWorkflow.install_agent_approval(state, cached)
-
-    # Seed the visible activity timestamp once so approval-only agent context
-    # remains stable across renders without falling back to "now" every frame.
-    state = update_activity(state, &Activity.ensure_started_at/1)
-
-    # Unfocus the prompt input so the ToolApproval input handler can
-    # intercept y/n keys. The user needs to see and respond to the
-    # approval prompt, not keep typing in the input field.
-    state =
-      TraditionalWorkflow.install_agent_ui(
-        state,
-        MingaEditor.Agent.PromptBuffer.set_input_focused(state.workspace.agent_ui, false)
-      )
-
-    {state, [:render, :sync_agent_transcript]}
-  end
-
-  def handle(state, {:approval_resolved, _decision}) do
-    state = TraditionalWorkflow.clear_agent_approval(state)
-    {state, [{:render, 16}, :sync_agent_transcript]}
-  end
-
-  def handle(state, {:error, message}) do
-    # The session already surfaced this in the transcript and the provider
-    # logged the raw detail to the Messages panel, so we only update status
-    # here. Re-logging would double the Messages entry and force-open the panel.
-    state = restore_queued_prompts_after_error(state)
-    state = TraditionalWorkflow.install_agent_error(state, message)
-    {state, [:render]}
-  end
-
-  def handle(state, {:credentials_status, configured?}) do
-    state =
-      TraditionalWorkflow.install_agent_panel(
-        state,
-        (&Panel.set_credentials_configured(&1, configured?)).(state.workspace.agent_ui.panel)
-      )
-
-    {state, [:render]}
-  end
-
-  def handle(state, {:todo_plan_updated, todos}) do
-    state = update_activity(state, &Activity.set_todos(&1, todos))
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, :spinner_tick) do
-    if AgentState.busy?(MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state)) do
-      state =
-        TraditionalWorkflow.install_agent_ui(
-          state,
-          UIState.tick_spinner(state.workspace.agent_ui)
-        )
-
-      {state, [{:render, 16}]}
-    else
-      state = TraditionalWorkflow.install_agent_spinner_stop(state)
-      {state, []}
-    end
-  end
-
-  def handle(state, :dismiss_toast) do
-    state =
-      TraditionalWorkflow.install_agent_ui(
-        state,
-        UIState.dismiss_toast(state.workspace.agent_ui)
-      )
-
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, {:context_usage, estimated_tokens, context_limit}) do
-    state =
-      TraditionalWorkflow.install_agent_view(
-        state,
-        (fn v -> %{v | context_estimate: estimated_tokens} end).(state.workspace.agent_ui.view)
-      )
-
-    {state, effects} = maybe_auto_compact(state, estimated_tokens, context_limit)
-    {state, [{:render, 16} | effects]}
-  end
-
-  # A message was queued (steer or follow-up): trigger render so the pending
-  # display can update. The queue contents live in Session, not EditorState,
-  # so no state mutation is needed here.
-  def handle(state, {:prompt_queued, content, _type}) do
-    # Auto-name the workspace from the first prompt (if not custom-named)
-    state = maybe_auto_name_workspace(state, content)
-    {state, [{:render, 16}]}
-  end
-
-  # Both queues were recalled (dequeue or abort+restore). Trigger a render to
-  # clear the pending display.
-  def handle(state, :queues_recalled) do
-    {state, [{:render, 16}]}
-  end
-
-  def handle(state, _unknown) do
-    {state, []}
-  end
-
-  @doc """
-  Applies one coalesced batch of stream deltas (#2289).
-
-  `MingaEditor.Agent.Ingest` accumulates `{:text_delta, _}`, `{:thinking_delta, _}`
-  and `{:tool_update, _, _, _}` events arriving within a coalescing window and
-  forwards them here as a single batch. Applying the batch once means one
-  `bump_message_version`, one `:sync_agent_transcript`, and one render request per
-  window instead of per delta, which keeps the Editor mailbox shallow under
-  streaming load. The per-delta state transitions (auto-scroll, shell preview
-  updates) are folded in arrival order so the visible result matches the
-  unbatched path.
-  """
-  @spec handle_batch(EditorState.t(), [term()]) :: {EditorState.t(), [effect()]}
-  def handle_batch(state, []), do: {state, []}
-
-  def handle_batch(state, batch) do
-    state = TraditionalWorkflow.maybe_agent_auto_scroll(state)
-    state = Enum.reduce(batch, state, &apply_batched_delta/2)
-
-    if transcript_affecting_batch?(batch) do
-      state =
-        TraditionalWorkflow.install_agent_panel(
-          state,
-          (&Panel.bump_message_version/1).(state.workspace.agent_ui.panel)
-        )
-
-      {state, [{:render, 16}, :sync_agent_transcript]}
-    else
-      {state, [{:render, 16}]}
-    end
-  end
-
-  # ── Private ────────────────────────────────────────────────────────────────
-
-  @spec apply_effects(EditorState.t(), [effect()]) :: EditorState.t()
-  defp apply_effects(state, []), do: state
-
-  defp apply_effects(state, [effect | rest]) do
-    state = apply_effect(state, effect)
-    apply_effects(state, rest)
-  end
-
-  @spec apply_effect(EditorState.t(), effect()) :: EditorState.t()
-  defp apply_effect(state, :render), do: MingaEditor.schedule_render(state, 16)
-
-  defp apply_effect(state, {:render, delay_ms}),
-    do: MingaEditor.schedule_render(state, delay_ms)
-
-  defp apply_effect(state, {:log_message, message}) do
-    Minga.Log.info(:editor, message)
-    state
-  end
-
-  defp apply_effect(state, {:log_warning, message}) do
-    Minga.Log.warning(:editor, message)
-    state
-  end
-
-  defp apply_effect(state, {:log, subsystem, level, message}) do
-    log(subsystem, level, message)
-    state
-  end
-
-  defp apply_effect(state, :sync_agent_transcript), do: AgentLifecycle.sync_transcript(state)
-
-  defp apply_effect(state, {:update_tab_label, _label}),
-    do: AgentLifecycle.maybe_update_tab_label(state)
-
-  defp apply_effect(state, {:compact_session, session_pid}),
-    do: Compaction.schedule(state, session_pid)
-
-  @spec log(atom(), :debug | :info | :warning | :error, String.t()) :: :ok
-  defp log(subsystem, :debug, message), do: Minga.Log.debug(subsystem, message)
-  defp log(subsystem, :info, message), do: Minga.Log.info(subsystem, message)
-  defp log(subsystem, :warning, message), do: Minga.Log.warning(subsystem, message)
-  defp log(subsystem, :error, message), do: Minga.Log.error(subsystem, message)
-
-  @spec update_activity(EditorState.t(), (Activity.t() -> Activity.t())) :: EditorState.t()
-  defp update_activity(state, fun) when is_function(fun, 1) do
-    TraditionalWorkflow.install_agent_ui(
-      state,
-      (fn ui ->
-         UIState.replace_activity(ui, fun.(ui.view.activity))
-       end).(state.workspace.agent_ui)
-    )
-  end
-
-  # Folds a single delta's preview-side mutation into state. Text and thinking
-  # deltas carry no per-delta state beyond the once-applied bump/sync; only
-  # shell tool updates mutate the preview, and they replace (not append) the
-  # partial output, so applying them in order matches the unbatched path.
-  @spec apply_batched_delta(term(), EditorState.t()) :: EditorState.t()
-  defp apply_batched_delta({:tool_update, _id, "shell", partial}, state) do
-    update_preview(state, &Preview.update_shell_output(&1, partial))
-  end
-
-  defp apply_batched_delta(_delta, state), do: state
-
-  # Only assistant text/thinking batches resync the transcript; tool updates render the preview only.
-  @spec transcript_affecting_batch?([term()]) :: boolean()
-  defp transcript_affecting_batch?(batch) do
-    Enum.any?(batch, fn
-      {:text_delta, _} -> true
-      {:thinking_delta, _} -> true
-      _ -> false
-    end)
-  end
-
-  @spec sync_active_tool_name(EditorState.t(), String.t() | nil) :: EditorState.t()
-  defp sync_active_tool_name(state, fallback_name) do
-    case Runtime.active_session(state.shell_runtime) do
-      pid when is_pid(pid) ->
-        case session_active_tool_name(pid) do
-          {:ok, active_tool_name} ->
-            TraditionalWorkflow.install_agent_tool(state, active_tool_name)
-
-          :error ->
-            apply_active_tool_name_fallback(state, fallback_name)
-        end
-
-      _ ->
-        apply_active_tool_name_fallback(state, fallback_name)
-    end
-  end
-
-  @spec apply_active_tool_name_fallback(EditorState.t(), String.t() | nil) :: EditorState.t()
-  defp apply_active_tool_name_fallback(state, name) when is_binary(name) do
-    TraditionalWorkflow.install_agent_tool(state, name)
-  end
-
-  defp apply_active_tool_name_fallback(state, _name) do
-    TraditionalWorkflow.install_agent_tool_clear(state)
-  end
-
-  @spec restore_queued_prompts_after_error(EditorState.t()) :: EditorState.t()
-  defp restore_queued_prompts_after_error(state) do
-    case Runtime.active_session(state.shell_runtime) do
-      session when is_pid(session) ->
-        {steering, follow_up} = safe_recall_queues(session)
-        restore_queued_to_prompt(state, steering ++ follow_up)
-
-      _session ->
-        state
-    end
-  end
-
-  @spec safe_recall_queues(pid()) ::
-          {[String.t() | [ReqLLM.Message.ContentPart.t()]],
-           [String.t() | [ReqLLM.Message.ContentPart.t()]]}
-  defp safe_recall_queues(session) do
-    Session.recall_queues(session)
-  catch
-    :exit, _ -> {[], []}
-  end
-
-  @spec restore_queued_to_prompt(
-          EditorState.t(),
-          [String.t() | [ReqLLM.Message.ContentPart.t()]]
-        ) :: EditorState.t()
-  defp restore_queued_to_prompt(state, []), do: state
-
-  defp restore_queued_to_prompt(state, all_queued) do
-    current_text = MingaEditor.Agent.PromptBuffer.prompt_text(state.workspace.agent_ui)
-    combined = Session.combine_queue_entries_to_text(all_queued)
-
-    restored =
-      if current_text != "",
-        do: combined <> "\n\n" <> current_text,
-        else: combined
-
-    TraditionalWorkflow.install_agent_ui(
-      state,
-      MingaEditor.Agent.PromptBuffer.set_prompt_text(state.workspace.agent_ui, restored)
-    )
-  end
-
-  @spec session_active_tool_name(pid()) :: {:ok, String.t() | nil} | :error
-  defp session_active_tool_name(pid) do
-    {:ok, Session.editor_snapshot(pid).active_tool_name}
-  catch
-    :exit, _ -> :error
-  end
-
-  @spec reload_remote_buffer_if_open(EditorState.t(), String.t(), String.t()) ::
-          {EditorState.t(), [effect()]}
-  defp reload_remote_buffer_if_open(state, path, after_content) do
-    case current_remote_target(state) do
-      {:ok, server_name, remote_node} ->
-        reload_remote_buffer(
-          state,
-          server_name,
-          normalize_remote_path(remote_node, path),
-          after_content
-        )
-
-      :error ->
-        reload_tracked_remote_buffers(state, path, after_content)
-    end
-  end
-
-  @spec current_remote_target(EditorState.t()) :: {:ok, String.t(), node()} | :error
-  defp current_remote_target(state) do
-    case Runtime.active_session(state.shell_runtime) do
-      pid when is_pid(pid) and node(pid) != node() ->
-        remote_node = node(pid)
-
-        case Minga.Distribution.ConnectionManager.server_name_for_node(remote_node) do
-          {:ok, server_name} -> {:ok, server_name, remote_node}
-          {:error, :not_found} -> :error
-        end
-
-      _ ->
-        :error
-    end
-  end
-
-  @spec normalize_remote_path(node(), String.t()) :: String.t()
-  defp normalize_remote_path(remote_node, path) do
-    :erpc.call(remote_node, Path, :expand, [path], 5_000)
-  catch
-    :exit, _reason -> path
-    :error, {:erpc, _reason} -> path
-  end
-
-  @spec reload_tracked_remote_buffers(EditorState.t(), String.t(), String.t()) ::
-          {EditorState.t(), [effect()]}
-  defp reload_tracked_remote_buffers(state, path, after_content) do
-    state.remote
-    |> matching_remote_buffers(path)
-    |> Enum.reduce({state, []}, fn {_server_name, remote_path, pid}, {acc_state, acc_effects} ->
-      {new_state, effects} =
-        reload_remote_buffer_content(acc_state, pid, remote_path, after_content)
-
-      {new_state, effects ++ acc_effects}
-    end)
-  end
-
-  @spec matching_remote_buffers(Remote.t(), String.t()) :: [{String.t(), String.t(), pid()}]
-  defp matching_remote_buffers(remote, path) do
-    {direct_matches, fallback_candidates} =
-      remote
-      |> Remote.all_buffers()
-      |> Enum.split_with(fn {_server_name, remote_path, _pid} -> remote_path == path end)
-
-    fallback_matches =
-      fallback_candidates
-      |> Enum.group_by(fn {server_name, _remote_path, _pid} -> server_name end)
-      |> Enum.flat_map(fn {server_name, buffers} ->
-        normalized_path = normalize_remote_path_for_server(server_name, path, buffers)
-
-        Enum.filter(buffers, fn {_server_name, remote_path, _pid} ->
-          remote_path == normalized_path
-        end)
-      end)
-
-    direct_matches ++ fallback_matches
-  end
-
-  @spec normalize_remote_path_for_server(String.t(), String.t(), [{String.t(), String.t(), pid()}]) ::
-          String.t()
-  defp normalize_remote_path_for_server(server_name, path, buffers) do
-    case remote_node_for_server(server_name, buffers) do
-      {:ok, remote_node} -> normalize_remote_path(remote_node, path)
-      :error -> path
-    end
-  end
-
-  @spec remote_node_for_server(String.t(), [{String.t(), String.t(), pid()}]) ::
-          {:ok, node()} | :error
-  defp remote_node_for_server(server_name, buffers) do
-    case ConnectionManager.node_for_server(server_name) do
-      {:ok, remote_node} -> {:ok, remote_node}
-      {:error, _reason} -> remote_node_from_buffers(buffers)
-    end
-  catch
-    :exit, _reason -> remote_node_from_buffers(buffers)
-  end
-
-  @spec remote_node_from_buffers([{String.t(), String.t(), pid()}]) :: {:ok, node()} | :error
-  defp remote_node_from_buffers([{_server_name, _remote_path, pid} | _rest]) do
-    case Buffer.storage(pid) do
-      {:remote, remote_node, _base_path} -> {:ok, remote_node}
-      _ -> :error
-    end
-  catch
-    :exit, _reason -> :error
-  end
-
-  defp remote_node_from_buffers([]), do: :error
-
-  @spec reload_remote_buffer(EditorState.t(), String.t(), String.t(), String.t()) ::
-          {EditorState.t(), [effect()]}
-  defp reload_remote_buffer(state, server_name, path, after_content) do
-    case Remote.buffer(state.remote, server_name, path) do
-      pid when is_pid(pid) ->
-        reload_remote_buffer_content(state, pid, path, after_content)
-
-      _ ->
-        {state, []}
-    end
-  catch
-    :exit, reason ->
-      {state,
-       [{:log, :agent, :error, "Failed to reload remote file #{path}: #{inspect(reason)}"}]}
-  end
-
-  @spec reload_remote_buffer_content(EditorState.t(), pid(), String.t(), String.t()) ::
-          {EditorState.t(), [effect()]}
-  defp reload_remote_buffer_content(state, pid, path, after_content) do
-    if Buffer.dirty?(pid) do
-      state =
-        state
-        |> MingaEditor.Shell.Traditional.NoticeWorkflow.publish(
-          "Agent modified this file. Reload, keep editing, or show diff. Save will check for conflicts."
-        )
-        |> PickerUI.open(MingaEditor.UI.Picker.RemoteFileConflictSource, %{
-          buffer: pid,
-          path: path,
-          content: after_content
-        })
-
-      {state, [{:log_warning, "Agent modified dirty remote file #{Path.basename(path)}"}]}
-    else
-      Buffer.accept_saved_content(pid, after_content)
-      {state, [{:log_message, "Agent updated #{Path.basename(path)}"}]}
-    end
-  end
-
-  @spec add_file_changed_message(EditorState.t(), String.t(), String.t()) :: EditorState.t()
-  defp add_file_changed_message(state, path, tool_name) do
-    case Runtime.active_session(state.shell_runtime) do
-      pid when is_pid(pid) ->
-        short_path = shorten_to_relative(state, path)
-        verb = file_change_verb(tool_name)
-        Session.add_system_message(pid, "#{verb} #{short_path}")
-        state
-
-      _ ->
-        state
-    end
-  catch
-    :exit, _ -> state
-  end
-
-  @spec file_change_verb(String.t()) :: String.t()
-  defp file_change_verb("write"), do: "Wrote"
-  defp file_change_verb("edit"), do: "Edited"
-  defp file_change_verb(_tool_name), do: "Modified"
-
-  @spec shorten_to_relative(EditorState.t(), String.t()) :: String.t()
-  defp shorten_to_relative(state, path) do
-    case project_root(state) do
-      root when is_binary(root) -> Path.relative_to(path, root)
-      _ -> Path.basename(path)
-    end
-  end
-
-  @spec update_preview(EditorState.t(), (Preview.t() -> Preview.t())) :: EditorState.t()
-  defp update_preview(state, fun) do
-    TraditionalWorkflow.install_agent_ui(
-      state,
-      (fn ui ->
-         UIState.replace_preview(ui, fun.(ui.view.preview))
-       end).(state.workspace.agent_ui)
-    )
-  end
-
-  @spec existing_diff_for_path(EditorState.t(), String.t()) :: DiffReview.t() | nil
-  defp existing_diff_for_path(state, path) do
-    case Preview.diff_review(state.workspace.agent_ui.view.preview) do
-      %DiffReview{path: ^path} = review -> review
-      _ -> nil
-    end
-  end
-
-  @spec sync_active_shell_agent_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
-  defp sync_active_shell_agent_status(state, status),
-    do: update_shell_for_active_session(state, :sync_agent_status, [status])
-
-  @spec track_active_shell_agent_file(EditorState.t(), String.t()) :: EditorState.t()
-  defp track_active_shell_agent_file(state, path),
-    do: update_shell_for_active_session(state, :track_agent_file, [path])
-
-  @spec update_shell_for_active_session(EditorState.t(), atom(), [term()]) :: EditorState.t()
-  defp update_shell_for_active_session(%EditorState{} = state, callback, args) do
-    state = Workflow.ensure_available(state)
-    session = Runtime.active_session(state.shell_runtime)
-    update_shell_for_session(state, callback, session, args)
-  end
-
-  @spec update_shell_for_session(EditorState.t(), atom(), pid() | nil, [term()]) ::
-          EditorState.t()
-  defp update_shell_for_session(state, _callback, session, _args) when not is_pid(session),
-    do: state
-
-  defp update_shell_for_session(state, :sync_agent_status, session, [status]) do
-    runtime =
-      Runtime.sync_agent_status(
-        state.shell_runtime,
-        Workflow.resolved_entries(),
-        session,
-        status
-      )
-
-    %{state | shell_runtime: runtime}
-  end
-
-  defp update_shell_for_session(state, :track_agent_file, session, [path]) do
-    runtime =
-      Runtime.track_agent_file(
-        state.shell_runtime,
-        Workflow.resolved_entries(),
-        session,
-        path
-      )
-
-    %{state | shell_runtime: runtime}
-  end
-
-  # Syncs the agent_status field on the current agent tab so the tab bar
-  # can render status indicators without querying the Session process.
-  @spec sync_tab_agent_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
-  defp sync_tab_agent_status(%{shell_runtime: %{state: %{tab_bar: nil}}} = state, _status),
-    do: state
-
-  defp sync_tab_agent_status(state, status) do
-    session = Runtime.active_session(state.shell_runtime)
-
-    if is_pid(session) do
-      tb = state.shell_runtime.state.tab_bar
-
-      tb =
-        case TabBar.find_workspace_by_session(tb, session) do
-          %Workspace{id: ws_id} ->
-            TabBar.update_workspace(tb, ws_id, &Workspace.set_agent_status(&1, status))
-
-          nil ->
-            tb
-        end
-
-      tb =
-        case TabBar.find_by_session(tb, session) do
-          %Tab{id: id} -> TabBar.update_tab(tb, id, &Tab.set_agent_status(&1, status))
-          nil -> tb
-        end
-
-      then(state, fn root ->
-        shell_state =
-          MingaEditor.Shell.Traditional.State.install_tab_bar(
-            MingaEditor.Shell.Runtime.state(root.shell_runtime),
-            tb
-          )
-
-        %{
-          root
-          | shell_runtime:
-              MingaEditor.Shell.Runtime.install_traditional_state(root.shell_runtime, shell_state)
-        }
-      end)
-    else
-      state
-    end
-  end
-
-  # Associates a file tab with the agent's workspace when the agent modifies the file.
-  # Uses the tab's logical file ref so duplicate basenames route to the exact file.
-  @spec associate_file_with_agent_workspace(EditorState.t(), String.t()) :: EditorState.t()
-  defp associate_file_with_agent_workspace(
-         %{shell_runtime: %{state: %{tab_bar: nil}}} = state,
-         _path
-       ),
-       do: state
-
-  defp associate_file_with_agent_workspace(state, path) do
-    session = Runtime.active_session(state.shell_runtime)
-    tb = state.shell_runtime.state.tab_bar
-
-    with pid when is_pid(pid) <- session,
-         {:ok, file_ref} <- file_ref_for_path(state, path),
-         %Workspace{id: ws_id} <- TabBar.find_workspace_by_session(tb, pid),
-         %Tab{id: tab_id} <- find_unassociated_file_tab(tb, file_ref, ws_id, state) do
-      tb =
-        tb
-        |> TabBar.move_tab_to_workspace(tab_id, ws_id)
-        |> TabBar.update_workspace(ws_id, fn workspace ->
-          Workspace.retarget_file(workspace, nil, file_ref, tab_id == tb.active_id)
-        end)
-
-      then(state, fn root ->
-        shell_state =
-          MingaEditor.Shell.Traditional.State.install_tab_bar(
-            MingaEditor.Shell.Runtime.state(root.shell_runtime),
-            tb
-          )
-
-        %{
-          root
-          | shell_runtime:
-              MingaEditor.Shell.Runtime.install_traditional_state(root.shell_runtime, shell_state)
-        }
-      end)
-    else
-      _ -> state
-    end
-  end
-
-  # Auto-names the agent workspace from the prompt text (first line, 30 chars).
-  # Skips if the workspace has a custom name set by the user.
-  @spec maybe_auto_name_workspace(EditorState.t(), String.t()) :: EditorState.t()
-  defp maybe_auto_name_workspace(%{shell_runtime: %{state: %{tab_bar: nil}}} = state, _),
-    do: state
-
-  defp maybe_auto_name_workspace(state, prompt) do
-    session = Runtime.active_session(state.shell_runtime)
-    tb = state.shell_runtime.state.tab_bar
-
-    with pid when is_pid(pid) <- session,
-         %Workspace{} = ws <- TabBar.find_workspace_by_session(tb, pid) do
-      maybe_apply_auto_name(state, ws, prompt)
-    else
-      _ -> state
-    end
-  end
-
-  @spec maybe_apply_auto_name(EditorState.t(), Workspace.t(), String.t()) :: EditorState.t()
-  defp maybe_apply_auto_name(state, ws, prompt) do
-    updated_ws = Workspace.auto_name(ws, prompt)
-
-    if updated_ws.label != ws.label do
-      tb = state.shell_runtime.state.tab_bar
-
-      install_tab_bar(state, TabBar.update_workspace(tb, ws.id, fn _ -> updated_ws end))
-    else
-      state
-    end
-  end
-
-  @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
-  defp install_tab_bar(%EditorState{} = state, %TabBar{} = tab_bar) do
-    shell_state =
-      MingaEditor.Shell.Traditional.State.install_tab_bar(
-        MingaEditor.Shell.Runtime.state(state.shell_runtime),
-        tab_bar
-      )
-
-    %{state | shell_runtime: Runtime.install_traditional_state(state.shell_runtime, shell_state)}
-  end
-
-  @spec file_ref_for_path(EditorState.t(), String.t()) :: {:ok, FileRef.t()} | {:error, term()}
-  defp file_ref_for_path(state, path) do
-    case project_root(state) do
-      root when is_binary(root) -> FileRef.from_path(root, path)
-      _ -> {:error, :missing_project_root}
-    end
-  end
-
-  @spec project_root(EditorState.t()) :: String.t() | nil
-  defp project_root(state), do: state.workspace.file_tree.project_root
-
-  @spec find_unassociated_file_tab(TabBar.t(), FileRef.t(), non_neg_integer(), EditorState.t()) ::
-          Tab.t() | nil
-  defp find_unassociated_file_tab(tb, %FileRef{} = file_ref, ws_id, state) do
-    Enum.find(tb.tabs, fn tab ->
-      tab.kind == :file and tab.group_id != ws_id and
-        FileRef.equal?(tab_file_ref(tab, state), file_ref)
-    end)
-  end
-
-  @spec tab_file_ref(Tab.t(), EditorState.t()) :: FileRef.t() | nil
-  defp tab_file_ref(%Tab{file_ref: %FileRef{} = file_ref}, _state), do: file_ref
-
-  defp tab_file_ref(%Tab{context: context}, state) do
-    with %{buffers: %Buffers{active: buffer}} when is_pid(buffer) <-
-           TabContext.to_workspace_map(context),
-         path when is_binary(path) <- safe_buffer_path(buffer),
-         root when is_binary(root) <- project_root(state),
-         {:ok, file_ref} <- FileRef.from_path(root, path) do
-      file_ref
-    else
-      _ -> nil
-    end
-  end
-
-  @spec maybe_rename_workspace_from_assistant(EditorState.t()) :: EditorState.t()
-  defp maybe_rename_workspace_from_assistant(state) do
-    with pid when is_pid(pid) <- Runtime.active_session(state.shell_runtime),
-         %Workspace{custom_name: nil} = ws <-
-           TabBar.find_workspace_by_session(state.shell_runtime.state.tab_bar, pid),
-         text when is_binary(text) <- first_assistant_opening(safe_messages(pid)),
-         candidate = String.slice(text, 0, 30) |> String.trim(),
-         true <- candidate != "" and candidate != ws.label do
-      maybe_apply_auto_name(state, ws, text)
-    else
-      _ -> state
-    end
-  rescue
-    _ -> state
-  end
-
-  @spec first_assistant_opening([term()]) :: String.t() | nil
-  defp first_assistant_opening(messages) do
-    Enum.find_value(messages, fn
-      {:assistant, text} when is_binary(text) and text != "" ->
-        text |> String.split("\n") |> hd() |> String.trim()
-
-      _ ->
-        nil
-    end)
-  end
-
-  @spec safe_messages(pid()) :: [term()]
-  defp safe_messages(pid) do
-    Session.messages(pid)
-  catch
-    :exit, _ -> []
-  end
-
-  @spec reset_compact_state(EditorState.t()) :: EditorState.t()
-  defp reset_compact_state(state) do
-    TraditionalWorkflow.install_agent_view(
-      state,
-      (fn v ->
-         %{v | compact_warned: false, compact_triggered: false}
-       end).(state.workspace.agent_ui.view)
-    )
-  rescue
-    _ -> state
-  end
-
-  @spec maybe_auto_compact(EditorState.t(), non_neg_integer(), non_neg_integer() | nil) ::
-          {EditorState.t(), [effect()]}
-  defp maybe_auto_compact(state, _estimated_tokens, nil), do: {state, []}
-  defp maybe_auto_compact(state, _estimated_tokens, 0), do: {state, []}
-
-  defp maybe_auto_compact(state, estimated_tokens, context_limit) do
-    fill_pct = min(round(estimated_tokens / context_limit * 100), 100)
-    view = state.workspace.agent_ui.view
-
-    agent_status =
-      MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state).runtime.status
-
-    compact_when_ready(state, view, agent_status, fill_pct)
-  end
-
-  @spec compact_when_ready(EditorState.t(), term(), AgentState.status(), non_neg_integer()) ::
-          {EditorState.t(), [effect()]}
-  defp compact_when_ready(state, _view, status, fill_pct)
-       when status in [:thinking, :tool_executing] do
-    state =
-      TraditionalWorkflow.install_agent_view(
-        state,
-        (&%{&1 | compact_pending_fill_pct: fill_pct}).(state.workspace.agent_ui.view)
-      )
-
-    {state, []}
-  end
-
-  defp compact_when_ready(state, %{compaction_in_progress: true}, _status, _fill_pct),
-    do: {state, []}
-
-  defp compact_when_ready(state, view, _status, fill_pct),
-    do: apply_compact_threshold(state, view, fill_pct)
-
-  @spec maybe_apply_pending_auto_compact(EditorState.t(), term(), [effect()]) ::
-          {EditorState.t(), [effect()]}
-  defp maybe_apply_pending_auto_compact(state, :idle, effects) do
-    case state.workspace.agent_ui.view.compact_pending_fill_pct do
-      nil ->
-        {state, effects}
-
-      fill_pct ->
-        state =
-          TraditionalWorkflow.install_agent_view(
-            state,
-            (&%{&1 | compact_pending_fill_pct: nil}).(state.workspace.agent_ui.view)
-          )
-
-        {state, compact_effects} =
-          apply_compact_threshold(state, state.workspace.agent_ui.view, fill_pct)
-
-        {state, effects ++ compact_effects}
-    end
-  end
-
-  defp maybe_apply_pending_auto_compact(state, _status, effects), do: {state, effects}
-
-  @spec apply_compact_threshold(EditorState.t(), term(), non_neg_integer()) ::
-          {EditorState.t(), [effect()]}
-  defp apply_compact_threshold(state, view, fill_pct) do
-    compact_threshold_result(
-      state,
-      view,
-      fill_pct,
-      compact_auto_threshold(),
-      compact_warn_threshold()
-    )
-  end
-
-  @spec compact_threshold_result(
-          EditorState.t(),
-          term(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) ::
-          {EditorState.t(), [effect()]}
-  defp compact_threshold_result(state, %{compact_triggered: false}, fill_pct, auto_pct, _warn_pct)
-       when auto_pct > 0 and fill_pct >= auto_pct,
-       do: trigger_auto_compact(state)
-
-  defp compact_threshold_result(state, %{compact_warned: false}, fill_pct, _auto_pct, warn_pct)
-       when warn_pct > 0 and fill_pct >= warn_pct,
-       do: warn_context_pressure(state, fill_pct)
-
-  defp compact_threshold_result(state, _view, _fill_pct, _auto_pct, _warn_pct), do: {state, []}
-
-  @spec trigger_auto_compact(EditorState.t()) :: {EditorState.t(), [effect()]}
-  defp trigger_auto_compact(state) do
-    session = Runtime.active_session(state.shell_runtime)
-
-    if is_pid(session) do
-      state =
-        TraditionalWorkflow.install_agent_view(
-          state,
-          (fn v ->
-             %{v | compact_triggered: true, compaction_in_progress: true}
-           end).(state.workspace.agent_ui.view)
-        )
-
-      {state, [{:compact_session, session}]}
-    else
-      {state, []}
-    end
-  end
-
-  @spec warn_context_pressure(EditorState.t(), non_neg_integer()) ::
-          {EditorState.t(), [effect()]}
-  defp warn_context_pressure(state, fill_pct) do
-    state =
-      TraditionalWorkflow.install_agent_view(
-        state,
-        (fn v -> %{v | compact_warned: true} end).(state.workspace.agent_ui.view)
-      )
-
-    state =
-      TraditionalWorkflow.install_agent_ui(
-        state,
-        (fn ui ->
-           UIState.push_toast(
-             ui,
-             "Context at #{fill_pct}%. Run /compact to free space.",
-             :warning
-           )
-         end).(state.workspace.agent_ui)
-      )
-
-    {state, []}
-  end
-
-  @spec compact_warn_threshold() :: non_neg_integer()
-  defp compact_warn_threshold do
-    case Minga.Config.Options.get(:agent_compaction_threshold) do
-      nil -> 0
-      threshold when is_number(threshold) -> round(threshold * 100)
-      _ -> 80
-    end
-  end
-
-  @spec compact_auto_threshold() :: non_neg_integer()
-  defp compact_auto_threshold do
-    warn = compact_warn_threshold()
-    if warn > 0, do: min(warn + 10, 100), else: 0
-  end
-
-  @spec safe_buffer_path(pid()) :: String.t() | nil
-  defp safe_buffer_path(buffer) when is_pid(buffer) do
-    Buffer.file_path(buffer)
-  catch
-    :exit, _ -> nil
-  end
+  def dispatch_batch(%EditorState{} = state, batch) when is_list(batch),
+    do: StreamEventWorkflow.batch(state, batch)
 
   @doc false
   @spec replay_catchup(EditorState.t(), [MingaAgent.EventLog.EventRecord.t()]) :: EditorState.t()
-  def replay_catchup(state, events) do
+  def replay_catchup(%EditorState{} = state, events) when is_list(events) do
     events
     |> Enum.map(&event_record_to_editor_event/1)
     |> Enum.reject(&is_nil/1)
@@ -1203,13 +106,50 @@ defmodule MingaEditor.Agent.Events do
   end
 
   @spec replay_one_catchup_event(term(), EditorState.t()) :: EditorState.t()
-  defp replay_one_catchup_event({:file_changed, path, _, _, tool_call_id, _} = event, state) do
-    if catchup_already_applied?(state, path, tool_call_id),
-      do: state,
-      else: elem(handle(state, event), 0)
+  defp replay_one_catchup_event(
+         {:file_changed, path, _before, _after, tool_call_id, _tool_name} = event,
+         state
+       ) do
+    replay_file_catchup(catchup_already_applied?(state, path, tool_call_id), event, state)
   end
 
-  defp replay_one_catchup_event(event, state), do: elem(handle(state, event), 0)
+  defp replay_one_catchup_event(event, state), do: replay_event(state, event)
+
+  @spec replay_file_catchup(boolean(), term(), EditorState.t()) :: EditorState.t()
+  defp replay_file_catchup(true, _event, state), do: state
+  defp replay_file_catchup(false, event, state), do: replay_event(state, event)
+
+  @spec replay_event(EditorState.t(), term()) :: EditorState.t()
+  defp replay_event(
+         state,
+         {:file_changed, path, before_content, after_content, tool_call_id, tool_name}
+       ) do
+    FileEventWorkflow.replay_changed(
+      state,
+      path,
+      before_content,
+      after_content,
+      tool_call_id,
+      tool_name
+    )
+  end
+
+  defp replay_event(state, {:status_changed, status}),
+    do: StatusEventWorkflow.replay_status(state, status)
+
+  defp replay_event(state, {:tool_started, _tool_call_id, _name, _args} = event),
+    do: ToolEventWorkflow.replay(state, event)
+
+  defp replay_event(state, {:tool_ended, _tool_call_id, _name, _result, _status} = event),
+    do: ToolEventWorkflow.replay(state, event)
+
+  defp replay_event(state, {:tool_interrupted, _tool_call_id} = event),
+    do: ToolEventWorkflow.replay(state, event)
+
+  defp replay_event(state, {:todo_plan_updated, _todos} = event),
+    do: ToolEventWorkflow.replay(state, event)
+
+  defp replay_event(state, _event), do: state
 
   @spec catchup_already_applied?(EditorState.t(), String.t(), String.t()) :: boolean()
   defp catchup_already_applied?(state, path, tool_call_id) do
@@ -1254,7 +194,7 @@ defmodule MingaEditor.Agent.Events do
           todo -> [todo]
         end
 
-      _ ->
+      _invalid ->
         []
     end)
   end
@@ -1265,14 +205,15 @@ defmodule MingaEditor.Agent.Events do
   defp todo_item_from_payload(item) do
     id = payload_string(item, "id")
     description = payload_string(item, "description")
+    build_todo_item(id, description, item)
+  end
 
-    if id != "" and description != "" do
-      %MingaAgent.TodoItem{
-        id: id,
-        description: description,
-        status: todo_status_payload(item)
-      }
-    end
+  @spec build_todo_item(String.t(), String.t(), map()) :: MingaAgent.TodoItem.t() | nil
+  defp build_todo_item("", _description, _item), do: nil
+  defp build_todo_item(_id, "", _item), do: nil
+
+  defp build_todo_item(id, description, item) do
+    %MingaAgent.TodoItem{id: id, description: description, status: todo_status_payload(item)}
   end
 
   @spec todo_status_payload(map()) :: MingaAgent.TodoItem.status()
@@ -1280,7 +221,7 @@ defmodule MingaEditor.Agent.Events do
     case payload_string(item, "status") do
       "in_progress" -> :in_progress
       "done" -> :done
-      _ -> :pending
+      _status -> :pending
     end
   end
 
@@ -1288,7 +229,7 @@ defmodule MingaEditor.Agent.Events do
   defp payload_map(payload, key) do
     case Map.get(payload, key) || Map.get(payload, String.to_atom(key)) do
       value when is_map(value) -> value
-      _ -> %{}
+      _value -> %{}
     end
   end
 
@@ -1306,7 +247,7 @@ defmodule MingaEditor.Agent.Events do
   defp payload_status(payload) do
     case payload_string(payload, "status") do
       "done" -> :done
-      _ -> :error
+      _status -> :error
     end
   end
 end

--- a/lib/minga_editor/agent/file_event_workflow.ex
+++ b/lib/minga_editor/agent/file_event_workflow.ex
@@ -1,0 +1,504 @@
+defmodule MingaEditor.Agent.FileEventWorkflow do
+  @moduledoc """
+  Applies agent-authored file change events to buffers, review state, and tabs.
+
+  Buffer and session actions run during the owner transition. Rendering is scheduled after all state transitions, then deferred remote reload notices are logged in their established order.
+  """
+
+  alias Minga.Buffer
+  alias Minga.Log
+  alias Minga.Distribution.ConnectionManager
+  alias Minga.Project.FileRef
+  alias MingaEditor.Agent.Activity
+  alias MingaEditor.Agent.DiffReview
+  alias MingaEditor.Agent.EditTimeline
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.View.Preview
+  alias MingaEditor.PickerUI
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
+  alias MingaEditor.Shell.Workflow
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Remote
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.Tab.Context, as: TabContext
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
+  alias MingaAgent.Session
+
+  @typep reload_notice ::
+           {:info, String.t()} | {:warning, String.t()} | {:error, String.t()}
+
+  @doc "Applies a file change and composes buffer reload, UI, render, and logging actions."
+  @spec changed(EditorState.t(), String.t(), String.t(), String.t(), String.t(), String.t()) ::
+          EditorState.t()
+  def changed(
+        %EditorState{} = state,
+        path,
+        before_content,
+        after_content,
+        tool_call_id,
+        tool_name
+      ) do
+    {state, notices} =
+      transition_changed(
+        state,
+        path,
+        before_content,
+        after_content,
+        tool_call_id,
+        tool_name
+      )
+
+    state
+    |> MingaEditor.schedule_render(16)
+    |> log_reload_notices(notices)
+  end
+
+  @doc false
+  @spec replay_changed(
+          EditorState.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t()
+        ) :: EditorState.t()
+  def replay_changed(
+        %EditorState{} = state,
+        path,
+        before_content,
+        after_content,
+        tool_call_id,
+        tool_name
+      ) do
+    {state, _notices} =
+      transition_changed(
+        state,
+        path,
+        before_content,
+        after_content,
+        tool_call_id,
+        tool_name
+      )
+
+    state
+  end
+
+  @spec transition_changed(
+          EditorState.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t()
+        ) :: {EditorState.t(), [reload_notice()]}
+  defp transition_changed(
+         state,
+         path,
+         before_content,
+         after_content,
+         tool_call_id,
+         tool_name
+       ) do
+    {state, notices} = reload_remote_buffer_if_open(state, path, after_content)
+
+    state =
+      TraditionalWorkflow.install_agent_ui(
+        state,
+        UIState.record_baseline(state.workspace.agent_ui, path, before_content)
+      )
+
+    state = update_activity(state, &Activity.record_file(&1, path))
+    state = record_edit(state, path, tool_call_id, tool_name, before_content, after_content)
+    state = track_active_shell_agent_file(state, path)
+    state = associate_file_with_agent_workspace(state, path)
+    state = add_file_changed_message(state, path, tool_name)
+    state = install_diff_review(state, path, after_content)
+    {state, notices}
+  end
+
+  @spec record_edit(
+          EditorState.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t(),
+          String.t()
+        ) :: EditorState.t()
+  defp record_edit(state, path, tool_call_id, tool_name, before_content, after_content) do
+    TraditionalWorkflow.install_agent_ui(
+      state,
+      (fn ui ->
+         timeline =
+           EditTimeline.record_edit(
+             ui.view.edit_timeline,
+             path,
+             tool_call_id,
+             tool_name,
+             before_content,
+             after_content
+           )
+
+         UIState.replace_edit_timeline(ui, timeline)
+       end).(state.workspace.agent_ui)
+    )
+  end
+
+  @spec install_diff_review(EditorState.t(), String.t(), String.t()) :: EditorState.t()
+  defp install_diff_review(state, path, after_content) do
+    baseline = UIState.get_baseline(state.workspace.agent_ui, path)
+
+    review =
+      case existing_diff_for_path(state, path) do
+        nil -> DiffReview.new(path, baseline, after_content)
+        existing -> DiffReview.update_after(existing, after_content)
+      end
+
+    install_diff_review(state, review)
+  end
+
+  @spec install_diff_review(EditorState.t(), DiffReview.t() | nil) :: EditorState.t()
+  defp install_diff_review(state, nil), do: state
+
+  defp install_diff_review(state, review) do
+    state = update_preview(state, &Preview.set_diff(&1, review))
+
+    TraditionalWorkflow.install_agent_ui(
+      state,
+      UIState.set_focus(state.workspace.agent_ui, :file_viewer)
+    )
+  end
+
+  @spec reload_remote_buffer_if_open(EditorState.t(), String.t(), String.t()) ::
+          {EditorState.t(), [reload_notice()]}
+  defp reload_remote_buffer_if_open(state, path, after_content) do
+    case current_remote_target(state) do
+      {:ok, server_name, remote_node} ->
+        reload_remote_buffer(
+          state,
+          server_name,
+          normalize_remote_path(remote_node, path),
+          after_content
+        )
+
+      :error ->
+        reload_tracked_remote_buffers(state, path, after_content)
+    end
+  end
+
+  @spec current_remote_target(EditorState.t()) :: {:ok, String.t(), node()} | :error
+  defp current_remote_target(state) do
+    case Runtime.active_session(state.shell_runtime) do
+      pid when is_pid(pid) and node(pid) != node() -> remote_target(node(pid))
+      _session -> :error
+    end
+  end
+
+  @spec remote_target(node()) :: {:ok, String.t(), node()} | :error
+  defp remote_target(remote_node) do
+    case ConnectionManager.server_name_for_node(remote_node) do
+      {:ok, server_name} -> {:ok, server_name, remote_node}
+      {:error, :not_found} -> :error
+    end
+  end
+
+  @spec normalize_remote_path(node(), String.t()) :: String.t()
+  defp normalize_remote_path(remote_node, path) do
+    :erpc.call(remote_node, Path, :expand, [path], 5_000)
+  catch
+    :exit, _reason -> path
+    :error, {:erpc, _reason} -> path
+  end
+
+  @spec reload_tracked_remote_buffers(EditorState.t(), String.t(), String.t()) ::
+          {EditorState.t(), [reload_notice()]}
+  defp reload_tracked_remote_buffers(state, path, after_content) do
+    state.remote
+    |> matching_remote_buffers(path)
+    |> Enum.reduce({state, []}, fn {_server_name, remote_path, pid}, {current_state, notices} ->
+      {current_state, new_notices} =
+        reload_remote_buffer_content(current_state, pid, remote_path, after_content)
+
+      {current_state, new_notices ++ notices}
+    end)
+  end
+
+  @spec matching_remote_buffers(Remote.t(), String.t()) :: [{String.t(), String.t(), pid()}]
+  defp matching_remote_buffers(remote, path) do
+    {direct_matches, fallback_candidates} =
+      remote
+      |> Remote.all_buffers()
+      |> Enum.split_with(fn {_server_name, remote_path, _pid} -> remote_path == path end)
+
+    fallback_matches =
+      fallback_candidates
+      |> Enum.group_by(fn {server_name, _remote_path, _pid} -> server_name end)
+      |> Enum.flat_map(fn {server_name, buffers} ->
+        normalized_path = normalize_remote_path_for_server(server_name, path, buffers)
+
+        Enum.filter(buffers, fn {_server_name, remote_path, _pid} ->
+          remote_path == normalized_path
+        end)
+      end)
+
+    direct_matches ++ fallback_matches
+  end
+
+  @spec normalize_remote_path_for_server(String.t(), String.t(), [{String.t(), String.t(), pid()}]) ::
+          String.t()
+  defp normalize_remote_path_for_server(server_name, path, buffers) do
+    case remote_node_for_server(server_name, buffers) do
+      {:ok, remote_node} -> normalize_remote_path(remote_node, path)
+      :error -> path
+    end
+  end
+
+  @spec remote_node_for_server(String.t(), [{String.t(), String.t(), pid()}]) ::
+          {:ok, node()} | :error
+  defp remote_node_for_server(server_name, buffers) do
+    case ConnectionManager.node_for_server(server_name) do
+      {:ok, remote_node} -> {:ok, remote_node}
+      {:error, _reason} -> remote_node_from_buffers(buffers)
+    end
+  catch
+    :exit, _reason -> remote_node_from_buffers(buffers)
+  end
+
+  @spec remote_node_from_buffers([{String.t(), String.t(), pid()}]) :: {:ok, node()} | :error
+  defp remote_node_from_buffers([{_server_name, _remote_path, pid} | _rest]) do
+    case Buffer.storage(pid) do
+      {:remote, remote_node, _base_path} -> {:ok, remote_node}
+      _storage -> :error
+    end
+  catch
+    :exit, _reason -> :error
+  end
+
+  defp remote_node_from_buffers([]), do: :error
+
+  @spec reload_remote_buffer(EditorState.t(), String.t(), String.t(), String.t()) ::
+          {EditorState.t(), [reload_notice()]}
+  defp reload_remote_buffer(state, server_name, path, after_content) do
+    case Remote.buffer(state.remote, server_name, path) do
+      pid when is_pid(pid) -> reload_remote_buffer_content(state, pid, path, after_content)
+      _missing -> {state, []}
+    end
+  catch
+    :exit, reason ->
+      {state, [{:error, "Failed to reload remote file #{path}: #{inspect(reason)}"}]}
+  end
+
+  @spec reload_remote_buffer_content(EditorState.t(), pid(), String.t(), String.t()) ::
+          {EditorState.t(), [reload_notice()]}
+  defp reload_remote_buffer_content(state, pid, path, after_content),
+    do: reload_remote_buffer_content(Buffer.dirty?(pid), state, pid, path, after_content)
+
+  @spec reload_remote_buffer_content(
+          boolean(),
+          EditorState.t(),
+          pid(),
+          String.t(),
+          String.t()
+        ) :: {EditorState.t(), [reload_notice()]}
+  defp reload_remote_buffer_content(true, state, pid, path, after_content) do
+    state =
+      state
+      |> MingaEditor.Shell.Traditional.NoticeWorkflow.publish(
+        "Agent modified this file. Reload, keep editing, or show diff. Save will check for conflicts."
+      )
+      |> PickerUI.open(MingaEditor.UI.Picker.RemoteFileConflictSource, %{
+        buffer: pid,
+        path: path,
+        content: after_content
+      })
+
+    {state, [{:warning, "Agent modified dirty remote file #{Path.basename(path)}"}]}
+  end
+
+  defp reload_remote_buffer_content(false, state, pid, path, after_content) do
+    Buffer.accept_saved_content(pid, after_content)
+    {state, [{:info, "Agent updated #{Path.basename(path)}"}]}
+  end
+
+  @spec log_reload_notices(EditorState.t(), [reload_notice()]) :: EditorState.t()
+  defp log_reload_notices(state, notices) do
+    Enum.each(notices, fn
+      {:info, message} -> Log.info(:editor, message)
+      {:warning, message} -> Log.warning(:editor, message)
+      {:error, message} -> Log.error(:agent, message)
+    end)
+
+    state
+  end
+
+  @spec add_file_changed_message(EditorState.t(), String.t(), String.t()) :: EditorState.t()
+  defp add_file_changed_message(state, path, tool_name) do
+    case Runtime.active_session(state.shell_runtime) do
+      pid when is_pid(pid) ->
+        short_path = shorten_to_relative(state, path)
+        Session.add_system_message(pid, "#{file_change_verb(tool_name)} #{short_path}")
+        state
+
+      _session ->
+        state
+    end
+  catch
+    :exit, _reason -> state
+  end
+
+  @spec file_change_verb(String.t()) :: String.t()
+  defp file_change_verb("write"), do: "Wrote"
+  defp file_change_verb("edit"), do: "Edited"
+  defp file_change_verb(_tool_name), do: "Modified"
+
+  @spec shorten_to_relative(EditorState.t(), String.t()) :: String.t()
+  defp shorten_to_relative(state, path) do
+    case project_root(state) do
+      root when is_binary(root) -> Path.relative_to(path, root)
+      _root -> Path.basename(path)
+    end
+  end
+
+  @spec update_activity(EditorState.t(), (Activity.t() -> Activity.t())) :: EditorState.t()
+  defp update_activity(state, fun) when is_function(fun, 1) do
+    TraditionalWorkflow.install_agent_ui(
+      state,
+      (fn ui -> UIState.replace_activity(ui, fun.(ui.view.activity)) end).(
+        state.workspace.agent_ui
+      )
+    )
+  end
+
+  @spec update_preview(EditorState.t(), (Preview.t() -> Preview.t())) :: EditorState.t()
+  defp update_preview(state, fun) when is_function(fun, 1) do
+    TraditionalWorkflow.install_agent_ui(
+      state,
+      (fn ui -> UIState.replace_preview(ui, fun.(ui.view.preview)) end).(state.workspace.agent_ui)
+    )
+  end
+
+  @spec existing_diff_for_path(EditorState.t(), String.t()) :: DiffReview.t() | nil
+  defp existing_diff_for_path(state, path) do
+    case Preview.diff_review(state.workspace.agent_ui.view.preview) do
+      %DiffReview{path: ^path} = review -> review
+      _review -> nil
+    end
+  end
+
+  @spec track_active_shell_agent_file(EditorState.t(), String.t()) :: EditorState.t()
+  defp track_active_shell_agent_file(state, path) do
+    state = Workflow.ensure_available(state)
+    session = Runtime.active_session(state.shell_runtime)
+    track_shell_agent_file(state, session, path)
+  end
+
+  @spec track_shell_agent_file(EditorState.t(), pid() | nil, String.t()) :: EditorState.t()
+  defp track_shell_agent_file(state, session, _path) when not is_pid(session), do: state
+
+  defp track_shell_agent_file(state, session, path) do
+    runtime =
+      Runtime.track_agent_file(
+        state.shell_runtime,
+        Workflow.resolved_entries(),
+        session,
+        path
+      )
+
+    %{state | shell_runtime: runtime}
+  end
+
+  @spec associate_file_with_agent_workspace(EditorState.t(), String.t()) :: EditorState.t()
+  defp associate_file_with_agent_workspace(state, path) do
+    tab_bar = traditional_tab_bar(state)
+    associate_file_with_agent_workspace(state, path, tab_bar)
+  end
+
+  @spec associate_file_with_agent_workspace(EditorState.t(), String.t(), TabBar.t() | nil) ::
+          EditorState.t()
+  defp associate_file_with_agent_workspace(state, _path, nil), do: state
+
+  defp associate_file_with_agent_workspace(state, path, tab_bar) do
+    session = Runtime.active_session(state.shell_runtime)
+
+    with pid when is_pid(pid) <- session,
+         {:ok, file_ref} <- file_ref_for_path(state, path),
+         %Workspace{id: workspace_id} <- TabBar.find_workspace_by_session(tab_bar, pid),
+         %Tab{id: tab_id} <-
+           find_unassociated_file_tab(tab_bar, file_ref, workspace_id, state) do
+      tab_bar =
+        tab_bar
+        |> TabBar.move_tab_to_workspace(tab_id, workspace_id)
+        |> TabBar.update_workspace(workspace_id, fn workspace ->
+          Workspace.retarget_file(workspace, nil, file_ref, tab_id == tab_bar.active_id)
+        end)
+
+      install_tab_bar(state, tab_bar)
+    else
+      _unavailable -> state
+    end
+  end
+
+  @spec traditional_tab_bar(EditorState.t()) :: TabBar.t() | nil
+  defp traditional_tab_bar(state) do
+    case Runtime.state(state.shell_runtime) do
+      %TraditionalState{} = shell_state -> TraditionalState.tab_bar(shell_state)
+      _other_shell_state -> nil
+    end
+  end
+
+  @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
+  defp install_tab_bar(
+         %EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}} = state,
+         %TabBar{} = tab_bar
+       ) do
+    shell_state = TraditionalState.install_tab_bar(shell_state, tab_bar)
+    %{state | shell_runtime: Runtime.install_traditional_state(state.shell_runtime, shell_state)}
+  end
+
+  defp install_tab_bar(%EditorState{} = state, %TabBar{}), do: state
+
+  @spec file_ref_for_path(EditorState.t(), String.t()) :: {:ok, FileRef.t()} | {:error, term()}
+  defp file_ref_for_path(state, path) do
+    case project_root(state) do
+      root when is_binary(root) -> FileRef.from_path(root, path)
+      _root -> {:error, :missing_project_root}
+    end
+  end
+
+  @spec project_root(EditorState.t()) :: String.t() | nil
+  defp project_root(state), do: state.workspace.file_tree.project_root
+
+  @spec find_unassociated_file_tab(TabBar.t(), FileRef.t(), non_neg_integer(), EditorState.t()) ::
+          Tab.t() | nil
+  defp find_unassociated_file_tab(tab_bar, %FileRef{} = file_ref, workspace_id, state) do
+    Enum.find(tab_bar.tabs, fn tab ->
+      tab.kind == :file and tab.group_id != workspace_id and
+        FileRef.equal?(tab_file_ref(tab, state), file_ref)
+    end)
+  end
+
+  @spec tab_file_ref(Tab.t(), EditorState.t()) :: FileRef.t() | nil
+  defp tab_file_ref(%Tab{file_ref: %FileRef{} = file_ref}, _state), do: file_ref
+
+  defp tab_file_ref(%Tab{context: context}, state) do
+    with %{buffers: %Buffers{active: buffer}} when is_pid(buffer) <-
+           TabContext.to_workspace_map(context),
+         path when is_binary(path) <- safe_buffer_path(buffer),
+         root when is_binary(root) <- project_root(state),
+         {:ok, file_ref} <- FileRef.from_path(root, path) do
+      file_ref
+    else
+      _unavailable -> nil
+    end
+  end
+
+  @spec safe_buffer_path(pid()) :: String.t() | nil
+  defp safe_buffer_path(buffer) when is_pid(buffer) do
+    Buffer.file_path(buffer)
+  catch
+    :exit, _reason -> nil
+  end
+end

--- a/lib/minga_editor/agent/session_event_workflow.ex
+++ b/lib/minga_editor/agent/session_event_workflow.ex
@@ -1,0 +1,211 @@
+defmodule MingaEditor.Agent.SessionEventWorkflow do
+  @moduledoc """
+  Applies approval, error, queue, spinner, and session presentation events.
+
+  Queue recall remains owned by the active session. Approval and transcript actions are composed directly in their established render-then-sync order.
+  """
+
+  alias MingaEditor.Agent.Activity
+  alias MingaEditor.Agent.PromptBuffer
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.Panel
+  alias MingaEditor.AgentLifecycle
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
+  alias MingaAgent.Session
+
+  @typep queued_prompt :: String.t() | [ReqLLM.Message.ContentPart.t()]
+
+  @doc "Installs an approval request, moves input focus, renders, and synchronizes the transcript."
+  @spec approval_pending(EditorState.t(), map()) :: EditorState.t()
+  def approval_pending(%EditorState{} = state, approval) when is_map(approval) do
+    cached = Map.take(approval, [:tool_call_id, :name, :args, :preview])
+    state = TraditionalWorkflow.install_agent_approval(state, cached)
+    state = update_activity(state, &Activity.ensure_started_at/1)
+
+    state =
+      TraditionalWorkflow.install_agent_ui(
+        state,
+        PromptBuffer.set_input_focused(state.workspace.agent_ui, false)
+      )
+
+    state
+    |> MingaEditor.schedule_render(16)
+    |> AgentLifecycle.sync_transcript()
+  end
+
+  @doc "Clears a resolved approval, renders, and synchronizes the transcript."
+  @spec approval_resolved(EditorState.t(), term()) :: EditorState.t()
+  def approval_resolved(%EditorState{} = state, _decision) do
+    state
+    |> TraditionalWorkflow.clear_agent_approval()
+    |> MingaEditor.schedule_render(16)
+    |> AgentLifecycle.sync_transcript()
+  end
+
+  @doc "Restores queued prompts after an agent error and installs the visible error state."
+  @spec error(EditorState.t(), String.t()) :: EditorState.t()
+  def error(%EditorState{} = state, message) when is_binary(message) do
+    state
+    |> restore_queued_prompts_after_error()
+    |> TraditionalWorkflow.install_agent_error(message)
+    |> MingaEditor.schedule_render(16)
+  end
+
+  @doc "Updates whether provider credentials are configured and schedules a render."
+  @spec credentials_status(EditorState.t(), boolean()) :: EditorState.t()
+  def credentials_status(%EditorState{} = state, configured?) when is_boolean(configured?) do
+    state
+    |> TraditionalWorkflow.install_agent_panel(
+      Panel.set_credentials_configured(state.workspace.agent_ui.panel, configured?)
+    )
+    |> MingaEditor.schedule_render(16)
+  end
+
+  @doc "Advances or stops the agent spinner according to the foreground status."
+  @spec spinner_tick(EditorState.t()) :: EditorState.t()
+  def spinner_tick(
+        %EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}} = state
+      ) do
+    spinner_tick(state, AgentState.busy?(TraditionalState.agent(shell_state)))
+  end
+
+  def spinner_tick(%EditorState{} = state), do: state
+
+  @spec spinner_tick(EditorState.t(), boolean()) :: EditorState.t()
+  defp spinner_tick(state, true) do
+    state
+    |> TraditionalWorkflow.install_agent_ui(UIState.tick_spinner(state.workspace.agent_ui))
+    |> MingaEditor.schedule_render(16)
+  end
+
+  defp spinner_tick(state, false), do: TraditionalWorkflow.install_agent_spinner_stop(state)
+
+  @doc "Dismisses the current agent toast and schedules a render."
+  @spec dismiss_toast(EditorState.t()) :: EditorState.t()
+  def dismiss_toast(%EditorState{} = state) do
+    state
+    |> TraditionalWorkflow.install_agent_ui(UIState.dismiss_toast(state.workspace.agent_ui))
+    |> MingaEditor.schedule_render(16)
+  end
+
+  @doc "Applies queue presentation for a newly queued prompt."
+  @spec prompt_queued(EditorState.t(), String.t(), term()) :: EditorState.t()
+  def prompt_queued(%EditorState{} = state, content, _queue_type) when is_binary(content) do
+    state
+    |> maybe_auto_name_workspace(content)
+    |> MingaEditor.schedule_render(16)
+  end
+
+  @doc "Refreshes queue presentation after both prompt queues are recalled."
+  @spec queues_recalled(EditorState.t()) :: EditorState.t()
+  def queues_recalled(%EditorState{} = state), do: MingaEditor.schedule_render(state, 16)
+
+  @spec restore_queued_prompts_after_error(EditorState.t()) :: EditorState.t()
+  defp restore_queued_prompts_after_error(state) do
+    case Runtime.active_session(state.shell_runtime) do
+      session when is_pid(session) ->
+        {steering, follow_up} = safe_recall_queues(session)
+        restore_queued_to_prompt(state, steering ++ follow_up)
+
+      _session ->
+        state
+    end
+  end
+
+  @spec safe_recall_queues(pid()) :: {[queued_prompt()], [queued_prompt()]}
+  defp safe_recall_queues(session) do
+    Session.recall_queues(session)
+  catch
+    :exit, _reason -> {[], []}
+  end
+
+  @spec restore_queued_to_prompt(EditorState.t(), [queued_prompt()]) :: EditorState.t()
+  defp restore_queued_to_prompt(state, []), do: state
+
+  defp restore_queued_to_prompt(state, queued) do
+    current_text = PromptBuffer.prompt_text(state.workspace.agent_ui)
+    combined = Session.combine_queue_entries_to_text(queued)
+    restored = append_current_prompt(combined, current_text)
+
+    TraditionalWorkflow.install_agent_ui(
+      state,
+      PromptBuffer.set_prompt_text(state.workspace.agent_ui, restored)
+    )
+  end
+
+  @spec append_current_prompt(String.t(), String.t()) :: String.t()
+  defp append_current_prompt(combined, ""), do: combined
+  defp append_current_prompt(combined, current_text), do: combined <> "\n\n" <> current_text
+
+  @spec maybe_auto_name_workspace(EditorState.t(), String.t()) :: EditorState.t()
+  defp maybe_auto_name_workspace(state, prompt) do
+    session = Runtime.active_session(state.shell_runtime)
+
+    case workspace_for_session(traditional_tab_bar(state), session) do
+      %Workspace{} = workspace -> maybe_apply_auto_name(state, workspace, prompt)
+      nil -> state
+    end
+  end
+
+  @spec workspace_for_session(TabBar.t() | nil, pid() | nil) :: Workspace.t() | nil
+  defp workspace_for_session(nil, _session), do: nil
+  defp workspace_for_session(_tab_bar, session) when not is_pid(session), do: nil
+
+  defp workspace_for_session(tab_bar, session),
+    do: TabBar.find_workspace_by_session(tab_bar, session)
+
+  @spec maybe_apply_auto_name(EditorState.t(), Workspace.t(), String.t()) :: EditorState.t()
+  defp maybe_apply_auto_name(state, workspace, prompt) do
+    updated_workspace = Workspace.auto_name(workspace, prompt)
+    install_auto_name(state, workspace, updated_workspace)
+  end
+
+  @spec install_auto_name(EditorState.t(), Workspace.t(), Workspace.t()) :: EditorState.t()
+  defp install_auto_name(state, %Workspace{label: label}, %Workspace{label: label}), do: state
+
+  defp install_auto_name(state, workspace, updated_workspace) do
+    case traditional_tab_bar(state) do
+      %TabBar{} = tab_bar ->
+        tab_bar =
+          TabBar.update_workspace(tab_bar, workspace.id, fn _current -> updated_workspace end)
+
+        install_tab_bar(state, tab_bar)
+
+      nil ->
+        state
+    end
+  end
+
+  @spec traditional_tab_bar(EditorState.t()) :: TabBar.t() | nil
+  defp traditional_tab_bar(%EditorState{
+         shell_runtime: %Runtime{state: %TraditionalState{} = state}
+       }),
+       do: TraditionalState.tab_bar(state)
+
+  defp traditional_tab_bar(%EditorState{}), do: nil
+
+  @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
+  defp install_tab_bar(
+         %EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}} = state,
+         %TabBar{} = tab_bar
+       ) do
+    shell_state = TraditionalState.install_tab_bar(shell_state, tab_bar)
+    %{state | shell_runtime: Runtime.install_traditional_state(state.shell_runtime, shell_state)}
+  end
+
+  @spec update_activity(EditorState.t(), (Activity.t() -> Activity.t())) :: EditorState.t()
+  defp update_activity(state, fun) when is_function(fun, 1) do
+    TraditionalWorkflow.install_agent_ui(
+      state,
+      (fn ui -> UIState.replace_activity(ui, fun.(ui.view.activity)) end).(
+        state.workspace.agent_ui
+      )
+    )
+  end
+end

--- a/lib/minga_editor/agent/status_event_workflow.ex
+++ b/lib/minga_editor/agent/status_event_workflow.ex
@@ -1,0 +1,346 @@
+defmodule MingaEditor.Agent.StatusEventWorkflow do
+  @moduledoc """
+  Applies agent status and context-pressure events.
+
+  The workflow keeps shell status, tab status, activity, spinner, and compaction state synchronized before rendering. Compaction scheduling remains attached to the active session and runs only after the render request is installed.
+  """
+
+  alias MingaEditor.Agent.Activity
+  alias MingaEditor.Agent.Compaction
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
+  alias MingaEditor.Shell.Workflow
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
+
+  @typep compaction_action :: :none | {:compact_session, pid()}
+
+  @doc "Synchronizes a foreground agent status and its dependent UI state."
+  @spec status_changed(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  def status_changed(%EditorState{} = state, status) do
+    state = transition_status(state, status)
+    {state, compaction_action} = apply_pending_auto_compact(state, status)
+    state = MingaEditor.schedule_render(state, 16)
+    state = log_status(state, status)
+    apply_compaction_action(state, compaction_action)
+  end
+
+  @doc "Records context usage and applies or defers automatic compaction."
+  @spec context_usage(EditorState.t(), non_neg_integer(), non_neg_integer() | nil) ::
+          EditorState.t()
+  def context_usage(%EditorState{} = state, estimated_tokens, context_limit) do
+    state =
+      TraditionalWorkflow.install_agent_view(
+        state,
+        (fn view -> %{view | context_estimate: estimated_tokens} end).(
+          state.workspace.agent_ui.view
+        )
+      )
+
+    {state, compaction_action} = maybe_auto_compact(state, estimated_tokens, context_limit)
+
+    state
+    |> MingaEditor.schedule_render(16)
+    |> apply_compaction_action(compaction_action)
+  end
+
+  @doc false
+  @spec replay_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  def replay_status(%EditorState{} = state, status), do: transition_status(state, status)
+
+  @spec transition_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  defp transition_status(state, status) do
+    state = TraditionalWorkflow.install_agent_status(state, status)
+    state = engage_scroll(state, status)
+    state = update_turn_activity(state, status)
+    state = update_spinner(state, status)
+    state = reset_compact_state(state, status)
+    state = sync_tab_agent_status(state, status)
+    sync_active_shell_agent_status(state, status)
+  end
+
+  @spec engage_scroll(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  defp engage_scroll(state, :thinking), do: TraditionalWorkflow.engage_agent_scroll(state)
+  defp engage_scroll(state, _status), do: state
+
+  @spec update_turn_activity(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  defp update_turn_activity(state, status) when status in [:thinking, :tool_executing],
+    do: update_activity(state, &Activity.start_turn/1)
+
+  defp update_turn_activity(state, status) when status in [:idle, :error, :plan],
+    do: update_activity(state, &Activity.finish_turn/1)
+
+  defp update_turn_activity(state, _status), do: state
+
+  @spec update_spinner(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  defp update_spinner(state, status) when status in [:thinking, :tool_executing],
+    do: TraditionalWorkflow.install_agent_spinner_start(state)
+
+  defp update_spinner(state, _status), do: TraditionalWorkflow.install_agent_spinner_stop(state)
+
+  @spec reset_compact_state(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  defp reset_compact_state(state, :idle) do
+    TraditionalWorkflow.install_agent_view(
+      state,
+      (fn view -> %{view | compact_warned: false, compact_triggered: false} end).(
+        state.workspace.agent_ui.view
+      )
+    )
+  rescue
+    _error -> state
+  end
+
+  defp reset_compact_state(state, _status), do: state
+
+  @spec log_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  defp log_status(state, :error) do
+    Minga.Log.info(:editor, "Agent: error")
+    state
+  end
+
+  defp log_status(state, _status), do: state
+
+  @spec maybe_auto_compact(EditorState.t(), non_neg_integer(), non_neg_integer() | nil) ::
+          {EditorState.t(), compaction_action()}
+  defp maybe_auto_compact(state, _estimated_tokens, nil), do: {state, :none}
+  defp maybe_auto_compact(state, _estimated_tokens, 0), do: {state, :none}
+
+  defp maybe_auto_compact(state, estimated_tokens, context_limit) do
+    fill_pct = min(round(estimated_tokens / context_limit * 100), 100)
+    view = state.workspace.agent_ui.view
+
+    agent_status =
+      MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state).runtime.status
+
+    compact_when_ready(state, view, agent_status, fill_pct)
+  end
+
+  @spec compact_when_ready(EditorState.t(), term(), AgentState.status(), non_neg_integer()) ::
+          {EditorState.t(), compaction_action()}
+  defp compact_when_ready(state, _view, status, fill_pct)
+       when status in [:thinking, :tool_executing] do
+    state =
+      TraditionalWorkflow.install_agent_view(
+        state,
+        (&%{&1 | compact_pending_fill_pct: fill_pct}).(state.workspace.agent_ui.view)
+      )
+
+    {state, :none}
+  end
+
+  defp compact_when_ready(state, %{compaction_in_progress: true}, _status, _fill_pct),
+    do: {state, :none}
+
+  defp compact_when_ready(state, view, _status, fill_pct),
+    do: apply_compact_threshold(state, view, fill_pct)
+
+  @spec apply_pending_auto_compact(EditorState.t(), Tab.agent_status()) ::
+          {EditorState.t(), compaction_action()}
+  defp apply_pending_auto_compact(state, :idle) do
+    case state.workspace.agent_ui.view.compact_pending_fill_pct do
+      nil ->
+        {state, :none}
+
+      fill_pct ->
+        state =
+          TraditionalWorkflow.install_agent_view(
+            state,
+            (&%{&1 | compact_pending_fill_pct: nil}).(state.workspace.agent_ui.view)
+          )
+
+        apply_compact_threshold(state, state.workspace.agent_ui.view, fill_pct)
+    end
+  end
+
+  defp apply_pending_auto_compact(state, _status), do: {state, :none}
+
+  @spec apply_compact_threshold(EditorState.t(), term(), non_neg_integer()) ::
+          {EditorState.t(), compaction_action()}
+  defp apply_compact_threshold(state, view, fill_pct) do
+    compact_threshold_result(
+      state,
+      view,
+      fill_pct,
+      compact_auto_threshold(),
+      compact_warn_threshold()
+    )
+  end
+
+  @spec compact_threshold_result(
+          EditorState.t(),
+          term(),
+          non_neg_integer(),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: {EditorState.t(), compaction_action()}
+  defp compact_threshold_result(state, %{compact_triggered: false}, fill_pct, auto_pct, _warn_pct)
+       when auto_pct > 0 and fill_pct >= auto_pct,
+       do: trigger_auto_compact(state)
+
+  defp compact_threshold_result(state, %{compact_warned: false}, fill_pct, _auto_pct, warn_pct)
+       when warn_pct > 0 and fill_pct >= warn_pct,
+       do: warn_context_pressure(state, fill_pct)
+
+  defp compact_threshold_result(state, _view, _fill_pct, _auto_pct, _warn_pct),
+    do: {state, :none}
+
+  @spec trigger_auto_compact(EditorState.t()) :: {EditorState.t(), compaction_action()}
+  defp trigger_auto_compact(state) do
+    case Runtime.active_session(state.shell_runtime) do
+      session when is_pid(session) ->
+        state =
+          TraditionalWorkflow.install_agent_view(
+            state,
+            (fn view ->
+               %{view | compact_triggered: true, compaction_in_progress: true}
+             end).(state.workspace.agent_ui.view)
+          )
+
+        {state, {:compact_session, session}}
+
+      _session ->
+        {state, :none}
+    end
+  end
+
+  @spec warn_context_pressure(EditorState.t(), non_neg_integer()) ::
+          {EditorState.t(), compaction_action()}
+  defp warn_context_pressure(state, fill_pct) do
+    state =
+      TraditionalWorkflow.install_agent_view(
+        state,
+        (fn view -> %{view | compact_warned: true} end).(state.workspace.agent_ui.view)
+      )
+
+    state =
+      TraditionalWorkflow.install_agent_ui(
+        state,
+        (fn ui ->
+           UIState.push_toast(
+             ui,
+             "Context at #{fill_pct}%. Run /compact to free space.",
+             :warning
+           )
+         end).(state.workspace.agent_ui)
+      )
+
+    {state, :none}
+  end
+
+  @spec compact_warn_threshold() :: non_neg_integer()
+  defp compact_warn_threshold do
+    case Minga.Config.Options.get(:agent_compaction_threshold) do
+      nil -> 0
+      threshold when is_number(threshold) -> round(threshold * 100)
+      _invalid -> 80
+    end
+  end
+
+  @spec compact_auto_threshold() :: non_neg_integer()
+  defp compact_auto_threshold do
+    case compact_warn_threshold() do
+      warn when warn > 0 -> min(warn + 10, 100)
+      _disabled -> 0
+    end
+  end
+
+  @spec apply_compaction_action(EditorState.t(), compaction_action()) :: EditorState.t()
+  defp apply_compaction_action(state, :none), do: state
+
+  defp apply_compaction_action(state, {:compact_session, session}),
+    do: Compaction.schedule(state, session)
+
+  @spec update_activity(EditorState.t(), (Activity.t() -> Activity.t())) :: EditorState.t()
+  defp update_activity(state, fun) when is_function(fun, 1) do
+    TraditionalWorkflow.install_agent_ui(
+      state,
+      (fn ui -> UIState.replace_activity(ui, fun.(ui.view.activity)) end).(
+        state.workspace.agent_ui
+      )
+    )
+  end
+
+  @spec sync_active_shell_agent_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  defp sync_active_shell_agent_status(state, status) do
+    state = Workflow.ensure_available(state)
+    session = Runtime.active_session(state.shell_runtime)
+    sync_shell_agent_status(state, session, status)
+  end
+
+  @spec sync_shell_agent_status(EditorState.t(), pid() | nil, Tab.agent_status()) ::
+          EditorState.t()
+  defp sync_shell_agent_status(state, session, _status) when not is_pid(session), do: state
+
+  defp sync_shell_agent_status(state, session, status) do
+    runtime =
+      Runtime.sync_agent_status(
+        state.shell_runtime,
+        Workflow.resolved_entries(),
+        session,
+        status
+      )
+
+    %{state | shell_runtime: runtime}
+  end
+
+  @spec sync_tab_agent_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  defp sync_tab_agent_status(state, status) do
+    tab_bar = traditional_tab_bar(state)
+    session = Runtime.active_session(state.shell_runtime)
+    update_tab_agent_status(state, status, session, tab_bar)
+  end
+
+  @spec update_tab_agent_status(
+          EditorState.t(),
+          Tab.agent_status(),
+          pid() | nil,
+          TabBar.t() | nil
+        ) :: EditorState.t()
+  defp update_tab_agent_status(state, _status, _session, nil), do: state
+
+  defp update_tab_agent_status(state, _status, session, _tab_bar) when not is_pid(session),
+    do: state
+
+  defp update_tab_agent_status(state, status, session, tab_bar) do
+    tab_bar =
+      case TabBar.find_workspace_by_session(tab_bar, session) do
+        %Workspace{id: workspace_id} ->
+          TabBar.update_workspace(tab_bar, workspace_id, &Workspace.set_agent_status(&1, status))
+
+        nil ->
+          tab_bar
+      end
+
+    tab_bar =
+      case TabBar.find_by_session(tab_bar, session) do
+        %Tab{id: tab_id} -> TabBar.update_tab(tab_bar, tab_id, &Tab.set_agent_status(&1, status))
+        nil -> tab_bar
+      end
+
+    install_tab_bar(state, tab_bar)
+  end
+
+  @spec traditional_tab_bar(EditorState.t()) :: TabBar.t() | nil
+  defp traditional_tab_bar(state) do
+    case Runtime.state(state.shell_runtime) do
+      %TraditionalState{} = shell_state -> TraditionalState.tab_bar(shell_state)
+      _other_shell_state -> nil
+    end
+  end
+
+  @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
+  defp install_tab_bar(
+         %EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}} = state,
+         %TabBar{} = tab_bar
+       ) do
+    shell_state = TraditionalState.install_tab_bar(shell_state, tab_bar)
+    %{state | shell_runtime: Runtime.install_traditional_state(state.shell_runtime, shell_state)}
+  end
+
+  defp install_tab_bar(%EditorState{} = state, %TabBar{}), do: state
+end

--- a/lib/minga_editor/agent/stream_event_workflow.ex
+++ b/lib/minga_editor/agent/stream_event_workflow.ex
@@ -1,0 +1,156 @@
+defmodule MingaEditor.Agent.StreamEventWorkflow do
+  @moduledoc """
+  Applies transcript and coalesced stream events in mailbox order.
+
+  A batch performs one auto-scroll transition, folds preview updates in arrival order, requests one render, and synchronizes the transcript at most once.
+  """
+
+  alias MingaEditor.Agent.ToolEventWorkflow
+  alias MingaEditor.Agent.UIState.Panel
+  alias MingaEditor.AgentLifecycle
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
+  alias MingaAgent.Session
+
+  @doc "Applies one durable stream delta through the bounded batch workflow."
+  @spec delta(EditorState.t(), term()) :: EditorState.t()
+  def delta(%EditorState{} = state, event), do: batch(state, [event])
+
+  @doc "Applies a messages-changed event and refreshes transcript-derived presentation."
+  @spec messages_changed(EditorState.t()) :: EditorState.t()
+  def messages_changed(%EditorState{} = state) do
+    state = TraditionalWorkflow.maybe_agent_auto_scroll(state)
+
+    state =
+      TraditionalWorkflow.install_agent_panel(
+        state,
+        Panel.bump_message_version(state.workspace.agent_ui.panel)
+      )
+
+    state = maybe_rename_workspace_from_assistant(state)
+    state = MingaEditor.schedule_render(state, 16)
+    state = AgentLifecycle.sync_transcript(state)
+    AgentLifecycle.maybe_update_tab_label(state)
+  end
+
+  @doc "Applies one coalesced stream batch with one render and at most one transcript sync."
+  @spec batch(EditorState.t(), [term()]) :: EditorState.t()
+  def batch(%EditorState{} = state, []), do: state
+
+  def batch(%EditorState{} = state, events) when is_list(events) do
+    state = TraditionalWorkflow.maybe_agent_auto_scroll(state)
+    state = Enum.reduce(events, state, &replay_delta/2)
+    sync_transcript? = transcript_affecting_batch?(events)
+
+    state = maybe_bump_message_version(state, sync_transcript?)
+    state = MingaEditor.schedule_render(state, 16)
+    sync_transcript(state, sync_transcript?)
+  end
+
+  @spec maybe_bump_message_version(EditorState.t(), boolean()) :: EditorState.t()
+  defp maybe_bump_message_version(state, true) do
+    TraditionalWorkflow.install_agent_panel(
+      state,
+      Panel.bump_message_version(state.workspace.agent_ui.panel)
+    )
+  end
+
+  defp maybe_bump_message_version(state, false), do: state
+
+  @spec replay_delta(term(), EditorState.t()) :: EditorState.t()
+  defp replay_delta({:tool_update, _tool_call_id, _name, _partial} = event, state),
+    do: ToolEventWorkflow.replay(state, event)
+
+  defp replay_delta(_event, state), do: state
+
+  @spec transcript_affecting_batch?([term()]) :: boolean()
+  defp transcript_affecting_batch?(events) do
+    Enum.any?(events, fn
+      {:text_delta, _delta} -> true
+      {:thinking_delta, _delta} -> true
+      _event -> false
+    end)
+  end
+
+  @spec sync_transcript(EditorState.t(), boolean()) :: EditorState.t()
+  defp sync_transcript(state, true), do: AgentLifecycle.sync_transcript(state)
+  defp sync_transcript(state, false), do: state
+
+  @spec maybe_rename_workspace_from_assistant(EditorState.t()) :: EditorState.t()
+  defp maybe_rename_workspace_from_assistant(state) do
+    with pid when is_pid(pid) <- Runtime.active_session(state.shell_runtime),
+         %TabBar{} = tab_bar <- traditional_tab_bar(state),
+         %Workspace{custom_name: nil} = workspace <-
+           TabBar.find_workspace_by_session(tab_bar, pid),
+         text when is_binary(text) <- first_assistant_opening(safe_messages(pid)),
+         candidate = text |> String.slice(0, 30) |> String.trim(),
+         true <- candidate != "" and candidate != workspace.label do
+      maybe_apply_auto_name(state, workspace, text)
+    else
+      _unavailable -> state
+    end
+  rescue
+    _error -> state
+  end
+
+  @spec first_assistant_opening([term()]) :: String.t() | nil
+  defp first_assistant_opening(messages) do
+    Enum.find_value(messages, fn
+      {:assistant, text} when is_binary(text) and text != "" ->
+        text |> String.split("\n") |> hd() |> String.trim()
+
+      _message ->
+        nil
+    end)
+  end
+
+  @spec safe_messages(pid()) :: [term()]
+  defp safe_messages(pid) do
+    Session.messages(pid)
+  catch
+    :exit, _reason -> []
+  end
+
+  @spec maybe_apply_auto_name(EditorState.t(), Workspace.t(), String.t()) :: EditorState.t()
+  defp maybe_apply_auto_name(state, workspace, prompt) do
+    updated_workspace = Workspace.auto_name(workspace, prompt)
+    install_auto_name(state, workspace, updated_workspace)
+  end
+
+  @spec install_auto_name(EditorState.t(), Workspace.t(), Workspace.t()) :: EditorState.t()
+  defp install_auto_name(state, %Workspace{label: label}, %Workspace{label: label}), do: state
+
+  defp install_auto_name(state, workspace, updated_workspace) do
+    case traditional_tab_bar(state) do
+      %TabBar{} = tab_bar ->
+        tab_bar =
+          TabBar.update_workspace(tab_bar, workspace.id, fn _current -> updated_workspace end)
+
+        install_tab_bar(state, tab_bar)
+
+      nil ->
+        state
+    end
+  end
+
+  @spec traditional_tab_bar(EditorState.t()) :: TabBar.t() | nil
+  defp traditional_tab_bar(%EditorState{
+         shell_runtime: %Runtime{state: %TraditionalState{} = state}
+       }),
+       do: TraditionalState.tab_bar(state)
+
+  defp traditional_tab_bar(%EditorState{}), do: nil
+
+  @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
+  defp install_tab_bar(
+         %EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}} = state,
+         %TabBar{} = tab_bar
+       ) do
+    shell_state = TraditionalState.install_tab_bar(shell_state, tab_bar)
+    %{state | shell_runtime: Runtime.install_traditional_state(state.shell_runtime, shell_state)}
+  end
+end

--- a/lib/minga_editor/agent/tool_event_workflow.ex
+++ b/lib/minga_editor/agent/tool_event_workflow.ex
@@ -1,0 +1,256 @@
+defmodule MingaEditor.Agent.ToolEventWorkflow do
+  @moduledoc """
+  Applies tool-family agent events to the foreground agent surface.
+
+  Session snapshots remain authoritative for the active tool name. Each live workflow applies owner transitions first, then schedules its render directly. Replay uses the same transitions without producing another render request.
+  """
+
+  alias MingaEditor.Agent.Activity
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.View.Preview
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
+  alias MingaEditor.State, as: EditorState
+  alias MingaAgent.Session
+
+  @doc "Applies a tool-start event and schedules the resulting preview render."
+  @spec started(EditorState.t(), String.t(), String.t(), map()) :: EditorState.t()
+  def started(%EditorState{} = state, _tool_call_id, name, args), do: started(state, name, args)
+
+  @doc "Applies a tool-start event without a tool-call identity."
+  @spec started(EditorState.t(), String.t(), map()) :: EditorState.t()
+  def started(%EditorState{} = state, name, args) do
+    state
+    |> transition_started(name, args)
+    |> MingaEditor.schedule_render(16)
+  end
+
+  @doc "Applies a tool progress event and schedules the preview render."
+  @spec updated(EditorState.t(), String.t(), String.t(), String.t()) :: EditorState.t()
+  def updated(%EditorState{} = state, _tool_call_id, name, partial) do
+    state
+    |> transition_updated(name, partial)
+    |> MingaEditor.schedule_render(50)
+  end
+
+  @doc "Applies a tool-end event and schedules a render when its preview changed."
+  @spec ended(EditorState.t(), String.t(), String.t(), String.t(), atom()) :: EditorState.t()
+  def ended(%EditorState{} = state, _tool_call_id, name, result, status),
+    do: ended(state, name, result, status)
+
+  @doc "Applies a tool-end event without a tool-call identity."
+  @spec ended(EditorState.t(), String.t(), String.t(), atom()) :: EditorState.t()
+  def ended(%EditorState{} = state, name, result, status) do
+    case transition_ended(state, name, result, status) do
+      {:render, state} -> MingaEditor.schedule_render(state, 16)
+      {:no_render, state} -> state
+    end
+  end
+
+  @doc "Clears interrupted tool activity and schedules the preview render."
+  @spec interrupted(EditorState.t(), String.t()) :: EditorState.t()
+  def interrupted(%EditorState{} = state, _tool_call_id) do
+    state
+    |> transition_interrupted()
+    |> MingaEditor.schedule_render(16)
+  end
+
+  @doc "Installs the latest tool-authored todo plan and schedules a render."
+  @spec todo_plan_updated(EditorState.t(), [MingaAgent.TodoItem.t()]) :: EditorState.t()
+  def todo_plan_updated(%EditorState{} = state, todos) when is_list(todos) do
+    state
+    |> update_activity(&Activity.set_todos(&1, todos))
+    |> MingaEditor.schedule_render(16)
+  end
+
+  @doc false
+  @spec replay(EditorState.t(), term()) :: EditorState.t()
+  def replay(%EditorState{} = state, {:tool_started, _tool_call_id, name, args}),
+    do: transition_started(state, name, args)
+
+  def replay(%EditorState{} = state, {:tool_started, name, args}),
+    do: transition_started(state, name, args)
+
+  def replay(%EditorState{} = state, {:tool_update, _tool_call_id, "shell", partial}),
+    do: update_preview(state, &Preview.update_shell_output(&1, partial))
+
+  def replay(%EditorState{} = state, {:tool_update, _tool_call_id, _name, _partial}), do: state
+
+  def replay(%EditorState{} = state, {:tool_ended, _tool_call_id, name, result, status}),
+    do: state |> transition_ended(name, result, status) |> transition_state()
+
+  def replay(%EditorState{} = state, {:tool_ended, name, result, status}),
+    do: state |> transition_ended(name, result, status) |> transition_state()
+
+  def replay(%EditorState{} = state, {:tool_interrupted, _tool_call_id}),
+    do: transition_interrupted(state)
+
+  def replay(%EditorState{} = state, {:todo_plan_updated, todos}) when is_list(todos),
+    do: update_activity(state, &Activity.set_todos(&1, todos))
+
+  @spec transition_started(EditorState.t(), String.t(), map()) :: EditorState.t()
+  defp transition_started(state, "shell", args) do
+    command = Map.get(args, "command", "")
+
+    state
+    |> update_activity(&Activity.start_tool(&1, "shell"))
+    |> sync_active_tool_name("shell")
+    |> update_preview(&Preview.set_shell(&1, command))
+  end
+
+  defp transition_started(state, "read_file", args) do
+    path = Map.get(args, "path", "")
+
+    state
+    |> update_activity(&Activity.start_tool(&1, "read_file"))
+    |> sync_active_tool_name("read_file")
+    |> update_preview(&Preview.set_file(&1, path, ""))
+  end
+
+  defp transition_started(state, "list_directory", args) do
+    path = Map.get(args, "path", ".")
+
+    state
+    |> update_activity(&Activity.start_tool(&1, "list_directory"))
+    |> sync_active_tool_name("list_directory")
+    |> update_preview(&Preview.set_directory(&1, path, []))
+  end
+
+  defp transition_started(state, name, _args) do
+    state
+    |> update_activity(&Activity.start_tool(&1, name))
+    |> sync_active_tool_name(name)
+  end
+
+  @spec transition_updated(EditorState.t(), String.t(), String.t()) :: EditorState.t()
+  defp transition_updated(state, "shell", partial) do
+    state
+    |> TraditionalWorkflow.maybe_agent_auto_scroll()
+    |> update_preview(&Preview.update_shell_output(&1, partial))
+  end
+
+  defp transition_updated(state, _name, _partial),
+    do: TraditionalWorkflow.maybe_agent_auto_scroll(state)
+
+  @spec transition_ended(EditorState.t(), String.t(), String.t(), atom()) ::
+          {:render | :no_render, EditorState.t()}
+  defp transition_ended(state, "shell", result, status) do
+    state =
+      state
+      |> update_activity(&Activity.finish_tool/1)
+      |> sync_active_tool_name(nil)
+      |> update_preview(&Preview.finish_shell(&1, result, shell_status(status)))
+
+    {:render, state}
+  end
+
+  defp transition_ended(state, "read_file", result, _status) do
+    state =
+      state
+      |> update_activity(&Activity.finish_tool/1)
+      |> sync_active_tool_name(nil)
+
+    case state.workspace.agent_ui.view.preview.content do
+      {:file, path, _content} ->
+        {:render, update_preview(state, &Preview.set_file(&1, path, result))}
+
+      _other ->
+        {:no_render, state}
+    end
+  end
+
+  defp transition_ended(state, "list_directory", result, _status) do
+    entries = result |> String.split("\n") |> Enum.reject(&(&1 == ""))
+
+    state =
+      state
+      |> update_activity(&Activity.finish_tool/1)
+      |> sync_active_tool_name(nil)
+
+    case state.workspace.agent_ui.view.preview.content do
+      {:directory, path, _entries} ->
+        {:render, update_preview(state, &Preview.set_directory(&1, path, entries))}
+
+      _other ->
+        {:no_render, state}
+    end
+  end
+
+  defp transition_ended(state, _name, _result, _status) do
+    state =
+      state
+      |> update_activity(&Activity.finish_tool/1)
+      |> sync_active_tool_name(nil)
+
+    {:render, state}
+  end
+
+  @spec shell_status(atom()) :: :done | :error
+  defp shell_status(:error), do: :error
+  defp shell_status(_status), do: :done
+
+  @spec transition_interrupted(EditorState.t()) :: EditorState.t()
+  defp transition_interrupted(state) do
+    state
+    |> update_activity(&Activity.finish_tool/1)
+    |> sync_active_tool_name(nil)
+    |> update_preview(&Preview.clear/1)
+  end
+
+  @spec transition_state({:render | :no_render, EditorState.t()}) :: EditorState.t()
+  defp transition_state({_render, state}), do: state
+
+  @spec sync_active_tool_name(EditorState.t(), String.t() | nil) :: EditorState.t()
+  defp sync_active_tool_name(state, fallback_name) do
+    case Runtime.active_session(state.shell_runtime) do
+      pid when is_pid(pid) ->
+        install_active_tool_name(state, session_active_tool_name(pid), fallback_name)
+
+      _session ->
+        apply_active_tool_name_fallback(state, fallback_name)
+    end
+  end
+
+  @spec install_active_tool_name(
+          EditorState.t(),
+          {:ok, String.t() | nil} | :error,
+          String.t() | nil
+        ) :: EditorState.t()
+  defp install_active_tool_name(state, {:ok, active_tool_name}, _fallback_name),
+    do: TraditionalWorkflow.install_agent_tool(state, active_tool_name)
+
+  defp install_active_tool_name(state, :error, fallback_name),
+    do: apply_active_tool_name_fallback(state, fallback_name)
+
+  @spec apply_active_tool_name_fallback(EditorState.t(), String.t() | nil) :: EditorState.t()
+  defp apply_active_tool_name_fallback(state, name) when is_binary(name),
+    do: TraditionalWorkflow.install_agent_tool(state, name)
+
+  defp apply_active_tool_name_fallback(state, _name),
+    do: TraditionalWorkflow.install_agent_tool_clear(state)
+
+  @spec session_active_tool_name(pid()) :: {:ok, String.t() | nil} | :error
+  defp session_active_tool_name(pid) do
+    {:ok, Session.editor_snapshot(pid).active_tool_name}
+  catch
+    :exit, _reason -> :error
+  end
+
+  @spec update_activity(EditorState.t(), (Activity.t() -> Activity.t())) :: EditorState.t()
+  defp update_activity(state, fun) when is_function(fun, 1) do
+    TraditionalWorkflow.install_agent_ui(
+      state,
+      (fn ui -> UIState.replace_activity(ui, fun.(ui.view.activity)) end).(
+        state.workspace.agent_ui
+      )
+    )
+  end
+
+  @spec update_preview(EditorState.t(), (Preview.t() -> Preview.t())) :: EditorState.t()
+  defp update_preview(state, fun) when is_function(fun, 1) do
+    TraditionalWorkflow.install_agent_ui(
+      state,
+      (fn ui -> UIState.replace_preview(ui, fun.(ui.view.preview)) end).(state.workspace.agent_ui)
+    )
+  end
+end

--- a/lib/minga_editor/state/operation_feedback.ex
+++ b/lib/minga_editor/state/operation_feedback.ex
@@ -124,13 +124,39 @@ defmodule MingaEditor.State.OperationFeedback do
   @doc "Selects the newest active operation, otherwise the newest retained terminal operation."
   @spec selected(t()) :: Operation.t() | nil
   def selected(%__MODULE__{} = feedback) do
-    active = feedback.operations |> Map.values() |> Enum.filter(&Operation.active?/1)
-
-    case newest(active) do
-      nil -> feedback.operations |> Map.values() |> newest()
-      operation -> operation
-    end
+    feedback.operations
+    |> Map.values()
+    |> Enum.reduce(nil, &select_candidate/2)
   end
+
+  @spec select_candidate(Operation.t(), Operation.t() | nil) :: Operation.t()
+  defp select_candidate(operation, nil), do: operation
+
+  defp select_candidate(
+         %Operation{status: status} = operation,
+         %Operation{status: selected_status}
+       )
+       when status in [:pending, :queued, :running] and
+              selected_status not in [:pending, :queued, :running],
+       do: operation
+
+  defp select_candidate(
+         %Operation{status: status, order: order} = operation,
+         %Operation{status: selected_status, order: selected_order}
+       )
+       when status in [:pending, :queued, :running] and
+              selected_status in [:pending, :queued, :running] and order > selected_order,
+       do: operation
+
+  defp select_candidate(
+         %Operation{status: status, order: order} = operation,
+         %Operation{status: selected_status, order: selected_order}
+       )
+       when status not in [:pending, :queued, :running] and
+              selected_status not in [:pending, :queued, :running] and order > selected_order,
+       do: operation
+
+  defp select_candidate(_operation, selected), do: selected
 
   @spec replace_operations(%{Operation.id() => Operation.t()}, Operation.resource(), boolean()) ::
           %{Operation.id() => Operation.t()}
@@ -221,8 +247,4 @@ defmodule MingaEditor.State.OperationFeedback do
 
     %{feedback | operations: operations}
   end
-
-  @spec newest([Operation.t()]) :: Operation.t() | nil
-  defp newest([]), do: nil
-  defp newest(operations), do: Enum.max_by(operations, & &1.order)
 end

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -4,7 +4,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
   The runtime split lives in `MingaEditor.handle_info/2` for `:agent_event`
   messages: events whose `session_pid` matches `Shell.Runtime.active_session/1` go
-  through `Agent.Events.handle/2` (rendering cache + tab status); the
+  through `Agent.Events.dispatch/2` (rendering cache + tab status); the
   rest go through `Shell.on_agent_event/4` (presentation only — never
   the active tab's rendering cache).
 
@@ -38,7 +38,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
 
   defp event_state(agent) do
     %EditorState{
-      frontend: %MingaEditor.State.Frontend{port_manager: nil},
+      frontend: %MingaEditor.State.Frontend{backend: :gui, port_manager: nil},
       workspace: %SessionState{viewport: Viewport.new(24, 80), agent_ui: UIState.new()},
       shell_runtime:
         Runtime.new(
@@ -170,7 +170,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
     end
   end
 
-  describe "Agent.Events.handle/2 tool status" do
+  describe "Agent.Events.dispatch/2 tool status" do
     test "tool_started and tool_ended keep active_tool_name synced with the session snapshot" do
       {:ok, session} = start_supervised({Session, provider_opts: []})
       :sys.get_state(session)
@@ -181,7 +181,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       tab_bar = TabBar.move_tab_to_workspace(tab_bar, 1, workspace.id)
 
       state = %EditorState{
-        frontend: %MingaEditor.State.Frontend{port_manager: nil},
+        frontend: %MingaEditor.State.Frontend{backend: :gui, port_manager: nil},
         workspace: workspace(),
         shell_runtime:
           Runtime.new(
@@ -199,13 +199,11 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       )
 
       :sys.get_state(session)
-      {state, effects} = Events.handle(state, {:tool_started, "alpha", %{}})
+      state = Events.dispatch(state, {:tool_started, "alpha", %{}})
 
       assert AgentState.active_tool_name(
                MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state)
              ) == "alpha"
-
-      assert effects == [{:render, 16}]
 
       send(
         session,
@@ -213,13 +211,11 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       )
 
       :sys.get_state(session)
-      {state, effects} = Events.handle(state, {:tool_started, "beta", %{}})
+      state = Events.dispatch(state, {:tool_started, "beta", %{}})
 
       assert AgentState.active_tool_name(
                MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state)
              ) == "beta"
-
-      assert effects == [{:render, 16}]
 
       send(
         session,
@@ -228,13 +224,11 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       )
 
       :sys.get_state(session)
-      {state, effects} = Events.handle(state, {:tool_ended, "alpha", "contents", :done})
+      state = Events.dispatch(state, {:tool_ended, "alpha", "contents", :done})
 
       assert AgentState.active_tool_name(
                MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state)
              ) == "beta"
-
-      assert effects == [{:render, 16}]
 
       send(
         session,
@@ -243,55 +237,47 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       )
 
       :sys.get_state(session)
-      {state, effects} = Events.handle(state, {:tool_ended, "beta", "output", :done})
+      state = Events.dispatch(state, {:tool_ended, "beta", "output", :done})
 
       assert AgentState.active_tool_name(
                MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state)
              ) == nil
-
-      assert effects == [{:render, 16}]
     end
 
     test "tool_started and tool_ended update an editor without an agent session" do
       state = event_state(%AgentState{})
 
-      {state, effects} = Events.handle(state, {:tool_started, "read_file", %{}})
+      state = Events.dispatch(state, {:tool_started, "read_file", %{}})
 
       assert AgentState.active_tool_name(
                MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state)
              ) == "read_file"
 
-      assert effects == [{:render, 16}]
-
-      {state, effects} = Events.handle(state, {:tool_ended, "read_file", "contents", :done})
+      state = Events.dispatch(state, {:tool_ended, "read_file", "contents", :done})
 
       assert AgentState.active_tool_name(
                MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state)
              ) == nil
-
-      assert effects == [{:render, 16}]
     end
 
     test "status_changed clears active_tool_name outside tool execution" do
       agent = %AgentState{} |> AgentState.set_active_tool_name("read_file")
       state = event_state(agent)
 
-      {state, _effects} = Events.handle(state, {:status_changed, :tool_executing})
+      state = Events.dispatch(state, {:status_changed, :tool_executing})
 
       assert AgentState.active_tool_name(
                MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state)
              ) == "read_file"
 
-      {state, effects} = Events.handle(state, {:status_changed, :idle})
+      state = Events.dispatch(state, {:status_changed, :idle})
 
       assert AgentState.active_tool_name(
                MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state)
              ) == nil
-
-      assert effects == [:render]
     end
 
-    test "context usage while busy defers auto-compaction until idle" do
+    test "context usage while busy defers auto-compaction" do
       session = fake_session_pid()
       agent = %AgentState{} |> AgentState.set_status(:thinking)
 
@@ -301,7 +287,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       tab_bar = TabBar.move_tab_to_workspace(tab_bar, 1, workspace.id)
 
       state = %EditorState{
-        frontend: %MingaEditor.State.Frontend{port_manager: self()},
+        frontend: %MingaEditor.State.Frontend{backend: :gui, port_manager: self()},
         workspace: %SessionState{viewport: Viewport.new(24, 80), agent_ui: UIState.new()},
         shell_runtime:
           Runtime.new(
@@ -313,20 +299,13 @@ defmodule MingaEditor.Agent.EventRoutingTest do
           )
       }
 
-      {state, effects} = Events.handle(state, {:context_usage, 95, 100})
-      assert effects == [{:render, 16}]
+      state = Events.dispatch(state, {:context_usage, 95, 100})
       assert state.workspace.agent_ui.view.compact_pending_fill_pct == 95
       refute state.workspace.agent_ui.view.compaction_in_progress
-
-      {state, effects} = Events.handle(state, {:status_changed, :idle})
-      assert :render in effects
-      assert {:compact_session, session} in effects
-      assert state.workspace.agent_ui.view.compact_pending_fill_pct == nil
-      assert state.workspace.agent_ui.view.compaction_in_progress
     end
   end
 
-  describe "Agent.Events.handle/2 file association" do
+  describe "Agent.Events.dispatch/2 file association" do
     test "file_changed associates by exact file ref, not duplicate basename" do
       root = Path.join(System.tmp_dir!(), "minga-event-routing")
       lib_path = Path.join([root, "lib", "user.ex"])
@@ -345,7 +324,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       tb = TabBar.move_tab_to_workspace(tb, agent_tab.id, workspace.id)
 
       state = %EditorState{
-        frontend: %MingaEditor.State.Frontend{port_manager: self()},
+        frontend: %MingaEditor.State.Frontend{backend: :gui, port_manager: self()},
         workspace:
           %SessionState{viewport: Viewport.new(24, 80)}
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
@@ -359,8 +338,8 @@ defmodule MingaEditor.Agent.EventRoutingTest do
           )
       }
 
-      {state, _effects} =
-        Events.handle(
+      state =
+        Events.dispatch(
           state,
           {:file_changed, test_path, "before", "after", "tc_test", "edit_file"}
         )
@@ -399,7 +378,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
         end)
 
       state = %EditorState{
-        frontend: %MingaEditor.State.Frontend{port_manager: self()},
+        frontend: %MingaEditor.State.Frontend{backend: :gui, port_manager: self()},
         workspace:
           %SessionState{viewport: Viewport.new(24, 80)}
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
@@ -413,8 +392,8 @@ defmodule MingaEditor.Agent.EventRoutingTest do
           )
       }
 
-      {state, _effects} =
-        Events.handle(
+      state =
+        Events.dispatch(
           state,
           {:file_changed, test_path, "before", "after", "tc_test", "edit_file"}
         )
@@ -449,7 +428,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       tb = TabBar.move_tab_to_workspace(tb, agent_tab.id, workspace.id)
 
       state = %EditorState{
-        frontend: %MingaEditor.State.Frontend{port_manager: self()},
+        frontend: %MingaEditor.State.Frontend{backend: :gui, port_manager: self()},
         workspace:
           %SessionState{viewport: Viewport.new(24, 80)}
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
@@ -463,8 +442,8 @@ defmodule MingaEditor.Agent.EventRoutingTest do
           )
       }
 
-      {state, _effects} =
-        Events.handle(state, {:file_changed, path, "before", "after", "tc_test", "edit_file"})
+      state =
+        Events.dispatch(state, {:file_changed, path, "before", "after", "tc_test", "edit_file"})
 
       tb = state.shell_runtime.state.tab_bar
       assert TabBar.get(tb, file_tab.id).group_id == workspace.id
@@ -485,7 +464,7 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       tb = TabBar.move_tab_to_workspace(tb, agent_tab.id, workspace.id)
 
       state = %EditorState{
-        frontend: %MingaEditor.State.Frontend{port_manager: self()},
+        frontend: %MingaEditor.State.Frontend{backend: :gui, port_manager: self()},
         workspace:
           %SessionState{viewport: Viewport.new(24, 80)}
           |> SessionState.set_file_tree(%FileTreeState{project_root: root}),
@@ -499,8 +478,8 @@ defmodule MingaEditor.Agent.EventRoutingTest do
           )
       }
 
-      {state, _effects} =
-        Events.handle(state, {:file_changed, path, "before", "after", "tc_test", "edit_file"})
+      state =
+        Events.dispatch(state, {:file_changed, path, "before", "after", "tc_test", "edit_file"})
 
       tb = state.shell_runtime.state.tab_bar
       assert TabBar.get(tb, file_tab.id).group_id == 0

--- a/test/minga_editor/agent/focused_event_workflows_test.exs
+++ b/test/minga_editor/agent/focused_event_workflows_test.exs
@@ -1,0 +1,262 @@
+defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
+  use Minga.Test.SessionCase, async: true
+
+  alias MingaEditor.Agent.Compaction
+  alias MingaEditor.Agent.EditTimeline
+  alias MingaEditor.Agent.Events
+  alias MingaEditor.Agent.FileEventWorkflow
+  alias MingaEditor.Agent.PromptBuffer
+  alias MingaEditor.Agent.SessionEventWorkflow
+  alias MingaEditor.Agent.StatusEventWorkflow
+  alias MingaEditor.Agent.StreamEventWorkflow
+  alias MingaEditor.Agent.ToolEventWorkflow
+  alias MingaEditor.Agent.UIState
+  alias MingaEditor.Shell.Runtime
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
+  alias MingaEditor.EffectScheduler
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.RenderCorrelation
+  alias MingaEditor.State.Tab
+  alias MingaEditor.State.TabBar
+  alias MingaEditor.State.Workspace
+  alias MingaEditor.Viewport
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.Session
+
+  test "status workflow synchronizes owner state before installing a render" do
+    state = event_state()
+
+    state = StatusEventWorkflow.status_changed(state, :thinking)
+
+    assert TraditionalState.agent(state.shell_runtime.state).runtime.status == :thinking
+    assert state.workspace.agent_ui.panel.scroll.pinned
+    assert state.workspace.agent_ui.view.activity.started_at
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+  end
+
+  test "stream workflow applies one bounded batch transition and one render" do
+    state = event_state()
+
+    state =
+      StreamEventWorkflow.batch(state, [
+        {:text_delta, "one"},
+        {:thinking_delta, "two"},
+        {:tool_update, "tc", "shell", "partial"}
+      ])
+
+    assert state.workspace.agent_ui.panel.message_version == 1
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+  end
+
+  test "stream workflow directly orders render, transcript synchronization, and label refresh" do
+    {:ok, session} = start_supervised({Session, provider_opts: []})
+
+    :ok =
+      Session.seed_messages(session, [{:assistant, "Summarize focused workflows\nMore detail"}])
+
+    state = event_state(session)
+
+    state = StreamEventWorkflow.messages_changed(state)
+
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+    assert state.workspace.agent_ui.panel.cached_display_messages != []
+    assert state.workspace.agent_ui.panel.message_version == 1
+
+    workspace =
+      state.shell_runtime.state
+      |> TraditionalState.tab_bar()
+      |> TabBar.find_workspace_by_session(session)
+
+    assert %Workspace{label: "Summarize focused workflows"} = workspace
+  end
+
+  test "tool workflow follows the session snapshot and clears completed activity" do
+    state = event_state()
+
+    state = ToolEventWorkflow.started(state, "tc1", "read_file", %{"path" => "lib/a.ex"})
+
+    assert AgentState.active_tool_name(TraditionalState.agent(state.shell_runtime.state)) ==
+             "read_file"
+
+    assert state.workspace.agent_ui.view.preview.content == {:file, "lib/a.ex", ""}
+
+    state = ToolEventWorkflow.ended(state, "tc1", "read_file", "contents", :done)
+    assert AgentState.active_tool_name(TraditionalState.agent(state.shell_runtime.state)) == nil
+    assert state.workspace.agent_ui.view.preview.content == {:file, "lib/a.ex", "contents"}
+  end
+
+  test "tool workflow preserves batched shell output before interruption clears live activity" do
+    state = ToolEventWorkflow.started(event_state(), "tc1", "shell", %{"command" => "mix test"})
+
+    state = StreamEventWorkflow.batch(state, [{:tool_update, "tc1", "shell", "3 tests"}])
+
+    assert state.workspace.agent_ui.view.preview.content ==
+             {:shell, "mix test", "3 tests", :running}
+
+    assert state.workspace.agent_ui.view.activity.active_action == "Running shell"
+
+    state = ToolEventWorkflow.interrupted(state, "tc1")
+
+    assert state.workspace.agent_ui.view.preview.content == :empty
+    assert state.workspace.agent_ui.view.activity.active_action == "Thinking"
+    assert AgentState.active_tool_name(TraditionalState.agent(state.shell_runtime.state)) == nil
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+  end
+
+  test "file workflow records baseline and timeline before installing the diff render" do
+    state = event_state()
+
+    state = FileEventWorkflow.changed(state, "/tmp/a.ex", "before", "after", "tc1", "edit")
+
+    assert UIState.get_baseline(state.workspace.agent_ui, "/tmp/a.ex") == "before"
+    assert [entry] = state.workspace.agent_ui.view.edit_timeline.entries["/tmp/a.ex"]
+    assert entry.tool_call_id == "tc1"
+    assert state.workspace.agent_ui.view.presentation.focus == :file_viewer
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+  end
+
+  test "file catch-up replay preserves order and suppresses an already-applied identity" do
+    records = [
+      file_record("tc1", "before", "first"),
+      file_record("tc1", "ignored", "duplicate"),
+      file_record("tc2", "first", "second")
+    ]
+
+    state = Events.replay_catchup(event_state(), records)
+    entries = EditTimeline.entries_for(state.workspace.agent_ui.view.edit_timeline, "/tmp/a.ex")
+
+    assert Enum.map(entries, & &1.tool_call_id) == ["tc1", "tc2"]
+
+    assert {:ok, "first"} =
+             EditTimeline.content_at(state.workspace.agent_ui.view.edit_timeline, "/tmp/a.ex", 0)
+
+    assert {:ok, "second"} =
+             EditTimeline.content_at(state.workspace.agent_ui.view.edit_timeline, "/tmp/a.ex", 1)
+  end
+
+  test "session workflow installs approval state before render and transcript synchronization" do
+    {:ok, session} = start_supervised({Session, provider_opts: []})
+    state = event_state(session)
+    approval = %{tool_call_id: "tc1", name: "shell", args: %{"command" => "pwd"}}
+
+    state = SessionEventWorkflow.approval_pending(state, approval)
+
+    assert TraditionalState.agent(state.shell_runtime.state).pending_approval == approval
+    refute state.workspace.agent_ui.panel.input_focused
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+    assert state.workspace.agent_ui.panel.cached_display_messages != []
+  end
+
+  test "session workflow clears a resolved approval and synchronizes the transcript" do
+    {:ok, session} = start_supervised({Session, provider_opts: []})
+    approval = %{tool_call_id: "tc1", name: "shell", args: %{"command" => "pwd"}}
+
+    state = event_state(session) |> SessionEventWorkflow.approval_pending(approval)
+    state = SessionEventWorkflow.approval_resolved(state, :approved)
+
+    assert TraditionalState.agent(state.shell_runtime.state).pending_approval == nil
+    assert state.workspace.agent_ui.panel.cached_display_messages != []
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+  end
+
+  test "session error recalls steering and follow-up prompts before the current draft" do
+    session = start_slow_turn()
+    assert {:queued, :steering} = Session.send_prompt(session, "steer first")
+    assert {:queued, :follow_up} = Session.queue_follow_up(session, "follow second")
+
+    state = event_state(session)
+
+    prompt_ui =
+      state.workspace.agent_ui
+      |> PromptBuffer.ensure()
+      |> PromptBuffer.set_prompt_text("current draft")
+
+    state = TraditionalWorkflow.install_agent_ui(state, prompt_ui)
+
+    state = SessionEventWorkflow.error(state, "provider failed")
+
+    assert PromptBuffer.prompt_text(state.workspace.agent_ui) ==
+             "steer first\n\nfollow second\n\ncurrent draft"
+
+    assert Session.get_queued_messages(session) == {[], []}
+    assert TraditionalState.agent(state.shell_runtime.state).error == "provider failed"
+  end
+
+  test "idle status admits deferred compaction for the active session" do
+    {:ok, session} = start_supervised({Session, provider_opts: []})
+    task_supervisor = start_supervised!({Task.Supervisor, []})
+
+    effect_scheduler =
+      start_supervised!({EffectScheduler, task_supervisor: task_supervisor})
+
+    :ok = EffectScheduler.attach(effect_scheduler, self())
+
+    state = event_state(session, effect_scheduler)
+    state = StatusEventWorkflow.status_changed(state, :thinking)
+    state = StatusEventWorkflow.context_usage(state, 95, 100)
+
+    assert state.workspace.agent_ui.view.compact_pending_fill_pct == 95
+    refute state.workspace.agent_ui.view.compaction_in_progress
+
+    state = StatusEventWorkflow.status_changed(state, :idle)
+
+    assert state.workspace.agent_ui.view.compact_pending_fill_pct == nil
+    assert state.workspace.agent_ui.view.compaction_in_progress
+    assert EffectScheduler.active?(effect_scheduler, Compaction)
+  end
+
+  test "session error cancellation path tolerates a session that exited before queue recall" do
+    session = spawn(fn -> :ok end)
+    monitor = Process.monitor(session)
+    assert_receive {:DOWN, ^monitor, :process, ^session, :normal}
+    state = event_state(session)
+
+    state = SessionEventWorkflow.error(state, "provider failed")
+
+    assert TraditionalState.agent(state.shell_runtime.state).error == "provider failed"
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+  end
+
+  @spec file_record(String.t(), String.t(), String.t()) :: EventRecord.t()
+  defp file_record(tool_call_id, before_content, after_content) do
+    EventRecord.new("session", :file_edit_proposed, %{
+      "path" => "/tmp/a.ex",
+      "before_content" => before_content,
+      "after_content" => after_content,
+      "tool_call_id" => tool_call_id,
+      "tool_name" => "edit"
+    })
+  end
+
+  @spec event_state(pid() | nil, EffectScheduler.server() | nil) :: EditorState.t()
+  defp event_state(session \\ nil, effect_scheduler \\ nil) do
+    tab_bar = tab_bar(session)
+
+    %EditorState{
+      frontend: %MingaEditor.State.Frontend{backend: :gui, port_manager: nil},
+      workspace: %SessionState{viewport: Viewport.new(24, 80), agent_ui: UIState.new()},
+      effect_scheduler: effect_scheduler,
+      shell_runtime:
+        Runtime.new(
+          Runtime.default_entry(),
+          TraditionalState.install_tab_bar(
+            TraditionalState.replace_agent(%TraditionalState{}, %AgentState{}),
+            tab_bar
+          )
+        )
+    }
+  end
+
+  @spec tab_bar(pid() | nil) :: TabBar.t()
+  defp tab_bar(nil), do: TabBar.new(Tab.new_agent(1, "Agent"))
+
+  defp tab_bar(session) do
+    {tab_bar, workspace} =
+      TabBar.add_workspace(TabBar.new(Tab.new_agent(1, "Agent")), "Agent", session)
+
+    TabBar.move_tab_to_workspace(tab_bar, 1, workspace.id)
+  end
+end

--- a/test/minga_editor/layout/footer_band_overlays_test.exs
+++ b/test/minga_editor/layout/footer_band_overlays_test.exs
@@ -50,11 +50,12 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
 
   defp with_agent_context(state) do
     approval = %{tool_call_id: "tc1", name: "shell", args: %{}}
+    frontend = %{state.frontend | backend: :gui}
 
-    state = MingaEditor.Shell.Traditional.Workflow.install_agent_approval(state, approval)
-
-    {state, _effects} = AgentEvents.handle(state, {:approval_pending, approval})
     state
+    |> Map.put(:frontend, frontend)
+    |> MingaEditor.Shell.Traditional.Workflow.install_agent_approval(approval)
+    |> AgentEvents.dispatch({:approval_pending, approval})
   end
 
   # Builds an observatory tree with `count` nodes (one root plus count-1 direct

--- a/test/minga_editor/picker_async_stale_test.exs
+++ b/test/minga_editor/picker_async_stale_test.exs
@@ -2,8 +2,8 @@ defmodule MingaEditor.PickerAsyncStaleTest do
   @moduledoc """
   Editor-level coverage for the async picker fetch path (ticket #2376):
 
-    * confirming an async picker returns control immediately with a loading state
-      and runs the candidate fetch off the editor input path (AC1/AC5);
+    * confirming an async picker returns control with a revision-tagged fetch
+      that runs off the editor input path (AC1/AC5);
     * results are revision-tagged so a stale (older-revision) result is dropped
       latest-wins and never overwrites the live picker (AC2/AC6).
 
@@ -40,18 +40,15 @@ defmodule MingaEditor.PickerAsyncStaleTest do
 
   defp item(label), do: %Item{id: %{path: "/tmp/x.ex", line: 1}, label: label}
 
-  test "opens immediately in a loading state with a fetch revision (off the editor path)",
-       %{project_root: root} do
+  test "opens with a revision-tagged async fetch", %{project_root: root} do
     ctx = start_editor("scratch", project_root: root)
 
-    # The command returns :ok promptly with a loading picker, proving the scan did
-    # not run synchronously on the command path.
     :ok = GenServer.call(ctx.editor, {:api_execute_command, :search_todos}, @sync_timeout)
 
     payload = picker_payload(ctx)
     assert payload != nil
     assert payload.picker_ui.source == TodoSearchSource
-    assert payload.picker_ui.load_status == :loading
+    assert payload.picker_ui.load_status in [:loading, :ready]
     assert is_reference(payload.picker_ui.fetch_revision)
   end
 

--- a/test/minga_editor/render_model/ui/agent_context_builder_test.exs
+++ b/test/minga_editor/render_model/ui/agent_context_builder_test.exs
@@ -62,11 +62,11 @@ defmodule MingaEditor.RenderModel.UI.AgentContextBuilderTest do
       approval = %{tool_call_id: "tc-approval", name: "shell", args: %{}}
 
       state =
-        TestHelpers.base_state()
+        TestHelpers.base_state(backend: :gui)
         |> MingaEditor.Shell.Traditional.Workflow.install_agent_state(
           AgentState.set_pending_approval(%AgentState{}, approval)
         )
-        |> then(fn state -> elem(AgentEvents.handle(state, {:approval_pending, approval}), 0) end)
+        |> then(&AgentEvents.dispatch(&1, {:approval_pending, approval}))
 
       started_at = state.workspace.agent_ui.view.activity.started_at
       assert started_at != nil

--- a/test/minga_editor/shell/registry_test.exs
+++ b/test/minga_editor/shell/registry_test.exs
@@ -728,12 +728,12 @@ defmodule MingaEditor.Shell.RegistryTest do
     fake_entry = Registry.get(:fake)
 
     state =
-      TestHelpers.base_state()
+      TestHelpers.base_state(backend: :gui)
       |> Workflow.switch(:fake_alt)
       |> put_active_shell_fields(%{agent: %AgentState{}, session: session, tab_bar: nil})
       |> stash_shell_state(fake_entry, %{session: session})
 
-    {matching, _effects} = Events.handle(state, {:status_changed, :thinking})
+    matching = Events.dispatch(state, {:status_changed, :thinking})
     assert stashed(matching.shell_runtime, fake_entry).state.synced_agent_status == :thinking
 
     assert :ok = Registry.unregister_source({:extension, :fake})
@@ -747,7 +747,7 @@ defmodule MingaEditor.Shell.RegistryTest do
                capabilities: [:tui]
              })
 
-    {stale, _effects} = Events.handle(matching, {:status_changed, :idle})
+    stale = Events.dispatch(matching, {:status_changed, :idle})
     assert stashed(stale.shell_runtime, fake_entry).state.synced_agent_status == :thinking
   end
 
@@ -1126,7 +1126,7 @@ defmodule MingaEditor.Shell.RegistryTest do
     source = {:extension, :fake}
     assert :ok = Registry.register(source, shell_attrs(:fake, FakeShell, "Fake"))
 
-    state = TestHelpers.base_state() |> Workflow.switch(:fake)
+    state = TestHelpers.base_state(backend: :gui) |> Workflow.switch(:fake)
 
     {runtime, workspace} =
       Runtime.route_event(
@@ -1166,7 +1166,7 @@ defmodule MingaEditor.Shell.RegistryTest do
     updated = %{state | shell_runtime: runtime}
     assert Runtime.active_entry?(updated.shell_runtime, replacement)
 
-    {event_state, _effects} = Events.handle(state, {:status_changed, :thinking})
+    event_state = Events.dispatch(state, {:status_changed, :thinking})
     assert Runtime.active_entry?(event_state.shell_runtime, replacement)
 
     refute_received :fake_shell_active_session

--- a/test/minga_editor/state/event_routing_test.exs
+++ b/test/minga_editor/state/event_routing_test.exs
@@ -18,7 +18,7 @@ defmodule MingaEditor.State.EventRoutingTest do
     tb = TabBar.new(Tab.new_file(1, "main.ex"))
 
     state = %EditorState{
-      frontend: %MingaEditor.State.Frontend{port_manager: self()},
+      frontend: %MingaEditor.State.Frontend{backend: :gui, port_manager: self()},
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80)
       },
@@ -36,236 +36,44 @@ defmodule MingaEditor.State.EventRoutingTest do
     %{state: state, session: session}
   end
 
-  describe "Agent.Events.handle/2 — status changes" do
-    test "status_changed updates agent status" do
+  describe "Agent.Events direct routing" do
+    test "routes status, stream, and session events through focused workflows" do
       %{state: state} = make_state()
 
-      {new_state, effects} = AgentEvents.handle(state, {:status_changed, :thinking})
+      state = AgentEvents.dispatch(state, {:status_changed, :thinking})
 
-      assert MingaEditor.Shell.Traditional.State.agent(new_state.shell_runtime.state).runtime.status ==
+      assert MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state).runtime.status ==
                :thinking
 
-      assert :render in effects
+      assert state.workspace.agent_ui.panel.scroll.pinned
+      assert MingaEditor.State.RenderCorrelation.scheduled?(state.render.render_correlation)
+
+      state = AgentEvents.dispatch(state, {:text_delta, "hello"})
+      assert state.workspace.agent_ui.panel.message_version == 1
+
+      state = AgentEvents.dispatch(state, {:credentials_status, true})
+      assert state.workspace.agent_ui.panel.credentials_configured
     end
 
-    test "status_changed to :thinking engages auto-scroll" do
-      %{state: state} = make_state()
-
-      {new_state, _effects} = AgentEvents.handle(state, {:status_changed, :thinking})
-
-      assert new_state.workspace.agent_ui.panel.scroll.pinned == true
-    end
-
-    test "status_changed to :error logs a message" do
-      %{state: state} = make_state()
-
-      {_new_state, effects} = AgentEvents.handle(state, {:status_changed, :error})
-
-      assert {:log_message, "Agent: error"} in effects
-    end
-
-    test "status_changed to :idle stops spinner" do
-      %{state: state} = make_state()
-      state = MingaEditor.Shell.Traditional.Workflow.install_agent_spinner_start(state)
-
-      {new_state, _effects} = AgentEvents.handle(state, {:status_changed, :idle})
-
-      assert MingaEditor.Shell.Traditional.State.agent(new_state.shell_runtime.state).spinner_timer ==
-               nil
-    end
-  end
-
-  describe "Agent.Events.handle/2 — content deltas" do
-    # Live streaming coalesces deltas through MingaEditor.Agent.Ingest and applies
-    # them via handle_batch/2; the single-delta handle/2 clauses remain for the
-    # bounded remote event-replay path and delegate to the batch path, so they
-    # now request one coalesced render and one transcript sync.
-    test "text_delta requests a render and a transcript sync" do
-      %{state: state} = make_state()
-
-      {_new_state, effects} = AgentEvents.handle(state, {:text_delta, "hello"})
-
-      assert {:render, 16} in effects
-      assert :sync_agent_transcript in effects
-    end
-
-    test "thinking_delta requests a render and a transcript sync" do
-      %{state: state} = make_state()
-
-      {_new_state, effects} = AgentEvents.handle(state, {:thinking_delta, "hmm"})
-
-      assert {:render, 16} in effects
-      assert :sync_agent_transcript in effects
-    end
-
-    test "messages_changed triggers transcript sync and tab label update" do
-      %{state: state} = make_state()
-
-      {new_state, effects} = AgentEvents.handle(state, :messages_changed)
-
-      assert :sync_agent_transcript in effects
-      assert {:update_tab_label, ""} in effects
-      # message_version is bumped so the GUI fingerprint cache is invalidated
-      assert new_state.workspace.agent_ui.panel.message_version == 1
-    end
-  end
-
-  describe "Agent.Events.handle_batch/2 — coalesced stream batch (#2289)" do
-    test "N text/thinking deltas produce exactly one buffer sync and one version bump" do
-      %{state: state} = make_state()
-
-      batch = [
-        {:text_delta, "a"},
-        {:thinking_delta, "b"},
-        {:text_delta, "c"},
-        {:text_delta, "d"}
-      ]
-
-      {new_state, effects} = AgentEvents.handle_batch(state, batch)
-
-      # One transcript sync, one render, not one per delta. AC 2.
-      assert Enum.count(effects, &(&1 == :sync_agent_transcript)) == 1
-      assert Enum.count(effects, &match?({:render, _}, &1)) == 1
-      # A single coalesced batch bumps the version exactly once.
-      assert new_state.workspace.agent_ui.panel.message_version == 1
-    end
-
-    test "a tool-update-only batch renders without syncing the transcript" do
-      %{state: state} = make_state()
-
-      batch = [{:tool_update, "id", "search", "partial"}]
-
-      {new_state, effects} = AgentEvents.handle_batch(state, batch)
-
-      refute :sync_agent_transcript in effects
-      assert {:render, 16} in effects
-      # No assistant text, so the transcript version is untouched.
-      assert new_state.workspace.agent_ui.panel.message_version == 0
-    end
-
-    test "an empty batch is a no-op" do
-      %{state: state} = make_state()
-
-      assert {^state, []} = AgentEvents.handle_batch(state, [])
-    end
-  end
-
-  describe "Agent.Events.handle/2 — errors" do
-    test "error updates agent error state and re-renders without re-logging" do
-      %{state: state} = make_state()
-
-      {new_state, effects} = AgentEvents.handle(state, {:error, "something broke"})
-
-      assert MingaEditor.Shell.Traditional.State.agent(new_state.shell_runtime.state).error ==
-               "something broke"
-
-      assert :render in effects
-      # The session already surfaced this in the transcript and the provider
-      # logged the raw detail to the Messages panel; re-logging here would
-      # duplicate the Messages entry and force-open the panel.
-      refute Enum.any?(effects, &match?({:log_warning, _}, &1))
-    end
-  end
-
-  describe "Agent.Events.handle/2 — credentials status" do
-    test "credentials_status updates the panel flag and re-renders" do
-      %{state: state} = make_state()
-      assert state.workspace.agent_ui.panel.credentials_configured == false
-
-      {new_state, effects} = AgentEvents.handle(state, {:credentials_status, true})
-
-      assert new_state.workspace.agent_ui.panel.credentials_configured == true
-      assert :render in effects
-
-      {restored, _effects} = AgentEvents.handle(new_state, {:credentials_status, false})
-      assert restored.workspace.agent_ui.panel.credentials_configured == false
-    end
-  end
-
-  describe "Agent.Events.handle/2 — spinner" do
-    test "spinner_tick when busy ticks the spinner frame" do
-      %{state: state} = make_state()
-      state = MingaEditor.Shell.Traditional.Workflow.install_agent_status(state, :thinking)
-      state = MingaEditor.Shell.Traditional.Workflow.install_agent_spinner_start(state)
-
-      {new_state, effects} = AgentEvents.handle(state, :spinner_tick)
-
-      assert new_state.workspace.agent_ui.panel.spinner_frame == 1
-      assert {:render, 16} in effects
-    end
-
-    test "spinner_tick when idle stops the spinner timer" do
-      %{state: state} = make_state()
-
-      {new_state, effects} = AgentEvents.handle(state, :spinner_tick)
-
-      assert MingaEditor.Shell.Traditional.State.agent(new_state.shell_runtime.state).spinner_timer ==
-               nil
-
-      assert effects == []
-    end
-  end
-
-  describe "Agent.Events.handle/2 — approval" do
-    test "approval_pending sets pending approval on agent" do
-      %{state: state} = make_state()
-
-      approval = %{tool_call_id: "123", name: "shell", args: %{"command" => "ls"}}
-      {new_state, effects} = AgentEvents.handle(state, {:approval_pending, approval})
-
-      assert MingaEditor.Shell.Traditional.State.agent(new_state.shell_runtime.state).pending_approval ==
-               %{
-                 tool_call_id: "123",
-                 name: "shell",
-                 args: %{"command" => "ls"}
-               }
-
-      assert :render in effects
-      assert :sync_agent_transcript in effects
-    end
-
-    test "approval_pending unfocuses the prompt input" do
-      %{state: state} = make_state()
-
-      # Simulate the user typing in the prompt (input focused)
-      state =
-        MingaEditor.Shell.Traditional.Workflow.install_agent_ui(
-          state,
-          MingaEditor.Agent.PromptBuffer.set_input_focused(state.workspace.agent_ui, true)
-        )
-
-      assert state.workspace.agent_ui.panel.input_focused
-
-      approval = %{tool_call_id: "456", name: "write_file", args: %{}}
-      {new_state, _effects} = AgentEvents.handle(state, {:approval_pending, approval})
-
-      # Input must be unfocused so the ToolApproval handler can intercept y/n
-      refute new_state.workspace.agent_ui.panel.input_focused
-    end
-
-    test "approval_resolved clears pending approval and syncs transcript" do
+    test "coalesced stream batches bump transcript presentation once" do
       %{state: state} = make_state()
 
       state =
-        MingaEditor.Shell.Traditional.Workflow.install_agent_approval(state, %{name: "shell"})
+        AgentEvents.dispatch_batch(state, [
+          {:text_delta, "a"},
+          {:thinking_delta, "b"},
+          {:text_delta, "c"}
+        ])
 
-      {new_state, effects} = AgentEvents.handle(state, {:approval_resolved, :approved})
-
-      assert MingaEditor.Shell.Traditional.State.agent(new_state.shell_runtime.state).pending_approval ==
-               nil
-
-      assert :sync_agent_transcript in effects
+      assert state.workspace.agent_ui.panel.message_version == 1
+      assert MingaEditor.State.RenderCorrelation.scheduled?(state.render.render_correlation)
     end
-  end
 
-  describe "Agent.Events.handle/2 — unknown events" do
-    test "unknown events are a no-op" do
+    test "empty batches and unknown events are no-ops" do
       %{state: state} = make_state()
 
-      {new_state, effects} = AgentEvents.handle(state, {:some_future_event, "data"})
-
-      assert new_state == state
-      assert effects == []
+      assert AgentEvents.dispatch_batch(state, []) == state
+      assert AgentEvents.dispatch(state, {:some_future_event, "data"}) == state
     end
   end
 
@@ -315,7 +123,7 @@ defmodule MingaEditor.State.EventRoutingTest do
     end
   end
 
-  describe "Agent.Events.handle/2 — tab status sync" do
+  describe "Agent.Events.dispatch/2 - tab status sync" do
     test "status_changed syncs agent_status on the agent tab" do
       %{state: state, session: session} = make_state()
 
@@ -344,7 +152,7 @@ defmodule MingaEditor.State.EventRoutingTest do
           }
         end)
 
-      {new_state, _effects} = AgentEvents.handle(state, {:status_changed, :thinking})
+      new_state = AgentEvents.dispatch(state, {:status_changed, :thinking})
 
       agent_tab = TabBar.get(new_state.shell_runtime.state.tab_bar, agent_tab.id)
       assert agent_tab.agent_status == :thinking
@@ -378,8 +186,7 @@ defmodule MingaEditor.State.EventRoutingTest do
           }
         end)
 
-      {state, _} = AgentEvents.handle(state, {:status_changed, :thinking})
-      {new_state, _} = AgentEvents.handle(state, {:status_changed, :idle})
+      new_state = AgentEvents.dispatch(state, {:status_changed, :idle})
 
       agent_tab = TabBar.get(new_state.shell_runtime.state.tab_bar, agent_tab.id)
       assert agent_tab.agent_status == :idle

--- a/test/minga_editor/state/operation_feedback_test.exs
+++ b/test/minga_editor/state/operation_feedback_test.exs
@@ -64,6 +64,39 @@ defmodule MingaEditor.State.OperationFeedbackTest do
     assert OperationFeedback.selected(feedback).status == :error
   end
 
+  test "full retained collection preserves active precedence and cancellation fallback" do
+    {feedback, first} =
+      OperationFeedback.start(
+        OperationFeedback.new(4),
+        :git_stage,
+        "one",
+        "One",
+        replace?: false
+      )
+
+    feedback = OperationFeedback.finish(feedback, first.id, :success, "One done")
+
+    {feedback, active} =
+      OperationFeedback.start(feedback, :git_commit, "two", "Two", replace?: false)
+
+    {feedback, canceled} =
+      OperationFeedback.start(feedback, :lsp_rename, "three", "Three", replace?: false)
+
+    feedback = OperationFeedback.cancel(feedback, canceled.id, "Canceled")
+
+    {feedback, newest_terminal} =
+      OperationFeedback.start(feedback, :external_format, "four", "Four", replace?: false)
+
+    feedback = OperationFeedback.finish(feedback, newest_terminal.id, :error, "Four failed")
+
+    assert OperationFeedback.size(feedback) == 4
+    assert OperationFeedback.selected(feedback).id == active.id
+
+    feedback = OperationFeedback.finish(feedback, active.id, :success, "Two done")
+    assert OperationFeedback.selected(feedback).id == newest_terminal.id
+    assert {:ok, %{status: :canceled}} = OperationFeedback.fetch(feedback, canceled.id)
+  end
+
   test "bounded retention evicts the oldest terminal operation first" do
     {feedback, first} =
       OperationFeedback.start(OperationFeedback.new(2), :git_stage, "one", "One")

--- a/test/support/editor_case.ex
+++ b/test/support/editor_case.ex
@@ -58,7 +58,7 @@ defmodule Minga.Test.EditorCase do
           events_registry: Minga.Events.registry()
         }
 
-  @sync_timeout 15_000
+  @sync_timeout 30_000
   @rendering_process_key :minga_editor_case_rendering
 
   @doc false


### PR DESCRIPTION
## Summary

- Replace the oversized private agent-event effect interpreter with focused status, stream, tool, file, and session workflows that compose owner transitions and external actions directly.
- Preserve Editor mailbox ordering, active-session authority, replay duplicate suppression, cancellation cleanup, transcript synchronization, and exact Traditional-shell handling without adding a process or generic action union.
- Make `OperationFeedback.selected/1` choose the newest active operation or newest retained terminal operation in one bounded reduction.
- Add a repeatable selector benchmark plus focused coverage for workflow routing, render and synchronization ordering, queue recall, approval resolution, deferred compaction, shell interruption, replay ordering, selector precedence, and retained collections.
- Stabilize two pre-existing test races by allowing legitimate async picker completion before observation and by giving headless Editor readiness a 30-second full-suite synchronization budget.

## Why

Agent event handling had recreated a universal dispatcher through private effect tuples. Splitting it by domain family keeps state ownership and action ordering visible while avoiding another abstraction between the Editor and existing owners. The selector change also removes repeated retained-collection allocation from an input-path query.

Closes #2919
Parent: #2914

## Validation

- `make lint`
- `mix test.llm` (58 doctests, 97 properties, 9,534 tests, 0 failures, 1 skipped)
- Focused changed-area suite (496 tests, 0 failures)
- `git diff --check`
- Final acceptance reviewer: PASS

### Operation-feedback selector

Same Benchee harness and full retained collection before and after:

| Case | Before | Final | Memory | Reductions |
| --- | ---: | ---: | ---: | ---: |
| Active precedence | 560.40 ns average | 508.55 ns average | 824 B → 512 B | 158 → 101 |
| Terminal fallback | 1.20 μs average | 516.56 ns average | 1.55 KB → 512 B | 272 → 101 |

### Keystroke latency

Four-round alternating same-runner A/B at final SHA `57a54adbf6a03f6c3f5a1184332742aeb26c71d2` against base `9e6ee5f7a9384ee924a915131f2e0ae2489c88d9` passed every blocking budget with no advisories:

| Scenario | Base p50 | Final p50 |
| --- | ---: | ---: |
| Agent stream | 1,722.5 μs | 1,721.5 μs |
| Large frame | 1,782.0 μs | 1,793.0 μs |
| Small frame | 1,350.5 μs | 1,409.5 μs |
