### PR TITLE
fix(ui): preserve project file candidate actions

### DIFF
--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -64,22 +64,29 @@ defmodule Minga.Buffer do
     abs_path = Path.expand(path)
     options_server = Keyword.get(opts, :options_server, Minga.Config.Options.default_server())
 
+    history_attribution =
+      Keyword.get(opts, :history_attribution, :active_workspace)
+
     case pid_for_path(abs_path) do
       {:ok, pid} ->
         {:ok, pid}
 
       :not_found ->
         if File.exists?(abs_path) do
-          start_buffer_for_path(abs_path, events_registry, options_server)
+          start_buffer_for_path(abs_path, events_registry, options_server, history_attribution)
         else
           {:error, :enoent}
         end
     end
   end
 
-  @spec start_buffer_for_path(String.t(), Minga.Events.registry(), Minga.Config.Options.server()) ::
-          {:ok, pid()} | {:error, term()}
-  defp start_buffer_for_path(abs_path, events_registry, options_server) do
+  @spec start_buffer_for_path(
+          String.t(),
+          Minga.Events.registry(),
+          Minga.Config.Options.server(),
+          Minga.Events.BufferEvent.history_attribution()
+        ) :: {:ok, pid()} | {:error, term()}
+  defp start_buffer_for_path(abs_path, events_registry, options_server, history_attribution) do
     case DynamicSupervisor.start_child(
            Minga.Buffer.Supervisor,
            {__MODULE__,
@@ -90,7 +97,8 @@ defmodule Minga.Buffer do
           :buffer_opened,
           %Minga.Events.BufferEvent{
             buffer: pid,
-            path: abs_path
+            path: abs_path,
+            history_attribution: history_attribution
           },
           events_registry
         )

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -72,9 +72,15 @@ defmodule Minga.Events do
   defmodule BufferEvent do
     @moduledoc "Payload for `:buffer_saved` and `:buffer_opened` events."
     @enforce_keys [:buffer, :path]
-    defstruct [:buffer, :path]
+    defstruct [:buffer, :path, history_attribution: :active_workspace]
 
-    @type t :: %__MODULE__{buffer: pid(), path: String.t()}
+    @type history_attribution :: :active_workspace | :caller_managed
+
+    @type t :: %__MODULE__{
+            buffer: pid(),
+            path: String.t(),
+            history_attribution: history_attribution()
+          }
   end
 
   defmodule BufferClosedEvent do

--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -220,6 +220,19 @@ defmodule Minga.Project do
     GenServer.cast(server, {:record_file, file_path})
   end
 
+  @doc """
+  Records a workspace-relative file under its captured project root.
+
+  Unlike `record_file/2`, this does not consult the active workspace. The path
+  is re-authorized through the supplied root before that project's recent-file
+  and frecency history is updated.
+  """
+  @spec record_file_for_root(GenServer.server(), Root.t(), String.t()) :: :ok
+  def record_file_for_root(server \\ __MODULE__, %Root{kind: :directory} = root, relative_path)
+      when is_binary(relative_path) do
+    GenServer.cast(server, {:record_file_for_root, root, relative_path})
+  end
+
   @doc "Returns the list of recently opened files for the current project (relative paths, most recent first)."
   @spec recent_files(GenServer.server()) :: [String.t()]
   def recent_files(server \\ __MODULE__) do
@@ -430,6 +443,10 @@ defmodule Minga.Project do
     {:noreply, do_record_file(state, file_path)}
   end
 
+  def handle_cast({:record_file_for_root, root, relative_path}, state) do
+    {:noreply, do_record_file_for_root(state, root, relative_path)}
+  end
+
   def handle_cast({:record_command, command_name}, state) do
     {:noreply, do_record_command(state, command_name)}
   end
@@ -522,35 +539,47 @@ defmodule Minga.Project do
     root = workspace_path(state.workspace)
 
     case make_relative(expanded, root) do
-      nil ->
-        state
-
-      rel_path ->
-        limit = recent_files_limit()
-        existing = Map.get(state.recent_files, root, [])
-        updated = [rel_path | Enum.reject(existing, &(&1 == rel_path))]
-        updated = Enum.take(updated, limit)
-        new_recent = Map.put(state.recent_files, root, updated)
-
-        now_unix = System.system_time(:second)
-
-        new_frecency =
-          state.frecency_events
-          |> Map.get(root, %{})
-          |> Map.update(rel_path, [now_unix], fn timestamps ->
-            [now_unix | timestamps] |> Enum.take(@frecency_events_per_file_limit)
-          end)
-          |> then(&Map.put(state.frecency_events, root, &1))
-
-        state = %{state | recent_files: new_recent, frecency_events: new_frecency}
-
-        if persist_recent_files?() do
-          persist_recent_files(new_recent)
-          persist_frecency_events(new_frecency)
-        end
-
-        state
+      nil -> state
+      rel_path -> update_file_history(state, root, rel_path)
     end
+  end
+
+  @spec do_record_file_for_root(t(), Root.t(), String.t()) :: t()
+  defp do_record_file_for_root(state, %Root{kind: :directory} = root, relative_path) do
+    with {:ok, safe_relative} when safe_relative != "" <- Path.safe_relative(relative_path),
+         {:ok, _canonical_path} <- Root.resolve_file(root, safe_relative) do
+      update_file_history(state, root.path, safe_relative)
+    else
+      _invalid_or_missing_path -> state
+    end
+  end
+
+  @spec update_file_history(t(), String.t(), String.t()) :: t()
+  defp update_file_history(state, root, rel_path) do
+    limit = recent_files_limit()
+    existing = Map.get(state.recent_files, root, [])
+    updated = [rel_path | Enum.reject(existing, &(&1 == rel_path))]
+    updated = Enum.take(updated, limit)
+    new_recent = Map.put(state.recent_files, root, updated)
+
+    now_unix = System.system_time(:second)
+
+    new_frecency =
+      state.frecency_events
+      |> Map.get(root, %{})
+      |> Map.update(rel_path, [now_unix], fn timestamps ->
+        [now_unix | timestamps] |> Enum.take(@frecency_events_per_file_limit)
+      end)
+      |> then(&Map.put(state.frecency_events, root, &1))
+
+    state = %{state | recent_files: new_recent, frecency_events: new_frecency}
+
+    if persist_recent_files?() do
+      persist_recent_files(new_recent)
+      persist_frecency_events(new_frecency)
+    end
+
+    state
   end
 
   @spec do_record_command(t(), atom()) :: t()

--- a/lib/minga/project.ex
+++ b/lib/minga/project.ex
@@ -492,6 +492,14 @@ defmodule Minga.Project do
     {:noreply, clear_rebuild(state)}
   end
 
+  def handle_info(
+        {:minga_event, :buffer_opened,
+         %Minga.Events.BufferEvent{history_attribution: :caller_managed}},
+        state
+      ) do
+    {:noreply, state}
+  end
+
   def handle_info({:minga_event, :buffer_opened, %Minga.Events.BufferEvent{path: path}}, state) do
     {:noreply, do_record_file(state, path)}
   end

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -774,14 +774,22 @@ defmodule MingaEditor.Commands do
 
   @doc "Returns the existing buffer for a file path, or starts one if needed."
   @spec start_buffer(String.t()) :: {:ok, pid()} | {:error, term()}
+  def start_buffer(file_path), do: start_buffer(file_path, nil, [])
+
   @spec start_buffer(String.t(), Minga.Config.Options.server() | nil) ::
           {:ok, pid()} | {:error, term()}
-  def start_buffer(file_path, options_server \\ nil) do
+  def start_buffer(file_path, options_server), do: start_buffer(file_path, options_server, [])
+
+  @spec start_buffer(String.t(), Minga.Config.Options.server() | nil, keyword()) ::
+          {:ok, pid()} | {:error, term()}
+  def start_buffer(file_path, options_server, opts) do
     options_server = normalize_options_server(options_server)
+    history_attribution = Keyword.get(opts, :history_attribution, :active_workspace)
 
     MingaEditor.HugeFile.guard(file_path, options_server, fn ->
       Buffer.ensure_for_path(file_path, Minga.Events.default_registry(),
-        options_server: options_server
+        options_server: options_server,
+        history_attribution: history_attribution
       )
     end)
   end

--- a/lib/minga_editor/render_model/ui/picker_builder.ex
+++ b/lib/minga_editor/render_model/ui/picker_builder.ex
@@ -8,6 +8,7 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
   alias Minga.RenderModel.UI.Picker.ActionMenu
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Picker.FileSource
   alias MingaEditor.UI.Picker.ProjectFileCandidate
 
   @max_items 100
@@ -162,10 +163,11 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
   end
 
   # Build preview lines for a file path item.
-  @spec build_preview_for_item(Context.t(), Picker.Item.t()) ::
+  @spec build_preview_for_item(Context.t(), module() | nil, Picker.Item.t()) ::
           [[PickerModel.preview_segment()]] | nil
   defp build_preview_for_item(
          ctx,
+         _source,
          %Picker.Item{id: %ProjectFileCandidate{} = candidate}
        ) do
     abs_path =
@@ -177,18 +179,20 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
     build_file_preview(ctx, abs_path)
   end
 
-  defp build_preview_for_item(ctx, %Picker.Item{id: id}) when is_binary(id) do
+  defp build_preview_for_item(_ctx, FileSource, %Picker.Item{}), do: nil
+
+  defp build_preview_for_item(ctx, _source, %Picker.Item{id: id}) when is_binary(id) do
     build_file_preview(ctx, resolve_preview_path(id, Minga.Project.resolve_root()))
   end
 
-  defp build_preview_for_item(ctx, %Picker.Item{id: idx}) when is_integer(idx) do
+  defp build_preview_for_item(ctx, _source, %Picker.Item{id: idx}) when is_integer(idx) do
     case Enum.at(ctx.buffers.list, idx) do
       nil -> nil
       buf_pid -> preview_from_buffer(ctx, buf_pid)
     end
   end
 
-  defp build_preview_for_item(_ctx, _id), do: nil
+  defp build_preview_for_item(_ctx, _source, _item), do: nil
 
   @spec build_file_preview(Context.t(), String.t() | nil) ::
           [[PickerModel.preview_segment()]] | nil

--- a/lib/minga_editor/render_model/ui/picker_builder.ex
+++ b/lib/minga_editor/render_model/ui/picker_builder.ex
@@ -156,7 +156,7 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
 
       %Picker.Item{} = item ->
         case Picker.Source.preview(source, item, ctx, callback_source) do
-          nil -> build_preview_for_item(ctx, item)
+          nil -> build_preview_for_item(ctx, source, item)
           lines -> lines
         end
     end

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -159,7 +159,9 @@ defmodule MingaEditor.UI.Picker.FileSource do
   defp open_selected_file({:ok, abs_path}, candidate, state) do
     case MingaEditor.Handlers.BufferRegistry.find_buffer_by_path(state, abs_path) do
       nil ->
-        case MingaEditor.Commands.start_buffer(abs_path, state.interaction.options_server) do
+        case MingaEditor.Commands.start_buffer(abs_path, state.interaction.options_server,
+               history_attribution: :caller_managed
+             ) do
           {:ok, pid} ->
             Log.debug(:editor, "[file_picker] new buffer pid=#{inspect(pid)}")
             new_state = MingaEditor.Handlers.BufferRegistry.add_buffer(state, pid)

--- a/lib/minga_editor/ui/picker/file_source.ex
+++ b/lib/minga_editor/ui/picker/file_source.ex
@@ -131,6 +131,8 @@ defmodule MingaEditor.UI.Picker.FileSource do
     }
   end
 
