### PR TITLE
fix(ui): harden TODO search safety

### DIFF
--- a/lib/minga/project/workspace_snapshot.ex
+++ b/lib/minga/project/workspace_snapshot.ex
@@ -9,20 +9,29 @@ defmodule Minga.Project.WorkspaceSnapshot do
 
   alias Minga.Project.Root
 
-  @enforce_keys [:root, :files, :rebuilding?]
-  defstruct [:root, :files, :rebuilding?]
+  @enforce_keys [:root, :activation_id, :files, :rebuilding?]
+  defstruct [:root, :activation_id, :files, :rebuilding?]
+
+  @typedoc "A monotonic identity assigned to one explicit workspace activation."
+  @type activation_id :: pos_integer()
 
   @typedoc "A coherent directory workspace and its cached inventory state."
   @type t :: %__MODULE__{
           root: Root.t(),
+          activation_id: activation_id(),
           files: [String.t()],
           rebuilding?: boolean()
         }
 
-  @doc "Installs a directory root with an empty, idle inventory."
+  @doc "Installs a directory root with a fresh activation identity and an empty inventory."
   @spec activate(Root.t()) :: t()
   def activate(%Root{kind: :directory} = root) do
-    %__MODULE__{root: root, files: [], rebuilding?: false}
+    %__MODULE__{
+      root: root,
+      activation_id: System.unique_integer([:monotonic, :positive]),
+      files: [],
+      rebuilding?: false
+    }
   end
 
   @doc "Clears cached inventory before discovery starts."

--- a/lib/minga_editor/effects/todo_search.ex
+++ b/lib/minga_editor/effects/todo_search.ex
@@ -4,12 +4,13 @@ defmodule MingaEditor.Effects.TodoSearch do
 
   Repository probing and grep execution run in the generation-owned effect
   scheduler. The editor only applies the correlated picker result when its
-  source, workspace root, and fetch revision are still live.
+  source, workspace activation, and fetch revision are still live.
   """
 
   @behaviour MingaEditor.Effect
 
   alias Minga.Project.Root
+  alias Minga.Project.WorkspaceSnapshot
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effect.Policy
   alias MingaEditor.Effect.Request
@@ -21,18 +22,29 @@ defmodule MingaEditor.Effects.TodoSearch do
   alias MingaEditor.UI.Picker.TodoSearchSource
 
   @keyword_pattern "(^|[[:space:]])(#|//|/\\*|%|--)[[:space:]]*(TODO|FIXME|HACK|NOTE|REVIEW|DEPRECATED)([^[:alnum:]_]|$)"
+  @truncated_status "Results truncated to #{TodoSearchSource.max_results()}"
 
-  @enforce_keys [:root, :revision]
-  defstruct [:root, :revision, impl: TodoSearchPort]
+  @enforce_keys [:root, :activation_id, :revision]
+  defstruct [:root, :activation_id, :revision, impl: TodoSearchPort]
 
   @type impl :: module()
-  @type t :: %__MODULE__{root: Root.t(), revision: reference(), impl: impl()}
+  @type t :: %__MODULE__{
+          root: Root.t(),
+          activation_id: WorkspaceSnapshot.activation_id(),
+          revision: reference(),
+          impl: impl()
+        }
+  @type output_format :: TodoSearchSource.output_format()
 
-  @doc "Builds a latest-wins TODO search request for one project root."
-  @spec request(Root.t(), reference()) :: Request.t()
-  def request(%Root{} = root, revision) when is_reference(revision) do
+  @doc "Builds a latest-wins TODO search request for one captured workspace activation."
+  @spec request(WorkspaceSnapshot.t(), reference()) :: Request.t()
+  def request(
+        %WorkspaceSnapshot{root: %Root{} = root, activation_id: activation_id},
+        revision
+      )
+      when is_reference(revision) do
     Request.new(
-      %__MODULE__{root: root, revision: revision, impl: impl()},
+      %__MODULE__{root: root, activation_id: activation_id, revision: revision, impl: impl()},
       {:todo_search, root},
       Policy.latest_wins()
     )
@@ -73,7 +85,7 @@ defmodule MingaEditor.Effects.TodoSearch do
       effect,
       failure_message(reason),
       outcome,
-      active_workspace_root()
+      active_workspace_snapshot()
     )
   end
 
@@ -84,19 +96,17 @@ defmodule MingaEditor.Effects.TodoSearch do
   def render?(%Outcome{}), do: true
 
   @spec run_authorized(t(), String.t()) :: {:ok, Result.t()} | {:error, String.t()}
-  defp run_authorized(%__MODULE__{revision: revision, impl: impl}, canonical_root) do
-    with {:ok, output} <- search_output(canonical_root, impl) do
-      items =
-        output
-        |> TodoSearchSource.parse_output()
-        |> TodoSearchSource.build_candidates(canonical_root)
+  defp run_authorized(%__MODULE__{root: root, revision: revision, impl: impl}, canonical_root) do
+    with {:ok, output, format} <- search_output(canonical_root, impl) do
+      {markers, truncated?} = TodoSearchSource.parse_output(output, format)
+      items = TodoSearchSource.build_candidates(markers, root)
 
       {:ok,
        %Result{
          revision: revision,
          items: items,
          candidates: Candidate.from_items(items),
-         meta: %{}
+         meta: result_meta(truncated?)
        }}
     end
   end
@@ -104,7 +114,7 @@ defmodule MingaEditor.Effects.TodoSearch do
   @spec apply_matching_revision(EditorState.t(), t(), Result.t(), Outcome.t(), boolean()) ::
           {EditorState.t(), Outcome.t()}
   defp apply_matching_revision(state, effect, result, outcome, true) do
-    apply_completed_for_workspace(state, effect, result, outcome, active_workspace_root())
+    apply_completed_for_workspace(state, effect, result, outcome, active_workspace_snapshot())
   end
 
   defp apply_matching_revision(state, _effect, _result, outcome, false) do
@@ -116,19 +126,19 @@ defmodule MingaEditor.Effects.TodoSearch do
           t(),
           Result.t(),
           Outcome.t(),
-          Root.t() | nil
+          WorkspaceSnapshot.t() | nil
         ) :: {EditorState.t(), Outcome.t()}
   defp apply_completed_for_workspace(
          state,
-         %__MODULE__{root: root} = effect,
+         %__MODULE__{root: root, activation_id: activation_id} = effect,
          result,
          outcome,
-         root
+         %WorkspaceSnapshot{root: root, activation_id: activation_id}
        ) do
     apply_completed_result(state, effect, result, outcome)
   end
 
-  defp apply_completed_for_workspace(state, _effect, _result, outcome, _active_root) do
+  defp apply_completed_for_workspace(state, _effect, _result, outcome, _active_workspace) do
     {state, Outcome.stale(outcome, :workspace_rerooted)}
   end
 
@@ -137,13 +147,19 @@ defmodule MingaEditor.Effects.TodoSearch do
           t(),
           String.t(),
           Outcome.t(),
-          Root.t() | nil
+          WorkspaceSnapshot.t() | nil
         ) :: {EditorState.t(), Outcome.t()}
-  defp apply_failed_for_workspace(state, %__MODULE__{root: root} = effect, reason, outcome, root) do
+  defp apply_failed_for_workspace(
+         state,
+         %__MODULE__{root: root, activation_id: activation_id} = effect,
+         reason,
+         outcome,
+         %WorkspaceSnapshot{root: root, activation_id: activation_id}
+       ) do
     apply_failed_result(state, effect, reason, outcome)
   end
 
-  defp apply_failed_for_workspace(state, _effect, _reason, outcome, _active_root) do
+  defp apply_failed_for_workspace(state, _effect, _reason, outcome, _active_workspace) do
     {state, Outcome.stale(outcome, :workspace_rerooted)}
   end
 
@@ -170,9 +186,9 @@ defmodule MingaEditor.Effects.TodoSearch do
     end
   end
 
-  @spec active_workspace_root() :: Root.t() | nil
-  defp active_workspace_root do
-    Minga.Project.workspace_root()
+  @spec active_workspace_snapshot() :: WorkspaceSnapshot.t() | nil
+  defp active_workspace_snapshot do
+    Minga.Project.snapshot()
   catch
     :exit, _reason -> nil
   end
@@ -182,21 +198,27 @@ defmodule MingaEditor.Effects.TodoSearch do
     Application.get_env(:minga, :todo_search_port_module, TodoSearchPort)
   end
 
-  @spec search_output(String.t(), impl()) :: {:ok, String.t()} | {:error, String.t()}
+  @spec result_meta(boolean()) :: MingaEditor.UI.Picker.Source.fetch_meta()
+  defp result_meta(true), do: %{status: @truncated_status}
+  defp result_meta(false), do: %{}
+
+  @spec search_output(String.t(), impl()) ::
+          {:ok, String.t(), output_format()} | {:error, String.t()}
   defp search_output(canonical_root, port_backend) do
     if git_repo?(canonical_root, port_backend) do
       run_search_command(
         port_backend,
         "git",
-        ["-C", canonical_root, "grep", "-n", "-I", "-E", @keyword_pattern, "--", "."]
+        ["-C", canonical_root, "grep", "-n", "-I", "-E", "-z", @keyword_pattern, "--", "."],
+        :git
       )
     else
-      run_search_command(port_backend, "grep", [
-        "-rnEI",
-        "--exclude-dir=.git",
-        @keyword_pattern,
-        canonical_root
-      ])
+      run_search_command(
+        port_backend,
+        "grep",
+        ["-rnEIZ", "--exclude-dir=.git", @keyword_pattern, canonical_root],
+        :grep
+      )
     end
   end
 
@@ -208,12 +230,12 @@ defmodule MingaEditor.Effects.TodoSearch do
     end
   end
 
-  @spec run_search_command(impl(), String.t(), [String.t()]) ::
-          {:ok, String.t()} | {:error, String.t()}
-  defp run_search_command(port_backend, command, args) do
+  @spec run_search_command(impl(), String.t(), [String.t()], output_format()) ::
+          {:ok, String.t(), output_format()} | {:error, String.t()}
+  defp run_search_command(port_backend, command, args, format) do
     case port_backend.run(command, args) do
-      {output, 0} -> {:ok, output}
-      {_output, 1} -> {:ok, ""}
+      {output, 0} -> {:ok, output, format}
+      {_output, 1} -> {:ok, "", format}
       {output, status} -> {:error, "#{command} exited with status #{status}: #{output}"}
     end
   end

--- a/lib/minga_editor/effects/todo_search_port.ex
+++ b/lib/minga_editor/effects/todo_search_port.ex
@@ -2,17 +2,20 @@ defmodule MingaEditor.Effects.TodoSearch.Port do
   @moduledoc """
   Executes the bounded git and grep Ports used by TODO search.
 
