### PR TITLE
fix(editor): close ownership audit gaps

### DIFF
--- a/credo/checks/editor_state_ownership/config.exs
+++ b/credo/checks/editor_state_ownership/config.exs
@@ -316,7 +316,6 @@ defmodule Minga.Credo.EditorStateOwnership.Config do
       struct: "MingaEditor.State.Workspace",
       owners: ["MingaEditor.State.Workspace"],
       paths: [],
-      pure: false,
       boundary: "MingaEditor.State.Workspace transition API",
       workflow: "a focused workspace workflow"
     ],
@@ -339,7 +338,6 @@ defmodule Minga.Credo.EditorStateOwnership.Config do
       struct: "MingaEditor.State.ModalOverlay.Picker",
       owners: ["MingaEditor.State.ModalOverlay.Picker"],
       paths: [],
-      pure: false,
       boundary: "MingaEditor.State.ModalOverlay.Picker transition API",
       workflow: "MingaEditor.Shell.Traditional.ModalWorkflow"
     ],
@@ -347,7 +345,6 @@ defmodule Minga.Credo.EditorStateOwnership.Config do
       struct: "MingaEditor.State.ModalOverlay.Prompt",
       owners: ["MingaEditor.State.ModalOverlay.Prompt"],
       paths: [],
-      pure: false,
       boundary: "MingaEditor.State.ModalOverlay.Prompt transition API",
       workflow: "MingaEditor.Shell.Traditional.ModalWorkflow"
     ],
@@ -355,7 +352,6 @@ defmodule Minga.Credo.EditorStateOwnership.Config do
       struct: "MingaEditor.State.ModalOverlay.Completion",
       owners: ["MingaEditor.State.ModalOverlay.Completion"],
       paths: [],
-      pure: false,
       boundary: "MingaEditor.State.ModalOverlay.Completion transition API",
       workflow: "MingaEditor.Shell.Traditional.ModalWorkflow"
     ],
@@ -363,7 +359,6 @@ defmodule Minga.Credo.EditorStateOwnership.Config do
       struct: "MingaEditor.State.ModalOverlay.CommandCompletion",
       owners: ["MingaEditor.State.ModalOverlay.CommandCompletion"],
       paths: [],
-      pure: false,
       boundary: "MingaEditor.State.ModalOverlay.CommandCompletion transition API",
       workflow: "MingaEditor.Shell.Traditional.ModalWorkflow"
     ],
@@ -371,7 +366,6 @@ defmodule Minga.Credo.EditorStateOwnership.Config do
       struct: "MingaEditor.State.ModalOverlay.Conflict",
       owners: ["MingaEditor.State.ModalOverlay.Conflict"],
       paths: [],
-      pure: false,
       boundary: "MingaEditor.State.ModalOverlay.Conflict transition API",
       workflow: "MingaEditor.Shell.Traditional.ModalWorkflow"
     ]

--- a/credo/checks/editor_state_ownership/validator.exs
+++ b/credo/checks/editor_state_ownership/validator.exs
@@ -91,14 +91,14 @@ defmodule Minga.Credo.EditorStateOwnership.Validator do
          exact_module?(Keyword.get(ownership, :struct)) and
          valid_owner_list?(Keyword.get(ownership, :owners)) and
          valid_paths?(Keyword.get(ownership, :paths)) and
-         optional_boolean?(Keyword.get(ownership, :pure, true)) and
+         Keyword.get(ownership, :pure, true) == true and
          optional_boolean?(Keyword.get(ownership, :generic_api, true)) and
          documented?(Keyword.get(ownership, :boundary)) and
          documented?(Keyword.get(ownership, :workflow)) do
       []
     else
       [
-        "ownership entries require an exact struct, non-empty owners, bounded atom paths, boundary, and workflow"
+        "ownership entries require an exact struct, non-empty owners, bounded atom paths, boundary, and workflow; owner purity cannot be disabled"
       ]
     end
   end
@@ -139,15 +139,24 @@ defmodule Minga.Credo.EditorStateOwnership.Validator do
       |> Enum.flat_map(&Keyword.fetch!(&1, :owners))
       |> MapSet.new()
 
-    Enum.flat_map(modules, fn module ->
-      if MapSet.member?(declared_owners, module) do
-        []
-      else
-        [
-          "pure_modules entry #{module} is not a declared ownership owner; add it to an ownership :owners list or remove it from pure_modules"
-        ]
-      end
-    end)
+    configured_modules = MapSet.new(modules)
+
+    undeclared_errors =
+      modules
+      |> Enum.reject(&MapSet.member?(declared_owners, &1))
+      |> Enum.map(fn module ->
+        "pure_modules entry #{module} is not a declared ownership owner; add it to an ownership :owners list or remove it from pure_modules"
+      end)
+
+    omitted_errors =
+      declared_owners
+      |> MapSet.difference(configured_modules)
+      |> Enum.sort()
+      |> Enum.map(fn module ->
+        "declared ownership owner #{module} is missing from pure_modules; use :owners or include every declared owner"
+      end)
+
+    undeclared_errors ++ omitted_errors
   end
 
   @spec validate_allowlist(term()) :: [error()]

--- a/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/commands.ex
@@ -397,7 +397,11 @@ defmodule MingaGitPorcelain.Commands do
   @doc "Schedules staged-diff commit-message generation."
   @spec schedule_commit_generation(state(), keyword()) :: state()
   def schedule_commit_generation(state, opts \\ []) when is_list(opts) do
-    request = CommitMessageGeneration.request(opts)
+    repository_context = CommitMessageGeneration.repository_context(state)
+    git = Keyword.get(opts, :git, Git)
+    project = Keyword.get(opts, :project, Minga.Project)
+    repository = CommitMessageGeneration.resolve_repository(git, project)
+    request = CommitMessageGeneration.request(repository_context, repository, opts)
 
     case EffectScheduler.schedule(state.effect_scheduler, request) do
       {:ok, _request_id, _disposition} ->

--- a/extensions/git_porcelain/lib/minga_git_porcelain/effects/commit_message_generation.ex
+++ b/extensions/git_porcelain/lib/minga_git_porcelain/effects/commit_message_generation.ex
@@ -19,29 +19,44 @@ defmodule MingaGitPorcelain.Effects.CommitMessageGeneration do
   @generator MingaGitPorcelain.Git.CommitMessageGenerator
 
   @type source :: CallbackInvoker.source()
+  @type repository_context :: {
+          project_root :: String.t() | nil,
+          original_root :: String.t() | nil,
+          root_generation :: non_neg_integer()
+        }
+  @type repository_resolution :: {:ok, String.t()} | {:error, term()}
 
-  @enforce_keys [:source, :git, :generator, :project, :admission]
-  defstruct [:source, :git, :generator, :project, :admission]
+  @enforce_keys [:source, :git, :generator, :admission, :repository_context, :repository]
+  defstruct [:source, :git, :generator, :admission, :repository_context, :repository]
 
   @type t :: %__MODULE__{
           source: source(),
           git: module(),
           generator: module(),
-          project: module(),
-          admission: GenServer.server()
+          admission: GenServer.server(),
+          repository_context: repository_context(),
+          repository: repository_resolution()
         }
 
-  @doc "Builds a single-slot commit-generation request."
-  @spec request(keyword()) :: Request.t()
-  def request(opts \\ []) when is_list(opts) do
+  @doc "Builds a single-slot request correlated to an exact root lifecycle and repository."
+  @spec request(repository_context(), repository_resolution(), keyword()) :: Request.t()
+  def request(
+        {project_root, original_root, generation} = repository_context,
+        repository,
+        opts \\ []
+      )
+      when (is_binary(project_root) or is_nil(project_root)) and
+             (is_binary(original_root) or is_nil(original_root)) and
+             is_integer(generation) and generation >= 0 and is_list(opts) do
     {:extension, _name} = source = Keyword.get(opts, :source, @source)
 
     effect = %__MODULE__{
       source: source,
       git: Keyword.get(opts, :git, Git),
       generator: Keyword.get(opts, :generator, @generator),
-      project: Keyword.get(opts, :project, Minga.Project),
-      admission: Keyword.get(opts, :admission, CodeLease)
+      admission: Keyword.get(opts, :admission, CodeLease),
+      repository_context: repository_context,
+      repository: repository
     }
 
     Request.new(effect, {:git_porcelain_commit_generation, source}, Policy.fifo(0),
@@ -79,7 +94,7 @@ defmodule MingaGitPorcelain.Effects.CommitMessageGeneration do
   @doc false
   @spec execute(t()) :: {:ok, {:generated, String.t()}} | {:error, term()}
   def execute(%__MODULE__{} = effect) do
-    with {:ok, root} <- resolve_root(effect),
+    with {:ok, root} <- effect.repository,
          {:ok, diff} <- staged_diff(effect.git, root),
          {:non_empty, true} <- {:non_empty, diff != ""},
          {:ok, message} <- generate(effect.generator, diff) do
@@ -94,17 +109,47 @@ defmodule MingaGitPorcelain.Effects.CommitMessageGeneration do
   @spec coalesce(t(), t()) :: t()
   def coalesce(_older, newer), do: newer
 
-  @doc "Applies generation feedback and opens the existing commit prompt."
+  @doc "Returns the exact project roots that identify the active repository context."
+  @spec repository_context(EditorState.t()) :: repository_context()
+  def repository_context(%EditorState{workspace: %{file_tree: file_tree}}) do
+    {file_tree.project_root, file_tree.original_root,
+     MingaEditor.State.FileTree.root_generation(file_tree)}
+  end
+
+  @doc "Resolves the exact repository root captured before worker admission."
+  @spec resolve_repository(module(), module()) :: repository_resolution()
+  def resolve_repository(git, project) when is_atom(git) and is_atom(project) do
+    case git.root_for(project.resolve_root()) do
+      {:ok, root} -> {:ok, root}
+      :not_git -> {:error, :not_a_repository}
+      {:error, reason} -> {:error, {:root_resolution_failed, reason}}
+    end
+  end
+
+  @doc "Applies generation feedback only while the originating repository remains active."
   @impl true
   @spec apply(EditorState.t(), Outcome.t()) :: {EditorState.t(), Outcome.t()}
-  def apply(state, %Outcome{status: :running} = outcome) do
+  def apply(
+        %EditorState{} = state,
+        %Outcome{
+          request: %Request{effect: %__MODULE__{repository_context: expected_context}}
+        } = outcome
+      ) do
+    case repository_context(state) do
+      ^expected_context -> apply_current(state, outcome)
+      _current_context -> stale_repository_result(state, outcome)
+    end
+  end
+
+  @spec apply_current(EditorState.t(), Outcome.t()) :: {EditorState.t(), Outcome.t()}
+  defp apply_current(state, %Outcome{status: :running} = outcome) do
     {publish_notice(state, "Generating commit message…"), outcome}
   end
 
-  def apply(
-        %{shell_runtime: %{state: %TraditionalState{modal: modal}}} = state,
-        %Outcome{status: :completed, result: {:generated, message}} = outcome
-      ) do
+  defp apply_current(
+         %{shell_runtime: %{state: %TraditionalState{modal: modal}}} = state,
+         %Outcome{status: :completed, result: {:generated, message}} = outcome
+       ) do
     state =
       if ModalOverlay.active?(modal) do
         NoticeWorkflow.publish(state, "Commit message ready (prompt already open)")
@@ -117,34 +162,35 @@ defmodule MingaGitPorcelain.Effects.CommitMessageGeneration do
     {state, outcome}
   end
 
-  def apply(state, %Outcome{status: :completed, result: {:generated, _message}} = outcome),
-    do: {state, outcome}
+  defp apply_current(
+         state,
+         %Outcome{status: :completed, result: {:generated, _message}} = outcome
+       ),
+       do: {state, outcome}
 
-  def apply(state, %Outcome{status: :failed, reason: reason} = outcome) do
+  defp apply_current(state, %Outcome{status: :failed, reason: reason} = outcome) do
     {publish_notice(state, failure_message(reason)), outcome}
   end
 
-  def apply(state, %Outcome{status: :canceled, reason: :source_canceled} = outcome),
+  defp apply_current(state, %Outcome{status: :canceled, reason: :source_canceled} = outcome),
     do: {state, outcome}
 
-  def apply(state, %Outcome{status: :canceled} = outcome) do
+  defp apply_current(state, %Outcome{status: :canceled} = outcome) do
     {publish_notice(state, "Commit message generation canceled"), outcome}
   end
 
-  def apply(state, %Outcome{status: :stale} = outcome), do: {state, outcome}
+  defp apply_current(state, %Outcome{status: :stale} = outcome), do: {state, outcome}
+
+  @spec stale_repository_result(EditorState.t(), Outcome.t()) ::
+          {EditorState.t(), Outcome.t()}
+  defp stale_repository_result(state, outcome) do
+    state = publish_notice(state, "Commit message result ignored after repository changed")
+    {state, Outcome.stale(outcome, :repository_changed)}
+  end
 
   @impl true
   @spec render?(Outcome.t()) :: boolean()
   def render?(%Outcome{}), do: true
-
-  @spec resolve_root(t()) :: {:ok, String.t()} | {:error, :not_a_repository | term()}
-  defp resolve_root(%__MODULE__{git: git, project: project}) do
-    case git.root_for(project.resolve_root()) do
-      {:ok, root} -> {:ok, root}
-      :not_git -> {:error, :not_a_repository}
-      {:error, reason} -> {:error, {:root_resolution_failed, reason}}
-    end
-  end
 
   @spec staged_diff(module(), String.t()) :: {:ok, String.t()} | {:error, term()}
   defp staged_diff(git, root) do

--- a/extensions/git_porcelain/test/minga_git_porcelain/effects/commit_message_generation_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/effects/commit_message_generation_test.exs
@@ -8,12 +8,15 @@ defmodule MingaGitPorcelain.Effects.CommitMessageGenerationTest do
   use ExUnit.Case, async: false
 
   alias Minga.Extension.CodeLease
+  alias Minga.Project.FileTree
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effect.Policy
   alias MingaEditor.EffectScheduler
   alias MingaEditor.Shell.Registry, as: ShellRegistry
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.Test.FakeShell
   alias MingaEditor.Viewport
   alias MingaGitPorcelain.Commands
@@ -63,11 +66,11 @@ defmodule MingaGitPorcelain.Effects.CommitMessageGenerationTest do
     assert request.source == @source
     refute contains_runtime_authority?(request.effect)
 
-    assert_receive {:dependency_called, :project_root, worker, nil}, @timeout
-    assert worker != self()
-    assert_receive {:dependency_called, :git_root, ^worker, "/tmp/project"}, @timeout
+    assert_receive {:dependency_called, :project_root, caller, nil}, @timeout
+    assert caller == self()
+    assert_receive {:dependency_called, :git_root, ^caller, "/tmp/project"}, @timeout
 
-    assert_receive {:dependency_called, :staged_diff, ^worker, {"/tmp/repo", [staged: true]}},
+    assert_receive {:dependency_called, :staged_diff, worker, {"/tmp/repo", [staged: true]}},
                    @timeout
 
     assert_receive {:dependency_called, :generator, ^worker, "diff --git"}, @timeout
@@ -153,7 +156,10 @@ defmodule MingaGitPorcelain.Effects.CommitMessageGenerationTest do
              "Commit message source unavailable:"
            )
 