+  defp enrich_item(%Item{} = item), do: item
+
   @spec log_error(String.t()) :: []
   defp log_error(msg) do
     Minga.Log.error(:editor, "find_file: #{msg}")
@@ -141,26 +143,27 @@ defmodule MingaEditor.UI.Picker.FileSource do
   @spec on_select(Item.t(), term()) :: term()
   def on_select(%Item{id: %ProjectFileCandidate{} = candidate}, state) do
     Log.debug(:editor, "[file_picker] on_select path=#{candidate.path}")
-    open_selected_file(ProjectFileCandidate.resolve(candidate), state)
+    open_selected_file(ProjectFileCandidate.resolve(candidate), candidate, state)
   end
 
   @spec open_selected_file(
           {:ok, String.t()} | {:error, ProjectFileCandidate.error()},
+          ProjectFileCandidate.t(),
           term()
         ) :: term()
-  defp open_selected_file({:error, reason}, state) do
+  defp open_selected_file({:error, reason}, _candidate, state) do
     Log.error(:editor, "Failed to resolve project file candidate: #{inspect(reason)}")
     state
   end
 
-  defp open_selected_file({:ok, abs_path}, state) do
+  defp open_selected_file({:ok, abs_path}, candidate, state) do
     case MingaEditor.Handlers.BufferRegistry.find_buffer_by_path(state, abs_path) do
       nil ->
         case MingaEditor.Commands.start_buffer(abs_path, state.interaction.options_server) do
           {:ok, pid} ->
             Log.debug(:editor, "[file_picker] new buffer pid=#{inspect(pid)}")
             new_state = MingaEditor.Handlers.BufferRegistry.add_buffer(state, pid)
