### PR TITLE
fix(project): reject lexical parent traversal

### DIFF
--- a/lib/minga/project/root.ex
+++ b/lib/minga/project/root.ex
@@ -151,6 +151,14 @@ defmodule Minga.Project.Root do
   @spec safe_relative_path(String.t(), String.t()) ::
           {:ok, String.t()} | {:error, :parent_traversal}
   defp safe_relative_path(path, canonical_root) do
+    safe_relative_path(path, canonical_root, Enum.member?(Path.split(path), ".."))
+  end
+
+  @spec safe_relative_path(String.t(), String.t(), boolean()) ::
+          {:ok, String.t()} | {:error, :parent_traversal}
+  defp safe_relative_path(_path, _canonical_root, true), do: {:error, :parent_traversal}
+
+  defp safe_relative_path(path, canonical_root, false) do
     lexical_target = Path.expand(path, canonical_root)
     relative_target = Path.relative_to(lexical_target, canonical_root)
 

--- a/test/minga/project/file_find_test.exs
+++ b/test/minga/project/file_find_test.exs
@@ -230,6 +230,10 @@ defmodule Minga.Project.FileFindTest do
                {:error, :absolute_path}
 
       assert Root.resolve_file(root, "../outside.txt") == {:error, :parent_traversal}
+      assert Root.resolve_file(root, "lib/../inside.txt") == {:error, :parent_traversal}
+
+      assert Root.resolve_file(root, "../#{Path.basename(tmp_dir)}/inside.txt") ==
+               {:error, :parent_traversal}
     end
 
     test "rejects a symlink whose canonical target escapes the workspace", %{


### PR DESCRIPTION
# TL;DR

Workspace file resolution now rejects every lexical `..` segment before path normalization, including paths that leave and re-enter the same workspace or normalize back inside it.

Follow-up to #2940 and #2941.

## Context

The workspace authorization boundary rejected paths whose normalized target escaped the workspace, but normalization could erase parent traversal that landed back inside the authorized root. The authorization check must reject that lexical intent before joining or canonicalizing the target.

This refresh rebuilds the PR on current `main`. A stale macOS IPC integration-test commit was dropped because current `main` already contains the equivalent wait-race fix.

## Changes

- Inspect raw relative path segments before `Path.expand/2` normalization.
- Return the existing explicit `{:error, :parent_traversal}` for any exact `..` segment.
- Add regression coverage for traversal that normalizes within the root and traversal that exits then re-enters it.
- Preserve valid nested paths and canonically contained symlinks through the existing authorization flow.

## Verification

- `mix test.llm test/minga/project/file_find_test.exs test/minga_agent/file_mention_test.exs`, passed: 65 tests, 0 failures.
- `make lint`, passed with Credo clean and Dialyzer reporting 0 errors.
- `mix test.llm`, passed: 9,788 tests, 58 doctests, 97 properties, 0 failures, 1 skipped.
- Touched-file LSP diagnostics and `git diff --check`, passed.
- Focused security review, passed with no exploitable traversal or containment bypasses.
- Final acceptance review and targeted delivery-state re-review, passed.

## Acceptance Criteria Addressed

- Absolute paths and lexical parent traversal are rejected before workspace-relative resolution. ✅
- Traversal that normalizes inside the root or exits and re-enters is rejected. ✅
- The explicit `:parent_traversal` error remains stable. ✅
- Existing valid nested paths and authorized in-workspace symlinks remain supported. ✅
- The refreshed branch contains no unrelated stale changes. ✅

---
**Updated after refresh:** Rebuilt on current `main`, removed the superseded macOS test commit, and updated validation for commit `46e4b90dc`.