-    refute_received {:dependency_called, :project_root, _worker, nil}
+    assert_receive {:dependency_called, :project_root, caller, nil}
+    assert caller == self()
+    assert_receive {:dependency_called, :git_root, ^caller, "/tmp/project"}
+    refute_received {:dependency_called, :staged_diff, _worker, _payload}
     assert CodeLease.active_leases(server: @admission) == []
   end
 
@@ -233,6 +239,46 @@ defmodule MingaGitPorcelain.Effects.CommitMessageGenerationTest do
 
     assert_receive {:effect_terminal, %Outcome{status: :canceled, request: %{id: ^completed_id}}},
                    @timeout
+  end
+
+  test "delayed success cannot open a prompt after an A to B to A repository switch" do
+    Dependencies.put(:generator, {:block, {:ok, "late subject"}})
+    {state, scheduler} = build_state()
+
+    initial_file_tree =
+      FileTreeState.begin_root_scan(
+        state.workspace.file_tree,
+        FileTree.new("/tmp/repo-a"),
+        :project
+      )
+
+    initial_workspace = SessionState.set_file_tree(state.workspace, initial_file_tree)
+    initial = %{state | workspace: initial_workspace}
+    returned = Commands.schedule_commit_generation(initial, dependency_opts())
+    _running = receive_running()
+    assert_receive {:dependency_called, :generator, worker, "diff --git"}, @timeout
+
+    b_file_tree =
+      FileTreeState.begin_root_scan(
+        returned.workspace.file_tree,
+        FileTree.new("/tmp/repo-b"),
+        :project
+      )
+
+    a_file_tree =
+      FileTreeState.begin_root_scan(b_file_tree, FileTree.new("/tmp/repo-a"), :project)
+
+    switched_workspace = SessionState.set_file_tree(returned.workspace, a_file_tree)
+    switched = %{returned | workspace: switched_workspace}
+    send(worker, {:release_dependency, :generator})
+
+    {result, outcome} = receive_and_apply(switched, scheduler, :completed)
+    assert outcome.status == :stale
+    assert outcome.reason == :repository_changed
+    assert result.shell_runtime.state.modal == :none
+
+    assert result.shell_runtime.state.notice.message ==
+             "Commit message result ignored after repository changed"
   end
 
   test "delayed success respects an existing modal and a foreign shell" do

--- a/extensions/git_porcelain/test/minga_git_porcelain/lifecycle_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/lifecycle_test.exs
@@ -134,6 +134,8 @@ defmodule MingaGitPorcelain.LifecycleTest do
 
     request =
       CommitMessageGeneration.request(
+        {nil, nil, 0},
+        {:ok, "/tmp/repo"},
         source: @source,
         git: Dependencies,
         project: Dependencies,

--- a/lib/minga/extension/callback_invoker.ex
+++ b/lib/minga/extension/callback_invoker.ex
@@ -86,7 +86,7 @@ defmodule Minga.Extension.CallbackInvoker do
   @spec invalid_return(source(), module(), atom(), term()) :: failure()
   def invalid_return({:extension, name} = source, module, function, returned)
       when is_atom(name) and is_atom(module) and is_atom(function) do
-    failure = {:invalid_return, source, module, function, returned}
+    failure = {:invalid_return, source, module, function, invalid_return_summary(returned)}
     report_failure(failure)
     failure
   end
@@ -175,6 +175,23 @@ defmodule Minga.Extension.CallbackInvoker do
     report_failure(failure, semantics: semantics, stacktrace: stacktrace)
     {:error, failure}
   end
+
+  @spec invalid_return_summary(term()) :: map()
+  defp invalid_return_summary(value) when is_tuple(value) do
+    tag = if tuple_size(value) > 0 and is_atom(elem(value, 0)), do: elem(value, 0), else: nil
+    %{kind: :tuple, size: tuple_size(value), tag: tag}
+  end
+
+  defp invalid_return_summary(%module{}), do: %{kind: :struct, module: module}
+  defp invalid_return_summary(value) when is_map(value), do: %{kind: :map, size: map_size(value)}
+  defp invalid_return_summary(value) when is_list(value), do: %{kind: :list, empty?: value == []}
+
+  defp invalid_return_summary(value) when is_binary(value),
+    do: %{kind: :binary, size: byte_size(value)}
+
+  defp invalid_return_summary(value) when is_atom(value), do: %{kind: :atom, value: value}
+  defp invalid_return_summary(value) when is_number(value), do: %{kind: :number}
+  defp invalid_return_summary(_value), do: %{kind: :other}
 
   @spec report_failure(failure(), keyword()) :: :ok
   defp report_failure(failure, diagnostic_opts \\ []) do

--- a/lib/minga/extension/code_lease.ex
+++ b/lib/minga/extension/code_lease.ex
@@ -187,12 +187,18 @@ defmodule Minga.Extension.CodeLease do
 
   @impl true
   def handle_call({:activate_source, source, modules}, _from, state) do
-    case validate_modules(modules) do
-      {:ok, module_set} ->
-        record = %{status: :active, modules: module_set}
-        {:reply, :ok, %{state | sources: Map.put(state.sources, source, record)}}
+    case {validate_modules(modules), Map.get(state.sources, source)} do
+      {{:ok, _module_set}, %{status: {:quiescing, token}}} ->
+        {:reply, {:error, {:source_quiescing, source, token}}, state}
 
-      {:error, _reason} = error ->
+      {{:ok, module_set}, _record} ->
+        record = %{status: :active, modules: module_set}
+        token_sources = drop_source_tokens(state.token_sources, source)
+
+        {:reply, :ok,
+         %{state | sources: Map.put(state.sources, source, record), token_sources: token_sources}}
+
+      {{:error, _reason} = error, _record} ->
         {:reply, error, state}
     end
   end
@@ -315,16 +321,60 @@ defmodule Minga.Extension.CodeLease do
   @spec transition_unload_token(state(), unload_token(), source_status()) ::
           {:reply, :ok | {:error, term()}, state()}
   defp transition_unload_token(state, token, next_status) do
-    case Map.pop(state.token_sources, token) do
-      {nil, _tokens} ->
+    case Map.get(state.token_sources, token) do
+      nil ->
         {:reply, {:error, {:invalid_unload_token, token}}, state}
 
-      {source, tokens} ->
-        record = Map.fetch!(state.sources, source)
-        record = %{record | status: next_status}
-        sources = Map.put(state.sources, source, record)
-        {:reply, :ok, %{state | sources: sources, token_sources: tokens}}
+      source ->
+        transition_current_unload(state, source, token, next_status)
     end
+  end
+
+  @spec transition_current_unload(
+          state(),
+          ContributionCleanup.contribution_source(),
+          unload_token(),
+          source_status()
+        ) :: {:reply, :ok | {:error, term()}, state()}
+  defp transition_current_unload(state, source, token, :inactive) do
+    case {Map.fetch!(state.sources, source), matching_leases(state, source, :_)} do
+      {%{status: {:quiescing, ^token}}, []} ->
+        commit_unload_transition(state, source, token, :inactive)
+
+      {%{status: {:quiescing, ^token}}, leases} ->
+        {:reply, {:error, {:active_source_leases, source, length(leases)}}, state}
+
+      {%{status: status}, _leases} ->
+        {:reply, {:error, {:stale_unload_token, source, status}}, state}
+    end
+  end
+
+  defp transition_current_unload(state, source, token, :active) do
+    case Map.fetch!(state.sources, source) do
+      %{status: {:quiescing, ^token}} ->
+        commit_unload_transition(state, source, token, :active)
+
+      %{status: status} ->
+        {:reply, {:error, {:stale_unload_token, source, status}}, state}
+    end
+  end
+
+  @spec commit_unload_transition(
+          state(),
+          ContributionCleanup.contribution_source(),
+          unload_token(),
+          source_status()
+        ) :: {:reply, :ok, state()}
+  defp commit_unload_transition(state, source, token, next_status) do
+    record = Map.fetch!(state.sources, source)
+    sources = Map.put(state.sources, source, %{record | status: next_status})
+    token_sources = Map.delete(state.token_sources, token)
+    {:reply, :ok, %{state | sources: sources, token_sources: token_sources}}
+  end
+
+  @spec drop_source_tokens(%{unload_token() => term()}, term()) :: %{unload_token() => term()}
+  defp drop_source_tokens(token_sources, source) do
+    Map.reject(token_sources, fn {_token, token_source} -> token_source == source end)
   end
 
   @spec ordinary_source(state(), term(), module()) :: :ok | {:error, term()}

--- a/lib/minga/extension/instance/state.ex
+++ b/lib/minga/extension/instance/state.ex
@@ -51,7 +51,7 @@ defmodule Minga.Extension.Instance.State do
       declaration: declaration_only(declaration),
       registry: registry,
       instance_registry: instance_registry,
-      collaborators: collaborators
+      collaborators: stable_collaborators(collaborators)
     }
   end
 

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -542,14 +542,13 @@ defmodule MingaEditor do
   end
 
   def handle_cast({:unload_extension_source_request, source, context, {caller, ref}}, state) do
-    case SourceFinalizer.finalize_unload(state, source, context) do
+    case SourceFinalizer.finalize_unload(state, source, context, {caller, ref}) do
       {:ok, new_state} ->
-        send(caller, {:extension_source_finalized, ref, :ok})
-        {:noreply, Renderer.render_or_async(new_state)}
+        {:noreply, new_state}
 
-      {{:error, failures}, new_state} ->
-        send(caller, {:extension_source_finalized, ref, {:error, failures}})
-        {:noreply, Renderer.render_or_async(new_state)}
+      {:error, reason, new_state} ->
+        send(caller, {:extension_source_finalized, ref, {:error, reason}})
+        {:noreply, new_state}
     end
   end
 
@@ -911,6 +910,12 @@ defmodule MingaEditor do
   # Correlated file-tree debounce timers enter the domain workflow directly.
   def handle_info({:file_tree_refresh_timer, token}, state) when is_reference(token) do
     {:noreply, MingaEditor.FileTree.Freshness.begin_refresh(state, token)}
+  end
+
+  def handle_info({:file_tree_watcher_retry, token, opts}, state)
+      when is_reference(token) and is_list(opts) do
+    state = MingaEditor.FileTree.Freshness.retry_watcher_sync(state, token, opts)
+    {:noreply, schedule_render(state, 16)}
   end
 
   # Renderer.Server writeback after each async frame completes.

--- a/lib/minga_editor/agent/status_event_workflow.ex
+++ b/lib/minga_editor/agent/status_event_workflow.ex
@@ -110,15 +110,19 @@ defmodule MingaEditor.Agent.StatusEventWorkflow do
   defp maybe_auto_compact(state, _estimated_tokens, nil), do: {state, :none}
   defp maybe_auto_compact(state, _estimated_tokens, 0), do: {state, :none}
 
-  defp maybe_auto_compact(state, estimated_tokens, context_limit) do
+  defp maybe_auto_compact(
+         %EditorState{shell_runtime: %Runtime{state: %TraditionalState{} = shell_state}} = state,
+         estimated_tokens,
+         context_limit
+       ) do
     fill_pct = min(round(estimated_tokens / context_limit * 100), 100)
     view = state.workspace.agent_ui.view
-
-    agent_status =
-      MingaEditor.Shell.Traditional.State.agent(state.shell_runtime.state).runtime.status
-
+    agent_status = TraditionalState.agent(shell_state).runtime.status
     compact_when_ready(state, view, agent_status, fill_pct)
   end
+
+  defp maybe_auto_compact(%EditorState{} = state, _estimated_tokens, _context_limit),
+    do: {state, :none}
 
   @spec compact_when_ready(EditorState.t(), term(), AgentState.status(), non_neg_integer()) ::
           {EditorState.t(), compaction_action()}

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -27,7 +27,7 @@ defmodule MingaEditor.Commands do
   alias Minga.Buffer
   alias Minga.Extension.CallbackInvoker
   alias Minga.Extension.InvocationContext
-  alias MingaEditor.Extension.EventDispatcher, as: ExtensionEventDispatcher
+  alias MingaEditor.Extension.EventWorkflow, as: ExtensionEventWorkflow
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
   alias MingaEditor.Shell.Traditional.ToolPrompts
   alias MingaEditor.Shell.Traditional.ToolPromptWorkflow
@@ -827,15 +827,10 @@ defmodule MingaEditor.Commands do
   @spec execute_git_porcelain_command(state(), atom() | tuple()) :: state()
   defp execute_git_porcelain_command(state, command) do
     if git_porcelain_running?() do
-      case ExtensionEventDispatcher.dispatch_editor_action(
-             state,
-             :execute_git_command,
-             command
-           ) do
-        {:handled, updated_state} -> updated_state
-        :not_matched -> state
-        {:callback_failed, _failure} -> state
-      end
+      ExtensionEventWorkflow.dispatch(
+        state,
+        {:editor_action, :execute_git_command, command}
+      )
     else
       state
     end

--- a/lib/minga_editor/commands/agent_session.ex
+++ b/lib/minga_editor/commands/agent_session.ex
@@ -982,7 +982,7 @@ defmodule MingaEditor.Commands.AgentSession do
   defp session_project_view(%{shell_runtime: %{state: %{tab_bar: %TabBar{} = tb}}} = state) do
     case TabBar.active_workspace(tb) do
       %Workspace{kind: :agent} = workspace ->
-        if Workspace.project_view_active?(workspace) do
+        if MingaEditor.WorkspaceWorkflow.project_view_active?(workspace) do
           {workspace.project_view, false}
         else
           project_view_from_root(state)

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -1391,7 +1391,7 @@ defmodule MingaEditor.Commands.BufferManagement do
        ) do
     case project_view_changed_files(workspace) do
       {:ok, []} ->