-            record_selection(abs_path, state)
+            record_selection(candidate, state)
             new_state
 
           {:error, reason} ->
@@ -170,7 +173,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
 
       idx ->
         new_state = switch_existing_buffer(state, idx)
-        record_selection(abs_path, state)
+        record_selection(candidate, state)
         new_state
     end
   end
@@ -222,7 +225,7 @@ defmodule MingaEditor.UI.Picker.FileSource do
         %Item{id: %ProjectFileCandidate{} = candidate},
         state
       ) do
-    delete_selected_file(ProjectFileCandidate.resolve(candidate), state)
+    delete_selected_file(ProjectFileCandidate.authorized_entry_path(candidate), state)
   end
 
   def on_action(_action, _item, state), do: state
@@ -268,12 +271,12 @@ defmodule MingaEditor.UI.Picker.FileSource do
     Enum.reduce(items, state, fn item, acc -> on_select(item, acc) end)
   end
 
-  @spec record_selection(String.t(), term()) :: :ok
-  defp record_selection(_abs_path, %{buffer_lifecycle: %{buffer_add_context: :preview}}),
+  @spec record_selection(ProjectFileCandidate.t(), term()) :: :ok
+  defp record_selection(_candidate, %{buffer_lifecycle: %{buffer_add_context: :preview}}),
     do: :ok
 