-  This is a focused execution seam for TODO search. Workspace authorization
-  remains in `MingaEditor.Effects.TodoSearch` and must complete before this
-  module is called.
+  Commands have a five-second timeout and an 8 MiB total-output ceiling. The
+  Port is closed as soon as either bound is crossed, before excess output is
+  appended. Workspace authorization remains in `MingaEditor.Effects.TodoSearch`
+  and must complete before this module is called.
   """
 
   @command_timeout_ms 5_000
+  @max_output_bytes 8 * 1_024 * 1_024
+  @output_limit_status 125
 
   @typedoc "A completed TODO-search command result."
   @type result :: {String.t(), non_neg_integer()}
 
-  @doc "Runs one TODO-search command through a Port with a bounded timeout."
+  @doc "Runs one TODO-search command through a Port with bounded time and output."
   @callback run(String.t(), [String.t()]) :: result()
 
   @spec run(String.t(), [String.t()]) :: result()
@@ -37,19 +40,53 @@ defmodule MingaEditor.Effects.TodoSearch.Port do
         {:line, 65_536}
       ])
 
-    collect_port_output(port, [])
+    deadline = System.monotonic_time(:millisecond) + @command_timeout_ms
+    collect_port_output(port, [], 0, deadline)
   end
 
-  @spec collect_port_output(port(), iodata()) :: result()
-  defp collect_port_output(port, acc) do
-    receive do
-      {^port, {:data, {:eol, chunk}}} -> collect_port_output(port, ["\n", chunk | acc])
-      {^port, {:data, {:noeol, chunk}}} -> collect_port_output(port, [chunk | acc])
-      {^port, {:exit_status, status}} -> {acc |> Enum.reverse() |> IO.iodata_to_binary(), status}
-    after
-      @command_timeout_ms ->
-        Port.close(port)
-        {"command timed out", 124}
+  @spec collect_port_output(port(), iodata(), non_neg_integer(), integer()) :: result()
+  defp collect_port_output(port, acc, byte_count, deadline) do
+    case remaining_timeout(deadline) do
+      0 ->
+        timeout(port)
+
+      timeout_ms ->
+        receive do
+          {^port, {:data, {:eol, chunk}}} ->
+            collect_chunk(port, acc, byte_count, chunk, "\n", deadline)
+
+          {^port, {:data, {:noeol, chunk}}} ->
+            collect_chunk(port, acc, byte_count, chunk, "", deadline)
+
+          {^port, {:exit_status, status}} ->
+            {acc |> Enum.reverse() |> IO.iodata_to_binary(), status}
+        after
+          timeout_ms -> timeout(port)
+        end
     end
+  end
+
+  @spec collect_chunk(port(), iodata(), non_neg_integer(), binary(), binary(), integer()) ::
+          result()
+  defp collect_chunk(port, acc, byte_count, chunk, suffix, deadline) do
+    next_byte_count = byte_count + byte_size(chunk) + byte_size(suffix)
+
+    if next_byte_count > @max_output_bytes do
+      Port.close(port)
+      {"command output exceeded #{@max_output_bytes} bytes", @output_limit_status}
+    else
+      collect_port_output(port, [suffix, chunk | acc], next_byte_count, deadline)
+    end
+  end
+
+  @spec timeout(port()) :: result()
+  defp timeout(port) do
+    Port.close(port)
+    {"command timed out", 124}
+  end
+
+  @spec remaining_timeout(integer()) :: non_neg_integer()
+  defp remaining_timeout(deadline) do
+    max(deadline - System.monotonic_time(:millisecond), 0)
   end
 end

--- a/lib/minga_editor/effects/todo_search_port.ex
+++ b/lib/minga_editor/effects/todo_search_port.ex
@@ -2,18 +2,22 @@ defmodule MingaEditor.Effects.TodoSearch.Port do
   @moduledoc """
   Executes the bounded git and grep Ports used by TODO search.
 
