### PR TITLE
refactor(extension): centralize lifecycle authority

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -246,9 +246,18 @@ graph TD
     INDEP --> TASKSUP["Eval.TaskSupervisor"]
     INDEP --> CMDREG["Command.Registry"]
     INDEP --> DIAG["Diagnostics"]
-    SVC --> EXTREG["Extension.Registry"]
+    SVC --> EXTREG["Extension.Registry<br/><i>declaration/status projection</i>"]
+    SVC --> EXTINFRA["Artifact admission, code leases,<br/>and callback registries"]
+    SVC --> INSTREG["Extension.InstanceRegistry<br/><i>stable process names</i>"]
+    SVC --> ROOTSUP["Extension.RootSupervisor<br/><i>DynamicSupervisor</i>"]
+    ROOTSUP --> ROOT1["Extension.Root: git_porcelain<br/><i>rest_for_one</i>"]
+    ROOT1 --> RTSUP1["RuntimeSupervisor<br/><i>temporary runtime children</i>"]
+    ROOT1 --> INST1["Instance<br/><i>lifecycle authority</i>"]
+    RTSUP1 --> EXT1["Extension runtime child"]
+    ROOTSUP --> ROOT2["Extension.Root: user_extension<br/><i>rest_for_one</i>"]
+    ROOT2 --> RTSUP2["RuntimeSupervisor"]
+    ROOT2 --> INST2["Instance"]
     SVC --> AGENTREG["Agent contribution registries"]
-    SVC --> EXTSUP["Extension.Supervisor"]
     SVC --> LOADER["Config.Loader"]
     SVC --> LSPSUP["LSP.Supervisor<br/><i>DynamicSupervisor</i>"]
     LSPSUP --> LSP1["LSP Client: elixir-ls"]
@@ -262,6 +271,14 @@ graph TD
 
     style SVC fill:#6c3483,stroke:#4a235a,color:#fff
     style INDEP fill:#6c3483,stroke:#4a235a,color:#fff
+    style ROOTSUP fill:#1a5276,stroke:#154360,color:#fff
+    style ROOT1 fill:#6c3483,stroke:#4a235a,color:#fff
+    style ROOT2 fill:#6c3483,stroke:#4a235a,color:#fff
+    style INST1 fill:#884ea0,stroke:#6c3483,color:#fff
+    style INST2 fill:#884ea0,stroke:#6c3483,color:#fff
+    style RTSUP1 fill:#1a5276,stroke:#154360,color:#fff
+    style RTSUP2 fill:#1a5276,stroke:#154360,color:#fff
+    style EXT1 fill:#2471a3,stroke:#1a5276,color:#fff
     style LSPSUP fill:#1a5276,stroke:#154360,color:#fff
     style AGENTSUP fill:#1a5276,stroke:#154360,color:#fff
     style TASKSUP fill:#1a5276,stroke:#154360,color:#fff
@@ -271,6 +288,8 @@ graph TD
     style LSP1 fill:#2471a3,stroke:#1a5276,color:#fff
     style LSP2 fill:#2471a3,stroke:#1a5276,color:#fff
 ```
+
+Each extension declaration gets one ordered root beneath `Minga.Extension.RootSupervisor`. The root starts its local `RuntimeSupervisor` before its permanent `Instance`, using `rest_for_one` so replacing the runtime supervisor also replaces the Instance only after an empty local runtime supervisor exists. An Instance crash leaves its own runtime supervisor in place, allowing the replacement Instance to adopt only that extension's local runtime. Runtime children never serve as lifecycle identities.
 
 `Minga.Project` only starts recursive file inventory for an explicit directory workspace root. Root paths are canonicalized before authorization so symlink aliases cannot bypass broad-root protection. Each inventory runs in a monitored `Minga.Project.FileFind.Worker` that owns the external `git`, `fd`, or `find` process, bounds command output, and enforces a timeout for synchronous callers. Switching or closing the workspace, timing out, or stopping the Project service waits for the worker to terminate the external process tree.
 
@@ -316,7 +335,7 @@ graph TD
 
 ### Why this structure matters
 
-The nested supervisors constrain blast radius. Losing your LSP connection doesn't affect editing. A plugin error doesn't corrupt your buffers. A filesystem watcher flake restarts only FileWatcher, not the renderer. The `rest_for_one` chains within Foundation and Services preserve real dependency ordering (Events → Config subscribers, Extension.Registry → Config.Loader) while preventing unrelated siblings from cascading into each other.
+The nested supervisors constrain blast radius. Losing your LSP connection doesn't affect editing. A plugin error doesn't corrupt your buffers. A filesystem watcher flake restarts only FileWatcher, not the renderer. The `rest_for_one` chains within Foundation and Services preserve real dependency ordering, including Events before Config subscribers and extension admission, callback, registry, and root authorities before Config.Loader, while preventing unrelated siblings from cascading into each other.
 
 The system degrades in pieces rather than failing all at once. The BEAM was designed for telecom systems that run for years without downtime. The same supervision engineering applies here.
 
@@ -859,7 +878,17 @@ The custom Credo check `Minga.Credo.DependencyDirectionCheck` enforces both maps
 
 Safety-critical ownership does not move to optional packs. Credentials, approval, plan-mode refusal, retry, cost, compaction, session orchestration, event and message types, `MingaAgent.ToolRouter`, changesets, buffer forks, edit boundaries, and extension callback code leases stay in Level 0 or Level 1.
 
-### Extension artifact ownership and callback admission
+### Extension lifecycle, artifact, and callback ownership
+
+Every declared extension has one stable `Minga.Extension.Instance` mailbox that serializes eager start, lazy or deferred activation, stop, failure rollback, runtime exit, restart, and unload. The runtime child PID is an observed implementation detail. `Minga.Extension.Registry` is only the compatible declaration and status projection: `Instance` publishes the current PID, status, module, manifest, and error from its tagged phase, while callers never consult registry lifecycle fields to decide the next transition. `Minga.Extension.Supervisor` remains the compatible public facade for bulk prerequisites and the existing start, stop, list, and deferred APIs, but routes individual lifecycle requests to the Instance.
+
+Each `Minga.Extension.Root(name)` is a `rest_for_one` supervisor whose first child is a local `Minga.Extension.RuntimeSupervisor(name)` and whose second child is the permanent Instance. The runtime supervisor handles child mechanics only. It forces every runtime child spec to `:temporary`; the Instance preserves and interprets the extension's original `:permanent`, `:transient`, or `:temporary` restart policy exactly once. Runtime exits arrive through the Instance monitor, so replacement publication and restart telemetry are event-driven. If an Instance crashes, its replacement may adopt only the sole child of its own local runtime supervisor. If that supervisor crashes, `rest_for_one` stops the old Instance and starts a new Instance against a new empty runtime supervisor.
+
+Source resolution, artifact identity, and runtime admission are separate boundaries. Module, Hex/application, and bundled trusted-application declarations adopt verified resident application inventories. Resolved Git and path declarations compile from bounded immutable snapshots, and deterministic JSON is the fallback only when a path contains no Elixir source. All paths converge on one immutable current-generation artifact containing the module, manifest, owned modules, normalized child spec, and declared restart policy. Artifact admission owns code provenance for the BEAM generation; the Instance owns whether that admitted artifact has a stub, is starting, running, stopping, failed, or stopped.
+
+Lazy command races and deferred work call the same Instance mailbox as eager startup. A lazy stub captures the admitted artifact, concurrent triggers join one start, and deferred work verifies the captured declaration identity before activation. Stop joins concurrent callers, queues a start that arrives during finalization, and retains explicit retry state if safe cleanup cannot complete. Editor-owned effect cancellation, unload callbacks, and presentation cleanup are requested by cast and acknowledged asynchronously, so the Editor never blocks its mailbox waiting for an Instance that is itself waiting for Editor finalization.
+
+Runtime stop, disable, and restart keep admitted modules resident. Source edits and Git updates only report pending restart state; they do not compile, purge, or replace live code in the current VM. The same rule applies after lazy admission and after failure cleanup. A fresh BEAM process is the only activation boundary for changed code.
 
 Path and Git source is copied from verified regular-file descriptors into a bounded private snapshot, and that same immutable snapshot supplies both the cache key and a standalone disposable compiler OS process. Standard output and error cross only a bounded, discarded byte Port; extension source shares no ETF-capable host control channel. Compiler reports use bounded descriptor-verified UTF-8 files. A separate standalone validator process structurally parses untrusted BEAM atom tables and compressed Attr/LitT ETF against a private artifact snapshot before semantic decoding. Inflation is streaming and bounded, actual and declared sizes must agree, every external term is consumed exactly, and atom/decompressed totals are enforced per artifact and inventory. `Minga.Extension.ArtifactInventory` receives bounded binary metadata before the host creates module atoms or loads code: module identity and filenames must agree, duplicate emissions and symlink/non-regular entries are rejected, cache manifests must be complete, and artifact count, per/total bytes, atoms, manifest bytes, and reserved host atom headroom are limited. This isolates host validation; trusted extension execution still has the OS user's filesystem and network authority. `Minga.Extension.ArtifactAdmission` then claims the full set atomically for one source. Host/application and cross-extension collisions fail before any artifact is loaded. Cache hits and misses use this same admission path.
 

--- a/docs/EXTENSION_API.md
+++ b/docs/EXTENSION_API.md
@@ -61,24 +61,29 @@ end
 
 The `option` macro follows the same pattern as Ecto's `field`: you declare it at the module level, and `use Minga.Extension` generates a `__option_schema__/0` function from the accumulated declarations. You never write the introspection function yourself.
 
-**Lifecycle:** The user declares the extension in `config.exs`. Minga compiles it, introspects its manifest, validates config options against the schema, calls `init/1`, then starts `child_spec/1` under `Extension.Supervisor`. Runtime lifecycle and code activation are separate: Minga can stop, disable, lazily start, or restart an extension in the current session, but changed extension code activates only after Minga starts a fresh BEAM OS process. See [ADR-0003](adr/0003-extension-code-updates-require-a-new-vm-generation.md) for the accepted contract and migration scope.
+**Lifecycle:** The user declares the extension in `config.exs`. Minga resolves the source to one admitted current-generation artifact, introspects its manifest, validates config options against the schema, calls `init/1`, then starts `child_spec/1` beneath that extension's runtime supervisor. Runtime lifecycle and code activation are separate: Minga can stop, disable, lazily start, or restart an extension in the current session, but changed extension code activates only after Minga starts a fresh BEAM OS process. See [ADR-0003](adr/0003-extension-code-updates-require-a-new-vm-generation.md) for the accepted contract and migration scope.
 
 `init/1` is setup-only. It may register runtime-dynamic source-owned contributions and return `{:ok, state}` to report success, but the default child process does not receive that returned state. The default child stores the validated config keyword list so existing extensions keep working. If your extension has runtime state, put that state in your own GenServer or supervision tree and return it from your custom `child_spec/1`.
 
-Each extension runs under a `DynamicSupervisor` with `:one_for_one` strategy. If your extension crashes, only your extension restarts. The editor and other extensions keep running.
+Each declaration has one stable `Minga.Extension.Instance` process beneath `Minga.Extension.RootSupervisor`. Calls through the compatible `Minga.Extension.Supervisor` facade route start, stop, lazy activation, deferred activation, failure, restart, and unload through that Instance mailbox. The current runtime PID is not the extension's identity. It is a projection of the Instance's current phase, along with status, module, manifest, and last error, in `Minga.Extension.Registry`.
+
+The per-extension `Minga.Extension.Root` uses `rest_for_one` and starts `Minga.Extension.RuntimeSupervisor` before the Instance. A runtime supervisor failure therefore replaces the Instance after a new empty runtime supervisor exists. An Instance failure leaves its local runtime supervisor in place, so the replacement Instance can recover only that extension's child. Other extensions and the editor remain unaffected.
 
 ### Lifecycle ordering and cleanup
 
 The lifecycle contract is intentionally boring:
 
-1. **Load:** path and Git source compiles in a standalone disposable BEAM OS process with byte-only standard streams. The complete validated BEAM artifact set atomically establishes module ownership before host loading; hex extensions load from their installed application.
-2. **Manifest:** Minga records the extension name, version, source type, commands, keybindings, modeline segments, and declared capabilities before `init/1` runs.
-3. **Options:** declared options are validated and registered.
-4. **Init:** `init/1` runs. If it returns `{:error, reason}` or raises, startup fails.
-5. **Child start:** `child_spec/1` starts under the extension supervisor.
-6. **DSL registration:** declarative commands, keybindings, modeline segments, and runtime event handlers are registered with source `{:extension, name}`.
+1. **Source resolution:** module, Hex/application, and bundled sources identify a trusted resident application inventory. Resolved Git and path sources identify an immutable source snapshot. A path with no Elixir source may use the deterministic JSON fallback.
+2. **Artifact admission:** the complete module inventory establishes current-generation ownership before host loading. Path and resolved Git source compiles in a standalone disposable BEAM OS process with byte-only standard streams. Resident application sources are adopted rather than overwritten.
+3. **Manifest:** Minga records the extension name, version, source type, commands, keybindings, modeline segments, and declared capabilities before `init/1` runs.
+4. **Options:** declared options are validated and registered.
+5. **Init:** `init/1` runs. If it returns `{:error, reason}` or raises, startup fails.
+6. **Child start:** the child spec is normalized to `:temporary` and starts under the extension's local runtime supervisor. The Instance alone preserves and interprets the extension's declared `:permanent`, `:transient`, or `:temporary` restart policy.
+7. **DSL registration:** declarative commands, keybindings, modeline segments, and runtime event handlers are registered with source `{:extension, name}`.
 
-Stop, failed start, and reload all run source-owned cleanup. Cleanup families are aggregated: a failure in one family is logged and returned, but later cleanup families still run. This prevents a bad command cleanup from leaving stale keymaps, themes, languages, tool recipes, or modeline segments behind.
+Stop, failed start, and reload all converge through the Instance's source-owned cleanup transition. Concurrent starts join one start and receive the same runtime PID. Concurrent stops finalize once, and a start that reaches the mailbox during stop waits for safe cleanup before starting one replacement. A cleanup failure retains retry state rather than allowing a new start to bypass unfinished work. Cleanup families are aggregated: a failure in one family is logged and returned, but later cleanup families still run. This prevents a bad command cleanup from leaving stale keymaps, themes, languages, tool recipes, or modeline segments behind.
+
+Editor-owned finalization is asynchronous. The Instance casts effect cancellation, unload, and presentation cleanup requests to the Editor and waits for explicit acknowledgements without occupying the Editor mailbox. This ordering keeps config reload and effect-worker initiated reload paths from forming an Editor/Instance call cycle.
 
 Runtime disable closes new source-owned work, invokes source-unload handlers with unload-only authority, removes dispatch-visible contributions, cancels or settles source-owned effects, stops the runtime subtree, runs source cleanup, and removes Editor-owned presentation state. Loaded modules remain resident. A later start in the same session may use only the exact artifact admitted for that extension in the current VM generation; installing, updating, or editing extension code reports that a Minga restart is required.
 
@@ -128,9 +133,10 @@ end
 **How it works:**
 
 1. At boot, Minga admits the extension's isolated compiler artifact (via the validated compile cache, so this is fast for unchanged sources) and reads its schema callbacks (`__command_schema__/0`, `__keybind_schema__/0`, etc.).
-2. For non-eager extensions, Minga registers stub commands whose execute function triggers a synchronous autoload, then re-dispatches the command. Keybindings are registered normally (they reference command names, so the autoload happens via the stub command).
-3. `init/1` and `child_spec/1` are NOT called until the trigger fires.
-4. On first trigger: init runs, child starts, stub contributions are replaced with real handlers, and the original command executes. The user sees no difference besides first-invocation latency.
+2. For non-eager extensions, the Instance registers stub commands whose execute function triggers synchronous autoload through the same mailbox, then re-dispatches the command. Keybindings are registered normally because they reference command names.
+3. `init/1` and `child_spec/1` are not called until the trigger fires.
+4. Racing triggers join one Instance start and receive the same runtime. The stub is replaced with real handlers before the original command executes.
+5. Deferred activation also uses the same Instance and checks that its captured declaration identity is still current. Stale deferred work does not activate a re-registered extension.
 
 **What must stay eager:**
 

--- a/extensions/git_porcelain/test/minga_git_porcelain/lifecycle_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/lifecycle_test.exs
@@ -7,8 +7,11 @@ defmodule MingaGitPorcelain.LifecycleTest do
   use ExUnit.Case, async: false
 
   alias Minga.Command.Registry, as: CommandRegistry
+  alias Minga.Extension.ArtifactAdmission
   alias Minga.Extension.CodeLease
+  alias Minga.Extension.InstanceRegistry
   alias Minga.Extension.Registry, as: ExtRegistry
+  alias Minga.Extension.RuntimeSupervisor
   alias Minga.Extension.Supervisor, as: ExtSupervisor
   alias Minga.Keymap.Active, as: ActiveKeymap
   alias Minga.Keymap.Bindings
@@ -161,8 +164,16 @@ defmodule MingaGitPorcelain.LifecycleTest do
   test "reload terminates the old child and replaces source-owned contributions without duplicates" do
     ctx = start_lifecycle_context()
 
+    code_locations =
+      Map.new([MingaGitPorcelain, MingaGitPorcelain.Commands], &{&1, :code.which(&1)})
+
     first_pid = start_git_porcelain!(ctx)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx)) == {:ok, first_pid}
     assert_git_porcelain_contributions_registered(ctx)
+    assert {:ok, admitted} = ArtifactAdmission.source_modules(@source)
+    assert MingaGitPorcelain in admitted
+    assert MingaGitPorcelain.Commands in admitted
+    assert Map.new(Map.keys(code_locations), &{&1, :code.which(&1)}) == code_locations
 
     ref = Process.monitor(first_pid)
     stop_git_porcelain!(ctx)
@@ -170,6 +181,7 @@ defmodule MingaGitPorcelain.LifecycleTest do
     assert_git_porcelain_contributions_removed(ctx)
 
     second_pid = start_git_porcelain!(ctx)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx)) == {:ok, second_pid}
     assert second_pid != first_pid
     assert_git_porcelain_contributions_registered(ctx)
     assert Enum.count(Input.surface_handlers(), &(&1 == MingaGitPorcelain.Input.GitStatus)) == 1
@@ -202,6 +214,11 @@ defmodule MingaGitPorcelain.LifecycleTest do
 
   defp unique_name(prefix) do
     :"#{prefix}_#{System.unique_integer([:positive])}"
+  end
+
+  defp runtime_supervisor(ctx) do
+    registry = InstanceRegistry.registry_for_root(ctx.supervisor)
+    InstanceRegistry.via(registry, :runtime, :minga_git_porcelain)
   end
 
   defp start_git_porcelain!(ctx) do

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -111,7 +111,6 @@ defmodule Minga.Application do
     base_children =
       [
         MingaEditor.Shell.Registry,
-        Minga.Extension.CallbackRegistry,
         Minga.Foundation.Supervisor,
         {Registry, keys: :unique, name: Minga.Buffer.Registry},
         {DynamicSupervisor, name: Minga.Buffer.Supervisor, strategy: :one_for_one},

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -415,7 +415,7 @@ defmodule Minga.Config.Loader do
         plugin_error = discover_and_register_plugins(config_home)
 
         start_all_error =
-          if Process.whereis(Minga.Extension.Supervisor) != nil &&
+          if Process.whereis(Minga.Extension.RootSupervisor) != nil &&
                Application.get_env(:minga, :load_extensions, true) do
             start_all_extensions(cleanup_callbacks)
           end

--- a/lib/minga/events.ex
+++ b/lib/minga/events.ex
@@ -47,6 +47,7 @@ defmodule Minga.Events do
   | `:node_connected` | `Minga.Distribution.Events.NodeConnectedEvent` | `server_name, node, connected_at` |
   | `:node_disconnected` | `Minga.Distribution.Events.NodeDisconnectedEvent` | `server_name, node, reason, disconnected_at` |
   | `:power_thermal_state_changed` | `PowerThermalStateEvent` | `low_power?, thermal_state` |
+  | `:extension_deferred_batch_complete` | `Minga.Extension.DeferredBatchCompleteEvent` | `count, failures` |
 
   ## Why Registry?
 
@@ -340,6 +341,7 @@ defmodule Minga.Events do
           | :file_written
           | :extension_updates_available
           | :extension_restart_required
+          | :extension_deferred_batch_complete
           | :ghost_cursor_removed
 
   @typedoc "Typed event payloads. Each topic has a specific struct."
@@ -371,6 +373,7 @@ defmodule Minga.Events do
           | MingaAgent.Changeset.MergedEvent.t()
           | MingaAgent.Changeset.BudgetExhaustedEvent.t()
           | Minga.Extension.UpdatesAvailableEvent.t()
+          | Minga.Extension.DeferredBatchCompleteEvent.t()
           | map()
 
   # ── Child spec ──────────────────────────────────────────────────────────────
@@ -501,6 +504,10 @@ defmodule Minga.Events do
   @spec broadcast(:file_written, FileWrittenEvent.t()) :: :ok
   @spec broadcast(:extension_updates_available, Minga.Extension.UpdatesAvailableEvent.t()) :: :ok
   @spec broadcast(:extension_agent_contributions_started, map()) :: :ok
+  @spec broadcast(
+          :extension_deferred_batch_complete,
+          Minga.Extension.DeferredBatchCompleteEvent.t()
+        ) :: :ok
   @spec broadcast(:agent_mcp_servers_changed, map()) :: :ok
   @spec broadcast(:agent_tools_changed, AgentToolsChangedEvent.t()) :: :ok
   def broadcast(topic, payload) when is_atom(topic) and is_map(payload) do

--- a/lib/minga/extension/code_lease.ex
+++ b/lib/minga/extension/code_lease.ex
@@ -41,16 +41,18 @@ defmodule Minga.Extension.CodeLease do
           reason: reason()
         }
 
-  @typep source_status :: :active | {:quiescing, unload_token()} | :inactive
+  @type source_status :: :active | {:quiescing, unload_token()} | :inactive
   @typep source_record :: %{status: source_status(), modules: MapSet.t(module())}
 
+  @typep drain_waiter :: {pid(), reference()}
   @typep state :: %{
            leases: %{reference() => t()},
            owner_refs: %{pid() => MapSet.t(reference())},
            owner_monitors: %{pid() => reference()},
            monitor_owners: %{reference() => pid()},
            sources: %{ContributionCleanup.contribution_source() => source_record()},
-           token_sources: %{unload_token() => ContributionCleanup.contribution_source()}
+           token_sources: %{unload_token() => ContributionCleanup.contribution_source()},
+           drain_waiters: %{ContributionCleanup.contribution_source() => [drain_waiter()]}
          }
 
   @doc "Starts the code lease service."
@@ -74,6 +76,19 @@ defmodule Minga.Extension.CodeLease do
   def quiesce_source(source, opts \\ []) do
     server = Keyword.get(opts, :server, __MODULE__)
     safe_call(server, {:quiesce_source, source}, {:error, :not_started})
+  end
+
+  @doc "Sends an event as soon as a source has no active callback leases."
+  @spec notify_when_drained(
+          ContributionCleanup.contribution_source(),
+          pid(),
+          reference(),
+          keyword()
+        ) :: :ok | {:error, term()}
+  def notify_when_drained(source, recipient, ref, opts \\ [])
+      when is_pid(recipient) and is_reference(ref) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    safe_call(server, {:notify_when_drained, source, recipient, ref}, {:error, :not_started})
   end
 
   @doc "Marks a quiescing source inactive after unload callbacks finish."
@@ -138,6 +153,14 @@ defmodule Minga.Extension.CodeLease do
     safe_call(server, {:release, id}, :ok)
   end
 
+  @doc "Returns one source's admission status for lifecycle crash recovery."
+  @spec source_status(ContributionCleanup.contribution_source(), keyword()) ::
+          source_status() | :unknown
+  def source_status(source, opts \\ []) do
+    server = Keyword.get(opts, :server, __MODULE__)
+    safe_call(server, {:source_status, source}, :unknown)
+  end
+
   @doc "Returns active leases matching a module, source, or both."
   @spec active_leases(keyword()) :: [summary()]
   def active_leases(opts \\ []) do
@@ -157,7 +180,8 @@ defmodule Minga.Extension.CodeLease do
        owner_monitors: %{},
        monitor_owners: %{},
        sources: %{},
-       token_sources: %{}
+       token_sources: %{},
+       drain_waiters: %{}
      }}
   end
 
@@ -197,6 +221,20 @@ defmodule Minga.Extension.CodeLease do
     end
   end
 
+  def handle_call({:notify_when_drained, source, recipient, ref}, _from, state) do
+    case matching_leases(state, source, :_) do
+      [] ->
+        send(recipient, {__MODULE__, :drained, source, ref})
+        {:reply, :ok, state}
+
+      [_lease | _rest] ->
+        waiters =
+          Map.update(state.drain_waiters, source, [{recipient, ref}], &[{recipient, ref} | &1])
+
+        {:reply, :ok, %{state | drain_waiters: waiters}}
+    end
+  end
+
   def handle_call({:complete_unload, token}, _from, state) do
     transition_unload_token(state, token, :inactive)
   end
@@ -224,7 +262,17 @@ defmodule Minga.Extension.CodeLease do
   end
 
   def handle_call({:release, id}, _from, state) do
-    {:reply, :ok, drop_lease(state, id)}
+    {:reply, :ok, state |> drop_lease(id) |> notify_drained_sources()}
+  end
+
+  def handle_call({:source_status, source}, _from, state) do
+    status =
+      case Map.get(state.sources, source) do
+        %{status: source_status} -> source_status
+        nil -> :unknown
+      end
+
+    {:reply, status, state}
   end
 
   def handle_call({:active_leases, source, module}, _from, state) do
@@ -234,7 +282,7 @@ defmodule Minga.Extension.CodeLease do
   @impl true
   def handle_info({:DOWN, ref, :process, owner, _reason}, state) do
     case Map.get(state.monitor_owners, ref) do
-      ^owner -> {:noreply, drop_owner_leases(state, owner)}
+      ^owner -> {:noreply, state |> drop_owner_leases(owner) |> notify_drained_sources()}
       _other -> {:noreply, state}
     end
   end
@@ -412,6 +460,30 @@ defmodule Minga.Extension.CodeLease do
       {nil, _owner_monitors} ->
         state
     end
+  end
+
+  @spec notify_drained_sources(state()) :: state()
+  defp notify_drained_sources(state) do
+    Enum.reduce(Map.keys(state.drain_waiters), state, &notify_drained_source/2)
+  end
+
+  @spec notify_drained_source(ContributionCleanup.contribution_source(), state()) :: state()
+  defp notify_drained_source(source, current) do
+    case matching_leases(current, source, :_) do
+      [] -> notify_drain_waiters(current, source)
+      [_lease | _rest] -> current
+    end
+  end
+
+  @spec notify_drain_waiters(state(), ContributionCleanup.contribution_source()) :: state()
+  defp notify_drain_waiters(current, source) do
+    {waiters, remaining} = Map.pop(current.drain_waiters, source, [])
+
+    Enum.each(waiters, fn {recipient, ref} ->
+      send(recipient, {__MODULE__, :drained, source, ref})
+    end)
+
+    %{current | drain_waiters: remaining}
   end
 
   @spec matching_leases(state(), ContributionCleanup.contribution_source() | :_, module() | :_) ::

--- a/lib/minga/extension/contribution_cleanup.ex
+++ b/lib/minga/extension/contribution_cleanup.ex
@@ -54,6 +54,11 @@ defmodule Minga.Extension.ContributionCleanup do
     :ok
   end
 
+  @doc false
+  @spec merge_callbacks(%{atom() => registered_cleanup_fun()}) ::
+          %{atom() => registered_cleanup_fun()}
+  def merge_callbacks(overrides) when is_map(overrides), do: Map.merge(callbacks(), overrides)
+
   @doc "Runs one targeted source finalizer before runtime termination."
   @spec finalize_source(contribution_source(), atom(), cleanup_opts()) ::
           :ok | {:error, cleanup_failure()}
@@ -111,11 +116,19 @@ defmodule Minga.Extension.ContributionCleanup do
     ]
     |> Kernel.++(
       cbs
-      |> Enum.filter(fn {_family, fun} -> is_function(fun, 1) end)
+      |> Enum.filter(fn {family, fun} ->
+        is_function(fun, 1) and include_full_cleanup_family?(source, family)
+      end)
       |> Enum.sort_by(fn {family, _fun} -> Atom.to_string(family) end)
       |> Enum.map(fn {family, fun} -> {family, fn -> fun.(source) end} end)
     )
   end
+
+  @spec include_full_cleanup_family?(contribution_source(), atom()) :: boolean()
+  defp include_full_cleanup_family?({:extension, _name}, family),
+    do: family not in [:editor_effects, :editor_extension_unload]
+
+  defp include_full_cleanup_family?(_source, _family), do: true
 
   @spec put_callback(atom(), registered_cleanup_fun()) :: :ok
   defp put_callback(name, fun) do

--- a/lib/minga/extension/deferred_batch_complete_event.ex
+++ b/lib/minga/extension/deferred_batch_complete_event.ex
@@ -1,0 +1,15 @@
+defmodule Minga.Extension.DeferredBatchCompleteEvent do
+  @moduledoc "Result of asynchronously loading one batch of deferred extensions."
+
+  @enforce_keys [:count, :failures]
+  defstruct [:count, :failures]
+
+  @type failure :: %{extension: atom(), reason: term()}
+  @type t :: %__MODULE__{count: non_neg_integer(), failures: [failure()]}
+
+  @doc "Builds a deferred batch completion payload."
+  @spec new(non_neg_integer(), [failure()]) :: t()
+  def new(count, failures) when is_integer(count) and count >= 0 do
+    %__MODULE__{count: count, failures: failures}
+  end
+end

--- a/lib/minga/extension/entry.ex
+++ b/lib/minga/extension/entry.ex
@@ -35,7 +35,6 @@ defmodule Minga.Extension.Entry do
     :pid,
     :manifest,
     :last_error,
-    lifecycle_ref: nil,
     config: [],
     status: :stopped,
     load_policy: nil
@@ -50,7 +49,6 @@ defmodule Minga.Extension.Entry do
           pid: pid() | nil,
           manifest: Extension.Manifest.t() | nil,
           last_error: term() | nil,
-          lifecycle_ref: reference() | nil,
           config: keyword(),
           status: Extension.extension_status(),
           load_policy: Extension.load_policy() | nil

--- a/lib/minga/extension/instance.ex
+++ b/lib/minga/extension/instance.ex
@@ -1,0 +1,159 @@
+defmodule Minga.Extension.Instance do
+  @moduledoc """
+  Stable per-extension lifecycle authority.
+
+  Public requests, runtime exits, drain events, and finalizer acknowledgements
+  share this one mailbox. Handler modules compute transitions, while this sole
+  GenServer owns message ordering and lifecycle authority.
+  """
+
+  use GenServer
+
+  alias Minga.Extension.CodeLease
+  alias Minga.Extension.Instance.Lifecycle
+  alias Minga.Extension.Instance.QuiescenceTransition
+  alias Minga.Extension.Instance.Recovery
+  alias Minga.Extension.Instance.StartTransition
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.Instance.StopTransition
+  alias Minga.Extension.Instance.TransitionHandler
+  alias Minga.Extension.Instance.Worker
+  alias Minga.Extension.InstanceRegistry
+
+  @type server :: GenServer.server()
+  @type result :: {:ok, pid()} | {:error, term()}
+
+  @doc "Builds the permanent authority child spec."
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    %{
+      id: __MODULE__,
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :permanent,
+      type: :worker
+    }
+  end
+
+  @doc "Starts one named lifecycle authority."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :extension)
+    registry = Keyword.get(opts, :instance_registry, InstanceRegistry)
+    GenServer.start_link(__MODULE__, opts, name: InstanceRegistry.via(registry, :instance, name))
+  end
+
+  @doc "Updates the declaration snapshot used by later transitions."
+  @spec declare(server(), Minga.Extension.Entry.t(), GenServer.server(), keyword()) ::
+          :ok | {:error, term()}
+  def declare(server, declaration, registry, opts) do
+    GenServer.call(server, {:declare, declaration, registry, opts}, :infinity)
+  end
+
+  @doc "Starts or joins the extension's current start transition."
+  @spec start(server()) :: result()
+  def start(server), do: GenServer.call(server, :start, :infinity)
+
+  @doc "Starts only when the captured deferred declaration is still current."
+  @spec start_deferred(server(), Minga.Extension.Entry.t()) :: result()
+  def start_deferred(server, declaration) do
+    GenServer.call(server, {:start_deferred, declaration}, :infinity)
+  end
+
+  @doc "Projects a bulk prerequisite failure through the lifecycle authority."
+  @spec fail_start(server(), term()) :: {:error, term()}
+  def fail_start(server, reason), do: GenServer.call(server, {:fail_start, reason}, :infinity)
+
+  @doc "Prepares and captures the declaration artifact and returns its load policy."
+  @spec load_policy(server()) :: {:ok, Minga.Extension.load_policy()} | {:error, term()}
+  def load_policy(server), do: GenServer.call(server, :load_policy, :infinity)
+
+  @doc "Registers a lazy stub through this authority."
+  @spec stub(server()) :: :ok | {:error, term()}
+  def stub(server), do: GenServer.call(server, :stub, :infinity)
+
+  @doc "Stops or joins the extension's current stop transition."
+  @spec stop(server(), keyword()) :: :ok | {:error, term()}
+  def stop(server, opts \\ []), do: GenServer.call(server, {:stop, opts}, :infinity)
+
+  @doc "Returns the tagged authority phase for diagnostics and focused tests."
+  @spec phase(server()) :: State.phase()
+  def phase(server), do: GenServer.call(server, :phase)
+
+  @impl true
+  @spec init(keyword()) :: {:ok, State.t(), {:continue, :recover_local_runtime}}
+  def init(opts) do
+    Process.flag(:trap_exit, true)
+    name = Keyword.fetch!(opts, :extension)
+    declaration_registry = Keyword.fetch!(opts, :declaration_registry)
+
+    declaration =
+      case Minga.Extension.Registry.get(declaration_registry, name) do
+        {:ok, current} -> current
+        :error -> Keyword.fetch!(opts, :declaration)
+      end
+
+    state =
+      State.new(
+        name,
+        declaration,
+        declaration_registry,
+        Keyword.get(opts, :instance_registry, InstanceRegistry),
+        Keyword.get(opts, :collaborators, [])
+      )
+
+    :ok = InstanceRegistry.notify_waiters(state.instance_registry, :instance, state.name, self())
+    {:ok, state, {:continue, :recover_local_runtime}}
+  end
+
+  @impl true
+  def handle_continue(:recover_local_runtime, state), do: Recovery.recover_local_runtime(state)
+
+  @impl true
+  def handle_call({:declare, declaration, registry, opts}, _from, state),
+    do: Lifecycle.declare(state, declaration, registry, opts)
+
+  def handle_call(:phase, _from, state), do: {:reply, state.phase, state}
+  def handle_call(:load_policy, _from, state), do: StartTransition.load_policy_result(state)
+  def handle_call(:start, from, state), do: StartTransition.request_start(state, from)
+
+  def handle_call({:fail_start, reason}, from, state),
+    do: StartTransition.request_prerequisite_failure(state, from, reason)
+
+  def handle_call({:start_deferred, declaration}, from, state),
+    do: StartTransition.request_deferred_start(state, from, declaration)
+
+  def handle_call(:stub, _from, state), do: StartTransition.request_stub(state)
+
+  def handle_call({:stop, opts}, from, state),
+    do: StopTransition.request_stop(State.configure(state, opts), from)
+
+  @impl true
+  def handle_info(:perform_start, state), do: StartTransition.perform_start(state)
+
+  def handle_info({Worker, :runtime_started, id, pid}, state),
+    do: StartTransition.runtime_started(state, id, pid)
+
+  def handle_info({Worker, :done, id, result}, state),
+    do: TransitionHandler.transition_done(state, id, result)
+
+  def handle_info({Worker, :timeout, id, kind}, state),
+    do: TransitionHandler.transition_timeout(state, id, kind)
+
+  def handle_info({CodeLease, :drained, source, ref}, state),
+    do: QuiescenceTransition.source_drained(state, source, ref)
+
+  def handle_info({CodeLease, :drain_timeout, ref}, state),
+    do: QuiescenceTransition.drain_timeout(state, ref)
+
+  def handle_info({:extension_finalizer_ack, ref, family, result}, state),
+    do: QuiescenceTransition.finalizer_ack(state, ref, family, result)
+
+  def handle_info({:extension_cleanup_ack, ref, result}, state),
+    do: StopTransition.cleanup_ack(state, ref, result)
+
+  def handle_info({:DOWN, ref, :process, pid, reason}, state),
+    do: TransitionHandler.process_down(state, ref, pid, reason)
+
+  def handle_info({:EXIT, _pid, _reason}, state), do: {:noreply, state}
+  def handle_info(_message, state), do: {:noreply, state}
+end

--- a/lib/minga/extension/instance/artifact.ex
+++ b/lib/minga/extension/instance/artifact.ex
@@ -1,0 +1,63 @@
+defmodule Minga.Extension.Instance.Artifact do
+  @moduledoc "Immutable current-generation artifact view and normalized runtime child policy."
+
+  alias Minga.Extension.Manifest
+
+  @type restart :: :permanent | :transient | :temporary
+
+  @enforce_keys [:module, :manifest, :source, :owned_modules, :child_spec, :restart]
+  defstruct [:module, :manifest, :source, :owned_modules, :child_spec, :restart]
+
+  @type t :: %__MODULE__{
+          module: module(),
+          manifest: Manifest.t(),
+          source: {:extension, atom()},
+          owned_modules: [module()],
+          child_spec: Supervisor.child_spec(),
+          restart: restart()
+        }
+
+  @doc "Builds an artifact while preserving the declaration's original restart policy."
+  @spec build(atom(), module(), Manifest.t(), [module()], keyword()) ::
+          {:ok, t()} | {:error, term()}
+  def build(name, module, manifest, owned_modules, config) do
+    original =
+      module.child_spec(config) |> Supervisor.child_spec([]) |> Map.put(:modules, [module])
+
+    restart = Map.get(original, :restart, :permanent)
+
+    if restart in [:permanent, :transient, :temporary] do
+      {:ok,
+       %__MODULE__{
+         module: module,
+         manifest: manifest,
+         source: {:extension, name},
+         owned_modules: Enum.sort(Enum.uniq(owned_modules)),
+         child_spec: Map.put(original, :restart, :temporary),
+         restart: restart
+       }}
+    else
+      {:error, {:invalid_restart_policy, restart}}
+    end
+  rescue
+    error -> {:error, {:child_spec_failed, Exception.message(error)}}
+  catch
+    kind, reason -> {:error, {:child_spec_failed, {kind, reason}}}
+  end
+
+  @doc "Returns whether a runtime exit should be replaced."
+  @spec restart?(restart(), term()) :: boolean()
+  def restart?(:permanent, _reason), do: true
+  def restart?(:temporary, _reason), do: false
+  def restart?(:transient, :normal), do: false
+  def restart?(:transient, :shutdown), do: false
+  def restart?(:transient, {:shutdown, _reason}), do: false
+  def restart?(:transient, _reason), do: true
+
+  @doc "Returns whether an exit is a crash for public lifecycle projection."
+  @spec crash?(term()) :: boolean()
+  def crash?(:normal), do: false
+  def crash?(:shutdown), do: false
+  def crash?({:shutdown, _reason}), do: false
+  def crash?(_reason), do: true
+end

--- a/lib/minga/extension/instance/cleanup_failure.ex
+++ b/lib/minga/extension/instance/cleanup_failure.ex
@@ -1,0 +1,18 @@
+defmodule Minga.Extension.Instance.CleanupFailure do
+  @moduledoc "Typed failed-cleanup phase with its authority-owned retry context."
+
+  alias Minga.Extension.Instance.StopContext
+
+  @enforce_keys [:reason, :retry]
+  defstruct [:reason, :retry]
+
+  @type t :: %__MODULE__{reason: term(), retry: StopContext.t()}
+
+  @doc "Captures a cleanup failure and resumable stop context."
+  @spec new(term(), StopContext.t()) :: t()
+  def new(reason, retry), do: %__MODULE__{reason: reason, retry: retry}
+
+  @doc "Replaces the externally reported reason after projection failure."
+  @spec replace_reason(t(), term()) :: t()
+  def replace_reason(failure, reason), do: %{failure | reason: reason}
+end

--- a/lib/minga/extension/instance/contributions.ex
+++ b/lib/minga/extension/instance/contributions.ex
@@ -1,0 +1,321 @@
+defmodule Minga.Extension.Instance.Contributions do
+  @moduledoc "Registration, callback admission, finalization, and cleanup for one Instance."
+
+  alias Minga.Command
+  alias Minga.Extension.ArtifactAdmission
+  alias Minga.Extension.CallbackInvoker
+  alias Minga.Extension.CallbackRegistry
+  alias Minga.Extension.CodeLease
+  alias Minga.Extension.ContributionCleanup
+  alias Minga.Extension.Instance.Artifact
+  alias Minga.Log
+
+  @type result :: :ok | {:error, term()}
+
+  @doc "Runs setup callbacks which must complete before a runtime child starts."
+  @spec prepare_runtime(atom(), Artifact.t(), keyword(), keyword()) :: result()
+  def prepare_runtime(name, artifact, config, opts) do
+    with :ok <- register_options(name, artifact.module, config),
+         {:ok, _setup} <- call_init(artifact.module, config) do
+      register_modeline_segments(artifact.module, name, opts)
+    end
+  end
+
+  @doc "Registers all runtime contributions after the child is alive."
+  @spec register_runtime(atom(), Artifact.t(), keyword()) :: result()
+  def register_runtime(name, artifact, opts) do
+    command_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
+    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
+
+    with :ok <- register_commands(artifact.module, name, command_registry, opts),
+         :ok <- register_keybinds(artifact.module, name, keymap),
+         :ok <- register_event_handlers(artifact.module, name, opts) do
+      CodeLease.activate_source(artifact.source, artifact.owned_modules, server: code_lease(opts))
+    end
+  end
+
+  @doc "Registers lazy command/key stubs which activate through the captured Instance."
+  @spec register_stub(
+          GenServer.server(),
+          atom(),
+          Minga.Extension.Entry.t(),
+          Artifact.t(),
+          keyword(),
+          keyword()
+        ) :: result()
+  def register_stub(instance, name, declaration, artifact, config, opts) do
+    command_registry = Keyword.get(opts, :command_registry, Command.Registry)
+    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
+
+    with :ok <- register_options(name, artifact.module, config),
+         :ok <-
+           register_stub_commands(instance, name, declaration, artifact.module, command_registry) do
+      register_stub_keybinds(name, artifact.module, keymap)
+    end
+  end
+
+  @doc "Runs one source finalizer inside an Instance-owned bounded worker."
+  @spec finalize(atom(), atom(), map(), keyword()) :: :ok | {:error, term()}
+  def finalize(name, family, context, opts) do
+    source = {:extension, name}
+    cleanup_opts = opts |> Keyword.take([:callbacks]) |> Keyword.put(:context, context)
+
+    lifecycle_span(name, :quiesce, fn ->
+      ContributionCleanup.finalize_source(source, family, cleanup_opts)
+    end)
+  end
+
+  @doc "Removes all source-owned contributions exactly once per cleanup attempt."
+  @spec cleanup(atom(), keyword()) :: :ok | {:error, [map()]}
+  def cleanup(name, opts) do
+    source = {:extension, name}
+
+    callback_registry =
+      Keyword.get(opts, :callback_registry, Minga.Extension.CallbackRegistry.default_table())
+
+    callbacks =
+      opts
+      |> Keyword.get(:callbacks, %{})
+      |> Map.put_new(:callback_registry, fn cleanup_source ->
+        Minga.Extension.CallbackRegistry.unregister_source(cleanup_source, callback_registry)
+      end)
+      |> ContributionCleanup.merge_callbacks()
+
+    cleanup_opts = [
+      command_registry: Keyword.get(opts, :command_registry, Minga.Command.Registry),
+      keymap: Keyword.get(opts, :keymap, Minga.Keymap.Active),
+      callbacks: callbacks
+    ]
+
+    lifecycle_span(name, :cleanup, fn ->
+      ContributionCleanup.unregister_source(source, cleanup_opts)
+    end)
+  end
+
+  @spec lifecycle_span(atom(), atom(), (-> result)) :: result when result: var
+  defp lifecycle_span(name, phase, fun) do
+    Minga.Telemetry.span_with_stop_metadata(
+      [:minga, :extension, :lifecycle],
+      %{extension: name, phase: phase},
+      fn ->
+        result = fun.()
+        metadata = if match?({:error, _}, result), do: %{outcome: :error}, else: %{outcome: :ok}
+        {result, metadata}
+      end
+    )
+  end
+
+  @doc "Runs extension option validation."
+  @spec register_options(atom(), module(), keyword()) :: result()
+  def register_options(name, module, config) do
+    if function_exported?(module, :__option_schema__, 0) do
+      Minga.Config.register_extension_schema(name, module.__option_schema__(), config)
+    else
+      :ok
+    end
+  rescue
+    error -> {:error, "__option_schema__/0 crashed: #{Exception.message(error)}"}
+  end
+
+  @spec call_init(module(), keyword()) :: {:ok, term()} | {:error, term()}
+  defp call_init(module, config) do
+    case module.init(config) do
+      {:ok, state} -> {:ok, state}
+      {:error, reason} -> {:error, "init failed: #{inspect(reason)}"}
+      other -> {:error, "init returned unexpected value: #{inspect(other)}"}
+    end
+  rescue
+    error -> {:error, "init crashed: #{Exception.message(error)}"}
+  end
+
+  @spec register_commands(module(), atom(), GenServer.server(), keyword()) :: result()
+  defp register_commands(module, name, registry, opts) do
+    Enum.reduce_while(schema(module, :__command_schema__), :ok, fn spec, :ok ->
+      command = command_from_spec(spec, name, opts)
+
+      case Command.Registry.register_command(registry, {:extension, name}, command) do
+        :ok -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, reason}}
+      end
+    end)
+  rescue
+    error -> {:error, {:command_registration_failed, Exception.message(error)}}
+  end
+
+  @spec command_from_spec(Minga.Extension.command_spec(), atom(), keyword()) :: Command.t()
+  defp command_from_spec({name, description, command_opts}, extension, opts) do
+    {module, function} = Keyword.fetch!(command_opts, :execute)
+    admission = code_lease(opts)
+
+    %Command{
+      name: name,
+      description: description,
+      requires_buffer: Keyword.get(command_opts, :requires_buffer, false),
+      execute: fn state ->
+        source = {:extension, extension}
+        result = CallbackInvoker.invoke(source, module, function, [state], :command, admission)
+        {:extension_callback, source, module, function, result}
+      end
+    }
+  end
+
+  @spec register_modeline_segments(module(), atom(), keyword()) :: result()
+  defp register_modeline_segments(module, extension, opts) do
+    Enum.reduce_while(schema(module, :__modeline_segment_schema__), :ok, fn
+      {name, segment_opts, {callback_module, callback_function}}, :ok ->
+        callback =
+          modeline_callback(extension, callback_module, callback_function, code_lease(opts))
+
+        case Minga.Config.ModelineSegments.register(
+               name,
+               segment_opts,
+               callback,
+               {:extension, extension}
+             ) do
+          :ok -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, {:modeline_segment_rejected, name, reason}}}
+        end
+    end)
+  rescue
+    error -> {:error, {:modeline_segment_registration_failed, Exception.message(error)}}
+  end
+
+  @spec modeline_callback(atom(), module(), atom(), GenServer.server()) :: (map() -> term())
+  defp modeline_callback(extension, module, function, admission) do
+    fn context ->
+      source = {:extension, extension}
+
+      result =
+        CallbackInvoker.invoke(source, module, function, [context], :modeline_segment, admission)
+
+      {:extension_callback, source, module, function, result}
+    end
+  end
+
+  @spec register_keybinds(module(), atom(), GenServer.server()) :: result()
+  defp register_keybinds(module, extension, keymap) do
+    Enum.reduce_while(schema(module, :__keybind_schema__), :ok, fn
+      {mode, key, command, description, bind_opts}, :ok ->
+        case Minga.Keymap.Active.bind(
+               keymap,
+               mode,
+               key,
+               command,
+               description,
+               Keyword.put(bind_opts, :source, {:extension, extension})
+             ) do
+          :ok -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, {:keybind_registration_failed, key, reason}}}
+        end
+    end)
+  rescue
+    error -> {:error, {:keybind_registration_failed, :schema, Exception.message(error)}}
+  end
+
+  @spec register_event_handlers(module(), atom(), keyword()) :: result()
+  defp register_event_handlers(module, name, opts) do
+    CallbackRegistry.register_extension(name, schema(module, :__editor_event_handler_schema__),
+      registry: Keyword.get(opts, :callback_registry, CallbackRegistry.default_table()),
+      artifact_admission: Keyword.get(opts, :artifact_admission, ArtifactAdmission)
+    )
+  end
+
+  @spec register_stub_commands(
+          GenServer.server(),
+          atom(),
+          Minga.Extension.Entry.t(),
+          module(),
+          GenServer.server()
+        ) :: result()
+  defp register_stub_commands(instance, extension, declaration, module, registry) do
+    Enum.reduce_while(schema(module, :__command_schema__), :ok, fn
+      {name, description, command_opts}, :ok ->
+        requires_buffer = Keyword.get(command_opts, :requires_buffer, false)
+
+        command = %Command{
+          name: name,
+          description: description,
+          requires_buffer: requires_buffer,
+          execute: fn state ->
+            case safe_lazy_start(instance, declaration, extension) do
+              {:ok, _pid} -> execute_autoloaded(registry, extension, name, state)
+              {:error, _reason} -> state
+            end
+          end
+        }
+
+        case Command.Registry.register_command(registry, {:extension, extension}, command) do
+          :ok -> {:cont, :ok}
+          {:error, reason} -> {:halt, {:error, {:stub_command_rejected, name, reason}}}
+        end
+    end)
+  end
+
+  @spec safe_lazy_start(GenServer.server(), Minga.Extension.Entry.t(), atom()) ::
+          {:ok, pid()} | {:error, term()}
+  defp safe_lazy_start(instance, declaration, extension) do
+    case Minga.Extension.Instance.start_deferred(instance, declaration) do
+      {:ok, _pid} = started ->
+        started
+
+      {:error, reason} = error ->
+        Log.warning(:config, "Extension #{extension} lazy activation failed: #{inspect(reason)}")
+        error
+    end
+  catch
+    :exit, reason ->
+      failure = {:authority_call_exit, extension, reason}
+      Log.warning(:config, "Extension #{extension} lazy activation failed: #{inspect(failure)}")
+      {:error, failure}
+  end
+
+  @spec execute_autoloaded(GenServer.server(), atom(), atom(), term()) :: term()
+  defp execute_autoloaded(registry, extension, name, state) do
+    case Command.Registry.lookup(registry, name) do
+      {:ok, command} ->
+        command.execute.(state)
+
+      :error ->
+        Log.warning(
+          :config,
+          "Extension #{extension} lazy activation missing command #{name} after start"
+        )
+
+        state
+    end
+  rescue
+    error ->
+      reason = {:command_activation_exception, Exception.message(error)}
+      log_lazy_command_failure(extension, name, reason)
+      state
+  catch
+    :exit, reason ->
+      log_lazy_command_failure(extension, name, {:command_activation_exit, reason})
+      state
+
+    kind, reason ->
+      log_lazy_command_failure(extension, name, {kind, reason})
+      state
+  end
+
+  @spec log_lazy_command_failure(atom(), atom(), term()) :: :ok
+  defp log_lazy_command_failure(extension, name, reason) do
+    Log.warning(
+      :config,
+      "Extension #{extension} lazy command #{name} failed: #{inspect(reason)}"
+    )
+  end
+
+  @spec register_stub_keybinds(atom(), module(), GenServer.server()) :: result()
+  defp register_stub_keybinds(extension, module, keymap) do
+    register_keybinds(module, extension, keymap)
+  end
+
+  @spec schema(module(), atom()) :: [term()]
+  defp schema(module, function) do
+    if function_exported?(module, function, 0), do: apply(module, function, []), else: []
+  end
+
+  @spec code_lease(keyword()) :: GenServer.server()
+  defp code_lease(opts), do: Keyword.get(opts, :code_lease, CodeLease)
+end

--- a/lib/minga/extension/instance/lifecycle.ex
+++ b/lib/minga/extension/instance/lifecycle.ex
@@ -1,0 +1,153 @@
+defmodule Minga.Extension.Instance.Lifecycle do
+  @moduledoc "Shared lifecycle operations used by Instance transition handlers."
+
+  alias Minga.Extension.CodeLease
+  alias Minga.Extension.Instance.PhaseFailure
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.Instance.StopContext
+  alias Minga.Extension.InstanceRegistry
+
+  @doc "Applies a declaration update and preserves the current state on rejection."
+  @spec declare(State.t(), Minga.Extension.Entry.t(), GenServer.server(), keyword()) ::
+          {:reply, :ok | {:error, term()}, State.t()}
+  def declare(state, declaration, registry, opts) do
+    case State.declare(state, declaration, registry, opts) do
+      {:ok, updated} -> {:reply, :ok, updated}
+      {:error, _reason} = error -> {:reply, error, state}
+    end
+  end
+
+  @doc "Returns the local runtime supervisor identity for this authority."
+  @spec runtime_supervisor(State.t()) :: GenServer.server()
+  def runtime_supervisor(state) do
+    InstanceRegistry.via(state.instance_registry, :runtime, state.name)
+  end
+
+  @spec terminal_finalizer_error(:normal | :crash, term()) :: term()
+  def terminal_finalizer_error(:crash, reason),
+    do: {:terminal_crash_cleanup_failed, [quiesce: reason]}
+
+  def terminal_finalizer_error(:normal, reason),
+    do: {:terminal_exit_cleanup_failed, [quiesce: reason]}
+
+  @spec terminal_cleanup_error(StopContext.t(), term()) :: term()
+  def terminal_cleanup_error(
+        %StopContext{exit_kind: :crash, finalizer_error: finalizer},
+        failures
+      ),
+      do: {:terminal_crash_cleanup_failed, [quiesce: finalizer, cleanup: failures]}
+
+  def terminal_cleanup_error(
+        %StopContext{exit_kind: :normal, finalizer_error: finalizer},
+        failures
+      ),
+      do: {:terminal_exit_cleanup_failed, [quiesce: finalizer, cleanup: failures]}
+
+  def terminal_cleanup_error(%StopContext{}, failures), do: {:cleanup_failed, failures}
+
+  @spec maybe_abort_unload(State.t()) :: :ok | {:error, term()}
+  def maybe_abort_unload(%State{phase: {:stopping, %StopContext{token: token}}} = state)
+      when is_reference(token) do
+    server = Keyword.get(state.collaborators, :code_lease, CodeLease)
+    CodeLease.abort_unload(token, server: server)
+  end
+
+  def maybe_abort_unload(_state), do: :ok
+
+  @spec abort_failure(State.t(), term()) :: term()
+  def abort_failure(state, reason) do
+    case maybe_abort_unload(state) do
+      :ok ->
+        reason
+
+      {:error, abort_reason} ->
+        {:multiple_cleanup_failures, [reason, {:abort_unload, abort_reason}]}
+    end
+  end
+
+  @spec cancel_timer(reference() | nil) :: :ok
+  def cancel_timer(nil), do: :ok
+
+  def cancel_timer(timer) do
+    _ = Process.cancel_timer(timer)
+    :ok
+  end
+
+  @spec wrap_cleanup_failure(term(), {:error, term()}) :: term()
+  def wrap_cleanup_failure(reason, {:error, failures}), do: {:cleanup_failed, reason, failures}
+
+  @spec maybe_demonitor(Runtime.t() | nil) :: :ok
+  def maybe_demonitor(runtime), do: Runtime.demonitor(runtime)
+
+  @spec lifecycle_span(atom(), atom(), (-> result)) :: result when result: var
+  def lifecycle_span(name, phase, fun) do
+    Minga.Telemetry.span_with_stop_metadata(
+      [:minga, :extension, :lifecycle],
+      %{extension: name, phase: phase},
+      fn ->
+        result = fun.()
+        {result, lifecycle_result_metadata(result)}
+      end
+    )
+  end
+
+  @spec lifecycle_result_metadata(term()) :: map()
+  def lifecycle_result_metadata({:error, reason}), do: %{outcome: :error, reason: reason}
+
+  def lifecycle_result_metadata({:error, reason, _state, _runtime}),
+    do: %{outcome: :error, reason: reason}
+
+  def lifecycle_result_metadata(_result), do: %{outcome: :ok}
+
+  @spec emit_terminal_phase(atom(), State.phase()) :: :ok
+  def emit_terminal_phase(name, phase) do
+    Minga.Telemetry.execute(
+      [:minga, :extension, :lifecycle, :terminal],
+      %{count: 1},
+      %{extension: name, phase: telemetry_phase(phase)}
+    )
+  end
+
+  @spec telemetry_phase(State.phase()) :: State.phase() | {:crashed | :load_error, map()}
+  defp telemetry_phase({tag, %PhaseFailure{reason: reason}}) when tag in [:crashed, :load_error],
+    do: {tag, %{reason: reason}}
+
+  defp telemetry_phase(phase), do: phase
+
+  @spec emit_restart_count(atom(), non_neg_integer()) :: :ok
+  def emit_restart_count(name, count) do
+    Minga.Telemetry.execute(
+      [:minga, :extension, :lifecycle, :crash_restart_count],
+      %{count: count},
+      %{extension: name, phase: :crash_restart_count}
+    )
+  end
+
+  @spec broadcast_started(State.t()) :: :ok
+  def broadcast_started(%State{artifact: {:prepared, artifact}} = state) do
+    Minga.Events.broadcast(:extension_agent_contributions_started, %{
+      source: artifact.source,
+      module: artifact.module,
+      manifest: artifact.manifest,
+      root: extension_root(state.declaration, artifact.module)
+    })
+  end
+
+  @spec extension_root(Minga.Extension.Entry.t(), module()) :: String.t() | nil
+  def extension_root(%{path: path}, _module) when is_binary(path), do: Path.expand(path)
+
+  def extension_root(%{hex: %{app: app}}, _module) when is_atom(app) do
+    case :code.lib_dir(app) do
+      path when is_list(path) -> List.to_string(path)
+      _other -> nil
+    end
+  end
+
+  def extension_root(_declaration, module) do
+    case :code.which(module) do
+      path when is_list(path) -> path |> List.to_string() |> Path.dirname() |> Path.dirname()
+      _other -> nil
+    end
+  end
+end

--- a/lib/minga/extension/instance/phase_failure.ex
+++ b/lib/minga/extension/instance/phase_failure.ex
@@ -1,0 +1,12 @@
+defmodule Minga.Extension.Instance.PhaseFailure do
+  @moduledoc "Typed terminal failure context for crashed and load-error phases."
+
+  @enforce_keys [:reason]
+  defstruct [:reason]
+
+  @type t :: %__MODULE__{reason: term()}
+
+  @doc "Captures a terminal lifecycle reason."
+  @spec new(term()) :: t()
+  def new(reason), do: %__MODULE__{reason: reason}
+end

--- a/lib/minga/extension/instance/projection.ex
+++ b/lib/minga/extension/instance/projection.ex
@@ -1,0 +1,68 @@
+defmodule Minga.Extension.Instance.Projection do
+  @moduledoc "The sole writer of extension lifecycle fields in `Extension.Registry`."
+
+  alias Minga.Extension.Instance.CleanupFailure
+  alias Minga.Extension.Instance.PhaseFailure
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.Instance.StopContext
+  alias Minga.Extension.Registry
+
+  @doc "Publishes the current tagged phase as the compatible registry view."
+  @spec publish(State.t()) :: :ok | {:error, term()}
+  def publish(%State{} = state) do
+    Registry.update(state.registry, state.name, fields(state))
+  catch
+    :exit, reason -> {:error, {:projection_unavailable, state.name, reason}}
+  end
+
+  @doc "Returns lifecycle fields for a tagged Instance phase."
+  @spec fields(State.t()) :: keyword()
+  def fields(%State{phase: phase} = state) do
+    artifact_fields = artifact_fields(state)
+    Keyword.merge(artifact_fields, phase_fields(phase))
+  end
+
+  @spec artifact_fields(State.t()) :: keyword()
+  defp artifact_fields(%State{artifact: {:prepared, artifact}}) do
+    [module: artifact.module, manifest: artifact.manifest]
+  end
+
+  defp artifact_fields(%State{}), do: []
+
+  @spec phase_fields(State.phase()) :: keyword()
+  defp phase_fields(:stopped), do: [status: :stopped, pid: nil, last_error: nil]
+  defp phase_fields({:stub, _artifact}), do: [status: :stub, pid: nil, last_error: nil]
+
+  defp phase_fields({:starting, _context}),
+    do: [status: :stopped, pid: nil, last_error: {:lifecycle_transition, :starting}]
+
+  defp phase_fields({:running, %Runtime{} = runtime}),
+    do: [status: :running, pid: runtime.pid, last_error: nil]
+
+  defp phase_fields({:stopping, %StopContext{} = context}) do
+    pid = if context.runtime == nil, do: nil, else: context.runtime.pid
+
+    [
+      status: :stopped,
+      pid: pid,
+      last_error: {:lifecycle_transition, {:stopping, context.stage}}
+    ]
+  end
+
+  defp phase_fields({:crashed, %PhaseFailure{} = context}),
+    do: [status: :crashed, pid: nil, last_error: context.reason]
+
+  defp phase_fields({:load_error, %PhaseFailure{} = context}),
+    do: [status: :load_error, pid: nil, last_error: context.reason]
+
+  defp phase_fields({:cleanup_failed, %CleanupFailure{} = context}) do
+    pid =
+      case context.retry.runtime do
+        %{pid: runtime_pid} -> runtime_pid
+        nil -> nil
+      end
+
+    [status: :load_error, pid: pid, last_error: context.reason]
+  end
+end

--- a/lib/minga/extension/instance/quiescence_transition.ex
+++ b/lib/minga/extension/instance/quiescence_transition.ex
@@ -1,0 +1,254 @@
+defmodule Minga.Extension.Instance.QuiescenceTransition do
+  @moduledoc "Code-lease drain and editor-finalizer transitions for an extension stop."
+
+  alias Minga.Extension.CodeLease
+  alias Minga.Extension.Instance.Contributions
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.Instance.StopContext
+  alias Minga.Extension.Instance.Worker
+
+  import Minga.Extension.Instance.Lifecycle
+
+  @spec begin_quiesce(State.t()) :: {:noreply, State.t()}
+  def begin_quiesce(%State{phase: {:stopping, context}} = state) do
+    source = {:extension, state.name}
+    lease_server = Keyword.get(state.collaborators, :code_lease, CodeLease)
+
+    case CodeLease.quiesce_source(source, server: lease_server) do
+      {:ok, token} ->
+        begin_drain(state, context, source, token, lease_server)
+
+      {:error, {:source_not_active, ^source}} ->
+        request_editor_without_token(state)
+
+      {:error, {:source_inactive, ^source}} ->
+        request_editor_without_token(state)
+
+      {:error, reason} ->
+        Minga.Extension.Instance.StopTransition.stop_failed(
+          state,
+          {:source_quiesce_failed, reason}
+        )
+    end
+  end
+
+  @spec begin_drain(State.t(), StopContext.t(), term(), reference(), GenServer.server()) ::
+          {:noreply, State.t()}
+  def begin_drain(state, context, source, token, lease_server) do
+    drain_ref = make_ref()
+
+    case CodeLease.notify_when_drained(source, self(), drain_ref, server: lease_server) do
+      :ok ->
+        timer =
+          Process.send_after(
+            self(),
+            {CodeLease, :drain_timeout, drain_ref},
+            Minga.Extension.Instance.TransitionHandler.drain_timeout_ms(state)
+          )
+
+        finalizer_context = %{
+          token: token,
+          callback_registry:
+            Keyword.get(
+              state.collaborators,
+              :callback_registry,
+              Minga.Extension.CallbackRegistry.default_table()
+            ),
+          callback_admission: lease_server
+        }
+
+        updated_context = StopContext.begin_drain(context, token, drain_ref, timer)
+        state = State.stopping(state, updated_context)
+        start_finalizer(state, :editor_effects, finalizer_context)
+
+      {:error, reason} ->
+        state =
+          State.stopping(state, StopContext.remember_failed_drain(context, token, drain_ref))
+
+        Minga.Extension.Instance.StopTransition.stop_failed(
+          state,
+          abort_failure(state, {:code_lease_drain_failed, reason})
+        )
+    end
+  end
+
+  @spec request_editor_without_token(State.t()) :: {:noreply, State.t()}
+  def request_editor_without_token(%State{phase: {:stopping, context}} = state) do
+    state = State.stopping(state, StopContext.begin_editor_finalize(context))
+    start_finalizer(state, :editor_effects, %{})
+  end
+
+  @spec start_finalizer(State.t(), atom(), map()) :: {:noreply, State.t()}
+  def start_finalizer(%State{phase: {:stopping, context}} = state, family, finalizer_context) do
+    worker =
+      Worker.start(
+        self(),
+        {:finalizer, family},
+        Minga.Extension.Instance.TransitionHandler.callback_timeout(state),
+        fn ->
+          Contributions.finalize(state.name, family, finalizer_context, state.collaborators)
+        end
+      )
+
+    updated = StopContext.attach_finalizer(context, worker)
+    {:noreply, State.stopping(state, updated)}
+  end
+
+  @spec source_drained(State.t(), term(), reference()) :: {:noreply, State.t()}
+  def source_drained(
+        %State{name: name, phase: {:stopping, %StopContext{drain_ref: ref} = context}} = state,
+        {:extension, name},
+        ref
+      ) do
+    cancel_timer(context.drain_timer)
+
+    continue_after_barrier(State.stopping(state, StopContext.source_drained(context)))
+  end
+
+  def source_drained(state, _source, _ref), do: {:noreply, state}
+
+  @spec drain_timeout(State.t(), reference()) :: {:noreply, State.t()}
+  def drain_timeout(
+        %State{phase: {:stopping, %StopContext{drain_ref: ref, drain_done?: false} = context}} =
+          state,
+        ref
+      ) do
+    state = State.stopping(state, StopContext.clear_drain_timer(context))
+
+    reason =
+      {:code_lease_drain_timeout,
+       Minga.Extension.Instance.TransitionHandler.drain_timeout_ms(state)}
+
+    Minga.Extension.Instance.StopTransition.stop_failed(state, abort_failure(state, reason))
+  end
+
+  def drain_timeout(state, _ref), do: {:noreply, state}
+
+  @spec finalizer_ack(State.t(), reference(), atom(), term()) :: {:noreply, State.t()}
+  def finalizer_ack(
+        %State{phase: {:stopping, %StopContext{editor_ref: ref} = context}} = state,
+        ref,
+        :editor_effects,
+        result
+      ) do
+    updated_context = StopContext.editor_effects_done(context, result)
+    continue_after_barrier(State.stopping(state, updated_context))
+  end
+
+  def finalizer_ack(
+        %State{phase: {:stopping, %StopContext{editor_ref: ref, exit_kind: :explicit} = context}} =
+          state,
+        ref,
+        :editor_extension_unload,
+        {:error, reason}
+      ) do
+    state = State.stopping(state, StopContext.fail_finalizer(context, reason))
+
+    Minga.Extension.Instance.StopTransition.stop_failed(
+      state,
+      abort_failure(state, {:source_quiesce_failed, reason})
+    )
+  end
+
+  def finalizer_ack(
+        %State{phase: {:stopping, %StopContext{editor_ref: ref} = context}} = state,
+        ref,
+        :editor_extension_unload,
+        result
+      ) do
+    context = StopContext.merge_finalizer_result(context, result)
+    complete_unload(State.stopping(state, context))
+  end
+
+  def finalizer_ack(state, _ref, _family, _result), do: {:noreply, state}
+
+  @spec continue_after_barrier(State.t()) :: {:noreply, State.t()}
+  def continue_after_barrier(
+        %State{
+          phase:
+            {:stopping,
+             %{
+               drain_done?: true,
+               editor_done?: true,
+               exit_kind: :explicit,
+               finalizer_error: nil
+             }}
+        } = state
+      ),
+      do: continue_after_successful_barrier(state)
+
+  def continue_after_barrier(
+        %State{
+          phase:
+            {:stopping,
+             %{
+               drain_done?: true,
+               editor_done?: true,
+               exit_kind: :explicit,
+               finalizer_error: reason
+             }}
+        } = state
+      ) do
+    Minga.Extension.Instance.StopTransition.stop_failed(
+      state,
+      abort_failure(state, {:source_quiesce_failed, reason})
+    )
+  end
+
+  def continue_after_barrier(
+        %State{phase: {:stopping, %StopContext{drain_done?: true, editor_done?: true}}} = state
+      ),
+      do: continue_after_successful_barrier(state)
+
+  def continue_after_barrier(state), do: {:noreply, state}
+
+  @spec continue_after_successful_barrier(State.t()) :: {:noreply, State.t()}
+  def continue_after_successful_barrier(
+        %State{phase: {:stopping, %StopContext{token: token} = context}} = state
+      )
+      when is_reference(token) do
+    finalizer_context = %{
+      token: token,
+      callback_registry:
+        Keyword.get(
+          state.collaborators,
+          :callback_registry,
+          Minga.Extension.CallbackRegistry.default_table()
+        ),
+      callback_admission: Keyword.get(state.collaborators, :code_lease, CodeLease)
+    }
+
+    state = State.stopping(state, StopContext.begin_editor_unload(context))
+    start_finalizer(state, :editor_extension_unload, finalizer_context)
+  end
+
+  def continue_after_successful_barrier(state), do: finish_quiesce(state)
+
+  @spec complete_unload(State.t()) :: {:noreply, State.t()}
+  def complete_unload(%State{phase: {:stopping, context}} = state) do
+    server = Keyword.get(state.collaborators, :code_lease, CodeLease)
+    result = CodeLease.complete_unload(context.token, server: server)
+    context = StopContext.merge_finalizer_result(context, result)
+    finish_quiesce(State.stopping(state, context))
+  end
+
+  @spec finish_quiesce(State.t()) :: {:noreply, State.t()}
+  def finish_quiesce(
+        %State{phase: {:stopping, %StopContext{exit_kind: :explicit, finalizer_error: nil}}} =
+          state
+      ),
+      do: Minga.Extension.Instance.StopTransition.advance_runtime_termination(state)
+
+  def finish_quiesce(
+        %State{phase: {:stopping, %StopContext{exit_kind: :explicit, finalizer_error: reason}}} =
+          state
+      ) do
+    Minga.Extension.Instance.StopTransition.stop_failed(
+      state,
+      abort_failure(state, {:source_quiesce_failed, reason})
+    )
+  end
+
+  def finish_quiesce(%State{phase: {:stopping, _context}} = state),
+    do: Minga.Extension.Instance.StopTransition.advance_runtime_termination(state)
+end

--- a/lib/minga/extension/instance/recovery.ex
+++ b/lib/minga/extension/instance/recovery.ex
@@ -1,0 +1,208 @@
+defmodule Minga.Extension.Instance.Recovery do
+  @moduledoc "Extension Instance recovery logic."
+
+  alias Minga.Extension.CodeLease
+  alias Minga.Extension.Instance.Projection
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.RuntimeSupervisor
+
+  import Minga.Extension.Instance.Lifecycle
+
+  @spec recover_local_runtime(State.t()) :: {:noreply, State.t()}
+  def recover_local_runtime(state) do
+    case RuntimeSupervisor.local_child(
+           runtime_supervisor(state),
+           Minga.Extension.Instance.TransitionHandler.runtime_query_timeout(state)
+         ) do
+      {:ok, pid} ->
+        recover_adopted_runtime(state, pid)
+
+      :empty ->
+        recover_empty_runtime(state)
+
+      {:error, reason} ->
+        Minga.Extension.Instance.TransitionHandler.replace_runtime_branch(
+          state,
+          {:runtime_recovery_failed, reason}
+        )
+    end
+  end
+
+  @spec recover_adopted_runtime(State.t(), pid()) :: {:noreply, State.t()}
+  def recover_adopted_runtime(state, pid) do
+    state.registry
+    |> Minga.Extension.Registry.get(state.name)
+    |> recover_adopted_projection(state, pid)
+  end
+
+  @spec recover_adopted_projection(term(), State.t(), pid()) :: {:noreply, State.t()}
+  def recover_adopted_projection({:ok, %{status: :running}}, state, pid) do
+    case Minga.Extension.Instance.StartTransition.prepare_artifact(state) do
+      {:ok, _artifact, prepared} ->
+        publish_adopted_runtime(prepared, pid)
+
+      {:error, reason, prepared} ->
+        Minga.Extension.Instance.StartTransition.begin_start_rollback(
+          prepared,
+          [],
+          [],
+          reason,
+          pid
+        )
+    end
+  end
+
+  def recover_adopted_projection(
+        {:ok, %{status: :stopped, last_error: {:lifecycle_transition, {:stopping, _stage}}}},
+        state,
+        pid
+      ),
+      do: recover_interrupted_stop(state, pid)
+
+  def recover_adopted_projection({:ok, %{status: :stopped} = projection}, state, pid) do
+    reason = projection.last_error || {:interrupted_lifecycle, :stopped}
+    Minga.Extension.Instance.StartTransition.begin_start_rollback(state, [], [], reason, pid)
+  end
+
+  def recover_adopted_projection({:ok, projection}, state, pid) do
+    reason = projection.last_error || {:interrupted_lifecycle, projection.status}
+    Minga.Extension.Instance.StartTransition.begin_start_rollback(state, [], [], reason, pid)
+  end
+
+  def recover_adopted_projection(:error, state, pid),
+    do:
+      Minga.Extension.Instance.StartTransition.begin_start_rollback(
+        state,
+        [],
+        [],
+        {:extension_not_declared, state.name},
+        pid
+      )
+
+  @spec publish_adopted_runtime(State.t(), pid()) :: {:noreply, State.t()}
+  def publish_adopted_runtime(prepared, pid) do
+    running = State.running(prepared, Runtime.monitor(pid))
+
+    case Projection.publish(running) do
+      :ok ->
+        {:noreply, running}
+
+      {:error, reason} ->
+        Minga.Extension.Instance.StartTransition.begin_start_rollback(
+          running,
+          [],
+          [],
+          reason,
+          pid
+        )
+    end
+  end
+
+  @spec recover_empty_runtime(State.t()) :: {:noreply, State.t()}
+  def recover_empty_runtime(state) do
+    projection = Minga.Extension.Registry.get(state.registry, state.name)
+    lease_server = Keyword.get(state.collaborators, :code_lease, CodeLease)
+    source_status = CodeLease.source_status({:extension, state.name}, server: lease_server)
+    recover_empty_runtime(state, projection, source_status)
+  end
+
+  @spec recover_empty_runtime(State.t(), term(), term()) :: {:noreply, State.t()}
+  def recover_empty_runtime(state, {:ok, %{status: :running}}, :active),
+    do: recover_runtime_supervisor_replacement(state)
+
+  def recover_empty_runtime(
+        state,
+        {:ok, %{status: :stopped, last_error: {:lifecycle_transition, {:stopping, _stage}}}},
+        _source_status
+      ),
+      do: recover_interrupted_stop(state, nil)
+
+  def recover_empty_runtime(state, {:ok, %{status: :stopped}}, {:quiescing, _token}),
+    do: recover_interrupted_stop(state, nil)
+
+  def recover_empty_runtime(state, {:ok, projection}, {:quiescing, _token}) do
+    reason = projection.last_error || {:interrupted_lifecycle, :quiescing}
+    Minga.Extension.Instance.StartTransition.begin_start_rollback(state, [], [], reason, nil)
+  end
+
+  def recover_empty_runtime(state, {:ok, %{status: :stopped}}, status)
+      when status in [:active, :inactive] do
+    recover_interrupted_stop(state, nil)
+  end
+
+  def recover_empty_runtime(state, {:ok, %{status: :stopped, pid: nil, last_error: nil}}, status)
+      when status in [:inactive, :unknown] do
+    case Minga.Extension.Instance.TransitionHandler.publish_terminal(state, :recovery_stopped) do
+      {published, _reason, :ok} -> {:noreply, published}
+      {failed, _reason, :error} -> {:noreply, failed}
+    end
+  end
+
+  def recover_empty_runtime(state, {:ok, projection}, _source_status) do
+    reason = projection.last_error || {:interrupted_lifecycle, projection.status}
+    Minga.Extension.Instance.StartTransition.begin_start_rollback(state, [], [], reason, nil)
+  end
+
+  def recover_empty_runtime(state, :error, source_status)
+      when source_status in [:active, :inactive] or is_tuple(source_status) do
+    Minga.Extension.Instance.StartTransition.begin_start_rollback(
+      state,
+      [],
+      [],
+      {:extension_not_declared, state.name},
+      nil
+    )
+  end
+
+  def recover_empty_runtime(state, :error, :unknown) do
+    reason = {:extension_not_declared, state.name}
+    failed = State.load_error(state, reason)
+
+    {failed, _reply_reason, _publication} =
+      Minga.Extension.Instance.TransitionHandler.publish_terminal(failed, reason)
+
+    {:noreply, failed}
+  end
+
+  @spec recover_interrupted_stop(State.t(), pid() | nil) :: {:noreply, State.t()}
+  def recover_interrupted_stop(state, runtime_pid) do
+    base = Minga.Extension.Instance.StartTransition.rollback_runtime_state(state, runtime_pid)
+    stopping = State.stopping(base, nil, :explicit, :instance_recovery)
+
+    case Projection.publish(stopping) do
+      :ok ->
+        Minga.Extension.Instance.QuiescenceTransition.begin_quiesce(stopping)
+
+      {:error, projection_reason} ->
+        failure =
+          Minga.Extension.Instance.TransitionHandler.publication_failure(
+            state.name,
+            :instance_recovery,
+            projection_reason
+          )
+
+        Minga.Extension.Instance.StopTransition.stop_failed(stopping, failure)
+    end
+  end
+
+  @spec recover_runtime_supervisor_replacement(State.t()) :: {:noreply, State.t()}
+  def recover_runtime_supervisor_replacement(state) do
+    case Minga.Extension.Instance.StartTransition.prepare_artifact(state) do
+      {:ok, artifact, prepared} ->
+        Minga.Extension.Instance.RuntimeTransition.begin_runtime_replacement_start(
+          prepared,
+          artifact
+        )
+
+      {:error, reason, prepared} ->
+        Minga.Extension.Instance.StartTransition.begin_start_rollback(
+          prepared,
+          [],
+          [],
+          reason,
+          nil
+        )
+    end
+  end
+end

--- a/lib/minga/extension/instance/runtime.ex
+++ b/lib/minga/extension/instance/runtime.ex
@@ -1,0 +1,31 @@
+defmodule Minga.Extension.Instance.Runtime do
+  @moduledoc "Monitored runtime identity owned by an extension Instance."
+
+  @enforce_keys [:pid, :monitor]
+  defstruct [:pid, :monitor]
+
+  @type t :: %__MODULE__{pid: pid(), monitor: reference()}
+
+  @doc "Monitors and captures a runtime process."
+  @spec monitor(pid()) :: t()
+  def monitor(pid) when is_pid(pid), do: %__MODULE__{pid: pid, monitor: Process.monitor(pid)}
+
+  @doc "Returns the existing identity when it already names the process, otherwise monitors it."
+  @spec ensure(t() | nil, pid()) :: t()
+  def ensure(%__MODULE__{pid: pid} = runtime, pid), do: runtime
+  def ensure(_runtime, pid), do: monitor(pid)
+
+  @doc "Reports whether a DOWN identity matches this runtime."
+  @spec matches?(t(), reference(), pid()) :: boolean()
+  def matches?(%__MODULE__{pid: pid, monitor: monitor}, monitor, pid), do: true
+  def matches?(%__MODULE__{}, _monitor, _pid), do: false
+
+  @doc "Drops this runtime's monitor and any queued DOWN message."
+  @spec demonitor(t() | nil) :: :ok
+  def demonitor(nil), do: :ok
+
+  def demonitor(%__MODULE__{monitor: monitor}) do
+    Process.demonitor(monitor, [:flush])
+    :ok
+  end
+end

--- a/lib/minga/extension/instance/runtime_transition.ex
+++ b/lib/minga/extension/instance/runtime_transition.ex
@@ -1,0 +1,145 @@
+defmodule Minga.Extension.Instance.RuntimeTransition do
+  @moduledoc "Extension Instance runtime transition logic."
+
+  alias Minga.Extension.Instance.Artifact
+  alias Minga.Extension.Instance.Projection
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.StartContext
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.Instance.StopContext
+  alias Minga.Extension.Instance.Worker
+  alias Minga.Extension.RuntimeSupervisor
+
+  import Minga.Extension.Instance.Lifecycle
+
+  @spec runtime_down(State.t(), reference(), pid(), term()) :: {:noreply, State.t()}
+  def runtime_down(
+        %State{
+          phase:
+            {:starting,
+             %{
+               runtime: %Runtime{monitor: ref, pid: pid},
+               worker: %Worker{} = worker
+             } = context}
+        } = state,
+        ref,
+        pid,
+        reason
+      ) do
+    :ok = Worker.cancel(worker)
+
+    starting = State.starting(state, StartContext.runtime_exited(context))
+
+    Minga.Extension.Instance.StartTransition.begin_start_rollback(
+      starting,
+      context.waiters,
+      context.stop_waiters,
+      reason,
+      nil
+    )
+  end
+
+  def runtime_down(
+        %State{phase: {:running, %Runtime{monitor: ref, pid: pid}}} = state,
+        ref,
+        pid,
+        reason
+      ) do
+    {:ok, artifact} = State.artifact(state)
+
+    if Artifact.restart?(artifact.restart, reason) do
+      replace_runtime(state, artifact, reason)
+    else
+      exit_kind = if Artifact.crash?(reason), do: :crash, else: :normal
+      stopped = State.stopping(state, nil, exit_kind, reason)
+
+      case Projection.publish(stopped) do
+        :ok ->
+          Minga.Extension.Instance.QuiescenceTransition.begin_quiesce(stopped)
+
+        {:error, projection_reason} ->
+          failure =
+            Minga.Extension.Instance.TransitionHandler.publication_failure(
+              state.name,
+              reason,
+              projection_reason
+            )
+
+          {:stopping, context} = stopped.phase
+
+          updated = StopContext.record_terminal_failure(context, failure)
+
+          Minga.Extension.Instance.QuiescenceTransition.begin_quiesce(
+            State.stopping(stopped, updated)
+          )
+      end
+    end
+  end
+
+  def runtime_down(
+        %State{
+          phase: {:stopping, %StopContext{runtime: %Runtime{monitor: ref, pid: pid}} = context}
+        } = state,
+        ref,
+        pid,
+        _reason
+      ) do
+    {:noreply, State.stopping(state, StopContext.runtime_exited(context))}
+  end
+
+  def runtime_down(state, _ref, _pid, _reason), do: {:noreply, state}
+
+  @spec replace_runtime(State.t(), Artifact.t(), term()) :: {:noreply, State.t()}
+  def replace_runtime(state, artifact, _reason) do
+    begin_runtime_replacement_start(state, artifact)
+  end
+
+  @spec begin_runtime_replacement_start(State.t(), Artifact.t()) :: {:noreply, State.t()}
+  def begin_runtime_replacement_start(state, artifact) do
+    owner = self()
+    id = make_ref()
+    restarting = State.increment_restart(state)
+    context = StartContext.new([], state.phase)
+    starting = State.starting(restarting, context)
+
+    case Projection.publish(starting) do
+      :ok ->
+        worker =
+          Worker.start(
+            owner,
+            :start,
+            Minga.Extension.Instance.TransitionHandler.transition_timeout(state),
+            id,
+            fn ->
+              replacement_workflow(restarting, artifact, owner, id)
+            end
+          )
+
+        {:noreply, State.starting(starting, StartContext.begin_work(context, worker))}
+
+      {:error, reason} ->
+        Minga.Extension.Instance.StartTransition.begin_start_rollback(
+          starting,
+          [],
+          [],
+          reason,
+          nil
+        )
+    end
+  end
+
+  @spec replacement_workflow(State.t(), Artifact.t(), pid(), reference()) ::
+          {:ok, pid(), State.t()} | {:error, term(), State.t(), nil}
+  def replacement_workflow(state, artifact, owner, transition_id) do
+    case lifecycle_span(state.name, :child_start, fn ->
+           RuntimeSupervisor.start_child(runtime_supervisor(state), artifact.child_spec)
+         end) do
+      {:ok, pid} ->
+        send(owner, {Worker, :runtime_started, transition_id, pid})
+        {:ok, pid, state}
+
+      {:error, reason} ->
+        {:error, {:restart_failed, reason}, state, nil}
+    end
+  end
+end

--- a/lib/minga/extension/instance/source.ex
+++ b/lib/minga/extension/instance/source.ex
@@ -1,0 +1,411 @@
+defmodule Minga.Extension.Instance.Source do
+  @moduledoc """
+  Sole source preparation path for every extension lifecycle policy.
+
+  Committed current-generation artifacts are always reused first. Path and
+  resolved Git declarations use `CompileCache`; deterministic JSON bundles use
+  `JsonLoader`; module, bundled, and Hex declarations adopt trusted resident
+  inventories without replacing code in this VM.
+  """
+
+  alias Minga.Extension.ArtifactAdmission
+  alias Minga.Extension.BundledApplications
+  alias Minga.Extension.CompileCache
+  alias Minga.Extension.Entry
+  alias Minga.Extension.Instance.Artifact
+  alias Minga.Extension.Manifest
+
+  @doc "Prepares the exact admitted artifact for one declaration."
+  @spec prepare(atom(), Entry.t(), keyword()) :: {:ok, Artifact.t()} | {:error, term()}
+  def prepare(name, %Entry{} = declaration, opts) when is_atom(name) and is_list(opts) do
+    source = {:extension, name}
+    admission = admission(opts)
+
+    with {:ok, module, owned_modules} <- resolve(name, declaration, source, admission, opts),
+         :ok <- validate_behaviour(module, name),
+         {:ok, manifest} <- manifest(module, declaration.source_type) do
+      Artifact.build(name, module, manifest, owned_modules, declaration.config)
+    end
+  end
+
+  @doc "Discovers a declaration's load policy through the same admitted artifact path."
+  @spec discover_load_policy(atom(), Entry.t(), keyword()) ::
+          {:ok, Minga.Extension.load_policy(), Artifact.t()} | {:error, term()}
+  def discover_load_policy(name, declaration, opts) do
+    with {:ok, artifact} <- prepare(name, declaration, opts) do
+      policy =
+        if function_exported?(artifact.module, :__load_policy__, 0) do
+          artifact.module.__load_policy__()
+        else
+          :eager
+        end
+
+      {:ok, policy, artifact}
+    end
+  end
+
+  @doc "Reports a staged path/Git source change without loading new code."
+  @spec pending_restart?(atom(), Entry.t(), keyword()) :: boolean()
+  def pending_restart?(name, %{source_type: source_type, path: path}, opts)
+      when source_type in [:path, :git] and is_binary(path) do
+    expanded = Path.expand(path)
+    files = source_files(expanded)
+    report_staged_source_change(name, expanded, files, {:extension, name}, opts)
+  end
+
+  def pending_restart?(_name, _declaration, _opts), do: false
+
+  @spec resolve(atom(), Entry.t(), term(), GenServer.server(), keyword()) ::
+          {:ok, module(), [module()]} | {:error, term()}
+  defp resolve(name, declaration, source, admission, opts) do
+    case ArtifactAdmission.source_modules(source, server: admission) do
+      {:ok, [_module | _rest] = modules} -> reuse_committed(name, declaration, modules, opts)
+      {:ok, []} -> {:error, {:source_artifact_unavailable, source}}
+      :error -> admit_initial(name, declaration, source, admission, opts)
+    end
+  end
+
+  @spec reuse_committed(atom(), Entry.t(), [module()], keyword()) ::
+          {:ok, module(), [module()]} | {:error, term()}
+  defp reuse_committed(name, declaration, modules, opts) do
+    _changed? = pending_restart?(name, declaration, opts)
+
+    with :ok <- ensure_modules_loaded(modules),
+         {:ok, module} <- find_extension_module(modules) do
+      {:ok, module, modules}
+    end
+  end
+
+  @spec admit_initial(atom(), Entry.t(), term(), GenServer.server(), keyword()) ::
+          {:ok, module(), [module()]} | {:error, term()}
+  defp admit_initial(name, %{source_type: :module, module: module}, source, admission, opts) do
+    with {:module, ^module} <- Code.ensure_loaded(module),
+         {:ok, application} <- runtime_application(module, opts),
+         {:ok, modules} <- declared_runtime_modules(module, application, opts),
+         :ok <- ensure_modules_loaded(modules),
+         :ok <- admit_resident(source, modules, application, admission) do
+      {:ok, module, modules}
+    else
+      {:error, _reason} = error -> error
+      other -> {:error, {:module_load_failed, name, other}}
+    end
+  end
+
+  defp admit_initial(_name, %{source_type: :hex, hex: %{app: app}}, source, admission, _opts) do
+    with :ok <- ensure_hex_application_started(app),
+         {:ok, modules} <- application_modules(app),
+         :ok <- ensure_modules_loaded(modules),
+         {:ok, module} <- find_extension_module(modules),
+         :ok <- admit_resident(source, modules, app, admission) do
+      {:ok, module, modules}
+    end
+  end
+
+  defp admit_initial(_name, %{source_type: :git, path: nil}, _source, _admission, _opts),
+    do: {:error, :clone_failed}
+
+  defp admit_initial(name, %{source_type: source_type, path: path}, source, admission, opts)
+       when source_type in [:path, :git] and is_binary(path) do
+    expanded = Path.expand(path)
+
+    if File.dir?(expanded) do
+      compile_path(name, expanded, source, admission, opts)
+    else
+      {:error, "extension path does not exist: #{expanded}"}
+    end
+  end
+
+  @spec compile_path(atom(), String.t(), term(), GenServer.server(), keyword()) ::
+          {:ok, module(), [module()]} | {:error, term()}
+  defp compile_path(name, expanded, source, admission, opts) do
+    case source_files(expanded) do
+      [] -> load_json(name, expanded, source, admission, opts)
+      files -> load_compiled(name, expanded, files, source, admission, opts)
+    end
+  end
+
+  @spec load_json(atom(), String.t(), term(), GenServer.server(), keyword()) ::
+          {:ok, module(), [module()]} | {:error, term()}
+  defp load_json(name, expanded, source, admission, _opts) do
+    with {:ok, module} <-
+           Minga.Extension.JsonLoader.load(expanded, name, artifact_admission: admission),
+         {:ok, modules} <- ArtifactAdmission.source_modules(source, server: admission) do
+      {:ok, module, modules}
+    end
+  end
+
+  @spec load_compiled(atom(), String.t(), [String.t()], term(), GenServer.server(), keyword()) ::
+          {:ok, module(), [module()]} | {:error, term()}
+  defp load_compiled(name, expanded, files, source, admission, _opts) do
+    compile_opts = [
+      source: source,
+      artifact_admission: admission,
+      trusted_application: BundledApplications.trusted_application(name)
+    ]
+
+    with {:ok, %{modules: compiled, diagnostics: diagnostics}} <-
+           CompileCache.load_or_compile(expanded, files, compile_opts),
+         :ok <- log_diagnostics(diagnostics),
+         {:ok, modules} <- committed_modules(source, admission, compiled),
+         {:ok, module} <- find_extension_module(modules) do
+      {:ok, module, modules}
+    end
+  end
+
+  @spec committed_modules(term(), GenServer.server(), [module()]) ::
+          {:ok, [module()]} | {:error, term()}
+  defp committed_modules(source, admission, fallback) do
+    case ArtifactAdmission.source_modules(source, server: admission) do
+      {:ok, [_module | _rest] = modules} -> {:ok, modules}
+      _ -> {:ok, fallback}
+    end
+  end
+
+  @spec admit_resident(term(), [module()], atom(), GenServer.server()) :: :ok | {:error, term()}
+  defp admit_resident(source, modules, application, admission) do
+    fingerprint = resident_fingerprint(application, modules)
+
+    with {:ok, claim} <-
+           ArtifactAdmission.claim_source_modules(source, modules, fingerprint,
+             server: admission,
+             trusted_application: application,
+             exclusive_adoption: true,
+             source_fingerprint: fingerprint
+           ),
+         :ok <- verify_adoption(claim, modules, admission) do
+      ArtifactAdmission.commit_attempt(claim, server: admission)
+    end
+  end
+
+  @spec verify_adoption(ArtifactAdmission.claim(), [module()], GenServer.server()) ::
+          :ok | {:error, term()}
+  defp verify_adoption(claim, modules, admission) do
+    if claim.load_modules == [] and claim.adopted_modules == Enum.sort(modules) do
+      :ok
+    else
+      _ = ArtifactAdmission.abort_attempt(claim, server: admission)
+
+      {:error,
+       {:runtime_inventory_not_adopted, claim.source, claim.load_modules, claim.adopted_modules}}
+    end
+  end
+
+  @spec runtime_application(module(), keyword()) :: {:ok, atom()} | {:error, term()}
+  defp runtime_application(module, opts) do
+    case Keyword.fetch(opts, :runtime_application) do
+      {:ok, application} when is_atom(application) ->
+        {:ok, application}
+
+      {:ok, invalid} ->
+        {:error, {:invalid_runtime_application, invalid}}
+
+      :error ->
+        case :application.get_application(module) do
+          {:ok, application} -> {:ok, application}
+          :undefined -> {:error, {:runtime_application_unavailable, module}}
+        end
+    end
+  end
+
+  @spec declared_runtime_modules(module(), atom(), keyword()) ::
+          {:ok, [module()]} | {:error, term()}
+  defp declared_runtime_modules(module, application, opts) when is_list(opts) do
+    if Keyword.has_key?(opts, :runtime_application) do
+      application_modules(application)
+    else
+      {:ok, runtime_owned_modules(module, opts)}
+    end
+  end
+
+  @spec runtime_owned_modules(module(), keyword()) :: [module()]
+  defp runtime_owned_modules(module, opts) do
+    command_modules =
+      for {_name, _description, command_opts} <- schema(module, :__command_schema__),
+          is_list(command_opts),
+          Keyword.keyword?(command_opts),
+          {callback_module, callback_function} <- [Keyword.get(command_opts, :execute)],
+          is_atom(callback_module) and is_atom(callback_function),
+          do: callback_module
+
+    modeline_modules =
+      for {_name, _segment_opts, {callback_module, callback_function}} <-
+            schema(module, :__modeline_segment_schema__),
+          is_atom(callback_module) and is_atom(callback_function),
+          do: callback_module
+
+    event_modules =
+      for {callback_module, _families, _handler_opts} <-
+            schema(module, :__editor_event_handler_schema__),
+          is_atom(callback_module),
+          do: callback_module
+
+    [
+      module
+      | command_modules ++
+          modeline_modules ++ event_modules ++ Keyword.get(opts, :runtime_owned_modules, [])
+    ]
+    |> Enum.uniq()
+    |> Enum.sort()
+  end
+
+  @spec schema(module(), atom()) :: [term()]
+  defp schema(module, function),
+    do: if(function_exported?(module, function, 0), do: apply(module, function, []), else: [])
+
+  @spec application_modules(atom()) :: {:ok, [module()]} | {:error, term()}
+  defp application_modules(application) do
+    case :application.get_key(application, :modules) do
+      {:ok, [_module | _rest] = modules} -> {:ok, Enum.sort(Enum.uniq(modules))}
+      {:ok, []} -> {:error, {:runtime_application_has_no_modules, application}}
+      :undefined -> {:error, {:invalid_runtime_application, application}}
+    end
+  end
+
+  @spec ensure_hex_application_started(atom()) :: :ok | {:error, term()}
+  defp ensure_hex_application_started(app) do
+    case Application.ensure_all_started(app) do
+      {:ok, _applications} -> :ok
+      {:error, reason} -> {:error, {:hex_application_start_failed, app, reason}}
+    end
+  end
+
+  @spec ensure_modules_loaded([module()]) :: :ok | {:error, term()}
+  defp ensure_modules_loaded(modules) do
+    Enum.reduce_while(modules, :ok, fn module, :ok ->
+      case Code.ensure_loaded(module) do
+        {:module, ^module} -> {:cont, :ok}
+        {:error, reason} -> {:halt, {:error, {:runtime_module_unavailable, module, reason}}}
+      end
+    end)
+  end
+
+  @spec find_extension_module([module()]) :: {:ok, module()} | {:error, String.t()}
+  defp find_extension_module(modules) do
+    case Enum.find(modules, &implements_extension?/1) do
+      nil -> {:error, "no module implementing Minga.Extension behaviour found"}
+      module -> {:ok, module}
+    end
+  end
+
+  @spec implements_extension?(module()) :: boolean()
+  defp implements_extension?(module) do
+    Code.ensure_loaded?(module) and
+      function_exported?(module, :name, 0) and
+      function_exported?(module, :description, 0) and
+      function_exported?(module, :version, 0) and
+      function_exported?(module, :init, 1)
+  end
+
+  @spec validate_behaviour(module(), atom()) :: :ok | {:error, String.t()}
+  defp validate_behaviour(module, name) do
+    missing =
+      Enum.reject([:name, :description, :version, :init], fn
+        :init -> function_exported?(module, :init, 1)
+        function -> function_exported?(module, function, 0)
+      end)
+
+    case missing do
+      [] -> :ok
+      functions -> {:error, "extension #{name} missing callbacks: #{inspect(functions)}"}
+    end
+  end
+
+  @spec manifest(module(), Manifest.source_type()) :: {:ok, Manifest.t()} | {:error, term()}
+  defp manifest(module, source_type) do
+    {:ok, Manifest.from_module(module, source_type)}
+  rescue
+    error -> {:error, "manifest introspection failed: #{Exception.message(error)}"}
+  catch
+    kind, reason -> {:error, "manifest introspection failed: #{inspect(kind)} #{inspect(reason)}"}
+  end
+
+  @spec source_files(String.t()) :: [String.t()]
+  defp source_files(expanded),
+    do: expanded |> Path.join("**/*.ex") |> Path.wildcard() |> Enum.sort()
+
+  @spec report_staged_source_change(atom(), String.t(), [String.t()], term(), keyword()) ::
+          boolean()
+  defp report_staged_source_change(name, expanded, files, source, opts) do
+    admission = admission(opts)
+
+    with {:ok, admitted} <- ArtifactAdmission.source_fingerprint(source, server: admission),
+         {:ok, current} <- current_source_fingerprint(name, expanded, files, opts),
+         false <- admitted == current do
+      Minga.Events.broadcast(
+        :extension_restart_required,
+        %Minga.Events.ExtensionRestartRequiredEvent{
+          extension: name,
+          reason: :source_changed,
+          old_ref: Base.encode16(admitted, case: :lower),
+          new_ref: Base.encode16(current, case: :lower)
+        }
+      )
+
+      true
+    else
+      _unchanged_or_unavailable -> false
+    end
+  end
+
+  @spec current_source_fingerprint(atom(), String.t(), [String.t()], keyword()) ::
+          {:ok, binary()} | {:error, term()}
+  defp current_source_fingerprint(name, expanded, [], _opts) do
+    json_path = Path.join(expanded, "plugin.json")
+
+    with {:ok, raw} <- File.read(json_path),
+         {:ok, manifest} when is_map(manifest) <- JSON.decode(raw) do
+      substituted = substitute_json_root(manifest, expanded)
+
+      module_name =
+        name
+        |> Atom.to_string()
+        |> String.replace("-", "_")
+        |> Macro.camelize()
+        |> then(&Module.concat(Minga.Extension.Plugin, &1))
+
+      payload =
+        :erlang.term_to_binary(
+          {Atom.to_string(module_name), Path.expand(expanded), substituted},
+          [:deterministic]
+        )
+
+      {:ok, :crypto.hash(:sha256, payload)}
+    else
+      {:error, reason} -> {:error, reason}
+      _invalid -> {:error, :invalid_plugin_json}
+    end
+  end
+
+  defp current_source_fingerprint(_name, expanded, files, opts) do
+    CompileCache.source_fingerprint(expanded, files, opts)
+  end
+
+  @spec substitute_json_root(term(), String.t()) :: term()
+  defp substitute_json_root(value, root) when is_binary(value),
+    do: String.replace(value, "${MINGA_PLUGIN_ROOT}", root)
+
+  defp substitute_json_root(value, root) when is_map(value),
+    do: Map.new(value, fn {key, item} -> {key, substitute_json_root(item, root)} end)
+
+  defp substitute_json_root(value, root) when is_list(value),
+    do: Enum.map(value, &substitute_json_root(&1, root))
+
+  defp substitute_json_root(value, _root), do: value
+
+  @spec resident_fingerprint(atom(), [module()]) :: binary()
+  defp resident_fingerprint(application, modules) do
+    digests = Enum.map(modules, &{&1, &1.module_info(:md5)})
+    :crypto.hash(:sha256, :erlang.term_to_binary({:runtime_inventory_v1, application, digests}))
+  end
+
+  @spec log_diagnostics([map()]) :: :ok
+  defp log_diagnostics(diagnostics) do
+    Enum.each(diagnostics, fn diagnostic ->
+      message = Map.get(diagnostic, :message, "")
+      Minga.Log.warning(:editor, "[ext] #{message}")
+    end)
+  end
+
+  @spec admission(keyword()) :: GenServer.server()
+  defp admission(opts), do: Keyword.get(opts, :artifact_admission, ArtifactAdmission)
+end

--- a/lib/minga/extension/instance/start_context.ex
+++ b/lib/minga/extension/instance/start_context.ex
@@ -1,0 +1,46 @@
+defmodule Minga.Extension.Instance.StartContext do
+  @moduledoc "Phase-owned state for one extension start transition."
+
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.Worker
+
+  @enforce_keys [:waiters, :stop_waiters, :previous]
+  defstruct [:waiters, :stop_waiters, :previous, runtime: nil, worker: nil]
+
+  @type t :: %__MODULE__{
+          waiters: [GenServer.from()],
+          stop_waiters: [GenServer.from()],
+          previous: term(),
+          runtime: Runtime.t() | nil,
+          worker: Worker.t() | nil
+        }
+
+  @doc "Starts a transition with its callers and previous phase."
+  @spec new([GenServer.from()], term()) :: t()
+  def new(waiters, previous),
+    do: %__MODULE__{waiters: waiters, stop_waiters: [], previous: previous}
+
+  @doc "Adds a caller waiting for the in-flight start."
+  @spec join(t(), GenServer.from()) :: t()
+  def join(context, from), do: %{context | waiters: [from | context.waiters]}
+
+  @doc "Queues a stop caller behind the in-flight start."
+  @spec queue_stop(t(), GenServer.from()) :: t()
+  def queue_stop(context, from), do: %{context | stop_waiters: [from | context.stop_waiters]}
+
+  @doc "Records the bounded worker performing the transition."
+  @spec begin_work(t(), Worker.t()) :: t()
+  def begin_work(context, worker), do: %{context | worker: worker}
+
+  @doc "Records the runtime started by the transition."
+  @spec runtime_started(t(), Runtime.t()) :: t()
+  def runtime_started(context, runtime), do: %{context | runtime: runtime}
+
+  @doc "Clears completed or failed worker bookkeeping."
+  @spec finish_work(t()) :: t()
+  def finish_work(context), do: %{context | worker: nil}
+
+  @doc "Clears runtime and worker ownership after the runtime exits during start."
+  @spec runtime_exited(t()) :: t()
+  def runtime_exited(context), do: %{context | runtime: nil, worker: nil}
+end

--- a/lib/minga/extension/instance/start_transition.ex
+++ b/lib/minga/extension/instance/start_transition.ex
@@ -1,0 +1,394 @@
+defmodule Minga.Extension.Instance.StartTransition do
+  @moduledoc "Extension Instance start transition logic."
+
+  alias Minga.Extension.Instance.Artifact
+  alias Minga.Extension.Instance.Contributions
+  alias Minga.Extension.Instance.Projection
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.Source
+  alias Minga.Extension.Instance.StartContext
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.Instance.StopContext
+  alias Minga.Extension.Instance.Worker
+  alias Minga.Extension.RuntimeSupervisor
+
+  import Minga.Extension.Instance.Lifecycle
+
+  @type callback_result :: {:reply, term(), State.t()} | {:noreply, State.t()}
+
+  @spec request_start(State.t(), GenServer.from()) :: callback_result()
+  def request_start(%State{phase: {:running, runtime}} = state, from) do
+    case Projection.publish(state) do
+      :ok -> {:reply, {:ok, runtime.pid}, state}
+      {:error, reason} -> begin_start_rollback(state, [from], [], reason, runtime.pid)
+    end
+  end
+
+  def request_start(%State{phase: {:starting, context}} = state, from) do
+    {:noreply, State.starting(state, StartContext.join(context, from))}
+  end
+
+  def request_start(%State{phase: {:stopping, _context}} = state, from),
+    do: {:noreply, State.queue_start(state, {:current, from})}
+
+  def request_start(%State{phase: {:cleanup_failed, failure}} = state, _from),
+    do: {:reply, {:error, {:cleanup_retry_required, failure.reason}}, state}
+
+  def request_start(state, from) do
+    context = StartContext.new([from], state.phase)
+    starting = State.starting(state, context)
+
+    case Projection.publish(starting) do
+      :ok ->
+        send(self(), :perform_start)
+        {:noreply, starting}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, State.load_error(state, reason)}
+    end
+  end
+
+  @spec request_deferred_start(State.t(), GenServer.from(), Minga.Extension.Entry.t()) ::
+          callback_result()
+  def request_deferred_start(state, from, declaration) do
+    if State.declaration_only(declaration) == state.declaration do
+      request_current_deferred_start(state, from, declaration)
+    else
+      {:reply, {:error, :stale_deferred_declaration}, state}
+    end
+  end
+
+  @spec request_current_deferred_start(State.t(), GenServer.from(), Minga.Extension.Entry.t()) ::
+          callback_result()
+  def request_current_deferred_start(
+        %State{phase: {:stopping, _context}} = state,
+        from,
+        declaration
+      ),
+      do: {:noreply, State.queue_start(state, {:deferred, from, declaration})}
+
+  def request_current_deferred_start(state, from, _declaration), do: request_start(state, from)
+
+  @spec request_prerequisite_failure(State.t(), GenServer.from(), term()) :: callback_result()
+  def request_prerequisite_failure(%State{phase: {:running, runtime}} = state, _from, _reason),
+    do: {:reply, {:error, {:already_running, runtime.pid}}, state}
+
+  def request_prerequisite_failure(%State{phase: {:stopping, _context}} = state, from, reason) do
+    GenServer.reply(from, {:error, reason})
+    {:noreply, state}
+  end
+
+  def request_prerequisite_failure(state, from, reason) do
+    begin_start_rollback(state, [from], [], reason, nil)
+  end
+
+  @spec load_policy_result(State.t()) :: callback_result()
+  def load_policy_result(state) do
+    case prepare_artifact(state) do
+      {:ok, artifact, prepared} ->
+        policy = state.declaration.load_policy || artifact.manifest.load_policy || :eager
+
+        case Projection.publish(prepared) do
+          :ok ->
+            {:reply, {:ok, policy}, prepared}
+
+          {:error, reason} ->
+            {:reply, {:error, reason}, State.load_error(prepared, reason)}
+        end
+
+      {:error, reason, prepared} ->
+        failed = State.load_error(prepared, reason)
+
+        {failed, reply_reason, _publication} =
+          Minga.Extension.Instance.TransitionHandler.publish_terminal(failed, reason)
+
+        {:reply, {:error, reply_reason}, failed}
+    end
+  end
+
+  @spec request_stub(State.t()) :: callback_result()
+  def request_stub(%State{phase: {:stub, _artifact}} = state), do: {:reply, :ok, state}
+  def request_stub(%State{phase: {:running, _runtime}} = state), do: {:reply, :ok, state}
+  def request_stub(%State{phase: :stopped} = state), do: register_stub(state)
+  def request_stub(%State{phase: {:load_error, _error}} = state), do: register_stub(state)
+  def request_stub(%State{phase: {:crashed, _error}} = state), do: register_stub(state)
+  def request_stub(state), do: {:reply, {:error, {:unexpected_phase, state.phase}}, state}
+
+  @spec register_stub(State.t()) :: callback_result()
+  def register_stub(state) do
+    case prepare_artifact(state) do
+      {:ok, artifact, prepared} -> register_prepared_stub(state, artifact, prepared)
+      {:error, reason, prepared} -> stub_failure(prepared, reason)
+    end
+  end
+
+  @spec register_prepared_stub(State.t(), Artifact.t(), State.t()) :: callback_result()
+  def register_prepared_stub(state, artifact, prepared) do
+    result =
+      Contributions.register_stub(
+        self(),
+        state.name,
+        state.declaration,
+        artifact,
+        state.declaration.config,
+        state.collaborators
+      )
+
+    publish_registered_stub(result, artifact, prepared)
+  end
+
+  @spec publish_registered_stub(:ok | {:error, term()}, Artifact.t(), State.t()) ::
+          callback_result()
+  def publish_registered_stub(:ok, artifact, prepared) do
+    updated = State.stubbed(prepared, artifact)
+
+    case Projection.publish(updated) do
+      :ok -> {:reply, :ok, updated}
+      {:error, reason} -> stub_failure(prepared, reason)
+    end
+  end
+
+  def publish_registered_stub({:error, reason}, _artifact, prepared),
+    do: stub_failure(prepared, reason)
+
+  @spec stub_failure(State.t(), term()) :: callback_result()
+  def stub_failure(state, reason) do
+    case Contributions.cleanup(state.name, state.collaborators) do
+      :ok ->
+        updated = State.load_error(state, reason)
+
+        {updated, reply_reason, _publication} =
+          Minga.Extension.Instance.TransitionHandler.publish_terminal(updated, reason)
+
+        {:reply, {:error, reply_reason}, updated}
+
+      {:error, failures} ->
+        failure = wrap_cleanup_failure(reason, {:error, failures})
+        stopping = State.stopping(state, nil, :explicit, :stub_failure)
+        {:stopping, context} = stopping.phase
+        retry = StopContext.cleanup_retry(context, stage: :cleanup)
+        updated = State.cleanup_failed(state, failure, retry)
+
+        {updated, reply_reason, _publication} =
+          Minga.Extension.Instance.TransitionHandler.publish_terminal(updated, failure)
+
+        {:reply, {:error, reply_reason}, updated}
+    end
+  end
+
+  @spec perform_start(State.t()) :: {:noreply, State.t()}
+  def perform_start(%State{phase: {:starting, %StartContext{worker: nil} = context}} = state) do
+    owner = self()
+    id = make_ref()
+
+    worker =
+      Worker.start(
+        owner,
+        :start,
+        Minga.Extension.Instance.TransitionHandler.transition_timeout(state),
+        id,
+        fn ->
+          start_workflow(state, context.previous, owner, id)
+        end
+      )
+
+    {:noreply, State.starting(state, StartContext.begin_work(context, worker))}
+  end
+
+  def perform_start(state), do: {:noreply, state}
+
+  @spec start_workflow(State.t(), State.phase(), pid(), reference()) ::
+          {:ok, pid(), State.t()} | {:error, term(), State.t(), pid() | nil}
+  def start_workflow(state, previous_phase, owner, transition_id) do
+    lifecycle_span(state.name, :load, fn ->
+      run_start_workflow(state, previous_phase, owner, transition_id)
+    end)
+  end
+
+  @spec run_start_workflow(State.t(), State.phase(), pid(), reference()) ::
+          {:ok, pid(), State.t()} | {:error, term(), State.t(), pid() | nil}
+  def run_start_workflow(state, previous_phase, owner, transition_id) do
+    with {:ok, artifact, prepared} <- prepare_artifact(state),
+         :ok <- cleanup_stub_if_needed(previous_phase, state),
+         :ok <- prepare_runtime(state, artifact),
+         {:ok, pid} <- start_runtime_child(state, artifact) do
+      send(owner, {Worker, :runtime_started, transition_id, pid})
+      register_runtime(state, artifact, prepared, pid)
+    else
+      {:error, reason, prepared} -> {:error, reason, prepared, nil}
+      {:error, reason} -> {:error, reason, state, nil}
+    end
+  end
+
+  @spec prepare_runtime(State.t(), Artifact.t()) :: :ok | {:error, term()}
+  def prepare_runtime(state, artifact) do
+    lifecycle_span(state.name, :init, fn ->
+      Contributions.prepare_runtime(
+        state.name,
+        artifact,
+        state.declaration.config,
+        state.collaborators
+      )
+    end)
+  end
+
+  @spec start_runtime_child(State.t(), Artifact.t()) :: {:ok, pid()} | {:error, term()}
+  def start_runtime_child(state, artifact) do
+    lifecycle_span(state.name, :child_start, fn ->
+      RuntimeSupervisor.start_child(runtime_supervisor(state), artifact.child_spec)
+    end)
+  end
+
+  @spec register_runtime(State.t(), Artifact.t(), State.t(), pid()) ::
+          {:ok, pid(), State.t()} | {:error, term(), State.t(), pid()}
+  def register_runtime(state, artifact, prepared, pid) do
+    case Contributions.register_runtime(state.name, artifact, state.collaborators) do
+      :ok -> {:ok, pid, prepared}
+      {:error, reason} -> {:error, reason, prepared, pid}
+    end
+  end
+
+  @spec runtime_started(State.t(), reference(), pid()) :: {:noreply, State.t()}
+  def runtime_started(
+        %State{phase: {:starting, %StartContext{worker: %Worker{id: id}} = context}} = state,
+        id,
+        pid
+      ) do
+    runtime = Runtime.monitor(pid)
+    {:noreply, State.starting(state, StartContext.runtime_started(context, runtime))}
+  end
+
+  def runtime_started(state, _id, pid) do
+    Process.exit(pid, :kill)
+    {:noreply, state}
+  end
+
+  @spec start_workflow_done(State.t(), term()) :: {:noreply, State.t()}
+  def start_workflow_done(%State{phase: {:starting, context}} = state, {:ok, pid, prepared}) do
+    runtime = Runtime.ensure(context.runtime, pid)
+    running = State.running(prepared, runtime)
+
+    case Projection.publish(running) do
+      :ok ->
+        complete_started_workflow(state, context, running, pid)
+
+      {:error, reason} ->
+        begin_start_rollback(running, context.waiters, context.stop_waiters, reason, pid)
+    end
+  end
+
+  def start_workflow_done(
+        %State{phase: {:starting, context}},
+        {:error, reason, prepared, runtime_pid}
+      ) do
+    begin_start_rollback(prepared, context.waiters, context.stop_waiters, reason, runtime_pid)
+  end
+
+  @spec complete_started_workflow(State.t(), StartContext.t(), State.t(), pid()) ::
+          {:noreply, State.t()}
+  def complete_started_workflow(state, context, running, pid) do
+    emit_restart_count(state.name, state.restart_count)
+    broadcast_started(running)
+    Enum.each(context.waiters, &GenServer.reply(&1, {:ok, pid}))
+    continue_after_queued_stop(context.stop_waiters, running)
+  end
+
+  @spec continue_after_queued_stop([GenServer.from()], State.t()) :: {:noreply, State.t()}
+  def continue_after_queued_stop([], running), do: {:noreply, running}
+
+  def continue_after_queued_stop(stop_waiters, running) do
+    stopping = State.stopping(running, nil, :explicit, :queued_stop)
+    {:stopping, stop_context} = stopping.phase
+    stopping = State.stopping(stopping, StopContext.transfer_waiters(stop_context, stop_waiters))
+
+    case Projection.publish(stopping) do
+      :ok ->
+        Minga.Extension.Instance.QuiescenceTransition.begin_quiesce(stopping)
+
+      {:error, reason} ->
+        Minga.Extension.Instance.StopTransition.stop_failed(
+          stopping,
+          {:projection_failed, reason}
+        )
+    end
+  end
+
+  @spec begin_start_rollback(
+          State.t(),
+          [GenServer.from()],
+          [GenServer.from()],
+          term(),
+          pid() | nil
+        ) ::
+          {:noreply, State.t()}
+  def begin_start_rollback(state, start_waiters, stop_waiters, reason, runtime_pid) do
+    base = rollback_runtime_state(state, runtime_pid)
+    stopping = State.stopping(base, nil, :explicit, :failed_start)
+    {:stopping, context} = stopping.phase
+
+    context = StopContext.rollback_start(context, reason, start_waiters, stop_waiters)
+    stopping = State.stopping(stopping, context)
+
+    case Projection.publish(stopping) do
+      :ok ->
+        Minga.Extension.Instance.QuiescenceTransition.begin_quiesce(stopping)
+
+      {:error, projection_reason} ->
+        failure =
+          Minga.Extension.Instance.TransitionHandler.publication_failure(
+            state.name,
+            reason,
+            projection_reason
+          )
+
+        {:stopping, failed_context} = stopping.phase
+
+        failed_context =
+          StopContext.replace_start_failure(failed_context, failure, start_waiters)
+
+        Minga.Extension.Instance.QuiescenceTransition.begin_quiesce(
+          State.stopping(stopping, failed_context)
+        )
+    end
+  end
+
+  @spec rollback_runtime_state(State.t(), pid() | nil) :: State.t()
+  def rollback_runtime_state(state, nil), do: state
+
+  def rollback_runtime_state(%State{phase: {:running, %{pid: pid}}} = state, pid), do: state
+
+  def rollback_runtime_state(
+        %State{phase: {:starting, %StartContext{runtime: %Runtime{pid: pid} = runtime}}} = state,
+        pid
+      ) do
+    State.running(state, runtime)
+  end
+
+  def rollback_runtime_state(state, pid), do: State.running(state, Runtime.monitor(pid))
+
+  @spec prepare_artifact(State.t()) ::
+          {:ok, Artifact.t(), State.t()} | {:error, term(), State.t()}
+  def prepare_artifact(state) do
+    case State.artifact(state) do
+      {:ok, artifact} ->
+        _changed? = Source.pending_restart?(state.name, state.declaration, state.collaborators)
+        {:ok, artifact, state}
+
+      :error ->
+        case Source.prepare(state.name, state.declaration, state.collaborators) do
+          {:ok, artifact} -> {:ok, artifact, State.put_artifact(state, artifact)}
+          {:error, reason} -> {:error, reason, state}
+        end
+    end
+  end
+
+  @spec cleanup_stub_if_needed(State.phase(), State.t()) :: :ok | {:error, term()}
+  def cleanup_stub_if_needed({:stub, _artifact}, state) do
+    case Contributions.cleanup(state.name, state.collaborators) do
+      :ok -> :ok
+      {:error, failures} -> {:error, {:cleanup_failed, failures}}
+    end
+  end
+
+  def cleanup_stub_if_needed(_phase, _state), do: :ok
+end

--- a/lib/minga/extension/instance/state.ex
+++ b/lib/minga/extension/instance/state.ex
@@ -1,0 +1,226 @@
+defmodule Minga.Extension.Instance.State do
+  @moduledoc "Pure lifecycle state and phase transitions for one extension Instance."
+
+  alias Minga.Extension.Entry
+  alias Minga.Extension.Instance.Artifact
+  alias Minga.Extension.Instance.CleanupFailure
+  alias Minga.Extension.Instance.PhaseFailure
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.StartContext
+  alias Minga.Extension.Instance.StopContext
+
+  @type queued_start :: {:current, GenServer.from()} | {:deferred, GenServer.from(), Entry.t()}
+  @type phase ::
+          :stopped
+          | {:stub, Artifact.t()}
+          | {:starting, StartContext.t()}
+          | {:running, Runtime.t()}
+          | {:stopping, StopContext.t()}
+          | {:crashed, PhaseFailure.t()}
+          | {:load_error, PhaseFailure.t()}
+          | {:cleanup_failed, CleanupFailure.t()}
+
+  @enforce_keys [:name, :declaration, :registry, :instance_registry, :collaborators]
+  defstruct [
+    :name,
+    :declaration,
+    :registry,
+    :instance_registry,
+    :collaborators,
+    artifact: :unprepared,
+    restart_count: 0,
+    phase: :stopped
+  ]
+
+  @type t :: %__MODULE__{
+          name: atom(),
+          declaration: Entry.t(),
+          registry: GenServer.server(),
+          instance_registry: atom(),
+          collaborators: keyword(),
+          artifact: :unprepared | {:prepared, Artifact.t()},
+          restart_count: non_neg_integer(),
+          phase: phase()
+        }
+
+  @doc "Constructs a stopped lifecycle state from its declaration."
+  @spec new(atom(), Entry.t(), GenServer.server(), atom(), keyword()) :: t()
+  def new(name, declaration, registry, instance_registry, collaborators) do
+    %__MODULE__{
+      name: name,
+      declaration: declaration_only(declaration),
+      registry: registry,
+      instance_registry: instance_registry,
+      collaborators: collaborators
+    }
+  end
+
+  @doc "Updates declaration identity and collaborators while no transition is active."
+  @spec declare(t(), Entry.t(), GenServer.server(), keyword()) :: {:ok, t()} | {:error, term()}
+  def declare(%__MODULE__{phase: phase} = state, declaration, registry, collaborators)
+      when phase == :stopped or
+             (is_tuple(phase) and elem(phase, 0) in [:load_error, :crashed]) do
+    {:ok,
+     %{
+       state
+       | declaration: declaration_only(declaration),
+         registry: registry,
+         collaborators: current_collaborators(state.collaborators, collaborators),
+         artifact: declaration_artifact(state.declaration, declaration, state.artifact)
+     }}
+  end
+
+  def declare(%__MODULE__{declaration: current} = state, declaration, registry, collaborators) do
+    if declaration_only(current) == declaration_only(declaration) do
+      {:ok,
+       %{
+         state
+         | registry: registry,
+           collaborators: current_collaborators(state.collaborators, collaborators)
+       }}
+    else
+      {:error, {:declaration_busy, state.name}}
+    end
+  end
+
+  @doc "Replaces per-request lifecycle collaborators while retaining stable injections."
+  @spec configure(t(), keyword()) :: t()
+  def configure(state, collaborators) do
+    %{state | collaborators: current_collaborators(state.collaborators, collaborators)}
+  end
+
+  @doc "Removes request-scoped callbacks, hooks, and timeout overrides."
+  @spec stable_collaborators(keyword()) :: keyword()
+  def stable_collaborators(collaborators) do
+    Enum.reject(collaborators, fn {key, _value} -> request_override?(key) end)
+  end
+
+  @doc "Stores the immutable current-generation artifact."
+  @spec put_artifact(t(), Artifact.t()) :: t()
+  def put_artifact(state, artifact), do: %{state | artifact: {:prepared, artifact}}
+
+  @doc "Returns the prepared artifact when available."
+  @spec artifact(t()) :: {:ok, Artifact.t()} | :error
+  def artifact(%__MODULE__{artifact: {:prepared, artifact}}), do: {:ok, artifact}
+  def artifact(%__MODULE__{}), do: :error
+
+  @doc "Moves the authority into a start transition."
+  @spec starting(t(), StartContext.t()) :: t()
+  def starting(state, context), do: %{state | phase: {:starting, context}}
+
+  @doc "Moves the authority into the running phase."
+  @spec running(t(), Runtime.t()) :: t()
+  def running(state, runtime), do: %{state | phase: {:running, runtime}}
+
+  @doc "Moves the authority into a stop transition with an existing context."
+  @spec stopping(t(), StopContext.t()) :: t()
+  def stopping(state, context), do: %{state | phase: {:stopping, context}}
+
+  @doc "Builds the initial asynchronous stop context."
+  @spec stopping(t(), GenServer.from() | nil, :explicit | :normal | :crash, term()) :: t()
+  def stopping(state, waiter, exit_kind, exit_reason) do
+    context = StopContext.new(waiter, exit_kind, exit_reason, runtime(state.phase))
+    stopping(state, context)
+  end
+
+  @doc "Moves the authority to the lazy stub phase."
+  @spec stubbed(t(), Artifact.t()) :: t()
+  def stubbed(state, artifact), do: %{state | phase: {:stub, artifact}}
+
+  @doc "Moves the authority to a terminal stopped phase."
+  @spec stopped(t()) :: t()
+  def stopped(state), do: %{state | phase: :stopped}
+
+  @doc "Applies the terminal phase implied by a completed stop context."
+  @spec terminal(t(), StopContext.t()) :: t()
+  def terminal(state, %StopContext{exit_kind: :crash, exit_reason: reason}),
+    do: crashed(state, reason)
+
+  def terminal(state, %StopContext{}), do: stopped(state)
+
+  @doc "Moves the authority to a terminal crash phase."
+  @spec crashed(t(), term()) :: t()
+  def crashed(state, reason), do: %{state | phase: {:crashed, PhaseFailure.new(reason)}}
+
+  @doc "Moves the authority to a terminal load-error phase."
+  @spec load_error(t(), term()) :: t()
+  def load_error(state, reason), do: %{state | phase: {:load_error, PhaseFailure.new(reason)}}
+
+  @doc "Moves the authority to cleanup-failed with a resumable stop context."
+  @spec cleanup_failed(t(), term(), StopContext.t()) :: t()
+  def cleanup_failed(state, reason, retry) do
+    %{state | phase: {:cleanup_failed, CleanupFailure.new(reason, retry)}}
+  end
+
+  @doc "Replaces the reason of the current terminal failure phase."
+  @spec replace_terminal_failure(t(), term()) :: t()
+  def replace_terminal_failure(%__MODULE__{phase: {:cleanup_failed, failure}} = state, reason) do
+    %{state | phase: {:cleanup_failed, CleanupFailure.replace_reason(failure, reason)}}
+  end
+
+  def replace_terminal_failure(state, reason), do: load_error(state, reason)
+
+  @doc "Increments the authority-owned crash restart count."
+  @spec increment_restart(t()) :: t()
+  def increment_restart(state), do: %{state | restart_count: state.restart_count + 1}
+
+  @doc "Adds a caller to a transition's stop waiter list."
+  @spec join_stop(t(), GenServer.from()) :: t()
+  def join_stop(%__MODULE__{phase: {:stopping, context}} = state, from) do
+    stopping(state, StopContext.join(context, from))
+  end
+
+  @doc "Queues a start intent behind a safe stop."
+  @spec queue_start(t(), queued_start()) :: t()
+  def queue_start(%__MODULE__{phase: {:stopping, context}} = state, queued_start) do
+    stopping(state, StopContext.queue_start(context, queued_start))
+  end
+
+  @doc "Returns runtime identity only from phases that own it."
+  @spec runtime(phase()) :: Runtime.t() | nil
+  def runtime({:running, runtime}), do: runtime
+  def runtime({:stopping, %StopContext{runtime: runtime}}), do: runtime
+  def runtime(_phase), do: nil
+
+  @doc "Removes projection fields from a registry snapshot."
+  @spec declaration_only(Entry.t()) :: Entry.t()
+  def declaration_only(%Entry{} = entry) do
+    declared_module = if entry.source_type == :module, do: entry.module, else: nil
+
+    %{
+      entry
+      | module: declared_module,
+        pid: nil,
+        manifest: nil,
+        last_error: nil,
+        status: :stopped
+    }
+  end
+
+  @spec current_collaborators(keyword(), keyword()) :: keyword()
+  defp current_collaborators(previous, current) do
+    previous
+    |> stable_collaborators()
+    |> Keyword.merge(current)
+  end
+
+  @spec request_override?(atom()) :: boolean()
+  defp request_override?(:callbacks), do: true
+  defp request_override?(:test_hooks), do: true
+  defp request_override?(:slow_lifecycle_threshold_ms), do: true
+
+  defp request_override?(key) when is_atom(key) do
+    key
+    |> Atom.to_string()
+    |> String.ends_with?("_timeout_ms")
+  end
+
+  @spec declaration_artifact(
+          Entry.t(),
+          Entry.t(),
+          :unprepared | {:prepared, Artifact.t()}
+        ) :: :unprepared | {:prepared, Artifact.t()}
+  defp declaration_artifact(old, new, artifact) do
+    if declaration_only(old) == declaration_only(new), do: artifact, else: :unprepared
+  end
+end

--- a/lib/minga/extension/instance/stop_context.ex
+++ b/lib/minga/extension/instance/stop_context.ex
@@ -1,0 +1,202 @@
+defmodule Minga.Extension.Instance.StopContext do
+  @moduledoc "Phase-owned state and transitions for one extension stop operation."
+
+  alias Minga.Extension.Entry
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.Worker
+
+  @type queued_start :: {:current, GenServer.from()} | {:deferred, GenServer.from(), Entry.t()}
+  @type completion :: :stop | {:start_failure, term(), [GenServer.from()]}
+  @type stage ::
+          :quiescing | :draining | :editor_finalize | :editor_unload | :terminating | :cleanup
+
+  @enforce_keys [:waiters, :exit_kind, :exit_reason, :runtime]
+  defstruct [
+    :waiters,
+    :exit_kind,
+    :exit_reason,
+    :runtime,
+    start_waiters: [],
+    stage: :quiescing,
+    token: nil,
+    drain_ref: nil,
+    editor_ref: nil,
+    drain_done?: false,
+    editor_done?: false,
+    finalizer_error: nil,
+    drain_timer: nil,
+    worker: nil,
+    completion: :stop
+  ]
+
+  @type t :: %__MODULE__{
+          waiters: [GenServer.from()],
+          start_waiters: [queued_start()],
+          stage: stage(),
+          token: reference() | nil,
+          drain_ref: reference() | nil,
+          editor_ref: reference() | nil,
+          drain_done?: boolean(),
+          editor_done?: boolean(),
+          finalizer_error: term() | nil,
+          exit_kind: :explicit | :normal | :crash,
+          exit_reason: term(),
+          runtime: Runtime.t() | nil,
+          drain_timer: reference() | nil,
+          worker: Worker.t() | nil,
+          completion: completion()
+        }
+
+  @doc "Builds an initial quiescing stop transition."
+  @spec new(GenServer.from() | nil, :explicit | :normal | :crash, term(), Runtime.t() | nil) ::
+          t()
+  def new(waiter, exit_kind, exit_reason, runtime) do
+    waiters = if waiter == nil, do: [], else: [waiter]
+
+    %__MODULE__{
+      waiters: waiters,
+      exit_kind: exit_kind,
+      exit_reason: exit_reason,
+      runtime: runtime
+    }
+  end
+
+  @doc "Adds another stop caller."
+  @spec join(t(), GenServer.from()) :: t()
+  def join(context, from), do: %{context | waiters: [from | context.waiters]}
+
+  @doc "Queues a start intent behind this stop."
+  @spec queue_start(t(), queued_start()) :: t()
+  def queue_start(context, start), do: %{context | start_waiters: [start | context.start_waiters]}
+
+  @doc "Replaces stop waiters when a queued stop is transferred from a start."
+  @spec transfer_waiters(t(), [GenServer.from()]) :: t()
+  def transfer_waiters(context, waiters), do: %{context | waiters: waiters}
+
+  @doc "Records that this stop is rolling back a failed start."
+  @spec rollback_start(t(), term(), [GenServer.from()], [GenServer.from()]) :: t()
+  def rollback_start(context, reason, start_waiters, stop_waiters) do
+    %{context | waiters: stop_waiters, completion: {:start_failure, reason, start_waiters}}
+  end
+
+  @doc "Replaces the failed-start reason after projection also fails."
+  @spec replace_start_failure(t(), term(), [GenServer.from()]) :: t()
+  def replace_start_failure(context, reason, start_waiters) do
+    %{context | completion: {:start_failure, reason, start_waiters}}
+  end
+
+  @doc "Begins lease draining."
+  @spec begin_drain(t(), reference(), reference(), reference()) :: t()
+  def begin_drain(context, token, drain_ref, timer) do
+    %{context | stage: :draining, token: token, drain_ref: drain_ref, drain_timer: timer}
+  end
+
+  @doc "Remembers a failed drain request so unload can be aborted correctly."
+  @spec remember_failed_drain(t(), reference(), reference()) :: t()
+  def remember_failed_drain(context, token, drain_ref),
+    do: %{context | token: token, drain_ref: drain_ref}
+
+  @doc "Moves directly to editor finalization when no active lease exists."
+  @spec begin_editor_finalize(t()) :: t()
+  def begin_editor_finalize(context), do: %{context | stage: :editor_finalize, drain_done?: true}
+
+  @doc "Attaches the worker and acknowledgement identity for an editor finalizer."
+  @spec attach_finalizer(t(), Worker.t()) :: t()
+  def attach_finalizer(context, worker), do: %{context | worker: worker, editor_ref: worker.id}
+
+  @doc "Marks the code source drained and clears timer ownership."
+  @spec source_drained(t()) :: t()
+  def source_drained(context), do: %{context | drain_done?: true, drain_timer: nil}
+
+  @doc "Clears a fired or cancelled drain timer."
+  @spec clear_drain_timer(t()) :: t()
+  def clear_drain_timer(context), do: %{context | drain_timer: nil}
+
+  @doc "Records completion of editor effects and merges a finalizer result."
+  @spec editor_effects_done(t(), :ok | {:error, term()}) :: t()
+  def editor_effects_done(context, result) do
+    %{context | editor_done?: true, finalizer_error: merge_error(context.finalizer_error, result)}
+  end
+
+  @doc "Records an explicit finalizer failure."
+  @spec fail_finalizer(t(), term()) :: t()
+  def fail_finalizer(context, reason), do: %{context | finalizer_error: reason}
+
+  @doc "Merges an unload or completion result into finalizer failure state."
+  @spec merge_finalizer_result(t(), :ok | {:error, term()}) :: t()
+  def merge_finalizer_result(context, result) do
+    %{context | finalizer_error: merge_error(context.finalizer_error, result)}
+  end
+
+  @doc "Moves the stop barrier to editor unload."
+  @spec begin_editor_unload(t()) :: t()
+  def begin_editor_unload(context), do: %{context | stage: :editor_unload}
+
+  @doc "Moves the stop operation to runtime termination."
+  @spec begin_termination(t()) :: t()
+  def begin_termination(context), do: %{context | stage: :terminating}
+
+  @doc "Records the worker performing termination or cleanup."
+  @spec attach_worker(t(), Worker.t()) :: t()
+  def attach_worker(context, worker), do: %{context | worker: worker}
+
+  @doc "Moves to cleanup and records its worker."
+  @spec begin_cleanup(t(), Worker.t()) :: t()
+  def begin_cleanup(context, worker), do: %{context | stage: :cleanup, worker: worker}
+
+  @doc "Clears completed or failed worker bookkeeping."
+  @spec finish_work(t()) :: t()
+  def finish_work(context), do: %{context | worker: nil}
+
+  @doc "Records a terminal-runtime cleanup failure."
+  @spec record_terminal_failure(t(), term()) :: t()
+  def record_terminal_failure(context, failure), do: %{context | finalizer_error: failure}
+
+  @doc "Clears runtime identity after its DOWN arrives during stop."
+  @spec runtime_exited(t()) :: t()
+  def runtime_exited(context), do: %{context | runtime: nil}
+
+  @doc "Builds a clean retry after cleanup failed."
+  @spec cleanup_retry(t(), keyword()) :: t()
+  def cleanup_retry(context, opts \\ []) do
+    %{
+      context
+      | waiters: [],
+        start_waiters: [],
+        stage: Keyword.get(opts, :stage, context.stage),
+        completion: Keyword.get(opts, :completion, context.completion),
+        drain_timer: nil,
+        worker: nil
+    }
+  end
+
+  @doc "Starts a cleanup-only retry for one caller."
+  @spec retry_cleanup(t(), GenServer.from()) :: t()
+  def retry_cleanup(context, from), do: %{context | waiters: [from], start_waiters: []}
+
+  @doc "Restarts quiescence retry state for one caller."
+  @spec retry_quiescence(t(), GenServer.from()) :: t()
+  def retry_quiescence(context, from) do
+    %{
+      context
+      | waiters: [from],
+        start_waiters: [],
+        stage: :quiescing,
+        token: nil,
+        drain_ref: nil,
+        drain_timer: nil,
+        editor_ref: nil,
+        drain_done?: false,
+        editor_done?: false,
+        finalizer_error: nil,
+        worker: nil
+    }
+  end
+
+  @spec merge_error(term() | nil, :ok | {:error, term()}) :: term() | nil
+  defp merge_error(current, :ok), do: current
+  defp merge_error(nil, {:error, reason}), do: reason
+
+  defp merge_error(current, {:error, reason}),
+    do: {:multiple_finalizer_failures, [current, reason]}
+end

--- a/lib/minga/extension/instance/stop_transition.ex
+++ b/lib/minga/extension/instance/stop_transition.ex
@@ -1,0 +1,376 @@
+defmodule Minga.Extension.Instance.StopTransition do
+  @moduledoc "Extension Instance stop transition logic."
+
+  alias Minga.Extension.Instance.Contributions
+  alias Minga.Extension.Instance.Projection
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.StartContext
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.Instance.StopContext
+  alias Minga.Extension.Instance.TransitionHandler
+  alias Minga.Extension.Instance.Worker
+  alias Minga.Extension.RuntimeSupervisor
+
+  import Minga.Extension.Instance.Lifecycle
+
+  @type callback_result :: {:reply, term(), State.t()} | {:noreply, State.t()}
+
+  @spec request_stop(State.t(), GenServer.from()) :: callback_result()
+  def request_stop(%State{phase: :stopped} = state, _from) do
+    case Projection.publish(state) do
+      :ok ->
+        {:reply, :ok, state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, TransitionHandler.put_terminal_failure(state, reason)}
+    end
+  end
+
+  def request_stop(%State{phase: {:stopping, _context}} = state, from),
+    do: {:noreply, State.join_stop(state, from)}
+
+  def request_stop(%State{phase: {:starting, context}} = state, from) do
+    {:noreply, State.starting(state, StartContext.queue_stop(context, from))}
+  end
+
+  def request_stop(%State{phase: {:cleanup_failed, failure}} = state, from) do
+    retry = failure.retry
+    retry_stop(State.stopping(state, retry), retry, from)
+  end
+
+  def request_stop(state, from) do
+    updated = State.stopping(state, from, :explicit, :explicit_stop)
+
+    case Projection.publish(updated) do
+      :ok -> Minga.Extension.Instance.QuiescenceTransition.begin_quiesce(updated)
+      {:error, reason} -> stop_failed(updated, {:projection_failed, reason})
+    end
+  end
+
+  @spec advance_runtime_termination(State.t()) :: {:noreply, State.t()}
+  def advance_runtime_termination(%State{phase: {:stopping, context}} = state) do
+    begin_runtime_termination(State.stopping(state, StopContext.begin_termination(context)))
+  end
+
+  @spec begin_runtime_termination(State.t()) :: {:noreply, State.t()}
+  def begin_runtime_termination(%State{phase: {:stopping, %StopContext{runtime: nil}}} = state),
+    do: request_cleanup(state)
+
+  def begin_runtime_termination(%State{phase: {:stopping, context}} = state) do
+    worker =
+      Worker.start(
+        self(),
+        :terminate,
+        Minga.Extension.Instance.TransitionHandler.callback_timeout(state),
+        fn ->
+          terminate_runtime(state, context.runtime)
+        end
+      )
+
+    {:noreply, State.stopping(state, StopContext.attach_worker(context, worker))}
+  end
+
+  @spec terminate_runtime(State.t(), Runtime.t()) :: :ok | {:error, term()}
+  def terminate_runtime(state, runtime) do
+    lifecycle_span(state.name, :stop, fn ->
+      case RuntimeSupervisor.terminate_child(runtime_supervisor(state), runtime.pid) do
+        :ok -> :ok
+        {:error, :not_found} -> :ok
+        {:error, _reason} = error -> error
+      end
+    end)
+  end
+
+  @spec request_cleanup(State.t()) :: {:noreply, State.t()}
+  def request_cleanup(%State{phase: {:stopping, context}} = state) do
+    worker =
+      Worker.start(
+        self(),
+        :cleanup,
+        Minga.Extension.Instance.TransitionHandler.callback_timeout(state),
+        fn ->
+          Contributions.cleanup(state.name, state.collaborators)
+        end
+      )
+
+    updated = StopContext.begin_cleanup(context, worker)
+    {:noreply, State.stopping(state, updated)}
+  end
+
+  @spec cleanup_ack(State.t(), reference(), term()) :: {:noreply, State.t()}
+  def cleanup_ack(
+        %State{phase: {:stopping, %StopContext{stage: :cleanup, editor_ref: ref} = context}} =
+          state,
+        ref,
+        result
+      ) do
+    finish_stop(state, context, result)
+  end
+
+  def cleanup_ack(state, _ref, _result), do: {:noreply, state}
+
+  @spec finish_stop(State.t(), StopContext.t(), term()) :: {:noreply, State.t()}
+  def finish_stop(
+        state,
+        %{exit_kind: exit_kind, finalizer_error: reason} = context,
+        :ok
+      )
+      when exit_kind in [:normal, :crash] and not is_nil(reason) do
+    maybe_demonitor(context.runtime)
+    failure = terminal_finalizer_error(exit_kind, reason)
+    failed = State.load_error(state, failure)
+
+    {failed, reply_reason, _publication} =
+      Minga.Extension.Instance.TransitionHandler.publish_terminal(failed, failure)
+
+    Minga.Extension.Instance.TransitionHandler.reply_terminal_waiters(
+      context,
+      {:error, reply_reason}
+    )
+
+    {:noreply, failed}
+  end
+
+  def finish_stop(
+        state,
+        %{completion: {:start_failure, reason, start_waiters}} = context,
+        :ok
+      ) do
+    maybe_demonitor(context.runtime)
+    failed = State.load_error(state, reason)
+
+    {failed, reply_reason, publication} =
+      Minga.Extension.Instance.TransitionHandler.publish_terminal(failed, reason)
+
+    Enum.each(start_waiters, &GenServer.reply(&1, {:error, reply_reason}))
+
+    reply_queued_starts(
+      context.start_waiters,
+      {:error, reply_reason}
+    )
+
+    stop_reply = if publication == :ok, do: :ok, else: {:error, reply_reason}
+    Enum.each(context.waiters, &GenServer.reply(&1, stop_reply))
+    {:noreply, failed}
+  end
+
+  def finish_stop(state, context, :ok) do
+    maybe_demonitor(context.runtime)
+    stopped = State.terminal(state, context)
+    phase = stopped.phase
+
+    case Minga.Extension.Instance.TransitionHandler.publish_terminal(
+           stopped,
+           {:terminal_projection, phase}
+         ) do
+      {published, _reason, :ok} ->
+        finish_published_stop(published, context, phase)
+
+      {failed, reason, :error} ->
+        Minga.Extension.Instance.TransitionHandler.reply_terminal_waiters(
+          context,
+          {:error, reason}
+        )
+
+        {:noreply, failed}
+    end
+  end
+
+  def finish_stop(
+        state,
+        %{completion: {:start_failure, start_reason, start_waiters}} = context,
+        {:error, failures}
+      ) do
+    reason = wrap_cleanup_failure(start_reason, {:error, failures})
+    retry = StopContext.cleanup_retry(context, completion: :stop)
+    failed = State.cleanup_failed(state, reason, retry)
+
+    {failed, reply_reason, _publication} =
+      Minga.Extension.Instance.TransitionHandler.publish_terminal(failed, reason)
+
+    Enum.each(start_waiters, &GenServer.reply(&1, {:error, reply_reason}))
+
+    reply_queued_starts(
+      context.start_waiters,
+      {:error, reply_reason}
+    )
+
+    Enum.each(context.waiters, &GenServer.reply(&1, {:error, reply_reason}))
+    {:noreply, failed}
+  end
+
+  def finish_stop(state, %{exit_kind: :explicit} = context, {:error, failures}) do
+    reason = terminal_cleanup_error(context, failures)
+    retry = StopContext.cleanup_retry(context)
+    failed = State.cleanup_failed(state, reason, retry)
+
+    {failed, reply_reason, _publication} =
+      Minga.Extension.Instance.TransitionHandler.publish_terminal(failed, reason)
+
+    Enum.each(context.waiters, &GenServer.reply(&1, {:error, reply_reason}))
+
+    reply_queued_starts(
+      context.start_waiters,
+      {:error, {:cleanup_retry_required, reply_reason}}
+    )
+
+    {:noreply, failed}
+  end
+
+  def finish_stop(state, context, {:error, failures}) do
+    reason = terminal_cleanup_error(context, failures)
+
+    retry = StopContext.cleanup_retry(context, stage: :cleanup)
+    failed = State.cleanup_failed(state, reason, retry)
+
+    {failed, reply_reason, _publication} =
+      Minga.Extension.Instance.TransitionHandler.publish_terminal(failed, reason)
+
+    Minga.Extension.Instance.TransitionHandler.reply_terminal_waiters(
+      context,
+      {:error, reply_reason}
+    )
+
+    {:noreply, failed}
+  end
+
+  @spec finish_published_stop(State.t(), StopContext.t(), State.phase()) ::
+          {:noreply, State.t()}
+  def finish_published_stop(stopped, context, phase) do
+    emit_terminal_phase(stopped.name, phase)
+    Enum.each(context.waiters, &GenServer.reply(&1, :ok))
+
+    {waiters, stale_waiters} =
+      queued_start_waiters(
+        stopped,
+        context.start_waiters
+      )
+
+    Enum.each(stale_waiters, &GenServer.reply(&1, {:error, :stale_deferred_declaration}))
+
+    case waiters do
+      [] ->
+        {:noreply, stopped}
+
+      valid_waiters ->
+        start_context = StartContext.new(valid_waiters, stopped.phase)
+        starting = State.starting(stopped, start_context)
+
+        case Projection.publish(starting) do
+          :ok ->
+            send(self(), :perform_start)
+            {:noreply, starting}
+
+          {:error, reason} ->
+            Enum.each(valid_waiters, &GenServer.reply(&1, {:error, reason}))
+            {:noreply, State.load_error(stopped, reason)}
+        end
+    end
+  end
+
+  @spec retry_stop(State.t(), StopContext.t(), GenServer.from()) :: {:noreply, State.t()}
+  def retry_stop(state, %{stage: :cleanup} = context, from) do
+    updated_context = StopContext.retry_cleanup(context, from)
+    request_cleanup(State.stopping(state, updated_context))
+  end
+
+  def retry_stop(state, context, from) do
+    updated_context = StopContext.retry_quiescence(context, from)
+
+    Minga.Extension.Instance.QuiescenceTransition.begin_quiesce(
+      State.stopping(state, updated_context)
+    )
+  end
+
+  @spec stop_failed(State.t(), term()) :: {:noreply, State.t()}
+  def stop_failed(
+        %State{
+          phase:
+            {:stopping,
+             %StopContext{completion: {:start_failure, start_reason, start_waiters}} = context}
+        } =
+          state,
+        reason
+      ) do
+    cancel_timer(context.drain_timer)
+    failure = wrap_cleanup_failure(start_reason, {:error, rollback_stage_failure(reason)})
+
+    retry = StopContext.cleanup_retry(context, completion: :stop)
+    failed = State.cleanup_failed(state, failure, retry)
+
+    {failed, reply_reason, _publication} =
+      Minga.Extension.Instance.TransitionHandler.publish_terminal(failed, failure)
+
+    Enum.each(start_waiters, &GenServer.reply(&1, {:error, reply_reason}))
+
+    reply_queued_starts(
+      context.start_waiters,
+      {:error, reply_reason}
+    )
+
+    Enum.each(context.waiters, &GenServer.reply(&1, {:error, reply_reason}))
+    {:noreply, failed}
+  end
+
+  def stop_failed(%State{phase: {:stopping, context}} = state, reason) do
+    cancel_timer(context.drain_timer)
+    retry = StopContext.clear_drain_timer(context)
+    failed = State.cleanup_failed(state, reason, retry)
+
+    {failed, reply_reason, _publication} =
+      Minga.Extension.Instance.TransitionHandler.publish_terminal(failed, reason)
+
+    Enum.each(context.waiters, &GenServer.reply(&1, {:error, reply_reason}))
+
+    reply_queued_starts(
+      context.start_waiters,
+      {:error, {:cleanup_retry_required, reply_reason}}
+    )
+
+    {:noreply, failed}
+  end
+
+  @spec rollback_stage_failure(term()) :: keyword()
+  def rollback_stage_failure({:runtime_termination_failed, reason}),
+    do: [runtime_termination: reason]
+
+  def rollback_stage_failure(reason), do: [quiesce: reason]
+
+  @spec queued_start_waiters(State.t(), [
+          State.queued_start()
+        ]) ::
+          {[GenServer.from()], [GenServer.from()]}
+  def queued_start_waiters(state, queued_starts) do
+    current_declaration = Minga.Extension.Registry.get(state.registry, state.name)
+
+    queued_starts
+    |> Enum.reduce({[], []}, fn
+      {:current, from}, {valid, stale} ->
+        {[from | valid], stale}
+
+      {:deferred, from, declaration}, {valid, stale} ->
+        if deferred_declaration_current?(current_declaration, declaration) do
+          {[from | valid], stale}
+        else
+          {valid, [from | stale]}
+        end
+    end)
+  end
+
+  @spec deferred_declaration_current?(term(), Minga.Extension.Entry.t()) :: boolean()
+  def deferred_declaration_current?({:ok, current}, declaration),
+    do: State.declaration_only(current) == State.declaration_only(declaration)
+
+  def deferred_declaration_current?(_current, _declaration), do: false
+
+  @spec reply_queued_starts(
+          [State.queued_start()],
+          term()
+        ) :: :ok
+  def reply_queued_starts(queued_starts, reply) do
+    Enum.each(queued_starts, fn
+      {:current, from} -> GenServer.reply(from, reply)
+      {:deferred, from, _declaration} -> GenServer.reply(from, reply)
+    end)
+  end
+end

--- a/lib/minga/extension/instance/transition_handler.ex
+++ b/lib/minga/extension/instance/transition_handler.ex
@@ -1,0 +1,499 @@
+defmodule Minga.Extension.Instance.TransitionHandler do
+  @moduledoc "Extension Instance  transitionhandler logic."
+
+  alias Minga.Extension.Instance.Projection
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.StartContext
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.Instance.StopContext
+  alias Minga.Extension.Instance.Worker
+  alias Minga.Extension.InstanceRegistry
+  alias Minga.Extension.RuntimeSupervisor
+  alias Minga.Log
+
+  import Minga.Extension.Instance.Lifecycle
+
+  @type callback_result :: {:reply, term(), State.t()} | {:noreply, State.t()}
+  @default_transition_timeout_ms 120_000
+  @default_callback_timeout_ms 5_000
+  @default_runtime_query_timeout_ms 100
+  @default_drain_timeout_ms 5_000
+
+  @spec transition_done(State.t(), reference(), term()) :: {:noreply, State.t()}
+  def transition_done(
+        %State{phase: {:starting, %StartContext{worker: %Worker{id: id} = worker} = context}} =
+          state,
+        id,
+        result
+      ) do
+    :ok = Worker.complete(worker)
+    state = State.starting(state, StartContext.finish_work(context))
+
+    case result do
+      {:ok, workflow_result} ->
+        Minga.Extension.Instance.StartTransition.start_workflow_done(state, workflow_result)
+
+      {:error, reason} ->
+        start_worker_failed(state, reason)
+    end
+  end
+
+  def transition_done(
+        %State{
+          phase:
+            {:stopping,
+             %StopContext{worker: %Worker{id: id, kind: {:finalizer, family}} = worker} = context}
+        } = state,
+        id,
+        result
+      ) do
+    :ok = Worker.complete(worker)
+    state = State.stopping(state, StopContext.finish_work(context))
+    callback_result = if match?({:ok, _}, result), do: elem(result, 1), else: result
+
+    Minga.Extension.Instance.QuiescenceTransition.finalizer_ack(
+      state,
+      id,
+      family,
+      callback_result
+    )
+  end
+
+  def transition_done(
+        %State{
+          phase:
+            {:stopping,
+             %StopContext{worker: %Worker{id: id, kind: :terminate} = worker} = context}
+        } =
+          state,
+        id,
+        result
+      ) do
+    :ok = Worker.complete(worker)
+    state = State.stopping(state, StopContext.finish_work(context))
+
+    case result do
+      {:ok, :ok} ->
+        Minga.Extension.Instance.StopTransition.request_cleanup(state)
+
+      {:ok, {:error, reason}} ->
+        runtime_termination_failed(state, reason)
+
+      {:error, reason} ->
+        runtime_termination_failed(state, reason)
+    end
+  end
+
+  def transition_done(
+        %State{
+          phase:
+            {:stopping, %StopContext{worker: %Worker{id: id, kind: :cleanup} = worker} = context}
+        } =
+          state,
+        id,
+        result
+      ) do
+    :ok = Worker.complete(worker)
+    context = StopContext.finish_work(context)
+
+    cleanup_result =
+      case result do
+        {:ok, value} -> value
+        {:error, reason} -> {:error, [worker_cleanup_failure(state.name, reason)]}
+      end
+
+    Minga.Extension.Instance.StopTransition.finish_stop(
+      State.stopping(state, context),
+      context,
+      cleanup_result
+    )
+  end
+
+  def transition_done(state, _id, _result), do: {:noreply, state}
+
+  @spec transition_timeout(State.t(), reference(), Worker.kind()) :: {:noreply, State.t()}
+  def transition_timeout(
+        %State{phase: {:starting, %StartContext{worker: %Worker{id: id} = worker}}} = state,
+        id,
+        kind
+      ) do
+    :ok = Worker.timeout(worker)
+    reason = {:transition_timeout, kind, transition_timeout(state)}
+    start_timeout_failed(state, worker, reason)
+  end
+
+  def transition_timeout(
+        %State{
+          phase:
+            {:stopping,
+             %StopContext{worker: %Worker{id: id, kind: :terminate} = worker} = context}
+        } = state,
+        id,
+        :terminate
+      ) do
+    :ok = Worker.timeout(worker)
+
+    reason =
+      {:runtime_termination_failed, {:transition_timeout, :terminate, callback_timeout(state)}}
+
+    replace_runtime_branch(State.stopping(state, StopContext.finish_work(context)), reason)
+  end
+
+  def transition_timeout(
+        %State{phase: {:stopping, %StopContext{worker: %Worker{id: id} = worker}}} = state,
+        id,
+        kind
+      ) do
+    :ok = Worker.timeout(worker)
+    transition_failed(state, worker, {:transition_timeout, kind, callback_timeout(state)})
+  end
+
+  def transition_timeout(state, _id, _kind), do: {:noreply, state}
+
+  @spec process_down(State.t(), reference(), pid(), term()) :: {:noreply, State.t()}
+  def process_down(
+        %State{
+          phase: {:starting, %StartContext{worker: %Worker{monitor: ref, pid: pid} = worker}}
+        } = state,
+        ref,
+        pid,
+        reason
+      ) do
+    :ok = Worker.down(worker)
+    transition_failed(state, worker, {:transition_worker_down, worker.kind, reason})
+  end
+
+  def process_down(
+        %State{phase: {:stopping, %StopContext{worker: %Worker{monitor: ref, pid: pid} = worker}}} =
+          state,
+        ref,
+        pid,
+        reason
+      ) do
+    :ok = Worker.down(worker)
+    transition_failed(state, worker, {:transition_worker_down, worker.kind, reason})
+  end
+
+  def process_down(state, ref, pid, reason),
+    do: Minga.Extension.Instance.RuntimeTransition.runtime_down(state, ref, pid, reason)
+
+  @spec transition_failed(State.t(), Worker.t(), term()) :: {:noreply, State.t()}
+  def transition_failed(%State{phase: {:starting, context}} = state, _worker, reason) do
+    state = State.starting(state, StartContext.finish_work(context))
+    start_worker_failed(state, reason)
+  end
+
+  def transition_failed(
+        %State{phase: {:stopping, context}} = state,
+        %Worker{kind: {:finalizer, family}, id: id},
+        reason
+      ) do
+    state = State.stopping(state, StopContext.finish_work(context))
+
+    Minga.Extension.Instance.QuiescenceTransition.finalizer_ack(
+      state,
+      id,
+      family,
+      {:error, reason}
+    )
+  end
+
+  def transition_failed(
+        %State{phase: {:stopping, context}} = state,
+        %Worker{kind: :terminate},
+        reason
+      ) do
+    runtime_termination_failed(
+      State.stopping(state, StopContext.finish_work(context)),
+      reason
+    )
+  end
+
+  def transition_failed(
+        %State{phase: {:stopping, context}} = state,
+        %Worker{kind: :cleanup},
+        reason
+      ) do
+    context = StopContext.finish_work(context)
+
+    Minga.Extension.Instance.StopTransition.finish_stop(
+      State.stopping(state, context),
+      context,
+      {:error, [worker_cleanup_failure(state.name, reason)]}
+    )
+  end
+
+  @spec start_timeout_failed(
+          State.t(),
+          Worker.t(),
+          term()
+        ) :: {:noreply, State.t()}
+  def start_timeout_failed(
+        %State{phase: {:starting, %StartContext{runtime: %Runtime{pid: pid}} = context}} = state,
+        _worker,
+        reason
+      ) do
+    state = State.starting(state, StartContext.finish_work(context))
+
+    Minga.Extension.Instance.StartTransition.begin_start_rollback(
+      state,
+      context.waiters,
+      context.stop_waiters,
+      reason,
+      pid
+    )
+  end
+
+  def start_timeout_failed(
+        %State{phase: {:starting, context}} = state,
+        _worker,
+        reason
+      ) do
+    state = State.starting(state, StartContext.finish_work(context))
+
+    case RuntimeSupervisor.local_child(runtime_supervisor(state), runtime_query_timeout(state)) do
+      {:ok, pid} ->
+        Minga.Extension.Instance.StartTransition.begin_start_rollback(
+          state,
+          context.waiters,
+          context.stop_waiters,
+          reason,
+          pid
+        )
+
+      :empty ->
+        Minga.Extension.Instance.StartTransition.begin_start_rollback(
+          state,
+          context.waiters,
+          context.stop_waiters,
+          reason,
+          nil
+        )
+
+      {:error, {:runtime_supervisor_unavailable, :timeout}} ->
+        replace_runtime_branch(state, reason)
+
+      {:error, _reason} ->
+        replace_runtime_branch(state, reason)
+    end
+  end
+
+  @spec start_worker_failed(State.t(), term()) ::
+          {:noreply, State.t()}
+  def start_worker_failed(
+        %State{phase: {:starting, %StartContext{runtime: %Runtime{pid: pid}} = context}} = state,
+        reason
+      ) do
+    Minga.Extension.Instance.StartTransition.begin_start_rollback(
+      state,
+      context.waiters,
+      context.stop_waiters,
+      reason,
+      pid
+    )
+  end
+
+  def start_worker_failed(
+        %State{phase: {:starting, context}} = state,
+        reason
+      ) do
+    case RuntimeSupervisor.local_child(runtime_supervisor(state), runtime_query_timeout(state)) do
+      {:ok, pid} ->
+        Minga.Extension.Instance.StartTransition.begin_start_rollback(
+          state,
+          context.waiters,
+          context.stop_waiters,
+          reason,
+          pid
+        )
+
+      :empty ->
+        Minga.Extension.Instance.StartTransition.begin_start_rollback(
+          state,
+          context.waiters,
+          context.stop_waiters,
+          reason,
+          nil
+        )
+
+      {:error, _supervisor_reason} ->
+        replace_runtime_branch(state, reason)
+    end
+  end
+
+  @spec runtime_termination_failed(State.t(), term()) ::
+          {:noreply, State.t()}
+  def runtime_termination_failed(
+        %State{phase: {:stopping, context}} = state,
+        reason
+      ) do
+    failure = {:runtime_termination_failed, reason}
+
+    case context.exit_kind do
+      :explicit ->
+        Minga.Extension.Instance.StopTransition.stop_failed(state, failure)
+
+      _terminal ->
+        updated = StopContext.record_terminal_failure(context, failure)
+        Minga.Extension.Instance.StopTransition.request_cleanup(State.stopping(state, updated))
+    end
+  end
+
+  @spec worker_cleanup_failure(atom(), term()) :: map()
+  def worker_cleanup_failure(name, reason) do
+    %{family: :cleanup_worker, source: {:extension, name}, reason: reason}
+  end
+
+  @spec transition_timeout(State.t()) :: pos_integer()
+  def transition_timeout(state) do
+    Keyword.get(state.collaborators, :transition_timeout_ms, @default_transition_timeout_ms)
+  end
+
+  @spec callback_timeout(State.t()) :: pos_integer()
+  def callback_timeout(state) do
+    Keyword.get(state.collaborators, :callback_timeout_ms, @default_callback_timeout_ms)
+  end
+
+  @spec drain_timeout_ms(State.t()) :: pos_integer()
+  def drain_timeout_ms(state) do
+    Keyword.get(state.collaborators, :drain_timeout_ms, @default_drain_timeout_ms)
+  end
+
+  @spec runtime_query_timeout(State.t()) :: pos_integer()
+  def runtime_query_timeout(state) do
+    Keyword.get(
+      state.collaborators,
+      :runtime_query_timeout_ms,
+      @default_runtime_query_timeout_ms
+    )
+  end
+
+  @spec replace_runtime_branch(State.t(), term()) :: {:noreply, State.t()}
+  def replace_runtime_branch(%State{phase: {:starting, context}} = state, reason) do
+    failed = State.load_error(state, reason)
+    reply_reason = publish_failure_reason(failed, reason)
+    Enum.each(context.waiters, &GenServer.reply(&1, {:error, reply_reason}))
+    Enum.each(context.stop_waiters, &GenServer.reply(&1, {:error, reply_reason}))
+    replace_runtime_branch_processes(state, context.runtime)
+    {:noreply, failed}
+  end
+
+  def replace_runtime_branch(%State{phase: {:stopping, context}} = state, reason) do
+    retry = StopContext.cleanup_retry(context)
+    failed = State.cleanup_failed(state, reason, retry)
+    reply_reason = publish_failure_reason(failed, reason)
+    reply_stop_context(context, reply_reason)
+    replace_runtime_branch_processes(state, context.runtime)
+    {:noreply, failed}
+  end
+
+  def replace_runtime_branch(state, reason) do
+    failed = State.load_error(state, reason)
+    _reply_reason = publish_failure_reason(failed, reason)
+    replace_runtime_branch_processes(state, State.runtime(state.phase))
+    {:noreply, failed}
+  end
+
+  @spec publish_failure_reason(State.t(), term()) :: term()
+  def publish_failure_reason(state, reason) do
+    case Projection.publish(state) do
+      :ok ->
+        reason
+
+      {:error, projection_reason} ->
+        publication_failure(state.name, reason, projection_reason)
+    end
+  end
+
+  @spec publish_terminal(State.t(), term()) :: {State.t(), term(), :ok | :error}
+  def publish_terminal(state, reason) do
+    case Projection.publish(state) do
+      :ok ->
+        {state, reason, :ok}
+
+      {:error, projection_reason} ->
+        failure = publication_failure(state.name, reason, projection_reason)
+        {put_terminal_failure(state, failure), failure, :error}
+    end
+  end
+
+  @spec put_terminal_failure(State.t(), term()) :: State.t()
+  def put_terminal_failure(state, failure), do: State.replace_terminal_failure(state, failure)
+
+  @spec publication_failure(atom(), term(), term()) :: term()
+  def publication_failure(name, reason, reason) do
+    log_publication_failure(name, reason)
+    reason
+  end
+
+  def publication_failure(
+        name,
+        {:lifecycle_failure, _reason, _projection} = failure,
+        _projection_reason
+      ) do
+    log_publication_failure(name, failure)
+    failure
+  end
+
+  def publication_failure(name, reason, projection_reason) do
+    failure = {:lifecycle_failure, reason, {:projection_failed, projection_reason}}
+    log_publication_failure(name, failure)
+    failure
+  end
+
+  @spec log_publication_failure(atom(), term()) :: :ok
+  def log_publication_failure(name, failure) do
+    Log.error(
+      :ext,
+      "Extension #{name} lifecycle projection failed: #{inspect(failure)}"
+    )
+  end
+
+  @spec reply_terminal_waiters(StopContext.t(), term()) :: :ok
+  def reply_terminal_waiters(context, reply) do
+    case context.completion do
+      {:start_failure, _reason, start_waiters} ->
+        Enum.each(start_waiters, &GenServer.reply(&1, reply))
+
+      :stop ->
+        :ok
+    end
+
+    Enum.each(context.waiters, &GenServer.reply(&1, reply))
+    Minga.Extension.Instance.StopTransition.reply_queued_starts(context.start_waiters, reply)
+  end
+
+  @spec reply_stop_context(StopContext.t(), term()) :: :ok
+  def reply_stop_context(context, reason) do
+    case context.completion do
+      {:start_failure, _start_reason, start_waiters} ->
+        Enum.each(start_waiters, &GenServer.reply(&1, {:error, reason}))
+
+      :stop ->
+        :ok
+    end
+
+    Enum.each(context.waiters, &GenServer.reply(&1, {:error, reason}))
+
+    Minga.Extension.Instance.StopTransition.reply_queued_starts(
+      context.start_waiters,
+      {:error, {:cleanup_retry_required, reason}}
+    )
+  end
+
+  @spec replace_runtime_branch_processes(State.t(), Runtime.t() | nil) :: :ok
+  def replace_runtime_branch_processes(state, runtime) do
+    if runtime != nil, do: Process.exit(runtime.pid, :kill)
+
+    case InstanceRegistry.whereis(state.instance_registry, :runtime, state.name) do
+      pid when is_pid(pid) ->
+        Process.flag(:trap_exit, false)
+        Process.exit(pid, :kill)
+
+      nil ->
+        Process.exit(self(), :kill)
+    end
+
+    :ok
+  end
+end

--- a/lib/minga/extension/instance/worker.ex
+++ b/lib/minga/extension/instance/worker.ex
@@ -1,0 +1,87 @@
+defmodule Minga.Extension.Instance.Worker do
+  @moduledoc "Linked, monitored, bounded transition work owned by one Instance."
+
+  @typedoc "Identity and cancellation handles for one asynchronous transition."
+  @enforce_keys [:id, :kind, :pid, :monitor, :timer]
+  defstruct [:id, :kind, :pid, :monitor, :timer]
+
+  @type kind :: :start | :terminate | {:finalizer, atom()} | :cleanup
+  @type failure ::
+          {:transition_worker_failed, kind(),
+           {:raise, Exception.t(), Exception.stacktrace()}
+           | {:throw | :exit, term(), Exception.stacktrace()}}
+  @type t :: %__MODULE__{
+          id: reference(),
+          kind: kind(),
+          pid: pid(),
+          monitor: reference(),
+          timer: reference()
+        }
+
+  @doc "Starts linked transition work and arms its deterministic timeout."
+  @spec start(pid(), kind(), pos_integer(), (-> term())) :: t()
+  def start(owner, kind, timeout_ms, fun)
+      when is_pid(owner) and is_integer(timeout_ms) and timeout_ms > 0 and is_function(fun, 0) do
+    start(owner, kind, timeout_ms, make_ref(), fun)
+  end
+
+  @doc "Starts transition work with a caller-owned identity for progress messages."
+  @spec start(pid(), kind(), pos_integer(), reference(), (-> term())) :: t()
+  def start(owner, kind, timeout_ms, id, fun)
+      when is_pid(owner) and is_integer(timeout_ms) and timeout_ms > 0 and is_reference(id) and
+             is_function(fun, 0) do
+    {pid, monitor} =
+      :erlang.spawn_opt(
+        fn -> send(owner, {__MODULE__, :done, id, normalize(kind, fun)}) end,
+        [:link, :monitor]
+      )
+
+    timer = Process.send_after(owner, {__MODULE__, :timeout, id, kind}, timeout_ms)
+    %__MODULE__{id: id, kind: kind, pid: pid, monitor: monitor, timer: timer}
+  end
+
+  @doc "Cancels timeout/monitor bookkeeping after a matching completion."
+  @spec complete(t()) :: :ok
+  def complete(%__MODULE__{} = worker) do
+    _ = Process.cancel_timer(worker.timer)
+    Process.demonitor(worker.monitor, [:flush])
+    :ok
+  end
+
+  @doc "Kills work which exceeded its authority-owned deadline."
+  @spec timeout(t()) :: :ok
+  def timeout(%__MODULE__{} = worker) do
+    Process.unlink(worker.pid)
+    Process.exit(worker.pid, :kill)
+    Process.demonitor(worker.monitor, [:flush])
+    :ok
+  end
+
+  @doc "Cancels work whose transition lost lifecycle authority."
+  @spec cancel(t()) :: :ok
+  def cancel(%__MODULE__{} = worker) do
+    _ = Process.cancel_timer(worker.timer)
+    Process.unlink(worker.pid)
+    Process.exit(worker.pid, :kill)
+    Process.demonitor(worker.monitor, [:flush])
+    :ok
+  end
+
+  @doc "Clears timer bookkeeping after a worker DOWN."
+  @spec down(t()) :: :ok
+  def down(%__MODULE__{} = worker) do
+    _ = Process.cancel_timer(worker.timer)
+    :ok
+  end
+
+  @spec normalize(kind(), (-> term())) :: {:ok, term()} | {:error, failure()}
+  defp normalize(kind, fun) do
+    {:ok, fun.()}
+  rescue
+    error ->
+      {:error, {:transition_worker_failed, kind, {:raise, error, __STACKTRACE__}}}
+  catch
+    thrown_kind, reason ->
+      {:error, {:transition_worker_failed, kind, {thrown_kind, reason, __STACKTRACE__}}}
+  end
+end

--- a/lib/minga/extension/instance_registry.ex
+++ b/lib/minga/extension/instance_registry.ex
@@ -1,0 +1,115 @@
+defmodule Minga.Extension.InstanceRegistry do
+  @moduledoc """
+  Unique process names for per-extension roots, runtime supervisors, and instances.
+
+  The extension name identifies one stable lifecycle mailbox. Runtime process PIDs
+  are deliberately not registered here because they are implementation details
+  owned by that instance.
+  """
+
+  @type role :: :root | :runtime | :instance
+  @type registry :: atom()
+
+  @default_await_timeout_ms 5_000
+
+  @doc "Builds the unique registry child specification."
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    Supervisor.child_spec({Registry, keys: :unique, name: name}, id: name)
+  end
+
+  @doc "Starts a unique Registry used by the extension process trees."
+  @spec start_link(keyword()) :: GenServer.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    Registry.start_link(keys: :unique, name: name)
+  end
+
+  @doc "Returns a via tuple for the production instance authority."
+  @spec via(atom()) :: {:via, Registry, {registry(), {role(), atom()}}}
+  def via(name) when is_atom(name), do: via(__MODULE__, :instance, name)
+
+  @doc "Returns a via tuple for a role in an explicit registry."
+  @spec via(registry(), role(), atom()) :: {:via, Registry, {registry(), {role(), atom()}}}
+  def via(registry, role, name)
+      when is_atom(registry) and role in [:root, :runtime, :instance] and is_atom(name) do
+    {:via, Registry, {registry, {role, name}}}
+  end
+
+  @doc "Looks up one registered per-extension process."
+  @spec whereis(registry(), role(), atom()) :: pid() | nil
+  def whereis(registry, role, name) do
+    case Process.whereis(registry) do
+      nil ->
+        nil
+
+      _pid ->
+        case Registry.lookup(registry, {role, name}) do
+          [{pid, _value}] -> pid
+          [] -> nil
+        end
+    end
+  end
+
+  @doc "Waits event-first for a process registration, closing the lookup/register race."
+  @spec await(registry(), role(), atom(), timeout()) :: {:ok, pid()} | {:error, term()}
+  def await(registry, role, name, timeout \\ @default_await_timeout_ms)
+      when is_atom(registry) and role in [:root, :runtime, :instance] and is_atom(name) do
+    ref = make_ref()
+    key = {:registration_waiter, role, name, ref}
+    {:ok, _owner} = Registry.register(registry, key, nil)
+
+    result =
+      case whereis(registry, role, name) do
+        pid when is_pid(pid) ->
+          {:ok, pid}
+
+        nil ->
+          receive do
+            {__MODULE__, :registered, ^role, ^name, pid} when is_pid(pid) -> {:ok, pid}
+          after
+            timeout -> {:error, {:authority_unavailable, name, :registration_timeout}}
+          end
+      end
+
+    Registry.unregister(registry, key)
+    result
+  end
+
+  @doc "Notifies processes waiting for a newly registered lifecycle authority."
+  @spec notify_waiters(registry(), role(), atom(), pid()) :: :ok
+  def notify_waiters(registry, role, name, pid) do
+    registry
+    |> Registry.select([
+      {{{:registration_waiter, role, name, :_}, :"$1", :_}, [], [:"$1"]}
+    ])
+    |> Enum.each(&send(&1, {__MODULE__, :registered, role, name, pid}))
+
+    :ok
+  end
+
+  @doc "Lists extension names which currently have a root."
+  @spec root_names(registry()) :: [atom()]
+  def root_names(registry \\ __MODULE__) do
+    registry
+    |> Registry.select([{{{:root, :"$1"}, :_, :_}, [], [:"$1"]}])
+    |> Enum.sort()
+  end
+
+  @doc "Returns the instance registry associated with an extension root supervisor."
+  @spec registry_for_root(GenServer.server()) :: registry()
+  def registry_for_root(Minga.Extension.RootSupervisor), do: __MODULE__
+  def registry_for_root(Minga.Extension.Supervisor), do: __MODULE__
+
+  def registry_for_root(root) when is_atom(root) do
+    String.to_atom("#{root}.InstanceRegistry")
+  end
+
+  def registry_for_root(root) when is_pid(root) do
+    case Process.info(root, :registered_name) do
+      {:registered_name, name} when is_atom(name) and name != [] -> registry_for_root(name)
+      _other -> __MODULE__
+    end
+  end
+end

--- a/lib/minga/extension/lazy.ex
+++ b/lib/minga/extension/lazy.ex
@@ -1,38 +1,20 @@
 defmodule Minga.Extension.Lazy do
-  @moduledoc """
-  Lazy loading for extensions with non-eager load policies.
+  @moduledoc "Lazy/deferred activation helpers routed through stable extension Instances."
 
-  Extensions that declare a load policy other than `:eager` are compiled
-  at boot (via the compile cache, so this is fast for unchanged sources)
-  but their `init/1` and child process are deferred. Instead, lightweight
-  stub commands and keybindings are registered from the compiled module's
-  schema callbacks. The first time a stub is triggered, the extension
-  loads fully (init + child start) and the stub is replaced with the
-  real handler, all synchronously within the command dispatch.
-
-  This keeps startup cost proportional to the number of *eager*
-  extensions, not the total installed count.
-  """
-
-  alias Minga.Command
-  alias Minga.Extension.BundledApplications
-  alias Minga.Extension.CompileCache
-  alias Minga.Extension.Manifest
+  alias Minga.Extension.DeferredBatchCompleteEvent
+  alias Minga.Extension.Instance
+  alias Minga.Extension.Instance.Source
+  alias Minga.Extension.InstanceRegistry
   alias Minga.Extension.Registry, as: ExtRegistry
   alias Minga.Extension.Supervisor, as: ExtSupervisor
   alias Minga.Log
 
-  @typedoc "Result from registering stubs for a lazy extension."
+  @typedoc "Result from registering lazy stubs."
   @type stub_result :: :ok | {:error, term()}
 
-  @doc """
-  Compiles a path/git extension, reads its schema, and registers stub
-  commands and keybindings without calling init or starting a child.
+  @authority_retry_attempts 2
 
-  The extension's module is loaded into the VM (so schema callbacks are
-  callable) but no runtime side effects run. The registry entry is
-  updated to `:stub` status with the compiled module and manifest.
-  """
+  @doc "Registers path/Git/Hex stubs through the extension Instance."
   @spec register_stubs(
           GenServer.server(),
           GenServer.server(),
@@ -41,22 +23,10 @@ defmodule Minga.Extension.Lazy do
           ExtSupervisor.start_opts()
         ) :: stub_result()
   def register_stubs(supervisor, registry, name, entry, opts) do
-    case compile_extension(name, entry, opts) do
-      {:ok, module} ->
-        do_register_stubs(supervisor, registry, name, module, entry, opts, set_module: true)
-
-      {:error, reason} ->
-        log_stub_failure(name, reason, registry)
-        {:error, reason}
-    end
+    ExtSupervisor.register_lazy_extension(supervisor, registry, name, entry, opts)
   end
 
-  @doc """
-  Compiles a module-sourced extension and registers stubs without init.
-
-  For bundled extensions already on the code path, no compilation is
-  needed beyond `Code.ensure_loaded/1`.
-  """
+  @doc "Registers module-source stubs through the same extension Instance."
   @spec register_module_stubs(
           GenServer.server(),
           GenServer.server(),
@@ -65,492 +35,33 @@ defmodule Minga.Extension.Lazy do
           ExtSupervisor.start_opts()
         ) :: stub_result()
   def register_module_stubs(supervisor, registry, name, entry, opts) do
-    module = entry.module
-
-    case Code.ensure_loaded(module) do
-      {:module, ^module} ->
-        do_register_stubs(supervisor, registry, name, module, entry, opts, set_module: false)
-
-      {:error, reason} ->
-        log_stub_failure(name, {:module_load_failed, reason}, registry)
-        {:error, {:module_load_failed, reason}}
-    end
+    register_stubs(supervisor, registry, name, entry, opts)
   end
 
-  @doc """
-  Fully loads a previously-stubbed extension: runs init, starts its
-  child process, and replaces stub commands/keybinds with real handlers.
-
-  Called synchronously when a stub command or keybinding is first
-  triggered. Uses the same lifecycle lock as `start_extension` to
-  prevent races between concurrent stub triggers.
-
-  Returns `{:ok, pid}` on success or `{:error, reason}` if the
-  extension fails to load.
-  """
+  @doc "Activates the captured lazy declaration through its stable mailbox."
   @spec autoload(
           GenServer.server(),
           GenServer.server(),
           atom(),
           ExtSupervisor.start_opts()
         ) :: {:ok, pid()} | {:error, term()}
-  def autoload(supervisor, registry, name, opts) do
-    with_autoload_lock(registry, name, fn ->
-      case ExtRegistry.get(registry, name) do
-        {:ok, %{status: :stub} = entry} ->
-          do_autoload(supervisor, registry, name, entry, opts)
-
-        {:ok, %{status: :running, pid: pid}} when is_pid(pid) ->
-          {:ok, pid}
-
-        {:ok, %{status: status}} ->
-          {:error, {:unexpected_status, status}}
-
-        :error ->
-          {:error, :not_registered}
-      end
-    end)
-  end
-
-  # ── Private ────────────────────────────────────────────────────────────
-
-  @spec do_register_stubs(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          module(),
-          ExtRegistry.entry(),
-          ExtSupervisor.start_opts(),
-          keyword()
-        ) :: stub_result()
-  defp do_register_stubs(supervisor, registry, name, module, entry, opts, internal_opts) do
-    cmd_registry = Keyword.get(opts, :command_registry, Command.Registry)
-    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
-
-    with :ok <- ExtSupervisor.validate_behaviour(module, name),
-         {:ok, manifest} <- build_manifest(module, entry.source_type),
-         :ok <- ExtSupervisor.register_and_validate_options(name, module, entry.config) do
-      registry_fields =
-        if Keyword.get(internal_opts, :set_module, false) do
-          [module: module, manifest: manifest, status: :stub]
-        else
-          [manifest: manifest, status: :stub]
-        end
-
-      ExtRegistry.update(registry, name, registry_fields)
-
-      with :ok <- register_stub_commands(supervisor, registry, name, module, cmd_registry, opts),
-           :ok <- register_stub_keybinds(name, module, keymap) do
-        Log.info(
-          :config,
-          "Extension #{name} registered as stub (#{inspect(manifest.load_policy)})"
-        )
-
-        :ok
-      else
-        {:error, reason} ->
-          rollback_stub_registration(name, cmd_registry, keymap, registry, opts)
-          {:error, reason}
-      end
-    else
-      {:error, reason} ->
-        log_stub_failure(name, reason, registry)
-        {:error, reason}
-    end
-  end
-
-  @spec log_stub_failure(atom(), term(), GenServer.server()) :: :ok
-  defp log_stub_failure(name, reason, registry) do
-    Log.warning(
-      :config,
-      "Extension #{name} stub registration failed: #{inspect(reason)}"
-    )
-
-    ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
-    :ok
-  end
-
-  @spec rollback_stub_registration(
-          atom(),
-          GenServer.server(),
-          GenServer.server(),
-          GenServer.server(),
-          ExtSupervisor.start_opts()
-        ) :: :ok
-  defp rollback_stub_registration(name, cmd_registry, keymap, registry, opts) do
-    ExtSupervisor.cleanup_extension_contributions(name, cmd_registry, keymap, opts)
-    ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
-    :ok
-  end
-
-  @spec do_autoload(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          ExtSupervisor.start_opts()
-        ) :: {:ok, pid()} | {:error, term()}
-  defp do_autoload(supervisor, registry, name, entry, opts) do
-    cmd_registry = Keyword.get(opts, :command_registry, Command.Registry)
-    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
-
-    Log.info(:config, "Extension #{name} autoloading on first use")
-
-    ExtSupervisor.cleanup_extension_contributions(name, cmd_registry, keymap, opts)
-    ExtRegistry.update(registry, name, status: :stopped)
-
-    case ExtSupervisor.start_extension(supervisor, registry, name, entry, opts) do
-      {:ok, pid} ->
-        Log.info(:config, "Extension #{name} autoloaded successfully")
-        {:ok, pid}
-
-      {:error, reason} ->
-        Log.warning(:config, "Extension #{name} autoload failed: #{inspect(reason)}")
-        {:error, reason}
-    end
-  end
-
-  @spec with_autoload_lock(GenServer.server(), atom(), (-> result)) :: result when result: var
-  defp with_autoload_lock(registry, name, fun) when is_atom(name) and is_function(fun, 0) do
-    resource_id = {ExtSupervisor, :lifecycle, canonical_registry_id(registry), name}
-    requester_id = self()
-    :global.trans({resource_id, requester_id}, fun, [node()], :infinity)
-  end
-
-  @spec canonical_registry_id(GenServer.server()) :: term()
-  defp canonical_registry_id(registry) when is_pid(registry) do
-    case Process.info(registry, :registered_name) do
-      {:registered_name, reg_name} when is_atom(reg_name) -> {:local_name, reg_name}
-      _other -> {:pid, registry}
-    end
-  end
-
-  defp canonical_registry_id(registry) when is_atom(registry) do
-    case Process.whereis(registry) do
-      pid when is_pid(pid) -> canonical_registry_id(pid)
-      nil -> {:local_name, registry}
-    end
-  end
-
-  defp canonical_registry_id({:global, reg_name}), do: {:global_name, reg_name}
-  defp canonical_registry_id({:via, module, reg_name}), do: {:via, module, reg_name}
-  defp canonical_registry_id(registry), do: registry
-
-  @spec compile_extension(atom(), ExtRegistry.entry(), ExtSupervisor.start_opts()) ::
-          {:ok, module()} | {:error, term()}
-  defp compile_extension(name, %{source_type: :path, path: path}, opts) when is_binary(path) do
-    compile_from_path(name, Path.expand(path), opts)
-  end
-
-  defp compile_extension(name, %{source_type: :git, path: path}, opts) when is_binary(path) do
-    compile_from_path(name, Path.expand(path), opts)
-  end
-
-  defp compile_extension(_name, %{source_type: :git, path: nil}, _opts) do
-    {:error, :clone_failed}
-  end
-
-  defp compile_extension(_name, %{source_type: :module, module: module}, _opts) do
-    case Code.ensure_loaded(module) do
-      {:module, ^module} -> {:ok, module}
-      {:error, reason} -> {:error, {:module_load_failed, reason}}
-    end
-  end
-
-  defp compile_extension(_name, %{source_type: :hex, hex: %{app: app}} = entry, _opts) do
-    app_atom =
-      if is_atom(app) and app != nil, do: app, else: entry.manifest && entry.manifest.name
-
-    resolve_hex_module(app_atom)
-  end
-
-  @spec resolve_hex_module(atom() | nil) :: {:ok, module()} | {:error, term()}
-  defp resolve_hex_module(nil), do: {:error, :hex_app_name_unknown}
-
-  defp resolve_hex_module(app_atom) do
-    with :ok <- load_hex_app_metadata(app_atom),
-         {:ok, modules} <- hex_modules(app_atom) do
-      find_extension_module(modules)
-    end
-  end
-
-  @spec load_hex_app_metadata(atom()) :: :ok | {:error, term()}
-  defp load_hex_app_metadata(app_atom) do
-    case Application.load(app_atom) do
-      :ok -> :ok
-      {:error, {:already_loaded, ^app_atom}} -> :ok
-      {:error, reason} -> {:error, {:hex_app_load_failed, app_atom, reason}}
-    end
-  end
-
-  @spec hex_modules(atom()) :: {:ok, [module()]} | {:error, String.t()}
-  defp hex_modules(app_atom) do
-    case :application.get_key(app_atom, :modules) do
-      {:ok, modules} -> {:ok, modules}
-      :undefined -> {:error, "hex application #{app_atom} not found after install"}
-    end
-  end
-
-  @spec compile_from_path(atom(), String.t(), ExtSupervisor.start_opts()) ::
-          {:ok, module()} | {:error, term()}
-  defp compile_from_path(name, expanded, opts) do
-    if File.dir?(expanded) do
-      files = expanded |> Path.join("**/*.ex") |> Path.wildcard() |> Enum.sort()
-      compile_source_files(name, expanded, files, opts)
-    else
-      {:error, "extension path does not exist: #{expanded}"}
-    end
-  end
-
-  @spec compile_source_files(atom(), String.t(), [String.t()], ExtSupervisor.start_opts()) ::
-          {:ok, module()} | {:error, term()}
-  defp compile_source_files(_name, _expanded, [], _opts), do: {:error, "no .ex files found"}
-
-  defp compile_source_files(name, expanded, files, opts) do
-    admission = Keyword.get(opts, :artifact_admission, Minga.Extension.ArtifactAdmission)
-    source = {:extension, name}
-
-    case Minga.Extension.ArtifactAdmission.source_modules(source, server: admission) do
-      {:ok, modules} ->
-        report_staged_source_change(name, expanded, files, source, admission, opts)
-        find_extension_module(modules)
-
-      :error ->
-        case CompileCache.load_or_compile(expanded, files,
-               source: source,
-               artifact_admission: admission,
-               trusted_application: BundledApplications.trusted_application(name)
-             ) do
-          {:ok, %{modules: modules}} -> find_extension_module(modules)
-          {:error, reason} -> {:error, reason}
-        end
-    end
-  end
-
-  @spec report_staged_source_change(
-          atom(),
-          String.t(),
-          [String.t()],
-          term(),
-          GenServer.server(),
-          ExtSupervisor.start_opts()
-        ) :: :ok
-  defp report_staged_source_change(name, expanded, files, source, admission, opts) do
-    with {:ok, admitted} <-
-           Minga.Extension.ArtifactAdmission.source_fingerprint(source, server: admission),
-         {:ok, current} <- CompileCache.source_fingerprint(expanded, files, opts),
-         false <- admitted == current do
-      Minga.Events.broadcast(
-        :extension_restart_required,
-        %Minga.Events.ExtensionRestartRequiredEvent{
-          extension: name,
-          reason: :source_changed,
-          old_ref: Base.encode16(admitted, case: :lower),
-          new_ref: Base.encode16(current, case: :lower)
-        }
+  def autoload(supervisor, _registry, name, opts) do
+    registry =
+      Keyword.get(
+        opts,
+        :instance_registry,
+        InstanceRegistry.registry_for_root(root_supervisor(supervisor))
       )
-    else
-      _unchanged_or_unavailable -> :ok
+
+    case InstanceRegistry.whereis(registry, :instance, name) do
+      pid when is_pid(pid) -> safe_start(name, InstanceRegistry.via(registry, :instance, name))
+      nil -> {:error, :not_registered}
     end
   end
 
-  @spec find_extension_module([module()]) :: {:ok, module()} | {:error, String.t()}
-  defp find_extension_module(modules) do
-    case Enum.find(modules, &ExtSupervisor.implements_extension?/1) do
-      nil -> {:error, "no module implementing Minga.Extension behaviour found"}
-      mod -> {:ok, mod}
-    end
-  end
-
-  @spec build_manifest(module(), Manifest.source_type()) ::
-          {:ok, Manifest.t()} | {:error, term()}
-  defp build_manifest(module, source) do
-    {:ok, Manifest.from_module(module, source)}
-  rescue
-    e -> {:error, "manifest introspection failed: #{Exception.message(e)}"}
-  catch
-    kind, reason ->
-      {:error, "manifest introspection failed: #{inspect(kind)} #{inspect(reason)}"}
-  end
-
-  @spec register_stub_commands(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          module(),
-          GenServer.server(),
-          ExtSupervisor.start_opts()
-        ) :: :ok | {:error, term()}
-  defp register_stub_commands(supervisor, registry, name, module, cmd_registry, opts) do
-    schema = command_schema(module)
-
-    Enum.reduce_while(schema, :ok, fn {cmd_name, description, cmd_opts}, :ok ->
-      case validate_command_spec(name, cmd_name, cmd_opts) do
-        :ok ->
-          register_single_stub_command(
-            supervisor,
-            registry,
-            name,
-            cmd_name,
-            description,
-            cmd_opts,
-            cmd_registry,
-            opts
-          )
-
-        {:error, _reason} = error ->
-          {:halt, error}
-      end
-    end)
-  end
-
-  @spec validate_command_spec(atom(), atom(), keyword()) :: :ok | {:error, term()}
-  defp validate_command_spec(ext_name, cmd_name, cmd_opts) do
-    case Keyword.fetch(cmd_opts, :execute) do
-      {:ok, {mod, fun}} when is_atom(mod) and is_atom(fun) ->
-        :ok
-
-      {:ok, invalid} ->
-        reason = {:invalid_execute, cmd_name, invalid}
-
-        Log.warning(
-          :config,
-          "Extension #{ext_name} command #{cmd_name} has invalid :execute: #{inspect(invalid)}"
-        )
-
-        {:error, reason}
-
-      :error ->
-        reason = {:missing_execute, cmd_name}
-
-        Log.warning(
-          :config,
-          "Extension #{ext_name} command #{cmd_name} is missing required :execute option"
-        )
-
-        {:error, reason}
-    end
-  end
-
-  @spec register_single_stub_command(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          atom(),
-          String.t(),
-          keyword(),
-          GenServer.server(),
-          ExtSupervisor.start_opts()
-        ) :: {:cont, :ok} | {:halt, {:error, term()}}
-  defp register_single_stub_command(
-         supervisor,
-         registry,
-         name,
-         cmd_name,
-         description,
-         cmd_opts,
-         cmd_registry,
-         opts
-       ) do
-    requires_buffer = Keyword.get(cmd_opts, :requires_buffer, false)
-
-    stub_cmd = %Command{
-      name: cmd_name,
-      description: description,
-      requires_buffer: requires_buffer,
-      execute: stub_execute_fn(supervisor, registry, name, cmd_name, cmd_registry, opts)
-    }
-
-    case Command.Registry.register_command(cmd_registry, {:extension, name}, stub_cmd) do
-      :ok ->
-        {:cont, :ok}
-
-      {:error, reason} ->
-        Log.warning(
-          :config,
-          "Extension #{name} stub command #{cmd_name} rejected: #{inspect(reason)}"
-        )
-
-        {:halt, {:error, {:stub_command_rejected, cmd_name, reason}}}
-    end
-  end
-
-  @spec stub_execute_fn(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          atom(),
-          GenServer.server(),
-          ExtSupervisor.start_opts()
-        ) :: (term() -> term())
-  defp stub_execute_fn(supervisor, registry, name, cmd_name, cmd_registry, opts) do
-    fn state ->
-      case autoload(supervisor, registry, name, opts) do
-        {:ok, _pid} -> execute_autoloaded_command(cmd_registry, cmd_name, state)
-        {:error, _reason} -> state
-      end
-    end
-  end
-
-  @spec execute_autoloaded_command(GenServer.server(), atom(), term()) :: term()
-  defp execute_autoloaded_command(cmd_registry, cmd_name, state) do
-    case Command.Registry.lookup(cmd_registry, cmd_name) do
-      {:ok, cmd} -> cmd.execute.(state)
-      :error -> state
-    end
-  end
-
-  @spec register_stub_keybinds(atom(), module(), GenServer.server()) ::
-          :ok | {:error, term()}
-  defp register_stub_keybinds(name, module, keymap) do
-    schema = keybind_schema(module)
-
-    Enum.reduce_while(schema, :ok, fn {mode, key_str, command, description, bind_opts}, :ok ->
-      source_opts = Keyword.put(bind_opts, :source, {:extension, name})
-
-      case Minga.Keymap.Active.bind(keymap, mode, key_str, command, description, source_opts) do
-        :ok ->
-          {:cont, :ok}
-
-        {:error, reason} ->
-          Log.warning(
-            :config,
-            "Extension #{name} stub keybind #{inspect(key_str)} failed: #{reason}"
-          )
-
-          {:halt, {:error, {:stub_keybind_rejected, key_str, reason}}}
-      end
-    end)
-  end
-
-  @spec command_schema(module()) :: [Minga.Extension.command_spec()]
-  defp command_schema(module) do
-    if function_exported?(module, :__command_schema__, 0),
-      do: module.__command_schema__(),
-      else: []
-  end
-
-  @spec keybind_schema(module()) :: [Minga.Extension.keybind_spec()]
-  defp keybind_schema(module) do
-    if function_exported?(module, :__keybind_schema__, 0),
-      do: module.__keybind_schema__(),
-      else: []
-  end
-
-  @doc """
-  Resolves the effective load policy for an extension entry.
-
-  If the entry has an explicit `load_policy` set from config (non-nil),
-  that wins. Otherwise falls back to the module's declared
-  `__load_policy__/0` if the module is loaded, then to `:eager`.
-  """
+  @doc "Returns the effective policy already present on a declaration."
   @spec effective_load_policy(ExtRegistry.entry()) :: Minga.Extension.load_policy()
-  def effective_load_policy(%{load_policy: policy}) when is_atom(policy) and policy != nil,
-    do: policy
-
-  def effective_load_policy(%{load_policy: policy}) when is_tuple(policy), do: policy
-
-  def effective_load_policy(%{module: module}) when is_atom(module) and not is_nil(module) do
+  def effective_load_policy(%{load_policy: nil, module: module}) when is_atom(module) do
     if Code.ensure_loaded?(module) and function_exported?(module, :__load_policy__, 0) do
       module.__load_policy__()
     else
@@ -558,142 +69,207 @@ defmodule Minga.Extension.Lazy do
     end
   end
 
+  def effective_load_policy(%{load_policy: nil}), do: :eager
+  def effective_load_policy(%{load_policy: policy}), do: policy
   def effective_load_policy(_entry), do: :eager
 
-  @doc """
-  Compiles a path/git extension to discover the module's declared
-  load policy when no config-level override is set.
-
-  Returns `{:ok, policy, module}` on success so the caller can reuse the
-  artifact admitted for this VM generation. Returns `{:error, reason}` if
-  boot-time admission fails, in which case the caller falls back to `:eager`.
-  """
+  @doc "Discovers policy through the single source preparation path."
   @spec discover_load_policy(atom(), ExtRegistry.entry(), ExtSupervisor.start_opts()) ::
           {:ok, Minga.Extension.load_policy(), module()} | {:error, term()}
   def discover_load_policy(name, entry, opts) do
-    case compile_extension(name, entry, opts) do
-      {:ok, module} ->
-        policy = module_load_policy(module)
-        {:ok, policy, module}
-
-      {:error, reason} ->
-        {:error, reason}
+    with {:ok, policy, artifact} <- Source.discover_load_policy(name, entry, opts) do
+      {:ok, entry.load_policy || policy, artifact.module}
     end
   end
 
-  @spec module_load_policy(module()) :: Minga.Extension.load_policy()
-  defp module_load_policy(module) do
-    if function_exported?(module, :__load_policy__, 0) do
-      module.__load_policy__()
-    else
-      :eager
-    end
-  end
-
-  @doc """
-  Returns true if the given load policy requires eager loading at boot.
-  """
+  @doc "Returns true for eager policy."
   @spec eager?(Minga.Extension.load_policy()) :: boolean()
   def eager?(:eager), do: true
   def eager?(_policy), do: false
 
-  @doc """
-  Returns true if the given load policy is deferred (post-first-paint).
-  """
+  @doc "Returns true for deferred policy."
   @spec deferred?(Minga.Extension.load_policy()) :: boolean()
   def deferred?(:deferred), do: true
   def deferred?(_policy), do: false
 
-  @doc """
-  Returns true if the load policy is trigger-based (on_command, on_filetype, on_key).
-  """
+  @doc "Returns true for trigger-based policy."
   @spec trigger_based?(Minga.Extension.load_policy()) :: boolean()
-  def trigger_based?({:on_command, _}), do: true
-  def trigger_based?({:on_filetype, _}), do: true
-  def trigger_based?({:on_key, _}), do: true
+  def trigger_based?({tag, _trigger}) when tag in [:on_command, :on_filetype, :on_key], do: true
   def trigger_based?(_policy), do: false
 
   @deferred_load_delay_ms 100
 
-  @doc """
-  Schedules deferred extensions to load in the background after a short
-  delay, allowing the editor to render the first frame first.
-  """
+  @doc "Schedules captured Instance identities after first-paint delay."
+  @spec schedule_deferred_loads([{GenServer.server(), atom(), ExtRegistry.entry()}]) :: :ok
+  def schedule_deferred_loads([]), do: :ok
+
+  def schedule_deferred_loads(instances) do
+    schedule_deferred_batch(instances, [], length(instances))
+  end
+
+  @doc "Registers declarations and schedules their deferred Instance activations."
   @spec schedule_deferred_loads(
           GenServer.server(),
           GenServer.server(),
           [{atom(), ExtRegistry.entry()}],
           ExtSupervisor.start_opts()
         ) :: :ok
-  def schedule_deferred_loads(_supervisor, _registry, [], _opts), do: :ok
+  def schedule_deferred_loads(supervisor, registry, entries, opts) do
+    {instances, failures} =
+      Enum.reduce(entries, {[], []}, fn {name, entry}, {instances, failures} ->
+        case ExtSupervisor.register_lazy_extension(supervisor, registry, name, entry, opts) do
+          :ok ->
+            instance_registry =
+              Keyword.get(
+                opts,
+                :instance_registry,
+                InstanceRegistry.registry_for_root(root_supervisor(supervisor))
+              )
 
-  def schedule_deferred_loads(supervisor, registry, deferred_entries, opts) do
-    Task.start(fn ->
-      receive do
-      after
-        @deferred_load_delay_ms -> :ok
-      end
+            instance = {InstanceRegistry.via(instance_registry, :instance, name), name, entry}
+            {[instance | instances], failures}
 
-      Enum.each(deferred_entries, fn {name, entry} ->
-        start_deferred_extension(supervisor, registry, name, entry, opts)
+          {:error, reason} ->
+            failure = %{extension: name, reason: reason}
+
+            Log.warning(
+              :config,
+              "Extension #{name} deferred stub registration failed: #{inspect(reason)}"
+            )
+
+            {instances, [failure | failures]}
+        end
       end)
-    end)
+
+    schedule_deferred_batch(Enum.reverse(instances), Enum.reverse(failures), length(entries))
+  end
+
+  @spec schedule_deferred_batch(
+          [{GenServer.server(), atom(), ExtRegistry.entry()}],
+          [DeferredBatchCompleteEvent.failure()],
+          non_neg_integer()
+        ) :: :ok
+  defp schedule_deferred_batch(instances, registration_failures, total_count) do
+    {:ok, _pid} =
+      Task.start(fn ->
+        receive do
+        after
+          @deferred_load_delay_ms -> :ok
+        end
+
+        failures =
+          instances
+          |> Enum.reduce(
+            Enum.reverse(registration_failures),
+            &start_deferred_instance/2
+          )
+          |> Enum.reverse()
+
+        event = DeferredBatchCompleteEvent.new(total_count, failures)
+        Minga.Events.broadcast(:extension_deferred_batch_complete, event)
+      end)
 
     :ok
   end
 
-  @spec start_deferred_extension(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          ExtSupervisor.start_opts()
-        ) :: :ok
-  defp start_deferred_extension(supervisor, registry, name, entry, opts) do
-    case ExtRegistry.get(registry, name) do
-      {:ok, %{status: :stopped}} ->
-        do_start_deferred(supervisor, registry, name, entry, opts)
-
-      {:ok, %{status: status}} ->
-        Log.debug(
-          :config,
-          "Extension #{name} deferred load skipped (status: #{status})"
-        )
-
-      :error ->
-        Log.debug(:config, "Extension #{name} deferred load skipped (unregistered)")
-    end
-
-    :ok
-  rescue
-    e ->
-      Log.warning(
-        :config,
-        "Extension #{name} deferred load crashed: #{Exception.message(e)}"
-      )
-
-      :ok
-  end
-
-  @spec do_start_deferred(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          ExtSupervisor.start_opts()
-        ) :: :ok
-  defp do_start_deferred(supervisor, registry, name, entry, opts) do
-    case ExtSupervisor.start_extension(supervisor, registry, name, entry, opts) do
+  @spec start_deferred_instance(
+          {GenServer.server(), atom(), ExtRegistry.entry()},
+          [DeferredBatchCompleteEvent.failure()]
+        ) :: [DeferredBatchCompleteEvent.failure()]
+  defp start_deferred_instance({instance, name, declaration}, failures) do
+    case safe_start_deferred(name, instance, declaration) do
       {:ok, _pid} ->
         Log.info(:config, "Extension #{name} deferred load complete")
+        failures
 
       {:error, reason} ->
-        Log.warning(
-          :config,
-          "Extension #{name} deferred load failed: #{inspect(reason)}"
-        )
+        Log.warning(:config, "Extension #{name} deferred load failed: #{inspect(reason)}")
+        [%{extension: name, reason: reason} | failures]
     end
-
-    :ok
   end
+
+  @spec safe_start(atom(), GenServer.server()) :: {:ok, pid()} | {:error, term()}
+  defp safe_start(name, instance) do
+    case retry_instance_call(name, instance, &Instance.start/1, @authority_retry_attempts) do
+      {:authority_call_exit, reason} ->
+        failure = {:authority_call_exit, name, reason}
+        Log.warning(:config, "Extension #{name} lazy activation failed: #{inspect(failure)}")
+        {:error, failure}
+
+      result ->
+        result
+    end
+  end
+
+  @spec safe_start_deferred(atom(), GenServer.server(), ExtRegistry.entry()) ::
+          {:ok, pid()} | {:error, term()}
+  defp safe_start_deferred(name, instance, declaration) do
+    case retry_instance_call(
+           name,
+           instance,
+           fn current -> Instance.start_deferred(current, declaration) end,
+           @authority_retry_attempts
+         ) do
+      {:authority_call_exit, reason} -> {:error, {:instance_call_exit, reason}}
+      result -> result
+    end
+  end
+
+  @spec retry_instance_call(
+          atom(),
+          GenServer.server(),
+          (GenServer.server() -> result),
+          non_neg_integer()
+        ) :: result | {:authority_call_exit, term()}
+        when result: var
+  defp retry_instance_call(name, instance, fun, retries) do
+    fun.(instance)
+  catch
+    :exit, reason ->
+      retry_instance_call_after_exit(name, instance, fun, retries, reason)
+  end
+
+  @spec retry_instance_call_after_exit(
+          atom(),
+          GenServer.server(),
+          (GenServer.server() -> result),
+          non_neg_integer(),
+          term()
+        ) :: result | {:authority_call_exit, term()}
+        when result: var
+  defp retry_instance_call_after_exit(name, instance, fun, retries, reason) do
+    if retries > 0 and restart_gap?(reason) do
+      case await_current_instance(instance, name) do
+        {:ok, current} -> retry_instance_call(name, current, fun, retries - 1)
+        {:error, _reason} -> {:authority_call_exit, reason}
+      end
+    else
+      {:authority_call_exit, reason}
+    end
+  end
+
+  @spec await_current_instance(GenServer.server(), atom()) ::
+          {:ok, GenServer.server()} | {:error, term()}
+  defp await_current_instance(
+         {:via, Registry, {registry, {:instance, name}}} = instance,
+         name
+       ) do
+    case InstanceRegistry.await(registry, :instance, name) do
+      {:ok, _pid} -> {:ok, instance}
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp await_current_instance(_instance, name),
+    do: {:error, {:authority_unavailable, name, :unregistered_server}}
+
+  @spec restart_gap?(term()) :: boolean()
+  defp restart_gap?(:noproc), do: true
+  defp restart_gap?({:noproc, _call}), do: true
+  defp restart_gap?({:authority_unavailable, _name, reason}), do: restart_gap?(reason)
+  defp restart_gap?(_reason), do: false
+
+  @spec root_supervisor(GenServer.server()) :: GenServer.server()
+  defp root_supervisor(ExtSupervisor), do: Minga.Extension.RootSupervisor
+  defp root_supervisor(supervisor), do: supervisor
 end

--- a/lib/minga/extension/registry.ex
+++ b/lib/minga/extension/registry.ex
@@ -137,25 +137,27 @@ defmodule Minga.Extension.Registry do
     Agent.get(server, &Map.fetch(&1, name))
   end
 
-  @doc "Updates fields on an existing extension entry."
-  @spec update(atom(), keyword()) :: :ok
-  @spec update(GenServer.server(), atom(), keyword()) :: :ok
+  @doc "Updates an existing declaration or reports that projection authority disappeared."
+  @spec update(atom(), keyword()) :: :ok | {:error, {:extension_not_declared, atom()}}
+  @spec update(GenServer.server(), atom(), keyword()) ::
+          :ok | {:error, {:extension_not_declared, atom()}}
   def update(name, updates) when is_atom(name) and is_list(updates),
     do: update(__MODULE__, name, updates)
 
   def update(server, name, updates) when is_atom(name) and is_list(updates) do
-    Agent.update(server, &apply_updates(&1, name, updates))
+    Agent.get_and_update(server, &apply_updates(&1, name, updates))
   end
 
-  @spec apply_updates(state(), atom(), keyword()) :: state()
+  @spec apply_updates(state(), atom(), keyword()) ::
+          {:ok | {:error, {:extension_not_declared, atom()}}, state()}
   defp apply_updates(state, name, updates) do
     case Map.fetch(state, name) do
       {:ok, entry} ->
         updated = struct!(entry, updates)
-        Map.put(state, name, updated)
+        {:ok, Map.put(state, name, updated)}
 
       :error ->
-        state
+        {{:error, {:extension_not_declared, name}}, state}
     end
   end
 

--- a/lib/minga/extension/root.ex
+++ b/lib/minga/extension/root.ex
@@ -1,0 +1,54 @@
+defmodule Minga.Extension.Root do
+  @moduledoc """
+  Ordered supervision root for one extension declaration.
+
+  `:rest_for_one` keeps the local runtime supervisor before the permanent
+  lifecycle authority. Replacing the runtime supervisor therefore restarts the
+  Instance only after an empty local supervisor exists, while an Instance crash
+  leaves its runtime supervisor available for local adoption.
+  """
+
+  use Supervisor
+
+  alias Minga.Extension.Instance
+  alias Minga.Extension.InstanceRegistry
+  alias Minga.Extension.RuntimeSupervisor
+
+  @doc "Builds the dynamic child spec for an extension root."
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    name = Keyword.fetch!(opts, :extension)
+
+    %{
+      id: {__MODULE__, name},
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :permanent,
+      type: :supervisor
+    }
+  end
+
+  @doc "Starts one extension root."
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :extension)
+    registry = Keyword.get(opts, :instance_registry, InstanceRegistry)
+    Supervisor.start_link(__MODULE__, opts, name: InstanceRegistry.via(registry, :root, name))
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, {Supervisor.sup_flags(), [Supervisor.child_spec()]}}
+  def init(opts) do
+    name = Keyword.fetch!(opts, :extension)
+    registry = Keyword.get(opts, :instance_registry, InstanceRegistry)
+
+    children = [
+      Supervisor.child_spec(
+        {RuntimeSupervisor, extension: name, instance_registry: registry},
+        id: RuntimeSupervisor
+      ),
+      Supervisor.child_spec({Instance, opts}, id: Instance)
+    ]
+
+    Supervisor.init(children, strategy: :rest_for_one)
+  end
+end

--- a/lib/minga/extension/root_supervisor.ex
+++ b/lib/minga/extension/root_supervisor.ex
@@ -1,0 +1,112 @@
+defmodule Minga.Extension.RootSupervisor do
+  @moduledoc "Dynamic supervisor owning one ordered `Root(name)` per declaration."
+
+  use DynamicSupervisor
+
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.InstanceRegistry
+  alias Minga.Extension.Root
+
+  @doc "Starts the extension root supervisor."
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, __MODULE__)
+    DynamicSupervisor.start_link(__MODULE__, opts, name: name)
+  end
+
+  @doc "Ensures one root exists and returns its stable Instance server."
+  @spec ensure_root(
+          GenServer.server(),
+          atom(),
+          Minga.Extension.Entry.t(),
+          GenServer.server(),
+          keyword()
+        ) ::
+          {:ok, GenServer.server()} | {:error, term()}
+  def ensure_root(supervisor, name, declaration, declaration_registry, opts \\ []) do
+    instance_registry =
+      Keyword.get(opts, :instance_registry, InstanceRegistry.registry_for_root(supervisor))
+
+    child_opts = [
+      extension: name,
+      declaration: declaration,
+      declaration_registry: declaration_registry,
+      instance_registry: instance_registry,
+      collaborators: State.stable_collaborators(opts)
+    ]
+
+    case InstanceRegistry.whereis(instance_registry, :root, name) do
+      pid when is_pid(pid) -> await_instance(pid, instance_registry, name)
+      nil -> start_root(supervisor, child_opts, instance_registry, name)
+    end
+  end
+
+  @doc "Locates an existing root authority, synchronizing through Instance registration."
+  @spec existing_authority(GenServer.server(), atom(), keyword()) ::
+          {:ok, GenServer.server()} | :absent | {:error, term()}
+  def existing_authority(supervisor, name, opts \\ []) do
+    instance_registry =
+      Keyword.get(opts, :instance_registry, InstanceRegistry.registry_for_root(supervisor))
+
+    case InstanceRegistry.whereis(instance_registry, :root, name) do
+      pid when is_pid(pid) ->
+        await_instance(pid, instance_registry, name)
+
+      nil ->
+        :absent
+    end
+  end
+
+  @doc "Terminates the root for a declaration which no longer exists."
+  @spec terminate_root(GenServer.server(), atom(), keyword()) :: :ok | {:error, term()}
+  def terminate_root(supervisor, name, opts \\ []) do
+    instance_registry =
+      Keyword.get(opts, :instance_registry, InstanceRegistry.registry_for_root(supervisor))
+
+    case InstanceRegistry.whereis(instance_registry, :root, name) do
+      nil -> :ok
+      pid -> DynamicSupervisor.terminate_child(supervisor, pid)
+    end
+  catch
+    :exit, reason -> {:error, {:authority_unavailable, name, reason}}
+  end
+
+  @doc "Waits through root initialization/restart and returns its permanent authority."
+  @spec await_instance(pid(), atom(), atom()) :: {:ok, GenServer.server()} | {:error, term()}
+  def await_instance(root, instance_registry, name)
+      when is_pid(root) and is_atom(instance_registry) and is_atom(name) do
+    _children = Supervisor.which_children(root)
+
+    case InstanceRegistry.await(instance_registry, :instance, name) do
+      {:ok, _pid} -> {:ok, InstanceRegistry.via(instance_registry, :instance, name)}
+      {:error, _reason} = error -> error
+    end
+  catch
+    :exit, reason -> {:error, {:authority_unavailable, name, reason}}
+  end
+
+  @doc "Returns declared root names without inspecting runtime children."
+  @spec names(GenServer.server(), keyword()) :: [atom()]
+  def names(supervisor, opts \\ []) do
+    registry =
+      Keyword.get(opts, :instance_registry, InstanceRegistry.registry_for_root(supervisor))
+
+    InstanceRegistry.root_names(registry)
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, DynamicSupervisor.sup_flags()}
+  def init(_opts), do: DynamicSupervisor.init(strategy: :one_for_one)
+
+  @spec start_root(GenServer.server(), keyword(), atom(), atom()) ::
+          {:ok, GenServer.server()} | {:error, term()}
+  defp start_root(supervisor, child_opts, instance_registry, name) do
+    case DynamicSupervisor.start_child(supervisor, {Root, child_opts}) do
+      {:ok, pid} -> await_instance(pid, instance_registry, name)
+      {:error, {:already_started, pid}} -> await_instance(pid, instance_registry, name)
+      {:error, _reason} = error -> error
+    end
+  catch
+    :exit, reason -> {:error, {:authority_unavailable, name, reason}}
+  end
+end

--- a/lib/minga/extension/runtime_supervisor.ex
+++ b/lib/minga/extension/runtime_supervisor.ex
@@ -1,0 +1,56 @@
+defmodule Minga.Extension.RuntimeSupervisor do
+  @moduledoc """
+  Local `DynamicSupervisor` for one extension's runtime implementation.
+
+  Child mechanics live here. Every child spec is forced to `:temporary`; the
+  sibling `Instance` is the only process that interprets the declaration's
+  original restart policy.
+  """
+
+  use DynamicSupervisor
+
+  alias Minga.Extension.InstanceRegistry
+
+  @doc "Starts the runtime supervisor for one extension root."
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts) do
+    name = Keyword.fetch!(opts, :extension)
+    registry = Keyword.get(opts, :instance_registry, InstanceRegistry)
+
+    DynamicSupervisor.start_link(__MODULE__, opts,
+      name: InstanceRegistry.via(registry, :runtime, name)
+    )
+  end
+
+  @doc "Starts one temporary runtime child."
+  @spec start_child(GenServer.server(), Supervisor.child_spec()) ::
+          {:ok, pid()} | {:error, term()}
+  def start_child(supervisor, child_spec) do
+    DynamicSupervisor.start_child(supervisor, Map.put(child_spec, :restart, :temporary))
+  end
+
+  @doc "Terminates the currently owned runtime child."
+  @spec terminate_child(GenServer.server(), pid()) :: :ok | {:error, term()}
+  def terminate_child(supervisor, pid) when is_pid(pid) do
+    DynamicSupervisor.terminate_child(supervisor, pid)
+  catch
+    :exit, reason -> {:error, {:exit, reason}}
+  end
+
+  @doc "Returns this supervisor's sole local runtime child, bounded by the caller's deadline."
+  @spec local_child(GenServer.server(), timeout()) :: {:ok, pid()} | :empty | {:error, term()}
+  def local_child(supervisor, timeout \\ 5_000) do
+    case GenServer.call(supervisor, :which_children, timeout) do
+      [{_id, pid, _type, _modules}] when is_pid(pid) -> {:ok, pid}
+      [] -> :empty
+      children -> {:error, {:multiple_local_runtime_children, length(children)}}
+    end
+  catch
+    :exit, {:timeout, _call} -> {:error, {:runtime_supervisor_unavailable, :timeout}}
+    :exit, reason -> {:error, {:runtime_supervisor_unavailable, reason}}
+  end
+
+  @impl true
+  @spec init(keyword()) :: {:ok, DynamicSupervisor.sup_flags()}
+  def init(_opts), do: DynamicSupervisor.init(strategy: :one_for_one)
+end

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -1,306 +1,143 @@
 defmodule Minga.Extension.Supervisor do
   @moduledoc """
-  DynamicSupervisor managing extension process trees.
+  Public extension lifecycle facade.
 
-  Each extension gets its own child under this supervisor. If an extension
-  crashes, only that extension restarts. The editor and other extensions
-  are unaffected.
-
-  ## Lifecycle
-
-  1. Config eval registers extensions in `Extension.Registry`
-  2. `start_all/0` reads the registry and starts each extension
-  3. `stop_all/0` terminates all running extensions (used by reload)
+  Per-extension ordering and policy live exclusively in `Extension.Instance`.
+  This module retains bulk Git/Hex prerequisites, declaration reconciliation,
+  iteration/error aggregation, pending-restart queries, and list projection.
   """
 
-  use DynamicSupervisor
-
-  alias Minga.Extension.ArtifactAdmission
-  alias Minga.Extension.BundledApplications
-  alias Minga.Extension.CallbackInvoker
-  alias Minga.Extension.CallbackRegistry
-  alias Minga.Extension.CodeLease
-  alias Minga.Extension.CompileCache
   alias Minga.Extension.Git, as: ExtGit
   alias Minga.Extension.Hex, as: ExtHex
+  alias Minga.Extension.Instance
+  alias Minga.Extension.Instance.Contributions
+  alias Minga.Extension.Instance.Source
+  alias Minga.Extension.InstanceRegistry
   alias Minga.Extension.Lazy
-  alias Minga.Extension.Manifest
   alias Minga.Extension.Registry, as: ExtRegistry
+  alias Minga.Extension.RootSupervisor
   alias Minga.Log
 
-  # ── Client API ──────────────────────────────────────────────────────────────
+  @type start_failure :: %{extension: atom(), reason: term()}
+  @type stop_failure :: %{extension: atom(), reason: term()}
 
-  @doc "Starts the extension supervisor."
-  @spec start_link(keyword()) :: Supervisor.on_start()
-  def start_link(opts \\ []) do
-    name = Keyword.get(opts, :name, __MODULE__)
-    DynamicSupervisor.start_link(__MODULE__, opts, name: name)
+  @authority_retry_attempts 2
+
+  @typedoc "Injected lifecycle collaborators."
+  @type start_opts :: [
+          command_registry: GenServer.server(),
+          keymap: GenServer.server(),
+          callbacks: %{atom() => function()},
+          code_lease: GenServer.server(),
+          callback_registry: atom(),
+          artifact_admission: GenServer.server(),
+          runtime_application: atom(),
+          runtime_owned_modules: [module()],
+          instance_registry: atom(),
+          slow_lifecycle_threshold_ms: non_neg_integer(),
+          transition_timeout_ms: pos_integer(),
+          callback_timeout_ms: pos_integer(),
+          runtime_query_timeout_ms: pos_integer(),
+          drain_timeout_ms: pos_integer(),
+          test_hooks: map()
+        ]
+
+  @doc false
+  @spec child_spec(keyword()) :: Supervisor.child_spec()
+  def child_spec(opts) do
+    name = Keyword.get(opts, :name, RootSupervisor)
+
+    %{
+      id: name,
+      start: {__MODULE__, :start_link, [opts]},
+      restart: :permanent,
+      type: :supervisor
+    }
   end
 
-  @doc """
-  Starts all extensions declared in the registry.
+  @doc "Starts an isolated root supervisor for tests and embedded callers."
+  @spec start_link(keyword()) :: Supervisor.on_start()
+  def start_link(opts \\ []) do
+    name = Keyword.get(opts, :name, RootSupervisor)
 
-  Processes extensions in order:
-  1. Install all hex extensions via a single Mix.install/2 call
-  2. Clone/checkout all git extensions to local cache
-  3. Compile and start all extensions (path, git, hex)
+    instance_registry =
+      Keyword.get(opts, :instance_registry, InstanceRegistry.registry_for_root(name))
 
-  Errors at any stage are logged to *Messages* and stored in the
-  registry as `:load_error` without affecting other extensions.
-  """
-  @type start_failure :: %{extension: atom(), reason: term()}
+    case Process.whereis(instance_registry) do
+      nil ->
+        {:ok, _pid} = InstanceRegistry.start_link(name: instance_registry)
 
+      _pid ->
+        :ok
+    end
+
+    RootSupervisor.start_link(Keyword.put(opts, :name, name))
+  end
+
+  @doc "Starts all declared extensions after bulk source prerequisites."
   @spec start_all() :: :ok | {:error, [start_failure()]}
   @spec start_all(GenServer.server(), GenServer.server()) :: :ok | {:error, [start_failure()]}
   @spec start_all(GenServer.server(), GenServer.server(), start_opts()) ::
           :ok | {:error, [start_failure()]}
-  def start_all, do: start_all(__MODULE__, ExtRegistry)
-
+  def start_all, do: start_all(__MODULE__, ExtRegistry, [])
   def start_all(supervisor, registry), do: start_all(supervisor, registry, [])
 
   def start_all(supervisor, registry, opts) do
-    hex_install_failure =
-      case ExtHex.install_all(registry) do
-        :ok ->
-          nil
+    reconciliation_failures = reconcile_declarations(supervisor, registry, opts)
+    authority_failures = ensure_declared_authorities(supervisor, registry, opts)
 
-        {:error, reason} ->
-          Log.warning(:config, reason)
-          mark_hex_entries_load_error(registry)
-          %{extension: :hex_install, reason: reason}
-      end
-
+    hex_failure = install_hex(registry)
     git_failures = resolve_git_extensions(registry)
-    failed_git_names = MapSet.new(Enum.map(git_failures, & &1.extension))
+    prerequisite_failures = git_failures ++ List.wrap(hex_failure)
 
-    {failures, deferred_entries} =
-      ExtRegistry.all(registry)
-      |> Enum.reduce({[], []}, fn {name, entry}, acc ->
-        maybe_start_registered_extension(
-          supervisor,
-          registry,
-          name,
-          entry,
-          failed_git_names,
-          hex_install_failure,
-          acc,
-          opts
-        )
+    routing_failures =
+      route_prerequisite_failures(
+        supervisor,
+        registry,
+        prerequisite_failures,
+        hex_failure,
+        opts
+      )
+
+    failed_names = MapSet.new(Enum.map(prerequisite_failures, & &1.extension))
+
+    initial_failures =
+      reconciliation_failures ++
+        authority_failures ++ prerequisite_failures ++ routing_failures
+
+    {reversed_failures, deferred} =
+      registry
+      |> ExtRegistry.all()
+      |> Enum.reduce({Enum.reverse(initial_failures), []}, fn {name, entry},
+                                                              {failures, deferred} ->
+        if failed_prerequisite?(name, entry, failed_names, hex_failure) or
+             Enum.any?(authority_failures, &(&1.extension == name)) do
+          {failures, deferred}
+        else
+          start_by_policy(supervisor, registry, name, entry, opts, failures, deferred)
+        end
       end)
 
-    failures =
-      failures
-      |> prepend_failure(hex_install_failure)
-      |> Kernel.++(git_failures)
+    Lazy.schedule_deferred_loads(deferred)
 
-    Lazy.schedule_deferred_loads(supervisor, registry, deferred_entries, opts)
-
-    case failures do
+    case Enum.reverse(reversed_failures) do
       [] -> :ok
       failures -> {:error, failures}
     end
   end
 
-  @typep start_acc :: {[start_failure()], [{atom(), ExtRegistry.entry()}]}
-
-  @spec maybe_start_registered_extension(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          MapSet.t(atom()),
-          start_failure() | nil,
-          start_acc(),
-          start_opts()
-        ) :: start_acc()
-  defp maybe_start_registered_extension(
-         _supervisor,
-         _registry,
-         name,
-         %{source_type: :git, path: nil},
-         failed_git_names,
-         _hex_install_failure,
-         {failures, deferred},
-         _opts
-       ) do
-    if MapSet.member?(failed_git_names, name) do
-      {failures, deferred}
-    else
-      {Enum.concat(failures, [%{extension: name, reason: :clone_failed}]), deferred}
-    end
-  end
-
-  defp maybe_start_registered_extension(
-         _supervisor,
-         _registry,
-         _name,
-         %{source_type: :hex},
-         _failed_git_names,
-         hex_install_failure,
-         acc,
-         _opts
-       )
-       when is_map(hex_install_failure) do
-    acc
-  end
-
-  defp maybe_start_registered_extension(
-         supervisor,
-         registry,
-         name,
-         entry,
-         _failed_git_names,
-         _hex_install_failure,
-         {failures, deferred},
-         opts
-       ) do
-    case resolve_load_policy(name, entry, opts) do
-      :eager ->
-        start_eager(supervisor, registry, name, entry, opts, failures, deferred)
-
-      :deferred ->
-        case validate_deferred_extension(name, entry, opts) do
-          :ok ->
-            {failures, [{name, entry} | deferred]}
-
-          {:error, reason} ->
-            {Enum.concat(failures, [%{extension: name, reason: reason}]), deferred}
-        end
-
-      {:on_command, _} ->
-        register_lazy_or_fail(supervisor, registry, name, entry, opts, failures, deferred)
-
-      {:on_filetype, _} ->
-        log_reserved_trigger(name, :on_filetype)
-        register_lazy_or_fail(supervisor, registry, name, entry, opts, failures, deferred)
-
-      {:on_key, _} ->
-        log_reserved_trigger(name, :on_key)
-        register_lazy_or_fail(supervisor, registry, name, entry, opts, failures, deferred)
-    end
-  end
-
-  @spec resolve_load_policy(atom(), ExtRegistry.entry(), start_opts()) ::
-          Minga.Extension.load_policy()
-  defp resolve_load_policy(name, %{load_policy: nil} = entry, opts) do
-    case Minga.Extension.Lazy.discover_load_policy(name, entry, opts) do
-      {:ok, policy, _module} -> validate_load_policy(policy)
-      {:error, _reason} -> :eager
-    end
-  end
-
-  defp resolve_load_policy(_name, %{load_policy: policy}, _opts),
-    do: validate_load_policy(policy)
-
-  @valid_policy_atoms [:eager, :deferred]
-  @valid_trigger_tags [:on_command, :on_filetype, :on_key]
-
-  @spec validate_load_policy(term()) :: Minga.Extension.load_policy()
-  defp validate_load_policy(policy) when policy in @valid_policy_atoms, do: policy
-
-  defp validate_load_policy({tag, _} = policy) when tag in @valid_trigger_tags, do: policy
-
-  defp validate_load_policy(invalid) do
-    Log.warning(
-      :config,
-      "Invalid load_policy #{inspect(invalid)}, falling back to :eager"
-    )
-
-    :eager
-  end
-
-  @spec log_reserved_trigger(atom(), atom()) :: :ok
-  defp log_reserved_trigger(name, trigger) do
-    Log.warning(
-      :config,
-      "Extension #{name}: #{trigger} trigger is reserved; stub commands autoload on invocation but the event hook is not yet wired"
-    )
-  end
-
-  @spec register_lazy_or_fail(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          start_opts(),
-          [start_failure()],
-          [{atom(), ExtRegistry.entry()}]
-        ) :: start_acc()
-  defp register_lazy_or_fail(supervisor, registry, name, entry, opts, failures, deferred) do
-    case register_lazy_stubs(supervisor, registry, name, entry, opts) do
-      :ok -> {failures, deferred}
-      {:error, reason} -> {Enum.concat(failures, [%{extension: name, reason: reason}]), deferred}
-    end
-  end
-
-  @spec validate_deferred_extension(atom(), ExtRegistry.entry(), start_opts()) ::
-          :ok | {:error, term()}
-  defp validate_deferred_extension(name, entry, opts) do
-    case Minga.Extension.Lazy.discover_load_policy(name, entry, opts) do
-      {:ok, _policy, module} ->
-        with :ok <- validate_behaviour(module, name) do
-          register_and_validate_options(name, module, entry.config)
-        end
-
-      {:error, reason} ->
-        Log.warning(
-          :config,
-          "Extension #{name} deferred validation failed: #{inspect(reason)}"
-        )
-
-        {:error, reason}
-    end
-  end
-
-  @spec register_lazy_stubs(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          start_opts()
-        ) :: :ok | {:error, term()}
-  defp register_lazy_stubs(supervisor, registry, name, %{source_type: :module} = entry, opts) do
-    Lazy.register_module_stubs(supervisor, registry, name, entry, opts)
-  end
-
-  defp register_lazy_stubs(supervisor, registry, name, entry, opts) do
-    Lazy.register_stubs(supervisor, registry, name, entry, opts)
-  end
-
-  @spec start_eager(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          start_opts(),
-          [start_failure()],
-          [{atom(), ExtRegistry.entry()}]
-        ) :: {[start_failure()], [{atom(), ExtRegistry.entry()}]}
-  defp start_eager(supervisor, registry, name, entry, opts, failures, deferred) do
-    case start_extension(supervisor, registry, name, entry, opts) do
-      {:ok, _pid} -> {failures, deferred}
-      {:error, reason} -> {Enum.concat(failures, [%{extension: name, reason: reason}]), deferred}
-    end
-  end
-
-  @doc """
-  Stops all running extensions while retaining this VM generation's code.
-
-  Used by config reload to cleanly tear down before re-loading.
-  """
-  @type stop_failure :: %{extension: atom(), reason: term()}
-
+  @doc "Stops all declared extension authorities, aggregating failures."
   @spec stop_all() :: :ok | {:error, [stop_failure()]}
   @spec stop_all(GenServer.server(), GenServer.server()) :: :ok | {:error, [stop_failure()]}
   @spec stop_all(GenServer.server(), GenServer.server(), start_opts()) ::
           :ok | {:error, [stop_failure()]}
-  def stop_all, do: stop_all(__MODULE__, ExtRegistry)
-
+  def stop_all, do: stop_all(__MODULE__, ExtRegistry, [])
   def stop_all(supervisor, registry), do: stop_all(supervisor, registry, [])
 
   def stop_all(supervisor, registry, opts) do
     failures =
-      ExtRegistry.all(registry)
+      registry
+      |> ExtRegistry.all()
       |> Enum.reduce([], fn {name, entry}, failures ->
         case stop_extension(supervisor, registry, name, entry, opts) do
           :ok -> failures
@@ -315,68 +152,7 @@ defmodule Minga.Extension.Supervisor do
     end
   end
 
-  @doc """
-  Reports path and Git sources whose on-disk bytes differ from this VM
-  generation's admitted artifacts.
-
-  This is a read-only preflight for config reload. It fingerprints immutable
-  source snapshots and emits one restart-required event per changed source;
-  it never compiles, stops, or replaces the running extension.
-  """
-  @spec pending_artifact_restarts(GenServer.server(), start_opts()) :: [atom()]
-  def pending_artifact_restarts(registry, opts \\ []) do
-    registry
-    |> ExtRegistry.all()
-    |> Enum.reduce([], fn
-      {name, %{source_type: source_type, path: path}}, changed
-      when source_type in [:path, :git] and is_binary(path) ->
-        expanded = Path.expand(path)
-        files = expanded |> Path.join("**/*.ex") |> Path.wildcard() |> Enum.sort()
-        source = {:extension, name}
-
-        if report_staged_source_change(name, expanded, files, source, opts),
-          do: [name | changed],
-          else: changed
-
-      {_name, _entry}, changed ->
-        changed
-    end)
-    |> Enum.reverse()
-  end
-
-  @doc """
-  Starts a single extension by name.
-
-  For path extensions, compiles the module from the local directory.
-  Git and hex extensions must be resolved to a local path or loaded
-  via Mix.install before calling this function.
-  """
-  @typedoc """
-  Options for extension start/stop that inject collaborator dependencies.
-
-  * `:command_registry` — the `Minga.Command.Registry` server to register
-    commands with (default: `Minga.Command.Registry`)
-  * `:keymap` — the `Minga.Keymap.Active` server to register keybindings
-    with (default: `Minga.Keymap.Active`)
-  * `:callbacks` — cleanup callbacks map, injected for test isolation
-    (default: reads from `ContributionCleanup` persistent_term)
-  * `:code_lease` — the `Minga.Extension.CodeLease` server used by active callbacks
-  * `:callback_registry` — the extension-only runtime callback registry
-  * `:artifact_admission` — the VM-generation module provenance authority
-  """
-  @type start_opts :: [
-          command_registry: GenServer.server(),
-          keymap: GenServer.server(),
-          callbacks: %{atom() => function()},
-          code_lease: GenServer.server(),
-          callback_registry: CallbackRegistry.registry(),
-          artifact_admission: GenServer.server(),
-          runtime_application: atom(),
-          runtime_owned_modules: [module()],
-          slow_lifecycle_threshold_ms: non_neg_integer(),
-          test_hooks: map()
-        ]
-
+  @doc "Starts one extension through its stable authority and returns the runtime PID."
   @spec start_extension(GenServer.server(), GenServer.server(), atom(), ExtRegistry.entry()) ::
           {:ok, pid()} | {:error, term()}
   @spec start_extension(
@@ -385,595 +161,69 @@ defmodule Minga.Extension.Supervisor do
           atom(),
           ExtRegistry.entry(),
           start_opts()
-        ) ::
-          {:ok, pid()} | {:error, term()}
-  def start_extension(supervisor, registry, name, _entry, opts \\ []) do
-    with_lifecycle_lock(registry, name, fn ->
-      case current_start_entry(supervisor, registry, name) do
-        {:ok, {:running, pid}} ->
-          {:ok, pid}
-
-        {:ok, entry} ->
-          start_current_entry_locked(supervisor, registry, name, entry, opts)
-
-        {:error, reason} ->
-          {:error, reason}
-      end
+        ) :: {:ok, pid()} | {:error, term()}
+  def start_extension(supervisor, registry, name, entry, opts \\ []) do
+    call_declared_instance(supervisor, registry, name, entry, opts, fn instance ->
+      start_instance(name, instance)
     end)
   end
 
-  @spec start_current_entry_locked(
+  @spec start_instance(atom(), GenServer.server()) :: {:ok, pid()} | {:error, term()}
+  defp start_instance(name, instance) do
+    case safe_instance_call(name, fn -> Instance.start(instance) end) do
+      {:error, {:interrupted_lifecycle, _phase}} ->
+        safe_instance_call(name, fn -> Instance.start(instance) end)
+
+      result ->
+        result
+    end
+  end
+
+  @doc "Registers one lazy declaration and its activation stubs through its stable authority."
+  @spec register_lazy_extension(
           GenServer.server(),
           GenServer.server(),
           atom(),
           ExtRegistry.entry(),
-          start_opts()
-        ) :: {:ok, pid()} | {:error, term()}
-  defp start_current_entry_locked(
-         _supervisor,
-         registry,
-         name,
-         %{source_type: :git, path: nil},
-         _opts
-       ) do
-    # Git extensions are resolved to a local path in resolve_git_extensions/1.
-    # If the current registry entry has no path, the clone failed.
-    mark_start_load_error(registry, name)
-    {:error, :clone_failed}
-  end
-
-  defp start_current_entry_locked(supervisor, registry, name, %{source_type: :hex} = entry, opts) do
-    # Hex extensions are loaded via Mix.install in start_all/2.
-    # Find the module implementing the Extension behaviour from the newly available code paths.
-    find_and_start_hex_extension_locked(supervisor, registry, name, entry, opts)
-  end
-
-  defp start_current_entry_locked(
-         supervisor,
-         registry,
-         name,
-         %{source_type: :module} = entry,
-         opts
-       ) do
-    start_from_module_locked(supervisor, registry, name, entry, opts)
-  end
-
-  defp start_current_entry_locked(supervisor, registry, name, entry, opts) do
-    start_from_path_locked(supervisor, registry, name, entry, opts)
-  end
-
-  @spec start_from_module_locked(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          start_opts()
-        ) ::
-          {:ok, pid()} | {:error, term()}
-  defp start_from_module_locked(supervisor, registry, name, entry, opts) do
-    cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
-    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
-    module = entry.module
-    opts = Keyword.put_new(opts, :runtime_owned_modules, [module])
-    mark_start_attempt(registry, name)
-
-    with {:module, ^module} <- Code.ensure_loaded(module),
-         :ok <- validate_behaviour(module, name),
-         :ok <- ensure_runtime_source_inventory(name, module, opts),
-         :ok <- record_extension_manifest(registry, name, module, entry.source_type),
-         :ok <- register_and_validate_options(name, module, entry.config),
-         {:ok, _state} <-
-           run_lifecycle_phase(name, :init, opts, fn -> call_init(module, entry.config) end) do
-      finalize_extension_start(
-        start_loaded_extension(
-          supervisor,
-          registry,
-          name,
-          module,
-          entry.config,
-          cmd_registry,
-          keymap,
-          opts
-        ),
-        registry,
-        name,
-        cmd_registry,
-        keymap,
-        opts
-      )
-    else
-      {:error, reason} ->
-        msg = "Extension #{name} load error: #{inspect(reason)}"
-        Log.warning(:config, msg)
-        ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
-        wrap_start_failure(name, reason, cmd_registry, keymap, opts)
-    end
-  end
-
-  @spec start_from_path_locked(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          start_opts()
-        ) ::
-          {:ok, pid()} | {:error, term()}
-  defp start_from_path_locked(supervisor, registry, name, entry, opts) do
-    cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
-    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
-    mark_start_attempt(registry, name)
-
-    with {:ok, module} <-
-           run_lifecycle_phase(name, :load, opts, fn ->
-             compile_extension(name, entry.path, opts)
-           end),
-         :ok <- validate_behaviour(module, name),
-         :ok <- ensure_runtime_source_inventory(name, module, opts),
-         :ok <- record_extension_manifest(registry, name, module, entry.source_type),
-         :ok <- register_and_validate_options(name, module, entry.config),
-         {:ok, _state} <-
-           run_lifecycle_phase(name, :init, opts, fn -> call_init(module, entry.config) end) do
-      finalize_extension_start(
-        start_loaded_extension(
-          supervisor,
-          registry,
-          name,
-          module,
-          entry.config,
-          cmd_registry,
-          keymap,
-          opts
-        ),
-        registry,
-        name,
-        cmd_registry,
-        keymap,
-        opts
-      )
-    else
-      {:error, reason} ->
-        msg = "Extension #{name} load error: #{inspect(reason)}"
-        Log.warning(:config, msg)
-        ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
-        wrap_start_failure(name, reason, cmd_registry, keymap, opts)
-    end
-  end
-
-  @spec start_loaded_extension(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          module(),
-          keyword(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts()
-        ) :: {:ok, pid()} | {:error, term()}
-  defp start_loaded_extension(
-         supervisor,
-         registry,
-         name,
-         module,
-         config,
-         cmd_registry,
-         keymap,
-         opts
-       ) do
-    case register_extension_modeline_segments(module, name, opts) do
-      :ok ->
-        start_child_then_register_dsl(
-          supervisor,
-          registry,
-          name,
-          module,
-          config,
-          cmd_registry,
-          keymap,
-          opts
-        )
-
-      {:error, _reason} = error ->
-        error
-    end
-  end
-
-  @spec start_child_then_register_dsl(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          module(),
-          keyword(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts()
-        ) :: {:ok, pid()} | {:error, term()}
-  defp start_child_then_register_dsl(
-         supervisor,
-         registry,
-         name,
-         module,
-         config,
-         cmd_registry,
-         keymap,
-         opts
-       ) do
-    case start_child(supervisor, registry, name, module, config, cmd_registry, keymap, opts) do
-      {:ok, pid} ->
-        register_dsl_for_started_child(supervisor, pid, module, name, cmd_registry, keymap, opts)
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  @spec register_dsl_for_started_child(
-          GenServer.server(),
-          pid(),
-          module(),
-          atom(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts()
-        ) :: {:ok, pid()} | {:error, term()}
-  defp register_dsl_for_started_child(supervisor, pid, module, name, cmd_registry, keymap, opts) do
-    with :ok <- register_extension_commands(module, name, cmd_registry, opts),
-         :ok <- register_extension_keybinds(module, name, keymap),
-         :ok <- register_extension_event_handlers(module, name, opts),
-         :ok <- activate_runtime_source(name, opts) do
-      {:ok, pid}
-    else
-      {:error, reason} -> handle_dsl_registration_failure(supervisor, pid, reason)
-    end
-  end
-
-  @spec register_extension_event_handlers(module(), atom(), start_opts()) ::
-          :ok | {:error, term()}
-  defp register_extension_event_handlers(module, name, opts) do
-    schema =
-      if function_exported?(module, :__editor_event_handler_schema__, 0) do
-        module.__editor_event_handler_schema__()
-      else
-        []
-      end
-
-    CallbackRegistry.register_extension(name, schema,
-      registry: callback_registry_server(opts),
-      artifact_admission: artifact_admission_server(opts)
-    )
-  end
-
-  @spec activate_runtime_source(atom(), start_opts()) :: :ok | {:error, term()}
-  defp activate_runtime_source(name, opts) do
-    source = {:extension, name}
-
-    case ArtifactAdmission.source_modules(source, server: artifact_admission_server(opts)) do
-      {:ok, [_module | _rest] = modules} ->
-        CodeLease.activate_source(source, modules, server: code_lease_server(opts))
-
-      {:ok, []} ->
-        {:error, {:source_artifact_unavailable, source}}
-
-      :error ->
-        {:error, {:source_artifact_unavailable, source}}
-    end
-  end
-
-  @spec ensure_runtime_source_inventory(atom(), module(), start_opts()) ::
-          :ok | {:error, term()}
-  defp ensure_runtime_source_inventory(name, module, opts) do
-    source = {:extension, name}
-    admission = artifact_admission_server(opts)
-
-    case ArtifactAdmission.source_modules(source, server: admission) do
-      {:ok, [_module | _rest]} ->
-        :ok
-
-      {:ok, []} ->
-        {:error, {:source_artifact_unavailable, source}}
-
-      :error ->
-        admit_loaded_runtime_inventory(source, module, admission, opts)
-    end
-  end
-
-  @spec admit_loaded_runtime_inventory(
-          CallbackInvoker.source(),
-          module(),
-          GenServer.server(),
           start_opts()
         ) :: :ok | {:error, term()}
-  defp admit_loaded_runtime_inventory(source, module, admission, opts) do
-    with {:ok, application} <- runtime_application(module, opts),
-         {:ok, modules} <- runtime_inventory_modules(module, application, opts),
-         :ok <- ensure_runtime_modules_loaded(modules),
-         fingerprint <- runtime_inventory_fingerprint(application, modules),
-         {:ok, claim} <-
-           ArtifactAdmission.claim_source_modules(source, modules, fingerprint,
-             server: admission,
-             trusted_application: application,
-             exclusive_adoption: true,
-             source_fingerprint: fingerprint
-           ),
-         :ok <- verify_adopted_runtime_inventory(claim, modules, admission) do
-      ArtifactAdmission.commit_attempt(claim, server: admission)
-    end
-  rescue
-    exception -> {:error, {:runtime_inventory_failed, Exception.message(exception)}}
-  catch
-    kind, reason -> {:error, {:runtime_inventory_failed, kind, reason}}
+  def register_lazy_extension(supervisor, registry, name, entry, opts \\ []) do
+    call_declared_instance(supervisor, registry, name, entry, opts, &Instance.stub/1)
   end
 
-  @spec runtime_application(module(), start_opts()) :: {:ok, atom()} | {:error, term()}
-  defp runtime_application(module, opts) do
-    case Keyword.fetch(opts, :runtime_application) do
-      {:ok, application} when is_atom(application) ->
-        {:ok, application}
-
-      {:ok, invalid} ->
-        {:error, {:invalid_runtime_application, invalid}}
-
-      :error ->
-        case :application.get_application(module) do
-          {:ok, application} -> {:ok, application}
-          :undefined -> {:error, {:runtime_application_unavailable, module}}
-        end
-    end
-  end
-
-  @spec runtime_inventory_modules(module(), atom(), start_opts()) ::
-          {:ok, [module()]} | {:error, term()}
-  defp runtime_inventory_modules(module, application, opts) do
-    if Keyword.has_key?(opts, :runtime_application) do
-      application_modules(application)
-    else
-      modules =
-        [
-          module
-          | declared_runtime_modules(module) ++ Keyword.get(opts, :runtime_owned_modules, [])
-        ]
-        |> Enum.uniq()
-        |> Enum.sort()
-
-      {:ok, modules}
-    end
-  end
-
-  @spec application_modules(atom()) :: {:ok, [module()]} | {:error, term()}
-  defp application_modules(application) do
-    case :application.get_key(application, :modules) do
-      {:ok, [_module | _rest] = modules} -> {:ok, Enum.sort(Enum.uniq(modules))}
-      {:ok, []} -> {:error, {:runtime_application_has_no_modules, application}}
-      :undefined -> {:error, {:invalid_runtime_application, application}}
-    end
-  end
-
-  @spec declared_runtime_modules(module()) :: [module()]
-  defp declared_runtime_modules(module) do
-    command_modules =
-      for {_name, _description, command_opts} <- extension_schema(module, :__command_schema__),
-          is_list(command_opts),
-          Keyword.keyword?(command_opts),
-          {callback_module, callback_function} <- [Keyword.get(command_opts, :execute)],
-          is_atom(callback_module) and is_atom(callback_function),
-          do: callback_module
-
-    modeline_modules =
-      for {_name, _segment_opts, {callback_module, callback_function}} <-
-            extension_schema(module, :__modeline_segment_schema__),
-          is_atom(callback_module) and is_atom(callback_function),
-          do: callback_module
-
-    event_modules =
-      for {callback_module, _families, _handler_opts} <-
-            extension_schema(module, :__editor_event_handler_schema__),
-          is_atom(callback_module),
-          do: callback_module
-
-    command_modules ++ modeline_modules ++ event_modules
-  end
-
-  @spec extension_schema(module(), atom()) :: [term()]
-  defp extension_schema(module, function) do
-    if function_exported?(module, function, 0), do: apply(module, function, []), else: []
-  end
-
-  @spec ensure_runtime_modules_loaded([module()]) :: :ok | {:error, term()}
-  defp ensure_runtime_modules_loaded(modules) do
-    Enum.reduce_while(modules, :ok, fn module, :ok ->
-      case Code.ensure_loaded(module) do
-        {:module, ^module} -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, {:runtime_module_unavailable, module, reason}}}
-      end
+  @doc "Starts a captured deferred declaration through the same Instance."
+  @spec start_deferred_extension(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts()
+        ) :: :ok
+  def start_deferred_extension(supervisor, _registry, name, entry, opts \\ []) do
+    supervisor
+    |> call_existing_instance(name, opts, fn instance ->
+      Instance.start_deferred(instance, entry)
     end)
+    |> start_deferred_instance(name)
   end
 
-  @spec runtime_inventory_fingerprint(atom(), [module()]) :: binary()
-  defp runtime_inventory_fingerprint(application, modules) do
-    module_digests = Enum.map(modules, &{&1, &1.module_info(:md5)})
-
-    :crypto.hash(
-      :sha256,
-      :erlang.term_to_binary({:runtime_inventory_v1, application, module_digests})
-    )
+  @spec start_deferred_instance(:absent | {:ok, pid()} | {:error, term()}, atom()) :: :ok
+  defp start_deferred_instance(:absent, name) do
+    Log.warning(:config, "Extension #{name} deferred load skipped: authority unavailable")
+    :ok
   end
 
-  @spec verify_adopted_runtime_inventory(
-          ArtifactAdmission.claim(),
-          [module()],
-          GenServer.server()
-        ) :: :ok | {:error, term()}
-  defp verify_adopted_runtime_inventory(claim, modules, admission) do
-    if claim.load_modules == [] and claim.adopted_modules == Enum.sort(modules) do
-      :ok
-    else
-      _result = ArtifactAdmission.abort_attempt(claim, server: admission)
+  defp start_deferred_instance(result, name), do: handle_deferred_start(result, name)
 
-      {:error,
-       {:runtime_inventory_not_adopted, claim.source, claim.load_modules, claim.adopted_modules}}
-    end
+  @spec handle_deferred_start({:ok, pid()} | {:error, term()}, atom()) :: :ok
+  defp handle_deferred_start({:ok, _pid}, _name), do: :ok
+
+  defp handle_deferred_start({:error, reason}, name) do
+    Log.warning(:config, "Extension #{name} deferred load failed: #{inspect(reason)}")
+    :ok
   end
 
-  @spec handle_dsl_registration_failure(GenServer.server(), pid(), term()) :: {:error, term()}
-  defp handle_dsl_registration_failure(supervisor, pid, reason) do
-    case terminate_extension_child(supervisor, pid) do
-      :ok ->
-        {:error, reason}
-
-      {:error, termination_reason} ->
-        {:error, {:registration_cleanup_failed, reason, termination_reason}}
-    end
-  end
-
-  @spec terminate_extension_child(GenServer.server(), pid()) :: :ok | {:error, term()}
-  defp terminate_extension_child(supervisor, pid) do
-    case DynamicSupervisor.terminate_child(supervisor, pid) do
-      :ok ->
-        :ok
-
-      {:error, reason} = error ->
-        Log.warning(
-          :config,
-          "Extension child #{inspect(pid)} termination failed: #{inspect(reason)}"
-        )
-
-        error
-    end
-  catch
-    :exit, reason ->
-      Log.warning(
-        :config,
-        "Extension child #{inspect(pid)} termination exited: #{inspect(reason)}"
-      )
-
-      {:error, {:exit, reason}}
-  end
-
-  @spec finalize_extension_start(
-          {:ok, pid()} | {:error, term()},
-          GenServer.server(),
-          atom(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts()
-        ) :: {:ok, pid()} | {:error, term()}
-  defp finalize_extension_start({:ok, pid}, _registry, _name, _cmd_registry, _keymap, _opts),
-    do: {:ok, pid}
-
-  defp finalize_extension_start({:error, reason}, registry, name, cmd_registry, keymap, opts) do
-    cleanup_result = cleanup_extension_contributions(name, cmd_registry, keymap, opts)
-    msg = "Extension #{name} load error: #{inspect(reason)}"
-    Log.warning(:config, msg)
-    ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
-
-    case cleanup_result do
-      :ok -> {:error, reason}
-      {:error, failures} -> {:error, {:cleanup_failed, reason, failures}}
-    end
-  end
-
-  @spec start_child(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          module(),
-          keyword(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts()
-        ) ::
-          {:ok, pid()} | {:error, term()}
-  defp start_child(supervisor, registry, name, module, config, cmd_registry, keymap, opts) do
-    lifecycle_ref = make_ref()
-    ExtRegistry.update(registry, name, lifecycle_ref: lifecycle_ref)
-
-    case run_lifecycle_phase(name, :child_start, opts, fn ->
-           start_extension_child(supervisor, module, config)
-         end) do
-      {:ok, {pid, restart}} ->
-        ExtRegistry.update(
-          registry,
-          name,
-          module: module,
-          status: :running,
-          pid: pid,
-          lifecycle_ref: lifecycle_ref,
-          last_error: nil
-        )
-
-        emit_restart_count(name, 0)
-
-        start_child_restart_monitor(
-          %{
-            supervisor: supervisor,
-            registry: registry,
-            name: name,
-            module: module,
-            lifecycle_ref: lifecycle_ref,
-            cmd_registry: cmd_registry,
-            keymap: keymap,
-            restart: restart,
-            opts: opts
-          },
-          pid
-        )
-
-        broadcast_agent_contributions_started(registry, name)
-        Log.info(:config, "Extension #{name} started (#{module})")
-        {:ok, pid}
-
-      {:error, reason} ->
-        msg = "Extension #{name} failed to start: #{inspect(reason)}"
-        Log.warning(:config, msg)
-
-        ExtRegistry.update(
-          registry,
-          name,
-          module: module,
-          status: :load_error,
-          pid: nil,
-          lifecycle_ref: nil
-        )
-
-        {:error, reason}
-    end
-  end
-
-  @spec broadcast_agent_contributions_started(GenServer.server(), atom()) :: :ok
-  defp broadcast_agent_contributions_started(registry, name) do
-    case ExtRegistry.get(registry, name) do
-      {:ok, %{manifest: %Manifest{} = manifest} = entry} ->
-        Minga.Events.broadcast(:extension_agent_contributions_started, %{
-          source: {:extension, name},
-          module: entry.module,
-          manifest: manifest,
-          root: extension_root(entry)
-        })
-
-      _other ->
-        :ok
-    end
-  end
-
-  @spec extension_root(ExtRegistry.entry()) :: String.t() | nil
-  defp extension_root(%{path: path}) when is_binary(path), do: Path.expand(path)
-
-  defp extension_root(%{hex: %{app: app}}) when is_atom(app) do
-    case :code.lib_dir(app) do
-      path when is_list(path) -> List.to_string(path)
-      _ -> nil
-    end
-  end
-
-  defp extension_root(%{module: module}) when is_atom(module) and not is_nil(module) do
-    case :code.which(module) do
-      path when is_list(path) -> path |> List.to_string() |> Path.dirname() |> Path.dirname()
-      _ -> nil
-    end
-  end
-
-  defp extension_root(_entry), do: nil
-
-  @doc "Stops one extension runtime without replacing or purging its admitted code."
+  @doc "Stops one extension authority. Stop is idempotent."
   @spec stop_extension(GenServer.server(), GenServer.server(), atom(), ExtRegistry.entry()) ::
           :ok | {:error, term()}
   @spec stop_extension(
@@ -984,1386 +234,101 @@ defmodule Minga.Extension.Supervisor do
           start_opts()
         ) :: :ok | {:error, term()}
   def stop_extension(supervisor, registry, name, entry, opts \\ []) do
-    with_lifecycle_lock(registry, name, fn ->
-      case current_stop_entry(registry, name, entry) do
-        {:ok, current_entry} ->
-          stop_current_extension(supervisor, registry, name, current_entry, opts)
-
-        :stale ->
-          :ok
-
-        :not_registered ->
-          :ok
-      end
-    end)
+    supervisor
+    |> call_existing_instance(name, opts, fn instance -> Instance.stop(instance, opts) end)
+    |> stop_existing_instance(supervisor, registry, name, entry, opts)
   end
 
-  @spec stop_current_extension(
+  @spec stop_existing_instance(
+          :ok | :absent | {:error, term()},
           GenServer.server(),
           GenServer.server(),
           atom(),
           ExtRegistry.entry(),
           start_opts()
         ) :: :ok | {:error, term()}
-  defp stop_current_extension(supervisor, registry, name, entry, opts) do
-    cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
-    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
+  defp stop_existing_instance(:ok, _supervisor, _registry, _name, _entry, _opts), do: :ok
 
-    # Runtime disable closes contribution admission and stops the process tree,
-    # but admitted modules remain resident for this VM generation.
-    ExtRegistry.update(registry, name, status: :stopped, lifecycle_ref: nil)
-
-    quiesce_and_stop_extension(
-      supervisor,
-      registry,
-      name,
-      entry,
-      cmd_registry,
-      keymap,
-      opts
-    )
-  end
-
-  @spec quiesce_and_stop_extension(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts()
-        ) :: :ok | {:error, term()}
-  defp quiesce_and_stop_extension(
-         supervisor,
-         registry,
-         name,
-         entry,
-         cmd_registry,
-         keymap,
-         opts
-       ) do
-    with :ok <- quiesce_extension_source(name, opts) do
-      termination_result =
-        run_lifecycle_phase(name, :stop, opts, fn ->
-          terminate_extension_process(supervisor, entry)
-        end)
-
-      cleanup_result = cleanup_extension_contributions(name, cmd_registry, keymap, opts)
-
-      finalize_explicit_stop_result(
-        termination_result,
-        cleanup_result,
-        registry,
-        name,
-        entry,
-        opts
-      )
-    end
-  end
-
-  @doc """
-  Returns a summary of all extensions: `[{name, version, status}]`.
-  """
-  @spec list_extensions() :: [{atom(), String.t(), Minga.Extension.extension_status()}]
-  @spec list_extensions(GenServer.server()) :: [
-          {atom(), String.t(), Minga.Extension.extension_status()}
-        ]
-  def list_extensions, do: list_extensions(ExtRegistry)
-
-  def list_extensions(registry) do
-    for {name, entry} <- ExtRegistry.all(registry) do
-      version =
-        if entry.module && Code.ensure_loaded?(entry.module) do
-          try do
-            entry.module.version()
-          rescue
-            e ->
-              Log.warning(
-                :config,
-                "Extension #{name} version() failed: #{Exception.message(e)}"
-              )
-
-              "unknown"
-          end
-        else
-          "unknown"
-        end
-
-      {name, version, entry.status}
-    end
-  end
-
-  # ── Supervisor Callbacks ───────────────────────────────────────────────────
-
-  @impl true
-  @spec init(keyword()) :: {:ok, DynamicSupervisor.sup_flags()}
-  def init(_opts) do
-    DynamicSupervisor.init(strategy: :one_for_one)
-  end
-
-  # ── Private ────────────────────────────────────────────────────────────────
-
-  @spec mark_start_attempt(GenServer.server(), atom()) :: :ok
-  defp mark_start_attempt(registry, name) do
-    ExtRegistry.update(registry, name, manifest: nil)
-  end
-
-  @spec code_lease_server(start_opts()) :: GenServer.server()
-  defp code_lease_server(opts), do: Keyword.get(opts, :code_lease, CodeLease)
-
-  @spec callback_registry_server(start_opts()) :: CallbackRegistry.registry()
-  defp callback_registry_server(opts),
-    do: Keyword.get(opts, :callback_registry, CallbackRegistry.default_table())
-
-  @spec artifact_admission_server(start_opts()) :: GenServer.server()
-  defp artifact_admission_server(opts),
-    do: Keyword.get(opts, :artifact_admission, ArtifactAdmission)
-
-  @spec extension_callback_result(
-          atom(),
-          module(),
-          atom(),
-          [term()],
-          CallbackInvoker.semantics(),
-          GenServer.server()
-        ) ::
-          {:extension_callback, CallbackInvoker.source(), module(), atom(),
-           CallbackInvoker.result(term())}
-  defp extension_callback_result(ext_name, module, function, args, semantics, admission) do
-    source = {:extension, ext_name}
-    result = CallbackInvoker.invoke(source, module, function, args, semantics, admission)
-    {:extension_callback, source, module, function, result}
-  end
-
-  @spec mark_start_load_error(GenServer.server(), atom()) :: :ok
-  defp mark_start_load_error(registry, name) do
-    ExtRegistry.update(registry, name,
-      status: :load_error,
-      pid: nil,
-      lifecycle_ref: nil,
-      manifest: nil
-    )
-  end
-
-  @spec record_extension_manifest(GenServer.server(), atom(), module(), Manifest.source_type()) ::
-          :ok | {:error, term()}
-  defp record_extension_manifest(registry, name, module, source) do
-    case safe_record_extension_manifest(module, source) do
-      {:ok, manifest} ->
-        ExtRegistry.update(registry, name, manifest: manifest)
-        :ok
-
-      {:error, reason} ->
-        {:error, reason}
-    end
-  end
-
-  @spec safe_record_extension_manifest(module(), Manifest.source_type()) ::
-          {:ok, Manifest.t()} | {:error, term()}
-  defp safe_record_extension_manifest(module, source) do
-    {:ok, Manifest.from_module(module, source)}
-  rescue
-    e -> {:error, "manifest introspection failed: #{Exception.message(e)}"}
-  catch
-    kind, reason ->
-      {:error, "manifest introspection failed: #{inspect(kind)} #{inspect(reason)}"}
-  end
-
-  @spec run_lifecycle_phase(atom(), atom(), start_opts(), (-> result)) :: result when result: var
-  defp run_lifecycle_phase(name, phase, opts, fun)
-       when is_atom(name) and is_atom(phase) and is_function(fun, 0) do
-    handler_id = attach_slow_lifecycle_handler(name, phase, opts)
-
-    try do
-      Minga.Telemetry.span(
-        [:minga, :extension, :lifecycle],
-        %{extension: name, phase: phase},
-        fun
-      )
-    after
-      detach_slow_lifecycle_handler(handler_id)
-    end
-  end
-
-  @spec with_lifecycle_lock(GenServer.server(), atom(), (-> result)) :: result when result: var
-  defp with_lifecycle_lock(registry, name, fun) when is_atom(name) and is_function(fun, 0) do
-    # The resource id identifies the extension lifecycle stream to serialize.
-    # The requester id identifies this caller for :global.trans/4 reentrancy bookkeeping.
-    # Restricting nodes to [node()] keeps the lock local to this editor VM.
-    resource_id = {__MODULE__, :lifecycle, canonical_registry_id(registry), name}
-    requester_id = self()
-
-    :global.trans({resource_id, requester_id}, fun, [node()], :infinity)
-  end
-
-  @spec canonical_registry_id(GenServer.server()) :: term()
-  defp canonical_registry_id(registry) when is_pid(registry) do
-    case Process.info(registry, :registered_name) do
-      {:registered_name, name} when is_atom(name) -> {:local_name, name}
-      _other -> {:pid, registry}
-    end
-  end
-
-  defp canonical_registry_id(registry) when is_atom(registry) do
-    case Process.whereis(registry) do
-      pid when is_pid(pid) -> canonical_registry_id(pid)
-      nil -> {:local_name, registry}
-    end
-  end
-
-  defp canonical_registry_id({:global, name}), do: {:global_name, name}
-  defp canonical_registry_id({:via, module, name}), do: {:via, module, name}
-  defp canonical_registry_id(registry), do: registry
-
-  @spec current_start_entry(GenServer.server(), GenServer.server(), atom()) ::
-          {:ok, ExtRegistry.entry() | {:running, pid()}} | {:error, term()}
-  defp current_start_entry(supervisor, registry, name) do
+  defp stop_existing_instance(:absent, supervisor, registry, name, entry, opts) do
     case ExtRegistry.get(registry, name) do
-      {:ok, %{pid: pid} = entry} when is_pid(pid) ->
-        current_running_or_restartable_entry(supervisor, registry, name, pid, entry)
-
-      {:ok, entry} ->
-        {:ok, entry}
-
-      :error ->
-        {:error, :not_registered}
+      :error -> :ok
+      {:ok, _declaration} -> stop_declared_instance(supervisor, registry, name, entry, opts)
     end
   end
 
-  @spec current_running_or_restartable_entry(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          pid(),
-          ExtRegistry.entry()
-        ) :: {:ok, {:running, pid()} | ExtRegistry.entry()} | {:error, term()}
-  defp current_running_or_restartable_entry(supervisor, registry, name, pid, entry) do
-    case extension_child_pid_by_pid(supervisor, pid) do
-      {:ok, ^pid} ->
-        {:ok, {:running, pid}}
-
-      :not_found ->
-        reconcile_dead_running_entry(supervisor, registry, name, entry)
-
-      {:error, reason} ->
-        Log.warning(
-          :config,
-          "Extension #{name} running child validation failed: #{inspect(reason)}"
-        )
-
-        mark_start_load_error(registry, name)
-        {:error, {:restart_lookup_failed, reason}}
-    end
-  end
-
-  @spec reconcile_dead_running_entry(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry()
-        ) ::
-          {:ok, {:running, pid()} | ExtRegistry.entry()} | {:error, term()}
-  defp reconcile_dead_running_entry(supervisor, registry, name, %{module: module} = entry)
-       when is_atom(module) and not is_nil(module) do
-    case extension_child_pid(supervisor, module) do
-      {:ok, pid} ->
-        ExtRegistry.update(registry, name, pid: pid)
-        {:ok, {:running, pid}}
-
-      :not_found ->
-        {:ok, entry}
-
-      {:error, reason} ->
-        Log.warning(
-          :config,
-          "Extension #{name} restart reconciliation failed: #{inspect(reason)}"
-        )
-
-        mark_start_load_error(registry, name)
-        {:error, {:restart_lookup_failed, reason}}
-    end
-  end
-
-  defp reconcile_dead_running_entry(_supervisor, _registry, _name, entry), do: {:ok, entry}
-
-  @spec current_stop_entry(GenServer.server(), atom(), ExtRegistry.entry()) ::
-          {:ok, ExtRegistry.entry()} | :stale | :not_registered
-  defp current_stop_entry(registry, name, requested_entry) do
-    case ExtRegistry.get(registry, name) do
-      {:ok, current_entry} -> current_stop_entry_for_request(requested_entry, current_entry)
-      :error -> :not_registered
-    end
-  end
-
-  @spec current_stop_entry_for_request(ExtRegistry.entry(), ExtRegistry.entry()) ::
-          {:ok, ExtRegistry.entry()} | :stale
-  defp current_stop_entry_for_request(
-         %{status: :running, lifecycle_ref: requested_ref},
-         %{status: :running, lifecycle_ref: requested_ref} = current_entry
-       )
-       when is_reference(requested_ref),
-       do: {:ok, current_entry}
-
-  defp current_stop_entry_for_request(
-         %{status: :running, pid: requested_pid, lifecycle_ref: nil},
-         %{status: :running, pid: requested_pid, lifecycle_ref: nil} = current_entry
-       )
-       when is_pid(requested_pid),
-       do: {:ok, current_entry}
-
-  defp current_stop_entry_for_request(
-         %{status: :running, pid: nil, module: requested_module, lifecycle_ref: nil},
-         %{status: :running, pid: nil, module: requested_module, lifecycle_ref: nil} =
-           current_entry
-       )
-       when is_atom(requested_module) and not is_nil(requested_module),
-       do: {:ok, current_entry}
-
-  defp current_stop_entry_for_request(
-         %{pid: requested_pid},
-         %{status: :stopped, pid: requested_pid, lifecycle_ref: nil} = current_entry
-       )
-       when is_pid(requested_pid),
-       do: {:ok, current_entry}
-
-  defp current_stop_entry_for_request(
-         %{status: requested_status, pid: nil, lifecycle_ref: nil},
-         %{status: requested_status, pid: nil, lifecycle_ref: nil} = current_entry
-       )
-       when requested_status != :running,
-       do: {:ok, current_entry}
-
-  defp current_stop_entry_for_request(_requested_entry, _current_entry), do: :stale
-
-  @spec attach_slow_lifecycle_handler(atom(), atom(), start_opts()) :: term()
-  defp attach_slow_lifecycle_handler(name, phase, opts) do
-    threshold_ms = Keyword.get(opts, :slow_lifecycle_threshold_ms, 50)
-    handler_id = {__MODULE__, :slow_lifecycle, self(), make_ref()}
-
-    :telemetry.attach(
-      handler_id,
-      [:minga, :extension, :lifecycle, :stop],
-      &__MODULE__.handle_slow_lifecycle_event/4,
-      %{extension: name, phase: phase, threshold_ms: threshold_ms}
-    )
-
-    handler_id
-  end
-
-  @spec detach_slow_lifecycle_handler(term()) :: :ok
-  defp detach_slow_lifecycle_handler(handler_id) do
-    :telemetry.detach(handler_id)
-    :ok
-  end
-
-  @spec handle_slow_lifecycle_event([atom()], map(), map(), map()) :: :ok
-  def handle_slow_lifecycle_event(
-        _event,
-        %{duration: duration},
-        %{extension: extension, phase: phase},
-        %{extension: extension, phase: phase, threshold_ms: threshold_ms}
-      ) do
-    maybe_log_slow_lifecycle_phase(extension, phase, duration, threshold_ms)
-  end
-
-  def handle_slow_lifecycle_event(_event, _measurements, _metadata, _config), do: :ok
-
-  @spec maybe_log_slow_lifecycle_phase(atom(), atom(), integer(), non_neg_integer()) :: :ok
-  defp maybe_log_slow_lifecycle_phase(name, phase, duration, threshold_ms) do
-    duration_ms = System.convert_time_unit(duration, :native, :millisecond)
-
-    if duration_ms >= threshold_ms do
-      Log.warning(
-        :config,
-        "Extension #{name} lifecycle phase #{phase} took #{duration_ms}ms"
-      )
-    else
-      :ok
-    end
-  end
-
-  @spec emit_restart_count(atom(), non_neg_integer()) :: :ok
-  defp emit_restart_count(name, count) do
-    Minga.Telemetry.execute(
-      [:minga, :extension, :lifecycle, :crash_restart_count],
-      %{count: count},
-      %{extension: name, phase: :crash_restart_count}
-    )
-  end
-
-  @spec run_test_hook(start_opts(), atom()) :: :ok
-  defp run_test_hook(opts, hook_name) do
-    case Keyword.get(opts, :test_hooks, %{}) do
-      %{^hook_name => hook} when is_function(hook, 0) -> hook.()
-      _ -> :ok
-    end
-  end
-
-  @spec start_extension_child(GenServer.server(), module(), keyword()) ::
-          {:ok, {pid(), child_restart()}} | {:error, term()}
-  defp start_extension_child(supervisor, module, config) do
-    child_spec = normalize_child_spec(module, config)
-    restart = Map.get(child_spec, :restart, :permanent)
-
-    case DynamicSupervisor.start_child(supervisor, child_spec) do
-      {:ok, pid} -> {:ok, {pid, restart}}
-      {:error, _reason} = error -> error
-    end
-  rescue
-    e -> {:error, {:child_spec_failed, Exception.message(e)}}
-  catch
-    kind, reason -> {:error, {:child_spec_failed, {kind, reason}}}
-  end
-
-  @spec normalize_child_spec(module(), keyword()) :: Supervisor.child_spec()
-  defp normalize_child_spec(module, config) do
-    module.child_spec(config)
-    |> Supervisor.child_spec([])
-    |> Map.put(:modules, [module])
-  end
-
-  @spec terminate_extension_process(GenServer.server(), ExtRegistry.entry()) ::
-          :ok | {:error, term()}
-  defp terminate_extension_process(supervisor, %{pid: pid} = entry) when is_pid(pid) do
-    case terminate_extension_child(supervisor, pid) do
-      {:error, :not_found} -> terminate_extension_process_by_module(supervisor, entry.module)
-      result -> result
-    end
-  end
-
-  defp terminate_extension_process(supervisor, %{module: module, status: :running})
-       when is_atom(module) and not is_nil(module) do
-    terminate_extension_process_by_module(supervisor, module)
-  end
-
-  defp terminate_extension_process(_supervisor, _entry), do: :ok
-
-  @spec terminate_extension_process_by_module(GenServer.server(), module() | nil) ::
-          :ok | {:error, term()}
-  defp terminate_extension_process_by_module(_supervisor, nil), do: {:error, :not_found}
-
-  defp terminate_extension_process_by_module(supervisor, module) do
-    case extension_child_pid(supervisor, module) do
-      {:ok, pid} -> terminate_extension_child(supervisor, pid)
-      :not_found -> {:error, :not_found}
-      {:error, reason} -> {:error, reason}
-    end
-  end
-
-  @typep child_restart :: :permanent | :transient | :temporary
-
-  @typep restart_monitor :: %{
-           supervisor: GenServer.server(),
-           registry: GenServer.server(),
-           name: atom(),
-           module: module(),
-           lifecycle_ref: reference(),
-           cmd_registry: GenServer.server(),
-           keymap: GenServer.server(),
-           restart: child_restart(),
-           opts: start_opts()
-         }
-
-  @spec start_child_restart_monitor(restart_monitor(), pid()) :: :ok
-  defp start_child_restart_monitor(monitor, pid) do
-    owner = self()
-    ready_ref = make_ref()
-
-    spawn(fn -> monitor_child_restarts(monitor, pid, 0, {owner, ready_ref}) end)
-
-    receive do
-      {:extension_restart_monitor_ready, ^ready_ref} -> :ok
-    end
-  end
-
-  @spec monitor_child_restarts(
-          restart_monitor(),
-          pid(),
-          non_neg_integer(),
-          {pid(), reference()} | nil
-        ) :: :ok
-  defp monitor_child_restarts(monitor, pid, count, ready) do
-    ref = Process.monitor(pid)
-    notify_restart_monitor_ready(ready)
-
-    receive do
-      {:DOWN, ^ref, :process, ^pid, reason} -> handle_child_down(monitor, pid, reason, count)
-    end
-  end
-
-  @spec notify_restart_monitor_ready({pid(), reference()} | nil) :: :ok
-  defp notify_restart_monitor_ready({owner, ready_ref}) do
-    send(owner, {:extension_restart_monitor_ready, ready_ref})
-    :ok
-  end
-
-  defp notify_restart_monitor_ready(nil), do: :ok
-
-  @spec handle_child_down(restart_monitor(), pid(), term(), non_neg_integer()) :: :ok
-  defp handle_child_down(monitor, pid, reason, count) do
-    wait_for_restarted_child(monitor, pid, reason, count + 1, 0)
-  end
-
-  @spec lifecycle_monitor_active?(GenServer.server(), atom(), reference()) :: boolean()
-  defp lifecycle_monitor_active?(registry, name, lifecycle_ref) do
-    case ExtRegistry.get(registry, name) do
-      {:ok, %{lifecycle_ref: ^lifecycle_ref, status: status}}
-      when status in [:running, :stopped] ->
-        true
-
-      _ ->
-        false
-    end
-  end
-
-  @spec crash_reason?(term()) :: boolean()
-  defp crash_reason?(:normal), do: false
-  defp crash_reason?(:shutdown), do: false
-  defp crash_reason?({:shutdown, _reason}), do: false
-  defp crash_reason?(_reason), do: true
-
-  @spec wait_for_restarted_child(
-          restart_monitor(),
-          pid(),
-          term(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) ::
-          :ok
-  defp wait_for_restarted_child(monitor, excluded_pid, reason, count, attempts) do
-    if lifecycle_monitor_active?(monitor.registry, monitor.name, monitor.lifecycle_ref) do
-      wait_for_active_monitor_child(monitor, excluded_pid, reason, count, attempts)
-    else
-      :ok
-    end
-  end
-
-  @spec wait_for_active_monitor_child(
-          restart_monitor(),
-          pid(),
-          term(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: :ok
-  defp wait_for_active_monitor_child(monitor, excluded_pid, reason, count, attempts) do
-    run_test_hook(monitor.opts, :before_restart_lookup)
-
-    case extension_child_pid(monitor.supervisor, monitor.module, excluded_pid) do
-      {:ok, pid} ->
-        handle_restarted_child(monitor, pid, count)
-
-      :not_found ->
-        wait_for_missing_restarted_child(monitor, excluded_pid, reason, count, attempts)
-
-      {:error, lookup_reason} ->
-        Log.warning(
-          :config,
-          "Extension #{monitor.name} restart reconciliation failed: #{inspect(lookup_reason)}"
-        )
-
-        finalize_terminal_child_exit(monitor, reason)
-    end
-  end
-
-  @spec wait_for_missing_restarted_child(
-          restart_monitor(),
-          pid(),
-          term(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: :ok
-  defp wait_for_missing_restarted_child(monitor, excluded_pid, reason, count, attempts) do
-    if restart_terminal_exit?(monitor.restart, reason) do
-      finalize_terminal_child_exit(monitor, reason)
-    else
-      if attempts >= restart_reconcile_attempt_limit() do
-        Log.warning(
-          :config,
-          "Extension #{monitor.name} restart reconciliation timed out after #{attempts} attempt(s)"
-        )
-
-        finalize_terminal_child_exit(monitor, reason)
-      else
-        receive do
-        after
-          10 -> wait_for_restarted_child(monitor, excluded_pid, reason, count, attempts + 1)
-        end
-      end
-    end
-  end
-
-  @spec finalize_terminal_child_exit(restart_monitor(), term()) :: :ok
-  defp finalize_terminal_child_exit(monitor, reason) do
-    run_test_hook(monitor.opts, :before_terminal_child_exit)
-
-    mark_terminal_child_exit(
-      monitor.registry,
-      monitor.name,
-      monitor.lifecycle_ref,
-      monitor.cmd_registry,
-      monitor.keymap,
-      monitor.opts,
-      reason
-    )
-  end
-
-  @spec restart_terminal_exit?(child_restart(), term()) :: boolean()
-  defp restart_terminal_exit?(:temporary, _reason), do: true
-  defp restart_terminal_exit?(:transient, reason), do: not crash_reason?(reason)
-  defp restart_terminal_exit?(:permanent, _reason), do: false
-
-  @restart_reconcile_attempt_limit 50
-  @spec restart_reconcile_attempt_limit() :: non_neg_integer()
-  defp restart_reconcile_attempt_limit, do: @restart_reconcile_attempt_limit
-
-  @spec handle_restarted_child(restart_monitor(), pid(), non_neg_integer()) :: :ok
-  defp handle_restarted_child(monitor, pid, count) do
-    run_test_hook(monitor.opts, :before_restart_reconcile)
-
-    case reconcile_restarted_child(monitor, pid, count) do
-      :monitor -> monitor_child_restarts(monitor, pid, count, nil)
-      :stale -> :ok
-    end
-  end
-
-  @spec reconcile_restarted_child(restart_monitor(), pid(), non_neg_integer()) ::
-          :monitor | :stale
-  defp reconcile_restarted_child(monitor, pid, count) do
-    with_lifecycle_lock(monitor.registry, monitor.name, fn ->
-      if lifecycle_monitor_active?(monitor.registry, monitor.name, monitor.lifecycle_ref) do
-        ExtRegistry.update(monitor.registry, monitor.name, pid: pid)
-        emit_restart_count(monitor.name, count)
-        :monitor
-      else
-        :stale
-      end
-    end)
-  end
-
-  @spec mark_terminal_child_exit(
-          GenServer.server(),
-          atom(),
-          reference(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts(),
-          term()
-        ) :: :ok
-  defp mark_terminal_child_exit(registry, name, lifecycle_ref, cmd_registry, keymap, opts, reason) do
-    with_lifecycle_lock(registry, name, fn ->
-      if crash_reason?(reason) do
-        mark_crashed_without_replacement(
-          registry,
-          name,
-          lifecycle_ref,
-          cmd_registry,
-          keymap,
-          opts
-        )
-      else
-        mark_stopped_without_replacement(
-          registry,
-          name,
-          lifecycle_ref,
-          cmd_registry,
-          keymap,
-          opts
-        )
-      end
-    end)
-  end
-
-  @spec mark_crashed_without_replacement(
-          GenServer.server(),
-          atom(),
-          reference(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts()
-        ) :: :ok
-  defp mark_crashed_without_replacement(
-         registry,
-         name,
-         lifecycle_ref,
-         cmd_registry,
-         keymap,
-         opts
-       ) do
-    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
-      ExtRegistry.update(registry, name, status: :stopped)
-      quiesce_result = quiesce_terminal_source(name, :crash, opts)
-      cleanup_result = cleanup_extension_contributions(name, cmd_registry, keymap, opts)
-
-      finalize_crashed_source_result(
-        quiesce_result,
-        cleanup_result,
-        registry,
-        name,
-        lifecycle_ref
-      )
-    end
-
-    :ok
-  end
-
-  @spec finalize_crashed_source_result(
-          :ok | {:error, term()},
-          :ok | {:error, [map()]},
-          GenServer.server(),
-          atom(),
-          reference()
-        ) :: :ok
-  defp finalize_crashed_source_result(:ok, :ok, registry, name, lifecycle_ref) do
-    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
-      ExtRegistry.update(registry, name,
-        status: :crashed,
-        pid: nil,
-        lifecycle_ref: nil,
-        last_error: nil
-      )
-    end
-
-    :ok
-  end
-
-  defp finalize_crashed_source_result(
-         quiesce_result,
-         cleanup_result,
-         registry,
-         name,
-         lifecycle_ref
-       ) do
-    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
-      ExtRegistry.update(registry, name,
-        status: :load_error,
-        pid: nil,
-        lifecycle_ref: nil,
-        last_error: terminal_crash_cleanup_error(quiesce_result, cleanup_result)
-      )
-    end
-
-    :ok
-  end
-
-  @spec terminal_crash_cleanup_error(
-          :ok | {:error, term()},
-          :ok | {:error, [map()]}
-        ) :: {:terminal_crash_cleanup_failed, keyword()}
-  defp terminal_crash_cleanup_error(quiesce_result, cleanup_result) do
-    failures =
-      []
-      |> prepend_result_failure(:quiesce, quiesce_result)
-      |> prepend_result_failure(:cleanup, cleanup_result)
-      |> Enum.reverse()
-
-    {:terminal_crash_cleanup_failed, failures}
-  end
-
-  @spec prepend_result_failure(keyword(), atom(), :ok | {:error, term()}) :: keyword()
-  defp prepend_result_failure(failures, _phase, :ok), do: failures
-  defp prepend_result_failure(failures, phase, {:error, reason}), do: [{phase, reason} | failures]
-
-  @spec mark_stopped_without_replacement(
-          GenServer.server(),
-          atom(),
-          reference(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts()
-        ) :: :ok
-  defp mark_stopped_without_replacement(registry, name, lifecycle_ref, cmd_registry, keymap, opts) do
-    finalize_stopped_lifecycle_exit(registry, name, lifecycle_ref, cmd_registry, keymap, opts)
-    :ok
-  end
-
-  @spec finalize_stopped_lifecycle_exit(
-          GenServer.server(),
-          atom(),
-          reference(),
-          GenServer.server(),
-          GenServer.server(),
-          start_opts()
-        ) :: :ok
-  defp finalize_stopped_lifecycle_exit(registry, name, lifecycle_ref, cmd_registry, keymap, opts) do
-    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
-      case ExtRegistry.get(registry, name) do
-        {:ok, entry} ->
-          ExtRegistry.update(registry, name, status: :stopped)
-          quiesce_result = quiesce_terminal_source(name, :normal, opts)
-          cleanup_result = cleanup_extension_contributions(name, cmd_registry, keymap, opts)
-
-          finalize_terminal_source_result(
-            quiesce_result,
-            cleanup_result,
-            registry,
-            name,
-            lifecycle_ref,
-            entry,
-            opts
-          )
-
-        :error ->
-          :ok
-      end
-    end
-
-    :ok
-  end
-
-  @spec finalize_terminal_source_result(
-          :ok | {:error, term()},
-          :ok | {:error, [map()]},
-          GenServer.server(),
-          atom(),
-          reference(),
-          ExtRegistry.entry(),
-          start_opts()
-        ) :: :ok
-  defp finalize_terminal_source_result(
-         :ok,
-         :ok,
-         registry,
-         name,
-         lifecycle_ref,
-         entry,
-         opts
-       ) do
-    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
-      _result = finalize_stopped_extension(registry, name, entry, opts)
-    end
-
-    :ok
-  end
-
-  defp finalize_terminal_source_result(
-         quiesce_result,
-         cleanup_result,
-         registry,
-         name,
-         lifecycle_ref,
+  defp stop_existing_instance(
+         {:error, reason},
+         _supervisor,
+         _registry,
+         _name,
          _entry,
          _opts
-       ) do
-    if lifecycle_monitor_active?(registry, name, lifecycle_ref) do
-      ExtRegistry.update(registry, name,
-        status: :load_error,
-        pid: nil,
-        lifecycle_ref: nil,
-        last_error: terminal_exit_cleanup_error(quiesce_result, cleanup_result)
-      )
-    end
+       ),
+       do: {:error, reason}
 
-    :ok
-  end
-
-  @spec terminal_exit_cleanup_error(
-          :ok | {:error, term()},
-          :ok | {:error, [map()]}
-        ) :: {:terminal_exit_cleanup_failed, keyword()}
-  defp terminal_exit_cleanup_error(quiesce_result, cleanup_result) do
-    failures =
-      []
-      |> prepend_result_failure(:quiesce, quiesce_result)
-      |> prepend_result_failure(:cleanup, cleanup_result)
-      |> Enum.reverse()
-
-    {:terminal_exit_cleanup_failed, failures}
-  end
-
-  @spec extension_child_pid_by_pid(GenServer.server(), pid()) ::
-          {:ok, pid()} | :not_found | {:error, term()}
-  defp extension_child_pid_by_pid(supervisor, target_pid) do
-    supervisor
-    |> DynamicSupervisor.which_children()
-    |> Enum.find_value(:not_found, fn
-      {_id, ^target_pid, _type, _modules} -> {:ok, target_pid}
-      _child -> false
-    end)
-  catch
-    :exit, reason -> {:error, {:which_children_failed, reason}}
-  end
-
-  @spec extension_child_pid(GenServer.server(), module()) ::
-          {:ok, pid()} | :not_found | {:error, term()}
-  defp extension_child_pid(supervisor, module), do: extension_child_pid(supervisor, module, nil)
-
-  @spec extension_child_pid(GenServer.server(), module(), pid() | nil) ::
-          {:ok, pid()} | :not_found | {:error, term()}
-  defp extension_child_pid(supervisor, module, excluded_pid) do
-    supervisor
-    |> DynamicSupervisor.which_children()
-    |> Enum.find_value(:not_found, fn
-      {:undefined, pid, _type, [^module]} when is_pid(pid) and pid != excluded_pid -> {:ok, pid}
-      _child -> false
-    end)
-  catch
-    :exit, reason -> {:error, {:which_children_failed, reason}}
-  end
-
-  @spec resolve_git_extensions(GenServer.server()) :: [start_failure()]
-  defp resolve_git_extensions(registry) do
-    ExtRegistry.all(registry)
-    |> Enum.reduce([], fn {name, entry}, failures ->
-      resolve_git_extension(registry, name, entry, failures)
-    end)
-    |> Enum.reverse()
-  end
-
-  @spec resolve_git_extension(GenServer.server(), atom(), ExtRegistry.entry(), [start_failure()]) ::
-          [start_failure()]
-  defp resolve_git_extension(registry, name, %{source_type: :git} = entry, failures) do
-    case ExtGit.ensure_cloned(name, entry.git) do
-      {:ok, local_path} ->
-        ExtRegistry.update(registry, name, path: local_path)
-        failures
-
-      {:error, reason} ->
-        Log.warning(:config, "Extension #{name}: #{reason}")
-        mark_start_load_error(registry, name)
-        [%{extension: name, reason: reason} | failures]
-    end
-  end
-
-  defp resolve_git_extension(_registry, _name, _entry, failures), do: failures
-
-  @spec find_and_start_hex_extension_locked(
+  @spec stop_declared_instance(
           GenServer.server(),
           GenServer.server(),
           atom(),
           ExtRegistry.entry(),
           start_opts()
-        ) :: {:ok, pid()} | {:error, term()}
-  defp find_and_start_hex_extension_locked(supervisor, registry, name, entry, opts) do
-    cmd_registry = Keyword.get(opts, :command_registry, Minga.Command.Registry)
-    keymap = Keyword.get(opts, :keymap, Minga.Keymap.Active)
-    mark_start_attempt(registry, name)
+        ) :: :ok | {:error, term()}
+  defp stop_declared_instance(supervisor, registry, name, entry, opts) do
+    call_declared_instance(supervisor, registry, name, entry, opts, fn instance ->
+      Instance.stop(instance, opts)
+    end)
+  end
 
-    with {:ok, app_atom} <- hex_application_name(name, entry.hex),
-         :ok <-
-           run_lifecycle_phase(name, :load, opts, fn ->
-             ensure_hex_application_started(app_atom)
-           end),
-         {:ok, module} <- find_extension_module(app_atom),
-         :ok <- validate_behaviour(module, name),
-         runtime_opts = Keyword.put(opts, :runtime_application, app_atom),
-         :ok <- ensure_runtime_source_inventory(name, module, runtime_opts),
-         :ok <- record_extension_manifest(registry, name, module, entry.source_type),
-         :ok <- register_and_validate_options(name, module, entry.config),
-         {:ok, _state} <-
-           run_lifecycle_phase(name, :init, opts, fn -> call_init(module, entry.config) end) do
-      finalize_extension_start(
-        start_loaded_extension(
-          supervisor,
-          registry,
-          name,
-          module,
-          entry.config,
-          cmd_registry,
-          keymap,
-          runtime_opts
-        ),
-        registry,
-        name,
-        cmd_registry,
-        keymap,
-        runtime_opts
-      )
-    else
-      {:error, reason} ->
-        msg = "Extension #{name} load error: #{inspect(reason)}"
-        Log.warning(:config, msg)
-        ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
-        wrap_start_failure(name, reason, cmd_registry, keymap, opts)
+  @doc "Reports path/Git sources changed since current-generation admission."
+  @spec pending_artifact_restarts(GenServer.server(), start_opts()) :: [atom()]
+  def pending_artifact_restarts(registry, opts \\ []) do
+    for {name, entry} <- ExtRegistry.all(registry),
+        Source.pending_restart?(name, entry, opts),
+        do: name
+  end
+
+  @doc "Returns compatible `{name, version, status}` list projection."
+  @spec list_extensions() :: [{atom(), String.t(), Minga.Extension.extension_status()}]
+  @spec list_extensions(GenServer.server()) ::
+          [{atom(), String.t(), Minga.Extension.extension_status()}]
+  def list_extensions(registry \\ ExtRegistry) do
+    for {name, entry} <- ExtRegistry.all(registry) do
+      {name, version(entry.module), entry.status}
     end
   end
 
-  @spec find_extension_module(atom()) :: {:ok, module()} | {:error, String.t()}
-  defp find_extension_module(package_atom) do
-    # Try the application's modules for one implementing Minga.Extension
-    case :application.get_key(package_atom, :modules) do
-      {:ok, modules} ->
-        case Enum.find(modules, &implements_extension?/1) do
-          nil -> {:error, "no module implementing Minga.Extension found in #{package_atom}"}
-          mod -> {:ok, mod}
-        end
-
-      :undefined ->
-        {:error, "application #{package_atom} not found after Mix.install"}
-    end
-  end
-
-  @spec compile_extension(atom(), String.t(), start_opts()) ::
-          {:ok, module()} | {:error, String.t()}
-  defp compile_extension(name, path, opts) do
-    expanded = Path.expand(path)
-
-    if File.dir?(expanded) do
-      compile_extension_files(name, expanded, opts)
-    else
-      {:error, "extension path does not exist: #{expanded}"}
-    end
-  end
-
-  @spec compile_extension_files(atom(), String.t(), start_opts()) ::
-          {:ok, module()} | {:error, String.t()}
-  defp compile_extension_files(name, expanded, opts) do
-    source = {:extension, name}
-    files = expanded |> Path.join("**/*.ex") |> Path.wildcard() |> Enum.sort()
-
-    case ArtifactAdmission.source_modules(source, server: artifact_admission_server(opts)) do
-      {:ok, modules} ->
-        report_staged_source_change(name, expanded, files, source, opts)
-        find_extension_in_compiled(modules)
-
-      :error ->
-        compile_unadmitted_extension_files(name, expanded, files, source, opts)
-    end
-  end
-
-  @spec report_staged_source_change(atom(), String.t(), [String.t()], term(), start_opts()) ::
-          boolean()
-  defp report_staged_source_change(name, expanded, files, source, opts) do
-    admission = artifact_admission_server(opts)
-
-    with {:ok, admitted} <- ArtifactAdmission.source_fingerprint(source, server: admission),
-         {:ok, current} <- CompileCache.source_fingerprint(expanded, files, opts),
-         false <- admitted == current do
-      Minga.Events.broadcast(
-        :extension_restart_required,
-        %Minga.Events.ExtensionRestartRequiredEvent{
-          extension: name,
-          reason: :source_changed,
-          old_ref: Base.encode16(admitted, case: :lower),
-          new_ref: Base.encode16(current, case: :lower)
-        }
-      )
-
-      true
-    else
-      _unchanged_or_unavailable -> false
-    end
-  end
-
-  @spec compile_unadmitted_extension_files(atom(), String.t(), [String.t()], term(), start_opts()) ::
-          {:ok, module()} | {:error, String.t()}
-  defp compile_unadmitted_extension_files(name, expanded, files, source, opts) do
-    case files do
-      [] ->
-        compile_extension_files_fallback(name, expanded)
-
-      _files ->
-        compile_opts = [
-          source: source,
-          artifact_admission: artifact_admission_server(opts),
-          trusted_application: BundledApplications.trusted_application(name)
-        ]
-
-        case CompileCache.load_or_compile(expanded, files, compile_opts) do
-          {:ok, %{modules: modules, diagnostics: diagnostics}} ->
-            log_diagnostics(diagnostics)
-            find_extension_in_compiled(modules)
-
-          {:error, reason} ->
-            {:error, reason}
-        end
-    end
-  end
-
-  @spec compile_extension_files_fallback(atom(), String.t()) ::
-          {:ok, module()} | {:error, String.t()}
-  defp compile_extension_files_fallback(name, expanded) do
-    Minga.Extension.JsonLoader.load(expanded, name)
-  end
-
-  @spec find_extension_in_compiled([module()]) :: {:ok, module()} | {:error, String.t()}
-  defp find_extension_in_compiled(modules) do
-    case Enum.find(modules, &implements_extension?/1) do
-      nil -> {:error, "no module implementing Minga.Extension behaviour found"}
-      mod -> {:ok, mod}
-    end
-  end
-
-  @spec log_diagnostics([map()]) :: :ok
-  defp log_diagnostics([]), do: :ok
-
-  defp log_diagnostics(diagnostics) do
-    for diag <- diagnostics do
-      file = Map.get(diag, :file, "unknown")
-      position = Map.get(diag, :position, nil)
-      message = Map.get(diag, :message, "")
-      severity = Map.get(diag, :severity, :warning)
-      short_file = Path.basename(file)
-      pos_str = format_position(position)
-
-      case severity do
-        :error ->
-          Log.warning(:editor, "[ext:error] #{short_file}:#{pos_str}: #{message}")
-
-        :warning ->
-          Log.warning(:editor, "[ext] #{short_file}:#{pos_str}: #{message}")
-
-        _ ->
-          Log.debug(:editor, "[ext] #{short_file}:#{pos_str}: #{message}")
-      end
-    end
-
-    :ok
-  end
-
-  @spec format_position(term()) :: String.t()
-  defp format_position({line, col}) when is_integer(line) and is_integer(col),
-    do: "#{line}:#{col}"
-
-  defp format_position(line) when is_integer(line), do: "#{line}"
-  defp format_position(_), do: "?"
-
+  @doc "Returns whether a module exports the required extension callbacks."
   @spec implements_extension?(module()) :: boolean()
   def implements_extension?(module) do
-    Code.ensure_loaded?(module) &&
-      function_exported?(module, :name, 0) &&
-      function_exported?(module, :description, 0) &&
-      function_exported?(module, :version, 0) &&
+    Code.ensure_loaded?(module) and
+      function_exported?(module, :name, 0) and
+      function_exported?(module, :description, 0) and
+      function_exported?(module, :version, 0) and
       function_exported?(module, :init, 1)
   end
 
+  @doc "Validates that an extension module exports every required callback."
   @spec validate_behaviour(module(), atom()) :: :ok | {:error, String.t()}
   def validate_behaviour(module, name) do
     missing =
-      [:name, :description, :version, :init]
-      |> Enum.reject(fn
+      Enum.reject([:name, :description, :version, :init], fn
         :init -> function_exported?(module, :init, 1)
-        fun -> function_exported?(module, fun, 0)
+        function -> function_exported?(module, function, 0)
       end)
 
     case missing do
       [] -> :ok
-      funs -> {:error, "extension #{name} missing callbacks: #{inspect(funs)}"}
+      functions -> {:error, "extension #{name} missing callbacks: #{inspect(functions)}"}
     end
   end
 
-  @spec quiesce_extension_source(atom(), start_opts()) ::
-          :ok | {:error, {:source_quiesce_failed, term()}}
-  defp quiesce_extension_source(name, opts) do
-    source = {:extension, name}
-    admission = code_lease_server(opts)
+  @doc "Registers and validates an extension module's declared options."
+  @spec register_and_validate_options(atom(), module(), keyword()) :: :ok | {:error, term()}
+  defdelegate register_and_validate_options(name, module, config),
+    to: Contributions,
+    as: :register_options
 
-    case CodeLease.quiesce_source(source, server: admission) do
-      {:ok, token} ->
-        finalize_quiescing_source(name, source, token, admission, opts)
-
-      {:error, {:source_not_active, ^source}} ->
-        finalize_source_effects(name, source, opts)
-
-      {:error, {:source_inactive, ^source}} ->
-        finalize_source_effects(name, source, opts)
-
-      {:error, reason} ->
-        source_quiesce_failed(name, reason)
-    end
-  end
-
-  @typep terminal_exit_kind :: :crash | :normal
-
-  @spec quiesce_terminal_source(atom(), terminal_exit_kind(), start_opts()) ::
-          :ok | {:error, {:source_quiesce_failed, term()}}
-  defp quiesce_terminal_source(name, exit_kind, opts) do
-    source = {:extension, name}
-    admission = code_lease_server(opts)
-
-    case CodeLease.quiesce_source(source, server: admission) do
-      {:ok, token} ->
-        finalize_terminal_source(name, source, token, admission, exit_kind, opts)
-
-      {:error, {:source_not_active, ^source}} ->
-        finalize_source_effects(name, source, opts)
-
-      {:error, {:source_inactive, ^source}} ->
-        finalize_source_effects(name, source, opts)
-
-      {:error, reason} ->
-        source_quiesce_failed(name, reason)
-    end
-  end
-
-  @spec finalize_terminal_source(
-          atom(),
-          CallbackInvoker.source(),
-          CodeLease.unload_token(),
-          GenServer.server(),
-          terminal_exit_kind(),
-          start_opts()
-        ) :: :ok | {:error, {:source_quiesce_failed, term()}}
-  defp finalize_terminal_source(name, source, token, admission, exit_kind, opts) do
-    context = %{
-      token: token,
-      callback_registry: callback_registry_server(opts),
-      callback_admission: admission
-    }
-
-    cleanup_opts =
-      opts
-      |> Keyword.take([:callbacks])
-      |> Keyword.put(:context, context)
-
-    finalizer_result =
-      run_lifecycle_phase(name, :quiesce, opts, fn ->
-        editor_effects_result =
-          Minga.Extension.ContributionCleanup.finalize_source(
-            source,
-            :editor_effects,
-            cleanup_opts
-          )
-
-        :ok = await_source_callbacks(source, admission)
-
-        extension_unload_result =
-          Minga.Extension.ContributionCleanup.finalize_source(
-            source,
-            :editor_extension_unload,
-            cleanup_opts
-          )
-
-        combine_terminal_finalizer_results(editor_effects_result, extension_unload_result)
-      end)
-
-    unload_result = CodeLease.complete_unload(token, server: admission)
-    finalize_terminal_admission(name, exit_kind, finalizer_result, unload_result)
-  end
-
-  @spec combine_terminal_finalizer_results(
-          :ok | {:error, term()},
-          :ok | {:error, term()}
-        ) :: :ok | {:error, {:terminal_finalizers_failed, [term()]}}
-  defp combine_terminal_finalizer_results(:ok, :ok), do: :ok
-
-  defp combine_terminal_finalizer_results(editor_effects_result, extension_unload_result) do
-    failures =
-      []
-      |> prepend_result_failure(:editor_effects, editor_effects_result)
-      |> prepend_result_failure(:editor_extension_unload, extension_unload_result)
-      |> Enum.reverse()
-
-    {:error, {:terminal_finalizers_failed, failures}}
-  end
-
-  @spec finalize_terminal_admission(
-          atom(),
-          terminal_exit_kind(),
-          :ok | {:error, term()},
-          :ok | {:error, term()}
-        ) :: :ok | {:error, {:source_quiesce_failed, term()}}
-  defp finalize_terminal_admission(_name, _exit_kind, :ok, :ok), do: :ok
-
-  defp finalize_terminal_admission(name, exit_kind, finalizer_result, unload_result) do
-    failures =
-      []
-      |> prepend_result_failure(:finalizers, finalizer_result)
-      |> prepend_result_failure(:complete_unload, unload_result)
-      |> Enum.reverse()
-
-    source_quiesce_failed(name, terminal_quiesce_error(exit_kind, failures))
-  end
-
-  @spec terminal_quiesce_error(terminal_exit_kind(), keyword()) ::
-          {:terminal_crash_quiesce_failed | :terminal_exit_quiesce_failed, keyword()}
-  defp terminal_quiesce_error(:crash, failures),
-    do: {:terminal_crash_quiesce_failed, failures}
-
-  defp terminal_quiesce_error(:normal, failures),
-    do: {:terminal_exit_quiesce_failed, failures}
-
-  @spec finalize_source_effects(atom(), CallbackInvoker.source(), start_opts()) ::
-          :ok | {:error, term()}
-  defp finalize_source_effects(name, source, opts) do
-    cleanup_opts = Keyword.take(opts, [:callbacks])
-
-    run_lifecycle_phase(name, :quiesce, opts, fn ->
-      Minga.Extension.ContributionCleanup.finalize_source(
-        source,
-        :editor_effects,
-        cleanup_opts
-      )
-    end)
-  end
-
-  @spec finalize_quiescing_source(
-          atom(),
-          CallbackInvoker.source(),
-          CodeLease.unload_token(),
-          GenServer.server(),
-          start_opts()
-        ) :: :ok | {:error, {:source_quiesce_failed, term()}}
-  defp finalize_quiescing_source(name, source, token, admission, opts) do
-    context = %{
-      token: token,
-      callback_registry: callback_registry_server(opts),
-      callback_admission: admission
-    }
-
-    cleanup_opts =
-      opts
-      |> Keyword.take([:callbacks])
-      |> Keyword.put(:context, context)
-
-    result =
-      run_lifecycle_phase(name, :quiesce, opts, fn ->
-        with :ok <-
-               Minga.Extension.ContributionCleanup.finalize_source(
-                 source,
-                 :editor_effects,
-                 cleanup_opts
-               ),
-             :ok <- await_source_callbacks(source, admission) do
-          Minga.Extension.ContributionCleanup.finalize_source(
-            source,
-            :editor_extension_unload,
-            cleanup_opts
-          )
-        end
-      end)
-
-    finalize_quiescing_admission(name, token, admission, result)
-  end
-
-  @spec await_source_callbacks(CallbackInvoker.source(), GenServer.server()) :: :ok
-  defp await_source_callbacks(source, admission) do
-    case CodeLease.active_leases(server: admission, source: source) do
-      [] ->
-        :ok
-
-      [_lease | _rest] ->
-        receive do
-        after
-          5 -> await_source_callbacks(source, admission)
-        end
-    end
-  end
-
-  @spec finalize_quiescing_admission(
-          atom(),
-          CodeLease.unload_token(),
-          GenServer.server(),
-          :ok | {:error, term()}
-        ) :: :ok | {:error, {:source_quiesce_failed, term()}}
-  defp finalize_quiescing_admission(name, token, admission, :ok) do
-    case CodeLease.complete_unload(token, server: admission) do
-      :ok -> :ok
-      {:error, reason} -> source_quiesce_failed(name, reason)
-    end
-  end
-
-  defp finalize_quiescing_admission(name, token, admission, {:error, failure}) do
-    _result = CodeLease.abort_unload(token, server: admission)
-    source_quiesce_failed(name, failure)
-  end
-
-  @spec source_quiesce_failed(atom(), term()) ::
-          {:error, {:source_quiesce_failed, term()}}
-  defp source_quiesce_failed(name, failure) do
-    Log.warning(:config, "Extension #{name} source quiescence failed: #{inspect(failure)}")
-    {:error, {:source_quiesce_failed, failure}}
-  end
-
+  @doc "Removes command, keymap, and callback contributions owned by an extension."
   @spec cleanup_extension_contributions(
           atom(),
           GenServer.server(),
@@ -2371,353 +336,448 @@ defmodule Minga.Extension.Supervisor do
           start_opts()
         ) ::
           :ok | {:error, [map()]}
-  def cleanup_extension_contributions(name, cmd_registry, keymap, opts) do
-    source = {:extension, name}
-
-    cleanup_opts =
-      [command_registry: cmd_registry, keymap: keymap]
-      |> Keyword.merge(Keyword.take(opts, [:callbacks]))
-
-    case run_lifecycle_phase(name, :cleanup, opts, fn ->
-           Minga.Extension.ContributionCleanup.unregister_source(source, cleanup_opts)
-         end) do
-      :ok ->
-        :ok
-
-      {:error, failures} = error ->
-        Log.warning(
-          :config,
-          "Extension #{name} contribution cleanup failed: #{format_cleanup_failures(failures)}"
-        )
-
-        error
-    end
+  def cleanup_extension_contributions(name, command_registry, keymap, opts) do
+    Contributions.cleanup(
+      name,
+      opts
+      |> Keyword.put(:command_registry, command_registry)
+      |> Keyword.put(:keymap, keymap)
+    )
   end
 
-  @spec wrap_start_failure(atom(), term(), GenServer.server(), GenServer.server(), start_opts()) ::
-          {:error, term()}
-  defp wrap_start_failure(name, reason, cmd_registry, keymap, opts) do
-    case cleanup_extension_contributions(name, cmd_registry, keymap, opts) do
-      :ok -> {:error, reason}
-      {:error, failures} -> {:error, {:cleanup_failed, reason, failures}}
-    end
+  @spec start_by_policy(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts(),
+          [start_failure()],
+          [{GenServer.server(), atom(), ExtRegistry.entry()}]
+        ) :: {[start_failure()], [{GenServer.server(), atom(), ExtRegistry.entry()}]}
+  defp start_by_policy(supervisor, registry, name, entry, opts, failures, deferred) do
+    result =
+      call_declared_instance(supervisor, registry, name, entry, opts, fn instance ->
+        with {:ok, policy} <- Instance.load_policy(instance) do
+          apply_policy(policy, instance, name, entry)
+        end
+      end)
+
+    collect_policy_result(result, name, entry, failures, deferred)
   end
 
-  @spec finalize_explicit_stop_result(
-          :ok | {:error, term()},
-          :ok | {:error, [map()]},
+  @spec apply_policy(
+          Minga.Extension.load_policy(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry()
+        ) :: {:ok, pid()} | :ok | {:deferred, GenServer.server()} | {:error, term()}
+  defp apply_policy(:eager, instance, name, _entry), do: start_instance(name, instance)
+  defp apply_policy(:deferred, instance, _name, _entry), do: {:deferred, instance}
+
+  defp apply_policy({tag, _trigger}, instance, _name, _entry)
+       when tag in [:on_command, :on_filetype, :on_key],
+       do: Instance.stub(instance)
+
+  defp apply_policy(invalid, instance, name, entry) do
+    Log.warning(:config, "Invalid load_policy #{inspect(invalid)}, falling back to :eager")
+    apply_policy(:eager, instance, name, entry)
+  end
+
+  @spec collect_policy_result(
+          {:ok, pid()} | :ok | {:deferred, GenServer.server()} | {:error, term()},
+          atom(),
+          ExtRegistry.entry(),
+          [start_failure()],
+          [{GenServer.server(), atom(), ExtRegistry.entry()}]
+        ) :: {[start_failure()], [{GenServer.server(), atom(), ExtRegistry.entry()}]}
+  defp collect_policy_result({:ok, _pid}, _name, _entry, failures, deferred),
+    do: {failures, deferred}
+
+  defp collect_policy_result(:ok, _name, _entry, failures, deferred), do: {failures, deferred}
+
+  defp collect_policy_result({:deferred, instance}, name, entry, failures, deferred),
+    do: {failures, [{instance, name, entry} | deferred]}
+
+  defp collect_policy_result({:error, reason}, name, _entry, failures, deferred),
+    do: {[%{extension: name, reason: reason} | failures], deferred}
+
+  @spec locate_instance(
+          GenServer.server(),
           GenServer.server(),
           atom(),
           ExtRegistry.entry(),
           start_opts()
+        ) :: {:ok, GenServer.server()} | {:error, term()}
+  defp locate_instance(supervisor, registry, name, entry, opts) do
+    root = root_supervisor(supervisor)
+    instance_registry = instance_registry(supervisor, opts)
+
+    RootSupervisor.ensure_root(
+      root,
+      name,
+      entry,
+      registry,
+      Keyword.put(opts, :instance_registry, instance_registry)
+    )
+  end
+
+  @spec existing_instance(GenServer.server(), atom(), start_opts()) ::
+          {:ok, GenServer.server()} | :absent | {:error, term()}
+  defp existing_instance(supervisor, name, opts) do
+    root = root_supervisor(supervisor)
+    registry = instance_registry(supervisor, opts)
+    RootSupervisor.existing_authority(root, name, instance_registry: registry)
+  end
+
+  @spec reconcile_declarations(GenServer.server(), GenServer.server(), start_opts()) ::
+          [start_failure()]
+  defp reconcile_declarations(supervisor, registry, opts) do
+    root = root_supervisor(supervisor)
+    names = registry |> ExtRegistry.all() |> Enum.map(&elem(&1, 0)) |> MapSet.new()
+    registry_name = instance_registry(supervisor, opts)
+    root_opts = Keyword.put(opts, :instance_registry, registry_name)
+
+    root
+    |> RootSupervisor.names(root_opts)
+    |> Enum.reduce([], fn name, failures ->
+      reconcile_declaration(root, root_opts, name, MapSet.member?(names, name), failures)
+    end)
+    |> Enum.reverse()
+  end
+
+  @spec reconcile_declaration(
+          GenServer.server(),
+          keyword(),
+          atom(),
+          boolean(),
+          [start_failure()]
+        ) :: [start_failure()]
+  defp reconcile_declaration(_root, _root_opts, _name, true, failures), do: failures
+
+  defp reconcile_declaration(root, root_opts, name, false, failures) do
+    case RootSupervisor.terminate_root(root, name, root_opts) do
+      :ok ->
+        failures
+
+      {:error, reason} ->
+        [%{extension: name, reason: {:terminate_root_failed, reason}} | failures]
+    end
+  end
+
+  @spec root_supervisor(GenServer.server()) :: GenServer.server()
+  defp root_supervisor(__MODULE__), do: RootSupervisor
+  defp root_supervisor(supervisor), do: supervisor
+
+  @spec instance_registry(GenServer.server(), start_opts()) :: atom()
+  defp instance_registry(supervisor, opts) do
+    Keyword.get(
+      opts,
+      :instance_registry,
+      InstanceRegistry.registry_for_root(root_supervisor(supervisor))
+    )
+  end
+
+  @spec ensure_declared_authorities(GenServer.server(), GenServer.server(), start_opts()) ::
+          [start_failure()]
+  defp ensure_declared_authorities(supervisor, registry, opts) do
+    registry
+    |> ExtRegistry.all()
+    |> Enum.reduce([], fn {name, entry}, failures ->
+      ensure_declared_authority(supervisor, registry, name, entry, opts, failures)
+    end)
+    |> Enum.reverse()
+  end
+
+  @spec ensure_declared_authority(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts(),
+          [start_failure()]
+        ) :: [start_failure()]
+  defp ensure_declared_authority(supervisor, registry, name, entry, opts, failures) do
+    supervisor
+    |> call_declared_instance(registry, name, entry, opts, fn _instance -> :ok end)
+    |> collect_authority_failure(name, failures)
+  end
+
+  @spec collect_authority_failure(:ok | {:error, term()}, atom(), [start_failure()]) ::
+          [start_failure()]
+  defp collect_authority_failure(:ok, _name, failures), do: failures
+
+  defp collect_authority_failure({:error, reason}, name, failures),
+    do: [%{extension: name, reason: reason} | failures]
+
+  @spec route_prerequisite_failures(
+          GenServer.server(),
+          GenServer.server(),
+          [start_failure()],
+          start_failure() | nil,
+          start_opts()
+        ) :: [start_failure()]
+  defp route_prerequisite_failures(supervisor, registry, failures, hex_failure, opts) do
+    failed_by_name = Map.new(failures, &{&1.extension, &1.reason})
+
+    registry
+    |> ExtRegistry.all()
+    |> Enum.reduce([], fn {name, entry}, routing_failures ->
+      reason = prerequisite_reason(name, entry, failed_by_name, hex_failure)
+      collect_routing_failure(supervisor, name, reason, opts, routing_failures)
+    end)
+    |> Enum.reverse()
+  end
+
+  @spec collect_routing_failure(
+          GenServer.server(),
+          atom(),
+          term() | nil,
+          start_opts(),
+          [start_failure()]
+        ) :: [start_failure()]
+  defp collect_routing_failure(_supervisor, _name, nil, _opts, failures), do: failures
+
+  defp collect_routing_failure(supervisor, name, reason, opts, failures) do
+    case route_prerequisite_failure(supervisor, name, reason, opts) do
+      :ok -> failures
+      {:error, route_reason} -> [%{extension: name, reason: route_reason} | failures]
+    end
+  end
+
+  @spec route_prerequisite_failure(GenServer.server(), atom(), term(), start_opts()) ::
+          :ok | {:error, term()}
+  defp route_prerequisite_failure(supervisor, name, reason, opts) do
+    supervisor
+    |> call_existing_instance(name, opts, fn instance ->
+      {:instance_result, Instance.fail_start(instance, reason)}
+    end)
+    |> route_existing_prerequisite_failure(name, reason)
+  end
+
+  @spec route_existing_prerequisite_failure(
+          {:instance_result, term()} | :absent | {:error, term()},
+          atom(),
+          term()
         ) :: :ok | {:error, term()}
-  defp finalize_explicit_stop_result(:ok, :ok, registry, name, entry, opts) do
-    finalize_stopped_extension(registry, name, entry, opts)
+  defp route_existing_prerequisite_failure({:instance_result, result}, _name, reason),
+    do: prerequisite_rollback_result(result, reason)
+
+  defp route_existing_prerequisite_failure(:absent, name, _reason),
+    do: {:error, {:authority_unavailable, name, :absent}}
+
+  defp route_existing_prerequisite_failure({:error, authority_reason}, name, _reason),
+    do: {:error, {:authority_unavailable, name, authority_reason}}
+
+  @spec prerequisite_rollback_result(term(), term()) :: :ok | {:error, term()}
+  defp prerequisite_rollback_result({:error, reason}, reason), do: :ok
+
+  defp prerequisite_rollback_result({:error, rollback_reason}, reason),
+    do: {:error, {:prerequisite_rollback_failed, reason, rollback_reason}}
+
+  defp prerequisite_rollback_result(other, reason),
+    do: {:error, {:prerequisite_rollback_unexpected, reason, other}}
+
+  @spec prerequisite_reason(atom(), ExtRegistry.entry(), map(), start_failure() | nil) ::
+          term() | nil
+  defp prerequisite_reason(_name, %{source_type: :hex}, _failed, %{reason: reason}), do: reason
+  defp prerequisite_reason(name, _entry, failed, _hex_failure), do: Map.get(failed, name)
+
+  @spec install_hex(GenServer.server()) :: start_failure() | nil
+  defp install_hex(registry) do
+    case ExtHex.install_all(registry) do
+      :ok ->
+        nil
+
+      {:error, reason} ->
+        Log.warning(:config, inspect(reason))
+        %{extension: :hex_install, reason: reason}
+    end
   end
 
-  defp finalize_explicit_stop_result(:ok, {:error, failures}, registry, name, _entry, _opts) do
-    ExtRegistry.update(registry, name, status: :load_error, pid: nil, lifecycle_ref: nil)
-    {:error, {:cleanup_failed, failures}}
+  @spec resolve_git_extensions(GenServer.server()) :: [start_failure()]
+  defp resolve_git_extensions(registry) do
+    registry
+    |> ExtRegistry.all()
+    |> Enum.reduce([], &resolve_git_extension(registry, &1, &2))
+    |> Enum.reverse()
   end
 
-  defp finalize_explicit_stop_result({:error, reason}, :ok, registry, name, entry, opts) do
-    :ok = finalize_stopped_extension(registry, name, entry, opts)
-    {:error, reason}
+  @spec resolve_git_extension(
+          GenServer.server(),
+          {atom(), ExtRegistry.entry()},
+          [start_failure()]
+        ) :: [start_failure()]
+  defp resolve_git_extension(registry, {name, %{source_type: :git} = entry}, failures) do
+    name
+    |> ExtGit.ensure_cloned(entry.git)
+    |> update_resolved_git(registry, name, failures)
   end
 
-  defp finalize_explicit_stop_result(
-         {:error, reason},
-         {:error, failures},
-         registry,
-         name,
-         _entry,
-         _opts
-       ) do
-    ExtRegistry.update(registry, name, status: :load_error, lifecycle_ref: nil)
-    {:error, {:cleanup_failed, reason, failures}}
+  defp resolve_git_extension(_registry, {_name, _entry}, failures), do: failures
+
+  @spec update_resolved_git(
+          {:ok, String.t()} | {:error, term()},
+          GenServer.server(),
+          atom(),
+          [start_failure()]
+        ) :: [start_failure()]
+  defp update_resolved_git({:ok, path}, registry, name, failures) do
+    case ExtRegistry.update(registry, name, path: path) do
+      :ok -> failures
+      {:error, reason} -> [%{extension: name, reason: reason} | failures]
+    end
   end
 
-  @spec finalize_stopped_extension(GenServer.server(), atom(), ExtRegistry.entry(), start_opts()) ::
-          :ok
-  defp finalize_stopped_extension(registry, name, _entry, _opts) do
-    ExtRegistry.update(registry, name, status: :stopped, pid: nil, lifecycle_ref: nil)
+  defp update_resolved_git({:error, reason}, _registry, name, failures) do
+    Log.warning(:config, "Extension #{name}: #{reason}")
+    [%{extension: name, reason: reason} | failures]
+  end
+
+  @spec failed_prerequisite?(atom(), ExtRegistry.entry(), MapSet.t(atom()), start_failure() | nil) ::
+          boolean()
+  defp failed_prerequisite?(_name, %{source_type: :hex}, _failed, nil), do: false
+  defp failed_prerequisite?(_name, %{source_type: :hex}, _failed, _hex_failure), do: true
+  defp failed_prerequisite?(name, _entry, failed, _hex_failure), do: MapSet.member?(failed, name)
+
+  @spec call_declared_instance(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts(),
+          (GenServer.server() -> result)
+        ) :: result | {:error, term()}
+        when result: var
+  defp call_declared_instance(supervisor, registry, name, entry, opts, fun) do
+    call_declared_instance(
+      supervisor,
+      registry,
+      name,
+      entry,
+      opts,
+      fun,
+      @authority_retry_attempts
+    )
+  end
+
+  @spec call_declared_instance(
+          GenServer.server(),
+          GenServer.server(),
+          atom(),
+          ExtRegistry.entry(),
+          start_opts(),
+          (GenServer.server() -> result),
+          non_neg_integer()
+        ) :: result | {:error, term()}
+        when result: var
+  defp call_declared_instance(supervisor, registry, name, entry, opts, fun, retries) do
+    result =
+      with {:ok, instance} <- locate_instance(supervisor, registry, name, entry, opts),
+           :ok <- run_test_hook(opts, :after_authority_located, [name, instance]),
+           :ok <-
+             safe_instance_call(name, fn ->
+               Instance.declare(instance, entry, registry, opts)
+             end) do
+        safe_instance_call(name, fn -> fun.(instance) end)
+      end
+
+    maybe_retry_authority(result, name, opts, retries, fn ->
+      call_declared_instance(supervisor, registry, name, entry, opts, fun, retries - 1)
+    end)
+  end
+
+  @spec call_existing_instance(
+          GenServer.server(),
+          atom(),
+          start_opts(),
+          (GenServer.server() -> result)
+        ) :: result | :absent | {:error, term()}
+        when result: var
+  defp call_existing_instance(supervisor, name, opts, fun) do
+    call_existing_instance(supervisor, name, opts, fun, @authority_retry_attempts)
+  end
+
+  @spec call_existing_instance(
+          GenServer.server(),
+          atom(),
+          start_opts(),
+          (GenServer.server() -> result),
+          non_neg_integer()
+        ) :: result | :absent | {:error, term()}
+        when result: var
+  defp call_existing_instance(supervisor, name, opts, fun, retries) do
+    result =
+      with {:ok, instance} <- existing_instance(supervisor, name, opts),
+           :ok <- run_test_hook(opts, :after_authority_located, [name, instance]) do
+        safe_instance_call(name, fn -> fun.(instance) end)
+      end
+
+    maybe_retry_authority(result, name, opts, retries, fn ->
+      call_existing_instance(supervisor, name, opts, fun, retries - 1)
+    end)
+  end
+
+  @spec maybe_retry_authority(result, atom(), start_opts(), non_neg_integer(), (-> result)) ::
+          result
+        when result: var
+  defp maybe_retry_authority(result, name, opts, retries, retry) do
+    if retries > 0 and retryable_authority_error?(result, name) do
+      :ok = run_test_hook(opts, :before_authority_retry, [name])
+      retry.()
+    else
+      result
+    end
+  end
+
+  @spec retryable_authority_error?(term(), atom()) :: boolean()
+  defp retryable_authority_error?(
+         {:error, {:authority_unavailable, name, reason}},
+         name
+       ),
+       do: restart_gap?(reason)
+
+  defp retryable_authority_error?(_result, _name), do: false
+
+  @spec restart_gap?(term()) :: boolean()
+  defp restart_gap?(:noproc), do: true
+  defp restart_gap?(:registration_timeout), do: true
+  defp restart_gap?({:noproc, _call}), do: true
+  defp restart_gap?({:authority_unavailable, _name, reason}), do: restart_gap?(reason)
+  defp restart_gap?(_reason), do: false
+
+  @spec run_test_hook(start_opts(), atom(), [term()]) :: :ok
+  defp run_test_hook(opts, hook, args) do
+    hooks = Keyword.get(opts, :test_hooks, %{})
+
+    case Map.get(hooks, hook) do
+      nil -> :ok
+      fun when is_function(fun) -> _result = apply(fun, args)
+    end
+
     :ok
   end
 
-  @spec mark_hex_entries_load_error(GenServer.server()) :: :ok
-  defp mark_hex_entries_load_error(registry) do
-    for {name, entry} <- ExtRegistry.all(registry), entry.source_type == :hex do
-      mark_start_load_error(registry, name)
-    end
-
-    :ok
+  @spec safe_instance_call(atom(), (-> result)) :: result | {:error, term()} when result: var
+  defp safe_instance_call(name, fun) do
+    fun.()
+  catch
+    :exit, reason -> {:error, {:authority_unavailable, name, reason}}
   end
 
-  @spec hex_application_name(atom(), Minga.Extension.Entry.hex_opts()) ::
-          {:ok, atom()} | {:error, term()}
-  defp hex_application_name(_name, %{app: app}) when is_atom(app) and app != nil, do: {:ok, app}
-  defp hex_application_name(name, %{app: nil}), do: {:ok, name}
+  @spec version(module() | nil) :: String.t()
+  defp version(nil), do: "unknown"
 
-  @spec ensure_hex_application_started(atom()) :: :ok | {:error, term()}
-  defp ensure_hex_application_started(package_atom) do
-    case Application.ensure_all_started(package_atom) do
-      {:ok, _} ->
-        :ok
-
-      {:error, reason} ->
-        {:error, {:hex_application_start_failed, package_atom, reason}}
-    end
-  end
-
-  @spec prepend_failure([start_failure()], start_failure() | nil) :: [start_failure()]
-  defp prepend_failure(failures, nil), do: failures
-  defp prepend_failure(failures, failure), do: [failure | failures]
-
-  @spec format_cleanup_failures([map()]) :: String.t()
-  defp format_cleanup_failures(failures) do
-    Enum.map_join(failures, "; ", &format_cleanup_failure/1)
-  end
-
-  @spec format_cleanup_failure(map()) :: String.t()
-  defp format_cleanup_failure(%{family: family, source: source, reason: reason}) do
-    "#{inspect(family)} source=#{inspect(source)} reason=#{inspect(reason)}"
-  end
-
-  @spec register_extension_commands(module(), atom(), GenServer.server(), start_opts()) ::
-          :ok | {:error, term()}
-  defp register_extension_commands(module, ext_name, cmd_registry, opts) do
-    schema = command_schema(module)
-
-    case register_extension_command_schema(schema, ext_name, cmd_registry, opts) do
-      :ok ->
-        log_registered_commands(ext_name, schema)
-        :ok
-
-      {:error, _reason} = error ->
-        error
-    end
-  rescue
-    e ->
-      Log.warning(
-        :config,
-        "Extension #{ext_name} command registration failed: #{Exception.message(e)}"
-      )
-
-      {:error, {:command_registration_failed, Exception.message(e)}}
-  end
-
-  @spec register_extension_command_schema(
-          [Minga.Extension.command_spec()],
-          atom(),
-          GenServer.server(),
-          start_opts()
-        ) :: :ok | {:error, term()}
-  defp register_extension_command_schema(schema, ext_name, cmd_registry, opts) do
-    Enum.reduce_while(schema, :ok, fn spec, :ok ->
-      case register_extension_command_spec(spec, ext_name, cmd_registry, opts) do
-        :ok -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
-  end
-
-  @spec command_schema(module()) :: [Minga.Extension.command_spec()]
-  defp command_schema(module) do
-    if function_exported?(module, :__command_schema__, 0) do
-      module.__command_schema__()
+  defp version(module) when is_atom(module) do
+    if Code.ensure_loaded?(module) do
+      module.version()
     else
-      []
-    end
-  end
-
-  @spec register_extension_command_spec(
-          Minga.Extension.command_spec(),
-          atom(),
-          GenServer.server(),
-          start_opts()
-        ) :: :ok | {:error, term()}
-  defp register_extension_command_spec(spec, ext_name, cmd_registry, opts) do
-    case Minga.Command.Registry.register_command(
-           cmd_registry,
-           {:extension, ext_name},
-           build_command_from_spec(spec, ext_name, opts)
-         ) do
-      :ok ->
-        :ok
-
-      {:error, reason} = error ->
-        Log.warning(:config, "Extension #{ext_name} command rejected: #{inspect(reason)}")
-        error
-    end
-  end
-
-  @spec log_registered_commands(atom(), [Minga.Extension.command_spec()]) :: :ok
-  defp log_registered_commands(_ext_name, []), do: :ok
-
-  defp log_registered_commands(ext_name, schema) do
-    Log.debug(:config, "Extension #{ext_name}: registered #{length(schema)} commands")
-  end
-
-  @spec build_command_from_spec(Minga.Extension.command_spec(), atom(), start_opts()) ::
-          Minga.Command.t()
-  defp build_command_from_spec({name, description, command_opts}, ext_name, opts) do
-    {mod, fun} = Keyword.fetch!(command_opts, :execute)
-    requires_buffer = Keyword.get(command_opts, :requires_buffer, false)
-    admission = code_lease_server(opts)
-
-    %Minga.Command{
-      name: name,
-      description: description,
-      execute: fn state ->
-        extension_callback_result(ext_name, mod, fun, [state], :command, admission)
-      end,
-      requires_buffer: requires_buffer
-    }
-  end
-
-  @spec register_extension_modeline_segments(module(), atom(), start_opts()) ::
-          :ok | {:error, term()}
-  defp register_extension_modeline_segments(module, ext_name, opts) do
-    if function_exported?(module, :__modeline_segment_schema__, 0) do
-      register_extension_modeline_segment_schema(
-        module.__modeline_segment_schema__(),
-        ext_name,
-        opts
-      )
-    else
-      :ok
+      "unknown"
     end
   rescue
-    e ->
-      reason = {:modeline_segment_registration_failed, Exception.message(e)}
-
-      Log.warning(
-        :config,
-        "Extension #{ext_name} modeline segment registration failed: #{Exception.message(e)}"
-      )
-
-      {:error, reason}
+    error ->
+      Log.warning(:config, "Extension version() failed: #{Exception.message(error)}")
+      "unknown"
   end
 
-  @spec register_extension_modeline_segment_schema(
-          [Minga.Extension.modeline_segment_spec()],
-          atom(),
-          start_opts()
-        ) :: :ok | {:error, term()}
-  defp register_extension_modeline_segment_schema(schema, ext_name, opts) do
-    Enum.reduce_while(schema, :ok, fn spec, :ok ->
-      case register_extension_modeline_segment(spec, ext_name, opts) do
-        :ok -> {:cont, :ok}
-        {:error, reason} -> {:halt, {:error, reason}}
-      end
-    end)
-  end
-
-  @spec register_extension_modeline_segment(
-          Minga.Extension.modeline_segment_spec(),
-          atom(),
-          start_opts()
-        ) :: :ok | {:error, term()}
-  defp register_extension_modeline_segment({name, segment_opts, {mod, fun}}, ext_name, opts) do
-    admission = code_lease_server(opts)
-
-    case Minga.Config.ModelineSegments.register(
-           name,
-           segment_opts,
-           modeline_segment_callback(ext_name, mod, fun, admission),
-           {:extension, ext_name}
-         ) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        msg = Minga.Config.ModelineSegments.register_error_message(name, reason)
-        Log.warning(:config, "Extension #{ext_name} modeline segment rejected: #{msg}")
-        {:error, {:modeline_segment_rejected, name, reason}}
-    end
-  end
-
-  @spec modeline_segment_callback(atom(), module(), atom(), GenServer.server()) ::
-          (map() -> term())
-  defp modeline_segment_callback(ext_name, mod, fun, admission) do
-    fn ctx ->
-      extension_callback_result(ext_name, mod, fun, [ctx], :modeline_segment, admission)
-    end
-  end
-
-  @spec register_extension_keybinds(module(), atom(), GenServer.server()) ::
-          :ok | {:error, term()}
-  defp register_extension_keybinds(module, ext_name, keymap) do
-    if function_exported?(module, :__keybind_schema__, 0) do
-      register_extension_keybind_schema(module.__keybind_schema__(), ext_name, keymap)
-    else
-      :ok
-    end
-  rescue
-    e ->
-      Log.warning(
-        :config,
-        "Extension #{ext_name} keybind registration failed: #{Exception.message(e)}"
-      )
-
-      {:error, {:keybind_registration_failed, :schema, Exception.message(e)}}
-  end
-
-  @spec register_extension_keybind_schema(
-          [Minga.Extension.keybind_spec()],
-          atom(),
-          GenServer.server()
-        ) :: :ok | {:error, term()}
-  defp register_extension_keybind_schema(schema, ext_name, keymap) do
-    Enum.reduce_while(schema, :ok, fn spec, :ok ->
-      case bind_keybind_spec(spec, ext_name, keymap) do
-        :ok -> {:cont, :ok}
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
-  end
-
-  @spec bind_keybind_spec(Minga.Extension.keybind_spec(), atom(), GenServer.server()) ::
-          :ok | {:error, term()}
-  defp bind_keybind_spec({mode, key_str, command, description, opts}, ext_name, keymap) do
-    source_opts = Keyword.put(opts, :source, {:extension, ext_name})
-
-    case Minga.Keymap.Active.bind(keymap, mode, key_str, command, description, source_opts) do
-      :ok ->
-        :ok
-
-      {:error, reason} ->
-        Log.warning(
-          :config,
-          "Extension #{ext_name}: keybind #{inspect(key_str)} failed: #{reason}"
-        )
-
-        {:error, {:keybind_registration_failed, key_str, reason}}
-    end
-  end
-
-  @spec register_and_validate_options(atom(), module(), keyword()) ::
-          :ok | {:error, String.t()}
-  def register_and_validate_options(name, module, config) do
-    if function_exported?(module, :__option_schema__, 0) do
-      schema = module.__option_schema__()
-      Minga.Config.register_extension_schema(name, schema, config)
-    else
-      :ok
-    end
-  rescue
-    e ->
-      {:error, "__option_schema__/0 crashed: #{Exception.message(e)}"}
-  end
-
-  @spec call_init(module(), keyword()) :: {:ok, term()} | {:error, term()}
-  defp call_init(module, config) do
-    case module.init(config) do
-      {:ok, state} -> {:ok, state}
-      {:error, reason} -> {:error, "init failed: #{inspect(reason)}"}
-      other -> {:error, "init returned unexpected value: #{inspect(other)}"}
-    end
-  rescue
-    e -> {:error, "init crashed: #{Exception.message(e)}"}
-  end
+  defp version(_module), do: "unknown"
 end

--- a/lib/minga/services/supervisor.ex
+++ b/lib/minga/services/supervisor.ex
@@ -4,8 +4,9 @@ defmodule Minga.Services.Supervisor do
 
   Uses `rest_for_one` at this level to preserve two dependency chains:
 
-  1. Extension.Registry → Extension.Supervisor → Config.Loader
-     (Loader evaluates user config that registers and starts extensions)
+  1. Extension.Registry → artifact/callback authorities → InstanceRegistry →
+     Extension.RootSupervisor → Config.Loader
+     (Loader evaluates user config that declares and starts extension Instances)
   2. LSP.Supervisor → LSP.SyncServer
      (SyncServer calls into LSP.Supervisor to ensure clients)
 
@@ -28,6 +29,9 @@ defmodule Minga.Services.Supervisor do
       ├── Minga.Extension.ArtifactGenerationState Persistent VM-generation provenance owner
       ├── Minga.Extension.ArtifactAdmission  VM-generation module admission serializer
       ├── Minga.Extension.CodeLease          Process-owned leases for extension callback modules
+      ├── Minga.Extension.CallbackRegistry   Declarative runtime extension callbacks
+      ├── Minga.Extension.InstanceRegistry   Unique per-extension process names
+      ├── Minga.Extension.RootSupervisor     Dynamic owner of ordered extension roots
       ├── MingaAgent.ProviderRegistry        Source-owned provider declarations
       ├── MingaAgent.ProviderPacks.Native    Bundled native provider declaration
       ├── MingaAgent.Hooks.Registry          Source-owned agent hook declarations
@@ -35,7 +39,6 @@ defmodule Minga.Services.Supervisor do
       ├── MingaAgent.Skills.Registry         Source-owned extension skill paths
       ├── MingaEditor.Agent.SlashCommand.Registry Source-owned agent slash commands
       ├── MingaEditor.Agent.SemanticUI.Registry Source-owned semantic agent UI contributions
-      ├── Minga.Extension.Supervisor         DynamicSupervisor for extension processes
       ├── Minga.Config.Loader                Evaluates user config on init
       ├── Minga.Config.Writer                Debounced GUI settings overlay writer
       ├── Minga.LSP.Supervisor               DynamicSupervisor for LSP clients
@@ -80,6 +83,9 @@ defmodule Minga.Services.Supervisor do
         Minga.Extension.ArtifactAdmission
       ),
       StartupTimer.timed_child_spec(:svc_code_lease, Minga.Extension.CodeLease),
+      StartupTimer.timed_child_spec(:svc_callback_registry, Minga.Extension.CallbackRegistry),
+      StartupTimer.timed_child_spec(:svc_instance_registry, Minga.Extension.InstanceRegistry),
+      StartupTimer.timed_child_spec(:svc_ext_root_supervisor, Minga.Extension.RootSupervisor),
       StartupTimer.timed_child_spec(:svc_provider_registry, MingaAgent.ProviderRegistry),
       StartupTimer.timed_child_spec(:svc_provider_packs, MingaAgent.ProviderPacks.Native),
       StartupTimer.timed_child_spec(:svc_hooks_registry, MingaAgent.Hooks.Registry),
@@ -93,7 +99,6 @@ defmodule Minga.Services.Supervisor do
         :svc_semantic_ui_registry,
         MingaEditor.Agent.SemanticUI.Registry
       ),
-      StartupTimer.timed_child_spec(:svc_ext_supervisor, Minga.Extension.Supervisor),
       StartupTimer.timed_child_spec(:svc_config_loader, Minga.Config.Loader),
       StartupTimer.timed_child_spec(:svc_config_writer, Minga.Config.Writer),
       StartupTimer.timed_child_spec(:svc_lsp_supervisor, Minga.LSP.Supervisor),

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -447,18 +447,6 @@ defmodule MingaEditor do
     {:reply, :ok, Renderer.render_or_async(state)}
   end
 
-  def handle_call({:unload_extension_source, source, context}, _from, state) do
-    {:ok, new_state} = SourceFinalizer.finalize_unload(state, source, context)
-    {:reply, :ok, Renderer.render_or_async(new_state)}
-  end
-
-  def handle_call({:finalize_extension_source, source}, _from, state) do
-    case SourceFinalizer.finalize(state, source) do
-      {:ok, new_state} -> {:reply, :ok, Renderer.render_or_async(new_state)}
-      {{:error, reason}, new_state} -> {:reply, {:error, reason}, new_state}
-    end
-  end
-
   @spec handle_open_native(state(), String.t(), boolean()) ::
           {:reply, :ok | {:error, term()}, state()}
   defp handle_open_native(state, path, editor_mode?) do
@@ -541,6 +529,30 @@ defmodule MingaEditor do
 
   @impl true
   @spec handle_cast(term(), state()) :: {:noreply, state()}
+  def handle_cast({:finalize_extension_source_request, source, {caller, ref}}, state) do
+    case SourceFinalizer.finalize(state, source) do
+      {:ok, new_state} ->
+        send(caller, {:extension_source_finalized, ref, :ok})
+        {:noreply, Renderer.render_or_async(new_state)}
+
+      {{:error, reason}, new_state} ->
+        send(caller, {:extension_source_finalized, ref, {:error, reason}})
+        {:noreply, new_state}
+    end
+  end
+
+  def handle_cast({:unload_extension_source_request, source, context, {caller, ref}}, state) do
+    case SourceFinalizer.finalize_unload(state, source, context) do
+      {:ok, new_state} ->
+        send(caller, {:extension_source_finalized, ref, :ok})
+        {:noreply, Renderer.render_or_async(new_state)}
+
+      {{:error, failures}, new_state} ->
+        send(caller, {:extension_source_finalized, ref, {:error, failures}})
+        {:noreply, Renderer.render_or_async(new_state)}
+    end
+  end
+
   def handle_cast({:register_background_buffer, pid, abs_path}, state) do
     # Register a buffer that was started by Buffer.ensure_for_path (called
     # from agent tools or Editor.ensure_buffer_for_path). Only register if

--- a/lib/minga_editor/extension/source_finalizer.ex
+++ b/lib/minga_editor/extension/source_finalizer.ex
@@ -2,9 +2,9 @@ defmodule MingaEditor.Extension.SourceFinalizer do
   @moduledoc """
   Finalizes Editor-owned work and presentation for one contribution source.
 
-  Extension cleanup calls this workflow before the source is considered
-  disabled. The generation-owned effect scheduler is drained synchronously
-  first; only then may the live picker owned by that source be dismissed.
+  Extension cleanup requests this workflow asynchronously and waits for an
+  explicit Editor acknowledgement outside the lifecycle authority mailbox. The
+  generation-owned effect scheduler drains before source presentation is removed.
   """
 
   alias Minga.Extension.CallbackInvoker
@@ -72,7 +72,7 @@ defmodule MingaEditor.Extension.SourceFinalizer do
 
   @doc "Runs source-filtered unload callbacks and preserves their last successful state."
   @spec finalize_unload(EditorState.t(), CallbackInvoker.source(), unload_context()) ::
-          {:ok, EditorState.t()}
+          {:ok, EditorState.t()} | {{:error, term()}, EditorState.t()}
   def finalize_unload(%EditorState{} = state, {:extension, _name} = source, context) do
     token = Map.fetch!(context, :token)
     registry = Map.get(context, :callback_registry, CallbackRegistry.default_table())
@@ -80,7 +80,7 @@ defmodule MingaEditor.Extension.SourceFinalizer do
 
     case EventDispatcher.dispatch_source_unload(state, source, token, registry, admission) do
       {:ok, updated_state} -> {:ok, updated_state}
-      {:error, _failures, updated_state} -> {:ok, updated_state}
+      {:error, failures, updated_state} -> {{:error, failures}, updated_state}
     end
   end
 
@@ -95,15 +95,26 @@ defmodule MingaEditor.Extension.SourceFinalizer do
 
   @spec call_editor(pid(), source()) :: result()
   defp call_editor(pid, source) do
-    GenServer.call(pid, {:finalize_extension_source, source}, :infinity)
-  catch
-    :exit, reason -> {:error, {:editor_unavailable, reason}}
+    request_editor(pid, {:finalize_extension_source_request, source})
   end
 
   @spec call_editor_unload(pid(), source(), unload_context()) :: result()
   defp call_editor_unload(pid, source, context) do
-    GenServer.call(pid, {:unload_extension_source, source, context}, :infinity)
-  catch
-    :exit, reason -> {:error, {:editor_unavailable, reason}}
+    request_editor(pid, {:unload_extension_source_request, source, context})
+  end
+
+  @spec request_editor(pid(), tuple()) :: result()
+  defp request_editor(pid, request) do
+    ref = Process.monitor(pid)
+    GenServer.cast(pid, Tuple.insert_at(request, tuple_size(request), {self(), ref}))
+
+    receive do
+      {:extension_source_finalized, ^ref, result} ->
+        Process.demonitor(ref, [:flush])
+        result
+
+      {:DOWN, ^ref, :process, ^pid, reason} ->
+        {:error, {:editor_unavailable, reason}}
+    end
   end
 end

--- a/test/minga/architecture_test.exs
+++ b/test/minga/architecture_test.exs
@@ -69,6 +69,27 @@ defmodule Minga.ArchitectureTest do
     assert generation > 0
   end
 
+  test "extension lifecycle infrastructure is direct under Services in dependency order" do
+    children = Supervisor.which_children(Minga.Services.Supervisor)
+    ids = children |> Enum.map(&elem(&1, 0)) |> Enum.reverse()
+
+    expected = [
+      Minga.Extension.Registry,
+      Minga.Extension.ArtifactGenerationState,
+      Minga.Extension.ArtifactAdmission,
+      Minga.Extension.CodeLease,
+      Minga.Extension.CallbackRegistry,
+      Minga.Extension.InstanceRegistry,
+      Minga.Extension.RootSupervisor,
+      Minga.Config.Loader
+    ]
+
+    assert Enum.all?(expected, &(&1 in ids))
+    positions = Enum.map(expected, &Enum.find_index(ids, fn id -> id == &1 end))
+    assert positions == Enum.sort(positions)
+    refute Minga.Extension.Supervisor in ids
+  end
+
   test "MingaAgent.Supervisor is a top-level peer, not nested under Services" do
     top_children = Supervisor.which_children(Minga.Supervisor)
     top_ids = Enum.map(top_children, &elem(&1, 0))

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -15,7 +15,9 @@ defmodule Minga.Config.LoaderTest do
   alias Minga.Config.ModelineSegments
   alias Minga.Config.Options
   alias Minga.Extension.ContributionCleanup
+  alias Minga.Extension.InstanceRegistry
   alias Minga.Extension.Registry, as: ExtRegistry
+  alias Minga.Extension.RuntimeSupervisor
   alias Minga.Extension.Supervisor, as: ExtSupervisor
   alias Minga.Keymap.Active, as: KeymapActive
   alias Minga.Language
@@ -1062,93 +1064,6 @@ defmodule Minga.Config.LoaderTest do
       assert Loader.load_error(pid) =~ "Config reload cleanup for :config failed"
     end
 
-    test "reload surfaces stop_all failures instead of silently proceeding" do
-      {_dir, config_home, cleanup} =
-        make_config_dir("""
-        use Minga.Config
-        set :tab_width, 2
-        """)
-
-      on_exit(cleanup)
-
-      ensure_extension_runtime()
-
-      on_exit(fn ->
-        ExtSupervisor.stop_all()
-        ExtRegistry.reset()
-      end)
-
-      name = :"loader_reload_stop_all_failure_#{System.unique_integer([:positive])}"
-      {:ok, pid} = Loader.start_link(name: name, config_home: config_home)
-      assert Loader.load_error(pid) == nil
-      assert Options.get(test_options_server(), :tab_width) == 2
-
-      bogus_pid =
-        spawn(fn ->
-          receive do
-            :never -> :ok
-          end
-        end)
-
-      on_exit(fn ->
-        if Process.alive?(bogus_pid) do
-          Process.exit(bogus_pid, :kill)
-        end
-      end)
-
-      ext_name = :loader_reload_stop_all_failure
-      :ok = ExtRegistry.register(ext_name, "/tmp/loader_reload_stop_all_failure", [])
-      :ok = ExtRegistry.update(ext_name, pid: bogus_pid, module: nil, status: :running)
-
-      on_exit(fn -> ExtRegistry.unregister(ext_name) end)
-
-      ext_dir =
-        Path.join(
-          System.tmp_dir!(),
-          "minga_loader_reload_blocked_#{System.unique_integer([:positive])}"
-        )
-
-      File.mkdir_p!(ext_dir)
-
-      File.write!(Path.join(ext_dir, "reload_blocked_ext.ex"), """
-      defmodule Minga.TestExtensions.LoaderReloadBlockedExt do
-        use Minga.Extension
-
-        @impl true
-        def name, do: :loader_reload_blocked_ext
-
-        @impl true
-        def description, do: "Reload blocked extension"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-      end
-      """)
-
-      on_exit(fn ->
-        File.rm_rf!(ext_dir)
-        :code.purge(Minga.TestExtensions.LoaderReloadBlockedExt)
-        :code.delete(Minga.TestExtensions.LoaderReloadBlockedExt)
-      end)
-
-      File.write!(Path.join(Path.dirname(Loader.config_path(pid)), "config.exs"), """
-      use Minga.Config
-
-      set :tab_width, 7
-      extension :loader_reload_blocked_ext, path: #{inspect(ext_dir)}
-      """)
-
-      assert {:error, msg} = Loader.reload(pid)
-      assert msg =~ "Extension stop_all failed"
-      assert msg =~ "loader_reload_stop_all_failure"
-      assert Loader.load_error(pid) =~ "Extension stop_all failed"
-      assert Options.get(test_options_server(), :tab_width) == 2
-      assert ExtRegistry.get(:loader_reload_blocked_ext) == :error
-    end
-
     @tag :heavy
     test "reload surfaces start_all failures with cleanup details" do
       {minga_dir, config_home, cleanup} =
@@ -1329,10 +1244,10 @@ defmodule Minga.Config.LoaderTest do
       assert unchanged.manifest.version == "1.0.0"
       assert File.read!(compile_log) == "1.0.0\n"
 
-      assert Enum.any?(DynamicSupervisor.which_children(Minga.Extension.Supervisor), fn
-               {_id, ^runtime_pid, _type, _modules} -> true
-               _child -> false
-             end)
+      runtime_supervisor =
+        InstanceRegistry.via(InstanceRegistry, :runtime, extension_name)
+
+      assert RuntimeSupervisor.local_child(runtime_supervisor) == {:ok, runtime_pid}
     end
 
     test "reload picks up changed config values" do

--- a/test/minga/extension/contribution_cleanup_test.exs
+++ b/test/minga/extension/contribution_cleanup_test.exs
@@ -18,7 +18,7 @@ defmodule Minga.Extension.ContributionCleanupTest do
     {:ok, keymap: keymap}
   end
 
-  test "targeted finalization runs one family and full cleanup remains idempotent", %{
+  test "targeted finalization runs once and full cleanup skips targeted families", %{
     keymap: keymap
   } do
     source = {:extension, :cleanup_test}
@@ -48,8 +48,34 @@ defmodule Minga.Extension.ContributionCleanupTest do
                callbacks: callbacks
              )
 
-    assert_receive {:editor_effects_finalized, ^source}
+    refute_receive {:editor_effects_finalized, ^source}
     assert_receive {:later_family_cleaned, ^source}
+  end
+
+  test "config full cleanup includes Editor effects and presentation families", %{keymap: keymap} do
+    source = :config
+    test_pid = self()
+
+    callbacks = %{
+      editor_effects: fn callback_source ->
+        send(test_pid, {:config_editor_effects_cleaned, callback_source})
+        :ok
+      end,
+      editor_presentation: fn callback_source ->
+        send(test_pid, {:config_editor_presentation_cleaned, callback_source})
+        :ok
+      end
+    }
+
+    assert :ok =
+             ContributionCleanup.unregister_source(source,
+               command_registry: Minga.Command.Registry,
+               keymap: keymap,
+               callbacks: callbacks
+             )
+
+    assert_receive {:config_editor_effects_cleaned, :config}
+    assert_receive {:config_editor_presentation_cleaned, :config}
   end
 
   test "contextual finalizers receive authority only during targeted finalization", %{

--- a/test/minga/extension/instance_test.exs
+++ b/test/minga/extension/instance_test.exs
@@ -1,0 +1,116 @@
+defmodule Minga.Extension.InstanceTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Extension.Entry
+  alias Minga.Extension.Instance.Artifact
+  alias Minga.Extension.Instance.Projection
+  alias Minga.Extension.Instance.Runtime
+  alias Minga.Extension.Instance.State
+  alias Minga.Extension.Manifest
+  alias Minga.Extension.Registry
+
+  test "state strips lifecycle projection from declaration identity" do
+    declaration = %Entry{
+      source_type: :path,
+      path: "/tmp/example",
+      module: Some.Projected.Module,
+      pid: self(),
+      status: :running,
+      last_error: :stale
+    }
+
+    state = State.new(:example, declaration, :registry, :instances, [])
+    assert state.phase == :stopped
+    assert state.declaration.module == nil
+    assert state.declaration.pid == nil
+    assert state.declaration.status == :stopped
+    assert state.declaration.last_error == nil
+  end
+
+  test "projection is the compatible view of tagged phases" do
+    registry = :"instance_projection_#{System.unique_integer([:positive])}"
+    start_supervised!({Registry, name: registry})
+    :ok = Registry.register(registry, :projection, "/tmp/projection", [])
+    {:ok, declaration} = Registry.get(registry, :projection)
+    state = State.new(:projection, declaration, registry, :instances, [])
+
+    :ok = Projection.publish(state)
+    assert {:ok, %{status: :stopped, pid: nil}} = Registry.get(registry, :projection)
+
+    runtime = spawn(fn -> receive do: (:stop -> :ok) end)
+    running = State.running(state, Runtime.monitor(runtime))
+    :ok = Projection.publish(running)
+    assert {:ok, %{status: :running, pid: ^runtime}} = Registry.get(registry, :projection)
+
+    send(runtime, :stop)
+  end
+
+  test "projection fails when its registry declaration is absent" do
+    registry = :"missing_projection_#{System.unique_integer([:positive])}"
+    start_supervised!({Registry, name: registry})
+
+    declaration = %Entry{source_type: :module, module: __MODULE__.RestartFixture}
+    state = State.new(:missing_projection, declaration, registry, :instances, [])
+
+    assert {:error, {:extension_not_declared, :missing_projection}} = Projection.publish(state)
+  end
+
+  test "declaration replaces request overrides and preserves stable collaborators" do
+    declaration = %Entry{source_type: :module, module: __MODULE__.RestartFixture}
+
+    state =
+      State.new(:collaborators, declaration, :registry, :instances,
+        command_registry: :commands,
+        artifact_admission: self(),
+        transition_timeout_ms: 25,
+        callbacks: %{cleanup: fn _source -> :ok end}
+      )
+
+    assert {:ok, declared} =
+             State.declare(state, declaration, :current_registry, runtime_query_timeout_ms: 500)
+
+    assert declared.registry == :current_registry
+    assert declared.collaborators[:command_registry] == :commands
+    assert declared.collaborators[:artifact_admission] == self()
+    assert declared.collaborators[:runtime_query_timeout_ms] == 500
+    refute Keyword.has_key?(declared.collaborators, :transition_timeout_ms)
+    refute Keyword.has_key?(declared.collaborators, :callbacks)
+
+    configured = State.configure(declared, [])
+    assert configured.collaborators[:command_registry] == :commands
+    assert configured.collaborators[:artifact_admission] == self()
+    refute Keyword.has_key?(configured.collaborators, :runtime_query_timeout_ms)
+  end
+
+  test "artifact preserves declared restart policy and forces runtime temporary" do
+    manifest = %Manifest{
+      name: :artifact,
+      description: "artifact",
+      version: "1.0.0",
+      source: :module,
+      commands: [],
+      keybindings: [],
+      modeline_segments: [],
+      capabilities: [],
+      load_policy: :eager
+    }
+
+    module = __MODULE__.RestartFixture
+    assert {:ok, artifact} = Artifact.build(:artifact, module, manifest, [module], [])
+
+    assert artifact.restart == :transient
+    assert artifact.child_spec.restart == :temporary
+  end
+
+  defmodule RestartFixture do
+    @spec child_spec(keyword()) :: Supervisor.child_spec()
+    def child_spec(_opts) do
+      %{
+        id: __MODULE__,
+        start: {Agent, :start_link, [fn -> :ok end]},
+        restart: :transient,
+        type: :worker
+      }
+    end
+  end
+end

--- a/test/minga/extension/json_loader_test.exs
+++ b/test/minga/extension/json_loader_test.exs
@@ -196,7 +196,7 @@ defmodule Minga.Extension.JsonLoaderTest do
         {:error, message} -> assert message =~ "failed to read"
       end
 
-      assert_receive {:race_finished, ^racer}, 1_000
+      assert_receive {:race_finished, ^racer}, 5_000
     end)
   end
 

--- a/test/minga/extension/lazy_test.exs
+++ b/test/minga/extension/lazy_test.exs
@@ -5,7 +5,11 @@ defmodule Minga.Extension.LazyTest do
   # Runtime code compilation makes these inherently slow.
   @moduletag :heavy
 
+  import ExUnit.CaptureLog
+
   alias Minga.Command.Registry, as: CommandRegistry
+  alias Minga.Extension.DeferredBatchCompleteEvent
+  alias Minga.Extension.InstanceRegistry
   alias Minga.Extension.Lazy
   alias Minga.Extension.Registry, as: ExtRegistry
   alias Minga.Extension.Supervisor, as: ExtSupervisor
@@ -157,6 +161,123 @@ defmodule Minga.Extension.LazyTest do
 
       assert {:command, :lazy_key_cmd, _desc} =
                Minga.Keymap.Bindings.lookup_sequence(leader_trie, keys)
+    end
+
+    test "registered stub racing stop and redeclaration cannot activate its stale declaration",
+         ctx do
+      {path, cleanup} =
+        make_extension("LazyRedeclareRace", """
+        defmodule Minga.TestExtensions.LazyRedeclareRace do
+          use Minga.Extension
+
+          load_policy {:on_command, [:lazy_redeclare_race_cmd]}
+
+          command :lazy_redeclare_race_cmd, "Lazy redeclaration race",
+            execute: {Minga.TestExtensions.LazyRedeclareRace, :run}
+
+          @impl true
+          def name, do: :lazy_redeclare_race
+          @impl true
+          def description, do: "Lazy redeclaration race"
+          @impl true
+          def version, do: "1.0.0"
+
+          @impl true
+          def init(config) do
+            send(Keyword.fetch!(config, :test_pid), {:lazy_redeclare_init, config[:generation]})
+            {:ok, %{}}
+          end
+
+          def run(state), do: Map.put(state, :lazy_generation, :new)
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(Minga.TestExtensions.LazyRedeclareRace)
+        :code.delete(Minga.TestExtensions.LazyRedeclareRace)
+      end)
+
+      old_config = [
+        load_policy: {:on_command, [:lazy_redeclare_race_cmd]},
+        test_pid: self(),
+        generation: :old
+      ]
+
+      :ok = ExtRegistry.register(ctx.registry, :lazy_redeclare_race, path, old_config)
+      {:ok, old_declaration} = ExtRegistry.get(ctx.registry, :lazy_redeclare_race)
+
+      assert :ok =
+               Lazy.register_stubs(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :lazy_redeclare_race,
+                 old_declaration,
+                 start_opts(ctx)
+               )
+
+      assert {:ok, stale_stub} =
+               CommandRegistry.lookup(ctx.command_registry, :lazy_redeclare_race_cmd)
+
+      parent = self()
+
+      finalizer = fn _source ->
+        send(parent, {:lazy_stop_blocked, self()})
+        receive do: (:release -> :ok)
+      end
+
+      stop_opts = Keyword.put(start_opts(ctx), :callbacks, %{editor_effects: finalizer})
+
+      stop_task =
+        Task.async(fn ->
+          ExtSupervisor.stop_extension(
+            ctx.supervisor,
+            ctx.registry,
+            :lazy_redeclare_race,
+            old_declaration,
+            stop_opts
+          )
+        end)
+
+      assert_receive {:lazy_stop_blocked, finalizer_worker}
+
+      new_config =
+        Keyword.merge(old_config, generation: :new)
+
+      :ok = ExtRegistry.register(ctx.registry, :lazy_redeclare_race, path, new_config)
+      {:ok, new_declaration} = ExtRegistry.get(ctx.registry, :lazy_redeclare_race)
+
+      log =
+        capture_log(fn ->
+          stale_trigger = Task.async(fn -> stale_stub.execute.(%{untouched: true}) end)
+          refute Task.yield(stale_trigger, 25)
+          send(finalizer_worker, :release)
+          assert :ok = Task.await(stop_task)
+          assert %{untouched: true} = Task.await(stale_trigger)
+        end)
+
+      assert log =~ "Extension lazy_redeclare_race lazy activation failed"
+      assert log =~ "stale_deferred_declaration"
+      refute_receive {:lazy_redeclare_init, :old}
+
+      assert :ok =
+               Lazy.register_stubs(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :lazy_redeclare_race,
+                 new_declaration,
+                 start_opts(ctx)
+               )
+
+      assert {:ok, current_stub} =
+               CommandRegistry.lookup(ctx.command_registry, :lazy_redeclare_race_cmd)
+
+      assert {:extension_callback, {:extension, :lazy_redeclare_race},
+              Minga.TestExtensions.LazyRedeclareRace, :run, {:ok, %{lazy_generation: :new}}} =
+               current_stub.execute.(%{})
+
+      assert_receive {:lazy_redeclare_init, :new}
+      refute_receive {:lazy_redeclare_init, _duplicate}
     end
 
     test "extension with runtime error in body still registers stubs (AC4)", ctx do
@@ -363,6 +484,152 @@ defmodule Minga.Extension.LazyTest do
                       }}
     end
 
+    test "authority exit races return typed errors without crashing the caller", ctx do
+      {path, cleanup} =
+        make_extension("AutoloadAuthorityExit", """
+        defmodule Minga.TestExtensions.AutoloadAuthorityExit do
+          use Minga.Extension
+
+          load_policy {:on_command, [:autoload_authority_exit_cmd]}
+
+          command :autoload_authority_exit_cmd, "Authority exit",
+            execute: {Minga.TestExtensions.AutoloadAuthorityExit, :run}
+
+          @impl true
+          def name, do: :autoload_authority_exit
+          @impl true
+          def description, do: "Autoload authority exit"
+          @impl true
+          def version, do: "1.0.0"
+          @impl true
+          def init(_config), do: {:ok, %{}}
+          def run(state), do: Map.put(state, :should_not_run, true)
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(Minga.TestExtensions.AutoloadAuthorityExit)
+        :code.delete(Minga.TestExtensions.AutoloadAuthorityExit)
+      end)
+
+      :ok =
+        ExtRegistry.register(ctx.registry, :autoload_authority_exit, path,
+          load_policy: {:on_command, [:autoload_authority_exit_cmd]}
+        )
+
+      {:ok, entry} = ExtRegistry.get(ctx.registry, :autoload_authority_exit)
+
+      assert :ok =
+               Lazy.register_stubs(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :autoload_authority_exit,
+                 entry,
+                 start_opts(ctx)
+               )
+
+      registry = InstanceRegistry.registry_for_root(ctx.supervisor)
+      authority = InstanceRegistry.whereis(registry, :instance, :autoload_authority_exit)
+      :ok = :sys.suspend(authority)
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          capture_log(fn ->
+            result =
+              Lazy.autoload(
+                ctx.supervisor,
+                ctx.registry,
+                :autoload_authority_exit,
+                start_opts(ctx)
+              )
+
+            send(parent, {:autoload_exit_result, result})
+          end)
+        end)
+
+      refute Task.yield(task, 25)
+      Process.exit(authority, :kill)
+      log = Task.await(task)
+
+      assert_receive {:autoload_exit_result,
+                      {:error, {:authority_call_exit, :autoload_authority_exit, _reason}}}
+
+      assert log =~ "Extension autoload_authority_exit lazy activation failed"
+      assert log =~ "authority_call_exit"
+    end
+
+    test "stub command contains authority exit and leaves Editor state unchanged", ctx do
+      {path, cleanup} =
+        make_extension("LazyCommandAuthorityExit", """
+        defmodule Minga.TestExtensions.LazyCommandAuthorityExit do
+          use Minga.Extension
+
+          load_policy {:on_command, [:lazy_command_authority_exit_cmd]}
+
+          command :lazy_command_authority_exit_cmd, "Command authority exit",
+            execute: {Minga.TestExtensions.LazyCommandAuthorityExit, :run}
+
+          @impl true
+          def name, do: :lazy_command_authority_exit
+          @impl true
+          def description, do: "Lazy command authority exit"
+          @impl true
+          def version, do: "1.0.0"
+          @impl true
+          def init(_config), do: {:ok, %{}}
+          def run(state), do: Map.put(state, :should_not_run, true)
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(Minga.TestExtensions.LazyCommandAuthorityExit)
+        :code.delete(Minga.TestExtensions.LazyCommandAuthorityExit)
+      end)
+
+      :ok =
+        ExtRegistry.register(ctx.registry, :lazy_command_authority_exit, path,
+          load_policy: {:on_command, [:lazy_command_authority_exit_cmd]}
+        )
+
+      {:ok, entry} = ExtRegistry.get(ctx.registry, :lazy_command_authority_exit)
+
+      assert :ok =
+               Lazy.register_stubs(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :lazy_command_authority_exit,
+                 entry,
+                 start_opts(ctx)
+               )
+
+      assert {:ok, command} =
+               CommandRegistry.lookup(ctx.command_registry, :lazy_command_authority_exit_cmd)
+
+      registry = InstanceRegistry.registry_for_root(ctx.supervisor)
+      authority = InstanceRegistry.whereis(registry, :instance, :lazy_command_authority_exit)
+      :ok = :sys.suspend(authority)
+      parent = self()
+
+      task =
+        Task.async(fn ->
+          capture_log(fn ->
+            result = command.execute.(%{unchanged: true})
+            send(parent, {:lazy_command_exit_result, result})
+          end)
+        end)
+
+      refute Task.yield(task, 25)
+      Process.exit(authority, :kill)
+      log = Task.await(task)
+
+      assert_receive {:lazy_command_exit_result, %{unchanged: true}}
+      assert log =~ "Extension lazy_command_authority_exit lazy activation failed"
+      assert log =~ "authority_call_exit"
+    end
+
     test "autoload is idempotent (returns running pid on second call)", ctx do
       {path, cleanup} =
         make_extension("AutoloadIdempotent", """
@@ -419,6 +686,64 @@ defmodule Minga.Extension.LazyTest do
       # Second autoload should return the same pid
       assert {:ok, ^pid1} =
                Lazy.autoload(ctx.supervisor, ctx.registry, :autoload_idempotent, start_opts(ctx))
+    end
+  end
+
+  describe "compatibility deferred scheduler" do
+    test "logs and aggregates lazy stub registration failures", ctx do
+      {path, cleanup} =
+        make_extension("DeferredRegistrationFailure", """
+        defmodule Minga.TestExtensions.DeferredRegistrationFailure do
+          use Minga.Extension
+
+          load_policy :deferred
+
+          @impl true
+          def name, do: :deferred_registration_failure
+          @impl true
+          def description, do: "Deferred registration failure"
+          @impl true
+          def version, do: "1.0.0"
+          @impl true
+          def init(_config), do: {:ok, %{}}
+        end
+        """)
+
+      on_exit(fn ->
+        cleanup.()
+        :code.purge(Minga.TestExtensions.DeferredRegistrationFailure)
+        :code.delete(Minga.TestExtensions.DeferredRegistrationFailure)
+      end)
+
+      :ok =
+        ExtRegistry.register(ctx.registry, :deferred_registration_failure, path,
+          load_policy: :deferred
+        )
+
+      {:ok, entry} = ExtRegistry.get(ctx.registry, :deferred_registration_failure)
+      Minga.Events.subscribe(:extension_deferred_batch_complete)
+
+      log =
+        capture_log(fn ->
+          assert :ok =
+                   Lazy.schedule_deferred_loads(
+                     :missing_deferred_root,
+                     ctx.registry,
+                     [{:deferred_registration_failure, entry}],
+                     start_opts(ctx)
+                   )
+        end)
+
+      assert log =~ "Extension deferred_registration_failure deferred stub registration failed"
+
+      assert_receive {:minga_event, :extension_deferred_batch_complete,
+                      %DeferredBatchCompleteEvent{
+                        count: 1,
+                        failures: [
+                          %{extension: :deferred_registration_failure, reason: _reason}
+                        ]
+                      }},
+                     5_000
     end
   end
 

--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -1,2071 +1,2030 @@
 defmodule Minga.Extension.LifecycleContractTest do
   use ExUnit.Case, async: true
 
-  import ExUnit.CaptureLog
-
   alias Minga.Command.Registry, as: CommandRegistry
-  alias Minga.Extension.CallbackInvoker
+  alias Minga.Extension.ArtifactAdmission
+  alias Minga.Extension.ArtifactGenerationState
   alias Minga.Extension.CallbackRegistry
   alias Minga.Extension.CodeLease
+  alias Minga.Extension.DeferredBatchCompleteEvent
+  alias Minga.Extension.Instance
+  alias Minga.Extension.Instance.Worker
+  alias Minga.Extension.InstanceRegistry
+  alias Minga.Extension.Lazy
   alias Minga.Extension.Registry, as: ExtRegistry
+  alias Minga.Extension.RuntimeSupervisor
   alias Minga.Extension.Supervisor, as: ExtSupervisor
   alias Minga.Keymap.Active, as: KeymapActive
-  alias MingaEditor.Extension.Sidebar
+
+  defmodule Runtime do
+    use Minga.Extension
+
+    @impl true
+    def name, do: :instance_runtime
+    @impl true
+    def description, do: "Instance lifecycle runtime"
+    @impl true
+    def version, do: "1.0.0"
+
+    @impl true
+    def init(config) do
+      case Keyword.get(config, :init_gate) do
+        {test_pid, result} ->
+          send(test_pid, {:init_entered, self()})
+
+          receive do
+            :continue_init -> resolve_init_result(result)
+          end
+
+        nil ->
+          {:ok, %{}}
+      end
+    end
+
+    @spec resolve_init_result(term()) :: term()
+    defp resolve_init_result(result) when is_function(result, 0), do: result.()
+    defp resolve_init_result(result), do: result
+
+    @impl true
+    def child_spec(config) do
+      restart = Keyword.get(config, :restart, :permanent)
+      test_pid = Keyword.get(config, :runtime_test_pid)
+
+      %{
+        id: __MODULE__,
+        start: {__MODULE__, :start_runtime, [test_pid]},
+        restart: restart,
+        type: :worker
+      }
+    end
+
+    @spec start_runtime(pid() | nil) :: Agent.on_start()
+    def start_runtime(test_pid) do
+      result = Agent.start_link(fn -> %{test_pid: test_pid} end)
+      if is_pid(test_pid), do: send(test_pid, {:runtime_child_started, elem(result, 1)})
+      result
+    end
+  end
+
+  defmodule RuntimeTwo do
+    use Minga.Extension
+
+    @impl true
+    def name, do: :instance_runtime_two
+    @impl true
+    def description, do: "Second Instance lifecycle runtime"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+
+    @impl true
+    def child_spec(config) do
+      %{
+        id: __MODULE__,
+        start: {__MODULE__, :start_runtime, [Keyword.get(config, :runtime_test_pid)]},
+        restart: Keyword.get(config, :restart, :permanent),
+        type: :worker
+      }
+    end
+
+    @spec start_runtime(pid() | nil) :: Agent.on_start()
+    def start_runtime(test_pid) do
+      result = Agent.start_link(fn -> :runtime_two end)
+      if is_pid(test_pid), do: send(test_pid, {:runtime_child_started, elem(result, 1)})
+      result
+    end
+  end
+
+  defmodule ChildSpecFailure do
+    use Minga.Extension
+
+    @impl true
+    def name, do: :child_spec_failure
+    @impl true
+    def description, do: "Child spec failure"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+    @impl true
+    def child_spec(_config), do: raise("child spec exploded")
+  end
+
+  defmodule BlockedThenStarts do
+    use Minga.Extension
+
+    @impl true
+    def name, do: :blocked_then_starts
+    @impl true
+    def description, do: "Blocks its first child start MFA"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+
+    @impl true
+    def child_spec(config) do
+      %{
+        id: __MODULE__,
+        start:
+          {__MODULE__, :start_runtime,
+           [Keyword.fetch!(config, :attempts), Keyword.fetch!(config, :runtime_test_pid)]},
+        restart: :temporary,
+        type: :worker
+      }
+    end
+
+    @spec start_runtime(Agent.agent(), pid()) :: Agent.on_start()
+    def start_runtime(attempts, test_pid) do
+      case Agent.get_and_update(attempts, &{&1, &1 + 1}) do
+        0 ->
+          send(test_pid, {:blocked_child_start_mfa, self()})
+          receive do: (:never -> {:error, :unexpected_release})
+
+        _attempt ->
+          send(test_pid, {:retry_child_start_mfa, self()})
+
+          receive do
+            :release_retry_child_start -> Runtime.start_runtime(test_pid)
+          end
+      end
+    end
+  end
+
+  defmodule InfiniteShutdownThenStops do
+    use Minga.Extension
+
+    @impl true
+    def name, do: :infinite_shutdown_then_stops
+    @impl true
+    def description, do: "Ignores its first shutdown request"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+
+    @impl true
+    def child_spec(config) do
+      %{
+        id: __MODULE__,
+        start:
+          {__MODULE__, :start_runtime,
+           [Keyword.fetch!(config, :attempts), Keyword.fetch!(config, :runtime_test_pid)]},
+        restart: :temporary,
+        shutdown: :infinity,
+        type: :worker
+      }
+    end
+
+    @spec start_runtime(Agent.agent(), pid()) :: {:ok, pid()} | Agent.on_start()
+    def start_runtime(attempts, test_pid) do
+      case Agent.get_and_update(attempts, &{&1, &1 + 1}) do
+        0 ->
+          pid = spawn_link(fn -> ignore_shutdown(test_pid) end)
+          send(test_pid, {:runtime_child_started, pid})
+          {:ok, pid}
+
+        _attempt ->
+          Runtime.start_runtime(test_pid)
+      end
+    end
+
+    @spec ignore_shutdown(pid()) :: no_return()
+    defp ignore_shutdown(test_pid) do
+      Process.flag(:trap_exit, true)
+      send(test_pid, {:infinite_shutdown_ready, self()})
+
+      receive do
+        {:EXIT, _from, :shutdown} -> ignore_shutdown(test_pid)
+        _message -> ignore_shutdown(test_pid)
+      end
+    end
+  end
+
+  defmodule ChildStartFailure do
+    use Minga.Extension
+
+    @impl true
+    def name, do: :child_start_failure
+    @impl true
+    def description, do: "Child start failure"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+
+    @impl true
+    def child_spec(_config) do
+      %{
+        id: __MODULE__,
+        start: {__MODULE__, :refuse_start, []},
+        restart: :temporary,
+        type: :worker
+      }
+    end
+
+    @spec refuse_start() :: {:error, :child_refused_start}
+    def refuse_start, do: {:error, :child_refused_start}
+  end
+
+  defmodule CommandRegistrationFailure do
+    use Minga.Extension
+
+    command(:authority_duplicate_command, "Duplicate authority command",
+      execute: {__MODULE__, :run}
+    )
+
+    @impl true
+    def name, do: :command_registration_failure
+    @impl true
+    def description, do: "Command registration failure"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+    @spec run(term()) :: term()
+    def run(state), do: state
+  end
+
+  defmodule OptionFailure do
+    use Minga.Extension
+
+    option(:positive_count, :pos_integer, default: 1, description: "Positive count")
+
+    @impl true
+    def name, do: :option_failure
+    @impl true
+    def description, do: "Option failure"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+  end
+
+  defmodule ModelineFailure do
+    use Minga.Extension
+
+    modeline_segment :mode do
+      _context = ctx
+      {" invalid ", :default, :default, [], nil}
+    end
+
+    @impl true
+    def name, do: :modeline_failure
+    @impl true
+    def description, do: "Modeline failure"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+  end
+
+  defmodule KeybindRuntime do
+    use Minga.Extension
+
+    keybind(:normal, "SPC z z", :noop, "Keybind registration probe")
+
+    @impl true
+    def name, do: :keybind_runtime
+    @impl true
+    def description, do: "Keybind runtime"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+  end
+
+  defmodule EventRuntime do
+    use Minga.Extension
+
+    editor_event_handler(__MODULE__, [:buffer_saved])
+
+    @impl true
+    def name, do: :event_runtime
+    @impl true
+    def description, do: "Event runtime"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+
+    @spec handle_editor_event(term(), term()) :: {:handled, term()}
+    def handle_editor_event(state, _event), do: {:handled, state}
+  end
+
+  defmodule CrashContributionRuntime do
+    use Minga.Extension
+
+    command(:crash_contribution_command, "Crash contribution command",
+      execute: {__MODULE__, :run}
+    )
+
+    editor_event_handler(__MODULE__, [:buffer_saved])
+
+    @impl true
+    def name, do: :crash_contribution_runtime
+    @impl true
+    def description, do: "Crash contribution runtime"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+
+    @impl true
+    def child_spec(config) do
+      %{
+        id: __MODULE__,
+        start: {__MODULE__, :start_runtime, [Keyword.get(config, :runtime_test_pid)]},
+        restart: :temporary,
+        type: :worker
+      }
+    end
+
+    @spec start_runtime(pid() | nil) :: Agent.on_start()
+    def start_runtime(test_pid) do
+      result = Agent.start_link(fn -> :crash_contribution_runtime end)
+      if is_pid(test_pid), do: send(test_pid, {:runtime_child_started, elem(result, 1)})
+      result
+    end
+
+    @spec run(term()) :: term()
+    def run(state), do: state
+
+    @spec handle_editor_event(term(), term()) :: {:handled, term()}
+    def handle_editor_event(state, _event), do: {:handled, state}
+  end
+
+  defmodule LeaseRuntime do
+    use Minga.Extension
+
+    @impl true
+    def name, do: :lease_runtime
+    @impl true
+    def description, do: "Lease runtime"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+  end
+
+  defmodule RuntimeThree do
+    use Minga.Extension
+
+    @impl true
+    def name, do: :instance_runtime_three
+    @impl true
+    def description, do: "Third Instance lifecycle runtime"
+    @impl true
+    def version, do: "1.0.0"
+    @impl true
+    def init(_config), do: {:ok, %{}}
+
+    @impl true
+    def child_spec(config) do
+      %{
+        id: __MODULE__,
+        start: {Agent, :start_link, [fn -> :runtime_three end]},
+        restart: Keyword.get(config, :restart, :permanent),
+        type: :worker
+      }
+    end
+  end
 
   setup do
-    reg_name = :"ext_lifecycle_reg_#{System.unique_integer([:positive])}"
-    sup_name = :"ext_lifecycle_sup_#{System.unique_integer([:positive])}"
-    cmd_reg_name = :"ext_lifecycle_cmd_#{System.unique_integer([:positive])}"
-    keymap_name = :"ext_lifecycle_keymap_#{System.unique_integer([:positive])}"
+    suffix = System.unique_integer([:positive])
+    registry = :"instance_contract_registry_#{suffix}"
+    roots = :"instance_contract_roots_#{suffix}"
+    commands = :"instance_contract_commands_#{suffix}"
+    keymap = :"instance_contract_keymap_#{suffix}"
+    callback_registry = :"instance_contract_callbacks_#{suffix}"
+    owner = :"instance_contract_artifacts_#{suffix}"
+    persistence_key = {__MODULE__, suffix}
+    runtime_application = :"instance_contract_app_#{suffix}"
 
-    {:ok, _} = ExtRegistry.start_link(name: reg_name)
-    {:ok, _} = ExtSupervisor.start_link(name: sup_name)
-    {:ok, _} = CommandRegistry.start_link(name: cmd_reg_name)
-    {:ok, _} = KeymapActive.start_link(name: keymap_name)
+    :ok =
+      :application.load(
+        {:application, runtime_application,
+         [
+           description: ~c"instance contract",
+           vsn: ~c"1",
+           modules: [Runtime, RuntimeTwo, RuntimeThree],
+           registered: [],
+           applications: [:kernel, :stdlib]
+         ]}
+      )
 
-    {:ok,
-     registry: reg_name, supervisor: sup_name, command_registry: cmd_reg_name, keymap: keymap_name}
-  end
+    fixture_applications =
+      Enum.map(
+        [
+          ChildSpecFailure,
+          BlockedThenStarts,
+          InfiniteShutdownThenStops,
+          ChildStartFailure,
+          CommandRegistrationFailure,
+          OptionFailure,
+          ModelineFailure,
+          KeybindRuntime,
+          EventRuntime,
+          CrashContributionRuntime,
+          LeaseRuntime
+        ],
+        fn module ->
+          application =
+            :"instance_contract_#{module |> Module.split() |> List.last() |> Macro.underscore()}_#{suffix}"
 
-  test "default child stores config and init return is setup-only", ctx do
-    {path, cleanup} =
-      make_extension("DefaultChildState", """
-      defmodule Minga.TestExtensions.DefaultChildState do
-        use Minga.Extension
+          :ok =
+            :application.load(
+              {:application, application,
+               [
+                 description: ~c"instance contract fixture",
+                 vsn: ~c"1",
+                 modules: [module],
+                 registered: [],
+                 applications: [:kernel, :stdlib]
+               ]}
+            )
 
-        @impl true
-        def name, do: :default_child_state
-
-        @impl true
-        def description, do: "Default child state contract"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{runtime_state: true}}
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.DefaultChildState)
-      :code.delete(Minga.TestExtensions.DefaultChildState)
-    end)
-
-    :ok = ExtRegistry.register(ctx.registry, :default_child_state, path, greeting: "hello")
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :default_child_state)
-
-    assert {:ok, pid} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :default_child_state,
-               entry
-             )
-
-    assert Agent.get(pid, & &1) == [greeting: "hello"]
-  end
-
-  test "manifest is recorded before init side effects can fail", ctx do
-    {path, cleanup} =
-      make_extension("ManifestBeforeInit", """
-      defmodule Minga.TestExtensions.ManifestBeforeInit do
-        use Minga.Extension
-
-        command :manifest_before_init_cmd, "Manifest command", execute: {__MODULE__, :noop}
-        keybind :normal, "SPC m i", :manifest_before_init_cmd, "Manifest keybind"
-        modeline_segment :manifest_before_init_segment, side: :right do
-          _ = ctx
-          nil
+          application
         end
-        capability :ui, [:modeline]
-        capability :ui, [:sidebar]
-        capability :ui, [:modeline]
-
-        @impl true
-        def name, do: :manifest_before_init
-
-        @impl true
-        def description, do: "Manifest before init"
-
-        @impl true
-        def version, do: "1.2.3"
-
-        @impl true
-        def init(_config), do: {:error, :intentional_failure}
-
-        @spec noop(map()) :: map()
-        def noop(state), do: state
-      end
-      """)
+      )
 
     on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.ManifestBeforeInit)
-      :code.delete(Minga.TestExtensions.ManifestBeforeInit)
+      :application.unload(runtime_application)
+      Enum.each(fixture_applications, &:application.unload/1)
     end)
 
-    :ok = ExtRegistry.register(ctx.registry, :manifest_before_init, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :manifest_before_init)
+    start_supervised!({ExtRegistry, name: registry})
+    {:ok, _root_pid} = ExtSupervisor.start_link(name: roots)
+    start_supervised!({CommandRegistry, name: commands})
+    start_supervised!({KeymapActive, name: keymap})
+    start_supervised!({CallbackRegistry, name: callback_registry})
 
-    assert {:error, _reason} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :manifest_before_init,
-               entry,
-               command_registry: ctx.command_registry,
-               keymap: ctx.keymap
-             )
+    start_supervised!(
+      {ArtifactGenerationState, name: owner, persistence_key: persistence_key},
+      id: {ArtifactGenerationState, suffix}
+    )
 
-    {:ok, failed_entry} = ExtRegistry.get(ctx.registry, :manifest_before_init)
-    assert failed_entry.status == :load_error
-    assert failed_entry.manifest.name == :manifest_before_init
-    assert failed_entry.manifest.version == "1.2.3"
-    assert failed_entry.manifest.source == :path
+    admission =
+      start_supervised!(
+        {ArtifactAdmission, name: nil, state_owner: owner},
+        id: {ArtifactAdmission, suffix}
+      )
 
-    assert [{:manifest_before_init_cmd, "Manifest command", _opts}] =
-             failed_entry.manifest.commands
+    code_lease = start_supervised!({CodeLease, name: nil}, id: {CodeLease, suffix})
 
-    assert [{:normal, "SPC m i", :manifest_before_init_cmd, "Manifest keybind", []}] =
-             failed_entry.manifest.keybindings
+    on_exit(fn -> ArtifactGenerationState.reset_for_test(persistence_key) end)
 
-    assert [{:manifest_before_init_segment, [side: :right], _mfa}] =
-             failed_entry.manifest.modeline_segments
-
-    assert failed_entry.manifest.capabilities == [
-             ui: [:modeline],
-             ui: [:sidebar],
-             ui: [:modeline]
-           ]
-  end
-
-  test "same-generation restart uses the admitted artifact after source removal", ctx do
-    {path, cleanup} =
-      make_extension("StaleManifestCleared", """
-      defmodule Minga.TestExtensions.StaleManifestCleared do
-        use Minga.Extension
-
-        @impl true
-        def name, do: :stale_manifest_cleared
-
-        @impl true
-        def description, do: "Stale manifest cleared"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.StaleManifestCleared)
-      :code.delete(Minga.TestExtensions.StaleManifestCleared)
-    end)
-
-    :ok = ExtRegistry.register(ctx.registry, :stale_manifest_cleared, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :stale_manifest_cleared)
-
-    assert {:ok, _pid} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :stale_manifest_cleared,
-               entry
-             )
-
-    {:ok, running_entry} = ExtRegistry.get(ctx.registry, :stale_manifest_cleared)
-    assert running_entry.manifest.name == :stale_manifest_cleared
-
-    assert :ok =
-             ExtSupervisor.stop_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :stale_manifest_cleared,
-               running_entry
-             )
-
-    File.rm!(Path.join(path, "extension.ex"))
-
-    {:ok, stopped_entry} = ExtRegistry.get(ctx.registry, :stale_manifest_cleared)
-
-    assert {:ok, _pid} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :stale_manifest_cleared,
-               stopped_entry
-             )
-
-    {:ok, restarted_entry} = ExtRegistry.get(ctx.registry, :stale_manifest_cleared)
-    assert restarted_entry.status == :running
-    assert restarted_entry.module == Minga.TestExtensions.StaleManifestCleared
-    assert restarted_entry.manifest.name == :stale_manifest_cleared
-  end
-
-  test "manifest introspection failures become load errors", ctx do
-    cases = [
-      {"ManifestNameRaise", :name, "raise(\"name boom\")", :manifest_name_raise},
-      {"ManifestVersionExit", :version, "exit(:version_boom)", :manifest_version_exit},
-      {"ManifestDescriptionThrow", :description, "throw(:description_boom)",
-       :manifest_description_throw}
+    opts = [
+      command_registry: commands,
+      keymap: keymap,
+      callback_registry: callback_registry,
+      artifact_admission: admission,
+      code_lease: code_lease
     ]
 
-    for {module_name, callback, body, ext_name} <- cases do
-      source =
-        case callback do
-          :name ->
-            """
-            defmodule Minga.TestExtensions.#{module_name} do
-              use Minga.Extension
+    {:ok,
+     registry: registry,
+     roots: roots,
+     commands: commands,
+     keymap: keymap,
+     callback_registry: callback_registry,
+     admission: admission,
+     code_lease: code_lease,
+     runtime_application: runtime_application,
+     opts: opts}
+  end
 
-              @impl true
-              def name, do: #{body}
+  test "module and path declarations publish lifecycle through their Instance", ctx do
+    module_name = unique_name(:module_source)
+    module_entry = register_module(ctx, module_name, [])
+    assert {:ok, module_pid} = start_extension(ctx, module_name, module_entry)
+    assert InstanceRegistry.whereis(instance_registry(ctx), :instance, module_name)
+    assert {:ok, module_projection} = ExtRegistry.get(ctx.registry, module_name)
+    assert module_projection.status == :running
+    assert module_projection.pid == module_pid
+    assert module_projection.module == Runtime
+    assert module_projection.manifest.source == :module
+    assert :ok = stop_extension(ctx, module_name, ctx.opts)
 
-              @impl true
-              def description, do: "Manifest failure #{module_name}"
+    path_name = unique_name(:path_source)
+    path_dir = Path.join(System.tmp_dir!(), Atom.to_string(path_name))
+    path_module = Module.concat(Minga.TestExtensions, Macro.camelize(Atom.to_string(path_name)))
+    File.mkdir_p!(path_dir)
 
-              @impl true
-              def version, do: "1.0.0"
+    on_exit(fn -> File.rm_rf!(path_dir) end)
 
-              @impl true
-              def init(_config), do: {:ok, %{}}
-            end
-            """
+    File.write!(Path.join(path_dir, "extension.ex"), """
+    defmodule #{inspect(path_module)} do
+      use Minga.Extension
+      @impl true
+      def name, do: #{inspect(path_name)}
+      @impl true
+      def description, do: "Path lifecycle"
+      @impl true
+      def version, do: "1.0.0"
+      @impl true
+      def init(_config), do: {:ok, %{}}
+    end
+    """)
 
-          :version ->
-            """
-            defmodule Minga.TestExtensions.#{module_name} do
-              use Minga.Extension
+    :ok = ExtRegistry.register(ctx.registry, path_name, path_dir, [])
+    {:ok, path_entry} = ExtRegistry.get(ctx.registry, path_name)
+    assert {:ok, path_pid} = start_extension(ctx, path_name, path_entry)
+    assert InstanceRegistry.whereis(instance_registry(ctx), :instance, path_name)
+    assert {:ok, path_projection} = ExtRegistry.get(ctx.registry, path_name)
+    assert path_projection.status == :running
+    assert path_projection.pid == path_pid
+    assert path_projection.module == path_module
+    assert path_projection.manifest.source == :path
+    assert :ok = stop_extension(ctx, path_name, ctx.opts)
+  end
 
-              @impl true
-              def name, do: :#{ext_name}
+  test "Hex application declarations use the same Instance lifecycle", ctx do
+    name = unique_name(:hex_application_source)
 
-              @impl true
-              def description, do: "Manifest failure #{module_name}"
+    :ok =
+      ExtRegistry.register_hex(ctx.registry, name, Atom.to_string(ctx.runtime_application),
+        app: ctx.runtime_application
+      )
 
-              @impl true
-              def version, do: #{body}
+    {:ok, entry} = ExtRegistry.get(ctx.registry, name)
+    assert {:ok, pid} = start_extension(ctx, name, entry)
+    assert InstanceRegistry.whereis(instance_registry(ctx), :instance, name)
+    assert {:ok, projection} = ExtRegistry.get(ctx.registry, name)
+    assert projection.status == :running
+    assert projection.pid == pid
+    assert projection.module == Runtime
+    assert projection.manifest.source == :hex
 
-              @impl true
-              def init(_config), do: {:ok, %{}}
-            end
-            """
+    assert {:ok, modules} =
+             ArtifactAdmission.source_modules({:extension, name}, server: ctx.admission)
 
-          :description ->
-            """
-            defmodule Minga.TestExtensions.#{module_name} do
-              use Minga.Extension
+    assert modules == Enum.sort([Runtime, RuntimeTwo, RuntimeThree])
 
-              @impl true
-              def name, do: :#{ext_name}
+    assert :ok = stop_extension(ctx, name, ctx.opts)
+    assert {:ok, %{status: :stopped, pid: nil}} = ExtRegistry.get(ctx.registry, name)
+  end
 
-              @impl true
-              def description, do: #{body}
+  test "JSON and resolved Git declarations use the same Instance lifecycle", ctx do
+    json_name = unique_name(:json_source)
+    json_dir = Path.join(System.tmp_dir!(), Atom.to_string(json_name))
+    File.mkdir_p!(json_dir)
 
-              @impl true
-              def version, do: "1.0.0"
+    File.write!(Path.join(json_dir, "plugin.json"), """
+    {"name":"#{json_name}","version":"1.0.0","description":"JSON lifecycle"}
+    """)
 
-              @impl true
-              def init(_config), do: {:ok, %{}}
-            end
-            """
-        end
+    :ok = ExtRegistry.register(ctx.registry, json_name, json_dir, [])
+    {:ok, json_entry} = ExtRegistry.get(ctx.registry, json_name)
+    assert {:ok, json_pid} = start_extension(ctx, json_name, json_entry)
+    assert InstanceRegistry.whereis(instance_registry(ctx), :instance, json_name)
+    assert {:ok, json_projection} = ExtRegistry.get(ctx.registry, json_name)
+    assert json_projection.pid == json_pid
+    assert json_projection.manifest.source == :path
+    assert :ok = stop_extension(ctx, json_name, ctx.opts)
+    refute Process.alive?(json_pid)
 
-      {path, cleanup} = make_extension(module_name, source)
+    git_name = unique_name(:resolved_git_source)
+    git_dir = Path.join(System.tmp_dir!(), Atom.to_string(git_name))
+    git_module = Module.concat(Minga.TestExtensions, Macro.camelize(Atom.to_string(git_name)))
+    File.mkdir_p!(git_dir)
 
-      on_exit(fn ->
-        cleanup.()
-        :code.purge(Module.concat(Minga.TestExtensions, String.to_atom(module_name)))
-        :code.delete(Module.concat(Minga.TestExtensions, String.to_atom(module_name)))
+    File.write!(Path.join(git_dir, "extension.ex"), """
+    defmodule #{inspect(git_module)} do
+      use Minga.Extension
+      @impl true
+      def name, do: #{inspect(git_name)}
+      @impl true
+      def description, do: "Resolved Git lifecycle"
+      @impl true
+      def version, do: "1.0.0"
+      @impl true
+      def init(_config), do: {:ok, %{}}
+    end
+    """)
+
+    :ok = ExtRegistry.register_git(ctx.registry, git_name, "https://example.invalid/repo", [])
+    :ok = ExtRegistry.update(ctx.registry, git_name, path: git_dir)
+    {:ok, git_entry} = ExtRegistry.get(ctx.registry, git_name)
+    assert {:ok, git_pid} = start_extension(ctx, git_name, git_entry)
+    assert InstanceRegistry.whereis(instance_registry(ctx), :instance, git_name)
+    assert {:ok, git_projection} = ExtRegistry.get(ctx.registry, git_name)
+    assert git_projection.pid == git_pid
+    assert git_projection.manifest.source == :git
+    assert :ok = stop_extension(ctx, git_name, ctx.opts)
+    refute Process.alive?(git_pid)
+
+    File.rm_rf!(json_dir)
+    File.rm_rf!(git_dir)
+  end
+
+  test "first concurrent callers synchronize through root and Instance registration", ctx do
+    name = unique_name(:concurrent_root_start)
+    entry = register_module(ctx, name, init_gate: {self(), {:ok, %{}}})
+    parent = self()
+
+    callers =
+      for _index <- 1..12 do
+        Task.async(fn ->
+          send(parent, {:root_start_ready, self()})
+          receive do: (:start_now -> start_extension(ctx, name, entry))
+        end)
+      end
+
+    caller_pids =
+      Enum.map(callers, fn _caller ->
+        assert_receive {:root_start_ready, caller_pid}
+        caller_pid
       end)
 
-      :ok = ExtRegistry.register(ctx.registry, ext_name, path, [])
-      {:ok, entry} = ExtRegistry.get(ctx.registry, ext_name)
+    Enum.each(caller_pids, &send(&1, :start_now))
+    assert_receive {:init_entered, workflow}, 5_000
+    send(workflow, :continue_init)
 
-      assert {:error, reason} =
-               ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, ext_name, entry)
-
-      assert reason =~ "manifest introspection failed"
-
-      assert {:ok, %{status: :load_error, pid: nil}} = ExtRegistry.get(ctx.registry, ext_name)
-    end
+    results = Enum.map(callers, &Task.await(&1, 5_000))
+    assert [{:ok, runtime}] = Enum.uniq(results)
+    assert is_pid(runtime)
+    refute Enum.any?(results, &match?({:error, {:instance_not_started, _}}, &1))
+    refute_receive {:init_entered, _duplicate_workflow}
   end
 
-  test "direct manifest construction propagates raised declaration failures", _ctx do
-    {path, cleanup} =
-      make_extension("ManifestDirectRaise", """
-      defmodule Minga.TestExtensions.ManifestDirectRaise do
-        use Minga.Extension
+  test "concurrent starts join one transition and return the same runtime PID", ctx do
+    name = unique_name(:concurrent_start)
+    config = [init_gate: {self(), {:ok, %{}}}]
+    entry = register_module(ctx, name, config)
 
-        @impl true
-        def name, do: raise("direct manifest name boom")
+    first = Task.async(fn -> start_extension(ctx, name, entry) end)
+    assert_receive {:init_entered, workflow}, 5_000
 
-        @impl true
-        def description, do: "Direct manifest raise"
+    second = Task.async(fn -> start_extension(ctx, name, entry) end)
+    refute Task.yield(second, 50)
 
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-      end
-      """)
-
-    Code.compile_file(Path.join(path, "extension.ex"))
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.ManifestDirectRaise)
-      :code.delete(Minga.TestExtensions.ManifestDirectRaise)
-    end)
-
-    assert_raise RuntimeError, "direct manifest name boom", fn ->
-      Minga.Extension.manifest(Minga.TestExtensions.ManifestDirectRaise, :path)
-    end
+    send(workflow, :continue_init)
+    assert {:ok, pid} = Task.await(first)
+    assert {:ok, ^pid} = Task.await(second)
+    assert {:running, %{pid: ^pid}} = Instance.phase(instance(ctx, name))
   end
 
-  test "legacy behavior-only extensions receive default manifest schemas", ctx do
-    {path, cleanup} =
-      make_extension("LegacyManifestDefaults", """
-      defmodule Minga.TestExtensions.LegacyManifestDefaults do
-        @spec name() :: atom()
-        def name, do: :legacy_manifest_defaults
+  test "concurrent failed starts converge through one rollback", ctx do
+    name = unique_name(:failed_start)
+    config = [init_gate: {self(), {:error, :boom}}]
+    entry = register_module(ctx, name, config)
 
-        @spec description() :: String.t()
-        def description, do: "Legacy manifest defaults"
+    first = Task.async(fn -> start_extension(ctx, name, entry) end)
+    assert_receive {:init_entered, workflow}, 5_000
+    second = Task.async(fn -> start_extension(ctx, name, entry) end)
+    send(workflow, :continue_init)
 
-        @spec version() :: String.t()
-        def version, do: "1.0.0"
+    assert {:error, reason} = Task.await(first)
+    assert {:error, ^reason} = Task.await(second)
+    assert {:load_error, %{reason: ^reason}} = Instance.phase(instance(ctx, name))
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+  end
 
-        @spec init(keyword()) :: {:ok, map()}
-        def init(_config), do: {:ok, %{}}
+  test "child-spec and child-start failures keep exact facade tuples and safe retry state", ctx do
+    child_spec_name = unique_name(:child_spec_failure)
+    child_spec_entry = register_module(ctx, child_spec_name, [], ChildSpecFailure)
 
-        @spec child_spec(keyword()) :: Supervisor.child_spec()
-        def child_spec(config) do
-          %{id: __MODULE__, start: {Agent, :start_link, [fn -> config end]}, restart: :permanent, type: :worker}
-        end
-      end
-      """)
+    assert {:error, {:child_spec_failed, "child spec exploded"}} =
+             start_extension(ctx, child_spec_name, child_spec_entry)
 
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.LegacyManifestDefaults)
-      :code.delete(Minga.TestExtensions.LegacyManifestDefaults)
-    end)
+    assert {:ok,
+            %{
+              status: :load_error,
+              pid: nil,
+              last_error: {:child_spec_failed, "child spec exploded"}
+            }} = ExtRegistry.get(ctx.registry, child_spec_name)
 
-    :ok = ExtRegistry.register(ctx.registry, :legacy_manifest_defaults, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :legacy_manifest_defaults)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, child_spec_name)) == :empty
 
-    assert {:ok, _pid} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :legacy_manifest_defaults,
-               entry
+    child_start_name = unique_name(:child_start_failure)
+    child_start_entry = register_module(ctx, child_start_name, [], ChildStartFailure)
+
+    assert {:error, :child_refused_start} =
+             start_extension(ctx, child_start_name, child_start_entry)
+
+    assert {:ok, %{status: :load_error, pid: nil, last_error: :child_refused_start}} =
+             ExtRegistry.get(ctx.registry, child_start_name)
+
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, child_start_name)) == :empty
+  end
+
+  test "contribution registration failure rolls back exactly once and retry is safe", ctx do
+    name = unique_name(:command_registration_failure)
+    entry = register_module(ctx, name, [], CommandRegistrationFailure)
+
+    assert :ok =
+             CommandRegistry.register(
+               ctx.commands,
+               :config,
+               :authority_duplicate_command,
+               "Existing command",
+               fn state -> state end
              )
 
-    {:ok, started_entry} = ExtRegistry.get(ctx.registry, :legacy_manifest_defaults)
-    assert started_entry.manifest.name == :legacy_manifest_defaults
-    assert started_entry.manifest.commands == []
-    assert started_entry.manifest.keybindings == []
-    assert started_entry.manifest.modeline_segments == []
-    assert started_entry.manifest.capabilities == []
+    reason =
+      {:duplicate_name, :authority_duplicate_command, :config, {:extension, name}}
+
+    assert {:error, ^reason} = start_extension(ctx, name, entry)
+
+    assert {:ok, %{status: :load_error, pid: nil, last_error: ^reason}} =
+             ExtRegistry.get(ctx.registry, name)
+
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+    assert :ok = CommandRegistry.unregister(ctx.commands, :authority_duplicate_command)
+    assert {:ok, runtime} = start_extension(ctx, name, entry)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
+    assert {:ok, _command} = CommandRegistry.lookup(ctx.commands, :authority_duplicate_command)
   end
 
-  test "failed child start removes contributions registered during init", ctx do
-    {path, cleanup} =
-      make_extension("FailedChildStart", """
-      defmodule Minga.TestExtensions.FailedChildStart do
-        use Minga.Extension
+  test "failed stub cleanup blocks activation until cleanup retry succeeds", ctx do
+    name = unique_name(:stub_cleanup_failure)
 
-        @impl true
-        def name, do: :failed_child_start
+    entry =
+      register_module(
+        ctx,
+        name,
+        [load_policy: {:on_command, [:authority_duplicate_command]}],
+        CommandRegistrationFailure
+      )
 
-        @impl true
-        def description, do: "Failed child start"
+    assert :ok =
+             CommandRegistry.register(
+               ctx.commands,
+               :config,
+               :authority_duplicate_command,
+               "Existing command",
+               fn state -> state end
+             )
 
-        @impl true
-        def version, do: "1.0.0"
+    cleanup = fn _source -> {:error, :stub_cleanup_busy} end
+    opts = Keyword.put(ctx.opts, :callbacks, %{stub_cleanup_failure: cleanup})
 
-        @impl true
-        def init(config) do
-          source = {:extension, :failed_child_start}
-          command_registry = Keyword.fetch!(config, :command_registry)
-          command = %Minga.Command{name: :failed_child_start_cmd, description: "Failed child command", execute: &__MODULE__.noop/1}
-          :ok = Minga.Command.Registry.register_command(command_registry, source, command)
-          {:ok, %{}}
-        end
-
-        @impl true
-        def child_spec(_config) do
-          %{id: __MODULE__, start: {__MODULE__, :start_link, []}, restart: :permanent, type: :worker}
-        end
-
-        @spec start_link() :: {:error, atom()}
-        def start_link, do: {:error, :intentional_child_failure}
-
-        @spec noop(map()) :: map()
-        def noop(state), do: state
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.FailedChildStart)
-      :code.delete(Minga.TestExtensions.FailedChildStart)
-    end)
-
-    config = [command_registry: ctx.command_registry, keymap: ctx.keymap]
-    :ok = ExtRegistry.register(ctx.registry, :failed_child_start, path, config)
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :failed_child_start)
-
-    assert {:error, :intentional_child_failure} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
+    assert {:error, {:cleanup_failed, _stub_reason, failures}} =
+             ExtSupervisor.register_lazy_extension(
+               ctx.roots,
                ctx.registry,
-               :failed_child_start,
+               name,
                entry,
-               command_registry: ctx.command_registry,
-               keymap: ctx.keymap
+               opts
              )
 
-    assert :error = CommandRegistry.lookup(ctx.command_registry, :failed_child_start_cmd)
+    assert Enum.any?(failures, &match?(%{family: :stub_cleanup_failure}, &1))
+    assert {:cleanup_failed, _context} = Instance.phase(instance(ctx, name))
 
-    assert {:ok, failed_entry = %{status: :load_error, pid: nil}} =
-             ExtRegistry.get(ctx.registry, :failed_child_start)
+    assert {:error, {:cleanup_retry_required, _reason}} =
+             start_extension(ctx, name, entry, opts)
+
+    assert :ok = stop_extension(ctx, name, Keyword.put(ctx.opts, :callbacks, %{}))
+    assert :ok = CommandRegistry.unregister(ctx.commands, :authority_duplicate_command)
 
     assert :ok =
-             ExtSupervisor.stop_extension(
-               ctx.supervisor,
+             ExtSupervisor.register_lazy_extension(
+               ctx.roots,
                ctx.registry,
-               :failed_child_start,
-               failed_entry,
-               command_registry: ctx.command_registry,
-               keymap: ctx.keymap
+               name,
+               entry,
+               ctx.opts
              )
   end
 
-  test "reload order cleans old source-owned contributions before restart", ctx do
-    {path, cleanup} =
-      make_extension("ReloadOrder", """
-      defmodule Minga.TestExtensions.ReloadOrder do
-        use Minga.Extension
+  test "keybind event and lease registration failures retain exact projection and retry safely",
+       ctx do
+    cases = [
+      {:keybind, KeybindRuntime, [keymap: :missing_keymap_authority]},
+      {:event, EventRuntime, [callback_registry: :missing_callback_authority]},
+      {:lease, LeaseRuntime, [code_lease: :missing_lease_authority]}
+    ]
 
-        @impl true
-        def name, do: :reload_order
+    Enum.each(cases, fn {family, module, failing_opts} ->
+      name = unique_name(family)
+      entry = register_module(ctx, name, [], module)
+      opts = Keyword.merge(ctx.opts, failing_opts)
+      assert {:error, reason} = start_extension(ctx, name, entry, opts)
+      assert {:ok, projection} = ExtRegistry.get(ctx.registry, name)
+      assert projection.status == :load_error
+      assert projection.last_error == reason
 
-        @impl true
-        def description, do: "Reload order"
+      case projection.pid do
+        pid when is_pid(pid) ->
+          assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, pid}
 
-        @impl true
-        def version, do: "1.0.0"
+        nil ->
+          assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+      end
 
-        @impl true
-        def init(config) do
-          source = {:extension, :reload_order}
-          command_registry = Keyword.fetch!(config, :command_registry)
-          command = %Minga.Command{name: :reload_order_cmd, description: "Reload order command", execute: &__MODULE__.noop/1}
-          :ok = Minga.Command.Registry.register_command(command_registry, source, command)
-          {:ok, %{}}
+      if match?({:cleanup_failed, _, _}, reason) do
+        assert :ok = stop_extension(ctx, name, ctx.opts)
+      end
+
+      assert {:ok, runtime} = start_extension(ctx, name, entry, ctx.opts)
+      assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
+      assert :ok = stop_extension(ctx, name, ctx.opts)
+    end)
+  end
+
+  test "a safely rolled back failed start can retry through the same Instance", ctx do
+    name = unique_name(:failed_start_retry)
+    attempts = start_supervised!({Agent, fn -> 0 end})
+
+    init_result = fn ->
+      Agent.get_and_update(attempts, fn
+        0 -> {{:error, :first_attempt_failed}, 1}
+        count -> {{:ok, %{}}, count + 1}
+      end)
+    end
+
+    entry = register_module(ctx, name, init_gate: {self(), init_result})
+    first = Task.async(fn -> start_extension(ctx, name, entry) end)
+    assert_receive {:init_entered, first_workflow}, 5_000
+    send(first_workflow, :continue_init)
+    assert {:error, _reason} = Task.await(first)
+    assert {:load_error, _context} = Instance.phase(instance(ctx, name))
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+
+    second = Task.async(fn -> start_extension(ctx, name, entry) end)
+    assert_receive {:init_entered, second_workflow}, 5_000
+    send(second_workflow, :continue_init)
+    assert {:ok, replacement} = Task.await(second)
+    assert {:running, %{pid: ^replacement}} = Instance.phase(instance(ctx, name))
+  end
+
+  test "stop during a successful start replies both callers and cleans once", ctx do
+    name = unique_name(:stop_during_successful_start)
+    entry = register_module(ctx, name, init_gate: {self(), {:ok, %{}}})
+    parent = self()
+
+    cleanup = fn source ->
+      send(parent, {:stop_during_start_cleanup, source})
+      :ok
+    end
+
+    opts = Keyword.put(ctx.opts, :callbacks, %{cleanup_probe: cleanup})
+    start_task = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
+    assert_receive {:init_entered, workflow}, 5_000
+    stop_task = Task.async(fn -> stop_extension(ctx, name, opts) end)
+    send(workflow, :continue_init)
+
+    assert {:ok, runtime} = Task.await(start_task)
+    runtime_ref = Process.monitor(runtime)
+    assert :ok = Task.await(stop_task)
+    assert_receive {:stop_during_start_cleanup, {:extension, ^name}}
+    refute_receive {:stop_during_start_cleanup, {:extension, ^name}}
+    assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, _reason}
+  end
+
+  test "stop during a failed start reports incomplete rollback to both callers", ctx do
+    name = unique_name(:stop_during_failed_start)
+    entry = register_module(ctx, name, init_gate: {self(), {:error, :start_failed}})
+
+    cleanup = fn _source -> {:error, :rollback_cleanup_failed} end
+    opts = Keyword.put(ctx.opts, :callbacks, %{cleanup_failure: cleanup})
+    start_task = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
+    assert_receive {:init_entered, workflow}, 5_000
+    stop_task = Task.async(fn -> stop_extension(ctx, name, opts) end)
+    send(workflow, :continue_init)
+
+    assert {:error, {:cleanup_failed, "init failed: :start_failed", failures}} =
+             Task.await(start_task)
+
+    assert Enum.any?(failures, &match?(%{family: :cleanup_failure}, &1))
+
+    assert {:error, {:cleanup_failed, "init failed: :start_failed", ^failures}} =
+             Task.await(stop_task)
+
+    assert {:cleanup_failed, _context} = Instance.phase(instance(ctx, name))
+  end
+
+  test "concurrent stops finalize once", ctx do
+    name = unique_name(:concurrent_stop)
+    entry = register_module(ctx, name, [])
+    assert {:ok, _pid} = start_extension(ctx, name, entry)
+    test_pid = self()
+
+    finalizer = fn source ->
+      send(test_pid, {:finalizer_entered, self(), source})
+
+      receive do
+        :finish_finalizer -> :ok
+      end
+    end
+
+    opts = Keyword.put(ctx.opts, :callbacks, %{editor_effects: finalizer})
+    first = Task.async(fn -> stop_extension(ctx, name, opts) end)
+    assert_receive {:finalizer_entered, finalizer_pid, {:extension, ^name}}
+    second = Task.async(fn -> stop_extension(ctx, name, opts) end)
+    refute Task.yield(second, 50)
+    send(finalizer_pid, :finish_finalizer)
+
+    assert :ok = Task.await(first)
+    assert :ok = Task.await(second)
+    refute_receive {:finalizer_entered, _, _}
+    assert :stopped = Instance.phase(instance(ctx, name))
+  end
+
+  test "start during stop queues one deterministic intent", ctx do
+    name = unique_name(:start_during_stop)
+    entry = register_module(ctx, name, [])
+    assert {:ok, first_pid} = start_extension(ctx, name, entry)
+    test_pid = self()
+
+    finalizer = fn _source ->
+      send(test_pid, {:stop_barrier, self()})
+      receive do: (:release -> :ok)
+    end
+
+    opts = Keyword.put(ctx.opts, :callbacks, %{editor_effects: finalizer})
+    stop_task = Task.async(fn -> stop_extension(ctx, name, opts) end)
+    assert_receive {:stop_barrier, barrier}
+    start_task = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
+    refute Task.yield(start_task, 50)
+    send(barrier, :release)
+
+    assert :ok = Task.await(stop_task)
+    assert {:ok, replacement} = Task.await(start_task)
+    refute replacement == first_pid
+    assert {:running, %{pid: ^replacement}} = Instance.phase(instance(ctx, name))
+  end
+
+  test "failed finalization keeps retry context and start cannot bypass it", ctx do
+    name = unique_name(:finalizer_retry)
+    entry = register_module(ctx, name, [])
+    assert {:ok, runtime} = start_extension(ctx, name, entry)
+    attempts = start_supervised!({Agent, fn -> 0 end})
+
+    finalizer = fn _source ->
+      Agent.get_and_update(attempts, fn
+        0 -> {{:error, :editor_busy}, 1}
+        count -> {:ok, count + 1}
+      end)
+    end
+
+    opts = Keyword.put(ctx.opts, :callbacks, %{editor_effects: finalizer})
+
+    assert {:error, {:source_quiesce_failed, %{reason: :editor_busy}}} =
+             stop_extension(ctx, name, opts)
+
+    assert {:error, {:cleanup_retry_required, _reason}} = start_extension(ctx, name, entry, opts)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
+    assert :ok = stop_extension(ctx, name, opts)
+    assert :stopped = Instance.phase(instance(ctx, name))
+  end
+
+  test "second unload finalizer failure preserves an exact retry contract", ctx do
+    name = unique_name(:unload_finalizer_retry)
+    entry = register_module(ctx, name, [])
+    attempts = start_supervised!({Agent, fn -> 0 end})
+
+    unload_finalizer = fn _source ->
+      Agent.get_and_update(attempts, fn
+        0 -> {{:error, :unload_editor_busy}, 1}
+        count -> {:ok, count + 1}
+      end)
+    end
+
+    opts = Keyword.put(ctx.opts, :callbacks, %{editor_extension_unload: unload_finalizer})
+    assert {:ok, runtime} = start_extension(ctx, name, entry, opts)
+
+    assert {:error, {:source_quiesce_failed, %{reason: :unload_editor_busy}}} =
+             stop_extension(ctx, name, opts)
+
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
+    assert CodeLease.source_status({:extension, name}, server: ctx.code_lease) == :active
+    assert {:error, {:cleanup_retry_required, _reason}} = start_extension(ctx, name, entry, opts)
+    assert :ok = stop_extension(ctx, name, opts)
+    assert :stopped = Instance.phase(instance(ctx, name))
+  end
+
+  test "cleanup failure blocks start until a successful stop retry", ctx do
+    name = unique_name(:cleanup_retry)
+    entry = register_module(ctx, name, [])
+    assert {:ok, _runtime} = start_extension(ctx, name, entry)
+    attempts = start_supervised!({Agent, fn -> 0 end})
+
+    cleanup = fn _source ->
+      Agent.get_and_update(attempts, fn
+        0 -> {{:error, :cleanup_busy}, 1}
+        count -> {:ok, count + 1}
+      end)
+    end
+
+    opts = Keyword.put(ctx.opts, :callbacks, %{custom_cleanup: cleanup})
+    assert {:error, {:cleanup_failed, _failures}} = stop_extension(ctx, name, opts)
+    assert {:error, {:cleanup_retry_required, _reason}} = start_extension(ctx, name, entry, opts)
+    assert :ok = stop_extension(ctx, name, opts)
+    assert {:ok, _replacement} = start_extension(ctx, name, entry, opts)
+  end
+
+  test "racing lazy triggers activate one captured artifact", ctx do
+    name = unique_name(:lazy_race)
+    config = [load_policy: {:on_command, [:lazy_race]}, init_gate: {self(), {:ok, %{}}}]
+    _entry = register_module(ctx, name, config)
+    assert :ok = ExtSupervisor.start_all(ctx.roots, ctx.registry, ctx.opts)
+    authority = instance(ctx, name)
+
+    first = Task.async(fn -> Instance.start(authority) end)
+    assert_receive {:init_entered, workflow}, 5_000
+    second = Task.async(fn -> Instance.start(authority) end)
+    send(workflow, :continue_init)
+
+    assert {:ok, pid} = Task.await(first)
+    assert {:ok, ^pid} = Task.await(second)
+  end
+
+  test "deferred batch logs one authority exit and continues later declarations", ctx do
+    name = unique_name(:deferred_continues)
+    entry = register_module(ctx, name, load_policy: :deferred, runtime_test_pid: self())
+    assert :ok = stop_extension(ctx, name, ctx.opts)
+    Minga.Events.subscribe(:extension_deferred_batch_complete)
+
+    log =
+      ExUnit.CaptureLog.capture_log(fn ->
+        assert :ok =
+                 Lazy.schedule_deferred_loads([
+                   {:missing_deferred_authority, :missing_deferred, entry},
+                   {instance(ctx, name), name, entry}
+                 ])
+
+        assert_receive {:runtime_child_started, _runtime}, 5_000
+
+        assert_receive {:minga_event, :extension_deferred_batch_complete,
+                        %DeferredBatchCompleteEvent{count: 2}}
+      end)
+
+    assert log =~ "Extension missing_deferred deferred load failed"
+    assert log =~ "instance_call_exit"
+  end
+
+  test "deferred activation rejects a re-registered declaration identity", ctx do
+    name = unique_name(:deferred_identity)
+    original = register_module(ctx, name, load_policy: :deferred)
+    assert :ok = ExtSupervisor.start_all(ctx.roots, ctx.registry, ctx.opts)
+    authority = instance(ctx, name)
+
+    :ok = ExtRegistry.register_module(ctx.registry, name, RuntimeTwo, load_policy: :deferred)
+    {:ok, replacement} = ExtRegistry.get(ctx.registry, name)
+    assert :ok = Instance.declare(authority, replacement, ctx.registry, ctx.opts)
+    assert {:error, :stale_deferred_declaration} = Instance.start_deferred(authority, original)
+
+    receive do
+    after
+      150 -> :ok
+    end
+
+    assert :stopped = Instance.phase(authority)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+  end
+
+  test "stale monitor and acknowledgement messages cannot alter a later runtime", ctx do
+    name = unique_name(:stale_messages)
+    entry = register_module(ctx, name, [])
+    assert {:ok, pid} = start_extension(ctx, name, entry)
+    authority = instance(ctx, name)
+    authority_pid = instance_pid(ctx, name)
+
+    send(authority_pid, {:DOWN, make_ref(), :process, pid, :kill})
+    send(authority_pid, {:extension_finalizer_ack, make_ref(), :editor_effects, {:error, :stale}})
+    send(authority_pid, {CodeLease, :drained, {:extension, name}, make_ref()})
+    _ = Instance.phase(authority)
+
+    assert {:running, %{pid: ^pid}} = Instance.phase(authority)
+    assert {:ok, ^pid} = Instance.start(authority)
+  end
+
+  test "lifecycle spans preserve phases and structured failure metadata", ctx do
+    telemetry_id = {__MODULE__, unique_name(:lifecycle_spans)}
+    recipient = self()
+
+    :telemetry.attach(
+      telemetry_id,
+      [:minga, :extension, :lifecycle, :stop],
+      fn event, measurements, metadata, test_pid ->
+        send(test_pid, {:lifecycle_span, event, measurements, metadata})
+      end,
+      recipient
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+    success_name = unique_name(:span_success)
+    success_entry = register_module(ctx, success_name, [], Runtime)
+    assert {:ok, _runtime} = start_extension(ctx, success_name, success_entry)
+    assert :ok = stop_extension(ctx, success_name, ctx.opts)
+
+    for phase <- [:init, :child_start, :load, :stop, :cleanup] do
+      assert_receive {:lifecycle_span, [:minga, :extension, :lifecycle, :stop],
+                      %{duration: _duration},
+                      %{extension: ^success_name, phase: ^phase, outcome: :ok}}
+    end
+
+    failure_name = unique_name(:span_failure)
+    failure_entry = register_module(ctx, failure_name, [], ChildStartFailure)
+    assert {:error, :child_refused_start} = start_extension(ctx, failure_name, failure_entry)
+
+    assert_receive {:lifecycle_span, [:minga, :extension, :lifecycle, :stop],
+                    %{duration: _duration},
+                    %{
+                      extension: ^failure_name,
+                      phase: :child_start,
+                      outcome: :error,
+                      reason: :child_refused_start
+                    }}
+
+    assert_receive {:lifecycle_span, [:minga, :extension, :lifecycle, :stop],
+                    %{duration: _duration},
+                    %{
+                      extension: ^failure_name,
+                      phase: :load,
+                      outcome: :error,
+                      reason: :child_refused_start
+                    }}
+  end
+
+  test "permanent runtime crashes publish replacement telemetry before the next request", ctx do
+    name = unique_name(:permanent_restart)
+    telemetry_id = {__MODULE__, name}
+    test_pid = self()
+
+    :telemetry.attach(
+      telemetry_id,
+      [:minga, :extension, :lifecycle, :crash_restart_count],
+      fn _event, measurements, metadata, recipient ->
+        send(recipient, {:restart_telemetry, measurements, metadata})
+      end,
+      test_pid
+    )
+
+    on_exit(fn -> :telemetry.detach(telemetry_id) end)
+    entry = register_module(ctx, name, restart: :permanent)
+    assert {:ok, pid} = start_extension(ctx, name, entry)
+    assert_receive {:restart_telemetry, %{count: 0}, %{extension: ^name}}
+    Process.exit(pid, :kill)
+
+    replacement = await_runtime_replacement(ctx, name, pid)
+    assert_receive {:restart_telemetry, %{count: 1}, %{extension: ^name}}
+
+    assert {:ok, ^replacement} = Instance.start(instance(ctx, name))
+    assert {:ok, projected} = ExtRegistry.get(ctx.registry, name)
+    assert projected.pid == replacement
+  end
+
+  test "temporary and transient policies are interpreted only by Instance", ctx do
+    temporary = unique_name(:temporary_runtime)
+    temporary_entry = register_module(ctx, temporary, restart: :temporary)
+    assert {:ok, temporary_pid} = start_extension(ctx, temporary, temporary_entry)
+    Process.exit(temporary_pid, :kill)
+    assert_eventually_phase(ctx, temporary, :crashed)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, temporary)) == :empty
+
+    transient = unique_name(:transient_runtime)
+    transient_entry = register_module(ctx, transient, [restart: :transient], RuntimeTwo)
+    assert {:ok, transient_pid} = start_extension(ctx, transient, transient_entry)
+    assert :ok = Agent.stop(transient_pid, :normal)
+    assert_eventually_phase(ctx, transient, :stopped)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, transient)) == :empty
+  end
+
+  test "transient policy replaces an abnormally exited runtime", ctx do
+    name = unique_name(:transient_runtime_crash)
+    entry = register_module(ctx, name, [restart: :transient], RuntimeTwo)
+    assert {:ok, crashed_pid} = start_extension(ctx, name, entry)
+    Process.exit(crashed_pid, :kill)
+    replacement = await_runtime_replacement(ctx, name, crashed_pid)
+    assert {:ok, ^replacement} = Instance.start(instance(ctx, name))
+  end
+
+  test "Instance death cancels blocked start work before a child exists", ctx do
+    name = unique_name(:blocked_start_crash)
+    entry = register_module(ctx, name, init_gate: {self(), {:ok, %{}}})
+    parent = self()
+
+    caller =
+      spawn(fn ->
+        result = start_extension(ctx, name, entry)
+        send(parent, {:blocked_start_caller, result})
+      end)
+
+    caller_ref = Process.monitor(caller)
+    assert_receive {:init_entered, worker}, 5_000
+    worker_ref = Process.monitor(worker)
+    authority = instance_pid(ctx, name)
+    Process.exit(authority, :kill)
+
+    assert_receive {:DOWN, ^worker_ref, :process, ^worker, :killed}
+    assert_receive {:blocked_start_caller, {:error, {:authority_unavailable, ^name, _reason}}}
+    assert_receive {:DOWN, ^caller_ref, :process, ^caller, :normal}
+    assert :ok = stop_extension(ctx, name, ctx.opts)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+  end
+
+  test "Instance and RuntimeSupervisor death after child start clean without duplication", ctx do
+    for crash_target <- [:instance, :runtime_supervisor] do
+      name = unique_name(:"child_started_crash_#{crash_target}")
+      module = if crash_target == :instance, do: Runtime, else: RuntimeTwo
+      entry = register_module(ctx, name, [runtime_test_pid: self()], module)
+      callback_registry = Process.whereis(ctx.callback_registry)
+      :ok = :sys.suspend(callback_registry)
+      parent = self()
+
+      _caller =
+        spawn(fn ->
+          result = start_extension(ctx, name, entry)
+          send(parent, {:child_started_caller, crash_target, result})
+        end)
+
+      assert_receive {:runtime_child_started, runtime}, 5_000
+      runtime_ref = Process.monitor(runtime)
+
+      target =
+        case crash_target do
+          :instance -> instance_pid(ctx, name)
+          :runtime_supervisor -> runtime_supervisor_pid(ctx, name)
         end
 
-        @spec noop(map()) :: map()
-        def noop(state), do: state
-      end
-      """)
+      Process.exit(target, :kill)
 
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.ReloadOrder)
-      :code.delete(Minga.TestExtensions.ReloadOrder)
-    end)
+      assert_receive {:child_started_caller, ^crash_target,
+                      {:error, {:authority_unavailable, ^name, _reason}}}
 
-    config = [command_registry: ctx.command_registry, keymap: ctx.keymap]
-    :ok = ExtRegistry.register(ctx.registry, :reload_order, path, config)
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :reload_order)
+      assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, _reason}, 5_000
+      refute_receive {:runtime_child_started, _duplicate}
 
-    assert {:ok, _pid} =
-             ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, :reload_order, entry,
-               command_registry: ctx.command_registry,
-               keymap: ctx.keymap
-             )
+      :ok = :sys.resume(callback_registry)
+      assert :ok = stop_extension(ctx, name, ctx.opts)
+      assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
 
-    assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, :reload_order_cmd)
-
-    {:ok, running_entry} = ExtRegistry.get(ctx.registry, :reload_order)
-
-    assert :ok =
-             ExtSupervisor.stop_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :reload_order,
-               running_entry,
-               command_registry: ctx.command_registry,
-               keymap: ctx.keymap
-             )
-
-    assert :error = CommandRegistry.lookup(ctx.command_registry, :reload_order_cmd)
-
-    {:ok, stopped_entry} = ExtRegistry.get(ctx.registry, :reload_order)
-
-    assert {:ok, _pid} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :reload_order,
-               stopped_entry,
-               command_registry: ctx.command_registry,
-               keymap: ctx.keymap
-             )
-
-    assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, :reload_order_cmd)
+      assert {:ok, replacement} = start_extension(ctx, name, entry)
+      assert_receive {:runtime_child_started, ^replacement}
+      refute_receive {:runtime_child_started, _duplicate}
+      assert :ok = stop_extension(ctx, name, ctx.opts)
+    end
   end
 
-  test "lifecycle telemetry covers start, stop, cleanup, and restart count", ctx do
-    telemetry_id = {__MODULE__, self(), :telemetry}
+  test "Instance and RuntimeSupervisor crashes resume a blocked stop without leaks", ctx do
+    for crash_target <- [:instance, :runtime_supervisor] do
+      name = unique_name(crash_target)
+      module = if crash_target == :instance, do: Runtime, else: RuntimeTwo
+      entry = register_module(ctx, name, [], module)
+      assert {:ok, runtime} = start_extension(ctx, name, entry)
+      runtime_ref = Process.monitor(runtime)
+      parent = self()
+
+      finalizer = fn _source ->
+        send(parent, {:blocked_finalizer, crash_target, self()})
+        receive do: (:release -> :ok)
+      end
+
+      opts = Keyword.put(ctx.opts, :callbacks, %{editor_effects: finalizer})
+
+      caller =
+        spawn(fn ->
+          result = stop_extension(ctx, name, opts)
+          send(parent, {:blocked_stop_caller, crash_target, result})
+        end)
+
+      caller_ref = Process.monitor(caller)
+      assert_receive {:blocked_finalizer, ^crash_target, worker}
+      worker_ref = Process.monitor(worker)
+
+      target =
+        case crash_target do
+          :instance -> instance_pid(ctx, name)
+          :runtime_supervisor -> runtime_supervisor_pid(ctx, name)
+        end
+
+      Process.exit(target, :kill)
+      assert_receive {:DOWN, ^worker_ref, :process, ^worker, _worker_reason}
+
+      assert_receive {:blocked_stop_caller, ^crash_target,
+                      {:error, {:authority_unavailable, ^name, _reason}}}
+
+      assert_receive {:DOWN, ^caller_ref, :process, ^caller, :normal}
+      assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, _reason}, 5_000
+      assert :ok = stop_extension(ctx, name, ctx.opts)
+      assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+    end
+  end
+
+  test "runtime DOWN before start completion rolls back and rejects stale success", ctx do
+    name = unique_name(:runtime_down_during_start)
+    source = {:extension, name}
+    parent = self()
+
+    cleanup = fn cleanup_source ->
+      send(parent, {:runtime_down_start_cleanup, cleanup_source})
+      :ok
+    end
+
+    entry = register_module(ctx, name, [runtime_test_pid: self()], CrashContributionRuntime)
+    callback_registry = Process.whereis(ctx.callback_registry)
+    :ok = :sys.suspend(callback_registry)
+    opts = Keyword.put(ctx.opts, :callbacks, %{runtime_down_cleanup: cleanup})
+
+    first_start = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
+    assert_receive {:runtime_child_started, runtime}, 5_000
+    authority = instance(ctx, name)
+    authority_pid = instance_pid(ctx, name)
+
+    assert {:starting,
+            %{
+              runtime: %{pid: ^runtime},
+              worker: %Worker{id: transition_id, pid: start_worker}
+            }} =
+             eventually(fn ->
+               case Instance.phase(authority) do
+                 {:starting, %{runtime: %{pid: ^runtime}, worker: %Worker{}}} = phase -> phase
+                 _phase -> nil
+               end
+             end)
+
+    stale_prepared = :sys.get_state(authority_pid)
+    worker_ref = Process.monitor(start_worker)
+    second_start = Task.async(fn -> Instance.start(authority) end)
+    stop = Task.async(fn -> stop_extension(ctx, name, opts) end)
+
+    assert {:starting, %{waiters: [_, _] = waiters, stop_waiters: [_] = stop_waiters}} =
+             eventually(fn ->
+               case Instance.phase(authority) do
+                 {:starting, %{waiters: [_, _], stop_waiters: [_]}} = phase -> phase
+                 _phase -> nil
+               end
+             end)
+
+    assert [_, _] = waiters
+    assert [_] = stop_waiters
+
+    runtime_ref = Process.monitor(runtime)
+    Process.exit(runtime, :kill)
+    assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, :killed}
+
+    assert {:stopping, _context} =
+             eventually(fn ->
+               case Instance.phase(authority) do
+                 {:stopping, _context} = phase -> phase
+                 _phase -> nil
+               end
+             end)
+
+    assert_receive {:DOWN, ^worker_ref, :process, ^start_worker, :killed}
+
+    send(
+      authority_pid,
+      {Worker, :done, transition_id, {:ok, {:ok, runtime, stale_prepared}}}
+    )
+
+    assert {:stopping, _context} = Instance.phase(authority)
+    :ok = :sys.resume(callback_registry)
+
+    assert {:error, :killed} = Task.await(first_start)
+    assert {:error, :killed} = Task.await(second_start)
+    assert :ok = Task.await(stop)
+    assert_receive {:runtime_down_start_cleanup, ^source}
+    refute_receive {:runtime_down_start_cleanup, ^source}
+
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+    assert :error = CommandRegistry.lookup(ctx.commands, :crash_contribution_command)
+
+    assert CallbackRegistry.callbacks_for_source(:buffer_saved, source, ctx.callback_registry) ==
+             []
+
+    assert CodeLease.source_status(source, server: ctx.code_lease) == :unknown
+    assert CodeLease.active_leases(source: source, server: ctx.code_lease) == []
+    assert {:load_error, %{reason: :killed}} = Instance.phase(authority)
+
+    assert {:ok, %{status: :load_error, pid: nil, last_error: :killed}} =
+             ExtRegistry.get(ctx.registry, name)
+
+    retry_opts = Keyword.put(ctx.opts, :callbacks, %{})
+    assert {:ok, replacement} = start_extension(ctx, name, entry, retry_opts)
+    assert_receive {:runtime_child_started, ^replacement}
+    assert {:running, %{pid: ^replacement}} = Instance.phase(authority)
+    assert :ok = stop_extension(ctx, name, retry_opts)
+  end
+
+  test "transition timeout after child start rolls back the known runtime without duplication",
+       ctx do
+    name = unique_name(:known_runtime_timeout)
+    entry = register_module(ctx, name, [runtime_test_pid: self()], CrashContributionRuntime)
+    callback_registry = Process.whereis(ctx.callback_registry)
+    :ok = :sys.suspend(callback_registry)
+
+    opts = Keyword.put(ctx.opts, :transition_timeout_ms, 25)
+    start_task = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
+    assert_receive {:runtime_child_started, runtime}, 5_000
+    runtime_ref = Process.monitor(runtime)
+    Process.send_after(self(), :resume_callback_registry, 50)
+    assert_receive :resume_callback_registry
+    :ok = :sys.resume(callback_registry)
+
+    assert {:error, {:transition_timeout, :start, 25}} = Task.await(start_task)
+    assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, _reason}, 5_000
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+    assert :error = CommandRegistry.lookup(ctx.commands, :crash_contribution_command)
+    assert {:ok, projection} = ExtRegistry.get(ctx.registry, name)
+    assert projection.status == :load_error
+    assert projection.pid == nil
+
+    assert {:ok, replacement} = start_extension(ctx, name, entry)
+    assert_receive {:runtime_child_started, ^replacement}
+    assert {:ok, _command} = CommandRegistry.lookup(ctx.commands, :crash_contribution_command)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, replacement}
+    assert :ok = stop_extension(ctx, name, ctx.opts)
+  end
+
+  test "blocked child start MFA replaces the wedged runtime branch within the authority deadline",
+       ctx do
+    name = unique_name(:blocked_child_start)
+    attempts = start_supervised!({Agent, fn -> 0 end})
+
+    entry =
+      register_module(
+        ctx,
+        name,
+        [attempts: attempts, runtime_test_pid: self()],
+        BlockedThenStarts
+      )
+
+    opts =
+      ctx.opts
+      |> Keyword.put(:transition_timeout_ms, 25)
+      |> Keyword.put(:runtime_query_timeout_ms, 10)
+
+    start_task = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
+    assert_receive {:blocked_child_start_mfa, old_runtime_supervisor}
+    old_instance = instance_pid(ctx, name)
+    supervisor_ref = Process.monitor(old_runtime_supervisor)
+
+    assert {:error, {:transition_timeout, :start, 25}} = Task.await(start_task, 1_000)
+    assert_receive {:DOWN, ^supervisor_ref, :process, ^old_runtime_supervisor, :killed}
+    _new_instance = await_new_instance(ctx, name, old_instance)
+
+    assert eventually(fn ->
+             RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+           end)
+
+    retry_task = Task.async(fn -> start_extension(ctx, name, entry) end)
+    assert_receive {:retry_child_start_mfa, retry_runtime_supervisor}, 5_000
+    refute Task.yield(retry_task, 50)
+
+    state = :sys.get_state(instance(ctx, name))
+
+    assert Minga.Extension.Instance.TransitionHandler.transition_timeout(state) == 120_000
+
+    send(retry_runtime_supervisor, :release_retry_child_start)
+    assert {:ok, runtime} = Task.await(retry_task)
+    assert_receive {:runtime_child_started, ^runtime}
+    refute_receive {:runtime_child_started, _duplicate}
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
+    assert :ok = stop_extension(ctx, name, ctx.opts)
+  end
+
+  test "infinite runtime shutdown returns a typed failure and replaces the wedged branch", ctx do
+    name = unique_name(:infinite_shutdown)
+    attempts = start_supervised!({Agent, fn -> 0 end})
+
+    entry =
+      register_module(
+        ctx,
+        name,
+        [attempts: attempts, runtime_test_pid: self()],
+        InfiniteShutdownThenStops
+      )
+
+    assert {:ok, runtime} = start_extension(ctx, name, entry)
+    assert_receive {:runtime_child_started, ^runtime}
+    assert_receive {:infinite_shutdown_ready, ^runtime}
+    runtime_ref = Process.monitor(runtime)
+    old_instance = instance_pid(ctx, name)
+    old_runtime_supervisor = runtime_supervisor_pid(ctx, name)
+    supervisor_ref = Process.monitor(old_runtime_supervisor)
+    opts = Keyword.put(ctx.opts, :callback_timeout_ms, 25)
+
+    stop_task = Task.async(fn -> stop_extension(ctx, name, opts) end)
+
+    assert {:error, {:runtime_termination_failed, {:transition_timeout, :terminate, 25}}} =
+             Task.await(stop_task, 1_000)
+
+    assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, :killed}
+    assert_receive {:DOWN, ^supervisor_ref, :process, ^old_runtime_supervisor, :killed}
+    _new_instance = await_new_instance(ctx, name, old_instance)
+
+    assert {:ok, replacement} =
+             eventually(fn ->
+               case start_extension(ctx, name, entry) do
+                 {:ok, _pid} = started -> started
+                 {:error, _reason} -> nil
+               end
+             end)
+
+    assert_receive {:runtime_child_started, ^replacement}
+    refute replacement == runtime
+    refute_receive {:runtime_child_started, _duplicate}
+    assert :ok = stop_extension(ctx, name, ctx.opts)
+  end
+
+  test "bounded finalizer and cleanup workers reply queued callers with typed failures", ctx do
+    finalizer_name = unique_name(:finalizer_timeout)
+    finalizer_entry = register_module(ctx, finalizer_name, [])
+    assert {:ok, runtime} = start_extension(ctx, finalizer_name, finalizer_entry)
+    parent = self()
+
+    blocked_finalizer = fn _source ->
+      send(parent, {:timeout_worker, :finalizer, self()})
+      receive do: (:never -> :ok)
+    end
+
+    finalizer_opts =
+      ctx.opts
+      |> Keyword.put(:callback_timeout_ms, 25)
+      |> Keyword.put(:callbacks, %{editor_effects: blocked_finalizer})
+
+    finalizer_stop = Task.async(fn -> stop_extension(ctx, finalizer_name, finalizer_opts) end)
+    assert_receive {:timeout_worker, :finalizer, finalizer_worker}
+    finalizer_ref = Process.monitor(finalizer_worker)
+
+    assert {:error,
+            {:source_quiesce_failed, {:transition_timeout, {:finalizer, :editor_effects}, 25}}} =
+             Task.await(finalizer_stop)
+
+    assert_receive {:DOWN, ^finalizer_ref, :process, ^finalizer_worker, :killed}
+
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, finalizer_name)) ==
+             {:ok, runtime}
+
+    assert :ok = stop_extension(ctx, finalizer_name, Keyword.put(ctx.opts, :callbacks, %{}))
+
+    cleanup_name = unique_name(:cleanup_timeout)
+    cleanup_entry = register_module(ctx, cleanup_name, [], RuntimeTwo)
+    assert {:ok, _runtime} = start_extension(ctx, cleanup_name, cleanup_entry)
+
+    blocked_cleanup = fn _source ->
+      send(parent, {:timeout_worker, :cleanup, self()})
+      receive do: (:never -> :ok)
+    end
+
+    cleanup_opts =
+      ctx.opts
+      |> Keyword.put(:callback_timeout_ms, 25)
+      |> Keyword.put(:callbacks, %{blocked_cleanup: blocked_cleanup})
+
+    cleanup_stop = Task.async(fn -> stop_extension(ctx, cleanup_name, cleanup_opts) end)
+    assert_receive {:timeout_worker, :cleanup, cleanup_worker}
+    cleanup_ref = Process.monitor(cleanup_worker)
+
+    assert {:error,
+            {:cleanup_failed,
+             [
+               %{
+                 family: :cleanup_worker,
+                 reason: {:transition_timeout, :cleanup, 25}
+               }
+             ]}} = Task.await(cleanup_stop)
+
+    assert_receive {:DOWN, ^cleanup_ref, :process, ^cleanup_worker, :killed}
+    assert :ok = stop_extension(ctx, cleanup_name, Keyword.put(ctx.opts, :callbacks, %{}))
+  end
+
+  test "declaration removal after child start fails projection and rolls back", ctx do
+    name = unique_name(:projection_removal)
+    entry = register_module(ctx, name, runtime_test_pid: self())
+    callback_registry = Process.whereis(ctx.callback_registry)
+    :ok = :sys.suspend(callback_registry)
+    start_task = Task.async(fn -> start_extension(ctx, name, entry) end)
+    assert_receive {:runtime_child_started, runtime}, 5_000
+    runtime_ref = Process.monitor(runtime)
+    :ok = ExtRegistry.unregister(ctx.registry, name)
+    :ok = :sys.resume(callback_registry)
+
+    assert {:error, {:extension_not_declared, ^name}} = Task.await(start_task)
+    assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, _reason}, 5_000
+    assert :error = ExtRegistry.get(ctx.registry, name)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
+  end
+
+  test "replacement Instance reads the current redeclared config", ctx do
+    name = unique_name(:current_declaration)
+    original = register_module(ctx, name, [])
+    assert :ok = stop_extension(ctx, name, ctx.opts)
+    :ok = ExtRegistry.register_module(ctx.registry, name, RuntimeTwo, marker: :current)
+    {:ok, replacement} = ExtRegistry.get(ctx.registry, name)
+    assert :ok = Instance.declare(instance(ctx, name), replacement, ctx.registry, ctx.opts)
+
+    on_exit(fn ->
+      case InstanceRegistry.whereis(instance_registry(ctx), :root, name) do
+        pid when is_pid(pid) -> :sys.resume(pid)
+        nil -> :ok
+      end
+    end)
+
+    race = start_supervised!({Agent, fn -> :armed end})
+
+    after_located = fn ^name, _instance ->
+      case Agent.get_and_update(race, fn
+             :armed -> {:kill, :killed}
+             state -> {:skip, state}
+           end) do
+        :kill ->
+          root = InstanceRegistry.whereis(instance_registry(ctx), :root, name)
+          authority = instance_pid(ctx, name)
+          ref = Process.monitor(authority)
+          :ok = :sys.suspend(root)
+          Process.exit(authority, :kill)
+          assert_receive {:DOWN, ^ref, :process, ^authority, :killed}
+
+        :skip ->
+          :ok
+      end
+    end
+
+    before_retry = fn ^name ->
+      root = InstanceRegistry.whereis(instance_registry(ctx), :root, name)
+      :ok = :sys.resume(root)
+      Agent.update(race, fn :killed -> :retried end)
+    end
+
+    opts =
+      Keyword.put(ctx.opts, :test_hooks, %{
+        after_authority_located: after_located,
+        before_authority_retry: before_retry
+      })
+
+    assert {:ok, runtime} = start_extension(ctx, name, replacement, opts)
+    assert Agent.get(race, & &1) == :retried
+    assert Agent.get(runtime, & &1) == :runtime_two
+    refute_receive {:runtime_child_started, _duplicate}
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
+    refute replacement == original
+  end
+
+  test "restart policies cover normal shutdown tuple-shutdown and abnormal reasons", ctx do
+    telemetry_id = {__MODULE__, unique_name(:restart_matrix)}
+    recipient = self()
 
     :telemetry.attach_many(
       telemetry_id,
       [
+        [:minga, :extension, :lifecycle, :crash_restart_count],
         [:minga, :extension, :lifecycle, :stop],
-        [:minga, :extension, :lifecycle, :crash_restart_count]
+        [:minga, :extension, :lifecycle, :terminal]
       ],
       fn event, measurements, metadata, test_pid ->
-        send(test_pid, {:telemetry, event, measurements, metadata})
+        send(test_pid, {:policy_telemetry, event, measurements, metadata})
       end,
-      self()
+      recipient
     )
 
     on_exit(fn -> :telemetry.detach(telemetry_id) end)
 
-    {path, cleanup} =
-      make_extension("TelemetryExt", """
-      defmodule Minga.TestExtensions.TelemetryExt do
-        use Minga.Extension
+    permanent = unique_name(:permanent_matrix)
+    transient = unique_name(:transient_matrix)
+    temporary = unique_name(:temporary_matrix)
 
-        @impl true
-        def name, do: :telemetry_ext
+    permanent_entry = register_module(ctx, permanent, [restart: :permanent], Runtime)
+    transient_entry = register_module(ctx, transient, [restart: :transient], RuntimeTwo)
+    temporary_entry = register_module(ctx, temporary, [restart: :temporary], RuntimeThree)
 
-        @impl true
-        def description, do: "Telemetry extension"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.TelemetryExt)
-      :code.delete(Minga.TestExtensions.TelemetryExt)
-    end)
-
-    :ok = ExtRegistry.register(ctx.registry, :telemetry_ext, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :telemetry_ext)
-
-    assert {:ok, _pid} =
-             ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, :telemetry_ext, entry)
-
-    {:ok, running_entry} = ExtRegistry.get(ctx.registry, :telemetry_ext)
-
-    assert :ok =
-             ExtSupervisor.stop_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :telemetry_ext,
-               running_entry
-             )
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: duration},
-                    %{extension: :telemetry_ext, phase: :load}}
-
-    assert is_integer(duration)
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
-                    %{extension: :telemetry_ext, phase: :init}}
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
-                    %{extension: :telemetry_ext, phase: :child_start}}
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 0}, %{extension: :telemetry_ext, phase: :crash_restart_count}}
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
-                    %{extension: :telemetry_ext, phase: :stop}}
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
-                    %{extension: :telemetry_ext, phase: :cleanup}}
+    assert_policy_matrix(ctx, permanent, permanent_entry, :permanent)
+    assert_policy_matrix(ctx, transient, transient_entry, :transient)
+    assert_policy_matrix(ctx, temporary, temporary_entry, :temporary)
   end
 
-  test "crash restart telemetry increments when a supervised extension child restarts", ctx do
-    telemetry_id = {__MODULE__, self(), :restart_telemetry}
+  test "an Instance crash adopts only its own local runtime", ctx do
+    first = unique_name(:adopt_first)
+    second = unique_name(:adopt_second)
+    first_entry = register_module(ctx, first, [])
+    second_entry = register_module(ctx, second, [], RuntimeTwo)
+    assert {:ok, first_runtime} = start_extension(ctx, first, first_entry)
+    assert {:ok, second_runtime} = start_extension(ctx, second, second_entry)
 
-    :telemetry.attach_many(
-      telemetry_id,
-      [[:minga, :extension, :lifecycle, :crash_restart_count]],
-      fn event, measurements, metadata, test_pid ->
-        send(test_pid, {:telemetry, event, measurements, metadata})
-      end,
-      self()
-    )
+    old_instance = instance_pid(ctx, first)
+    Process.exit(old_instance, :kill)
+    new_instance = await_new_instance(ctx, first, old_instance)
 
-    on_exit(fn -> :telemetry.detach(telemetry_id) end)
-
-    {path, cleanup} =
-      make_extension("RestartTelemetry", """
-      defmodule Minga.TestExtensions.RestartTelemetry do
-        use Minga.Extension
-
-        @impl true
-        def name, do: :restart_telemetry
-
-        @impl true
-        def description, do: "Restart telemetry"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.RestartTelemetry)
-      :code.delete(Minga.TestExtensions.RestartTelemetry)
-    end)
-
-    :ok = ExtRegistry.register(ctx.registry, :restart_telemetry, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :restart_telemetry)
-
-    assert {:ok, pid} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :restart_telemetry,
-               entry
-             )
-
-    Process.exit(pid, :kill)
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 0}, %{extension: :restart_telemetry, phase: :crash_restart_count}}
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 1}, %{extension: :restart_telemetry, phase: :crash_restart_count}}
-
-    {:ok, restarted_entry} = ExtRegistry.get(ctx.registry, :restart_telemetry)
-    assert restarted_entry.pid != pid
-
-    assert :ok =
-             ExtSupervisor.stop_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :restart_telemetry,
-               restarted_entry
-             )
-
-    assert DynamicSupervisor.count_children(ctx.supervisor).active == 0
+    assert {:ok, ^first_runtime} = Instance.start(new_instance)
+    refute first_runtime == second_runtime
+    assert {:ok, ^second_runtime} = Instance.start(instance(ctx, second))
   end
 
-  test "concurrent double start with the same stale stopped entry is idempotent", ctx do
-    opts = [command_registry: ctx.command_registry, keymap: ctx.keymap]
+  test "RuntimeSupervisor replacement restarts Instance after an empty local supervisor", ctx do
+    name = unique_name(:runtime_supervisor_crash)
+    entry = register_module(ctx, name, [])
+    assert {:ok, runtime} = start_extension(ctx, name, entry)
+    old_instance = instance_pid(ctx, name)
+    old_runtime_supervisor = runtime_supervisor_pid(ctx, name)
 
-    :ok =
-      ExtRegistry.register_module(
-        ctx.registry,
-        :concurrent_double_start,
-        Minga.TestExtensions.ConcurrentDoubleStart,
-        test_pid: self()
-      )
-
-    {:ok, stale_stopped_entry} = ExtRegistry.get(ctx.registry, :concurrent_double_start)
-    parent_pid = self()
-
-    task_a =
-      Task.async(fn ->
-        ExtSupervisor.start_extension(
-          ctx.supervisor,
-          ctx.registry,
-          :concurrent_double_start,
-          stale_stopped_entry,
-          opts
-        )
-      end)
-
-    assert_receive {:concurrent_double_start_init_entered, init_pid}, 5_000
-
-    task_b =
-      Task.async(fn ->
-        send(parent_pid, {:concurrent_double_start_caller_ready, self()})
-
-        ExtSupervisor.start_extension(
-          ctx.supervisor,
-          ctx.registry,
-          :concurrent_double_start,
-          stale_stopped_entry,
-          opts
-        )
-      end)
-
-    assert_receive {:concurrent_double_start_caller_ready, task_b_pid}, 5_000
-    assert task_b_pid == task_b.pid
-    refute Task.yield(task_b, 50)
-    refute_receive {:concurrent_double_start_init_entered, _second_init_pid}, 50
-
-    send(init_pid, :release_concurrent_double_start_init)
-
-    assert [{:ok, pid_a}, {:ok, pid_b}] = [Task.await(task_a), Task.await(task_b)]
-    assert pid_a == pid_b
-    pid = pid_a
-
-    refute_receive {:concurrent_double_start_init_entered, _second_init_pid}, 50
-    assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, :concurrent_double_start_cmd)
-
-    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :concurrent_double_start)
-    assert final_entry.status == :running
-    assert final_entry.pid == pid
-    assert is_reference(final_entry.lifecycle_ref)
-
-    children = DynamicSupervisor.which_children(ctx.supervisor)
-
-    assert 1 ==
-             Enum.count(children, fn
-               {_id, child_pid, _type, [Minga.TestExtensions.ConcurrentDoubleStart]} ->
-                 child_pid == pid
-
-               _child ->
-                 false
-             end)
+    Process.exit(old_runtime_supervisor, :kill)
+    new_instance = await_new_instance(ctx, name, old_instance)
+    assert {:ok, replacement} = eventually(fn -> Instance.start(new_instance) end)
+    refute replacement == runtime
+    refute runtime_supervisor_pid(ctx, name) == old_runtime_supervisor
   end
 
-  test "stale stopped-entry stop does not stop or clean a newer lifecycle", ctx do
-    {path, cleanup} =
-      make_extension("StaleStoppedStop", """
-      defmodule Minga.TestExtensions.StaleStoppedStop do
-        use Minga.Extension
+  test "live CodeLease owner triggers a bounded retryable drain failure", ctx do
+    name = unique_name(:lease_drain_timeout)
+    entry = register_module(ctx, name, [])
+    assert {:ok, runtime} = start_extension(ctx, name, entry)
+    owner = spawn(fn -> receive do: (:done -> :ok) end)
+    on_exit(fn -> if Process.alive?(owner), do: Process.exit(owner, :kill) end)
 
-        command :stale_stopped_stop_cmd, "Stale stopped stop command",
-          execute: {__MODULE__, :noop}
-
-        @impl true
-        def name, do: :stale_stopped_stop
-
-        @impl true
-        def description, do: "Stale stopped stop"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-
-        @spec noop(map()) :: map()
-        def noop(state), do: state
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.StaleStoppedStop)
-      :code.delete(Minga.TestExtensions.StaleStoppedStop)
-    end)
-
-    opts = [command_registry: ctx.command_registry, keymap: ctx.keymap]
-
-    :ok = ExtRegistry.register(ctx.registry, :stale_stopped_stop, path, [])
-    {:ok, stale_stopped_entry} = ExtRegistry.get(ctx.registry, :stale_stopped_stop)
-
-    assert {:ok, pid} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :stale_stopped_stop,
-               stale_stopped_entry,
-               opts
+    assert {:ok, lease} =
+             CodeLease.admit_callback({:extension, name}, Runtime, :editor_event,
+               server: ctx.code_lease,
+               owner: owner
              )
 
-    assert :ok =
-             ExtSupervisor.stop_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :stale_stopped_stop,
-               stale_stopped_entry,
-               opts
-             )
+    opts = Keyword.put(ctx.opts, :drain_timeout_ms, 25)
 
-    assert {:ok, _} = CommandRegistry.lookup(ctx.command_registry, :stale_stopped_stop_cmd)
+    assert {:error, {:code_lease_drain_timeout, 25}} =
+             stop_extension(ctx, name, opts)
 
-    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :stale_stopped_stop)
-    assert final_entry.status == :running
-    assert final_entry.pid == pid
-    assert is_reference(final_entry.lifecycle_ref)
+    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
+    assert CodeLease.source_status({:extension, name}, server: ctx.code_lease) == :active
+
+    assert {:error, {:cleanup_retry_required, {:code_lease_drain_timeout, 25}}} =
+             start_extension(ctx, name, entry, opts)
+
+    assert :ok = CodeLease.release(lease)
+    send(owner, :done)
+    assert :ok = stop_extension(ctx, name, opts)
   end
 
-  test "stale terminal cleanup cannot remove newer lifecycle contributions", ctx do
-    test_pid = self()
-
-    {path, cleanup} =
-      make_extension("StaleTerminalCleanupRace", """
-      defmodule Minga.TestExtensions.StaleTerminalCleanupRace do
-        use Minga.Extension
-
-        command :stale_terminal_cleanup_race_cmd, "Stale terminal cleanup race command",
-          execute: {__MODULE__, :noop}
-
-        @impl true
-        def name, do: :stale_terminal_cleanup_race
-
-        @impl true
-        def description, do: "Stale terminal cleanup race"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-
-        @impl true
-        def child_spec(_config) do
-          %{
-            id: __MODULE__,
-            start: {Agent, :start_link, [fn -> :stale_terminal_cleanup_race end]},
-            restart: :temporary,
-            type: :worker
-          }
-        end
-
-        @spec noop(map()) :: map()
-        def noop(state), do: state
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.StaleTerminalCleanupRace)
-      :code.delete(Minga.TestExtensions.StaleTerminalCleanupRace)
-    end)
-
-    callbacks = %{
-      blocking_cleanup: fn source ->
-        send(test_pid, {:cleanup_started, self(), source})
-
-        receive do
-          :release_cleanup -> :ok
-        end
-      end
-    }
-
-    opts = [command_registry: ctx.command_registry, keymap: ctx.keymap, callbacks: callbacks]
-
-    :ok = ExtRegistry.register(ctx.registry, :stale_terminal_cleanup_race, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :stale_terminal_cleanup_race)
-
-    assert {:ok, pid_a} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :stale_terminal_cleanup_race,
-               entry,
-               opts
-             )
-
-    assert {:ok, _} =
-             CommandRegistry.lookup(ctx.command_registry, :stale_terminal_cleanup_race_cmd)
-
-    assert :ok = Agent.stop(pid_a, :normal)
-
-    assert_receive {:cleanup_started, cleanup_pid, {:extension, :stale_terminal_cleanup_race}}
-
-    start_task =
-      Task.async(fn ->
-        {:ok, current_entry} = ExtRegistry.get(ctx.registry, :stale_terminal_cleanup_race)
-
-        result =
-          ExtSupervisor.start_extension(
-            ctx.supervisor,
-            ctx.registry,
-            :stale_terminal_cleanup_race,
-            current_entry,
-            opts
-          )
-
-        send(test_pid, {:new_lifecycle_started, result})
-        result
-      end)
-
-    refute_receive {:new_lifecycle_started, _result}, 100
-
-    send(cleanup_pid, :release_cleanup)
-    assert {:ok, pid_b} = Task.await(start_task)
-    assert_receive {:new_lifecycle_started, {:ok, ^pid_b}}
-
-    assert {:ok, _} =
-             CommandRegistry.lookup(ctx.command_registry, :stale_terminal_cleanup_race_cmd)
-
-    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :stale_terminal_cleanup_race)
-    assert final_entry.pid == pid_b
-    assert final_entry.pid != pid_a
-    assert final_entry.status == :running
-    assert is_reference(final_entry.lifecycle_ref)
-  end
-
-  test "terminal cleanup failure is surfaced without clean stopped finalization", ctx do
-    telemetry_id = {__MODULE__, self(), :terminal_cleanup_failure_telemetry}
-
-    :telemetry.attach_many(
-      telemetry_id,
-      [[:minga, :extension, :lifecycle, :stop]],
-      fn event, measurements, metadata, test_pid ->
-        send(test_pid, {:telemetry, event, measurements, metadata})
-      end,
-      self()
-    )
-
-    on_exit(fn -> :telemetry.detach(telemetry_id) end)
-
-    {path, cleanup} =
-      make_extension("TerminalCleanupFailure", """
-      defmodule Minga.TestExtensions.TerminalCleanupFailure do
-        use Minga.Extension
-
-        command :terminal_cleanup_failure_cmd, "Terminal cleanup failure command",
-          execute: {__MODULE__, :noop}
-
-        @impl true
-        def name, do: :terminal_cleanup_failure
-
-        @impl true
-        def description, do: "Terminal cleanup failure"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-
-        @impl true
-        def child_spec(_config) do
-          %{
-            id: __MODULE__,
-            start: {Agent, :start_link, [fn -> :terminal_cleanup_failure end]},
-            restart: :temporary,
-            type: :worker
-          }
-        end
-
-        @spec noop(map()) :: map()
-        def noop(state), do: state
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.TerminalCleanupFailure)
-      :code.delete(Minga.TestExtensions.TerminalCleanupFailure)
-    end)
-
-    callbacks = %{failing_cleanup: fn _source -> {:error, :intentional_cleanup_failure} end}
-
-    :ok = ExtRegistry.register(ctx.registry, :terminal_cleanup_failure, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :terminal_cleanup_failure)
-
-    assert {:ok, pid} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :terminal_cleanup_failure,
-               entry,
-               command_registry: ctx.command_registry,
-               keymap: ctx.keymap,
-               callbacks: callbacks
-             )
-
-    assert :ok = Agent.stop(pid, :normal)
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :stop], %{duration: _},
-                    %{extension: :terminal_cleanup_failure, phase: :cleanup}}
-
-    failed_entry = wait_for_entry_status(ctx.registry, :terminal_cleanup_failure, :load_error)
-    assert failed_entry.pid == nil
-    assert failed_entry.lifecycle_ref == nil
-    assert failed_entry.module == Minga.TestExtensions.TerminalCleanupFailure
-  end
-
-  test "crashed child without replacement marks the registry crashed", ctx do
-    telemetry_id = {__MODULE__, self(), :crash_without_replacement_telemetry}
-
-    :telemetry.attach_many(
-      telemetry_id,
-      [[:minga, :extension, :lifecycle, :crash_restart_count]],
-      fn event, measurements, metadata, test_pid ->
-        send(test_pid, {:telemetry, event, measurements, metadata})
-      end,
-      self()
-    )
-
-    on_exit(fn -> :telemetry.detach(telemetry_id) end)
-
-    {path, cleanup} =
-      make_extension("CrashWithoutReplacement", """
-      defmodule Minga.TestExtensions.CrashWithoutReplacement do
-        use Minga.Extension
-
-        command :crash_without_replacement_cmd, "Crash cleanup command",
-          execute: {__MODULE__, :return_state}
-
-        editor_event_handler __MODULE__, [:editor_action]
-
-        @impl true
-        def name, do: :crash_without_replacement
-
-        @impl true
-        def description, do: "Crash without replacement"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-
-        @impl true
-        def child_spec(_config) do
-          %{
-            id: __MODULE__,
-            start: {Agent, :start_link, [fn -> :crash_without_replacement end]},
-            restart: :temporary,
-            type: :worker
-          }
-        end
-
-        @spec return_state(term()) :: term()
-        def return_state(state), do: state
-
-        @spec block(pid()) :: :settled
-        def block(test_pid) do
-          send(test_pid, {:crash_callback_running, self()})
-
-          receive do
-            :settle_crash_callback -> :settled
-          end
-        end
-
-        @spec handle_editor_event(term(), term()) :: :not_matched
-        def handle_editor_event(_state, _event), do: :not_matched
-
-        @spec handle_sidebar_action(term(), String.t(), map()) :: term()
-        def handle_sidebar_action(state, _action, _context), do: state
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.CrashWithoutReplacement)
-      :code.delete(Minga.TestExtensions.CrashWithoutReplacement)
-    end)
-
-    :ok = ExtRegistry.register(ctx.registry, :crash_without_replacement, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :crash_without_replacement)
-
-    assert {:ok, pid} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :crash_without_replacement,
-               entry,
-               command_registry: ctx.command_registry,
-               keymap: ctx.keymap
-             )
-
-    source = {:extension, :crash_without_replacement}
-    callback = Minga.TestExtensions.CrashWithoutReplacement
-    sidebar_id = "crash_cleanup_#{System.unique_integer([:positive])}"
-
-    assert :ok =
-             Sidebar.register(source, %{
-               id: sidebar_id,
-               display_name: "Crash cleanup",
-               description: "Removed after terminal crash",
-               action_handler: {callback, :handle_sidebar_action}
-             })
-
-    assert {:ok, _command} =
-             CommandRegistry.lookup(ctx.command_registry, :crash_without_replacement_cmd)
-
-    assert {source, callback} in CallbackRegistry.callbacks(:editor_action)
-    assert %Sidebar.Entry{} = Sidebar.get(sidebar_id)
-
-    test_pid = self()
-
-    callback_task =
-      Task.async(fn ->
-        CallbackInvoker.invoke(source, callback, :block, [test_pid], :command)
-      end)
-
-    assert_receive {:crash_callback_running, callback_owner}
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 0},
-                    %{extension: :crash_without_replacement, phase: :crash_restart_count}}
-
-    Process.exit(pid, :kill)
-
-    assert wait_for_admission_denial(source, callback) == :denied
-
-    assert {:ok, _command} =
-             CommandRegistry.lookup(ctx.command_registry, :crash_without_replacement_cmd)
-
-    assert %Sidebar.Entry{} = Sidebar.get(sidebar_id)
-    assert {source, callback} in CallbackRegistry.callbacks(:editor_action)
-
-    send(callback_owner, :settle_crash_callback)
-    assert {:ok, :settled} = Task.await(callback_task)
-
-    refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 1},
-                    %{extension: :crash_without_replacement, phase: :crash_restart_count}},
-                   150
-
-    crashed_entry = wait_for_entry_status(ctx.registry, :crash_without_replacement, :crashed)
-    assert crashed_entry.pid == nil
-    assert crashed_entry.lifecycle_ref == nil
-    assert :error = CommandRegistry.lookup(ctx.command_registry, :crash_without_replacement_cmd)
-    assert Sidebar.get(sidebar_id) == nil
-    refute {source, callback} in CallbackRegistry.callbacks(:editor_action)
-
-    assert {:error, {:source_unavailable, ^source, ^callback, :return_state, _reason}} =
-             CallbackInvoker.invoke(source, callback, :return_state, [:not_run], :command)
-
-    unrelated_source =
-      {:extension,
-       String.to_atom("crash_cleanup_unrelated_#{System.unique_integer([:positive])}")}
-
-    assert :ok = CodeLease.activate_source(unrelated_source, [callback])
-
-    assert {:ok, :unrelated} =
-             CallbackInvoker.invoke(
-               unrelated_source,
-               callback,
-               :return_state,
-               [:unrelated],
-               :command
-             )
-
-    assert {:ok, unrelated_token} = CodeLease.quiesce_source(unrelated_source)
-    assert :ok = CodeLease.complete_unload(unrelated_token)
-  end
-
-  test "terminal crash finalizer failure drains callbacks without reopening admission", ctx do
-    test_pid = self()
-    name = :crash_finalizer_failure
-    source = {:extension, name}
-
-    {path, cleanup} =
-      make_extension("CrashFinalizerFailure", """
-      defmodule Minga.TestExtensions.CrashFinalizerFailure do
-        use Minga.Extension
-
-        command :crash_finalizer_failure_cmd, "Crash finalizer failure command",
-          execute: {__MODULE__, :return_state}
-
-        editor_event_handler __MODULE__, [:editor_action]
-
-        @impl true
-        def name, do: :crash_finalizer_failure
-
-        @impl true
-        def description, do: "Crash finalizer failure"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-
-        @impl true
-        def child_spec(_config) do
-          %{
-            id: __MODULE__,
-            start: {Agent, :start_link, [fn -> :crash_finalizer_failure end]},
-            restart: :temporary,
-            type: :worker
-          }
-        end
-
-        @spec return_state(term()) :: term()
-        def return_state(state), do: state
-
-        @spec block(pid()) :: :settled
-        def block(test_pid) do
-          send(test_pid, {:failed_finalizer_callback_running, self()})
-
-          receive do
-            :settle_failed_finalizer_callback -> :settled
-          end
-        end
-
-        @spec handle_editor_event(term(), term()) :: :not_matched
-        def handle_editor_event(_state, _event), do: :not_matched
-
-        @spec handle_sidebar_action(term(), String.t(), map()) :: term()
-        def handle_sidebar_action(state, _action, _context), do: state
-      end
-      """)
-
-    callback = Minga.TestExtensions.CrashFinalizerFailure
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(callback)
-      :code.delete(callback)
-    end)
-
-    callbacks = %{
-      editor_effects: fn ^source, context ->
-        send(test_pid, {:terminal_crash_finalizer_failed, self(), context})
-        {:error, :editor_effects_unavailable}
-      end,
-      editor_sidebars: fn cleaned_source -> Sidebar.unregister_source(cleaned_source) end,
-      extension_callbacks: fn cleaned_source ->
-        CallbackRegistry.unregister_source(cleaned_source)
-      end,
-      zz_cleanup_observer: fn cleaned_source ->
-        send(test_pid, {:terminal_crash_cleanup_waiting, self(), cleaned_source})
-
-        receive do
-          :finish_terminal_crash_cleanup -> :ok
-        end
-      end
-    }
-
-    opts = [
-      command_registry: ctx.command_registry,
-      keymap: ctx.keymap,
-      callbacks: callbacks
-    ]
-
-    :ok = ExtRegistry.register(ctx.registry, name, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, name)
-
-    assert {:ok, runtime} =
-             ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, name, entry, opts)
-
-    sidebar_id = "crash_finalizer_failure_#{System.unique_integer([:positive])}"
-
-    assert :ok =
-             Sidebar.register(source, %{
-               id: sidebar_id,
-               display_name: "Crash finalizer failure",
-               description: "Removed after terminal crash",
-               action_handler: {callback, :handle_sidebar_action}
-             })
-
-    unrelated_name =
-      String.to_atom("crash_finalizer_unrelated_#{System.unique_integer([:positive])}")
-
-    unrelated_source = {:extension, unrelated_name}
-    unrelated_sidebar_id = "#{sidebar_id}_unrelated"
-
-    unrelated_command_name =
-      String.to_atom("crash_finalizer_unrelated_cmd_#{System.unique_integer([:positive])}")
-
-    unrelated_command = %Minga.Command{
-      name: unrelated_command_name,
-      description: "Unrelated crash cleanup command",
-      execute: fn state -> state end
-    }
-
-    assert :ok = CodeLease.activate_source(unrelated_source, [callback])
-
-    assert :ok =
-             CommandRegistry.register_command(
-               ctx.command_registry,
-               unrelated_source,
-               unrelated_command
-             )
-
-    assert :ok =
-             Sidebar.register(unrelated_source, %{
-               id: unrelated_sidebar_id,
-               display_name: "Unrelated crash cleanup",
-               description: "Must survive another source's crash",
-               action_handler: {callback, :handle_sidebar_action}
-             })
-
-    assert {:ok, _command} =
-             CommandRegistry.lookup(ctx.command_registry, :crash_finalizer_failure_cmd)
-
-    assert {:ok, _command} =
-             CommandRegistry.lookup(ctx.command_registry, unrelated_command_name)
-
-    assert {source, callback} in CallbackRegistry.callbacks(:editor_action)
-    assert %Sidebar.Entry{} = Sidebar.get(sidebar_id)
-    assert %Sidebar.Entry{} = Sidebar.get(unrelated_sidebar_id)
-
-    callback_task =
-      Task.async(fn ->
-        CallbackInvoker.invoke(source, callback, :block, [test_pid], :command)
-      end)
-
-    assert_receive {:failed_finalizer_callback_running, callback_owner}
-    Process.exit(runtime, :kill)
-
-    assert_receive {:terminal_crash_finalizer_failed, cleanup_owner,
-                    %{
-                      callback_admission: callback_admission,
-                      callback_registry: callback_registry,
-                      token: token
-                    }}
-
-    assert callback_admission == CodeLease
-    assert callback_registry == CallbackRegistry.default_table()
-    assert is_reference(token)
-
-    assert {:error,
-            {:source_unavailable, ^source, ^callback, :return_state, {:source_quiescing, ^source}}} =
-             CallbackInvoker.invoke(source, callback, :return_state, [:not_run], :command)
-
-    refute_receive {:terminal_crash_cleanup_waiting, _, ^source}
-
-    assert {:ok, _command} =
-             CommandRegistry.lookup(ctx.command_registry, :crash_finalizer_failure_cmd)
-
-    assert %Sidebar.Entry{} = Sidebar.get(sidebar_id)
-    assert {source, callback} in CallbackRegistry.callbacks(:editor_action)
-
-    send(callback_owner, :settle_failed_finalizer_callback)
-    assert {:ok, :settled} = Task.await(callback_task)
-
-    assert_receive {:terminal_crash_cleanup_waiting, ^cleanup_owner, ^source}
-
-    assert {:error,
-            {:source_unavailable, ^source, ^callback, :return_state, {:source_inactive, ^source}}} =
-             CallbackInvoker.invoke(source, callback, :return_state, [:not_run], :command)
-
-    assert :error = CommandRegistry.lookup(ctx.command_registry, :crash_finalizer_failure_cmd)
-    assert Sidebar.get(sidebar_id) == nil
-    refute {source, callback} in CallbackRegistry.callbacks(:editor_action)
-
-    assert {:ok, _command} =
-             CommandRegistry.lookup(ctx.command_registry, unrelated_command_name)
-
-    assert %Sidebar.Entry{} = Sidebar.get(unrelated_sidebar_id)
-
-    assert {:ok, :unrelated} =
-             CallbackInvoker.invoke(
-               unrelated_source,
-               callback,
-               :return_state,
-               [:unrelated],
-               :command
-             )
-
-    send(cleanup_owner, :finish_terminal_crash_cleanup)
-
-    failed_entry = wait_for_entry_status(ctx.registry, name, :load_error)
-    assert failed_entry.pid == nil
-    assert failed_entry.lifecycle_ref == nil
-
-    assert {:terminal_crash_cleanup_failed,
-            [
-              quiesce:
-                {:source_quiesce_failed,
-                 {:terminal_crash_quiesce_failed,
-                  [
-                    finalizers:
-                      {:terminal_finalizers_failed,
-                       [editor_effects: %{reason: :editor_effects_unavailable}]}
-                  ]}}
-            ]} = failed_entry.last_error
-
-    assert {:error,
-            {:source_unavailable, ^source, ^callback, :return_state, {:source_inactive, ^source}}} =
-             CallbackInvoker.invoke(source, callback, :return_state, [:not_run], :command)
-
-    assert :ok = CommandRegistry.unregister_source(ctx.command_registry, unrelated_source)
-    assert :ok = Sidebar.unregister_source(unrelated_source)
-    assert {:ok, unrelated_token} = CodeLease.quiesce_source(unrelated_source)
-    assert :ok = CodeLease.complete_unload(unrelated_token)
-  end
-
-  test "normal terminal finalizer failure drains callbacks without reopening admission", ctx do
-    test_pid = self()
-    name = :normal_exit_finalizer_failure
-    source = {:extension, name}
-
-    {path, cleanup} =
-      make_extension("NormalExitFinalizerFailure", """
-      defmodule Minga.TestExtensions.NormalExitFinalizerFailure do
-        use Minga.Extension
-
-        command :normal_exit_finalizer_failure_cmd, "Normal exit finalizer failure command",
-          execute: {__MODULE__, :return_state}
-
-        editor_event_handler __MODULE__, [:editor_action]
-
-        @impl true
-        def name, do: :normal_exit_finalizer_failure
-
-        @impl true
-        def description, do: "Normal exit finalizer failure"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-
-        @impl true
-        def child_spec(_config) do
-          %{
-            id: __MODULE__,
-            start: {Agent, :start_link, [fn -> :normal_exit_finalizer_failure end]},
-            restart: :temporary,
-            type: :worker
-          }
-        end
-
-        @spec return_state(term()) :: term()
-        def return_state(state), do: state
-
-        @spec block(pid()) :: :settled
-        def block(test_pid) do
-          send(test_pid, {:normal_exit_callback_running, self()})
-
-          receive do
-            :settle_normal_exit_callback -> :settled
-          end
-        end
-
-        @spec handle_editor_event(term(), term()) :: :not_matched
-        def handle_editor_event(_state, _event), do: :not_matched
-
-        @spec handle_sidebar_action(term(), String.t(), map()) :: term()
-        def handle_sidebar_action(state, _action, _context), do: state
-      end
-      """)
-
-    callback = Minga.TestExtensions.NormalExitFinalizerFailure
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(callback)
-      :code.delete(callback)
-    end)
-
-    callbacks = %{
-      editor_effects: fn ^source, context ->
-        send(test_pid, {:normal_exit_finalizer_failed, self(), context})
-        {:error, :editor_effects_unavailable}
-      end,
-      editor_sidebars: fn cleaned_source -> Sidebar.unregister_source(cleaned_source) end,
-      extension_callbacks: fn cleaned_source ->
-        CallbackRegistry.unregister_source(cleaned_source)
-      end,
-      zz_cleanup_observer: fn cleaned_source ->
-        send(test_pid, {:normal_exit_cleanup_waiting, self(), cleaned_source})
-
-        receive do
-          :finish_normal_exit_cleanup -> :ok
-        end
-      end
-    }
-
-    opts = [
-      command_registry: ctx.command_registry,
-      keymap: ctx.keymap,
-      callbacks: callbacks
-    ]
-
-    :ok = ExtRegistry.register(ctx.registry, name, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, name)
-
-    assert {:ok, runtime} =
-             ExtSupervisor.start_extension(ctx.supervisor, ctx.registry, name, entry, opts)
-
-    sidebar_id = "normal_exit_finalizer_failure_#{System.unique_integer([:positive])}"
-
-    assert :ok =
-             Sidebar.register(source, %{
-               id: sidebar_id,
-               display_name: "Normal exit finalizer failure",
-               description: "Removed after terminal normal exit",
-               action_handler: {callback, :handle_sidebar_action}
-             })
-
-    unrelated_name =
-      String.to_atom("normal_exit_unrelated_#{System.unique_integer([:positive])}")
-
-    unrelated_source = {:extension, unrelated_name}
-    unrelated_sidebar_id = "#{sidebar_id}_unrelated"
-
-    unrelated_command_name =
-      String.to_atom("normal_exit_unrelated_cmd_#{System.unique_integer([:positive])}")
-
-    unrelated_command = %Minga.Command{
-      name: unrelated_command_name,
-      description: "Unrelated normal exit cleanup command",
-      execute: fn state -> state end
-    }
-
-    assert :ok = CodeLease.activate_source(unrelated_source, [callback])
-
-    assert :ok =
-             CommandRegistry.register_command(
-               ctx.command_registry,
-               unrelated_source,
-               unrelated_command
-             )
-
-    assert :ok =
-             Sidebar.register(unrelated_source, %{
-               id: unrelated_sidebar_id,
-               display_name: "Unrelated normal exit cleanup",
-               description: "Must survive another source's normal exit",
-               action_handler: {callback, :handle_sidebar_action}
-             })
-
-    callback_task =
-      Task.async(fn ->
-        CallbackInvoker.invoke(source, callback, :block, [test_pid], :command)
-      end)
-
-    assert_receive {:normal_exit_callback_running, callback_owner}
-    runtime_monitor = Process.monitor(runtime)
-    assert :ok = Agent.stop(runtime, :normal)
-    assert_receive {:DOWN, ^runtime_monitor, :process, ^runtime, :normal}
-
-    assert_receive {:normal_exit_finalizer_failed, cleanup_owner,
-                    %{
-                      callback_admission: callback_admission,
-                      callback_registry: callback_registry,
-                      token: token
-                    }}
-
-    assert callback_admission == CodeLease
-    assert callback_registry == CallbackRegistry.default_table()
-    assert is_reference(token)
-
-    assert {:error,
-            {:source_unavailable, ^source, ^callback, :return_state, {:source_quiescing, ^source}}} =
-             CallbackInvoker.invoke(source, callback, :return_state, [%{}], :command)
-
-    refute_receive {:normal_exit_cleanup_waiting, _, ^source}
-
-    assert {:ok, _command} =
-             CommandRegistry.lookup(ctx.command_registry, :normal_exit_finalizer_failure_cmd)
-
-    assert %Sidebar.Entry{} = Sidebar.get(sidebar_id)
-    assert {source, callback} in CallbackRegistry.callbacks(:editor_action)
-
-    send(callback_owner, :settle_normal_exit_callback)
-    assert {:ok, :settled} = Task.await(callback_task)
-
-    assert_receive {:normal_exit_cleanup_waiting, ^cleanup_owner, ^source}
-
-    assert {:error,
-            {:source_unavailable, ^source, ^callback, :return_state, {:source_inactive, ^source}}} =
-             CallbackInvoker.invoke(source, callback, :return_state, [%{}], :command)
-
-    assert :error =
-             CommandRegistry.lookup(ctx.command_registry, :normal_exit_finalizer_failure_cmd)
-
-    assert Sidebar.get(sidebar_id) == nil
-    refute {source, callback} in CallbackRegistry.callbacks(:editor_action)
-
-    assert {:ok, _command} =
-             CommandRegistry.lookup(ctx.command_registry, unrelated_command_name)
-
-    assert %Sidebar.Entry{} = Sidebar.get(unrelated_sidebar_id)
-
-    assert {:ok, :unrelated} =
-             CallbackInvoker.invoke(
-               unrelated_source,
-               callback,
-               :return_state,
-               [:unrelated],
-               :command
-             )
-
-    send(cleanup_owner, :finish_normal_exit_cleanup)
-
-    failed_entry = wait_for_entry_status(ctx.registry, name, :load_error)
-    assert failed_entry.pid == nil
-    assert failed_entry.lifecycle_ref == nil
-
-    assert {:terminal_exit_cleanup_failed,
-            [
-              quiesce:
-                {:source_quiesce_failed,
-                 {:terminal_exit_quiesce_failed,
-                  [
-                    finalizers:
-                      {:terminal_finalizers_failed,
-                       [editor_effects: %{reason: :editor_effects_unavailable}]}
-                  ]}}
-            ]} = failed_entry.last_error
-
-    assert {:error,
-            {:source_unavailable, ^source, ^callback, :return_state, {:source_inactive, ^source}}} =
-             CallbackInvoker.invoke(source, callback, :return_state, [%{}], :command)
-
-    assert :ok = CommandRegistry.unregister_source(ctx.command_registry, unrelated_source)
-    assert :ok = Sidebar.unregister_source(unrelated_source)
-    assert {:ok, unrelated_token} = CodeLease.quiesce_source(unrelated_source)
-    assert :ok = CodeLease.complete_unload(unrelated_token)
-  end
-
-  test "delayed crash restart does not mark the lifecycle crashed before replacement starts",
-       ctx do
-    telemetry_id = {__MODULE__, self(), :restart_start_race_telemetry}
-    parent_pid = self()
-
-    :telemetry.attach_many(
-      telemetry_id,
-      [[:minga, :extension, :lifecycle, :crash_restart_count]],
-      fn event, measurements, metadata, test_pid ->
-        send(test_pid, {:telemetry, event, measurements, metadata})
-      end,
-      self()
-    )
-
-    on_exit(fn -> :telemetry.detach(telemetry_id) end)
-
-    {path, cleanup} =
-      make_extension("RestartStartRace", """
-      defmodule Minga.TestExtensions.RestartStartRace do
-        use Minga.Extension
-
-        command :restart_start_race_cmd, "Restart start race command", execute: {__MODULE__, :noop}
-
-        @impl true
-        def name, do: :restart_start_race
-
-        @impl true
-        def description, do: "Restart/start race"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-
-        @impl true
-        def child_spec(_config) do
-          %{
-            id: __MODULE__,
-            start: {Agent, :start_link, [fn -> :restart_start_race end]},
-            restart: :permanent,
-            type: :worker
-          }
-        end
-
-        @spec noop(map()) :: map()
-        def noop(state), do: state
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.RestartStartRace)
-      :code.delete(Minga.TestExtensions.RestartStartRace)
-    end)
-
-    :ok = ExtRegistry.register(ctx.registry, :restart_start_race, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :restart_start_race)
-    lookup_gate = start_supervised!({Agent, fn -> false end})
-
-    before_restart_lookup = fn ->
-      if Agent.get_and_update(lookup_gate, fn seen? -> {seen?, true} end) do
-        :ok
-      else
-        send(parent_pid, {:restart_lookup_blocked, self()})
-
-        receive do
-          :release_restart_lookup -> :ok
-        after
-          5_000 -> raise "restart lookup test hook timed out"
-        end
-      end
-    end
-
-    start_task =
-      Task.async(fn ->
-        ExtSupervisor.start_extension(
-          ctx.supervisor,
-          ctx.registry,
-          :restart_start_race,
-          entry,
-          command_registry: ctx.command_registry,
-          keymap: ctx.keymap,
-          test_hooks: %{before_restart_lookup: before_restart_lookup}
-        )
-      end)
-
-    assert {:ok, pid_a} = Task.await(start_task)
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 0}, %{extension: :restart_start_race, phase: :crash_restart_count}}
-
-    pid_a_ref = Process.monitor(pid_a)
-    Process.exit(pid_a, :kill)
-    assert_receive {:DOWN, ^pid_a_ref, :process, ^pid_a, _reason}, 1_000
-    assert_receive {:restart_lookup_blocked, restart_monitor_pid}, 1_000
-
-    {:ok, stale_running_entry} = ExtRegistry.get(ctx.registry, :restart_start_race)
-    assert stale_running_entry.status == :running
-    assert stale_running_entry.pid == pid_a
-
-    refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 1}, %{extension: :restart_start_race, phase: :crash_restart_count}},
-                   150
-
-    send(restart_monitor_pid, :release_restart_lookup)
-
-    pid_b = wait_for_child_pid(ctx.supervisor, Minga.TestExtensions.RestartStartRace, pid_a)
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 1}, %{extension: :restart_start_race, phase: :crash_restart_count}}
-
-    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :restart_start_race)
-    assert final_entry.status == :running
-    assert final_entry.pid == pid_b
-    assert 1 == count_children(ctx.supervisor, Minga.TestExtensions.RestartStartRace)
-    assert {:ok, _command} = CommandRegistry.lookup(ctx.command_registry, :restart_start_race_cmd)
-  end
-
-  test "restart reconciliation handles a dead supervisor without leaving stale state", ctx do
-    telemetry_id = {__MODULE__, self(), :restart_missing_replacement_telemetry}
-    parent_pid = self()
-
-    :telemetry.attach_many(
-      telemetry_id,
-      [[:minga, :extension, :lifecycle, :crash_restart_count]],
-      fn event, measurements, metadata, test_pid ->
-        send(test_pid, {:telemetry, event, measurements, metadata})
-      end,
-      self()
-    )
-
-    on_exit(fn -> :telemetry.detach(telemetry_id) end)
-
-    {path, cleanup} =
-      make_extension("RestartMissingReplacement", """
-      defmodule Minga.TestExtensions.RestartMissingReplacement do
-        use Minga.Extension
-
-        @impl true
-        def name, do: :restart_missing_replacement
-
-        @impl true
-        def description, do: "Restart missing replacement"
-
-        @impl true
-        def version, do: "1.0.0"
-
-        @impl true
-        def init(_config), do: {:ok, %{}}
-
-        @impl true
-        def child_spec(_config) do
-          %{
-            id: __MODULE__,
-            start: {Agent, :start_link, [fn -> :restart_missing_replacement end]},
-            restart: :permanent,
-            type: :worker
-          }
-        end
-      end
-      """)
-
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.RestartMissingReplacement)
-      :code.delete(Minga.TestExtensions.RestartMissingReplacement)
-    end)
-
-    :ok = ExtRegistry.register(ctx.registry, :restart_missing_replacement, path, [])
-
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :restart_missing_replacement)
-    lookup_gate = start_supervised!({Agent, fn -> false end})
-
-    before_restart_lookup = fn ->
-      if Agent.get_and_update(lookup_gate, fn seen? -> {seen?, true} end) do
-        :ok
-      else
-        send(parent_pid, {:restart_missing_replacement_lookup_blocked, self()})
-
-        receive do
-          :release_restart_lookup -> :ok
-        after
-          5_000 -> raise "restart lookup test hook timed out"
-        end
-      end
-    end
-
-    start_task =
-      Task.async(fn ->
-        ExtSupervisor.start_extension(
-          ctx.supervisor,
-          ctx.registry,
-          :restart_missing_replacement,
-          entry,
-          command_registry: ctx.command_registry,
-          keymap: ctx.keymap,
-          test_hooks: %{before_restart_lookup: before_restart_lookup}
-        )
-      end)
-
-    assert {:ok, pid} = Task.await(start_task)
-
-    pid_ref = Process.monitor(pid)
-    Process.exit(pid, :kill)
-    assert_receive {:DOWN, ^pid_ref, :process, ^pid, _reason}, 1_000
-    assert_receive {:restart_missing_replacement_lookup_blocked, restart_monitor_pid}, 1_000
-    previous_trap_exit = Process.flag(:trap_exit, true)
-    Process.exit(Process.whereis(ctx.supervisor), :kill)
-    assert_receive {:EXIT, _supervisor_pid, :killed}, 1_000
-    Process.flag(:trap_exit, previous_trap_exit)
-
-    {:ok, running_entry} = ExtRegistry.get(ctx.registry, :restart_missing_replacement)
-    assert running_entry.status == :running
-    assert running_entry.pid == pid
-
-    refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 1},
-                    %{extension: :restart_missing_replacement, phase: :crash_restart_count}},
-                   150
-
-    send(restart_monitor_pid, :release_restart_lookup)
-
-    crashed_entry =
-      wait_for_entry_status(ctx.registry, :restart_missing_replacement, :crashed, 20)
-
-    assert crashed_entry.pid == nil
-    assert crashed_entry.lifecycle_ref == nil
-  end
-
-  test "stale crash monitor does not overwrite a newer lifecycle", ctx do
-    telemetry_id = {__MODULE__, self(), :stale_monitor_race_telemetry}
-    test_pid = self()
-
-    :telemetry.attach_many(
-      telemetry_id,
-      [[:minga, :extension, :lifecycle, :crash_restart_count]],
-      fn event, measurements, metadata, test_pid ->
-        send(test_pid, {:telemetry, event, measurements, metadata})
-      end,
-      self()
-    )
-
-    on_exit(fn -> :telemetry.detach(telemetry_id) end)
-
-    stale_monitor_gate = fn ->
-      send(test_pid, {:stale_monitor_terminal_exit_blocked, self()})
+  test "terminal crash replies queued stop and start waiters exactly once", ctx do
+    name = unique_name(:terminal_queued_waiters)
+    parent = self()
+
+    finalizer = fn _source ->
+      send(parent, {:terminal_finalizer_blocked, self()})
 
       receive do
-        :release_stale_monitor_terminal_exit -> :ok
-      after
-        5_000 -> raise "timed out waiting to release stale monitor terminal exit"
+        :release -> {:error, :terminal_editor_failure}
       end
-
-      send(test_pid, {:stale_monitor_terminal_exit_released, self()})
-      :ok
     end
 
-    {path, cleanup} =
-      make_extension("StaleMonitorRace", """
-      defmodule Minga.TestExtensions.StaleMonitorRace do
-        use Minga.Extension
+    opts = Keyword.put(ctx.opts, :callbacks, %{editor_effects: finalizer})
+    entry = register_module(ctx, name, restart: :temporary)
+    assert {:ok, runtime} = start_extension(ctx, name, entry, opts)
+    GenServer.stop(runtime, :abnormal)
+    assert_receive {:terminal_finalizer_blocked, finalizer_worker}
 
-        @impl true
-        def name, do: :stale_monitor_race
+    start_task = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
+    stop_task = Task.async(fn -> stop_extension(ctx, name, opts) end)
+    refute Task.yield(start_task, 25)
+    refute Task.yield(stop_task, 25)
+    send(finalizer_worker, :release)
 
-        @impl true
-        def description, do: "Stale monitor race"
+    expected =
+      {:terminal_crash_cleanup_failed,
+       [
+         quiesce: %{
+           family: :editor_effects,
+           source: {:extension, name},
+           reason: :terminal_editor_failure
+         }
+       ]}
 
-        @impl true
-        def version, do: "1.0.0"
+    assert {:error, ^expected} = Task.await(start_task)
+    assert {:error, ^expected} = Task.await(stop_task)
+    assert {:load_error, %{reason: ^expected}} = Instance.phase(instance(ctx, name))
+    refute_receive {:terminal_finalizer_blocked, _duplicate}
+  end
 
-        @impl true
-        def init(_config), do: {:ok, %{}}
+  test "non-restarting abnormal crash removes contributions and publishes exact crash", ctx do
+    name = unique_name(:terminal_crash_projection)
+    entry = register_module(ctx, name, [], CrashContributionRuntime)
+    source = {:extension, name}
+    assert {:ok, runtime} = start_extension(ctx, name, entry)
+    assert {:ok, _command} = CommandRegistry.lookup(ctx.commands, :crash_contribution_command)
 
-        @impl true
-        def child_spec(_config) do
-          %{
-            id: __MODULE__,
-            start: {Agent, :start_link, [fn -> :stale_monitor_race end]},
-            restart: :temporary,
-            type: :worker
-          }
-        end
-      end
-      """)
+    assert CallbackRegistry.callbacks_for_source(:buffer_saved, source, ctx.callback_registry) !=
+             []
 
-    on_exit(fn ->
-      cleanup.()
-      :code.purge(Minga.TestExtensions.StaleMonitorRace)
-      :code.delete(Minga.TestExtensions.StaleMonitorRace)
-    end)
+    GenServer.stop(runtime, :abnormal)
 
-    opts = [test_hooks: %{before_terminal_child_exit: stale_monitor_gate}]
+    assert {:crashed, %{reason: :abnormal}} =
+             eventually(fn ->
+               case Instance.phase(instance(ctx, name)) do
+                 {:crashed, %{reason: :abnormal}} = phase -> phase
+                 _phase -> nil
+               end
+             end)
 
-    :ok = ExtRegistry.register(ctx.registry, :stale_monitor_race, path, [])
-    {:ok, entry} = ExtRegistry.get(ctx.registry, :stale_monitor_race)
+    assert {:ok, projection} = ExtRegistry.get(ctx.registry, name)
+    assert projection.status == :crashed
+    assert projection.pid == nil
+    assert projection.last_error == :abnormal
+    assert :error = CommandRegistry.lookup(ctx.commands, :crash_contribution_command)
 
-    assert {:ok, pid_a} =
-             ExtSupervisor.start_extension(
-               ctx.supervisor,
-               ctx.registry,
-               :stale_monitor_race,
-               entry,
-               opts
+    assert CallbackRegistry.callbacks_for_source(:buffer_saved, source, ctx.callback_registry) ==
+             []
+
+    assert CodeLease.source_status(source, server: ctx.code_lease) == :inactive
+  end
+
+  test "CodeLease drain completion is event-driven", ctx do
+    source = {:extension, unique_name(:lease_drain)}
+    assert :ok = CodeLease.activate_source(source, [Runtime], server: ctx.code_lease)
+    owner = spawn(fn -> receive do: (:done -> :ok) end)
+
+    assert {:ok, lease} =
+             CodeLease.admit_callback(source, Runtime, :editor_event,
+               server: ctx.code_lease,
+               owner: owner
              )
 
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 0}, %{extension: :stale_monitor_race, phase: :crash_restart_count}}
+    assert {:ok, _token} = CodeLease.quiesce_source(source, server: ctx.code_lease)
+    ref = make_ref()
+    assert :ok = CodeLease.notify_when_drained(source, self(), ref, server: ctx.code_lease)
+    refute_receive {CodeLease, :drained, ^source, ^ref}
+    assert :ok = CodeLease.release(lease)
+    assert_receive {CodeLease, :drained, ^source, ^ref}
+    send(owner, :done)
+  end
 
-    Process.exit(pid_a, :kill)
+  @spec assert_policy_matrix(
+          map(),
+          atom(),
+          ExtRegistry.entry(),
+          :permanent | :transient | :temporary
+        ) :: :ok
+  defp assert_policy_matrix(ctx, name, entry, policy) do
+    assert {:ok, initial_pid} = start_extension(ctx, name, entry)
 
-    assert_receive {:stale_monitor_terminal_exit_blocked, monitor_pid}, 5_000
+    assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: 0}, %{extension: ^name}}
 
-    restart_log =
-      capture_log(fn ->
-        result =
-          ExtSupervisor.start_extension(
-            ctx.supervisor,
-            ctx.registry,
-            :stale_monitor_race,
-            entry
-          )
+    final_pid =
+      Enum.reduce([:normal, :shutdown, {:shutdown, :policy}, :abnormal], initial_pid, fn reason,
+                                                                                         pid ->
+        terminate_with_reason(pid, reason)
 
-        send(test_pid, {:stale_monitor_restart_result, result})
+        assert_policy_transition(
+          ctx,
+          name,
+          entry,
+          reason,
+          pid,
+          restart_expected?(policy, reason)
+        )
       end)
 
-    assert_receive {:stale_monitor_restart_result, {:ok, pid_b}}, 5_000
-    refute restart_log =~ "redefining module Minga.TestExtensions.StaleMonitorRace"
-
-    assert_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 0}, %{extension: :stale_monitor_race, phase: :crash_restart_count}}
-
-    send(monitor_pid, :release_stale_monitor_terminal_exit)
-    assert_receive {:stale_monitor_terminal_exit_released, ^monitor_pid}, 5_000
-
-    refute_receive {:telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 1}, %{extension: :stale_monitor_race, phase: :crash_restart_count}},
-                   200
-
-    {:ok, final_entry} = ExtRegistry.get(ctx.registry, :stale_monitor_race)
-    assert final_entry.pid == pid_b
-    assert final_entry.status == :running
+    assert is_pid(final_pid)
+    assert :ok = stop_extension(ctx, name, ctx.opts)
+    :ok
   end
 
-  @spec wait_for_child_pid(GenServer.server(), module(), pid() | nil) :: pid()
-  defp wait_for_child_pid(supervisor, module, excluded_pid),
-    do: wait_for_child_pid(supervisor, module, excluded_pid, 50)
-
-  @spec wait_for_child_pid(GenServer.server(), module(), pid() | nil, non_neg_integer()) :: pid()
-  defp wait_for_child_pid(supervisor, module, excluded_pid, attempts_left) do
-    case child_pid(supervisor, module, excluded_pid) do
-      pid when is_pid(pid) ->
-        pid
-
-      nil when attempts_left > 0 ->
-        receive do
-        after
-          10 -> wait_for_child_pid(supervisor, module, excluded_pid, attempts_left - 1)
-        end
-
-      nil ->
-        flunk("expected #{inspect(module)} child to start")
-    end
-  end
-
-  @spec child_pid(GenServer.server(), module(), pid() | nil) :: pid() | nil
-  defp child_pid(supervisor, module, excluded_pid) do
-    supervisor
-    |> DynamicSupervisor.which_children()
-    |> Enum.find_value(fn
-      {_id, pid, _type, [^module]} when is_pid(pid) and pid != excluded_pid -> pid
-      _child -> nil
-    end)
-  end
-
-  @spec count_children(GenServer.server(), module()) :: non_neg_integer()
-  defp count_children(supervisor, module) do
-    supervisor
-    |> DynamicSupervisor.which_children()
-    |> Enum.count(fn
-      {_id, pid, _type, [^module]} when is_pid(pid) -> true
-      _child -> false
-    end)
-  end
-
-  @spec wait_for_admission_denial(CallbackInvoker.source(), module(), non_neg_integer()) ::
-          :denied
-  defp wait_for_admission_denial(source, callback, attempts \\ 100)
-
-  defp wait_for_admission_denial(source, callback, attempts) when attempts > 0 do
-    case CallbackInvoker.invoke(source, callback, :return_state, [:still_active], :command) do
-      {:error, {:source_unavailable, ^source, ^callback, :return_state, _reason}} ->
-        :denied
-
-      {:ok, :still_active} ->
-        receive do
-        after
-          5 -> wait_for_admission_denial(source, callback, attempts - 1)
-        end
-    end
-  end
-
-  defp wait_for_admission_denial(source, callback, 0) do
-    flunk("expected callback admission denial for #{inspect(source)} #{inspect(callback)}")
-  end
-
-  @spec wait_for_entry_status(GenServer.server(), atom(), Minga.Extension.extension_status()) ::
-          ExtRegistry.entry()
-  defp wait_for_entry_status(registry, name, status),
-    do: wait_for_entry_status(registry, name, status, 20)
-
-  @spec wait_for_entry_status(
-          GenServer.server(),
+  @spec assert_policy_transition(
+          map(),
           atom(),
-          Minga.Extension.extension_status(),
-          non_neg_integer()
-        ) ::
-          ExtRegistry.entry()
-  defp wait_for_entry_status(registry, name, status, attempts_left) do
-    case ExtRegistry.get(registry, name) do
-      {:ok, %{status: ^status} = entry} ->
-        entry
+          ExtRegistry.entry(),
+          term(),
+          pid(),
+          boolean()
+        ) :: pid()
+  defp assert_policy_transition(ctx, name, _entry, _reason, pid, true) do
+    assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: _count}, %{extension: ^name}}
 
-      _other when attempts_left > 0 ->
+    assert {:ok, replacement} = Instance.start(instance(ctx, name))
+    refute replacement == pid
+    replacement
+  end
+
+  defp assert_policy_transition(ctx, name, entry, reason, _pid, false) do
+    assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :stop],
+                    %{duration: _duration}, %{extension: ^name, phase: :cleanup, outcome: :ok}}
+
+    expected_phase = terminal_policy_phase(reason)
+
+    assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :terminal], %{count: 1},
+                    %{extension: ^name, phase: ^expected_phase}}
+
+    assert {:ok, replacement} = start_extension(ctx, name, entry)
+
+    assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
+                    %{count: _count}, %{extension: ^name}}
+
+    replacement
+  end
+
+  @spec terminal_policy_phase(term()) :: Minga.Extension.Instance.State.phase()
+  defp terminal_policy_phase(:abnormal), do: {:crashed, %{reason: :abnormal}}
+  defp terminal_policy_phase(_reason), do: :stopped
+
+  @spec terminate_with_reason(pid(), term()) :: :ok
+  defp terminate_with_reason(pid, :normal), do: Agent.stop(pid, :normal)
+  defp terminate_with_reason(pid, reason), do: GenServer.stop(pid, reason)
+
+  @spec restart_expected?(:permanent | :transient | :temporary, term()) :: boolean()
+  defp restart_expected?(:permanent, _reason), do: true
+  defp restart_expected?(:transient, :abnormal), do: true
+  defp restart_expected?(_policy, _reason), do: false
+
+  @spec register_module(map(), atom(), keyword(), module()) :: ExtRegistry.entry()
+  defp register_module(ctx, name, config, module \\ Runtime) do
+    :ok = ExtRegistry.register_module(ctx.registry, name, module, config)
+    {:ok, entry} = ExtRegistry.get(ctx.registry, name)
+    entry
+  end
+
+  @spec start_extension(map(), atom(), ExtRegistry.entry(), keyword()) ::
+          {:ok, pid()} | {:error, term()}
+  defp start_extension(ctx, name, entry, opts \\ []) do
+    ExtSupervisor.start_extension(
+      ctx.roots,
+      ctx.registry,
+      name,
+      entry,
+      Keyword.merge(ctx.opts, opts)
+    )
+  end
+
+  @spec stop_extension(map(), atom(), keyword()) :: :ok | {:error, term()}
+  defp stop_extension(ctx, name, opts) do
+    {:ok, entry} = ExtRegistry.get(ctx.registry, name)
+    ExtSupervisor.stop_extension(ctx.roots, ctx.registry, name, entry, opts)
+  end
+
+  @spec instance_registry(map()) :: atom()
+  defp instance_registry(ctx), do: InstanceRegistry.registry_for_root(ctx.roots)
+
+  @spec instance(map(), atom()) :: GenServer.server()
+  defp instance(ctx, name) do
+    InstanceRegistry.via(instance_registry(ctx), :instance, name)
+  end
+
+  @spec instance_pid(map(), atom()) :: pid()
+  defp instance_pid(ctx, name) do
+    InstanceRegistry.whereis(InstanceRegistry.registry_for_root(ctx.roots), :instance, name)
+  end
+
+  @spec runtime_supervisor(map(), atom()) :: GenServer.server()
+  defp runtime_supervisor(ctx, name) do
+    InstanceRegistry.via(InstanceRegistry.registry_for_root(ctx.roots), :runtime, name)
+  end
+
+  @spec runtime_supervisor_pid(map(), atom()) :: pid()
+  defp runtime_supervisor_pid(ctx, name) do
+    InstanceRegistry.whereis(InstanceRegistry.registry_for_root(ctx.roots), :runtime, name)
+  end
+
+  @spec await_runtime_replacement(map(), atom(), pid()) :: pid()
+  defp await_runtime_replacement(ctx, name, old_pid) do
+    eventually(fn ->
+      case RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) do
+        {:ok, pid} when pid != old_pid -> pid
+        _other -> nil
+      end
+    end)
+  end
+
+  @spec await_new_instance(map(), atom(), pid()) :: GenServer.server()
+  defp await_new_instance(ctx, name, old_pid) do
+    eventually(fn ->
+      case instance_pid(ctx, name) do
+        pid when is_pid(pid) and pid != old_pid -> instance(ctx, name)
+        _other -> nil
+      end
+    end)
+  end
+
+  @spec assert_eventually_phase(map(), atom(), atom()) :: :ok
+  defp assert_eventually_phase(ctx, name, tag) do
+    _ =
+      eventually(fn ->
+        case Instance.phase(instance(ctx, name)) do
+          {^tag, _context} -> :ok
+          ^tag -> :ok
+          _phase -> nil
+        end
+      end)
+
+    :ok
+  end
+
+  @spec eventually((-> result), non_neg_integer()) :: result when result: var
+  defp eventually(fun, attempts \\ 100)
+
+  defp eventually(fun, attempts) when attempts > 0 do
+    case fun.() do
+      nil ->
         receive do
         after
-          10 -> wait_for_entry_status(registry, name, status, attempts_left - 1)
+          10 -> eventually(fun, attempts - 1)
         end
 
-      other ->
-        flunk("expected #{inspect(name)} to reach #{inspect(status)}, got #{inspect(other)}")
+      false ->
+        receive do
+        after
+          10 -> eventually(fun, attempts - 1)
+        end
+
+      result ->
+        result
     end
   end
 
-  @spec make_extension(String.t(), String.t()) :: {String.t(), (-> :ok)}
-  defp make_extension(dir_name, source) do
-    dir =
-      Path.join(System.tmp_dir!(), "minga_ext_#{dir_name}_#{System.unique_integer([:positive])}")
+  defp eventually(fun, 0), do: flunk("condition not met: #{inspect(fun.())}")
 
-    File.mkdir_p!(dir)
-    File.write!(Path.join(dir, "extension.ex"), source)
-    {dir, fn -> File.rm_rf!(dir) end}
-  end
+  @spec unique_name(atom()) :: atom()
+  defp unique_name(prefix), do: :"#{prefix}_#{System.unique_integer([:positive])}"
 end

--- a/test/minga/extension/registry_test.exs
+++ b/test/minga/extension/registry_test.exs
@@ -203,8 +203,10 @@ defmodule Minga.Extension.RegistryTest do
       assert entry.path == "/tmp/ext"
     end
 
-    test "no-op for nonexistent extension", %{registry: r} do
-      :ok = Registry.update(r, :nonexistent, status: :running)
+    test "reports a missing declaration", %{registry: r} do
+      assert {:error, {:extension_not_declared, :nonexistent}} =
+               Registry.update(r, :nonexistent, status: :running)
+
       assert :error = Registry.get(r, :nonexistent)
     end
   end

--- a/test/minga/extension/supervisor_test.exs
+++ b/test/minga/extension/supervisor_test.exs
@@ -12,7 +12,9 @@ defmodule Minga.Extension.SupervisorTest do
   alias Minga.Extension.CallbackInvoker
   alias Minga.Extension.CallbackRegistry
   alias Minga.Extension.CodeLease
+  alias Minga.Extension.InstanceRegistry
   alias Minga.Extension.Registry, as: ExtRegistry
+  alias Minga.Extension.RuntimeSupervisor
   alias Minga.Extension.Supervisor, as: ExtSupervisor
   alias Minga.Keymap.Active, as: KeymapActive
 
@@ -114,13 +116,11 @@ defmodule Minga.Extension.SupervisorTest do
                  entry
                )
 
-      children = DynamicSupervisor.which_children(ctx.supervisor)
-
-      assert Enum.count(children, fn {_id, child_pid, _type, _modules} -> child_pid == pid end) ==
-               1
+      assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, :already_running_ext)) ==
+               {:ok, pid}
     end
 
-    test "reuses supervised child when registry running pid is stale", ctx do
+    test "registry projection is repaired from the Instance rather than used as authority", ctx do
       {path, cleanup} =
         make_extension("StaleRegistryPidExt", """
         defmodule Minga.TestExtensions.StaleRegistryPidExt do
@@ -176,10 +176,8 @@ defmodule Minga.Extension.SupervisorTest do
       {:ok, updated} = ExtRegistry.get(ctx.registry, :stale_registry_pid_ext)
       assert updated.pid == pid
 
-      children = DynamicSupervisor.which_children(ctx.supervisor)
-
-      assert Enum.count(children, fn {_id, child_pid, _type, _modules} -> child_pid == pid end) ==
-               1
+      assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, :stale_registry_pid_ext)) ==
+               {:ok, pid}
     end
 
     test "restarts when registry has stale running pid outside supervisor", ctx do
@@ -654,7 +652,7 @@ defmodule Minga.Extension.SupervisorTest do
   end
 
   describe "stop_extension/4" do
-    test "preserves supervisor lookup failures instead of reporting not found", ctx do
+    test "reports authority unavailable when a declared running projection has no root", ctx do
       :ok = ExtRegistry.register(ctx.registry, :lookup_failure, System.tmp_dir!(), [])
 
       :ok =
@@ -666,7 +664,7 @@ defmodule Minga.Extension.SupervisorTest do
 
       {:ok, entry} = ExtRegistry.get(ctx.registry, :lookup_failure)
 
-      assert {:error, {:which_children_failed, _reason}} =
+      assert {:error, {:authority_unavailable, :lookup_failure, _reason}} =
                ExtSupervisor.stop_extension(
                  :missing_extension_supervisor,
                  ctx.registry,
@@ -862,16 +860,15 @@ defmodule Minga.Extension.SupervisorTest do
 
       runtime_monitor = Process.monitor(runtime)
 
+      test_pid = self()
+
       finalizer = fn finalized_source ->
         {:ok, projected} = ExtRegistry.get(ctx.registry, name)
 
         runtime_present? =
-          Enum.any?(DynamicSupervisor.which_children(ctx.supervisor), fn
-            {_id, ^runtime, _type, _modules} -> true
-            _child -> false
-          end)
+          RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
 
-        send(self(), {:source_finalized, finalized_source, projected.status, runtime_present?})
+        send(test_pid, {:source_finalized, finalized_source, projected.status, runtime_present?})
         :ok
       end
 
@@ -887,7 +884,7 @@ defmodule Minga.Extension.SupervisorTest do
                )
 
       assert_receive {:source_finalized, ^source, :stopped, true}
-      assert_receive {:source_finalized, ^source, :stopped, false}
+      refute_receive {:source_finalized, ^source, _, _}
       assert_receive {:DOWN, ^runtime_monitor, :process, ^runtime, _reason}
     end
 
@@ -909,19 +906,17 @@ defmodule Minga.Extension.SupervisorTest do
 
       runtime_monitor = Process.monitor(runtime)
 
-      finalizer = fn finalized_source ->
-        attempts = Process.get({__MODULE__, :finalizer_attempts}, 0)
-        Process.put({__MODULE__, :finalizer_attempts}, attempts + 1)
-        send(self(), {:source_finalizer_called, finalized_source, attempts})
+      test_pid = self()
+      attempts = start_supervised!({Agent, fn -> 0 end})
 
-        case attempts do
-          0 -> {:error, :scheduler_unavailable}
-          _later_attempt -> :ok
-        end
+      finalizer = fn finalized_source ->
+        attempt = Agent.get_and_update(attempts, &{&1, &1 + 1})
+        send(test_pid, {:source_finalizer_called, finalized_source, attempt})
+        if attempt == 0, do: {:error, :scheduler_unavailable}, else: :ok
       end
 
       later_cleanup = fn cleaned_source ->
-        send(self(), {:later_cleanup_called, cleaned_source})
+        send(test_pid, {:later_cleanup_called, cleaned_source})
         :ok
       end
 
@@ -945,17 +940,13 @@ defmodule Minga.Extension.SupervisorTest do
       refute_receive {:later_cleanup_called, ^source}
       refute_receive {:DOWN, ^runtime_monitor, :process, ^runtime, _reason}
 
-      assert Enum.any?(DynamicSupervisor.which_children(ctx.supervisor), fn
-               {_id, ^runtime, _type, _modules} -> true
-               _child -> false
-             end)
+      assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
 
       {:ok, quiescing_entry} = ExtRegistry.get(ctx.registry, name)
-      assert quiescing_entry.status == :stopped
+      assert quiescing_entry.status == :load_error
       assert quiescing_entry.pid == runtime
-      assert quiescing_entry.lifecycle_ref == nil
 
-      assert {:ok, ^runtime} =
+      assert {:error, {:cleanup_retry_required, _reason}} =
                ExtSupervisor.start_extension(
                  ctx.supervisor,
                  ctx.registry,
@@ -963,11 +954,6 @@ defmodule Minga.Extension.SupervisorTest do
                  quiescing_entry,
                  authorities.opts
                )
-
-      assert Enum.count(DynamicSupervisor.which_children(ctx.supervisor), fn
-               {_id, ^runtime, _type, _modules} -> true
-               _child -> false
-             end) == 1
 
       assert :ok =
                ExtSupervisor.stop_extension(
@@ -982,7 +968,7 @@ defmodule Minga.Extension.SupervisorTest do
                )
 
       assert_receive {:source_finalizer_called, ^source, 1}
-      assert_receive {:source_finalizer_called, ^source, 2}
+      refute_receive {:source_finalizer_called, ^source, 2}
       assert_receive {:later_cleanup_called, ^source}
       assert_receive {:DOWN, ^runtime_monitor, :process, ^runtime, _reason}
     end
@@ -1034,6 +1020,96 @@ defmodule Minga.Extension.SupervisorTest do
 
       assert restarted_pid != pid
       refute restarted_pid == nil
+    end
+  end
+
+  describe "start failure contracts" do
+    test "option and modeline preparation failures publish exact load errors", ctx do
+      {option_path, option_cleanup} =
+        make_extension("OptionContractFailure", """
+        defmodule Minga.TestExtensions.OptionContractFailure do
+          use Minga.Extension
+
+          option :positive_count, :pos_integer,
+            default: 1,
+            description: "Positive count"
+
+          @impl true
+          def name, do: :option_contract_failure
+          @impl true
+          def description, do: "Option contract failure"
+          @impl true
+          def version, do: "1.0.0"
+          @impl true
+          def init(_config), do: {:ok, %{}}
+        end
+        """)
+
+      {modeline_path, modeline_cleanup} =
+        make_extension("ModelineContractFailure", """
+        defmodule Minga.TestExtensions.ModelineContractFailure do
+          use Minga.Extension
+
+          modeline_segment :mode do
+            _ctx = ctx
+            {" invalid ", :default, :default, [], nil}
+          end
+
+          @impl true
+          def name, do: :modeline_contract_failure
+          @impl true
+          def description, do: "Modeline contract failure"
+          @impl true
+          def version, do: "1.0.0"
+          @impl true
+          def init(_config), do: {:ok, %{}}
+        end
+        """)
+
+      on_exit(fn ->
+        option_cleanup.()
+        modeline_cleanup.()
+        :code.purge(Minga.TestExtensions.OptionContractFailure)
+        :code.delete(Minga.TestExtensions.OptionContractFailure)
+        :code.purge(Minga.TestExtensions.ModelineContractFailure)
+        :code.delete(Minga.TestExtensions.ModelineContractFailure)
+      end)
+
+      :ok =
+        ExtRegistry.register(ctx.registry, :option_contract_failure, option_path,
+          positive_count: 0
+        )
+
+      {:ok, option_entry} = ExtRegistry.get(ctx.registry, :option_contract_failure)
+
+      assert {:error, option_reason} =
+               ExtSupervisor.start_extension(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :option_contract_failure,
+                 option_entry
+               )
+
+      assert is_binary(option_reason)
+      assert option_reason =~ "positive_count"
+
+      assert {:ok, %{status: :load_error, pid: nil, last_error: ^option_reason}} =
+               ExtRegistry.get(ctx.registry, :option_contract_failure)
+
+      :ok = ExtRegistry.register(ctx.registry, :modeline_contract_failure, modeline_path, [])
+      {:ok, modeline_entry} = ExtRegistry.get(ctx.registry, :modeline_contract_failure)
+
+      assert {:error,
+              {:modeline_segment_rejected, :mode, {:reserved_name, :mode}} = modeline_reason} =
+               ExtSupervisor.start_extension(
+                 ctx.supervisor,
+                 ctx.registry,
+                 :modeline_contract_failure,
+                 modeline_entry
+               )
+
+      assert {:ok, %{status: :load_error, pid: nil, last_error: ^modeline_reason}} =
+               ExtRegistry.get(ctx.registry, :modeline_contract_failure)
     end
   end
 
@@ -1152,13 +1228,17 @@ defmodule Minga.Extension.SupervisorTest do
 
       assert {:error, failures} = ExtSupervisor.start_all(ctx.supervisor, ctx.registry)
 
-      assert Enum.any?(failures, fn
-               %{extension: :git_start_fail, reason: reason} ->
-                 is_binary(reason) and reason =~ "git clone failed"
+      assert %{extension: :git_start_fail, reason: clone_reason} =
+               Enum.find(failures, &(&1.extension == :git_start_fail))
 
-               _ ->
-                 false
-             end)
+      assert is_binary(clone_reason) and clone_reason =~ "git clone failed"
+      {:ok, failed_entry} = ExtRegistry.get(ctx.registry, :git_start_fail)
+      assert failed_entry.status == :load_error
+      assert failed_entry.last_error == clone_reason
+
+      instance_registry = InstanceRegistry.registry_for_root(ctx.supervisor)
+      assert InstanceRegistry.whereis(instance_registry, :root, :git_start_fail)
+      assert InstanceRegistry.whereis(instance_registry, :instance, :git_start_fail)
 
       {:ok, success_entry} = ExtRegistry.get(ctx.registry, :git_start_ok)
       assert success_entry.status == :running
@@ -1404,6 +1484,12 @@ defmodule Minga.Extension.SupervisorTest do
   end
 
   # ── Helpers ─────────────────────────────────────────────────────────────────
+
+  @spec runtime_supervisor(map(), atom()) :: GenServer.server()
+  defp runtime_supervisor(ctx, name) do
+    registry = InstanceRegistry.registry_for_root(ctx.supervisor)
+    InstanceRegistry.via(registry, :runtime, name)
+  end
 
   @spec wait_until((-> term()), non_neg_integer()) :: term()
   defp wait_until(fun, attempts \\ 100)

--- a/test/minga/extension/updater_apply_test.exs
+++ b/test/minga/extension/updater_apply_test.exs
@@ -44,8 +44,8 @@ defmodule Minga.Extension.UpdaterApplyTest do
 
     git!(root, ["init", "--bare", origin])
     git!(root, ["clone", origin, work])
-    git!(work, ["config", "user.email", "justin.smestad@gmail.com"])
-    git!(work, ["config", "user.name", "Justin Smestad"])
+    git!(work, ["config", "user.email", git_config("user.email", "minga-tests@example.invalid")])
+    git!(work, ["config", "user.name", git_config("user.name", "Minga Tests")])
     git!(work, ["config", "commit.gpgsign", "false"])
     File.write!(Path.join(work, "version.txt"), "v1")
     git!(work, ["add", "version.txt"])
@@ -127,6 +127,14 @@ defmodule Minga.Extension.UpdaterApplyTest do
 
     assert {:ok, ^admitted_before} =
              ArtifactAdmission.source_modules(admission_source, server: admission)
+  end
+
+  @spec git_config(String.t(), String.t()) :: String.t()
+  defp git_config(key, fallback) do
+    case System.cmd("git", ["config", "--get", key], stderr_to_stdout: true) do
+      {value, 0} -> String.trim(value)
+      {_output, _status} -> fallback
+    end
   end
 
   defp git!(directory, args) do

--- a/test/minga_agent/event_log_test.exs
+++ b/test/minga_agent/event_log_test.exs
@@ -319,7 +319,10 @@ defmodule MingaAgent.EventLogTest do
         record_and_await(first_name, event_type, payload)
       end)
 
+    first_writer = EventLog.writer_pid(first_name)
+    first_writer_ref = Process.monitor(first_writer)
     stop_supervised(first_id)
+    assert_receive {:DOWN, ^first_writer_ref, :process, ^first_writer, _reason}, @event_timeout
 
     second_name = unique_name("durable-log")
     start_event_log(second_name, db_dir: tmp_dir)

--- a/test/minga_editor/config_reload_instance_deadlock_test.exs
+++ b/test/minga_editor/config_reload_instance_deadlock_test.exs
@@ -1,0 +1,143 @@
+defmodule MingaEditor.ConfigReloadInstanceDeadlockTest do
+  # Mutates the production extension declaration registry used by Config.Loader.
+  use Minga.Test.EditorCase, async: false, rendering: :disabled
+
+  alias Minga.Config.Loader
+  alias Minga.Config.Options
+  alias Minga.Extension.ArtifactAdmission
+  alias Minga.Extension.ArtifactGenerationState
+  alias Minga.Extension.CallbackRegistry
+  alias Minga.Extension.CodeLease
+  alias Minga.Extension.Registry, as: ExtRegistry
+  alias Minga.Extension.RootSupervisor
+  alias Minga.Extension.Supervisor, as: ExtSupervisor
+  alias Minga.Keymap.Active, as: KeymapActive
+  alias MingaEditor.Commands.BufferManagement
+
+  @timeout 15_000
+
+  test "EffectScheduler worker can reload Config through Instance stop and asynchronous Editor ack" do
+    ctx = start_editor("reload ack")
+    suffix = System.unique_integer([:positive])
+    name = :config_reload_instance_ack
+    config_home = Path.join(System.tmp_dir!(), "minga_reload_ack_#{suffix}")
+    config_dir = Path.join(config_home, "minga")
+    extension_dir = Path.join(config_home, "extension")
+    File.mkdir_p!(config_dir)
+    File.mkdir_p!(extension_dir)
+    File.write!(Path.join(config_dir, "config.exs"), "use Minga.Config\n")
+
+    module = Minga.TestExtensions.ConfigReloadInstanceAck
+
+    File.write!(Path.join(extension_dir, "extension.ex"), """
+    defmodule #{inspect(module)} do
+      use Minga.Extension
+
+      @impl true
+      def name, do: :config_reload_instance_ack
+      @impl true
+      def description, do: "Config reload Instance ack"
+      @impl true
+      def version, do: "1.0.0"
+      @impl true
+      def init(_config), do: {:ok, %{}}
+    end
+    """)
+
+    owner = :"reload_ack_artifacts_#{suffix}"
+    persistence_key = {__MODULE__, suffix}
+
+    start_supervised!(
+      {ArtifactGenerationState, name: owner, persistence_key: persistence_key},
+      id: {ArtifactGenerationState, suffix}
+    )
+
+    admission =
+      start_supervised!(
+        {ArtifactAdmission, name: nil, state_owner: owner},
+        id: {ArtifactAdmission, suffix}
+      )
+
+    code_lease = start_supervised!({CodeLease, name: nil}, id: {CodeLease, suffix})
+    callbacks = :"reload_ack_callbacks_#{suffix}"
+    start_supervised!({CallbackRegistry, name: callbacks})
+    options = start_supervised!({Options, name: nil})
+    keymap = :"reload_ack_keymap_#{suffix}"
+    start_supervised!({KeymapActive, name: keymap})
+
+    loader =
+      start_supervised!(
+        {Loader,
+         name: nil,
+         config_home: config_home,
+         options_server: options,
+         keymap_server: keymap,
+         artifact_admission: admission},
+        id: {Loader, suffix}
+      )
+
+    :ok = ExtRegistry.register(name, extension_dir, [])
+    {:ok, declaration} = ExtRegistry.get(name)
+
+    opts = [
+      artifact_admission: admission,
+      code_lease: code_lease,
+      callback_registry: callbacks,
+      keymap: keymap
+    ]
+
+    assert {:ok, runtime} =
+             ExtSupervisor.start_extension(
+               Minga.Extension.Supervisor,
+               ExtRegistry,
+               name,
+               declaration,
+               opts
+             )
+
+    runtime_ref = Process.monitor(runtime)
+
+    File.write!(Path.join(config_dir, "config.exs"), """
+    use Minga.Config
+    extension #{inspect(name)}, path: #{inspect(extension_dir)}
+    """)
+
+    :sys.replace_state(
+      ctx.editor,
+      &BufferManagement.reload_config(&1, Loader, [loader])
+    )
+
+    assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, _reason}, @timeout
+    assert_registry_stopped(name)
+
+    on_exit(fn ->
+      ExtSupervisor.stop_all()
+      ExtRegistry.unregister(name)
+      RootSupervisor.terminate_root(Minga.Extension.RootSupervisor, name)
+      ArtifactGenerationState.reset_for_test(persistence_key)
+      File.rm_rf!(config_home)
+      :code.purge(module)
+      :code.delete(module)
+    end)
+  end
+
+  @spec assert_registry_stopped(atom(), non_neg_integer()) :: :ok
+  defp assert_registry_stopped(name, attempts \\ 1_000)
+
+  defp assert_registry_stopped(name, attempts) when attempts > 0 do
+    case ExtRegistry.get(name) do
+      {:ok, %{status: :stopped, pid: nil, last_error: nil}} ->
+        :ok
+
+      _projection ->
+        receive do
+        after
+          10 -> assert_registry_stopped(name, attempts - 1)
+        end
+    end
+  end
+
+  defp assert_registry_stopped(name, 0) do
+    flunk("expected stopped extension projection, got #{inspect(ExtRegistry.get(name))}")
+  end
+end

--- a/test/minga_editor/extension/source_finalizer_editor_test.exs
+++ b/test/minga_editor/extension/source_finalizer_editor_test.exs
@@ -23,6 +23,8 @@ defmodule MingaEditor.Extension.SourceFinalizerEditorTest do
   defmodule RootPickerExtension do
     use Minga.Extension
 
+    @unload_attempts :source_finalizer_unload_attempts
+
     command(:open_differently_nested_picker, "Open extension picker",
       execute: {__MODULE__, :open_picker}
     )
@@ -52,13 +54,27 @@ defmodule MingaEditor.Extension.SourceFinalizerEditorTest do
     @spec handle_editor_event(
             MingaEditor.State.t(),
             MingaEditor.Extension.EventHandler.event()
-          ) :: MingaEditor.Extension.EventHandler.callback_result()
+          ) :: MingaEditor.Extension.EventHandler.callback_result() | :invalid_unload_return
     def handle_editor_event(state, {:source_unload, {:extension, :finalized_picker}}) do
-      theme = MingaEditor.UI.Theme.get!(:doom_one)
-      {:handled, MingaEditor.State.apply_theme(state, theme)}
+      case Process.whereis(@unload_attempts) do
+        nil ->
+          apply_unload_theme(state)
+
+        _pid ->
+          case Agent.get_and_update(@unload_attempts, &{&1, &1 + 1}) do
+            0 -> :invalid_unload_return
+            _attempt -> apply_unload_theme(state)
+          end
+      end
     end
 
     def handle_editor_event(_state, _event), do: :not_matched
+
+    @spec apply_unload_theme(MingaEditor.State.t()) :: {:handled, MingaEditor.State.t()}
+    defp apply_unload_theme(state) do
+      theme = MingaEditor.UI.Theme.get!(:doom_one)
+      {:handled, MingaEditor.State.apply_theme(state, theme)}
+    end
   end
 
   defmodule Remote.Picker do
@@ -265,6 +281,64 @@ defmodule MingaEditor.Extension.SourceFinalizerEditorTest do
     unrelated_monitor = Process.monitor(unrelated_worker)
     assert :ok = EffectScheduler.cancel_source(scheduler, unrelated_source)
     assert_receive {:DOWN, ^unrelated_monitor, :process, ^unrelated_worker, _reason}
+    _barrier = :sys.get_state(ctx.editor)
+  end
+
+  test "Editor unload callback failure reaches Instance and preserves retry semantics" do
+    {:ok, attempts} = Agent.start_link(fn -> 0 end, name: :source_finalizer_unload_attempts)
+    on_exit(fn -> if Process.alive?(attempts), do: Agent.stop(attempts) end)
+    :ok = ExtensionRegistry.unregister(:finalized_picker)
+    :ok = ExtensionRegistry.register_module(:finalized_picker, RootPickerExtension, [])
+    {:ok, entry} = ExtensionRegistry.get(:finalized_picker)
+    ctx = start_editor("scratch", name: MingaEditor)
+
+    assert {:ok, runtime} =
+             ExtensionSupervisor.start_extension(
+               ExtensionSupervisor,
+               ExtensionRegistry,
+               :finalized_picker,
+               entry,
+               runtime_owned_modules: callback_modules()
+             )
+
+    source = {:extension, :finalized_picker}
+
+    callback_failure =
+      {:invalid_return, source, RootPickerExtension, :handle_editor_event, :invalid_unload_return}
+
+    finalizer_failure = %{
+      family: :editor_extension_unload,
+      source: source,
+      reason: [callback_failure]
+    }
+
+    assert {:error, {:source_quiesce_failed, ^finalizer_failure}} =
+             ExtensionSupervisor.stop_extension(
+               ExtensionSupervisor,
+               ExtensionRegistry,
+               :finalized_picker,
+               entry,
+               runtime_owned_modules: callback_modules()
+             )
+
+    assert {:ok, ^runtime} =
+             Minga.Extension.RuntimeSupervisor.local_child(
+               Minga.Extension.InstanceRegistry.via(
+                 Minga.Extension.InstanceRegistry,
+                 :runtime,
+                 :finalized_picker
+               )
+             )
+
+    assert :ok =
+             ExtensionSupervisor.stop_extension(
+               ExtensionSupervisor,
+               ExtensionRegistry,
+               :finalized_picker,
+               entry,
+               runtime_owned_modules: callback_modules()
+             )
+
     _barrier = :sys.get_state(ctx.editor)
   end
 


### PR DESCRIPTION
# TL;DR

Every declared extension now has one stable, process-owned lifecycle stream. A per-extension `Instance` mailbox serializes eager, lazy, deferred, start, stop, failure, crash, restart, cleanup, and unload transitions, while runtime PIDs and registry status are projections rather than lifecycle authority.

Closes #2936
Part of #2925

## Context

Extension lifecycle ordering was reconstructed across global locks, mutable registry decisions, child scans, detached restart monitors, polling, and stale lifecycle references. That made concurrent start/stop behavior and crash recovery hard to reason about and left multiple places capable of deciding whether an extension was running.

## Changes

- Add direct service children for `InstanceRegistry` and `RootSupervisor`.
- Add one ordered root per declaration using `:rest_for_one`:
  - local `RuntimeSupervisor` first;
  - permanent `Instance` authority second.
- Route every public lifecycle API and every module/path/resolved-Git/Hex/application/bundled/JSON source through the same Instance state machine.
- Keep runtime child specs temporary under the local supervisor; Instance alone interprets the declared permanent/transient/temporary restart policy.
- Replace registry lifecycle decisions with a single typed projection from Instance phase.
- Remove `Entry.lifecycle_ref`, global lifecycle/autoload locks, dead-PID reconciliation, global child scans, detached restart monitors, replacement polling, retry limits, and Lazy lifecycle writes.
- Add linked, monitored, bounded transition workers with readiness-gated recovery, stale-result rejection, wedged runtime-supervisor replacement, and deterministic waiter completion.
- Add typed start/stop/runtime/failure contexts owned by focused transition modules; keep the Instance GenServer as a 159-line mailbox wrapper.
- Add event-driven CodeLease drain notifications and bounded asynchronous Editor finalization/unload request-ack handling.
- Preserve retry-required cleanup state for failed starts/stops, projection failures, unload failures, drain timeouts, and terminal cleanup.
- Capture current declaration identity across Instance restarts and synchronize through authority restart gaps.
- Make bulk Git/Hex prerequisites, declaration reconciliation, lazy/deferred batches, and config cleanup surface errors instead of silently skipping work.
- Add a typed deferred-batch completion event.
- Preserve current-generation artifact pinning and restart-required code update behavior.
- Update architecture and extension lifecycle documentation.

## Verification

- `make lint`, passed with 0 Credo, compile, or Dialyzer errors.
- `mix test.llm`, passed: 9,750 tests, 0 failures, 1 skipped.
- Affected extension/config/finalization suite, passed: 385 tests.
- Heavy supervisor/lazy/config suite, passed: 47 tests.
- SDK suite, passed: 13 tests.
- Standalone Git Porcelain suite, passed: 108 tests.
- Additional focused race, recovery, timeout, projection, failure, and public-contract suites passed through the review loop.
- Required-deletion searches and `git diff --check`, passed.
- No extension/SDK-local dependency, build, or lock artifacts remain.
- Required Archie topology review and final architecture sign-off passed.
- Correctness, silent-failure, coverage, intent, and final acceptance reviews passed after all named blockers were fixed.

## Acceptance Criteria Addressed

- Same-extension lifecycle requests serialize through one stable authority. ✅
- All supported source types share one lifecycle state machine. ✅
- Registry state is declaration/status projection only. ✅
- Runtime crashes and restart policy are event-driven without scans or polling. ✅
- Failed starts converge through one rollback and safe retry path. ✅
- Lazy and deferred activation cannot create duplicate runtimes. ✅
- Editor finalization is asynchronous and deadlock-safe. ✅
- Public facade signatures, runtime PID returns, statuses, failure tuples, telemetry, and list behavior remain compatible. ✅