-  defp record_selection(abs_path, _state) do
-    Minga.Project.record_file(abs_path)
+  defp record_selection(%ProjectFileCandidate{root: root, path: path}, _state) do
+    Minga.Project.record_file_for_root(root, path)
   catch
     :exit, _ -> :ok
   end

--- a/lib/minga_editor/ui/picker/project_file_candidate.ex
+++ b/lib/minga_editor/ui/picker/project_file_candidate.ex
@@ -36,6 +36,20 @@ defmodule MingaEditor.UI.Picker.ProjectFileCandidate do
     Root.resolve_file(root, path)
   end
 
+  @doc """
+  Authorizes the candidate and returns its lexical workspace entry path.
+
+  This is for entry-level operations such as unlinking a symlink: authorization
+  follows the target through `Root`, while the returned path still names the
+  selected directory entry rather than its canonical referent.
+  """
+  @spec authorized_entry_path(t()) :: {:ok, String.t()} | {:error, error()}
+  def authorized_entry_path(%__MODULE__{root: %Root{} = root, path: path} = candidate) do
+    with {:ok, _canonical_path} <- resolve(candidate) do
+      {:ok, Path.join(root.path, path)}
+    end
+  end
+
   @spec safe_candidate(Root.t(), {:ok, String.t()} | :error) ::
           {:ok, t()} | {:error, :empty_path | :parent_traversal}
   defp safe_candidate(_root, {:ok, ""}), do: {:error, :empty_path}

--- a/sdk/lib/minga/events.ex
+++ b/sdk/lib/minga/events.ex
@@ -47,8 +47,14 @@ defmodule Minga.Events do
   defmodule BufferEvent do
     @moduledoc "Payload for `:buffer_saved` and `:buffer_opened` events."
     @enforce_keys [:buffer, :path]
-    defstruct [:buffer, :path]
+    defstruct [:buffer, :path, history_attribution: :active_workspace]
 
-    @type t :: %__MODULE__{buffer: pid(), path: String.t()}
+    @type history_attribution :: :active_workspace | :caller_managed
+
+    @type t :: %__MODULE__{
+            buffer: pid(),
+            path: String.t(),
+            history_attribution: history_attribution()
+          }
   end
 end