-  Commands have a five-second timeout and an 8 MiB total-output ceiling. The
-  Port is closed as soon as either bound is crossed, before excess output is
-  appended. Workspace authorization remains in `MingaEditor.Effects.TodoSearch`
-  and must complete before this module is called.
+  Commands have a five-second timeout and an 8 MiB total-output ceiling. When
+  either bound is crossed, the direct child is killed and its monitored Port is
+  confirmed down before the result is returned. Workspace authorization remains
+  in `MingaEditor.Effects.TodoSearch` and must complete before this module is
+  called.
   """
 
   @command_timeout_ms 5_000
+  @termination_timeout_ms 1_000
   @max_output_bytes 8 * 1_024 * 1_024
   @output_limit_status 125
 
   @typedoc "A completed TODO-search command result."
   @type result :: {String.t(), non_neg_integer()}
+
+  @typep command_port :: {port(), os_pid :: pos_integer(), kill_executable :: String.t()}
 
   @doc "Runs one TODO-search command through a Port with bounded time and output."
   @callback run(String.t(), [String.t()]) :: result()
@@ -22,67 +26,157 @@ defmodule MingaEditor.Effects.TodoSearch.Port do
   def run(command, args) when is_binary(command) and is_list(args) do
     case System.find_executable(command) do
       nil -> {"#{command} executable not found", 127}
-      executable -> open_port(executable, args)
+      executable -> open_port(executable, args, kill_executable!())
     end
   rescue
     error -> {Exception.message(error), 1}
   end
 
-  @spec open_port(String.t(), [String.t()]) :: result()
-  defp open_port(executable, args) do
+  @spec open_port(String.t(), [String.t()], String.t()) :: result()
+  defp open_port(executable, args, kill_executable) do
     port =
       Port.open({:spawn_executable, executable}, [
         :binary,
         :exit_status,
         :hide,
         :stderr_to_stdout,
-        {:args, args},
-        {:line, 65_536}
+        {:args, args}
       ])
 
+    command_port = {port, port_os_pid!(port), kill_executable}
     deadline = System.monotonic_time(:millisecond) + @command_timeout_ms
-    collect_port_output(port, [], 0, deadline)
+    collect_port_output(command_port, [], 0, deadline)
   end
 
-  @spec collect_port_output(port(), iodata(), non_neg_integer(), integer()) :: result()
-  defp collect_port_output(port, acc, byte_count, deadline) do
+  @spec collect_port_output(command_port(), iodata(), non_neg_integer(), integer()) :: result()
+  defp collect_port_output(
+         {port, _os_pid, _kill_executable} = command_port,
+         acc,
+         byte_count,
+         deadline
+       ) do
     case remaining_timeout(deadline) do
       0 ->
-        timeout(port)
+        terminate(command_port, {"command timed out", 124})
 
       timeout_ms ->
         receive do
-          {^port, {:data, {:eol, chunk}}} ->
-            collect_chunk(port, acc, byte_count, chunk, "\n", deadline)
-
-          {^port, {:data, {:noeol, chunk}}} ->
-            collect_chunk(port, acc, byte_count, chunk, "", deadline)
+          {^port, {:data, chunk}} ->
+            collect_chunk(command_port, acc, byte_count, chunk, deadline)
 
           {^port, {:exit_status, status}} ->
             {acc |> Enum.reverse() |> IO.iodata_to_binary(), status}
         after
-          timeout_ms -> timeout(port)
+          timeout_ms -> terminate(command_port, {"command timed out", 124})
         end
     end
   end
 
-  @spec collect_chunk(port(), iodata(), non_neg_integer(), binary(), binary(), integer()) ::
+  @spec collect_chunk(command_port(), iodata(), non_neg_integer(), binary(), integer()) ::
           result()
-  defp collect_chunk(port, acc, byte_count, chunk, suffix, deadline) do
-    next_byte_count = byte_count + byte_size(chunk) + byte_size(suffix)
+  defp collect_chunk(command_port, acc, byte_count, chunk, deadline) do
+    next_byte_count = byte_count + byte_size(chunk)
 
     if next_byte_count > @max_output_bytes do
-      Port.close(port)
-      {"command output exceeded #{@max_output_bytes} bytes", @output_limit_status}
+      terminate(
+        command_port,
+        {"command output exceeded #{@max_output_bytes} bytes", @output_limit_status}
+      )
     else
-      collect_port_output(port, [suffix, chunk | acc], next_byte_count, deadline)
+      collect_port_output(command_port, [chunk | acc], next_byte_count, deadline)
     end
   end
 
-  @spec timeout(port()) :: result()
-  defp timeout(port) do
+  @spec terminate(command_port(), result()) :: result()
+  defp terminate({port, os_pid, kill_executable}, result) do
+    monitor_ref = Port.monitor(port)
+    {kill_port, kill_monitor_ref} = hard_kill(kill_executable, os_pid)
+
+    wait_for_port_down(port, monitor_ref)
+    wait_for_kill_port_down(kill_port, kill_monitor_ref)
+    drain_port_messages(port, monitor_ref)
+    drain_port_messages(kill_port, kill_monitor_ref)
+    result
+  end
+
+  @spec hard_kill(String.t(), pos_integer()) :: {port(), reference()}
+  defp hard_kill(kill_executable, os_pid) do
+    kill_port =
+      Port.open({:spawn_executable, kill_executable}, [
+        :binary,
+        :exit_status,
+        :hide,
+        :stderr_to_stdout,
+        {:args, ["-KILL", Integer.to_string(os_pid)]}
+      ])
+
+    {kill_port, Port.monitor(kill_port)}
+  end
+
+  @spec wait_for_port_down(port(), reference()) :: :ok
+  defp wait_for_port_down(port, monitor_ref) do
+    receive do
+      {:DOWN, ^monitor_ref, :port, ^port, _reason} ->
+        :ok
+    after
+      @termination_timeout_ms ->
+        close_port(port)
+        wait_for_closed_port_down(port, monitor_ref)
+    end
+  end
+
+  @spec wait_for_closed_port_down(port(), reference()) :: :ok
+  defp wait_for_closed_port_down(port, monitor_ref) do
+    receive do
+      {:DOWN, ^monitor_ref, :port, ^port, _reason} -> :ok
+    after
+      @termination_timeout_ms ->
+        Port.demonitor(monitor_ref, [:flush])
+        :ok
+    end
+  end
+
+  @spec wait_for_kill_port_down(port(), reference()) :: :ok
+  defp wait_for_kill_port_down(kill_port, monitor_ref) do
+    receive do
+      {:DOWN, ^monitor_ref, :port, ^kill_port, _reason} -> :ok
+    after
+      @termination_timeout_ms ->
+        close_port(kill_port)
+        Port.demonitor(monitor_ref, [:flush])
+        :ok
+    end
+  end
+
+  @spec drain_port_messages(port(), reference()) :: :ok
+  defp drain_port_messages(port, monitor_ref) do
+    receive do
+      {^port, _message} -> drain_port_messages(port, monitor_ref)
+      {:DOWN, ^monitor_ref, :port, ^port, _reason} -> drain_port_messages(port, monitor_ref)
+    after
+      0 -> :ok
+    end
+  end
+
+  @spec port_os_pid!(port()) :: pos_integer()
+  defp port_os_pid!(port) do
+    case Port.info(port, :os_pid) do
+      {:os_pid, os_pid} when is_integer(os_pid) and os_pid > 0 -> os_pid
+      _other -> raise "TODO search Port did not expose an OS process ID"
+    end
+  end
+
+  @spec kill_executable!() :: String.t()
+  defp kill_executable! do
+    System.find_executable("kill") || raise "kill executable not found"
+  end
+
+  @spec close_port(port()) :: :ok
+  defp close_port(port) do
     Port.close(port)
-    {"command timed out", 124}
+    :ok
+  rescue
+    ArgumentError -> :ok
   end
 
   @spec remaining_timeout(integer()) :: non_neg_integer()

--- a/lib/minga_editor/shell/traditional/todo_search_workflow.ex
+++ b/lib/minga_editor/shell/traditional/todo_search_workflow.ex
@@ -3,7 +3,7 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
   Owns opening and scheduling the TODO-search picker workflow.
   """
 
-  alias Minga.Project.Root
+  alias Minga.Project.WorkspaceSnapshot
   alias MingaEditor.EffectScheduler
   alias MingaEditor.Effects.TodoSearch
   alias MingaEditor.PickerUI