-        case WorkspaceModel.close_project_view(workspace) do
+        case MingaEditor.WorkspaceWorkflow.close_project_view(workspace) do
           :ok ->
             remove_clean_project_view_workspace_after_session_down(
               state,
@@ -1818,7 +1818,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   defp close_agent_tab_without_session(state, tb, workspace, _workspace_view) do
     case project_view_changed_files(workspace) do
       {:ok, []} ->
-        case WorkspaceModel.close_project_view(workspace) do
+        case MingaEditor.WorkspaceWorkflow.close_project_view(workspace) do
           :ok ->
             state =
               WorkspaceWorkflow.install_tab_bar(

--- a/lib/minga_editor/commands/workspace.ex
+++ b/lib/minga_editor/commands/workspace.ex
@@ -327,7 +327,7 @@ defmodule MingaEditor.Commands.Workspace do
     else
       case project_view_changed_files(workspace) do
         {:ok, []} ->
-          case WorkspaceModel.close_project_view(workspace) do
+          case MingaEditor.WorkspaceWorkflow.close_project_view(workspace) do
             :ok ->
               remove_workspace_and_sync_agent_ui(state, tb, workspace_id)
 
@@ -399,7 +399,7 @@ defmodule MingaEditor.Commands.Workspace do
             "Stop the agent session before closing this workspace"
           )
         else
-          case WorkspaceModel.close_project_view(workspace) do
+          case MingaEditor.WorkspaceWorkflow.close_project_view(workspace) do
             :ok ->
               remove_workspace_and_sync_agent_ui(state, tb, workspace_id)
 

--- a/lib/minga_editor/extension/event_effect.ex
+++ b/lib/minga_editor/extension/event_effect.ex
@@ -1,0 +1,362 @@
+defmodule MingaEditor.Extension.EventEffect do
+  @moduledoc """
+  Runs extension-owned editor callbacks outside the Editor mailbox.
+
+  Each request carries an immutable Editor snapshot. A completed state transition
+  commits only while that exact snapshot remains current, so a slow extension
+  can never overwrite input or other state changes that arrived while it ran.
+  Timed-out, conflicting, and late results are terminal and never rerun.
+  """
+
+  @behaviour MingaEditor.Effect
+
+  alias Minga.Extension.CallbackRegistry
+  alias Minga.Extension.CodeLease
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.Effect.Policy
+  alias MingaEditor.Effect.Request
+  alias MingaEditor.Extension.EventDispatcher
+  alias MingaEditor.Extension.EventHandler
+  alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.State, as: EditorState
+
+  @resource :extension_editor_events
+  @max_queued 0
+  @timeout_ms 1_000
+
+  @type mode :: :ordinary | {:unload, CallbackRegistry.source(), CodeLease.unload_token()}
+  @type reply_to :: {pid(), reference()} | nil
+
+  @enforce_keys [:mode, :base_state, :event, :registry, :admission]
+  defstruct [:mode, :base_state, :event, :registry, :admission, :reply_to]
+
+  @type t :: %__MODULE__{
+          mode: mode(),
+          base_state: EditorState.t(),
+          event: EventHandler.event(),
+          registry: CallbackRegistry.registry(),
+          admission: GenServer.server(),
+          reply_to: reply_to()
+        }
+
+  @doc "Builds one bounded FIFO callback request for an ordinary editor event."
+  @spec request(EditorState.t(), EventHandler.event(), keyword()) :: Request.t()
+  def request(%EditorState{} = state, event, opts \\ []) do
+    effect = %__MODULE__{
+      mode: :ordinary,
+      base_state: state,
+      event: event,
+      registry: Keyword.get(opts, :callback_registry, CallbackRegistry.default_table()),
+      admission: Keyword.get(opts, :callback_admission, CodeLease),
+      reply_to: Keyword.get(opts, :reply_to)
+    }
+
+    Request.new(effect, @resource, Policy.fifo(@max_queued), timeout_ms: timeout(opts))
+  end
+
+  @doc "Builds one token-authorized unload callback request."
+  @spec unload_request(
+          EditorState.t(),
+          CallbackRegistry.source(),
+          CodeLease.unload_token(),
+          reply_to(),
+          keyword()
+        ) :: Request.t()
+  def unload_request(%EditorState{} = state, source, token, reply_to, opts \\ [])
+      when is_reference(token) do
+    effect = %__MODULE__{
+      mode: {:unload, source, token},
+      base_state: state,
+      event: {:source_unload, source},
+      registry: Keyword.get(opts, :callback_registry, CallbackRegistry.default_table()),
+      admission: Keyword.get(opts, :callback_admission, CodeLease),
+      reply_to: reply_to
+    }
+
+    Request.new(
+      effect,
+      {:extension_editor_unload, source},
+      Policy.fifo(@max_queued),
+      timeout_ms: timeout(opts)
+    )
+  end
+
+  @impl true
+  @spec run(t()) :: {:ok, EventHandler.result() | EventDispatcher.unload_result()}
+  def run(%__MODULE__{mode: :ordinary} = effect) do
+    {:ok,
+     EventDispatcher.dispatch(
+       effect.base_state,
+       effect.event,
+       effect.registry,
+       effect.admission
+     )}
+  end
+
+  def run(%__MODULE__{mode: {:unload, source, token}} = effect) do
+    {:ok,
+     EventDispatcher.dispatch_source_unload(
+       effect.base_state,
+       source,
+       token,
+       effect.registry,
+       effect.admission
+     )}
+  end
+
+  @impl true
+  @spec coalesce(t(), t()) :: t()
+  def coalesce(%__MODULE__{}, %__MODULE__{} = newer), do: newer
+
+  @impl true
+  @spec apply(EditorState.t(), Outcome.t()) :: {EditorState.t(), Outcome.t()}
+  def apply(
+        %EditorState{} = current,
+        %Outcome{
+          status: :completed,
+          result: result,
+          request: %Request{effect: %__MODULE__{base_state: base_state} = effect}
+        } = outcome
+      ) do
+    {state, final_outcome} = commit_result(current, base_state, result, outcome, effect.event)
+    reply(effect, unload_reply(result, final_outcome))
+    {state, final_outcome}
+  end
+
+  def apply(
+        %EditorState{} = state,
+        %Outcome{
+          status: status,
+          request: %Request{id: request_id, effect: %__MODULE__{} = effect}
+        } = outcome
+      )
+      when status in [:failed, :canceled, :stale] do
+    Minga.Log.warning(
+      :editor,
+      "Extension editor event terminal request=#{inspect(request_id)} mode=#{inspect(effect.mode)} event=#{inspect(event_label(effect.event))} status=#{status} reason=#{bounded_inspect(outcome.reason)}"
+    )
+
+    state = terminal_feedback(state, effect.event, status, outcome.reason)
+    reply(effect, {:error, {:extension_event_terminal, status, outcome.reason}})
+    {state, outcome}
+  end
+
+  def apply(%EditorState{} = state, %Outcome{} = outcome), do: {state, outcome}
+
+  @impl true
+  @spec render?(Outcome.t()) :: boolean()
+  def render?(%Outcome{status: :completed, result: {:handled, %EditorState{}}}), do: true
+
+  def render?(%Outcome{
+        status: :completed,
+        result: {:callback_failed, failures, %EditorState{}}
+      })
+      when is_list(failures),
+      do: true
+
+  def render?(%Outcome{
+        status: :completed,
+        result: {:ok, %EditorState{}}
+      }),
+      do: true
+
+  def render?(%Outcome{
+        status: :completed,
+        result: {:error, failures, %EditorState{}}
+      })
+      when is_list(failures),
+      do: true
+
+  def render?(%Outcome{
+        status: status,
+        result: result,
+        request: %Request{effect: %__MODULE__{event: {:editor_action, _action, _arguments}}}
+      })
+      when status in [:completed, :stale] and
+             (result == :not_matched or
+                (is_tuple(result) and tuple_size(result) >= 1 and
+                   elem(result, 0) == :callback_failed)),
+      do: true
+
+  def render?(%Outcome{
+        status: status,
+        request: %Request{effect: %__MODULE__{event: {:editor_action, _action, _arguments}}}
+      })
+      when status in [:failed, :canceled],
+      do: true
+
+  def render?(%Outcome{}), do: false
+
+  @spec commit_result(
+          EditorState.t(),
+          EditorState.t(),
+          term(),
+          Outcome.t(),
+          EventHandler.event()
+        ) :: {EditorState.t(), Outcome.t()}
+  defp commit_result(current, base_state, result, outcome, event) do
+    candidate = result_state(result, base_state, event)
+
+    case EditorState.accept_extension_event_result(current, base_state, candidate) do
+      {:ok, state} ->
+        {result_feedback(state, result, event), outcome}
+
+      :stale ->
+        request_id = outcome.request.id
+
+        Minga.Log.warning(
+          :editor,
+          "Discarded stale extension editor event request=#{inspect(request_id)} event=#{inspect(event_label(event))} reason=editor_state_changed"
+        )
+
+        state = result_feedback(current, result, event)
+        {state, Outcome.stale(outcome, :editor_state_changed)}
+    end
+  end
+
+  @spec result_state(term(), EditorState.t(), EventHandler.event()) :: EditorState.t()
+  defp result_state({:handled, %EditorState{} = state}, _base_state, _event), do: state
+
+  defp result_state(
+         {:callback_failed, failures, %EditorState{} = state},
+         _base_state,
+         event
+       )
+       when is_list(failures) do
+    report_callback_failure(event, failures)
+    state
+  end
+
+  defp result_state({:callback_failed, failure}, base_state, event) do
+    report_callback_failure(event, [failure])
+    base_state
+  end
+
+  defp result_state(:not_matched, base_state, _event), do: base_state
+
+  defp result_state({:ok, %EditorState{} = state}, _base_state, _event), do: state
+
+  defp result_state({:error, failures, %EditorState{} = state}, _base_state, event)
+       when is_list(failures) do
+    report_callback_failure(event, failures)
+    state
+  end
+
+  defp result_state(_result, base_state, _event), do: base_state
+
+  @spec result_feedback(EditorState.t(), term(), EventHandler.event()) :: EditorState.t()
+  defp result_feedback(state, {:callback_failed, _failures, %EditorState{}}, event),
+    do: interactive_failure(state, event)
+
+  defp result_feedback(state, {:callback_failed, _failure}, event),
+    do: interactive_failure(state, event)
+
+  defp result_feedback(state, :not_matched, event), do: interactive_unavailable(state, event)
+  defp result_feedback(state, _result, _event), do: state
+
+  @spec terminal_feedback(EditorState.t(), EventHandler.event(), atom(), term()) ::
+          EditorState.t()
+  defp terminal_feedback(
+         state,
+         {:editor_action, :open_git_diff_for_path, _arguments},
+         status,
+         reason
+       ),
+       do: NoticeWorkflow.publish(state, "Git diff #{status}: #{bounded_inspect(reason)}")
+
+  defp terminal_feedback(
+         state,
+         {:editor_action, :execute_git_command, _command},
+         status,
+         reason
+       ),
+       do: NoticeWorkflow.publish(state, "Git command #{status}: #{bounded_inspect(reason)}")
+
+  defp terminal_feedback(state, _event, _status, _reason), do: state
+
+  @spec interactive_failure(EditorState.t(), EventHandler.event()) :: EditorState.t()
+  defp interactive_failure(state, {:editor_action, :open_git_diff_for_path, _arguments}),
+    do: NoticeWorkflow.publish(state, "Git porcelain extension callback failed")
+
+  defp interactive_failure(state, {:editor_action, :execute_git_command, _command}),
+    do: NoticeWorkflow.publish(state, "Git command callback failed")
+
+  defp interactive_failure(state, _event), do: state
+
+  @spec interactive_unavailable(EditorState.t(), EventHandler.event()) :: EditorState.t()
+  defp interactive_unavailable(state, {:editor_action, :open_git_diff_for_path, _arguments}),
+    do: NoticeWorkflow.publish(state, "Git porcelain extension is disabled or failed to load")
+
+  defp interactive_unavailable(state, {:editor_action, :execute_git_command, _command}),
+    do: NoticeWorkflow.publish(state, "Git command unavailable")
+
+  defp interactive_unavailable(state, _event), do: state
+
+  @spec report_callback_failure(EventHandler.event(), [term()]) :: :ok
+  defp report_callback_failure(event, failures) do
+    summaries = Enum.map(failures, &failure_label/1)
+
+    Minga.Log.warning(
+      :editor,
+      "Extension editor callback failed event=#{inspect(event_label(event))} failures=#{inspect(summaries, limit: 20)}"
+    )
+  end
+
+  @spec event_label(EventHandler.event()) :: term()
+  defp event_label({:buffer_saved, _buffer}), do: :buffer_saved
+  defp event_label({:editor_action, action, _arguments}), do: {:editor_action, action}
+  defp event_label({:source_unload, source}), do: {:source_unload, source}
+
+  @spec failure_label(term()) :: term()
+  defp failure_label({:callback_failed, source, module, function, kind, _reason}),
+    do: {:callback_failed, source, module, function, kind}
+
+  defp failure_label({:source_unavailable, source, module, function, _reason}),
+    do: {:source_unavailable, source, module, function}
+
+  defp failure_label({:invalid_return, source, module, function, returned}),
+    do: {:invalid_return, source, module, function, term_kind(returned)}
+
+  defp failure_label(other), do: term_kind(other)
+
+  @spec term_kind(term()) :: atom() | {atom(), non_neg_integer()}
+  defp term_kind(value) when is_tuple(value), do: {:tuple, tuple_size(value)}
+  defp term_kind(value) when is_map(value), do: {:map, map_size(value)}
+  defp term_kind(value) when is_list(value), do: :list
+  defp term_kind(value) when is_binary(value), do: {:binary, byte_size(value)}
+  defp term_kind(value) when is_atom(value), do: :atom
+  defp term_kind(value) when is_number(value), do: :number
+  defp term_kind(_value), do: :other
+
+  @spec bounded_inspect(term()) :: String.t()
+  defp bounded_inspect(value), do: inspect(value, limit: 10, printable_limit: 200)
+
+  @spec unload_reply(term(), Outcome.t()) :: :ok | {:error, term()}
+  defp unload_reply(_result, %Outcome{status: :stale, reason: reason}),
+    do: {:error, {:extension_unload_stale, reason}}
+
+  defp unload_reply({:ok, %EditorState{}}, %Outcome{status: :completed}), do: :ok
+
+  defp unload_reply({:error, failures, %EditorState{}}, %Outcome{status: :completed})
+       when is_list(failures),
+       do: {:error, failures}
+
+  defp unload_reply(result, %Outcome{status: :completed}),
+    do: {:error, {:extension_unload_invalid_result, term_kind(result)}}
+
+  @spec timeout(keyword()) :: pos_integer()
+  defp timeout(opts) do
+    case Keyword.get(opts, :timeout_ms, @timeout_ms) do
+      timeout_ms when is_integer(timeout_ms) and timeout_ms > 0 -> min(timeout_ms, @timeout_ms)
+      _invalid -> @timeout_ms
+    end
+  end
+
+  @spec reply(t(), term()) :: :ok
+  defp reply(%__MODULE__{reply_to: nil}, _reply), do: :ok
+
+  defp reply(%__MODULE__{reply_to: {recipient, ref}}, result) do
+    send(recipient, {:extension_source_finalized, ref, result})
+    :ok
+  end
+end

--- a/lib/minga_editor/extension/event_handler.ex
+++ b/lib/minga_editor/extension/event_handler.ex
@@ -1,10 +1,12 @@
 defmodule MingaEditor.Extension.EventHandler do
   @moduledoc """
-  Contract for synchronous extension callbacks that transform editor state.
+  Contract for worker-executed extension callbacks that transform an editor snapshot.
 
   `:buffer_saved` callbacks fan out, `:editor_action` callbacks are first-match,
   and `:source_unload` callbacks run only for the source being finalized.
   Returning `:not_matched` means the callback ran successfully and declined.
+  The callback process identity is opaque, and a returned snapshot commits only
+  when it has not been superseded by newer Editor state.
   """
 
   alias Minga.Extension.CallbackInvoker
@@ -28,6 +30,6 @@ defmodule MingaEditor.Extension.EventHandler do
           | {:callback_failed, CallbackInvoker.failure()}
           | {:callback_failed, [CallbackInvoker.failure()], EditorState.t()}
 
-  @doc "Handles one runtime editor event synchronously in the Editor process."
+  @doc "Handles one runtime editor event in a bounded effect worker."
   @callback handle_editor_event(EditorState.t(), event()) :: callback_result()
 end

--- a/lib/minga_editor/extension/event_workflow.ex
+++ b/lib/minga_editor/extension/event_workflow.ex
@@ -1,0 +1,92 @@
+defmodule MingaEditor.Extension.EventWorkflow do
+  @moduledoc """
+  Admits extension editor events to the generation-owned effect scheduler.
+
+  The Editor only constructs bounded typed requests here. Extension code runs in
+  scheduler workers and correlated outcomes return through the normal effect path.
+  """
+
+  alias Minga.Extension.CallbackInvoker
+  alias Minga.Extension.CodeLease
+  alias MingaEditor.EffectScheduler
+  alias MingaEditor.Extension.EventEffect
+  alias MingaEditor.Extension.EventHandler
+  alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.State, as: EditorState
+
+  @type unload_context :: %{
+          required(:token) => CodeLease.unload_token(),
+          optional(:callback_registry) => GenServer.server(),
+          optional(:callback_admission) => GenServer.server()
+        }
+
+  @doc "Schedules an ordinary extension editor event without waiting in the Editor."
+  @spec dispatch(EditorState.t(), EventHandler.event(), keyword()) :: EditorState.t()
+  def dispatch(%EditorState{} = state, event, opts \\ []) do
+    schedule(state, EventEffect.request(state, event, opts))
+  end
+
+  @doc "Schedules token-authorized unload callbacks and defers the caller reply."
+  @spec dispatch_unload(
+          EditorState.t(),
+          CallbackInvoker.source(),
+          unload_context(),
+          {pid(), term()}
+        ) :: {:ok, EditorState.t()} | {:error, term(), EditorState.t()}
+  def dispatch_unload(%EditorState{} = state, source, context, reply_to) do
+    token = Map.fetch!(context, :token)
+
+    opts =
+      [
+        callback_registry: Map.get(context, :callback_registry),
+        callback_admission: Map.get(context, :callback_admission)
+      ]
+      |> Enum.reject(fn {_key, value} -> is_nil(value) end)
+
+    request = EventEffect.unload_request(state, source, token, reply_to, opts)
+
+    case admit(state, request) do
+      :ok -> {:ok, state}
+      {:error, reason} -> {:error, reason, state}
+    end
+  end
+
+  @spec schedule(EditorState.t(), MingaEditor.Effect.Request.t()) :: EditorState.t()
+  defp schedule(%EditorState{} = state, %MingaEditor.Effect.Request{} = request) do
+    case admit(state, request) do
+      :ok ->
+        state
+
+      {:error, reason} ->
+        event = request.effect.event
+
+        Minga.Log.warning(
+          :editor,
+          "Extension editor event not scheduled event=#{inspect(event)} reason=#{inspect(reason)}"
+        )
+
+        admission_failure(state, event, reason)
+    end
+  end
+
+  @spec admission_failure(EditorState.t(), EventHandler.event(), term()) :: EditorState.t()
+  defp admission_failure(state, {:editor_action, :open_git_diff_for_path, _arguments}, reason),
+    do: NoticeWorkflow.publish(state, "Git diff not scheduled: #{inspect(reason)}")
+
+  defp admission_failure(state, {:editor_action, :execute_git_command, _command}, reason),
+    do: NoticeWorkflow.publish(state, "Git command not scheduled: #{inspect(reason)}")
+
+  defp admission_failure(state, _event, _reason), do: state
+
+  @spec admit(EditorState.t(), MingaEditor.Effect.Request.t()) :: :ok | {:error, term()}
+  defp admit(%EditorState{effect_scheduler: nil}, _request), do: {:error, :scheduler_unavailable}
+
+  defp admit(%EditorState{} = state, request) do
+    case EffectScheduler.schedule(state.effect_scheduler, request) do
+      {:ok, _request_id, _disposition} -> :ok
+      {:error, reason} -> {:error, reason}
+    end
+  catch
+    :exit, reason -> {:error, reason}
+  end
+end

--- a/lib/minga_editor/extension/source_finalizer.ex
+++ b/lib/minga_editor/extension/source_finalizer.ex
@@ -12,12 +12,13 @@ defmodule MingaEditor.Extension.SourceFinalizer do
   alias Minga.Extension.CodeLease
   alias Minga.Extension.ContributionCleanup
   alias MingaEditor.EffectScheduler
-  alias MingaEditor.Extension.EventDispatcher
+  alias MingaEditor.Extension.EventWorkflow
   alias MingaEditor.PickerUI
   alias MingaEditor.State, as: EditorState
 
   @cleanup_family :editor_effects
   @unload_family :editor_extension_unload
+  @editor_request_timeout 2_000
 
   @type source :: ContributionCleanup.contribution_source()
   @type result :: :ok | {:error, term()}
@@ -70,18 +71,15 @@ defmodule MingaEditor.Extension.SourceFinalizer do
     end
   end
 
-  @doc "Runs source-filtered unload callbacks and preserves their last successful state."
-  @spec finalize_unload(EditorState.t(), CallbackInvoker.source(), unload_context()) ::
-          {:ok, EditorState.t()} | {{:error, term()}, EditorState.t()}
-  def finalize_unload(%EditorState{} = state, {:extension, _name} = source, context) do
-    token = Map.fetch!(context, :token)
-    registry = Map.get(context, :callback_registry, CallbackRegistry.default_table())
-    admission = Map.get(context, :callback_admission, CodeLease)
-
-    case EventDispatcher.dispatch_source_unload(state, source, token, registry, admission) do
-      {:ok, updated_state} -> {:ok, updated_state}
-      {:error, failures, updated_state} -> {{:error, failures}, updated_state}
-    end
+  @doc "Schedules source-filtered unload callbacks and defers the cleanup acknowledgement."
+  @spec finalize_unload(
+          EditorState.t(),
+          CallbackInvoker.source(),
+          unload_context(),
+          {pid(), reference()}
+        ) :: {:ok, EditorState.t()} | {:error, term(), EditorState.t()}
+  def finalize_unload(%EditorState{} = state, {:extension, _name} = source, context, reply_to) do
+    EventWorkflow.dispatch_unload(state, source, context, reply_to)
   end
 
   @doc "Cancels source work before removing its live picker presentation."
@@ -115,6 +113,10 @@ defmodule MingaEditor.Extension.SourceFinalizer do
 
       {:DOWN, ^ref, :process, ^pid, reason} ->
         {:error, {:editor_unavailable, reason}}
+    after
+      @editor_request_timeout ->
+        Process.demonitor(ref, [:flush])
+        {:error, {:editor_request_timeout, @editor_request_timeout}}
     end
   end
 end

--- a/lib/minga_editor/file_tree/freshness.ex
+++ b/lib/minga_editor/file_tree/freshness.ex
@@ -18,6 +18,7 @@ defmodule MingaEditor.FileTree.Freshness do
   alias MingaEditor.FileTree.Refresh
   alias MingaEditor.FileTree.WatcherSync
   alias MingaEditor.FileTree.WatcherSync.Result, as: WatcherResult
+  alias MingaEditor.Shell.Traditional.NoticeWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.FileTree, as: FileTreeState
 
@@ -25,6 +26,9 @@ defmodule MingaEditor.FileTree.Freshness do
 
   @refresh_retry_base_ms 25
   @refresh_retry_max_ms 1_000
+  @watcher_retry_base_ms 25
+  @watcher_retry_max_ms 1_000
+  @watcher_retry_max_attempts 6
 
   @doc "Returns true when the file tree is open."
   @spec open?(state()) :: boolean()
@@ -122,10 +126,21 @@ defmodule MingaEditor.FileTree.Freshness do
 
   def apply_refresh_outcome(
         state,
+        %Outcome{
+          status: :failed,
+          request: %Request{effect: %Refresh{} = effect} = request,
+          reason: reason
+        } = outcome
+      ) do
+    {finish_failed_refresh(state, effect, request.id, reason), outcome}
+  end
+
+  def apply_refresh_outcome(
+        state,
         %Outcome{status: status, request: %Request{effect: %Refresh{} = effect} = request} =
           outcome
       )
-      when status in [:failed, :canceled, :stale] do
+      when status in [:canceled, :stale] do
     {finish_terminal_refresh(state, effect, request.id), outcome}
   end
 
@@ -233,11 +248,30 @@ defmodule MingaEditor.FileTree.Freshness do
   def apply_watcher_outcome(
         state,
         %Outcome{
+          status: :failed,
+          request: %Request{effect: %WatcherSync{} = effect} = request,
+          reason: reason
+        } = outcome
+      ) do
+    case FileTreeState.finish_watcher_request(file_tree_state(state), request.id) do
+      {:current, file_tree} ->
+        state = set_file_tree(state, file_tree)
+        opts = watcher_options(effect.backend, effect.backend_context)
+        {schedule_watcher_retry(state, opts, reason), outcome}
+
+      {:stale, file_tree} ->
+        {set_file_tree(state, file_tree), Outcome.stale(outcome, :stale)}
+    end
+  end
+
+  def apply_watcher_outcome(
+        state,
+        %Outcome{
           status: status,
           request: %Request{effect: %WatcherSync{}} = request
         } = outcome
       )
-      when status in [:failed, :canceled, :stale] do
+      when status in [:canceled, :stale] do
     case FileTreeState.finish_watcher_request(file_tree_state(state), request.id) do
       {:current, file_tree} -> {set_file_tree(state, file_tree), outcome}
       {:stale, file_tree} -> {set_file_tree(state, file_tree), Outcome.stale(outcome, :stale)}
@@ -547,6 +581,20 @@ defmodule MingaEditor.FileTree.Freshness do
     schedule_watcher_sync(state, intent, opts)
   end
 
+  @doc "Consumes a correlated watcher retry timer and resubmits the retained intent."
+  @spec retry_watcher_sync(state(), reference(), keyword()) :: state()
+  def retry_watcher_sync(state, token, opts) when is_reference(token) and is_list(opts) do
+    case FileTreeState.watcher_retry_elapsed(file_tree_state(state), token) do
+      {:current, file_tree} ->
+        state
+        |> set_file_tree(file_tree)
+        |> synchronize_watchers(opts)
+
+      {:stale, file_tree} ->
+        set_file_tree(state, file_tree)
+    end
+  end
+
   @spec maybe_synchronize_watchers(state(), Refresh.t() | FilterWalk.t()) :: state()
   defp maybe_synchronize_watchers(state, %Refresh{synchronize_watchers?: false}), do: state
   defp maybe_synchronize_watchers(state, %FilterWalk{synchronize_watchers?: false}), do: state
@@ -579,9 +627,55 @@ defmodule MingaEditor.FileTree.Freshness do
         set_file_tree(state, file_tree)
 
       {:error, reason} ->
-        Minga.Log.warning(:editor, "File tree watcher sync not scheduled: #{inspect(reason)}")
-        state
+        schedule_watcher_retry(state, opts, {:schedule_failed, reason})
     end
+  end
+
+  @spec schedule_watcher_retry(state(), keyword(), term()) :: state()
+  defp schedule_watcher_retry(state, opts, reason) do
+    token = make_ref()
+    {attempt, file_tree} = FileTreeState.schedule_watcher_retry(file_tree_state(state), token)
+    state = set_file_tree(state, file_tree)
+
+    if attempt < @watcher_retry_max_attempts do
+      if attempt == 1 do
+        Minga.Log.warning(
+          :editor,
+          "File tree watcher sync failed: #{inspect(reason, limit: 20)}; retrying"
+        )
+      end
+
+      Process.send_after(
+        self(),
+        {:file_tree_watcher_retry, token, opts},
+        watcher_retry_delay(attempt)
+      )
+
+      state
+    else
+      watcher_retry_exhausted(state, attempt, reason)
+    end
+  end
+
+  @spec watcher_retry_exhausted(state(), pos_integer(), term()) :: state()
+  defp watcher_retry_exhausted(state, attempt, reason) do
+    file_tree = FileTreeState.exhaust_watcher_retry(file_tree_state(state))
+    target = FileTreeState.watcher_intent(file_tree).target
+
+    Minga.Log.error(
+      :editor,
+      "File tree watcher sync stopped target=#{inspect(target)} attempts=#{attempt} reason=#{inspect(reason, limit: 20)}"
+    )
+
+    state
+    |> set_file_tree(file_tree)
+    |> NoticeWorkflow.publish("File tree watcher recovery stopped after #{attempt} attempts")
+  end
+
+  @spec watcher_retry_delay(pos_integer()) :: pos_integer()
+  defp watcher_retry_delay(attempt) do
+    exponent = min(attempt - 1, 6)
+    min(@watcher_retry_base_ms * Integer.pow(2, exponent), @watcher_retry_max_ms)
   end
 
   @spec watcher_options(module() | nil, term()) :: keyword()

--- a/lib/minga_editor/file_tree/watcher_sync.ex
+++ b/lib/minga_editor/file_tree/watcher_sync.ex
@@ -68,6 +68,7 @@ defmodule MingaEditor.FileTree.WatcherSync do
 
   @impl true
   @spec render?(Outcome.t()) :: boolean()
+  def render?(%Outcome{status: :failed}), do: true
   def render?(%Outcome{}), do: false
 
   @spec unwatch_obsolete_roots(t()) :: :ok | {:error, term()}

--- a/lib/minga_editor/handlers/file_event_handler.ex
+++ b/lib/minga_editor/handlers/file_event_handler.ex
@@ -11,7 +11,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
   File-tree or LSP failures retain their existing domain reporting policy.
   """
 
-  alias MingaEditor.Extension.EventDispatcher
+  alias MingaEditor.Extension.EventWorkflow
   alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.LspActions
@@ -181,11 +181,7 @@ defmodule MingaEditor.Handlers.FileEventHandler do
 
   @spec dispatch_extension_buffer_saved(EditorState.t(), pid()) :: EditorState.t()
   defp dispatch_extension_buffer_saved(state, saved_buf) do
-    case EventDispatcher.dispatch(state, {:buffer_saved, saved_buf}) do
-      {:handled, updated_state} -> updated_state
-      :not_matched -> state
-      {:callback_failed, _failures, preserved_state} -> preserved_state
-    end
+    EventWorkflow.dispatch(state, {:buffer_saved, saved_buf})
   end
 
   @spec handle_buffer_changed(EditorState.t(), pid()) :: {EditorState.t(), [file_effect()]}

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -30,7 +30,7 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   alias MingaEditor.GitRepositoryResolver
   alias MingaEditor.FileTree.Freshness, as: FileTreeFreshness
   alias MingaEditor.Commands
-  alias MingaEditor.Extension.EventDispatcher, as: ExtensionEventDispatcher
+  alias MingaEditor.Extension.EventWorkflow, as: ExtensionEventWorkflow
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Handlers.BufferRegistry
   alias MingaEditor.HighlightSync
@@ -1282,22 +1282,10 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
   defp open_git_diff_for_path(state, git_root, git_path, abs_path, current_content, opts) do
     arguments = {git_root, git_path, abs_path, current_content, opts}
 
-    case ExtensionEventDispatcher.dispatch_editor_action(
-           state,
-           :open_git_diff_for_path,
-           arguments
-         ) do
-      {:handled, updated_state} -> updated_state
-      :not_matched -> git_porcelain_unavailable(state)
-      {:callback_failed, _failure} -> git_porcelain_callback_failed(state)
-    end
-  end
-
-  @spec git_porcelain_callback_failed(state()) :: state()
-  defp git_porcelain_callback_failed(state) do
-    message = "Git porcelain extension callback failed"
-    Minga.Log.warning(:editor, message)
-    NoticeWorkflow.publish(state, message)
+    ExtensionEventWorkflow.dispatch(
+      state,
+      {:editor_action, :open_git_diff_for_path, arguments}
+    )
   end
 
   @spec git_porcelain_unavailable(state()) :: state()

--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -61,7 +61,6 @@ defmodule MingaEditor.RenderPipeline.Input do
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Shell.Runtime
-  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.UI.FontRegistry
   alias MingaEditor.UI.NotificationCenter
   alias MingaEditor.UI.Panel.MessageStore
@@ -328,46 +327,21 @@ defmodule MingaEditor.RenderPipeline.Input do
       # Mode affects status bar label, minibuffer content, cursor shape
       input.workspace.editing.mode,
       input.workspace.editing.mode_state,
-      # Tab bar state
-      input.shell_state |> Map.get(:tab_bar),
-      # Ordinary notice and independent flash owners
-      input.shell_state |> Map.get(:notice),
-      input.shell_state |> Map.get(:flashes),
       # Sidebar registry state drives sidebar chrome/layout rebuilds.
       Sidebar.all(input.sidebar_registry),
       # File tree
       input.workspace.file_tree,
-      # Hover popup and signature help
-      input.shell_state |> Map.get(:hover_popup),
-      input.shell_state |> Map.get(:signature_help),
-      # Which-key popup
-      input.shell_state |> Map.get(:whichkey),
-      # Modal overlay (sum type covering picker, prompt, conflict,
-      # completion)
-      input.shell_state |> Map.get(:modal),
-      # Agent state (status, pending approval)
-      MingaEditor.Shell.Traditional.State.agent(input.shell_state),
       # Viewport dimensions (overlay positioning)
       input.terminal_viewport.rows,
       input.terminal_viewport.cols,
       # Window splits (separator rendering)
       input.workspace.windows.tree,
-      # Bottom panel
-      input.shell_state |> Map.get(:bottom_panel),
       # GUI notification center
       input.notifications,
-      # Git status panel
-      git_status_panel(input),
-      # Shell-owned chrome state that does not belong in the generic pipeline contract
+      # Shell-owned chrome state stays behind the shell contract.
       input.shell.chrome_fingerprint(input)
     })
   end
-
-  @spec git_status_panel(t()) :: MingaEditor.GitStatus.Panel.t() | nil
-  defp git_status_panel(%__MODULE__{shell_state: %TraditionalState{} = shell_state}),
-    do: TraditionalState.git_status_panel(shell_state)
-
-  defp git_status_panel(%__MODULE__{}), do: nil
 
   @spec status_bar_fingerprint(t()) :: integer()
   defp status_bar_fingerprint(%__MODULE__{} = input) do

--- a/lib/minga_editor/shell/traditional.ex
+++ b/lib/minga_editor/shell/traditional.ex
@@ -38,6 +38,7 @@ defmodule MingaEditor.Shell.Traditional do
   alias MingaEditor.WindowTree
   alias MingaEditor.Shell.BufferMetadata
   alias MingaEditor.Shell.Traditional.State, as: ShellState
+  alias MingaEditor.RenderPipeline.Input, as: RenderInput
   alias MingaEditor.Session.State, as: SessionState
 
   @impl true
@@ -183,6 +184,21 @@ defmodule MingaEditor.Shell.Traditional do
 
   @impl true
   @spec chrome_fingerprint(term()) :: term()
+  def chrome_fingerprint(%RenderInput{shell_state: %ShellState{} = shell_state}) do
+    {
+      shell_state.tab_bar,
+      shell_state.notice,
+      shell_state.flashes,
+      shell_state.hover_popup,
+      shell_state.signature_help,
+      shell_state.whichkey,
+      ShellState.modal(shell_state),
+      ShellState.agent(shell_state),
+      shell_state.bottom_panel,
+      ShellState.git_status_panel(shell_state)
+    }
+  end
+
   def chrome_fingerprint(editor_state),
     do: MingaEditor.Shell.Traditional.Chrome.chrome_fingerprint(editor_state)
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -134,6 +134,20 @@ defmodule MingaEditor.State do
     %{state | appearance: appearance, parser: parser}
   end
 
+  @doc "Commits an extension snapshot transition unless semantic Editor state superseded it."
+  @spec accept_extension_event_result(t(), t(), t()) :: {:ok, t()} | :stale
+  def accept_extension_event_result(
+        %__MODULE__{} = current,
+        %__MODULE__{} = base,
+        %__MODULE__{} = candidate
+      ) do
+    if current == %{base | render: current.render} do
+      {:ok, %{candidate | render: current.render}}
+    else
+      :stale
+    end
+  end
+
   @doc "Atomically integrates a synchronous focused renderer receipt."
   @spec integrate_synchronous_renderer_receipt(t(), RenderReceipt.t()) :: t()
   def integrate_synchronous_renderer_receipt(%__MODULE__{} = state, %RenderReceipt{} = receipt) do

--- a/lib/minga_editor/state/file_tree.ex
+++ b/lib/minga_editor/state/file_tree.ex
@@ -250,6 +250,10 @@ defmodule MingaEditor.State.FileTree do
   @spec watcher_intent(t()) :: Watchers.t()
   def watcher_intent(%__MODULE__{} = ft), do: ft.watchers
 
+  @doc "Returns the monotonic generation of the current root and watcher lineage."
+  @spec root_generation(t()) :: non_neg_integer()
+  def root_generation(%__MODULE__{} = ft), do: ft.watchers.generation
+
   @doc "Correlates the latest admitted watcher synchronization request."
   @spec track_watcher_request(t(), reference()) :: t()
   def track_watcher_request(%__MODULE__{} = ft, token) when is_reference(token) do
@@ -270,6 +274,27 @@ defmodule MingaEditor.State.FileTree do
     case Watchers.request_finished(ft.watchers, token) do
       {status, watchers} -> {status, %{ft | watchers: watchers}}
     end
+  end
+
+  @doc "Correlates a bounded watcher synchronization retry."
+  @spec schedule_watcher_retry(t(), reference()) :: {pos_integer(), t()}
+  def schedule_watcher_retry(%__MODULE__{} = ft, token) when is_reference(token) do
+    {attempt, watchers} = Watchers.retry_scheduled(ft.watchers, token)
+    {attempt, %{ft | watchers: watchers}}
+  end
+
+  @doc "Consumes only the current watcher retry timer."
+  @spec watcher_retry_elapsed(t(), reference()) :: {:current | :stale, t()}
+  def watcher_retry_elapsed(%__MODULE__{} = ft, token) when is_reference(token) do
+    case Watchers.retry_elapsed(ft.watchers, token) do
+      {status, watchers} -> {status, %{ft | watchers: watchers}}
+    end
+  end
+
+  @doc "Terminalizes watcher retry correlation after the bounded attempt budget."
+  @spec exhaust_watcher_retry(t()) :: t()
+  def exhaust_watcher_retry(%__MODULE__{} = ft) do
+    %{ft | watchers: Watchers.retry_exhausted(ft.watchers)}
   end
 
   @doc "Changes the watcher target to cleanup-only while retaining all known roots."

--- a/lib/minga_editor/state/file_tree/watchers.ex
+++ b/lib/minga_editor/state/file_tree/watchers.ex
@@ -15,10 +15,19 @@ defmodule MingaEditor.State.FileTree.Watchers do
           candidates: MapSet.t(String.t()),
           target: String.t() | nil,
           expanded_dirs: MapSet.t(String.t()),
-          request: request() | nil
+          request: request() | nil,
+          retry_token: reference() | nil,
+          retry_attempt: non_neg_integer(),
+          generation: non_neg_integer()
         }
 
-  defstruct candidates: MapSet.new(), target: nil, expanded_dirs: MapSet.new(), request: nil
+  defstruct candidates: MapSet.new(),
+            target: nil,
+            expanded_dirs: MapSet.new(),
+            request: nil,
+            retry_token: nil,
+            retry_attempt: 0,
+            generation: 0
 
   @doc "Records a desired tree while retaining every known cleanup root."
   @spec retarget(t(), [String.t()], FileTree.t()) :: t()
@@ -29,7 +38,10 @@ defmodule MingaEditor.State.FileTree.Watchers do
       watchers
       | candidates: add_roots(watchers.candidates, [target | roots]),
         target: target,
-        expanded_dirs: expand_set(tree.expanded)
+        expanded_dirs: expand_set(tree.expanded),
+        retry_token: nil,
+        retry_attempt: 0,
+        generation: watchers.generation + 1
     }
   end
 
@@ -40,25 +52,36 @@ defmodule MingaEditor.State.FileTree.Watchers do
       watchers
       | candidates: add_roots(watchers.candidates, roots),
         target: nil,
-        expanded_dirs: MapSet.new()
+        expanded_dirs: MapSet.new(),
+        retry_token: nil,
+        retry_attempt: 0,
+        generation: watchers.generation + 1
     }
   end
 
   @doc "Correlates the latest admitted watcher request with its exact target."
   @spec request_admitted(t(), reference()) :: t()
   def request_admitted(%__MODULE__{} = watchers, token) when is_reference(token) do
-    %{watchers | request: %{token: token, target: watchers.target}}
+    %{watchers | request: %{token: token, target: watchers.target}, retry_token: nil}
   end
 
   @doc "Collapses ownership only after the latest exact request succeeds."
   @spec synchronized(t(), reference(), String.t() | nil) :: {:current | :stale, t()}
   def synchronized(
-        %__MODULE__{request: %{token: token, target: target}} = watchers,
+        %__MODULE__{target: target, request: %{token: token, target: target}} = watchers,
         token,
         target
       ) do
     candidates = if is_binary(target), do: MapSet.new([target]), else: MapSet.new()
-    {:current, %{watchers | candidates: candidates, request: nil}}
+
+    {:current,
+     %{
+       watchers
+       | candidates: candidates,
+         request: nil,
+         retry_token: nil,
+         retry_attempt: 0
+     }}
   end
 
   def synchronized(%__MODULE__{} = watchers, _token, _target), do: {:stale, watchers}
@@ -70,6 +93,25 @@ defmodule MingaEditor.State.FileTree.Watchers do
   end
 
   def request_finished(%__MODULE__{} = watchers, _token), do: {:stale, watchers}
+
+  @doc "Correlates one bounded retry while retaining the current watcher intent."
+  @spec retry_scheduled(t(), reference()) :: {pos_integer(), t()}
+  def retry_scheduled(%__MODULE__{} = watchers, token) when is_reference(token) do
+    attempt = watchers.retry_attempt + 1
+    {attempt, %{watchers | retry_token: token, retry_attempt: attempt}}
+  end
+
+  @doc "Consumes only the current watcher retry timer."
+  @spec retry_elapsed(t(), reference()) :: {:current | :stale, t()}
+  def retry_elapsed(%__MODULE__{retry_token: token} = watchers, token) do
+    {:current, %{watchers | retry_token: nil}}
+  end
+
+  def retry_elapsed(%__MODULE__{} = watchers, _token), do: {:stale, watchers}
+
+  @doc "Terminalizes retry correlation while preserving the failed attempt count."
+  @spec retry_exhausted(t()) :: t()
+  def retry_exhausted(%__MODULE__{} = watchers), do: %{watchers | retry_token: nil}
 
   @spec add_roots(MapSet.t(String.t()), [String.t()]) :: MapSet.t(String.t())
   defp add_roots(candidates, roots) do

--- a/lib/minga_editor/state/modal_overlay/completion.ex
+++ b/lib/minga_editor/state/modal_overlay/completion.ex
@@ -66,7 +66,7 @@ defmodule MingaEditor.State.ModalOverlay.Completion do
       completion: Keyword.get(opts, :completion),
       trigger: Keyword.get(opts, :trigger, CompletionTrigger.new()),
       owner: owner,
-      opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
+      opened_at: Keyword.get(opts, :opened_at, 0)
     }
   end
 

--- a/lib/minga_editor/state/modal_overlay/conflict.ex
+++ b/lib/minga_editor/state/modal_overlay/conflict.ex
@@ -35,7 +35,7 @@ defmodule MingaEditor.State.ModalOverlay.Conflict do
       buffer: buffer,
       message: message,
       owner: Keyword.get(opts, :owner, buffer),
-      opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
+      opened_at: Keyword.get(opts, :opened_at, 0)
     }
   end
 end

--- a/lib/minga_editor/state/modal_overlay/picker.ex
+++ b/lib/minga_editor/state/modal_overlay/picker.ex
@@ -29,14 +29,14 @@ defmodule MingaEditor.State.ModalOverlay.Picker do
   Builds a picker payload wrapping the given `picker_ui` state.
 
   The optional `:owner` keyword defaults to `:global`. The optional
-  `:opened_at` keyword defaults to `System.monotonic_time(:millisecond)`.
+  `:opened_at` defaults to `0`; workflows may pass an explicit monotonic timestamp when ordering metadata is required.
   """
   @spec new(PickerState.t(), keyword()) :: t()
   def new(%PickerState{} = picker_ui, opts \\ []) do
     %__MODULE__{
       picker_ui: picker_ui,
       owner: Keyword.get(opts, :owner, :global),
-      opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
+      opened_at: Keyword.get(opts, :opened_at, 0)
     }
   end
 

--- a/lib/minga_editor/state/modal_overlay/prompt.ex
+++ b/lib/minga_editor/state/modal_overlay/prompt.ex
@@ -29,7 +29,7 @@ defmodule MingaEditor.State.ModalOverlay.Prompt do
     %__MODULE__{
       prompt_ui: prompt_ui,
       owner: Keyword.get(opts, :owner, :global),
-      opened_at: Keyword.get(opts, :opened_at, System.monotonic_time(:millisecond))
+      opened_at: Keyword.get(opts, :opened_at, 0)
     }
   end
 

--- a/lib/minga_editor/state/workspace.ex
+++ b/lib/minga_editor/state/workspace.ex
@@ -124,13 +124,6 @@ defmodule MingaEditor.State.Workspace do
     %{workspace | project_view: project_view}
   end
 
-  @doc "Releases the workspace's owned ProjectView resources, if any."
-  @spec close_project_view(t()) :: :ok | {:error, term()}
-  def close_project_view(%__MODULE__{project_view: %ProjectView{} = project_view}),
-    do: ProjectView.close(project_view)
-
-  def close_project_view(%__MODULE__{}), do: :ok
-
   @doc "Sets the session owned by the workspace."
   @spec set_session(t(), pid() | nil) :: t()
   def set_session(%__MODULE__{} = workspace, session) when is_pid(session) or is_nil(session) do
@@ -233,14 +226,6 @@ defmodule MingaEditor.State.Workspace do
   end
 
   def matches_remote_session?(%__MODULE__{}, _server_name, _session_id), do: false
-
-  @doc "Returns true when the workspace still has a live ProjectView."
-  @spec project_view_active?(t()) :: boolean()
-  def project_view_active?(%__MODULE__{project_view: %ProjectView{} = project_view}) do
-    ProjectView.active?(project_view)
-  end
-
-  def project_view_active?(%__MODULE__{}), do: false
 
   @doc "Returns a copy scoped to a project root for persistence."
   @spec with_project_root(t(), String.t() | nil) :: t()

--- a/lib/minga_editor/workspace_workflow.ex
+++ b/lib/minga_editor/workspace_workflow.ex
@@ -7,6 +7,7 @@ defmodule MingaEditor.WorkspaceWorkflow do
   deletes outside those owners.
   """
 
+  alias MingaAgent.ProjectView
   alias MingaEditor.Shell.Identity
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.StateStash
@@ -15,6 +16,20 @@ defmodule MingaEditor.WorkspaceWorkflow do
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace
   alias MingaEditor.State.Workspace.Persistence
+
+  @doc "Releases backend-owned resources for a workspace ProjectView."
+  @spec close_project_view(Workspace.t()) :: :ok | {:error, term()}
+  def close_project_view(%Workspace{project_view: %ProjectView{} = project_view}),
+    do: ProjectView.close(project_view)
+
+  def close_project_view(%Workspace{}), do: :ok
+
+  @doc "Returns whether a workspace ProjectView backend is still available."
+  @spec project_view_active?(Workspace.t()) :: boolean()
+  def project_view_active?(%Workspace{project_view: %ProjectView{} = project_view}),
+    do: ProjectView.active?(project_view)
+
+  def project_view_active?(%Workspace{}), do: false
 
   @doc "Persists durable workspace changes between two Editor root values."
   @spec persist_changes(EditorState.t(), EditorState.t()) :: EditorState.t()

--- a/test/minga/credo/editor_state_ownership_check_test.exs
+++ b/test/minga/credo/editor_state_ownership_check_test.exs
@@ -1211,6 +1211,30 @@ defmodule Minga.Credo.EditorStateOwnershipCheckTest do
     end
   end
 
+  test "rejects explicit pure module subsets that omit declared owners" do
+    source =
+      """
+      defmodule MingaEditor.State.RenderCorrelation do
+        def violate(value), do: MingaEditor.RenderPipeline.render(value)
+      end
+      """
+
+    issues =
+      check(
+        source,
+        "lib/minga_editor/state/render_correlation.ex",
+        pure_modules: ["MingaEditor.State.RenderCorrelation"]
+      )
+
+    assert issues != []
+    assert Enum.all?(issues, &(&1.trigger == "ownership configuration"))
+
+    assert Enum.any?(issues, fn issue ->
+             issue.message =~ "declared ownership owner" and
+               issue.message =~ "is missing from pure_modules"
+           end)
+  end
+
   test "reports malformed policy and skips source scanning entirely" do
     source =
       """
@@ -1225,6 +1249,18 @@ defmodule Minga.Credo.EditorStateOwnershipCheckTest do
     parameter_sets = [
       [ownerships: :invalid],
       [ownerships: [[struct: "Bad.*"]]],
+      [
+        ownerships: [
+          [
+            struct: "MingaEditor.State.Workspace",
+            owners: ["MingaEditor.State.Workspace"],
+            paths: [],
+            pure: false,
+            boundary: "workspace transitions",
+            workflow: "workspace workflow"
+          ]
+        ]
+      ],
       [pure_modules: :invalid],
       [pure_modules: ["Bad.*"]]
     ]

--- a/test/minga/extension/callback_invoker_test.exs
+++ b/test/minga/extension/callback_invoker_test.exs
@@ -236,6 +236,28 @@ defmodule Minga.Extension.CallbackInvokerTest do
     assert CodeLease.active_leases(server: admission, source: source) == []
   end
 
+  test "unload completion requires the exact quiescing token and zero active leases", %{
+    admission: admission,
+    source: source
+  } do
+    assert {:ok, lease} =
+             CodeLease.admit_callback(source, Probe, :editor_event, server: admission)
+
+    assert {:ok, token} = CodeLease.quiesce_source(source, server: admission)
+
+    assert {:error, {:active_source_leases, ^source, 1}} =
+             CodeLease.complete_unload(token, server: admission)
+
+    assert {:error, {:source_quiescing, ^source, ^token}} =
+             CodeLease.activate_source(source, [Probe], server: admission)
+
+    assert :ok = CodeLease.release(lease)
+    assert :ok = CodeLease.complete_unload(token, server: admission)
+
+    assert {:error, {:invalid_unload_token, ^token}} =
+             CodeLease.abort_unload(token, server: admission)
+  end
+
   test "completed unload authority denies later invocation", %{
     admission: admission,
     source: source

--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -1444,9 +1444,11 @@ defmodule Minga.Extension.LifecycleContractTest do
         BlockedThenStarts
       )
 
+    timeout_ms = 25
+
     opts =
       ctx.opts
-      |> Keyword.put(:transition_timeout_ms, 25)
+      |> Keyword.put(:transition_timeout_ms, timeout_ms)
       |> Keyword.put(:runtime_query_timeout_ms, 10)
 
     start_task = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
@@ -1454,7 +1456,7 @@ defmodule Minga.Extension.LifecycleContractTest do
     old_instance = instance_pid(ctx, name)
     supervisor_ref = Process.monitor(old_runtime_supervisor)
 
-    assert {:error, {:transition_timeout, :start, 25}} = Task.await(start_task, 1_000)
+    assert {:error, {:transition_timeout, :start, ^timeout_ms}} = Task.await(start_task, 1_000)
     assert_receive {:DOWN, ^supervisor_ref, :process, ^old_runtime_supervisor, :killed}
     _new_instance = await_new_instance(ctx, name, old_instance)
 

--- a/test/minga/extension/updater_apply_test.exs
+++ b/test/minga/extension/updater_apply_test.exs
@@ -47,6 +47,7 @@ defmodule Minga.Extension.UpdaterApplyTest do
     git!(work, ["config", "user.email", git_config("user.email", "minga-tests@example.invalid")])
     git!(work, ["config", "user.name", git_config("user.name", "Minga Tests")])
     git!(work, ["config", "commit.gpgsign", "false"])
+    git!(work, ["config", "core.hooksPath", "/dev/null"])
     File.write!(Path.join(work, "version.txt"), "v1")
     git!(work, ["add", "version.txt"])
     git!(work, ["commit", "-m", "v1"])

--- a/test/minga_editor/agent/focused_event_workflows_test.exs
+++ b/test/minga_editor/agent/focused_event_workflows_test.exs
@@ -11,6 +11,7 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
   alias MingaEditor.Agent.StreamEventWorkflow
   alias MingaEditor.Agent.ToolEventWorkflow
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Shell.Entry
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
@@ -25,6 +26,7 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
   alias MingaEditor.Session.State, as: SessionState
   alias MingaAgent.EventLog.EventRecord
   alias MingaAgent.Session
+  alias MingaEditor.Test.FakeShell
 
   test "status workflow synchronizes owner state before installing a render" do
     state = event_state()
@@ -37,6 +39,18 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
     assert RenderCorrelation.scheduled?(state.render.render_correlation)
   end
 
+  test "context usage remains shell-generic when the active shell is not Traditional" do
+    entry = Entry.builtin!(:fake, FakeShell, "Fake", "Fake shell", false)
+    shell_state = Map.put(FakeShell.init([]), :session, self())
+    state = %{event_state() | shell_runtime: Runtime.new(entry, shell_state)}
+
+    updated = StatusEventWorkflow.context_usage(state, 90, 100)
+
+    assert updated.workspace.agent_ui.view.context_estimate == 90
+    assert RenderCorrelation.scheduled?(updated.render.render_correlation)
+    assert Runtime.state(updated.shell_runtime) == shell_state
+  end
+
   test "stream workflow applies one bounded batch transition and one render" do
     state = event_state()
 
@@ -47,6 +61,18 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
         {:tool_update, "tc", "shell", "partial"}
       ])
 