--- a/test/minga/events_test.exs
+++ b/test/minga/events_test.exs
@@ -13,6 +13,7 @@ defmodule Minga.EventsTest do
     assert :ok = Events.subscribe(:buffer_opened, registry)
     payload = %Events.BufferEvent{buffer: self(), path: "/tmp/test.ex"}
 
+    assert payload.history_attribution == :active_workspace
     assert :ok = Events.broadcast(:buffer_opened, payload, registry)
     assert_receive {:minga_event, :buffer_opened, ^payload}
     assert self() in Events.subscribers(:buffer_opened, registry)

--- a/test/minga/project_test.exs
+++ b/test/minga/project_test.exs
@@ -422,6 +422,34 @@ defmodule Minga.ProjectTest do
       assert "lib/app.ex" in recent
     end
 
+    test "root-scoped recording updates captured project history without switching workspaces", %{
+      tmp_dir: tmp
+    } do
+      project_a = Path.join(tmp, "captured_project")
+      project_b = Path.join(tmp, "active_project")
+      File.mkdir_p!(project_a)
+      File.mkdir_p!(project_b)
+      File.write!(Path.join(project_a, "captured.ex"), "")
+      {:ok, root_a} = Root.directory(project_a)
+
+      {_pid, name} = start_project!()
+      Project.switch(name, project_b)
+      flush(name)
+
+      Project.record_file_for_root(name, root_a, "captured.ex")
+      flush(name)
+
+      assert %WorkspaceSnapshot{root: %Root{path: ^project_b}} = Project.snapshot(name)
+      assert Project.recent_files(name) == []
+      assert Project.frecency_scores(name) == %{}
+
+      Project.switch(name, project_a)
+      flush(name)
+
+      assert Project.recent_files(name) == ["captured.ex"]
+      assert Project.frecency_scores(name)["captured.ex"] > 0
+    end
+
     test "most recently opened file appears first", %{tmp_dir: tmp} do
       project = Path.join(tmp, "recent_order")
       lib = Path.join(project, "lib")

--- a/test/minga_editor/commands/start_buffer_test.exs
+++ b/test/minga_editor/commands/start_buffer_test.exs
@@ -34,5 +34,23 @@ defmodule MingaEditor.Commands.StartBufferTest do
       assert {:ok, pid} = Commands.start_buffer(path, options_server)
       assert BufferProcess.get_option(pid, :autopair_block) == false
     end
+
+    test "attributes a newly opened buffer's history to its caller when requested", %{
+      tmp_dir: tmp_dir
+    } do
+      path = Path.join(tmp_dir, "caller-managed.txt")
+      File.write!(path, "hello")
+      Minga.Events.subscribe(:buffer_opened)
+
+      assert {:ok, pid} =
+               Commands.start_buffer(path, nil, history_attribution: :caller_managed)
+
+      assert_receive {:minga_event, :buffer_opened,
+                      %Minga.Events.BufferEvent{
+                        buffer: ^pid,
+                        path: ^path,
+                        history_attribution: :caller_managed
+                      }}
+    end
   end
 end

--- a/test/minga_editor/ui/picker/file_source_async_test.exs
+++ b/test/minga_editor/ui/picker/file_source_async_test.exs
@@ -91,6 +91,23 @@ defmodule MingaEditor.UI.Picker.FileSourceAsyncTest do
              Path.join(original_root, "same.txt")
   end
 
+  test "delete unlinks an authorized symlink without deleting its target", %{tmp_dir: tmp_dir} do
+    project = Path.join(tmp_dir, "symlink-delete")
+    target = Path.join(project, "target.txt")
+    link = Path.join(project, "link.txt")
+    File.mkdir_p!(project)
+    File.write!(target, "keep me")
+    File.ln_s!("target.txt", link)
+    {:ok, root} = Root.directory(project)
+
+    state = TestHelpers.base_state(content: "initial")
+    item = %Item{id: candidate!(root, "link.txt"), label: "link.txt"}
+
+    assert FileSource.on_action(:delete, item, state) == state
+    assert {:error, :enoent} = File.lstat(link)
+    assert File.read!(target) == "keep me"
+  end
+
   test "bulk actions expose open all marked", %{tmp_dir: tmp_dir} do
     File.mkdir_p!(tmp_dir)
     {:ok, root} = Root.directory(tmp_dir)