@@ -13,20 +13,21 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
   @spec open(MingaEditor.State.t()) :: MingaEditor.State.t()
   def open(state) do
     {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
-    schedule(state, active_workspace_root(), revision)
+    schedule(state, active_workspace_snapshot(), revision)
   end
 
-  @spec schedule(MingaEditor.State.t(), Root.t() | nil, reference()) :: MingaEditor.State.t()
+  @spec schedule(MingaEditor.State.t(), WorkspaceSnapshot.t() | nil, reference()) ::
+          MingaEditor.State.t()
   defp schedule(state, nil, revision) do
     apply_failure(state, revision, "No directory workspace active")
   end
 
-  defp schedule(%{effect_scheduler: nil} = state, _root, revision) do
+  defp schedule(%{effect_scheduler: nil} = state, _snapshot, revision) do
     apply_failure(state, revision, "TODO search scheduler unavailable")
   end
 
-  defp schedule(state, %Root{} = root, revision) do
-    case EffectScheduler.schedule(state.effect_scheduler, TodoSearch.request(root, revision)) do
+  defp schedule(state, %WorkspaceSnapshot{} = snapshot, revision) do
+    case EffectScheduler.schedule(state.effect_scheduler, TodoSearch.request(snapshot, revision)) do
       {:ok, _request_id, _disposition} ->
         state
 
@@ -38,9 +39,9 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflow do
       apply_failure(state, revision, "TODO search scheduler unavailable: #{inspect(reason)}")
   end
 
-  @spec active_workspace_root() :: Root.t() | nil
-  defp active_workspace_root do
-    Minga.Project.workspace_root()
+  @spec active_workspace_snapshot() :: WorkspaceSnapshot.t() | nil
+  defp active_workspace_snapshot do
+    Minga.Project.snapshot()
   catch
     :exit, _reason -> nil
   end

--- a/lib/minga_editor/ui/picker/todo_search_source.ex
+++ b/lib/minga_editor/ui/picker/todo_search_source.ex
@@ -15,15 +15,19 @@ defmodule MingaEditor.UI.Picker.TodoSearchSource do
   alias Minga.Buffer
   alias Minga.Language
   alias Minga.Language.Devicon
+  alias Minga.Project.Root
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.Source
+
+  @max_results 1_000
 
   @type marker :: %{
           path: String.t(),
           line: pos_integer(),
           text: String.t()
         }
+  @type output_format :: :git | :grep
 
   @impl true
   @spec title() :: String.t()
@@ -41,27 +45,24 @@ defmodule MingaEditor.UI.Picker.TodoSearchSource do
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(_context), do: []
 
-  @doc "Parses grep-style `path:line:text` output into marker maps."
-  @spec parse_output(String.t()) :: [marker()]
-  def parse_output(output) when is_binary(output) do
-    output
-    |> String.split("\n", trim: true)
-    |> Enum.flat_map(&parse_line/1)
+  @doc "Maximum number of parsed TODO matches returned by one search."
+  @spec max_results() :: pos_integer()
+  def max_results, do: @max_results
+
+  @doc "Parses NUL-framed grep output and reports whether matches were truncated."
+  @spec parse_output(String.t(), output_format()) :: {[marker()], boolean()}
+  def parse_output(output, format) when is_binary(output) and format in [:git, :grep] do
+    markers = parse_records(output, format, @max_results + 1, [])
+    truncated? = length(markers) > @max_results
+    {Enum.take(markers, @max_results), truncated?}
   end
 
-  @doc "Builds picker items using the canonical root authorized by TODO search."
-  @spec build_candidates([marker()] | {:ok, String.t()} | {:error, String.t()}, String.t()) :: [
-          Item.t()
-        ]
-  def build_candidates({:ok, output}, canonical_root),
-    do: output |> parse_output() |> build_candidates(canonical_root)
-
-  def build_candidates({:error, _message}, _canonical_root), do: []
-
-  def build_candidates(markers, canonical_root) when is_list(markers) do
+  @doc "Builds picker items only for candidates authorized by the captured workspace Root."
+  @spec build_candidates([marker()], Root.t()) :: [Item.t()]
+  def build_candidates(markers, %Root{} = root) when is_list(markers) do
     markers
     |> Enum.with_index()
-    |> Enum.map(fn {marker, idx} -> marker_item(marker, idx, canonical_root) end)
+    |> Enum.flat_map(fn {marker, idx} -> marker_item(marker, idx, root) end)
   end
 
   @impl true
@@ -76,25 +77,83 @@ defmodule MingaEditor.UI.Picker.TodoSearchSource do
   @spec on_cancel(term()) :: term()
   def on_cancel(state), do: Source.restore_or_keep(state)
 
-  @spec parse_line(String.t()) :: [marker()]
-  defp parse_line(line) do
-    case String.split(line, ":", parts: 3) do
-      [path, line_number, text] -> parse_match(path, line_number, text)
-      _ -> []
+  @spec parse_records(binary(), output_format(), non_neg_integer(), [marker()]) :: [marker()]
+  defp parse_records(_output, _format, 0, acc), do: Enum.reverse(acc)
+  defp parse_records("", _format, _remaining, acc), do: Enum.reverse(acc)
+
+  defp parse_records(output, :git, remaining, acc) do
+    with {:ok, path, after_path} <- split_once(output, <<0>>),
+         {:ok, line_number, after_line} <- split_once(after_path, <<0>>),
+         {:ok, text, rest} <- take_record_line(after_line) do
+      parse_records(rest, :git, remaining - 1, add_match(acc, path, line_number, text))
+    else
+      :error -> Enum.reverse(acc)
     end
   end
 
-  @spec parse_match(String.t(), String.t(), String.t()) :: [marker()]
-  defp parse_match(path, line_number, text) do
+  defp parse_records(output, :grep, remaining, acc) do
+    with {:ok, path, after_path} <- split_once(output, <<0>>),
+         {:ok, record, rest} <- take_record_line(after_path),
+         [line_number, text] <- String.split(record, ":", parts: 2) do
+      parse_records(rest, :grep, remaining - 1, add_match(acc, path, line_number, text))
+    else
+      _ -> Enum.reverse(acc)
+    end
+  end
+
+  @spec add_match([marker()], String.t(), String.t(), String.t()) :: [marker()]
+  defp add_match(acc, path, line_number, text) do
     case Integer.parse(line_number) do
-      {line, ""} when line > 0 -> [%{path: path, line: line, text: text}]
-      _ -> []
+      {line, ""} when line > 0 -> [%{path: path, line: line, text: text} | acc]
+      _ -> acc
     end
   end
 
-  @spec marker_item(marker(), non_neg_integer(), String.t()) :: Item.t()
-  defp marker_item(marker, idx, canonical_root) do
-    path = Path.expand(marker.path, canonical_root)
+  @spec split_once(binary(), binary()) :: {:ok, binary(), binary()} | :error
+  defp split_once(binary, delimiter) do
+    case :binary.match(binary, delimiter) do
+      {offset, length} ->
+        before = binary_part(binary, 0, offset)
+        rest_offset = offset + length
+        rest = binary_part(binary, rest_offset, byte_size(binary) - rest_offset)
+        {:ok, before, rest}
+
+      :nomatch ->
+        :error
+    end
+  end
+
+  @spec take_record_line(binary()) :: {:ok, binary(), binary()} | :error
+  defp take_record_line(""), do: :error
+
+  defp take_record_line(binary) do
+    case split_once(binary, "\n") do
+      {:ok, line, rest} -> {:ok, line, rest}
+      :error -> {:ok, binary, ""}
+    end
+  end
+
+  @spec marker_item(marker(), non_neg_integer(), Root.t()) :: [Item.t()]
+  defp marker_item(marker, idx, %Root{} = root) do
+    relative_path = candidate_relative_path(marker.path, root.path)
+
+    case Root.resolve_file(root, relative_path) do
+      {:ok, path} -> [authorized_item(marker, idx, path, root.path)]
+      {:error, _reason} -> []
+    end
+  end
+
+  @spec candidate_relative_path(String.t(), String.t()) :: String.t()
+  defp candidate_relative_path(path, canonical_root) do
+    case Path.type(path) do
+      :absolute -> Path.relative_to(path, canonical_root)
+      :relative -> path
+      :volumerelative -> path
+    end
+  end
+
+  @spec authorized_item(marker(), non_neg_integer(), String.t(), String.t()) :: Item.t()
+  defp authorized_item(marker, idx, path, canonical_root) do
     rel_path = Path.relative_to(path, canonical_root)
     filename = Path.basename(path)
     filetype = Language.detect_filetype(filename)

--- a/test/minga/project_test.exs
+++ b/test/minga/project_test.exs
@@ -109,7 +109,10 @@ defmodule Minga.ProjectTest do
       {_pid, name} = start_project!(file_find_module: Minga.Project.SlowFileFind)
       Minga.Events.subscribe(:project_rebuilt)
 
-      assert {:ok, %WorkspaceSnapshot{rebuilding?: true}} = Project.activate(name, root)
+      assert {:ok, %WorkspaceSnapshot{rebuilding?: true} = activated} =
+               Project.activate(name, root)
+
+      activation_id = activated.activation_id
       worker = flush(name).rebuild_pid
       worker_ref = Process.monitor(worker)
 
@@ -123,6 +126,7 @@ defmodule Minga.ProjectTest do
 
       assert %WorkspaceSnapshot{
                root: ^root,
+               activation_id: ^activation_id,
                files: ["lib/app.ex", "README.md"],
                rebuilding?: false
              } = Project.snapshot(name)

--- a/test/minga_editor/effect_scheduler_test.exs
+++ b/test/minga_editor/effect_scheduler_test.exs
@@ -4,6 +4,7 @@ defmodule MingaEditor.EffectSchedulerTest do
   use ExUnit.Case, async: true
 
   alias Minga.Project.Root
+  alias Minga.Project.WorkspaceSnapshot
   alias Minga.Test.EffectOwner
   alias Minga.Test.EffectProbe
   alias MingaEditor.Effect.Outcome
@@ -17,11 +18,13 @@ defmodule MingaEditor.EffectSchedulerTest do
 
   test "TODO requests retain their typed Root through scheduler failure outcomes" do
     root = %Root{kind: :directory, path: "/missing/todo-search-root"}
-    request = TodoSearch.request(root, make_ref())
+    snapshot = WorkspaceSnapshot.activate(root)
+    request = TodoSearch.request(snapshot, make_ref())
     scheduler = start_scheduler()
 
     assert request.resource == {:todo_search, root}
     assert request.effect.root == root
+    assert request.effect.activation_id == snapshot.activation_id
     assert EffectScheduler.schedule(scheduler, request) == {:ok, request.id, :running}
 
     outcome = receive_candidate(scheduler, request.id, :failed)

--- a/test/minga_editor/effects/todo_search_port_test.exs
+++ b/test/minga_editor/effects/todo_search_port_test.exs
@@ -1,30 +1,83 @@
 defmodule MingaEditor.Effects.TodoSearch.PortTest do
-  # These tests spawn real OS Ports and compare the VM's global Port inventory.
+  # These tests serialize because real OS Port processes can trigger erl_child_setup EPIPE races.
   use ExUnit.Case, async: false
 
   alias MingaEditor.Effects.TodoSearch.Port, as: TodoSearchPort
 
   @moduletag :heavy
+  @moduletag :tmp_dir
 
-  test "uses an absolute five-second deadline despite intermittent output" do
-    ports_before = MapSet.new(Port.list())
+  test "uses an absolute five-second deadline and kills the direct child", %{tmp_dir: dir} do
+    {task, os_pid} = start_process_probe(dir, "exec sleep 60")
     started_at = System.monotonic_time(:millisecond)
 
-    command = "printf 'started\\n'; sleep 4; printf 'still-running\\n'; exec sleep 60"
-    assert TodoSearchPort.run("sh", ["-c", command]) == {"command timed out", 124}
+    assert Task.await(task, 8_000) == {"command timed out", 124}
 
     elapsed_ms = System.monotonic_time(:millisecond) - started_at
     assert elapsed_ms >= 4_500
     assert elapsed_ms < 8_000
-    assert MapSet.difference(MapSet.new(Port.list()), ports_before) == MapSet.new()
+    refute process_alive?(os_pid)
   end
 
-  test "closes the Port before retaining output beyond the total byte ceiling" do
-    ports_before = MapSet.new(Port.list())
+  test "kills an infinite producer after crossing the total byte ceiling", %{tmp_dir: dir} do
+    {task, os_pid} = start_process_probe(dir, "exec yes x")
 
-    assert TodoSearchPort.run("sh", ["-c", "head -c 9000000 /dev/zero"]) ==
+    assert Task.await(task, 8_000) ==
              {"command output exceeded 8388608 bytes", 125}
 
-    assert MapSet.difference(MapSet.new(Port.list()), ports_before) == MapSet.new()
+    refute process_alive?(os_pid)
+  end
+
+  @spec start_process_probe(String.t(), String.t()) :: {Task.t(), String.t()}
+  defp start_process_probe(dir, mode) do
+    fifo = Path.join(dir, "todo-port-pid-#{System.unique_integer([:positive])}")
+    mkfifo = System.find_executable("mkfifo") || raise "mkfifo executable not found"
+    assert {"", 0} = System.cmd(mkfifo, [fifo])
+
+    probe = open_fifo_probe(fifo)
+    probe_ref = Port.monitor(probe)
+    command = "printf '%s\\n' \"$$\" > \"$1\"; #{mode}"
+
+    task =
+      Task.async(fn ->
+        TodoSearchPort.run("sh", ["-c", command, "todo-search-port-probe", fifo])
+      end)
+
+    os_pid = read_probed_pid(probe)
+    assert_receive {:DOWN, ^probe_ref, :port, ^probe, _reason}, 1_000
+    drain_probe_messages(probe)
+    assert process_alive?(os_pid)
+    {task, os_pid}
+  end
+
+  @spec open_fifo_probe(String.t()) :: port()
+  defp open_fifo_probe(fifo) do
+    cat = System.find_executable("cat") || raise "cat executable not found"
+    Port.open({:spawn_executable, cat}, [:binary, :exit_status, {:args, [fifo]}])
+  end
+
+  @spec read_probed_pid(port()) :: String.t()
+  defp read_probed_pid(probe) do
+    receive do
+      {^probe, {:data, os_pid}} -> String.trim(os_pid)
+    after
+      1_000 -> flunk("TODO search child did not publish its PID")
+    end
+  end
+
+  @spec drain_probe_messages(port()) :: :ok
+  defp drain_probe_messages(probe) do
+    receive do
+      {^probe, _message} -> drain_probe_messages(probe)
+    after
+      0 -> :ok
+    end
+  end
+
+  @spec process_alive?(String.t()) :: boolean()
+  defp process_alive?(os_pid) do
+    kill = System.find_executable("kill") || raise "kill executable not found"
+    {_output, status} = System.cmd(kill, ["-0", os_pid], stderr_to_stdout: true)
+    status == 0
   end
 end

--- a/test/minga_editor/effects/todo_search_port_test.exs
+++ b/test/minga_editor/effects/todo_search_port_test.exs
@@ -1,0 +1,30 @@
+defmodule MingaEditor.Effects.TodoSearch.PortTest do
+  # These tests spawn real OS Ports and compare the VM's global Port inventory.
+  use ExUnit.Case, async: false
+
+  alias MingaEditor.Effects.TodoSearch.Port, as: TodoSearchPort
+
+  @moduletag :heavy
+
+  test "uses an absolute five-second deadline despite intermittent output" do
+    ports_before = MapSet.new(Port.list())
+    started_at = System.monotonic_time(:millisecond)
+
+    command = "printf 'started\\n'; sleep 4; printf 'still-running\\n'; exec sleep 60"
+    assert TodoSearchPort.run("sh", ["-c", command]) == {"command timed out", 124}
+
+    elapsed_ms = System.monotonic_time(:millisecond) - started_at
+    assert elapsed_ms >= 4_500
+    assert elapsed_ms < 8_000
+    assert MapSet.difference(MapSet.new(Port.list()), ports_before) == MapSet.new()
+  end
+
+  test "closes the Port before retaining output beyond the total byte ceiling" do
+    ports_before = MapSet.new(Port.list())
+
+    assert TodoSearchPort.run("sh", ["-c", "head -c 9000000 /dev/zero"]) ==
+             {"command output exceeded 8388608 bytes", 125}
+
+    assert MapSet.difference(MapSet.new(Port.list()), ports_before) == MapSet.new()
+  end
+end

--- a/test/minga_editor/picker_async_stale_test.exs
+++ b/test/minga_editor/picker_async_stale_test.exs
@@ -217,10 +217,11 @@ defmodule MingaEditor.PickerAsyncStaleTest do
     state = :sys.get_state(ctx.editor, @sync_timeout)
     {:ok, captured_root} = Root.directory(root_path)
     {:ok, reroot} = Root.directory(reroot_path)
-    assert Project.workspace_root() == captured_root
+    captured_snapshot = Project.snapshot()
+    assert captured_snapshot.root == captured_root
     assert {:ok, _snapshot} = Project.activate(reroot)
 
-    request = TodoSearch.request(captured_root, revision)
+    request = TodoSearch.request(captured_snapshot, revision)
 
     result = %TodoSearch.Result{
       revision: revision,

--- a/test/minga_editor/shell/traditional/todo_search_workflow_test.exs
+++ b/test/minga_editor/shell/traditional/todo_search_workflow_test.exs
@@ -28,7 +28,7 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflowTest do
     active_path = temporary_root("active")
     stale_file_tree_path = temporary_root("stale-file-tree")
     {:ok, active_root} = Root.directory(active_path)
-    activate_project!(active_root)
+    active_snapshot = activate_project!(active_root)
     scheduler = start_scheduler()
 
     state =
@@ -44,9 +44,14 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflowTest do
                       status: :running,
                       request: %Request{
                         resource: {:todo_search, ^active_root},
-                        effect: %TodoSearch{root: ^active_root}
+                        effect: %TodoSearch{
+                          root: ^active_root,
+                          activation_id: activation_id
+                        }
                       }
                     }}