+    assert state.workspace.agent_ui.panel.message_version == 1
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+  end
+
+  test "live-session stream batches synchronize the transcript once" do
+    {:ok, session} = start_supervised({Session, provider_opts: []})
+    :ok = Session.seed_messages(session, [{:assistant, "Live streamed answer"}])
+    state = event_state(session)
+
+    state = StreamEventWorkflow.batch(state, [{:text_delta, "Live streamed answer"}])
+
+    assert state.workspace.agent_ui.panel.cached_display_messages != []
     assert state.workspace.agent_ui.panel.message_version == 1
     assert RenderCorrelation.scheduled?(state.render.render_correlation)
   end
@@ -137,6 +163,42 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
              EditTimeline.content_at(state.workspace.agent_ui.view.edit_timeline, "/tmp/a.ex", 1)
   end
 
+  test "spinner ticks advance only while the foreground agent is busy" do
+    busy = StatusEventWorkflow.status_changed(event_state(), :thinking)
+    frame = busy.workspace.agent_ui.panel.spinner_frame
+    busy = SessionEventWorkflow.spinner_tick(busy)
+
+    assert busy.workspace.agent_ui.panel.spinner_frame == frame + 1
+    assert RenderCorrelation.scheduled?(busy.render.render_correlation)
+
+    idle = StatusEventWorkflow.status_changed(busy, :idle)
+    idle_frame = idle.workspace.agent_ui.panel.spinner_frame
+    idle = SessionEventWorkflow.spinner_tick(idle)
+
+    assert idle.workspace.agent_ui.panel.spinner_frame == idle_frame
+    assert TraditionalState.agent(idle.shell_runtime.state).spinner_timer == nil
+  end
+
+  test "credentials status alone updates presentation and schedules a render" do
+    state = event_state()
+    panel = state.workspace.agent_ui.panel
+    state = SessionEventWorkflow.credentials_status(state, true)
+
+    assert state.workspace.agent_ui.panel.credentials_configured
+    assert state.workspace.agent_ui.panel.message_version == panel.message_version
+    assert state.workspace.agent_ui.panel.cached_display_messages == panel.cached_display_messages
+    assert RenderCorrelation.scheduled?(state.render.render_correlation)
+  end
+
+  test "error status logs the user-visible agent failure marker" do
+    :ok = Minga.Events.subscribe(:log_message)
+    on_exit(fn -> Minga.Events.unsubscribe(:log_message) end)
+
+    _state = StatusEventWorkflow.status_changed(event_state(), :error)
+
+    assert_agent_error_logged()
+  end
+
   test "session workflow installs approval state before render and transcript synchronization" do
     {:ok, session} = start_supervised({Session, provider_opts: []})
     state = event_state(session)