--- a/test/minga_editor/ui/picker/file_source_project_switch_test.exs
+++ b/test/minga_editor/ui/picker/file_source_project_switch_test.exs
@@ -155,6 +155,44 @@ defmodule MingaEditor.UI.Picker.FileSourceProjectSwitchTest do
     assert Project.frecency_scores()["single.txt"] > 0
   end
 
+  test "a stale nested-root candidate attributes a new buffer open only to its captured root", %{
+    tmp_dir: tmp_dir
+  } do
+    project_b = Path.join(tmp_dir, "live_project")
+    project_a = Path.join(project_b, "stale_nested_project")
+    relative_path = "nested.txt"
+    absolute_path = Path.join(project_a, relative_path)
+
+    File.mkdir_p!(project_a)
+    File.write!(absolute_path, "nested")
+    {:ok, root_a} = Root.directory(project_a)
+    {:ok, root_b} = Root.directory(project_b)
+    {:ok, stale_candidate} = ProjectFileCandidate.new(root_a, relative_path)
+
+    activate_project!(root_b)
+
+    initial_state =
+      TestHelpers.base_state(content: "initial")
+      |> set_file_tree(%FileTree{project_root: project_b})
+
+    selected_state =
+      FileSource.on_select(
+        %Picker.Item{id: stale_candidate, label: relative_path},
+        initial_state
+      )
+
+    on_exit(fn -> stop_added_buffers(selected_state, initial_state) end)
+    _ = :sys.get_state(Project)
+
+    assert Minga.Buffer.file_path(selected_state.workspace.buffers.active) == absolute_path
+    assert Project.recent_files() == []
+    assert Project.frecency_scores() == %{}
+
+    activate_project!(root_a)
+    assert Project.recent_files() == [relative_path]
+    assert Project.frecency_scores() == %{relative_path => 100}
+  end
+
   @spec activate_project!(Root.t()) :: :ok
   defp activate_project!(%Root{path: path} = root) do
     Minga.Events.subscribe(:project_rebuilt)

--- a/test/minga_editor/ui/picker/file_source_project_switch_test.exs
+++ b/test/minga_editor/ui/picker/file_source_project_switch_test.exs
@@ -169,6 +169,8 @@ defmodule MingaEditor.UI.Picker.FileSourceProjectSwitchTest do
     {:ok, root_b} = Root.directory(project_b)
     {:ok, stale_candidate} = ProjectFileCandidate.new(root_a, relative_path)
 
+    activate_project!(root_a)
+    existing_score = Map.get(Project.frecency_scores(), relative_path, 0)
     activate_project!(root_b)
 
     initial_state =
@@ -190,7 +192,7 @@ defmodule MingaEditor.UI.Picker.FileSourceProjectSwitchTest do
 
     activate_project!(root_a)
     assert Project.recent_files() == [relative_path]
-    assert Project.frecency_scores() == %{relative_path => 100}
+    assert Project.frecency_scores()[relative_path] == existing_score + 100
   end
 
   @spec activate_project!(Root.t()) :: :ok

--- a/test/minga_editor/ui/picker/file_source_project_switch_test.exs
+++ b/test/minga_editor/ui/picker/file_source_project_switch_test.exs
@@ -52,6 +52,11 @@ defmodule MingaEditor.UI.Picker.FileSourceProjectSwitchTest do
 
     activate_project!(root_a)
 
+    Enum.each(1..2, fn _ ->
+      Project.record_file_for_root(root_a, "marked/two.txt")
+      _ = :sys.get_state(Project)
+    end)
+
     production_state =
       TestHelpers.base_state(content: "initial")
       |> set_file_tree(%FileTree{project_root: project_a})
@@ -64,6 +69,7 @@ defmodule MingaEditor.UI.Picker.FileSourceProjectSwitchTest do
     items_by_path = Map.new(items, fn item -> {item.id.path, item} end)
 
     assert Enum.sort(Map.keys(items_by_path)) == Enum.sort(relative_paths)