+
+    assert activation_id == active_snapshot.activation_id
   end
 
   test "does not reconstruct a Root from the file-tree path when no workspace is active" do
@@ -66,7 +71,7 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflowTest do
     refute_received {:effect_lifecycle, %Outcome{request: %Request{handler: TodoSearch}}}
   end
 
-  @spec activate_project!(Root.t()) :: :ok
+  @spec activate_project!(Root.t()) :: Minga.Project.WorkspaceSnapshot.t()
   defp activate_project!(%Root{path: path} = root) do
     Minga.Events.subscribe(:project_rebuilt)
     assert {:ok, snapshot} = Project.activate(root)
@@ -77,7 +82,7 @@ defmodule MingaEditor.Shell.Traditional.TodoSearchWorkflowTest do
                      5_000
     end
 
-    :ok
+    snapshot
   end
 
   @spec start_scheduler() :: pid()

--- a/test/minga_editor/ui/picker/todo_search_source_test.exs
+++ b/test/minga_editor/ui/picker/todo_search_source_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Project
   alias Minga.Project.Root
+  alias Minga.Project.WorkspaceSnapshot
   alias Minga.Test.TodoSearchPortProbe
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effects.TodoSearch
@@ -22,40 +23,54 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
     :ok
   end
 
-  describe "parse_output/1" do
-    test "parses grep path, line, and match text" do
-      output = "lib/example.ex:12:  # TODO ship it\nREADME.md:4:// FIXME docs\n"
+  describe "parse_output/2" do
+    test "parses NUL-framed git and recursive grep records with newlines in paths" do
+      git_output = "lib/a:b\nc.ex\012\0  # TODO ship it\n"
+      grep_output = "/workspace/a:b\nc.ex\0" <> "4:// FIXME docs\n"
 