@@ -219,6 +281,22 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
 
     assert TraditionalState.agent(state.shell_runtime.state).error == "provider failed"
     assert RenderCorrelation.scheduled?(state.render.render_correlation)
+  end
+
+  @spec assert_agent_error_logged(integer()) :: :ok
+  defp assert_agent_error_logged(deadline \\ System.monotonic_time(:millisecond) + 500) do
+    remaining = max(deadline - System.monotonic_time(:millisecond), 0)
+
+    receive do
+      {:minga_event, :log_message, %Minga.Events.LogMessageEvent{text: text}} ->
+        if String.contains?(text, "Agent: error") do
+          :ok
+        else
+          assert_agent_error_logged(deadline)
+        end
+    after
+      remaining -> flunk("Agent: error was not routed to the messages log")
+    end
   end
 
   @spec file_record(String.t(), String.t(), String.t()) :: EventRecord.t()

--- a/test/minga_editor/extension/event_dispatcher_test.exs
+++ b/test/minga_editor/extension/event_dispatcher_test.exs
@@ -147,7 +147,7 @@ defmodule MingaEditor.Extension.EventDispatcherTest do
 
     assert {:callback_failed,
             {:invalid_return, ^source, HandlerOne, :handle_editor_event,
-             {:handled, :invalid_state}}} =
+             %{kind: :tuple, size: 2, tag: :handled}}} =
              EventDispatcher.dispatch_editor_action(
                ctx.state,
                :invalid,

--- a/test/minga_editor/extension/event_effect_test.exs
+++ b/test/minga_editor/extension/event_effect_test.exs
@@ -1,0 +1,290 @@
+defmodule MingaEditor.Extension.EventEffectTest do
+  use ExUnit.Case, async: true
+
+  alias Minga.Extension.ArtifactAdmission
+  alias Minga.Extension.ArtifactGenerationState
+  alias Minga.Extension.CallbackRegistry
+  alias Minga.Extension.CodeLease
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.EffectScheduler
+  alias MingaEditor.Extension.EventEffect
+  alias MingaEditor.Extension.EventWorkflow
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Frontend
+  alias MingaEditor.State.Render, as: RenderState
+  alias MingaEditor.Test.ExtensionBlockingEventHandler, as: BlockingHandler
+  alias MingaEditor.Viewport
+
+  @timeout 2_000
+
+  setup do
+    registry = unique_name(:callback_registry)
+    admission = unique_name(:callback_admission)
+    generation = unique_name(:callback_generation)
+    persistence_key = {__MODULE__, make_ref()}
+    code_lease = unique_name(:callback_code_admission)
+
+    start_supervised!({CallbackRegistry, name: registry})
+
+    start_supervised!(
+      {ArtifactGenerationState, name: generation, persistence_key: persistence_key}
+    )
+
+    start_supervised!({ArtifactAdmission, name: admission, state_owner: generation})
+    start_supervised!({CodeLease, name: code_lease})
+
+    task_supervisor =
+      start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
+
+    scheduler =
+      start_supervised!(
+        Supervisor.child_spec(
+          {EffectScheduler, task_supervisor: task_supervisor, observer: self()},
+          id: make_ref()
+        )
+      )
+
+    :ok = EffectScheduler.attach(scheduler, self())
+    source = register_handler(registry, admission, code_lease)
+
+    state = %EditorState{
+      effect_scheduler: scheduler,
+      frontend: %Frontend{port_manager: nil},
+      workspace: %SessionState{viewport: Viewport.new(80, 24)}
+    }
+
+    on_exit(fn -> ArtifactGenerationState.reset_for_test(persistence_key) end)
+
+    %{
+      registry: registry,
+      code_lease: code_lease,
+      scheduler: scheduler,
+      source: source,
+      state: state
+    }
+  end
+
+  test "blocking callbacks run off the caller and commit against the exact snapshot", ctx do
+    token = make_ref()
+
+    returned =
+      EventWorkflow.dispatch(
+        ctx.state,
+        {:editor_action, :block, {self(), token}},
+        callback_registry: ctx.registry,
+        callback_admission: ctx.code_lease
+      )
+
+    assert returned == ctx.state
+
+    assert_receive {:effect_lifecycle,
+                    %Outcome{
+                      status: :running,
+                      request: %{id: request_id, effect: %EventEffect{}}
+                    }},
+                   @timeout
+
+    assert_receive {:extension_callback_entered, ^token, worker}, @timeout
+    refute worker == self()
+    send(worker, {:release_extension_callback, token})
+
+    outcome = receive_outcome(ctx.scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(ctx.scheduler, outcome)
+    assert {state, %Outcome{status: :completed} = applied} = EventEffect.apply(ctx.state, outcome)
+    assert state == ctx.state
+    EffectScheduler.finalize(ctx.scheduler, applied)
+  end
+
+  test "render-only progress does not invalidate an otherwise current callback result", ctx do
+    render = RenderState.append_message(ctx.state.render, "render advanced", :info, :editor)
+    current = %{ctx.state | render: render}
+    candidate = EditorState.apply_theme(ctx.state, MingaEditor.UI.Theme.get!(:doom_one))
+
+    assert {:ok, accepted} =
+             EditorState.accept_extension_event_result(current, ctx.state, candidate)
+
+    assert accepted.render == render
+    assert accepted.appearance == candidate.appearance
+  end
+
+  test "concurrent interactive events are rejected visibly instead of queued on stale state",
+       ctx do
+    token = make_ref()
+
+    state =
+      EventWorkflow.dispatch(
+        ctx.state,
+        {:editor_action, :block, {self(), token}},
+        callback_registry: ctx.registry,
+        callback_admission: ctx.code_lease
+      )
+
+    assert_receive {:effect_lifecycle, %Outcome{status: :running, request: %{id: request_id}}},
+                   @timeout
+
+    assert_receive {:extension_callback_entered, ^token, worker}, @timeout
+
+    rejected =
+      EventWorkflow.dispatch(
+        state,
+        {:editor_action, :execute_git_command, :status},
+        callback_registry: ctx.registry,
+        callback_admission: ctx.code_lease
+      )
+
+    assert rejected.shell_runtime.state.notice.message == "Git command not scheduled: :queue_full"
+    send(worker, {:release_extension_callback, token})
+    outcome = receive_outcome(ctx.scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(ctx.scheduler, outcome)
+    {_state, applied} = EventEffect.apply(rejected, outcome)
+    EffectScheduler.finalize(ctx.scheduler, applied)
+  end
+
+  test "a declined interactive Git action restores unavailable feedback", ctx do
+    state =
+      EventWorkflow.dispatch(
+        ctx.state,
+        {:editor_action, :open_git_diff_for_path, :arguments},
+        callback_registry: ctx.registry,
+        callback_admission: ctx.code_lease
+      )
+
+    assert_receive {:effect_lifecycle, %Outcome{status: :running, request: %{id: request_id}}},
+                   @timeout
+
+    outcome = receive_outcome(ctx.scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(ctx.scheduler, outcome)
+    current = EditorState.apply_theme(state, MingaEditor.UI.Theme.get!(:doom_one))
+    assert {result, %Outcome{status: :stale} = applied} = EventEffect.apply(current, outcome)
+
+    assert result.shell_runtime.state.notice.message ==
+             "Git porcelain extension is disabled or failed to load"
+
+    assert EventEffect.render?(applied)
+    EffectScheduler.finalize(ctx.scheduler, applied)
+  end
+
+  test "failing unload callbacks complete the deferred Editor reply with an error", ctx do
+    {:ok, token} = CodeLease.quiesce_source(ctx.source, server: ctx.code_lease)
+    reply_tag = make_ref()
+
+    context = %{
+      token: token,
+      callback_registry: ctx.registry,
+      callback_admission: ctx.code_lease
+    }
+
+    assert {:noreply, state} =
+             MingaEditor.handle_cast(
+               {:unload_extension_source_request, ctx.source, context, {self(), reply_tag}},
+               ctx.state
+             )
+
+    assert_receive {:effect_lifecycle,
+                    %Outcome{
+                      status: :running,
+                      request: %{id: request_id, source: nil, resource: resource}
+                    }},
+                   @timeout
+
+    assert resource == {:extension_editor_unload, ctx.source}
+    outcome = receive_outcome(ctx.scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(ctx.scheduler, outcome)
+    assert {:error, [failure], _callback_state} = outcome.result
+    assert {^state, %Outcome{status: :completed} = applied} = EventEffect.apply(state, outcome)
+    EffectScheduler.finalize(ctx.scheduler, applied)
+
+    assert_receive {:extension_source_finalized, ^reply_tag, {:error, [^failure]}}, @timeout
+  end
+
+  test "a callback result cannot overwrite newer Editor state", ctx do
+    token = make_ref()
+
+    _state =
+      EventWorkflow.dispatch(
+        ctx.state,
+        {:editor_action, :block, {self(), token}},
+        callback_registry: ctx.registry,
+        callback_admission: ctx.code_lease
+      )
+
+    assert_receive {:effect_lifecycle, %Outcome{status: :running, request: %{id: request_id}}},
+                   @timeout
+
+    assert_receive {:extension_callback_entered, ^token, worker}, @timeout
+    current = EditorState.apply_theme(ctx.state, MingaEditor.UI.Theme.get!(:doom_one))
+    refute current == ctx.state
+    send(worker, {:release_extension_callback, token})
+
+    outcome = receive_outcome(ctx.scheduler, request_id, :completed)
+    assert :ok = EffectScheduler.claim(ctx.scheduler, outcome)
+
+    assert {^current, %Outcome{status: :stale, reason: :editor_state_changed} = applied} =
+             EventEffect.apply(current, outcome)
+
+    EffectScheduler.finalize(ctx.scheduler, applied)
+  end
+
+  test "a callback that never returns times out without holding its code lease", ctx do
+    token = make_ref()
+
+    _state =
+      EventWorkflow.dispatch(
+        ctx.state,
+        {:editor_action, :block, {self(), token}},
+        callback_registry: ctx.registry,
+        callback_admission: ctx.code_lease,
+        timeout_ms: 25
+      )
+
+    assert_receive {:effect_lifecycle, %Outcome{status: :running, request: %{id: request_id}}},
+                   @timeout
+
+    assert_receive {:extension_callback_entered, ^token, _worker}, @timeout
+    outcome = receive_outcome(ctx.scheduler, request_id, :failed)
+    assert :ok = EffectScheduler.claim(ctx.scheduler, outcome)
+    assert {state, %Outcome{status: :failed} = applied} = EventEffect.apply(ctx.state, outcome)
+    assert state == ctx.state
+    EffectScheduler.finalize(ctx.scheduler, applied)
+    _lease_state = :sys.get_state(ctx.code_lease)
+    assert CodeLease.active_leases(server: ctx.code_lease, source: ctx.source) == []
+  end
+
+  defp register_handler(registry, admission, code_lease) do
+    source = {:extension, unique_name(:event_source)}
+
+    {:ok, claim} =
+      ArtifactAdmission.claim_source_modules(
+        source,
+        [BlockingHandler],
+        :crypto.hash(:sha256, inspect({source, BlockingHandler})),
+        server: admission,
+        trusted_application: :minga
+      )
+
+    :ok = ArtifactAdmission.commit_attempt(claim, server: admission)
+    :ok = CodeLease.activate_source(source, [BlockingHandler], server: code_lease)
+
+    :ok =
+      CallbackRegistry.register_extension(
+        elem(source, 1),
+        [{BlockingHandler, [:editor_action, :source_unload], []}],
+        registry: registry,
+        artifact_admission: admission
+      )
+
+    source
+  end
+
+  defp receive_outcome(scheduler, request_id, status) do
+    assert_receive {:effect_result, ^scheduler,
+                    %Outcome{request: %{id: ^request_id}, status: ^status} = outcome},
+                   @timeout
+
+    outcome
+  end
+
+  defp unique_name(prefix),
+    do: String.to_atom("#{prefix}_#{System.unique_integer([:positive])}")
+end

--- a/test/minga_editor/extension/source_finalizer_editor_test.exs
+++ b/test/minga_editor/extension/source_finalizer_editor_test.exs
@@ -304,7 +304,8 @@ defmodule MingaEditor.Extension.SourceFinalizerEditorTest do
     source = {:extension, :finalized_picker}
 
     callback_failure =
-      {:invalid_return, source, RootPickerExtension, :handle_editor_event, :invalid_unload_return}
+      {:invalid_return, source, RootPickerExtension, :handle_editor_event,
+       %{kind: :atom, value: :invalid_unload_return}}
 
     finalizer_failure = %{
       family: :editor_extension_unload,

--- a/test/minga_editor/file_tree/freshness_test.exs
+++ b/test/minga_editor/file_tree/freshness_test.exs
@@ -10,10 +10,12 @@ defmodule MingaEditor.FileTree.FreshnessTest do
   alias Minga.Project.FileTree
   alias Minga.Project.FileTree.BufferSync
   alias Minga.Test.FileTreeRefreshScanner
+  alias Minga.Test.FileTreeWatcherBackend
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.EffectScheduler
   alias MingaEditor.FileTree.Freshness
   alias MingaEditor.FileTree.Refresh
+  alias MingaEditor.FileTree.WatcherSync
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Frontend
 
@@ -131,9 +133,7 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     Process.cancel_timer(accepted.render.render_correlation.timer)
   end
 
-  test "failed and canceled outcomes clear current correlation without requesting rendering", %{
-    tmp_dir: root
-  } do
+  test "current failures publish an error and request rendering", %{tmp_dir: root} do
     state = state_with_tree(root)
     %Frontend{} = frontend = state.frontend
     state = %{state | frontend: %Frontend{frontend | backend: :tui}}
@@ -143,14 +143,22 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     assert {failed, %Outcome{status: :failed}} =
              Refresh.apply(tracked, Outcome.failed(request, :unreadable))
 
-    assert failed.render.render_correlation.timer == nil
+    assert {:error, reason} = FileTreeState.status(file_tree(failed))
+    assert reason =~ "unreadable"
     assert failed |> file_tree() |> then(& &1.refresh.current) == nil
+    assert is_reference(failed.render.render_correlation.timer)
+    Process.cancel_timer(failed.render.render_correlation.timer)
+  end
 
-    retry = Refresh.request(file_tree(failed).tree, failed.extension_surfaces.events_registry)
-    retracked = track(failed, retry)
+  test "canceled outcomes clear current correlation without requesting rendering", %{
+    tmp_dir: root
+  } do
+    state = state_with_tree(root)
+    request = Refresh.request(file_tree(state).tree, state.extension_surfaces.events_registry)
+    tracked = track(state, request)
 
     assert {canceled, %Outcome{status: :canceled}} =
-             Refresh.apply(retracked, Outcome.canceled(retry, :requested))
+             Refresh.apply(tracked, Outcome.canceled(request, :requested))
 
     assert canceled.render.render_correlation.timer == nil
     assert canceled |> file_tree() |> then(& &1.refresh.current) == nil
@@ -283,9 +291,10 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     Process.cancel_timer(loaded.render.render_correlation.timer)
   end
 
-  test "project-root scan failure installs the requested root error and a later scan recovers", %{
-    tmp_dir: root
-  } do
+  test "arbitrary project-root failure installs the requested root error and a later scan recovers",
+       %{
+         tmp_dir: root
+       } do
     old_root = Path.join(root, "old")
     failed_root = Path.join(root, "failed")
     recovered_root = Path.join(root, "recovered")
@@ -296,8 +305,9 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     failing =
       Freshness.update_project_root(state, failed_root,
         scanner: FileTreeRefreshScanner,
-        scanner_context: {self(), :failed_root, {:error, {:root_unavailable, :enoent}}},
-        synchronize_watchers?: false
+        scanner_context: {self(), :failed_root, {:error, {:invalid_refresh_result, :bad}}},
+        watcher_backend: FileTreeWatcherBackend,
+        watcher_context: {self(), :failed_cleanup, :immediate}
       )
 
     failed_id = file_tree(failing).refresh.current.token
@@ -313,6 +323,26 @@ defmodule MingaEditor.FileTree.FreshnessTest do
     assert {:error, reason} = FileTreeState.status(file_tree(failed))
     assert reason != ""
     Process.cancel_timer(failed.render.render_correlation.timer)
+
+    watcher_id = file_tree(failed).watchers.request.token
+
+    assert_receive {:file_tree_watcher_call, :failed_cleanup, :unwatch, first_root, worker},
+                   @timeout
+
+    assert_receive {:file_tree_watcher_call, :failed_cleanup, :unwatch, second_root, ^worker},
+                   @timeout
+
+    assert MapSet.new([first_root, second_root]) ==
+             MapSet.new([Path.expand(old_root), Path.expand(failed_root)])
+
+    cleanup_outcome = receive_outcome(scheduler, watcher_id, :completed)
+    assert :ok = EffectScheduler.claim(scheduler, cleanup_outcome)
+
+    assert {failed, %Outcome{status: :completed} = finalized_cleanup} =
+             WatcherSync.apply(failed, cleanup_outcome)
+
+    EffectScheduler.finalize(scheduler, finalized_cleanup)
+    assert file_tree(failed).watchers.candidates == MapSet.new()
 
     recovered_result = tree(recovered_root, [entry(recovered_root, "ok.ex")])
 

--- a/test/minga_editor/file_tree/watcher_sync_test.exs
+++ b/test/minga_editor/file_tree/watcher_sync_test.exs
@@ -16,6 +16,7 @@ defmodule MingaEditor.FileTree.WatcherSyncTest do
   alias MingaEditor.FileTree.WatcherSync
   alias MingaEditor.State.FileTree, as: FileTreeState
 
+  import ExUnit.CaptureLog
   import MingaEditor.RenderPipeline.TestHelpers
 
   @moduletag :tmp_dir
@@ -84,41 +85,77 @@ defmodule MingaEditor.FileTree.WatcherSyncTest do
     assert c_outcome.request.effect.target == c
   end
 
-  test "failed watcher sync retains lineage and the next exact request recovers", %{
-    tmp_dir: root
-  } do
+  test "an old-root success cannot cancel the current reroot retry", %{tmp_dir: root} do
+    a = Path.join(root, "a")
+    b = Path.join(root, "b")
+    old_token = make_ref()
+    retry_token = make_ref()
+
+    file_tree =
+      %FileTreeState{}
+      |> FileTreeState.open(tree(a), nil)
+      |> FileTreeState.track_watcher_request(old_token)
+      |> FileTreeState.begin_root_scan(tree(b), :project)
+
+    {1, file_tree} = FileTreeState.schedule_watcher_retry(file_tree, retry_token)
+
+    assert {:stale, retained} = FileTreeState.accept_watcher_result(file_tree, old_token, a)
+    assert retained.watchers.target == Path.expand(b)
+    assert retained.watchers.candidates == MapSet.new([Path.expand(a), Path.expand(b)])
+    assert retained.watchers.retry_token == retry_token
+    assert retained.watchers.retry_attempt == 1
+  end
+
+  test "partial watcher failure retains lineage and automatically retries", %{tmp_dir: root} do
     a = Path.join(root, "a")
     b = Path.join(root, "b")
     scheduler = start_scheduler()
     state = state_with_tree(a, scheduler) |> establish_owned_root(a, scheduler)
     state = retarget_state(state, b)
+    context = {self(), :partial, :wait}
 
     state =
       Freshness.synchronize_watchers(state,
         watcher_backend: FileTreeWatcherBackend,
-        watcher_context: {self(), :failed, {:fail, :unwatch, a, :unavailable}}
+        watcher_context: context
       )
 
     failed_id = file_tree(state).watchers.request.token
-    assert_receive {:file_tree_watcher_call, :failed, :unwatch, ^a, _worker}, @timeout
+    assert_receive {:file_tree_watcher_call, :partial, :unwatch, ^a, failed_worker}, @timeout
+    send(failed_worker, {:release_file_tree_watcher_call, :partial, :unwatch, a, :ok})
+    assert_receive {:file_tree_watcher_call, :partial, :watch, ^b, ^failed_worker}, @timeout
+
+    send(
+      failed_worker,
+      {:release_file_tree_watcher_call, :partial, :watch, b, {:error, :unavailable}}
+    )
+
     failed = receive_outcome(scheduler, failed_id, :failed)
     assert :ok = EffectScheduler.claim(scheduler, failed)
-    assert {state, %Outcome{status: :failed} = applied_failure} = WatcherSync.apply(state, failed)
-    EffectScheduler.finalize(scheduler, applied_failure)
 
+    {{state, %Outcome{status: :failed} = applied_failure}, log} =
+      with_log(fn -> WatcherSync.apply(state, failed) end)
+
+    EffectScheduler.finalize(scheduler, applied_failure)
+    assert log =~ "File tree watcher sync failed"
     assert file_tree(state).watchers.candidates == MapSet.new([a, b])
     assert file_tree(state).watchers.target == b
     assert file_tree(state).watchers.request == nil
+    assert file_tree(state).watchers.retry_attempt == 1
+    retry_token = file_tree(state).watchers.retry_token
 
-    state =
-      Freshness.synchronize_watchers(state,
-        watcher_backend: FileTreeWatcherBackend,
-        watcher_context: {self(), :recovered, :immediate}
-      )
+    assert_receive {:file_tree_watcher_retry, ^retry_token, retry_opts}, @timeout
+
+    assert {:noreply, state} =
+             MingaEditor.handle_info({:file_tree_watcher_retry, retry_token, retry_opts}, state)
 
     recovered_id = file_tree(state).watchers.request.token
-    assert_receive {:file_tree_watcher_call, :recovered, :unwatch, ^a, worker}, @timeout
-    assert_receive {:file_tree_watcher_call, :recovered, :watch, ^b, ^worker}, @timeout
+
+    assert_receive {:file_tree_watcher_call, :partial, :unwatch, ^a, recovered_worker}, @timeout
+    send(recovered_worker, {:release_file_tree_watcher_call, :partial, :unwatch, a, :ok})
+    assert_receive {:file_tree_watcher_call, :partial, :watch, ^b, ^recovered_worker}, @timeout
+    send(recovered_worker, {:release_file_tree_watcher_call, :partial, :watch, b, :ok})
+
     recovered = receive_outcome(scheduler, recovered_id, :completed)
     assert :ok = EffectScheduler.claim(scheduler, recovered)
 
@@ -127,6 +164,65 @@ defmodule MingaEditor.FileTree.WatcherSyncTest do
 
     EffectScheduler.finalize(scheduler, applied_recovery)
     assert file_tree(state).watchers.candidates == MapSet.new([b])
+    assert file_tree(state).watchers.retry_token == nil
+    assert file_tree(state).watchers.retry_attempt == 0
+  end
+
+  test "watcher recovery stops visibly after the bounded retry budget", %{tmp_dir: root} do
+    a = Path.join(root, "a")
+    b = Path.join(root, "b")
+    scheduler = start_scheduler()
+
+    state =
+      state_with_tree(a, scheduler) |> establish_owned_root(a, scheduler) |> retarget_state(b)
+
+    context = {self(), :exhausted, :wait}
+
+    state =
+      Enum.reduce(1..6, state, fn attempt, current ->
+        current =
+          if attempt == 1 do
+            Freshness.synchronize_watchers(current,
+              watcher_backend: FileTreeWatcherBackend,
+              watcher_context: context
+            )
+          else
+            assert_receive {:file_tree_watcher_retry, retry_token, retry_opts}, @timeout
+
+            assert {:noreply, retried} =
+                     MingaEditor.handle_info(
+                       {:file_tree_watcher_retry, retry_token, retry_opts},
+                       current
+                     )
+
+            retried
+          end
+
+        request_id = file_tree(current).watchers.request.token
+        assert_receive {:file_tree_watcher_call, :exhausted, :unwatch, ^a, worker}, @timeout
+
+        send(
+          worker,
+          {:release_file_tree_watcher_call, :exhausted, :unwatch, a, {:error, :unavailable}}
+        )
+
+        failed = receive_outcome(scheduler, request_id, :failed)
+        assert :ok = EffectScheduler.claim(scheduler, failed)
+
+        assert {failed_state, %Outcome{status: :failed} = applied} =
+                 WatcherSync.apply(current, failed)
+
+        EffectScheduler.finalize(scheduler, applied)
+        assert file_tree(failed_state).watchers.retry_attempt == attempt
+        failed_state
+      end)
+
+    assert file_tree(state).watchers.retry_token == nil
+
+    assert state.shell_runtime.state.notice.message ==
+             "File tree watcher recovery stopped after 6 attempts"
+
+    refute_receive {:file_tree_watcher_retry, _token, _opts}, 100
   end
 
   test "A to B filter-winning reroot followed by C leaves only C owned", %{tmp_dir: root} do

--- a/test/minga_editor/render_pipeline/chrome_dirty_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_dirty_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
+  alias MingaEditor.Test.FakeShell
 
   setup do
     table = Module.concat(__MODULE__, "Sidebar#{System.unique_integer([:positive])}")
@@ -199,6 +200,13 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
       fp2 = Input.chrome_fingerprint(input2)
 
       assert fp1 != fp2
+    end
+
+    test "generic fingerprint treats non-Traditional shell state as opaque" do
+      input = base_state() |> Input.from_editor_state() |> Map.put(:shell, FakeShell)
+      input = %{input | shell_state: {:opaque, :shell_state}}
+
+      assert is_integer(Input.chrome_fingerprint(input))
     end
 
     test "unchanged input between frames produces stable fingerprint" do

--- a/test/support/extension_blocking_event_handler.ex
+++ b/test/support/extension_blocking_event_handler.ex
@@ -1,0 +1,21 @@
+defmodule MingaEditor.Test.ExtensionBlockingEventHandler do
+  @moduledoc false
+
+  @behaviour MingaEditor.Extension.EventHandler
+
+  alias MingaEditor.State, as: EditorState
+
+  @impl true
+  @spec handle_editor_event(EditorState.t(), MingaEditor.Extension.EventHandler.event()) ::
+          MingaEditor.Extension.EventHandler.callback_result()
+  def handle_editor_event(state, {:editor_action, :block, {test_pid, token}}) do
+    send(test_pid, {:extension_callback_entered, token, self()})
+
+    receive do
+      {:release_extension_callback, ^token} -> {:handled, state}
+    end
+  end
+
+  def handle_editor_event(_state, {:source_unload, _source}), do: exit(:unload_failed)
+  def handle_editor_event(_state, _event), do: :not_matched
+end


### PR DESCRIPTION
# TL;DR
Closes the ownership and responsiveness gaps found by the post-delivery audit of #2914. Slow extension callbacks now run under the bounded effect scheduler, file-tree failures recover visibly, shell and repository results use exact correlation, and EX9012 cannot silently exempt declared owners from purity checks.

Closes #2914

## Context
The original seven #2914 slices established the Editor ownership model, but a current-main audit found several untested paths that could still block ordered input, apply stale work, strand file watchers, inspect Traditional-only state from another shell, or bypass value-owner purity enforcement. This PR closes those findings against the lifecycle authority merged in #2961.

## Changes
- Route extension editor callbacks through `EffectScheduler` with bounded execution, exact snapshot acceptance, visible interactive failures, and bounded unload acknowledgements.
- Require exact unload authority and zero active leases before `CodeLease` completes source unload, while preserving retry semantics through `Minga.Extension.Instance`.
- Make current reroot failures observable and add correlated, bounded watcher synchronization recovery that cannot be canceled by an old-root success.
- Remove Traditional-only assumptions from context-usage handling and asynchronous render fingerprints.
- Make EX9012 fail closed when an owner disables purity or an explicit `pure_modules` list omits any declared owner.
- Capture repository identity before commit-message generation enters the worker and reject delayed A to B to A results through root-generation correlation.
- Restore focused coverage for agent transcript synchronization, spinner transitions, credentials rendering, status-error logging, callback isolation, unload failures, and watcher recovery.
- Drop request-scoped lifecycle timeout overrides when a replacement `Instance` is constructed so a prior failed request cannot shorten the next request's deadline.

## Verification
- `make lint`, Credo clean across 2,162 files and Dialyzer with 0 errors.
- `mix test.llm`, 9,768 tests, 58 doctests, and 97 properties with 0 failures.
- Focused extension effect, source finalizer, lifecycle replacement, watcher recovery, EX9012, agent workflow, and Git commit-generation tests passed.
- `git diff --check` passed.
- Bundled Git porcelain source and `priv/` mirrors are byte-identical.
- Final acceptance review passed with no blockers.

## Acceptance Criteria Addressed
- Project-root and file-tree work stays off pure transitions and recovers from current failures. ✅
- Shell runtime and render paths remain shell-generic. ✅
- Timer, watcher, callback, and repository results reject stale ownership. ✅
- Workflow-owned effects remain bounded and outside the Editor mailbox. ✅
- Mechanical ownership enforcement covers every declared owner without exceptions. ✅
- Root state remains one 16-value Editor authority with no new process owner. ✅
- Focused regressions and required local gates preserve existing behavior. ✅