+    assert hd(items).id.path == "marked/two.txt"
 
     assert Enum.all?(items, fn item ->
              match?(%ProjectFileCandidate{root: ^root_a}, item.id) and
@@ -92,6 +98,16 @@ defmodule MingaEditor.UI.Picker.FileSourceProjectSwitchTest do
       |> PickerBuilder.build()
 
     assert %PickerModel{preview_lines: [[{"A:preview.txt", 0xCCCCCC, false}]]} = preview_model
+
+    for legacy_id <- ["preview.txt", Path.join(project_b, "preview.txt")] do
+      legacy_preview_model =
+        %Picker.Item{id: legacy_id, label: "preview.txt"}
+        |> picker_modal()
+        |> build_preview_context(rerooted_state)
+        |> PickerBuilder.build()
+
+      assert legacy_preview_model.preview_lines == nil
+    end
 
     FileSource.on_action(:delete, items_by_path["delete.txt"], rerooted_state)
     refute File.exists?(Path.join(project_a, "delete.txt"))
@@ -124,6 +140,8 @@ defmodule MingaEditor.UI.Picker.FileSourceProjectSwitchTest do
     assert Minga.Buffer.file_path(bulk_opened_state.workspace.buffers.active) ==
              Path.join(project_a, "bulk/two.txt")
 
+    assert Project.frecency_scores() == %{}
+
     assert %Minga.Project.WorkspaceSnapshot{
              root: ^root_b,
              files: project_b_files,
@@ -131,6 +149,10 @@ defmodule MingaEditor.UI.Picker.FileSourceProjectSwitchTest do
            } = Project.snapshot()
 
     assert Enum.sort(project_b_files) == Enum.sort(relative_paths)
+
+    activate_project!(root_a)
+    assert "single.txt" in Project.recent_files()
+    assert Project.frecency_scores()["single.txt"] > 0
   end
 
   @spec activate_project!(Root.t()) :: :ok

--- a/test/minga_editor/ui/picker/project_file_candidate_test.exs
+++ b/test/minga_editor/ui/picker/project_file_candidate_test.exs
@@ -37,6 +37,22 @@ defmodule MingaEditor.UI.Picker.ProjectFileCandidateTest do
     assert {:error, :enoent} = ProjectFileCandidate.resolve(missing)
   end
 
+  test "authorized entry path preserves an in-workspace symlink's lexical path", %{
+    tmp_dir: tmp_dir
+  } do
+    workspace = Path.join(tmp_dir, "workspace")
+    target = Path.join(workspace, "target.txt")
+    link = Path.join(workspace, "link.txt")
+    File.mkdir_p!(workspace)
+    File.write!(target, "target")
+    File.ln_s!("target.txt", link)
+    {:ok, root} = Root.directory(workspace)
+    {:ok, candidate} = ProjectFileCandidate.new(root, "link.txt")
+
+    assert ProjectFileCandidate.resolve(candidate) == {:ok, target}
+    assert ProjectFileCandidate.authorized_entry_path(candidate) == {:ok, link}
+  end
+
   test "resolution rejects a symlink escaping the captured Root", %{tmp_dir: tmp_dir} do
     workspace = Path.join(tmp_dir, "workspace")
     outside = Path.join(tmp_dir, "outside.txt")


### PR DESCRIPTION
# TL;DR
Project file picker actions now preserve each candidate's captured workspace for deletion and history updates, so delayed choices cannot affect the wrong file or workspace.

Follow-up to #2946 and #2947.

## Context
The typed candidate work prevented stale picker choices from resolving against a new workspace, but two action paths still lost part of that identity. Deleting an authorized symlink removed its canonical target, and opening a stale candidate recorded history through the currently active Project workspace.

## Changes
- Authorize symlink candidates through their canonical target while unlinking the lexical symlink entry.
- Record recency and frecency against the candidate's captured project root without changing the active workspace.
- Mark caller-managed buffer opens in the event payload so the live workspace cannot add a second history entry.
- Preserve active-workspace attribution for every existing buffer-open caller.
- Reject legacy binary preview IDs for project file sources.
- Preserve scored typed-candidate ranking and add direct regression coverage for each behavior.

## Verification
- Focused project, event, command, and picker tests (39 passed)
- SDK tests (12 passed)
- `make lint`
- `mix test.llm` (9,605 tests, 0 failures)
- `git diff --check`
- Touched-file diagnostics (0 errors)

## Acceptance Criteria Addressed
- Delete and open actions use the candidate's captured identity rather than live workspace state. ✅
- In-workspace symlink deletion removes the link without deleting its target. ✅
- Ranking, previews, and root-scoped history remain compatible. ✅