-      assert TodoSearchSource.parse_output(output) == [
-               %{path: "lib/example.ex", line: 12, text: "  # TODO ship it"},
-               %{path: "README.md", line: 4, text: "// FIXME docs"}
-             ]
+      assert TodoSearchSource.parse_output(git_output, :git) ==
+               {[%{path: "lib/a:b\nc.ex", line: 12, text: "  # TODO ship it"}], false}
+
+      assert TodoSearchSource.parse_output(grep_output, :grep) ==
+               {[%{path: "/workspace/a:b\nc.ex", line: 4, text: "// FIXME docs"}], false}
     end
 
     test "ignores malformed and non-positive line results" do
-      output = "not grep output\nfile.ex:nope:# TODO bad\nfile.ex:0:# TODO bad\n"
-      assert TodoSearchSource.parse_output(output) == []
+      output = "bad\0nope\0# TODO bad\nfile.ex\00\0# TODO bad\n"
+      assert TodoSearchSource.parse_output(output, :git) == {[], false}
+    end
+
+    test "caps parsed matches and reports truncation" do
+      output = Enum.map_join(1..1_001, fn line -> "file.ex\0#{line}\0# TODO item\n" end)
+
+      assert {markers, true} = TodoSearchSource.parse_output(output, :git)
+      assert length(markers) == TodoSearchSource.max_results()
     end
   end
 
   describe "build_candidates/2" do
-    test "creates picker items with icon, path line label, and trimmed description" do
-      [item] =
-        TodoSearchSource.build_candidates(
-          [%{path: "lib/example.ex", line: 3, text: "  # NOTE explain"}],
-          File.cwd!()
-        )
+    test "creates authorized picker items and rejects candidates outside the captured Root" do
+      root_path = temporary_root()
+      file = Path.join(root_path, "lib/example.ex")
+      File.mkdir_p!(Path.dirname(file))
+      File.write!(file, "# NOTE explain\n")
+      root = directory_root!(root_path)
 
-      assert item.label =~ "lib/example.ex:3"
+      markers = [
+        %{path: "lib/example.ex", line: 1, text: "  # NOTE explain"},
+        %{path: "/etc/passwd", line: 1, text: "# TODO forged"},
+        %{path: "../outside.ex", line: 1, text: "# TODO escaped"}
+      ]
+
+      assert [item] = TodoSearchSource.build_candidates(markers, root)
+      assert item.label =~ "lib/example.ex:1"
       assert item.description == "# NOTE explain"
       assert item.icon_color != nil
-      assert item.id.line == 3
-      assert String.ends_with?(item.id.path, "lib/example.ex")
+      assert item.id == %{path: file, line: 1, index: 0}
     end
 
-    test "empty and error results produce no items" do
-      assert TodoSearchSource.build_candidates({:ok, ""}, File.cwd!()) == []
-      assert TodoSearchSource.build_candidates({:error, "grep failed"}, File.cwd!()) == []
+    test "empty results produce no items" do
+      assert TodoSearchSource.build_candidates([], directory_root!(temporary_root())) == []
     end
   end
 
@@ -81,105 +96,124 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
       assert item.description == "# FIXME outside git"
     end
 
+    test "newline-containing filenames cannot forge an absolute candidate" do
+      root_path = temporary_root()
+      forged_path = Path.join([root_path, "prefix\n", "etc", "passwd:1:# TODO forged"])
+      File.mkdir_p!(Path.dirname(forged_path))
+      File.write!(forged_path, "# TODO real match\n")
+
+      assert {:ok, %TodoSearch.Result{items: [item]}} = TodoSearch.run(effect(root_path))
+      assert item.id.path == forged_path
+      refute item.id.path == "/etc/passwd"
+    end
+
     test "preserves command failure presentation" do
       root_path = temporary_root()
       :ok = TodoSearchPortProbe.configure(:failure)
 
       assert {:error, message} = TodoSearch.run(effect(root_path, impl: TodoSearchPortProbe))
-
       assert message == "grep exited with status 2: probe failure"
     end
 
-    test "marks a result stale when its revision differs from the request" do
-      root = directory_root!(temporary_root())
-      assert {:ok, _snapshot} = Project.activate(root)
-      state = base_state(content: "scratch")
-      {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
-      request = TodoSearch.request(root, revision)
+    test "surfaces the match cap in result metadata" do
+      root_path = temporary_root()
+      file = Path.join(root_path, "lib/example.ex")
+      File.mkdir_p!(Path.dirname(file))
+      File.write!(file, "# TODO probe\n")
 
-      result = %TodoSearch.Result{
-        revision: make_ref(),
-        items: [],
-        candidates: [],
-        meta: %{}
-      }
+      output =
+        Enum.map_join(1..1_001, fn line -> "lib/example.ex\0#{line}\0# TODO probe\n" end)
+
+      :ok = TodoSearchPortProbe.configure({:search_output, output})
+
+      assert {:ok, %TodoSearch.Result{items: items, meta: meta}} =
+               TodoSearch.run(effect(root_path, impl: TodoSearchPortProbe))
+
+      assert length(items) == TodoSearchSource.max_results()
+      assert meta == %{status: "Results truncated to #{TodoSearchSource.max_results()}"}
+    end
+  end
+
+  describe "stale outcome safety" do
+    test "applies completed and failed outcomes in the captured workspace activation" do
+      {snapshot, state, revision, request} = live_request()
+      assert Project.snapshot().activation_id == snapshot.activation_id
+
+      assert {completed_state, %Outcome{status: :completed}} =
+               TodoSearch.apply(state, Outcome.completed(request, result(revision)))
+
+      refute completed_state == state
+
+      assert {failed_state, %Outcome{status: :failed}} =
+               TodoSearch.apply(state, Outcome.failed(request, "probe failure"))
+
+      refute failed_state == state
+    end
+
+    test "marks completed and failed outcomes stale after rerooting" do
+      {_snapshot, state, revision, request} = live_request()
+      assert {:ok, _snapshot} = Project.activate(directory_root!(temporary_root()))
+
+      assert_stale_pair(state, request, revision, :workspace_rerooted)
+    end
+
+    test "marks completed and failed outcomes stale after picker replacement" do
+      {_snapshot, state, revision, request} = live_request()
+      {replaced_state, _replacement_revision} = PickerUI.open_loading(state, FileSource)
+
+      assert_stale_pair(replaced_state, request, revision, :picker_closed_or_replaced)
+    end
+
+    test "marks completed and failed outcomes stale after the picker revision changes" do
+      {_snapshot, state, revision, request} = live_request()
+      {newer_state, _new_revision} = PickerUI.open_loading(state, TodoSearchSource)
+
+      assert_stale_pair(newer_state, request, revision, :picker_closed_or_replaced)
+    end
+
+    test "marks a completed result stale when its carried revision differs" do
+      {_snapshot, state, _revision, request} = live_request()
 
       assert {^state, %Outcome{status: :stale, reason: :revision_mismatch}} =
-               TodoSearch.apply(state, Outcome.completed(request, result))
+               TodoSearch.apply(state, Outcome.completed(request, result(make_ref())))
     end
 
-    test "marks a result stale after another picker source replaces TODO search" do
-      root = directory_root!(temporary_root())
-      assert {:ok, _snapshot} = Project.activate(root)
-      state = base_state(content: "scratch")
-      {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
-      {state, _replacement_revision} = PickerUI.open_loading(state, FileSource)
-      request = TodoSearch.request(root, revision)
+    test "rejects completed and failed outcomes after an A to B to A activation cycle" do
+      {snapshot_a, state, revision, request} = live_request()
+      root_a = snapshot_a.root
+      assert {:ok, _snapshot_b} = Project.activate(directory_root!(temporary_root()))
+      assert {:ok, snapshot_a2} = Project.activate(root_a)
+      assert snapshot_a2.root == root_a
+      assert snapshot_a2.activation_id > snapshot_a.activation_id
 
-      result = %TodoSearch.Result{
-        revision: revision,
-        items: [],
-        candidates: [],
-        meta: %{}
-      }
-
-      assert {^state, %Outcome{status: :stale, reason: :picker_closed_or_replaced}} =
-               TodoSearch.apply(state, Outcome.completed(request, result))
-    end
-
-    test "rejects a result after the active workspace reroots" do
-      root_a = directory_root!(temporary_root())
-      root_b = directory_root!(temporary_root())
-      assert {:ok, _snapshot} = Project.activate(root_a)
-
-      state = base_state(content: "scratch")
-      {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
-      request = TodoSearch.request(root_a, revision)
-      assert {:ok, _snapshot} = Project.activate(root_b)
-
-      result = %TodoSearch.Result{
-        revision: revision,
-        items: [],
-        candidates: [],
-        meta: %{}
-      }
-
-      assert {^state, %Outcome{status: :stale, reason: :workspace_rerooted}} =
-               TodoSearch.apply(state, Outcome.completed(request, result))
+      assert_stale_pair(state, request, revision, :workspace_rerooted)
     end
   end
 
   describe "root authorization boundary" do
-    test "passes only the canonical path into Port arguments and candidate expansion" do
+    test "passes only the canonical path into Port arguments and candidate authorization" do
       container = temporary_root()
       canonical = Path.join(container, "canonical")
       alias_path = Path.join(container, "alias")
-      File.mkdir_p!(canonical)
+      file = Path.join(canonical, "lib/example.ex")
+      File.mkdir_p!(Path.dirname(file))
+      File.write!(file, "# TODO probe\n")
       File.ln_s!(canonical, alias_path)
       root = directory_root!(alias_path)
 
       assert {:ok, %TodoSearch.Result{items: [item]}} =
-               TodoSearch.run(%TodoSearch{
-                 root: root,
-                 revision: make_ref(),
-                 impl: TodoSearchPortProbe
-               })
+               TodoSearch.run(todo_effect(root, TodoSearchPortProbe))
 
       assert_received {:todo_search_port_opened, "git",
                        ["-C", ^canonical, "rev-parse", "--is-inside-work-tree"]}
 
-      assert item.id.path == Path.join(canonical, "lib/example.ex")
+      assert item.id.path == file
     end
 
     test "accepts a confirmed broad root before opening the probe Port" do
       root = %Root{kind: :directory, path: "/", broad_root_confirmed?: true}
 
-      assert {:ok, %TodoSearch.Result{}} =
-               TodoSearch.run(%TodoSearch{
-                 root: root,
-                 revision: make_ref(),
-                 impl: TodoSearchPortProbe
-               })
+      assert {:ok, %TodoSearch.Result{}} = TodoSearch.run(todo_effect(root, TodoSearchPortProbe))
 
       assert_received {:todo_search_port_opened, "git",
                        ["-C", "/", "rev-parse", "--is-inside-work-tree"]}
@@ -187,21 +221,18 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
 
     test "rejects broad roots without confirmation before a Port opens" do
       root = %Root{kind: :directory, path: "/", broad_root_confirmed?: false}
-
       assert_rejected_before_port(root, :broad_root_confirmation_required)
     end
 
     test "rejects invalid broad-root confirmation before a Port opens" do
       root_path = temporary_root()
       root = %Root{kind: :directory, path: root_path, broad_root_confirmed?: :invalid}
-
       assert_rejected_before_port(root, :invalid_broad_root_confirmation)
     end
 
     test "rejects file-scoped roots before a Port opens" do
       file = Path.join(temporary_root(), "file.ex")
       File.write!(file, "# TODO not recursive\n")
-
       assert_rejected_before_port(Root.file(file), :not_a_directory_root)
     end
 
@@ -210,7 +241,6 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
       root = directory_root!(root_path)
       File.rm_rf!(root_path)
       File.write!(root_path, "not a directory")
-
       assert_rejected_before_port(root, :not_a_directory)
     end
 
@@ -223,7 +253,6 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
       root = directory_root!(root_path)
       File.rm_rf!(root_path)
       File.ln_s!(replacement, root_path)
-
       assert_rejected_before_port(root, :root_changed)
     end
   end
@@ -249,13 +278,42 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
     end
   end
 
+  @spec live_request() :: {WorkspaceSnapshot.t(), EditorState.t(), reference(), term()}
+  defp live_request do
+    root = directory_root!(temporary_root())
+    assert {:ok, snapshot} = Project.activate(root)
+    state = base_state(content: "scratch")
+    {state, revision} = PickerUI.open_loading(state, TodoSearchSource)
+    {snapshot, state, revision, TodoSearch.request(snapshot, revision)}
+  end
+
+  @spec result(reference()) :: TodoSearch.Result.t()
+  defp result(revision) do
+    %TodoSearch.Result{revision: revision, items: [], candidates: [], meta: %{}}
+  end
+
+  @spec assert_stale_pair(EditorState.t(), term(), reference(), atom()) :: :ok
+  defp assert_stale_pair(state, request, revision, reason) do
+    assert {^state, %Outcome{status: :stale, reason: ^reason}} =
+             TodoSearch.apply(state, Outcome.completed(request, result(revision)))
+
+    assert {^state, %Outcome{status: :stale, reason: ^reason}} =
+             TodoSearch.apply(state, Outcome.failed(request, "probe failure"))
+
+    :ok
+  end
+
   @spec effect(String.t(), keyword()) :: TodoSearch.t()
   defp effect(root_path, opts \\ []) do
-    %TodoSearch{
-      root: directory_root!(root_path),
-      revision: make_ref(),
-      impl: Keyword.get(opts, :impl, MingaEditor.Effects.TodoSearch.Port)
-    }
+    todo_effect(
+      directory_root!(root_path),
+      Keyword.get(opts, :impl, MingaEditor.Effects.TodoSearch.Port)
+    )
+  end
+
+  @spec todo_effect(Root.t(), module()) :: TodoSearch.t()
+  defp todo_effect(root, impl) do
+    %TodoSearch{root: root, activation_id: 1, revision: make_ref(), impl: impl}
   end
 
   @spec directory_root!(String.t()) :: Root.t()
@@ -266,11 +324,8 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
 
   @spec assert_rejected_before_port(Root.t(), Root.error()) :: :ok
   defp assert_rejected_before_port(root, reason) do
-    assert TodoSearch.run(%TodoSearch{
-             root: root,
-             revision: make_ref(),
-             impl: TodoSearchPortProbe
-           }) == {:error, "TODO search root rejected: #{reason}"}
+    assert TodoSearch.run(todo_effect(root, TodoSearchPortProbe)) ==
+             {:error, "TODO search root rejected: #{reason}"}
 
     refute_received {:todo_search_port_opened, _command, _args}
     :ok
@@ -286,14 +341,14 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
     root_path
   end
 
-  @spec restore_project(Minga.Project.WorkspaceSnapshot.t() | nil) :: :ok
+  @spec restore_project(WorkspaceSnapshot.t() | nil) :: :ok
   defp restore_project(nil) do
     Project.close()
     _ = :sys.get_state(Project)
     :ok
   end
 
-  defp restore_project(%Minga.Project.WorkspaceSnapshot{root: root}) do
+  defp restore_project(%WorkspaceSnapshot{root: root}) do
     Project.close()
     _ = :sys.get_state(Project)
     _ = Project.activate(root)

--- a/test/support/todo_search_port_probe.ex
+++ b/test/support/todo_search_port_probe.ex
@@ -5,9 +5,16 @@ defmodule Minga.Test.TodoSearchPortProbe do
 
   @mode_key {__MODULE__, :mode}
 
+  @type mode :: :success | :failure | {:search_output, String.t()}
+
   @doc "Configures the probe response mode for the calling test process."
-  @spec configure(:success | :failure) :: :ok
+  @spec configure(mode()) :: :ok
   def configure(mode) when mode in [:success, :failure] do
+    Process.put(@mode_key, mode)
+    :ok
+  end
+
+  def configure({:search_output, output} = mode) when is_binary(output) do
     Process.put(@mode_key, mode)
     :ok
   end
@@ -20,11 +27,15 @@ defmodule Minga.Test.TodoSearchPortProbe do
     response(Process.get(@mode_key, :success), command, args)
   end
 
-  @spec response(:success | :failure, String.t(), [String.t()]) ::
-          {String.t(), non_neg_integer()}
+  @spec response(mode(), String.t(), [String.t()]) :: {String.t(), non_neg_integer()}
   defp response(:success, "git", [_flag, _root, "rev-parse" | _rest]), do: {"true\n", 0}
-  defp response(:success, "git", _args), do: {"lib/example.ex:1:# TODO probe\n", 0}
-  defp response(:success, _command, _args), do: {"example.ex:1:# TODO probe\n", 0}
+  defp response(:success, "git", _args), do: {"lib/example.ex\0" <> "1\0# TODO probe\n", 0}
+  defp response(:success, _command, _args), do: {"example.ex\0" <> "1:# TODO probe\n", 0}
   defp response(:failure, "git", [_flag, _root, "rev-parse" | _rest]), do: {"", 1}
   defp response(:failure, _command, _args), do: {"probe failure", 2}
+
+  defp response({:search_output, _output}, "git", [_flag, _root, "rev-parse" | _rest]),
+    do: {"true\n", 0}
+
+  defp response({:search_output, output}, _command, _args), do: {output, 0}
 end


### PR DESCRIPTION
# TL;DR
TODO search now enforces a fixed execution deadline, bounds output and result memory, rejects forged paths, and prevents stale A→B→A workspace results from reaching the picker.

Follow-up to #2948 and #2949.

## Context
The original typed-root change preserved authorization through scheduling, but grep output and stale-result checks still had unsafe gaps. Continuous output could extend the timeout indefinitely, hostile filenames could forge an absolute result path, and comparing only Root values could accept an old result after the workspace changed away and back.

## Changes
- Add a monotonic workspace activation identity and require it for successful and failed TODO search outcomes.
- Use NUL-framed git and recursive grep output, then authorize every parsed candidate through the captured Root.
- Enforce an absolute five-second Port deadline and an 8 MiB total output ceiling.
- Kill and reap the spawned OS process before returning timeout or overflow status.
- Cap parsed matches at 1,000 and expose truncation in result metadata.
- Add regression coverage for continuous-output timeout, output overflow, hostile filenames, authorization, truncation, and A→B→A stale outcomes.

## Verification
- Focused TODO search and workspace suites (94 passed)
- Heavy Port lifecycle tests (2 passed)
- Focused post-fix TODO search tests (26 passed)
- `make lint`
- `mix test.llm` (9,606 tests, 0 failures)
- Touched-file LSP diagnostics (0 findings)

## Acceptance Criteria Addressed
- Search execution remains generation-owned, cancellable, and bounded by an absolute five-second deadline. ✅
- Search candidates cannot escape the captured workspace authorization boundary. ✅
- Results from replaced picker revisions or prior workspace activations cannot install, including A→B→A transitions. ✅
