### PR TITLE
refactor(extension): converge lifecycle architecture

### DIFF
--- a/EXTENSION_API.md
+++ b/EXTENSION_API.md
@@ -8,7 +8,33 @@ All functions are safe to call with dead PIDs, stopped sessions, or when no sess
 
 Path and Git extensions compile only in a standalone disposable BEAM OS process. Its standard streams are bounded, discarded byte data rather than an ETF-capable host control channel. Source is bounded and copied into a private immutable snapshot before hashing or compilation. A second standalone process structurally validates bounded BEAM/ETF data and writes a descriptor-verified UTF-8 report before the host creates atoms or loads code. The complete validated BEAM artifact set establishes module ownership before host loading; direct, nested, atom-targeted, macro-generated, runtime-generated, and spawned-process-generated ordinary Elixir modules are supported when conflict-free. Cache hits enforce the same metadata, completeness, resource-limit, and ownership checks as fresh compilation. This protects host validation but does not sandbox trusted extension filesystem or network authority.
 
-Stopping or lazily starting an extension in the current session uses only the artifact admitted for that source when the VM generation began. Source edits and Git updates require a fresh Minga OS process and never purge, recompile, or replace active extension code.
+The validated artifact inventory, not an AST prediction or one entry module, owns the source's modules. A source can emit helper modules through ordinary Elixir compilation as long as every validated BEAM name matches its artifact and no module belongs to Minga, an OTP application, or another extension.
+
+Stopping, disabling, lazily starting, or restarting an extension in the current session uses only the artifact admitted for that source when the VM generation began. Source edits, user-module edits under `~/.config/minga/modules`, and Git updates require a fresh Minga OS process. Config reload reports a restart requirement instead of purging, recompiling, or replacing resident code. The updater stages accepted Git source for the next process and rolls the checkout back on a staging failure without disturbing the active runtime.
+
+## Lifecycle and child restart
+
+Every declaration has one stable `Minga.Extension.Instance` mailbox. Public start and stop APIs, lazy triggers, failed starts, runtime exits, and config reload all send lifecycle intent there. The PID in extension listings is only a projection of the current runtime child and is never an authority extension code should retain.
+
+The Instance validates options and runs `init/1` before it starts the child returned by `child_spec/1`. After the child is alive, it registers commands, keybindings, editor callbacks, and callback admission before publishing `:running`. If setup fails, it follows the same stop order as a normal disable and preserves the start diagnostic, wrapping it only when cleanup also fails.
+
+The top-level `restart` value returned by `child_spec/1` is interpreted by the Instance. Minga starts the actual runtime child as `:temporary` under the extension's local runtime supervisor, so OTP does not race the lifecycle authority. `:permanent` restarts after every terminal exit, `:transient` restarts after abnormal exits, and `:temporary` never restarts. If your child is itself a supervisor, that supervisor still owns its internal children normally.
+
+```elixir
+def child_spec(config) do
+  Supervisor.child_spec({MyExtension.Supervisor, config}, restart: :transient)
+end
+```
+
+A runtime disable leaves modules resident. The Instance first closes new callback admission, waits for source leases to drain, and asks the Editor to cancel source-owned effects. It then runs source-filtered `:source_unload` callbacks, terminates the runtime child, removes source-owned contributions once, publishes `:stopped`, and acknowledges the caller. Editor finalization is asynchronous, so an unload callback must not synchronously call back into extension lifecycle APIs.
+
+## Runtime callbacks and source-owned work
+
+Use `editor_event_handler/3` for the retained callback families: `:buffer_saved`, `:editor_action`, and `:source_unload`. Buffer-save handlers run as an ordered fan-out. Editor actions stop at the first `{:handled, state}` and continue only after `:not_matched`. Source-unload handlers run only for the extension being disabled.
+
+Dynamic extension callbacks cross `Minga.Extension.CallbackInvoker`. Exceptions, throws, exits, unavailable modules, and invalid return values become explicit callback failures and are reported without turning into a second callback protocol. Core callbacks execute directly and retain normal OTP crash behavior. Extension commands and editor handlers should return the documented state shape rather than rescuing framework failures themselves.
+
+Slow picker, Git, and similar work must be represented as a typed `MingaEditor.Effect` request. `MingaEditor.EffectScheduler` owns worker supervision, resource ordering, cancellation, and result application. Tag requests with the extension source so disable can cancel them before presentation and callback registrations are removed. Do not spawn an untracked task and send a custom result message to the Editor.
 
 ## Listing sessions
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -247,7 +247,10 @@ graph TD
     INDEP --> CMDREG["Command.Registry"]
     INDEP --> DIAG["Diagnostics"]
     SVC --> EXTREG["Extension.Registry<br/><i>declaration/status projection</i>"]
-    SVC --> EXTINFRA["Artifact admission, code leases,<br/>and callback registries"]
+    SVC --> ARTGEN["Extension.ArtifactGenerationState<br/><i>persistent provenance</i>"]
+    SVC --> ARTADM["Extension.ArtifactAdmission<br/><i>generation serializer</i>"]
+    SVC --> LEASE["Extension.CodeLease<br/><i>callback work drain</i>"]
+    SVC --> CALLBACKS["Extension.CallbackRegistry<br/><i>declarative callbacks</i>"]
     SVC --> INSTREG["Extension.InstanceRegistry<br/><i>stable process names</i>"]
     SVC --> ROOTSUP["Extension.RootSupervisor<br/><i>DynamicSupervisor</i>"]
     ROOTSUP --> ROOT1["Extension.Root: git_porcelain<br/><i>rest_for_one</i>"]
@@ -265,9 +268,6 @@ graph TD
     SVC --> SYNC["LSP.SyncServer"]
     SVC --> PROJ["Project"]
     PROJ -. "one per active inventory" .-> DISC["Project.FileFind.Worker<br/><i>monitored, cancellable</i>"]
-    SVC --> AGENTSUP["Agent.Supervisor<br/><i>DynamicSupervisor</i>"]
-    AGENTSUP --> AS1["Agent.Session<br/><i>Claude (refactoring)</i>"]
-    AGENTSUP --> AS2["Agent.Session<br/><i>Claude (tests)</i>"]
 
     style SVC fill:#6c3483,stroke:#4a235a,color:#fff
     style INDEP fill:#6c3483,stroke:#4a235a,color:#fff
@@ -280,11 +280,8 @@ graph TD
     style RTSUP2 fill:#1a5276,stroke:#154360,color:#fff
     style EXT1 fill:#2471a3,stroke:#1a5276,color:#fff
     style LSPSUP fill:#1a5276,stroke:#154360,color:#fff
-    style AGENTSUP fill:#1a5276,stroke:#154360,color:#fff
     style TASKSUP fill:#1a5276,stroke:#154360,color:#fff
     style DISC fill:#1a5276,stroke:#154360,color:#fff
-    style AS1 fill:#884ea0,stroke:#6c3483,color:#fff
-    style AS2 fill:#884ea0,stroke:#6c3483,color:#fff
     style LSP1 fill:#2471a3,stroke:#1a5276,color:#fff
     style LSP2 fill:#2471a3,stroke:#1a5276,color:#fff
 ```
@@ -767,11 +764,11 @@ Each layer lives in a different process. Setting a buffer-local override is a me
 
 This extends beyond simple options. Keybindings, mode behavior, auto-pair rules, highlight themes: anything that lives in process state can be customized per-buffer at runtime. Open a Markdown file and want different keybindings? That buffer's process holds its own keymap overlay. Working in a monorepo where one subdirectory uses different formatting? Those buffers carry their own formatter config. The process model makes "buffer-local everything" the default architecture, not a special case bolted on later.
 
-And because the BEAM supports hot code reloading, the customization story goes even deeper: you can redefine *functions* at runtime, not just data. Load a new module, replace a motion implementation, add a command, in a running editor, without restarting. This is the same capability that lets Erlang telecom systems upgrade without dropping calls. In Minga, it means your editor is as malleable as Emacs, but with process isolation that Emacs Lisp never had.
+The BEAM can replace running code, but Minga deliberately does not use that capability for extension or user-module updates. Runtime disable and restart keep admitted modules resident, while changed source activates only in a fresh Minga OS process. This trades ad hoc same-VM replacement for one artifact owner and predictable callback cleanup.
 
-### Hot code reloading
+### Code updates
 
-The BEAM supports replacing running code without restarting the VM. In the future, Minga could update its editor logic, add new commands, or fix bugs in a running session without closing files or losing state.
+Configuration data can be re-evaluated in the running editor, but compiled user modules and extension artifacts belong to the current BEAM generation. Editing either source makes config reload report that a restart is required. Git extension updates are staged on disk for the next process and never replace active code.
 
 ### Distributed editing
 
@@ -880,9 +877,22 @@ Safety-critical ownership does not move to optional packs. Credentials, approval
 
 ### Extension lifecycle, artifact, and callback ownership
 
-Every declared extension has one stable `Minga.Extension.Instance` mailbox that serializes eager start, lazy or deferred activation, stop, failure rollback, runtime exit, restart, and unload. The runtime child PID is an observed implementation detail. `Minga.Extension.Registry` is only the compatible declaration and status projection: `Instance` publishes the current PID, status, module, manifest, and error from its tagged phase, while callers never consult registry lifecycle fields to decide the next transition. `Minga.Extension.Supervisor` remains the compatible public facade for bulk prerequisites and the existing start, stop, list, and deferred APIs, but routes individual lifecycle requests to the Instance.
+Every declared extension has one stable `Minga.Extension.Instance` mailbox that serializes eager start, lazy or deferred activation, stop, failure rollback, runtime exit, restart, and unload. The runtime child PID is an observed implementation detail. `Minga.Extension.Registry` is only the compatible declaration and status projection: `Instance` publishes the current PID, status, module, manifest, and error from its tagged phase, while callers never consult registry lifecycle fields to decide the next transition. `Minga.Extension.Supervisor` remains the compatible public facade for bulk prerequisites and the existing start, stop, list, and deferred APIs, but routes individual lifecycle requests to the Instance without caller-side restart polling or retries.
 
 Each `Minga.Extension.Root(name)` is a `rest_for_one` supervisor whose first child is a local `Minga.Extension.RuntimeSupervisor(name)` and whose second child is the permanent Instance. The runtime supervisor handles child mechanics only. It forces every runtime child spec to `:temporary`; the Instance preserves and interprets the extension's original `:permanent`, `:transient`, or `:temporary` restart policy exactly once. Runtime exits arrive through the Instance monitor, so replacement publication and restart telemetry are event-driven. If an Instance crashes, its replacement may adopt only the sole child of its own local runtime supervisor. If that supervisor crashes, `rest_for_one` stops the old Instance and starts a new Instance against a new empty runtime supervisor.
+
+The lifecycle order is explicit and owned rather than inferred from registry snapshots:
+
+| Transition | Owner | Order |
+|---|---|---|
+| Start, eager or lazy | `Minga.Extension.Instance` | prepare or reuse the admitted artifact; remove any lazy stub; validate options and run `init/1`; start the temporary runtime child; register source-owned contributions and callback leases; publish `:running`; acknowledge callers |
+| Failed start | `Minga.Extension.Instance` | publish `:stopping`; quiesce callback admission and drain leases; ask the Editor finalizer to cancel source work; run source-filtered unload callbacks when a token exists; terminate any runtime child; remove contributions once; publish `:load_error`; acknowledge with the original diagnostic or cleanup wrapper |
+| Explicit stop or source disable | `Minga.Extension.Instance` | publish `:stopping`; quiesce and drain leases while Editor effect cancellation runs; run unload callbacks; close unload admission; terminate the runtime child; remove contributions and callback registrations once; publish `:stopped`; acknowledge waiters |
+| Terminal runtime exit | `Minga.Extension.Instance` | interpret the declared restart policy; either start one replacement child and publish it, or run the same quiesce, finalization, cleanup, and terminal publication order with distinct normal-exit or crash diagnostics |
+| Config reload | `MingaEditor.EffectScheduler`, then `Minga.Config.Loader` | serialize one typed reload effect; reject changed user-module or extension source; ask every Instance to stop; reset config-owned registries; re-evaluate data declarations without recompiling resident modules; ask the same Instances to start from admitted artifacts; apply one Editor outcome |
+| Git update and rollback | `Minga.Extension.Updater` | stage the accepted checkout for the next OS process; restore the previous checkout if staging fails; emit restart-required state; never stop, compile, or replace the active artifact |
+
+`Minga.Extension.ContributionCleanup` is the only upward-dependency seam for source cleanup. It removes core registries directly and invokes registered higher-layer cleanup callbacks without enumerating extension manifests a second time. `MingaEditor.Extension.SourceFinalizer` is retained only as that layer-safe Editor endpoint adapter. It owns no lifecycle state: the Instance owns correlation and ordering, while the adapter casts a request to the Editor, waits outside the Instance mailbox, and returns the acknowledgement to the Instance-owned bounded transition worker.
 
 Source resolution, artifact identity, and runtime admission are separate boundaries. Module, Hex/application, and bundled trusted-application declarations adopt verified resident application inventories. Resolved Git and path declarations compile from bounded immutable snapshots, and deterministic JSON is the fallback only when a path contains no Elixir source. All paths converge on one immutable current-generation artifact containing the module, manifest, owned modules, normalized child spec, and declared restart policy. Artifact admission owns code provenance for the BEAM generation; the Instance owns whether that admitted artifact has a stub, is starting, running, stopping, failed, or stopped.
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1056,7 +1056,7 @@ set :tab_width, TodoTools.preferred_tab_width()
 
 Press `SPC h r` to reload ordinary configuration without restarting the editor. Before changing runtime state, Minga fingerprints every admitted path and Git extension from a private source snapshot. If any source differs from the artifact admitted for the current VM generation, reload reports that a restart is required and leaves the running extension module, process, manifest version, and contributions unchanged. It does not compile the changed source.
 
-When admitted extension sources are unchanged, reload stops their runtime processes without purging code, purges user modules from `modules/`, resets config-owned options, keybindings, hooks, advice, and commands, re-evaluates `config.exs`, `.minga.exs`, and `after.exs`, then starts extensions from their already admitted artifacts. Changed keybindings and options take effect immediately. The status bar shows "Config reloaded" on success or an error message if something went wrong.
+Reload also fingerprints `~/.config/minga/modules/*.ex`. If those files changed, it reports that a fresh Minga process is required and leaves resident code and runtime state alone. When all compiled sources are unchanged, reload stops extension runtimes through their lifecycle Instances, keeps user modules resident, resets config-owned options, keybindings, hooks, advice, and commands, re-evaluates `config.exs`, `.minga.exs`, and `after.exs`, then starts extensions from their admitted artifacts. Changed data declarations take effect immediately. The status bar shows "Config reloaded" on success or an error message if something went wrong.
 
 You can also reload from the command line with `:reload-config` (not yet wired as an ex command, use `SPC h r`).
 

--- a/docs/EXTENSIBILITY.md
+++ b/docs/EXTENSIBILITY.md
@@ -22,9 +22,9 @@ These are the properties that make Emacs Emacs. Any replacement must match all s
 
 ## How Elixir on the BEAM matches each one
 
-### 1. Redefine any function at runtime ✅
+### 1. Replace behavior through declared extension boundaries ✅
 
-The BEAM was designed for hot code reloading. Erlang systems upgrade running code without dropping active connections. Elixir inherits this fully.
+The BEAM can hot-reload code, but Minga deliberately keeps compiled extension and user-module code fixed for one OS-process generation. Custom behavior is declared through commands, advice, hooks, keybindings, and extension callbacks, then a fresh Minga process admits changed modules as one validated artifact.
 
 **Elisp:**
 ```elisp
@@ -46,19 +46,11 @@ defmodule MyMotion do
   end
 end
 
-# Replace the motion in the running editor
+# Register the command or advice that uses MyMotion, then restart Minga after editing the module.
 Minga.Config.override(Minga.Motion.Word, :word_forward, &MyMotion.word_forward/2)
 ```
 
-Under the hood, the BEAM's code server manages two versions of a module simultaneously (the "current" and the "old"). When you load new code, existing function calls finish on the old version while new calls use the updated one. This is safer than Elisp's immediate replacement, where redefining a function mid-execution can cause subtle bugs.
-
-**Reloading a module you've edited:**
-```elixir
-# Recompile and reload (~50ms)
-r(MyMotion)
-
-# Or from the editor: SPC h r to reload all user modules
-```
+Minga does not expose the BEAM code server as an extension update mechanism. `SPC h r` re-evaluates configuration data, but it rejects changed extension or `~/.config/minga/modules` source. Restarting gives module ownership, callback admission, and cleanup one unambiguous generation boundary.
 
 ### 2. Advice system ✅
 

--- a/extensions/git_porcelain/test/minga_git_porcelain/input/status_diff_open_test.exs
+++ b/extensions/git_porcelain/test/minga_git_porcelain/input/status_diff_open_test.exs
@@ -7,12 +7,15 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
   alias Minga.Git
   alias Minga.Git.Stub, as: GitStub
   alias MingaGitPorcelain.Input.GitStatus
+  alias MingaEditor.Effect.Outcome
+  alias MingaEditor.EffectScheduler
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Viewport
 
   @none 0
+  @effect_timeout 1_000
   @moduletag :tmp_dir
 
   setup %{tmp_dir: dir} do
@@ -20,22 +23,38 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
     project_root = Minga.Project.resolve_root()
     GitStub.set_root(project_root, dir)
 
+    task_supervisor =
+      start_supervised!(Supervisor.child_spec({Task.Supervisor, []}, id: make_ref()))
+
+    scheduler =
+      start_supervised!(
+        Supervisor.child_spec(
+          {EffectScheduler, task_supervisor: task_supervisor, observer: self()},
+          id: make_ref()
+        )
+      )
+
+    :ok = EffectScheduler.attach(scheduler, self())
+
     on_exit(fn ->
       GitStub.clear(project_root)
       GitStub.clear(dir)
     end)
 
-    {:ok, git_root: dir}
+    {:ok, git_root: dir, scheduler: scheduler}
   end
 
-  test "previewing a staged status entry opens the staged index diff", %{git_root: git_root} do
+  test "previewing a staged status entry opens the staged index diff", %{
+    git_root: git_root,
+    scheduler: scheduler
+  } do
     rel_path = "file.txt"
     File.write!(Path.join(git_root, rel_path), "worktree\n")
     GitStub.set_head(git_root, rel_path, "head\n")
     GitStub.set_staged(git_root, rel_path, "staged\n")
 
     entry = %Git.StatusEntry{path: rel_path, status: :modified, staged: true}
-    state = state_with_selected_entry(entry)
+    state = state_with_selected_entry(entry, scheduler)
 
     {:handled, state} = GitStatus.handle_key(state, ?p, @none)
     active_buf = state.workspace.buffers.active
@@ -46,14 +65,12 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
   end
 
   test "previewing a deleted status entry opens a deletion diff without reading the missing file",
-       %{
-         git_root: git_root
-       } do
+       %{git_root: git_root, scheduler: scheduler} do
     rel_path = "deleted.txt"
     GitStub.set_head(git_root, rel_path, "removed\n")
 
     entry = %Git.StatusEntry{path: rel_path, status: :deleted, staged: true}
-    state = state_with_selected_entry(entry)
+    state = state_with_selected_entry(entry, scheduler)
 
     {:handled, state} = GitStatus.handle_key(state, ?p, @none)
     active_buf = state.workspace.buffers.active
@@ -63,7 +80,10 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
     refute MingaEditor.Shell.Traditional.NoticeWorkflow.message(state) =~ "Could not read"
   end
 
-  test "GUI open diff uses section when duplicate paths exist", %{git_root: git_root} do
+  test "GUI open diff uses section when duplicate paths exist", %{
+    git_root: git_root,
+    scheduler: scheduler
+  } do
     rel_path = "both.txt"
     File.write!(Path.join(git_root, rel_path), "worktree\n")
     GitStub.set_head(git_root, rel_path, "head\n")
@@ -72,32 +92,35 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
     staged_entry = %Git.StatusEntry{path: rel_path, status: :modified, staged: true}
     changed_entry = %Git.StatusEntry{path: rel_path, status: :modified, staged: false}
 
-    {:noreply, staged_state} =
+    {:noreply, staged_pending} =
       MingaEditor.handle_info(
         {:minga_input, {:gui_action, {:git_open_diff, rel_path, 0}}},
-        state_with_panel_entries([changed_entry, staged_entry])
+        state_with_panel_entries([changed_entry, staged_entry], scheduler)
       )
 
+    staged_state = receive_effect(staged_pending, scheduler)
     staged_buf = staged_state.workspace.buffers.active
     assert Buffer.buffer_name(staged_buf) == "both.txt [diff:staged]"
     assert buffer_content(staged_buf) =~ "staged"
     refute buffer_content(staged_buf) =~ "worktree"
 
-    {:noreply, changed_state} =
+    {:noreply, changed_pending} =
       MingaEditor.handle_info(
         {:minga_input, {:gui_action, {:git_open_diff, rel_path, 1}}},
-        state_with_panel_entries([staged_entry, changed_entry])
+        state_with_panel_entries([staged_entry, changed_entry], scheduler)
       )
 
+    changed_state = receive_effect(changed_pending, scheduler)
     changed_buf = changed_state.workspace.buffers.active
     assert Buffer.buffer_name(changed_buf) == "both.txt [diff:unstaged]"
     assert buffer_content(changed_buf) =~ "worktree"
     refute buffer_content(changed_buf) =~ "staged"
   end
 
-  defp state_with_selected_entry(entry), do: state_with_panel_entries([entry])
+  defp state_with_selected_entry(entry, scheduler),
+    do: state_with_panel_entries([entry], scheduler)
 
-  defp state_with_panel_entries(entries) do
+  defp state_with_panel_entries(entries, scheduler) do
     alias MingaEditor.GitStatus.TUIState, as: TuiState
 
     panel_data = %{
@@ -111,6 +134,7 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
     tui = %TuiState{cursor_index: 1, collapsed: %{}}
 
     %EditorState{
+      effect_scheduler: scheduler,
       frontend: %MingaEditor.State.Frontend{port_manager: self(), rendering: :disabled},
       workspace: %MingaEditor.Session.State{
         viewport: Viewport.new(24, 80),
@@ -122,6 +146,15 @@ defmodule MingaGitPorcelain.Input.GitStatusDiffOpenTest do
     }
     |> SidebarWorkflow.replace_git_status(GitStatusPanel.new(panel_data))
     |> SidebarWorkflow.replace_git_status_tui(tui)
+  end
+
+  defp receive_effect(state, scheduler) do
+    assert_receive {:effect_lifecycle, %Outcome{status: :running} = running}, @effect_timeout
+    {:noreply, state} = MingaEditor.handle_info({:effect_lifecycle, running}, state)
+
+    assert_receive {:effect_result, ^scheduler, %Outcome{} = outcome}, @effect_timeout
+    {:noreply, state} = MingaEditor.handle_info({:effect_result, scheduler, outcome}, state)
+    state
   end
 
   defp buffer_content(buf) do

--- a/lib/minga/application.ex
+++ b/lib/minga/application.ex
@@ -32,16 +32,30 @@ defmodule Minga.Application do
       │   │   ├── Minga.Command.Registry
       │   │   └── Minga.Diagnostics
       │   ├── Minga.Extension.Registry
+      │   ├── MingaEditor.Extension.Sidebar
+      │   ├── Minga.Extension.ArtifactGenerationState
+      │   ├── Minga.Extension.ArtifactAdmission
+      │   ├── Minga.Extension.CodeLease
+      │   ├── Minga.Extension.CallbackRegistry
+      │   ├── Minga.Extension.InstanceRegistry
+      │   ├── Minga.Extension.RootSupervisor
+      │   │   └── Minga.Extension.Root(name) (rest_for_one)
+      │   │       ├── Minga.Extension.RuntimeSupervisor(name)
+      │   │       └── Minga.Extension.Instance(name)
       │   ├── MingaAgent.ProviderRegistry
+      │   ├── MingaAgent.ProviderPacks.Native
       │   ├── MingaAgent.Hooks.Registry
       │   ├── MingaAgent.MCP.ServerRegistry
       │   ├── MingaAgent.Skills.Registry
       │   ├── MingaEditor.Agent.SlashCommand.Registry
-      │   ├── Minga.Extension.Supervisor
+      │   ├── MingaEditor.Agent.SemanticUI.Registry
       │   ├── Minga.Config.Loader
+      │   ├── Minga.Config.Writer
       │   ├── Minga.LSP.Supervisor
       │   ├── Minga.LSP.SyncServer
-      │   └── Minga.Project
+      │   ├── Minga.Project
+      │   ├── MingaAgent.SessionManager
+      │   └── MingaAgent.ReactiveDiagnostics
       ├── MingaAgent.Supervisor (DynamicSupervisor, one_for_one)
       ├── Minga.Runtime.Supervisor (one_for_one, conditional)
       │   ├── MingaEditor.Watchdog          (independent leaf)

--- a/lib/minga/config/loader.ex
+++ b/lib/minga/config/loader.ex
@@ -4,7 +4,7 @@ defmodule Minga.Config.Loader do
 
   ## Load order (both startup and reload)
 
-  1. `~/.config/minga/modules/*.ex` (compile user modules)
+  1. `~/.config/minga/modules/*.ex` (compile at OS-process startup; retain on reload)
   2. `~/.config/minga/themes/*.exs` (load user themes, before config eval)
   3. `~/.config/minga/config.exs` (global config)
   4. `.minga.exs` in the current working directory (project-local config)
@@ -42,6 +42,7 @@ defmodule Minga.Config.Loader do
 
   @type keymap_server :: Keymap.server()
   @type options_server :: Options.server()
+  @typep user_module_mode :: :compile | {:reuse, [module()], [String.t()]}
 
   @typedoc "Loader state: stores paths, loaded modules, and any errors from each stage."
   @type state :: %{
@@ -49,6 +50,8 @@ defmodule Minga.Config.Loader do
           load_error: String.t() | nil,
           loaded_modules: [module()],
           modules_errors: [String.t()],
+          modules_fingerprint: binary(),
+          extension_declarations_fingerprint: binary(),
           project_config_path: String.t() | nil,
           project_config_error: String.t() | nil,
           gui_settings_path: String.t(),
@@ -103,7 +106,8 @@ defmodule Minga.Config.Loader do
             options_server,
             Minga.SafeMode.active?(),
             cleanup_callbacks,
-            config_home
+            config_home,
+            :compile
           )
 
         :ok =
@@ -207,11 +211,11 @@ defmodule Minga.Config.Loader do
   def lsp_settings(server), do: get_lsp_settings(server)
 
   @doc """
-  Reloads all config from scratch.
+  Reloads data declarations while keeping user modules resident.
 
-  Purges previously loaded user modules, resets Options, Hooks,
-  Keymap.Active, and Command.Registry to defaults, then re-runs the
-  full load sequence. Returns `:ok` on success or `{:error, reason}`
+  Resets Options, Hooks, Keymap.Active, and Command.Registry to defaults,
+  then re-runs the config scripts. User module or extension source changes
+  require a fresh Minga process. Returns `:ok` on success or `{:error, reason}`
   if something went wrong (errors are also stored in state).
   """
   @spec reload() :: :ok | {:error, String.t()}
@@ -230,17 +234,192 @@ defmodule Minga.Config.Loader do
 
   @spec do_reload(GenServer.server()) :: :ok | {:error, String.t()}
   defp do_reload(server) do
+    with nil <- user_module_restart_required(server),
+         nil <- extension_declaration_restart_required(server) do
+      reload_current_extension_generation(server)
+    else
+      message when is_binary(message) -> reject_reload(server, message)
+    end
+  end
+
+  @spec reload_current_extension_generation(GenServer.server()) :: :ok | {:error, String.t()}
+  defp reload_current_extension_generation(server) do
     case ExtSupervisor.pending_artifact_restarts(Minga.Extension.Registry) do
       [] ->
         do_reload_unchanged_generation(server)
 
       changed ->
-        message =
-          "Extension restart required before config reload: #{Enum.map_join(changed, ", ", &Atom.to_string/1)}"
-
-        Agent.update(server, fn state -> %{state | load_error: message} end)
-        {:error, message}
+        names = Enum.map_join(changed, ", ", &Atom.to_string/1)
+        reject_reload(server, "Extension restart required before config reload: #{names}")
     end
+  end
+
+  @spec user_module_restart_required(GenServer.server()) :: String.t() | nil
+  defp user_module_restart_required(server) do
+    {config_path, admitted_fingerprint} =
+      Agent.get(server, fn state -> {state.config_path, state.modules_fingerprint} end)
+
+    current_fingerprint = user_modules_fingerprint(Path.dirname(config_path))
+
+    if current_fingerprint == admitted_fingerprint do
+      nil
+    else
+      "User module restart required before config reload"
+    end
+  end
+
+  @spec extension_declaration_restart_required(GenServer.server()) :: String.t() | nil
+  defp extension_declaration_restart_required(server) do
+    {config_path, gui_settings_path, admitted_fingerprint} =
+      Agent.get(server, fn state ->
+        {
+          state.config_path,
+          state.gui_settings_path,
+          state.extension_declarations_fingerprint
+        }
+      end)
+
+    current_fingerprint =
+      extension_declarations_fingerprint(
+        config_path,
+        resolve_project_config_path(),
+        gui_settings_path
+      )
+
+    if current_fingerprint == admitted_fingerprint do
+      nil
+    else
+      "Extension declarations changed; restart Minga before config reload"
+    end
+  end
+
+  @spec extension_declarations_fingerprint(String.t(), String.t() | nil, String.t()) :: binary()
+  defp extension_declarations_fingerprint(config_path, project_config_path, gui_settings_path) do
+    after_path = Path.join(Path.dirname(config_path), "after.exs")
+
+    declarations =
+      [config_path, project_config_path, gui_settings_path, after_path]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.flat_map(&extension_declarations/1)
+
+    :crypto.hash(:sha256, :erlang.term_to_binary({File.cwd!(), declarations}))
+  end
+
+  @spec extension_declarations(String.t()) :: [term()]
+  defp extension_declarations(path) do
+    case File.read(path) do
+      {:ok, source} -> extension_declarations(path, source)
+      {:error, :enoent} -> []
+      {:error, reason} -> [{path, {:read_error, reason}}]
+    end
+  end
+
+  @spec extension_declarations(String.t(), String.t()) :: [term()]
+  defp extension_declarations(path, source) do
+    case Code.string_to_quoted(source, file: path) do
+      {:ok, ast} ->
+        {_ast, {declarations, dynamic?}} =
+          Macro.prewalk(ast, {[], false}, fn
+            {:extension, _meta, [name, opts]} = node, acc ->
+              {node, collect_extension_declaration(path, name, opts, acc)}
+
+            {:extension, _meta, [module]} = node, acc ->
+              {node, collect_extension_declaration(path, module, [], acc)}
+
+            {{:., _dot_meta, [_module, :extension]}, _meta, [name, opts]} = node, acc ->
+              {node, collect_extension_declaration(path, name, opts, acc)}
+
+            {{:., _dot_meta, [_module, :extension]}, _meta, [module]} = node, acc ->
+              {node, collect_extension_declaration(path, module, [], acc)}
+
+            node, acc ->
+              {node, acc}
+          end)
+
+        if dynamic? do
+          [{path, {:dynamic_source_file, :crypto.hash(:sha256, source)}}]
+        else
+          Enum.reverse(declarations)
+        end
+
+      {:error, _reason} ->
+        [{path, {:invalid_config, :crypto.hash(:sha256, source)}}]
+    end
+  end
+
+  @spec collect_extension_declaration(
+          String.t(),
+          Macro.t(),
+          Macro.t(),
+          {[term()], boolean()}
+        ) :: {[term()], boolean()}
+  defp collect_extension_declaration(path, name, opts, {declarations, dynamic?}) do
+    case extension_source_identity(name, opts) do
+      {:ok, identity} -> {[{path, identity} | declarations], dynamic?}
+      :dynamic -> {declarations, true}
+    end
+  end
+
+  @spec extension_source_identity(Macro.t(), Macro.t()) :: {:ok, term()} | :dynamic
+  defp extension_source_identity(name_ast, opts) when is_list(opts) do
+    with true <- Keyword.keyword?(opts),
+         {:ok, name} <- extension_name_identity(name_ast) do
+      source_identity(name, opts)
+    else
+      _invalid -> :dynamic
+    end
+  end
+
+  defp extension_source_identity(_name_ast, _opts), do: :dynamic
+
+  @spec extension_name_identity(Macro.t()) :: {:ok, term()} | :dynamic
+  defp extension_name_identity(name) when is_atom(name), do: {:ok, name}
+  defp extension_name_identity({:__aliases__, _meta, parts}), do: {:ok, {:module, parts}}
+  defp extension_name_identity(_name), do: :dynamic
+
+  @spec source_identity(term(), keyword()) :: {:ok, term()} | :dynamic
+  defp source_identity(name, opts) do
+    source_keys = Enum.filter([:path, :git, :hex], &Keyword.has_key?(opts, &1))
+
+    case source_keys do
+      [] ->
+        {:ok, {:module, name}}
+
+      [:path] ->
+        with {:ok, path} <- literal_source_value(Keyword.fetch!(opts, :path)) do
+          {:ok, {:path, name, path}}
+        end
+
+      [:git] ->
+        with {:ok, url} <- literal_source_value(Keyword.fetch!(opts, :git)),
+             {:ok, branch} <- literal_source_value(Keyword.get(opts, :branch)),
+             {:ok, ref} <- literal_source_value(Keyword.get(opts, :ref)) do
+          {:ok, {:git, name, url, branch, ref}}
+        end
+
+      [:hex] ->
+        with {:ok, package} <- literal_source_value(Keyword.fetch!(opts, :hex)),
+             {:ok, version} <- literal_source_value(Keyword.get(opts, :version)),
+             {:ok, app} <- literal_source_value(Keyword.get(opts, :app)) do
+          {:ok, {:hex, name, package, version, app}}
+        end
+
+      _multiple_sources ->
+        :dynamic
+    end
+  end
+
+  @spec literal_source_value(Macro.t()) :: {:ok, term()} | :dynamic
+  defp literal_source_value(value)
+       when is_binary(value) or is_atom(value) or is_integer(value),
+       do: {:ok, value}
+
+  defp literal_source_value(_value), do: :dynamic
+
+  @spec reject_reload(GenServer.server(), String.t()) :: {:error, String.t()}
+  defp reject_reload(server, message) do
+    Agent.update(server, fn state -> %{state | load_error: message} end)
+    {:error, message}
   end
 
   @spec do_reload_unchanged_generation(GenServer.server()) :: :ok | {:error, String.t()}
@@ -255,37 +434,17 @@ defmodule Minga.Config.Loader do
       Agent.update(server, fn state -> %{state | load_error: stop_all_error} end)
       {:error, stop_all_error}
     else
-      # Get the old modules so we can purge them
-      old_modules = Agent.get(server, & &1.loaded_modules)
-
-      # Purge old user modules
-      for mod <- old_modules do
-        :code.purge(mod)
-        :code.delete(mod)
-      end
-
-      # Reset all registries to defaults
-      {keymap_server, options_server} =
-        Agent.get(server, fn
-          %{keymap_server: keymap_server, options_server: options_server} ->
-            {keymap_server, options_server}
-
-          # Defensive fallback: state shape predates the *_server fields.
-          # Unreachable in single-version processes; logged so a real schema
-          # mismatch doesn't degrade silently.
-          _ ->
-            Log.warning(
-              :config,
-              "loader state missing :keymap_server/:options_server; using defaults"
-            )
-
-            {
-              Process.get(:minga_config_keymap, Keymap.default_server()),
-              Process.get(:minga_config_options, Options.default_server())
-            }
+      # Reset all registries to defaults while preserving this VM's admitted user modules.
+      {keymap_server, options_server, config_home, loaded_modules, modules_errors} =
+        Agent.get(server, fn %{
+                               keymap_server: keymap_server,
+                               options_server: options_server,
+                               loaded_modules: loaded_modules,
+                               modules_errors: modules_errors
+                             } = state ->
+          {keymap_server, options_server, Map.get(state, :config_home), loaded_modules,
+           modules_errors}
         end)
-
-      config_home = Agent.get(server, &Map.get(&1, :config_home))
 
       maybe_reset_options(options_server)
       Hooks.reset()
@@ -298,7 +457,15 @@ defmodule Minga.Config.Loader do
 
       # Re-run the full load sequence (includes starting extensions).
       # Reload deliberately ignores startup safe mode so fixed config can be loaded without restarting.
-      new_state = load_all(keymap_server, options_server, false, cleanup_callbacks, config_home)
+      new_state =
+        load_all(
+          keymap_server,
+          options_server,
+          false,
+          cleanup_callbacks,
+          config_home,
+          {:reuse, loaded_modules, modules_errors}
+        )
 
       Agent.update(server, fn _ -> new_state end)
 
@@ -334,9 +501,17 @@ defmodule Minga.Config.Loader do
           options_server(),
           boolean(),
           %{atom() => ContributionCleanup.cleanup_fun()} | nil,
-          String.t() | nil
+          String.t() | nil,
+          user_module_mode()
         ) :: state()
-  defp load_all(keymap_server, options_server, safe_mode?, cleanup_callbacks, config_home)
+  defp load_all(
+         keymap_server,
+         options_server,
+         safe_mode?,
+         cleanup_callbacks,
+         config_home,
+         user_module_mode
+       )
        when is_boolean(safe_mode?) do
     previous_keymap_server = Process.put(:minga_config_keymap, keymap_server)
     previous_options_server = Process.put(:minga_config_options, options_server)
@@ -359,8 +534,9 @@ defmodule Minga.Config.Loader do
 
         StartupTimer.mark(:config_loader_start)
 
-        # 1. Compile user modules
-        {loaded_modules, modules_errors} = compile_user_modules(config_dir)
+        # 1. Compile user modules only at OS-process startup. Reload reuses residents.
+        {loaded_modules, modules_errors} = resolve_user_modules(config_dir, user_module_mode)
+        modules_fingerprint = user_modules_fingerprint(config_dir)
         StartupTimer.mark(:config_user_modules)
 
         # 2. Load user themes (before config eval so `set :theme, :my_custom` works)
@@ -438,6 +614,9 @@ defmodule Minga.Config.Loader do
           load_error: load_error,
           loaded_modules: loaded_modules,
           modules_errors: modules_errors,
+          modules_fingerprint: modules_fingerprint,
+          extension_declarations_fingerprint:
+            extension_declarations_fingerprint(config_path, project_path, gui_settings_path),
           project_config_path: project_path,
           project_config_error: project_config_error,
           gui_settings_path: gui_settings_path,
@@ -469,6 +648,13 @@ defmodule Minga.Config.Loader do
       load_error: nil,
       loaded_modules: [],
       modules_errors: [],
+      modules_fingerprint: user_modules_fingerprint(config_dir),
+      extension_declarations_fingerprint:
+        extension_declarations_fingerprint(
+          config_path,
+          nil,
+          Path.join(config_dir, "gui_settings.exs")
+        ),
       project_config_path: nil,
       project_config_error: nil,
       gui_settings_path: Path.join(config_dir, "gui_settings.exs"),
@@ -761,6 +947,31 @@ defmodule Minga.Config.Loader do
     # singleton hasn't booted under test). Other failure modes — wrong
     # log_level value, Logger crashes — are real bugs and should propagate.
     ArgumentError -> :ok
+  end
+
+  @spec resolve_user_modules(String.t(), user_module_mode()) :: {[module()], [String.t()]}
+  defp resolve_user_modules(config_dir, :compile), do: compile_user_modules(config_dir)
+
+  defp resolve_user_modules(_config_dir, {:reuse, loaded_modules, modules_errors}),
+    do: {loaded_modules, modules_errors}
+
+  @spec user_modules_fingerprint(String.t()) :: binary()
+  defp user_modules_fingerprint(config_dir) do
+    modules_dir = Path.join(config_dir, "modules")
+
+    snapshot =
+      case File.ls(modules_dir) do
+        {:ok, files} ->
+          files
+          |> Enum.filter(&String.ends_with?(&1, ".ex"))
+          |> Enum.sort()
+          |> Enum.map(fn file -> {file, File.read(Path.join(modules_dir, file))} end)
+
+        {:error, reason} ->
+          {:directory_error, reason}
+      end
+
+    :crypto.hash(:sha256, :erlang.term_to_binary(snapshot, [:deterministic]))
   end
 
   @spec compile_user_modules(String.t()) :: {[module()], [String.t()]}

--- a/lib/minga/extension/instance/state.ex
+++ b/lib/minga/extension/instance/state.ex
@@ -89,7 +89,7 @@ defmodule Minga.Extension.Instance.State do
     %{state | collaborators: current_collaborators(state.collaborators, collaborators)}
   end
 
-  @doc "Removes request-scoped callbacks, hooks, and timeout overrides."
+  @doc "Removes request-scoped callbacks and timeout overrides."
   @spec stable_collaborators(keyword()) :: keyword()
   def stable_collaborators(collaborators) do
     Enum.reject(collaborators, fn {key, _value} -> request_override?(key) end)
@@ -206,7 +206,6 @@ defmodule Minga.Extension.Instance.State do
 
   @spec request_override?(atom()) :: boolean()
   defp request_override?(:callbacks), do: true
-  defp request_override?(:test_hooks), do: true
   defp request_override?(:slow_lifecycle_threshold_ms), do: true
 
   defp request_override?(key) when is_atom(key) do

--- a/lib/minga/extension/lazy.ex
+++ b/lib/minga/extension/lazy.ex
@@ -12,8 +12,6 @@ defmodule Minga.Extension.Lazy do
   @typedoc "Result from registering lazy stubs."
   @type stub_result :: :ok | {:error, term()}
 
-  @authority_retry_attempts 2
-
   @doc "Registers path/Git/Hex stubs through the extension Instance."
   @spec register_stubs(
           GenServer.server(),
@@ -177,7 +175,7 @@ defmodule Minga.Extension.Lazy do
           [DeferredBatchCompleteEvent.failure()]
         ) :: [DeferredBatchCompleteEvent.failure()]
   defp start_deferred_instance({instance, name, declaration}, failures) do
-    case safe_start_deferred(name, instance, declaration) do
+    case safe_start_deferred(instance, declaration) do
       {:ok, _pid} ->
         Log.info(:config, "Extension #{name} deferred load complete")
         failures
@@ -190,7 +188,7 @@ defmodule Minga.Extension.Lazy do
 
   @spec safe_start(atom(), GenServer.server()) :: {:ok, pid()} | {:error, term()}
   defp safe_start(name, instance) do
-    case retry_instance_call(name, instance, &Instance.start/1, @authority_retry_attempts) do
+    case call_instance(instance, &Instance.start/1) do
       {:authority_call_exit, reason} ->
         failure = {:authority_call_exit, name, reason}
         Log.warning(:config, "Extension #{name} lazy activation failed: #{inspect(failure)}")
@@ -201,73 +199,23 @@ defmodule Minga.Extension.Lazy do
     end
   end
 
-  @spec safe_start_deferred(atom(), GenServer.server(), ExtRegistry.entry()) ::
+  @spec safe_start_deferred(GenServer.server(), ExtRegistry.entry()) ::
           {:ok, pid()} | {:error, term()}
-  defp safe_start_deferred(name, instance, declaration) do
-    case retry_instance_call(
-           name,
-           instance,
-           fn current -> Instance.start_deferred(current, declaration) end,
-           @authority_retry_attempts
-         ) do
+  defp safe_start_deferred(instance, declaration) do
+    case call_instance(instance, fn current -> Instance.start_deferred(current, declaration) end) do
       {:authority_call_exit, reason} -> {:error, {:instance_call_exit, reason}}
       result -> result
     end
   end
 
-  @spec retry_instance_call(
-          atom(),
-          GenServer.server(),
-          (GenServer.server() -> result),
-          non_neg_integer()
-        ) :: result | {:authority_call_exit, term()}
+  @spec call_instance(GenServer.server(), (GenServer.server() -> result)) ::
+          result | {:authority_call_exit, term()}
         when result: var
-  defp retry_instance_call(name, instance, fun, retries) do
+  defp call_instance(instance, fun) do
     fun.(instance)
   catch
-    :exit, reason ->
-      retry_instance_call_after_exit(name, instance, fun, retries, reason)
+    :exit, reason -> {:authority_call_exit, reason}
   end
-
-  @spec retry_instance_call_after_exit(
-          atom(),
-          GenServer.server(),
-          (GenServer.server() -> result),
-          non_neg_integer(),
-          term()
-        ) :: result | {:authority_call_exit, term()}
-        when result: var
-  defp retry_instance_call_after_exit(name, instance, fun, retries, reason) do
-    if retries > 0 and restart_gap?(reason) do
-      case await_current_instance(instance, name) do
-        {:ok, current} -> retry_instance_call(name, current, fun, retries - 1)
-        {:error, _reason} -> {:authority_call_exit, reason}
-      end
-    else
-      {:authority_call_exit, reason}
-    end
-  end
-
-  @spec await_current_instance(GenServer.server(), atom()) ::
-          {:ok, GenServer.server()} | {:error, term()}
-  defp await_current_instance(
-         {:via, Registry, {registry, {:instance, name}}} = instance,
-         name
-       ) do
-    case InstanceRegistry.await(registry, :instance, name) do
-      {:ok, _pid} -> {:ok, instance}
-      {:error, _reason} = error -> error
-    end
-  end
-
-  defp await_current_instance(_instance, name),
-    do: {:error, {:authority_unavailable, name, :unregistered_server}}
-
-  @spec restart_gap?(term()) :: boolean()
-  defp restart_gap?(:noproc), do: true
-  defp restart_gap?({:noproc, _call}), do: true
-  defp restart_gap?({:authority_unavailable, _name, reason}), do: restart_gap?(reason)
-  defp restart_gap?(_reason), do: false
 
   @spec root_supervisor(GenServer.server()) :: GenServer.server()
   defp root_supervisor(ExtSupervisor), do: Minga.Extension.RootSupervisor

--- a/lib/minga/extension/supervisor.ex
+++ b/lib/minga/extension/supervisor.ex
@@ -21,8 +21,6 @@ defmodule Minga.Extension.Supervisor do
   @type start_failure :: %{extension: atom(), reason: term()}
   @type stop_failure :: %{extension: atom(), reason: term()}
 
-  @authority_retry_attempts 2
-
   @typedoc "Injected lifecycle collaborators."
   @type start_opts :: [
           command_registry: GenServer.server(),
@@ -38,8 +36,7 @@ defmodule Minga.Extension.Supervisor do
           transition_timeout_ms: pos_integer(),
           callback_timeout_ms: pos_integer(),
           runtime_query_timeout_ms: pos_integer(),
-          drain_timeout_ms: pos_integer(),
-          test_hooks: map()
+          drain_timeout_ms: pos_integer()
         ]
 
   @doc false
@@ -169,15 +166,8 @@ defmodule Minga.Extension.Supervisor do
   end
 
   @spec start_instance(atom(), GenServer.server()) :: {:ok, pid()} | {:error, term()}
-  defp start_instance(name, instance) do
-    case safe_instance_call(name, fn -> Instance.start(instance) end) do
-      {:error, {:interrupted_lifecycle, _phase}} ->
-        safe_instance_call(name, fn -> Instance.start(instance) end)
-
-      result ->
-        result
-    end
-  end
+  defp start_instance(name, instance),
+    do: safe_instance_call(name, fn -> Instance.start(instance) end)
 
   @doc "Registers one lazy declaration and its activation stubs through its stable authority."
   @spec register_lazy_extension(
@@ -649,41 +639,13 @@ defmodule Minga.Extension.Supervisor do
         ) :: result | {:error, term()}
         when result: var
   defp call_declared_instance(supervisor, registry, name, entry, opts, fun) do
-    call_declared_instance(
-      supervisor,
-      registry,
-      name,
-      entry,
-      opts,
-      fun,
-      @authority_retry_attempts
-    )
-  end
-
-  @spec call_declared_instance(
-          GenServer.server(),
-          GenServer.server(),
-          atom(),
-          ExtRegistry.entry(),
-          start_opts(),
-          (GenServer.server() -> result),
-          non_neg_integer()
-        ) :: result | {:error, term()}
-        when result: var
-  defp call_declared_instance(supervisor, registry, name, entry, opts, fun, retries) do
-    result =
-      with {:ok, instance} <- locate_instance(supervisor, registry, name, entry, opts),
-           :ok <- run_test_hook(opts, :after_authority_located, [name, instance]),
-           :ok <-
-             safe_instance_call(name, fn ->
-               Instance.declare(instance, entry, registry, opts)
-             end) do
-        safe_instance_call(name, fn -> fun.(instance) end)
-      end
-
-    maybe_retry_authority(result, name, opts, retries, fn ->
-      call_declared_instance(supervisor, registry, name, entry, opts, fun, retries - 1)
-    end)
+    with {:ok, instance} <- locate_instance(supervisor, registry, name, entry, opts),
+         :ok <-
+           safe_instance_call(name, fn ->
+             Instance.declare(instance, entry, registry, opts)
+           end) do
+      safe_instance_call(name, fn -> fun.(instance) end)
+    end
   end
 
   @spec call_existing_instance(
@@ -694,67 +656,9 @@ defmodule Minga.Extension.Supervisor do
         ) :: result | :absent | {:error, term()}
         when result: var
   defp call_existing_instance(supervisor, name, opts, fun) do
-    call_existing_instance(supervisor, name, opts, fun, @authority_retry_attempts)
-  end
-
-  @spec call_existing_instance(
-          GenServer.server(),
-          atom(),
-          start_opts(),
-          (GenServer.server() -> result),
-          non_neg_integer()
-        ) :: result | :absent | {:error, term()}
-        when result: var
-  defp call_existing_instance(supervisor, name, opts, fun, retries) do
-    result =
-      with {:ok, instance} <- existing_instance(supervisor, name, opts),
-           :ok <- run_test_hook(opts, :after_authority_located, [name, instance]) do
-        safe_instance_call(name, fn -> fun.(instance) end)
-      end
-
-    maybe_retry_authority(result, name, opts, retries, fn ->
-      call_existing_instance(supervisor, name, opts, fun, retries - 1)
-    end)
-  end
-
-  @spec maybe_retry_authority(result, atom(), start_opts(), non_neg_integer(), (-> result)) ::
-          result
-        when result: var
-  defp maybe_retry_authority(result, name, opts, retries, retry) do
-    if retries > 0 and retryable_authority_error?(result, name) do
-      :ok = run_test_hook(opts, :before_authority_retry, [name])
-      retry.()
-    else
-      result
+    with {:ok, instance} <- existing_instance(supervisor, name, opts) do
+      safe_instance_call(name, fn -> fun.(instance) end)
     end
-  end
-
-  @spec retryable_authority_error?(term(), atom()) :: boolean()
-  defp retryable_authority_error?(
-         {:error, {:authority_unavailable, name, reason}},
-         name
-       ),
-       do: restart_gap?(reason)
-
-  defp retryable_authority_error?(_result, _name), do: false
-
-  @spec restart_gap?(term()) :: boolean()
-  defp restart_gap?(:noproc), do: true
-  defp restart_gap?(:registration_timeout), do: true
-  defp restart_gap?({:noproc, _call}), do: true
-  defp restart_gap?({:authority_unavailable, _name, reason}), do: restart_gap?(reason)
-  defp restart_gap?(_reason), do: false
-
-  @spec run_test_hook(start_opts(), atom(), [term()]) :: :ok
-  defp run_test_hook(opts, hook, args) do
-    hooks = Keyword.get(opts, :test_hooks, %{})
-
-    case Map.get(hooks, hook) do
-      nil -> :ok
-      fun when is_function(fun) -> _result = apply(fun, args)
-    end
-
-    :ok
   end
 
   @spec safe_instance_call(atom(), (-> result)) :: result | {:error, term()} when result: var

--- a/lib/minga/services/supervisor.ex
+++ b/lib/minga/services/supervisor.ex
@@ -15,6 +15,11 @@ defmodule Minga.Services.Supervisor do
   service crash restarts only that service without cascading into its
   siblings or the dependency chains below.
 
+  `InstanceRegistry` and `RootSupervisor` are direct service children. Each
+  dynamic `Root(name)` uses `rest_for_one` with `RuntimeSupervisor(name)` first
+  and the permanent `Instance(name)` second. Runtime children are temporary;
+  the Instance is the only process that interprets extension restart policy.
+
   ## Children
 
       Services.Supervisor (rest_for_one)

--- a/sdk/README.md
+++ b/sdk/README.md
@@ -43,12 +43,33 @@ defmodule MyExtension do
 end
 ```
 
+## Lifecycle contract
+
+Minga admits one complete validated artifact inventory for an extension source and keeps that code resident for the lifetime of the BEAM OS process. Disabling and restarting an extension stop its runtime and remove its source-owned contributions, but they do not unload modules. Editing path extension source, updating a Git extension, or changing a compiled user module takes effect only after a fresh Minga process starts.
+
+Each extension has one stable lifecycle authority. It runs `init/1`, starts the child from `child_spec/1`, registers contributions, and only then publishes the runtime as running. The `restart` value on your top-level child spec is honored by that authority: `:permanent` restarts after any terminal exit, `:transient` only after abnormal exits, and `:temporary` never restarts. Minga starts the top-level runtime child as temporary internally so OTP and the lifecycle authority cannot both restart it.
+
+```elixir
+def child_spec(config) do
+  Supervisor.child_spec({MyExtension.Supervisor, config}, restart: :transient)
+end
+```
+
+Runtime callbacks are declared with `editor_event_handler/3`. The supported families are `:buffer_saved`, `:editor_action`, and `:source_unload`. Callback exceptions, exits, unavailable code, and invalid returns are reported as explicit extension failures. A `:source_unload` callback runs during disable after new callback work is closed and before the runtime child and source contributions are removed. Keep it bounded and do not synchronously call extension start or stop from it.
+
+Extension-owned slow work must use a typed `MingaEditor.Effect` request scheduled by Minga's effect scheduler. Source tagging lets disable cancel in-flight work before presentation cleanup. Custom worker messages to the Editor are not part of the SDK contract.
+
+The runtime and SDK declaration sources are checked for parity in the main Minga test suite. When a runtime DSL macro, generated schema, callback, or callback family changes, the matching SDK declaration must change in the same commit.
+
 ## What's included
 
-- `Minga.Extension` behaviour and DSL macros (`option`, `command`, `keybind`, `modeline_segment`)
+- `Minga.Extension` behaviour and DSL macros (`option`, `command`, `keybind`, `modeline_segment`, `editor_event_handler`, `load_policy`)
+- `Minga.Extension.Agent` declarations for hooks, skills, MCP servers, slash commands, and semantic agent UI
 - `Minga.Extension.Overlay` API for rendering positioned overlays on the editor surface
 - `Minga.Extension.AgentAPI` for querying agent session state
 - `MingaEditor.Extension.EditorAPI` for triggering editor actions from commands
 - `Minga.Events` for subscribing to editor events
 - `Minga.Buffer` public API types
 - `Minga.Buffer.EditSource` and `Minga.Buffer.EditDelta` types for tracking edit origins and positions
+
+See [`EXTENSION_API.md`](../EXTENSION_API.md) for callback ordering, source-owned work, artifact ownership, and update behavior.

--- a/sdk/lib/minga/extension.ex
+++ b/sdk/lib/minga/extension.ex
@@ -76,7 +76,23 @@ defmodule Minga.Extension do
   """
 
   @typedoc "Extension runtime status."
-  @type extension_status :: :running | :stopped | :crashed | :load_error
+  @type extension_status :: :running | :stopped | :crashed | :load_error | :stub
+
+  @typedoc """
+  When an extension should be loaded.
+
+  * `:eager` — compile + init at boot (first-paint UI: segments, dashboard, theme).
+  * `:deferred` — load in the background shortly after first paint.
+  * `{:on_command, [atom()]}` — autoload when any listed command is first invoked.
+  * `{:on_filetype, [atom()]}` — autoload when a buffer with a matching filetype opens.
+  * `{:on_key, [{mode, key_string}]}` — autoload when a matching key sequence is pressed.
+  """
+  @type load_policy ::
+          :eager
+          | :deferred
+          | {:on_command, [atom()]}
+          | {:on_filetype, [atom()]}
+          | {:on_key, [{atom(), String.t()}]}
 
   @typedoc "Extension metadata and runtime info. See `Minga.Extension.Entry`."
   @type extension_info :: Minga.Extension.Entry.t()
@@ -168,14 +184,6 @@ defmodule Minga.Extension do
   @typedoc "A declarative runtime editor event callback."
   @type editor_event_handler_spec ::
           {module(), [editor_event_family()], editor_event_handler_opts()}
-
-  @typedoc "When an extension should be loaded."
-  @type load_policy ::
-          :eager
-          | :deferred
-          | {:on_command, [atom()]}
-          | {:on_filetype, [atom()]}
-          | {:on_key, [{bindable_mode(), String.t()}]}
 
   @doc """
   Builds a public manifest for a loaded extension module.
@@ -342,7 +350,30 @@ defmodule Minga.Extension do
   end
 
   @doc """
-  Declares when this extension should load.
+  Declares when this extension should be loaded.
+
+  Extensions default to `:eager` (loaded at boot). Use this macro to
+  defer loading until the extension is actually needed.
+
+  ## Policies
+
+  * `:eager` — compile + init at boot. Required for extensions that
+    contribute first-paint UI (modeline segments, themes, dashboard).
+  * `:deferred` — loaded in the background shortly after first paint.
+  * `{:on_command, [:cmd1, :cmd2]}` — loaded when any listed command
+    is first invoked. Commands and keybindings are registered as stubs
+    at boot; the extension loads transparently on first use.
+  * `{:on_filetype, [:elixir, :rust]}` — reserved for future use.
+    Registers stubs like `on_command` but filetype-open events do
+    not yet trigger autoload automatically.
+  * `{:on_key, [normal: "SPC m"]}` — reserved for future use.
+    Registers stubs like `on_command` but key-press events do not
+    yet trigger autoload automatically.
+
+  ## Examples
+
+      load_policy :deferred
+      load_policy {:on_command, [:open_tasks]}
   """
   defmacro load_policy(policy) do
     quote do
@@ -378,43 +409,41 @@ defmodule Minga.Extension do
 
   @doc false
   defmacro __before_compile__(env) do
-    options = Module.get_attribute(env.module, :__extension_options__) || []
-    commands = Module.get_attribute(env.module, :__extension_commands__) || []
-    keybinds = Module.get_attribute(env.module, :__extension_keybinds__) || []
-    modeline_segments = Module.get_attribute(env.module, :__extension_modeline_segments__) || []
-    capabilities = Module.get_attribute(env.module, :__extension_capabilities__) || []
-    load_policy = Module.get_attribute(env.module, :__extension_load_policy__) || :eager
-    # Accumulated attributes are in reverse order; restore declaration order
-    options = Enum.reverse(options)
-    commands = Enum.reverse(commands)
-    keybinds = Enum.reverse(keybinds)
-    modeline_segments = Enum.reverse(modeline_segments)
-    capabilities = Enum.reverse(capabilities)
+    {options, commands, keybinds, modeline_segments, capabilities, load_policy} =
+      read_extension_attributes(env.module)
 
     quote do
-      @doc false
       @spec __option_schema__() :: [Minga.Extension.option_spec()]
       def __option_schema__, do: unquote(Macro.escape(options))
 
-      @doc false
       @spec __command_schema__() :: [Minga.Extension.command_spec()]
       def __command_schema__, do: unquote(Macro.escape(commands))
 
-      @doc false
       @spec __keybind_schema__() :: [Minga.Extension.keybind_spec()]
       def __keybind_schema__, do: unquote(Macro.escape(keybinds))
 
-      @doc false
       @spec __modeline_segment_schema__() :: [Minga.Extension.modeline_segment_spec()]
       def __modeline_segment_schema__, do: unquote(Macro.escape(modeline_segments))
 
-      @doc false
       @spec __capability_schema__() :: [Minga.Extension.capability_spec()]
       def __capability_schema__, do: unquote(Macro.escape(capabilities))
 
-      @doc false
       @spec __load_policy__() :: Minga.Extension.load_policy()
       def __load_policy__, do: unquote(Macro.escape(load_policy))
     end
+  end
+
+  @spec read_extension_attributes(module()) :: {list(), list(), list(), list(), list(), term()}
+  defp read_extension_attributes(mod) do
+    options = mod |> Module.get_attribute(:__extension_options__, []) |> Enum.reverse()
+    commands = mod |> Module.get_attribute(:__extension_commands__, []) |> Enum.reverse()
+    keybinds = mod |> Module.get_attribute(:__extension_keybinds__, []) |> Enum.reverse()
+
+    modeline_segments =
+      mod |> Module.get_attribute(:__extension_modeline_segments__, []) |> Enum.reverse()
+
+    capabilities = mod |> Module.get_attribute(:__extension_capabilities__, []) |> Enum.reverse()
+    load_policy = Module.get_attribute(mod, :__extension_load_policy__) || :eager
+    {options, commands, keybinds, modeline_segments, capabilities, load_policy}
   end
 end

--- a/sdk/lib/minga/extension/agent.ex
+++ b/sdk/lib/minga/extension/agent.ex
@@ -2,7 +2,7 @@ defmodule Minga.Extension.Agent do
   @moduledoc """
   Agent surface for Minga extensions.
 
-  This module provides the DSL macros and compile-time wiring for agent-specific extension components: hooks, skills, MCP servers, and slash commands.
+  This module provides the DSL macros and compile-time wiring for agent-specific extension components: hooks, skills, MCP servers, slash commands, and semantic UI contributions.
 
   `use Minga.Extension.Agent` is the recommended way to define an extension that contributes agent-side features. It injects the `Minga.Extension` behaviour, registers compile-time accumulate attributes for each agent component, provides a default `child_spec/1`, and imports the agent DSL macros.
 
@@ -14,9 +14,11 @@ defmodule Minga.Extension.Agent do
 
   Skill specs are path strings pointing to a skill directory on disk.
 
-  MCP server specs are `{name, opts}` tuples where `name` is an atom identifier and `opts` is a keyword list with keys like `:command` and `:args`.
+  MCP server specs are `{name, opts}` tuples where `name` is an atom or string identifier and `opts` is a keyword list with keys like `:command` and `:args`.
 
-  Slash command specs are `{name, description, opts}` tuples where `name` is an atom, `description` is a human-readable string, and `opts` is a keyword list with keys like `:command`.
+  Slash command specs are `{name, description, opts}` tuples where `name` is an atom or string, `description` is a human-readable string, and `opts` is a keyword list with keys like `:command`.
+
+  Agent UI specs are maps or keyword lists that already contain semantic render-model values. The semantic UI registry validates that payloads are existing `Minga.RenderModel.UI.*` values before render builders read them.
 
   ## Usage
 
@@ -35,6 +37,8 @@ defmodule Minga.Extension.Agent do
         mcp_server :my_mcp, command: "servers/my-mcp", args: ["--port", "3000"]
 
         slash_command :my_cmd, "Runs my custom command", command: "commands/my-cmd.sh"
+
+        agent_ui id: "status", surface: :panel, payload: %Minga.RenderModel.UI.ExtensionPanel.Panel{...}
 
         @impl true
         def name, do: :minga_lint
@@ -55,9 +59,9 @@ defmodule Minga.Extension.Agent do
   @doc """
   Injects the `Minga.Extension` behaviour, agent DSL macros, and a default `child_spec/1`.
 
-  The injected macros are: `option/3`, `hook/2`, `skill/1`, `mcp_server/2`, and `slash_command/3`.
+  The injected macros are: `option/3`, `hook/2`, `skill/1`, `mcp_server/2`, `slash_command/3`, and `agent_ui/1`.
 
-  At compile time, each macro accumulates declarations into module attributes. The `__before_compile__` hook then generates `__option_schema__/0`, `__hook_schema__/0`, `__skill_schema__/0`, `__mcp_server_schema__/0`, and `__slash_command_schema__/0` functions that the framework reads at load time.
+  At compile time, each macro accumulates declarations into module attributes. The `__before_compile__` hook then generates `__option_schema__/0`, `__hook_schema__/0`, `__skill_schema__/0`, `__mcp_server_schema__/0`, `__slash_command_schema__/0`, and `__agent_ui_schema__/0` functions that the framework reads at load time.
   """
   defmacro __using__(_opts) do
     quote do
@@ -70,6 +74,7 @@ defmodule Minga.Extension.Agent do
       Module.register_attribute(__MODULE__, :__extension_skills__, accumulate: true)
       Module.register_attribute(__MODULE__, :__extension_mcp_servers__, accumulate: true)
       Module.register_attribute(__MODULE__, :__extension_slash_commands__, accumulate: true)
+      Module.register_attribute(__MODULE__, :__extension_agent_ui__, accumulate: true)
       @before_compile Minga.Extension.Agent
 
       unless Module.defines?(__MODULE__, {:child_spec, 1}) do
@@ -94,7 +99,8 @@ defmodule Minga.Extension.Agent do
           hook: 2,
           skill: 1,
           mcp_server: 2,
-          slash_command: 3
+          slash_command: 3,
+          agent_ui: 1
         ]
     end
   end
@@ -187,40 +193,70 @@ defmodule Minga.Extension.Agent do
     end
   end
 
+  @doc """
+  Declares a semantic agent UI contribution.
+
+  The payload must be an existing render-model value accepted by `MingaEditor.Agent.SemanticUI.Entry`, such as an agent chat message body, extension-panel content, or an extension-panel panel.
+
+  ## Examples
+
+      agent_ui id: "status", surface: :panel, payload: %Minga.RenderModel.UI.ExtensionPanel.Panel{...}
+      agent_ui id: "note", surface: :transcript_enrichment, payload: {:system, "Ready", :info}
+  """
+  defmacro agent_ui(attrs) do
+    quote do
+      @__extension_agent_ui__ unquote(attrs)
+    end
+  end
+
   @doc false
   defmacro __before_compile__(env) do
-    options = Module.get_attribute(env.module, :__extension_options__) || []
-    hooks = Module.get_attribute(env.module, :__extension_hooks__) || []
-    skills = Module.get_attribute(env.module, :__extension_skills__) || []
-    mcp_servers = Module.get_attribute(env.module, :__extension_mcp_servers__) || []
-    slash_commands = Module.get_attribute(env.module, :__extension_slash_commands__) || []
-    # Accumulated attributes are in reverse order; restore declaration order
-    options = Enum.reverse(options)
-    hooks = Enum.reverse(hooks)
-    skills = Enum.reverse(skills)
-    mcp_servers = Enum.reverse(mcp_servers)
-    slash_commands = Enum.reverse(slash_commands)
+    schemas = agent_schemas(env.module)
 
     quote do
-      @doc false
       @spec __option_schema__() :: [Minga.Extension.option_spec()]
-      def __option_schema__, do: unquote(Macro.escape(options))
+      def __option_schema__, do: unquote(Macro.escape(schemas.options))
 
-      @doc false
       @spec __hook_schema__() :: [{atom(), keyword()}]
-      def __hook_schema__, do: unquote(Macro.escape(hooks))
+      def __hook_schema__, do: unquote(Macro.escape(schemas.hooks))
 
-      @doc false
       @spec __skill_schema__() :: [String.t()]
-      def __skill_schema__, do: unquote(Macro.escape(skills))
+      def __skill_schema__, do: unquote(Macro.escape(schemas.skills))
 
-      @doc false
-      @spec __mcp_server_schema__() :: [{atom(), keyword()}]
-      def __mcp_server_schema__, do: unquote(Macro.escape(mcp_servers))
+      @spec __mcp_server_schema__() :: [{atom() | String.t(), keyword()}]
+      def __mcp_server_schema__, do: unquote(Macro.escape(schemas.mcp_servers))
 
-      @doc false
-      @spec __slash_command_schema__() :: [{atom(), String.t(), keyword()}]
-      def __slash_command_schema__, do: unquote(Macro.escape(slash_commands))
+      @spec __slash_command_schema__() :: [{atom() | String.t(), String.t(), keyword()}]
+      def __slash_command_schema__, do: unquote(Macro.escape(schemas.slash_commands))
+
+      @spec __agent_ui_schema__() :: [map() | keyword()]
+      def __agent_ui_schema__, do: unquote(Macro.escape(schemas.agent_ui))
     end
+  end
+
+  @spec agent_schemas(module()) :: %{
+          options: list(),
+          hooks: list(),
+          skills: list(),
+          mcp_servers: list(),
+          slash_commands: list(),
+          agent_ui: list()
+        }
+  defp agent_schemas(module) do
+    %{
+      options: schema_attribute(module, :__extension_options__),
+      hooks: schema_attribute(module, :__extension_hooks__),
+      skills: schema_attribute(module, :__extension_skills__),
+      mcp_servers: schema_attribute(module, :__extension_mcp_servers__),
+      slash_commands: schema_attribute(module, :__extension_slash_commands__),
+      agent_ui: schema_attribute(module, :__extension_agent_ui__)
+    }
+  end
+
+  @spec schema_attribute(module(), atom()) :: list()
+  defp schema_attribute(module, attribute) do
+    module
+    |> Module.get_attribute(attribute, [])
+    |> Enum.reverse()
   end
 end

--- a/sdk/lib/minga/extension/editor.ex
+++ b/sdk/lib/minga/extension/editor.ex
@@ -172,18 +172,6 @@ defmodule Minga.Extension.Editor do
   end
 
   @doc """
-  Declares a synchronous runtime editor callback owned by this extension.
-
-  Supported families are `:buffer_saved`, `:editor_action`, and `:source_unload`.
-  Options support an integer `:priority` (default `100`).
-  """
-  defmacro editor_event_handler(callback, families, opts \\ []) do
-    quote do
-      @__extension_editor_event_handlers__ {unquote(callback), unquote(families), unquote(opts)}
-    end
-  end
-
-  @doc """
   Declares a keybinding this extension provides.
 
   Accumulated at compile time and exposed via `__keybind_schema__/0`.
@@ -210,6 +198,19 @@ defmodule Minga.Extension.Editor do
   end
 
   @doc """
+  Declares a synchronous runtime editor callback owned by this extension.
+
+  Supported families are `:buffer_saved`, `:editor_action`, and `:source_unload`.
+  The framework derives source ownership during lifecycle registration. Options
+  support an integer `:priority` (default `100`).
+  """
+  defmacro editor_event_handler(callback, families, opts \\ []) do
+    quote do
+      @__extension_editor_event_handlers__ {unquote(callback), unquote(families), unquote(opts)}
+    end
+  end
+
+  @doc """
   Sets the extension's load policy.
 
   See `Minga.Extension` for supported policies and examples.
@@ -226,28 +227,21 @@ defmodule Minga.Extension.Editor do
       read_editor_attributes(env.module)
 
     quote do
-      @doc false
       @spec __option_schema__() :: [Minga.Extension.option_spec()]
       def __option_schema__, do: unquote(Macro.escape(options))
 
-      @doc false
       @spec __command_schema__() :: [Minga.Extension.command_spec()]
       def __command_schema__, do: unquote(Macro.escape(commands))
 
-      @doc false
       @spec __keybind_schema__() :: [Minga.Extension.keybind_spec()]
       def __keybind_schema__, do: unquote(Macro.escape(keybinds))
 
-      @doc false
       @spec __modeline_segment_schema__() :: [Minga.Extension.modeline_segment_spec()]
       def __modeline_segment_schema__, do: unquote(Macro.escape(modeline_segments))
 
-      @doc false
       @spec __capability_schema__() :: [Minga.Extension.capability_spec()]
       def __capability_schema__, do: unquote(Macro.escape(capabilities))
 
-      @doc false
-      @doc false
       @spec __editor_event_handler_schema__() :: [Minga.Extension.editor_event_handler_spec()]
       def __editor_event_handler_schema__, do: unquote(Macro.escape(event_handlers))
 

--- a/sdk/test/minga_sdk_test.exs
+++ b/sdk/test/minga_sdk_test.exs
@@ -40,6 +40,32 @@ defmodule MingaSdkTest do
     end
   end
 
+  describe "agent declaration contract" do
+    test "agent UI declarations compile into the SDK schema" do
+      defmodule TestAgentExtension do
+        use Minga.Extension.Agent
+
+        agent_ui(id: "status", surface: :panel, payload: %{text: "Ready"})
+
+        @impl true
+        def name, do: :test_agent_ext
+
+        @impl true
+        def description, do: "Test agent extension"
+
+        @impl true
+        def version, do: "0.1.0"
+
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+
+      assert TestAgentExtension.__agent_ui_schema__() == [
+               [id: "status", surface: :panel, payload: %{text: "Ready"}]
+             ]
+    end
+  end
+
   describe "runtime callback family contract" do
     test "family type contains only retained events" do
       {:ok, types} = Code.Typespec.fetch_types(Minga.Extension)
@@ -54,6 +80,17 @@ defmodule MingaSdkTest do
              |> Code.Typespec.type_to_quoted()
              |> Macro.to_string() ==
                "editor_event_family() :: :buffer_saved | :editor_action | :source_unload"
+
+      assert {:type, {:extension_status, status_type, []}} =
+               Enum.find(types, fn
+                 {:type, {:extension_status, _type, []}} -> true
+                 _other -> false
+               end)
+
+      assert {:extension_status, status_type, []}
+             |> Code.Typespec.type_to_quoted()
+             |> Macro.to_string() ==
+               "extension_status() :: :running | :stopped | :crashed | :load_error | :stub"
     end
   end
 

--- a/test/minga/config/loader_test.exs
+++ b/test/minga/config/loader_test.exs
@@ -1076,7 +1076,7 @@ defmodule Minga.Config.LoaderTest do
 
       previous_load_extensions = Application.get_env(:minga, :load_extensions)
       # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
-      Application.put_env(:minga, :load_extensions, true)
+      Application.put_env(:minga, :load_extensions, false)
 
       on_exit(fn ->
         restore_application_env(:load_extensions, previous_load_extensions)
@@ -1132,6 +1132,14 @@ defmodule Minga.Config.LoaderTest do
         end
       }
 
+      File.write!(
+        Path.join(minga_dir, "config.exs"),
+        """
+        use Minga.Config
+        extension :loader_start_all_failure, path: #{inspect(ext_dir)}
+        """
+      )
+
       name = :"loader_reload_start_all_#{System.unique_integer([:positive])}"
 
       {:ok, pid} =
@@ -1142,14 +1150,8 @@ defmodule Minga.Config.LoaderTest do
         )
 
       assert Loader.load_error(pid) == nil
-
-      File.write!(
-        Path.join(minga_dir, "config.exs"),
-        """
-        use Minga.Config
-        extension :loader_start_all_failure, path: #{inspect(ext_dir)}
-        """
-      )
+      # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
+      Application.put_env(:minga, :load_extensions, true)
 
       assert {:error, msg} = Loader.reload(pid)
       assert msg =~ "Extension start_all failed"
@@ -1158,6 +1160,141 @@ defmodule Minga.Config.LoaderTest do
       assert msg =~ "intentional_failure"
       assert msg =~ "cleanup failure"
       assert Loader.load_error(pid) =~ "Extension start_all failed"
+    end
+
+    test "reload detects one-argument module declaration changes" do
+      {minga_dir, config_home, cleanup} =
+        make_config_dir("""
+        use Minga.Config
+        extension Minga.Extensions.MCP
+        """)
+
+      on_exit(fn ->
+        ExtRegistry.reset()
+        cleanup.()
+      end)
+
+      name = :"loader_module_declaration_reload_#{System.unique_integer([:positive])}"
+      {:ok, loader} = Loader.start_link(name: name, config_home: config_home)
+      assert Loader.load_error(loader) == nil
+      assert {:ok, %{module: Minga.Extensions.MCP}} = ExtRegistry.get(:minga_mcp)
+
+      File.write!(Path.join(minga_dir, "config.exs"), "use Minga.Config\n")
+
+      assert {:error, message} = Loader.reload(loader)
+      assert message == "Extension declarations changed; restart Minga before config reload"
+      assert {:ok, %{module: Minga.Extensions.MCP}} = ExtRegistry.get(:minga_mcp)
+    end
+
+    test "reload detects a newly created project extension declaration" do
+      {_minga_dir, config_home, cleanup_config} = make_config_dir("use Minga.Config\n")
+      previous_cwd = File.cwd!()
+
+      project_dir =
+        Path.join(
+          System.tmp_dir!(),
+          "minga-loader-new-project-config-#{System.unique_integer([:positive])}"
+        )
+
+      File.mkdir_p!(project_dir)
+      File.cd!(project_dir)
+      extension_name = :loader_new_project_extension
+
+      on_exit(fn ->
+        File.cd!(previous_cwd)
+        File.rm_rf!(project_dir)
+        ExtRegistry.unregister(extension_name)
+        cleanup_config.()
+      end)
+
+      name = :"loader_new_project_config_#{System.unique_integer([:positive])}"
+      {:ok, loader} = Loader.start_link(name: name, config_home: config_home)
+      assert Loader.load_error(loader) == nil
+
+      File.write!(Path.join(project_dir, ".minga.exs"), """
+      use Minga.Config
+      extension #{inspect(extension_name)}, path: "/tmp/new-project-extension"
+      """)
+
+      assert {:error, message} = Loader.reload(loader)
+      assert message == "Extension declarations changed; restart Minga before config reload"
+      assert :error = ExtRegistry.get(extension_name)
+    end
+
+    @tag :heavy
+    test "reload rejects changed extension declarations before stopping the admitted runtime" do
+      ensure_extension_runtime()
+      suffix = System.unique_integer([:positive])
+      extension_name = String.to_atom("loader_declaration_pinned_#{suffix}")
+      extension_module = Module.concat(["LoaderDeclarationPinned#{suffix}"])
+      original_dir = Path.join(System.tmp_dir!(), "minga-loader-declaration-original-#{suffix}")
+
+      replacement_dir =
+        Path.join(System.tmp_dir!(), "minga-loader-declaration-replacement-#{suffix}")
+
+      File.mkdir_p!(original_dir)
+      File.mkdir_p!(replacement_dir)
+
+      source = """
+      defmodule #{inspect(extension_module)} do
+        use Minga.Extension
+        @impl true
+        def name, do: #{inspect(extension_name)}
+        @impl true
+        def description, do: "Config declaration generation fixture"
+        @impl true
+        def version, do: "1.0.0"
+        @impl true
+        def init(_config), do: {:ok, %{}}
+      end
+      """
+
+      File.write!(Path.join(original_dir, "extension.ex"), source)
+      File.write!(Path.join(replacement_dir, "extension.ex"), source)
+
+      {minga_dir, config_home, cleanup_config} =
+        make_config_dir("""
+        use Minga.Config
+        extension #{inspect(extension_name)}, path: #{inspect(original_dir)}
+        """)
+
+      on_exit(fn ->
+        ExtSupervisor.stop_all()
+        ExtRegistry.reset()
+        cleanup_config.()
+        File.rm_rf!(original_dir)
+        File.rm_rf!(replacement_dir)
+        :code.purge(extension_module)
+        :code.delete(extension_module)
+      end)
+
+      loader_name = String.to_atom("loader_declaration_reload_#{suffix}")
+      {:ok, loader} = Loader.start_link(name: loader_name, config_home: config_home)
+      assert Loader.load_error(loader) == nil
+      assert {:ok, declared} = ExtRegistry.get(extension_name)
+
+      assert {:ok, runtime_pid} =
+               ExtSupervisor.start_extension(
+                 Minga.Extension.Supervisor,
+                 ExtRegistry,
+                 extension_name,
+                 declared
+               )
+
+      File.write!(Path.join(minga_dir, "config.exs"), """
+      use Minga.Config
+      extension #{inspect(extension_name)}, path: #{inspect(replacement_dir)}
+      """)
+
+      assert {:error, message} = Loader.reload(loader)
+      assert message == "Extension declarations changed; restart Minga before config reload"
+
+      assert {:ok, unchanged} = ExtRegistry.get(extension_name)
+      assert unchanged.path == Path.expand(original_dir)
+      assert unchanged.pid == runtime_pid
+
+      runtime_supervisor = InstanceRegistry.via(InstanceRegistry, :runtime, extension_name)
+      assert RuntimeSupervisor.local_child(runtime_supervisor) == {:ok, runtime_pid}
     end
 
     @tag :heavy
@@ -1273,7 +1410,7 @@ defmodule Minga.Config.LoaderTest do
       assert Options.get(test_options_server(), :tab_width) == 7
     end
 
-    test "reload purges old user modules" do
+    test "reload rejects changed user modules and keeps admitted code resident" do
       {minga_dir, config_home, cleanup} = make_config_dir("")
       modules_dir = Path.join(minga_dir, "modules")
       File.mkdir_p!(modules_dir)
@@ -1300,8 +1437,8 @@ defmodule Minga.Config.LoaderTest do
       end
       """)
 
-      assert :ok = Loader.reload(pid)
-      assert apply(Minga.UserModules.Reloadable, :version, []) == 2
+      assert {:error, "User module restart required before config reload"} = Loader.reload(pid)
+      assert apply(Minga.UserModules.Reloadable, :version, []) == 1
     end
 
     test "reload clears stale user commands" do

--- a/test/minga/extension/convergence_guardrail_test.exs
+++ b/test/minga/extension/convergence_guardrail_test.exs
@@ -1,0 +1,39 @@
+defmodule Minga.Extension.ConvergenceGuardrailTest do
+  use ExUnit.Case, async: true
+
+  @lifecycle_files [
+    "lib/minga/extension/supervisor.ex",
+    "lib/minga/extension/lazy.ex",
+    "lib/minga/extension/instance.ex",
+    "lib/minga/extension/root_supervisor.ex",
+    "lib/minga_editor.ex"
+  ]
+
+  test "extension lifecycle has no legacy coordination paths" do
+    source = Enum.map_join(@lifecycle_files, "\n", &File.read!/1)
+
+    for obsolete <- [
+          "with_lifecycle_lock",
+          "wait_for_restarted_child",
+          "lifecycle_ref",
+          "editor_extension_event",
+          "claim_declared_modules",
+          "@authority_retry_attempts",
+          "retry_instance_call",
+          "test_hooks"
+        ] do
+      refute source =~ obsolete
+    end
+
+    refute File.exists?("lib/minga/extension/source_finalizer.ex")
+    refute File.exists?("lib/minga/extension/source_finalizer/state.ex")
+    refute File.exists?("lib/minga/extension/dev_reload.ex")
+  end
+
+  test "config reload never replaces resident user modules" do
+    loader = File.read!("lib/minga/config/loader.ex")
+
+    refute loader =~ ":code.purge"
+    refute loader =~ ":code.delete"
+  end
+end

--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -1305,7 +1305,7 @@ defmodule Minga.Extension.LifecycleContractTest do
     end
   end
 
-  test "runtime DOWN before start completion rolls back and rejects stale success", ctx do
+  test "runtime DOWN before start completion rolls back queued lifecycle requests", ctx do
     name = unique_name(:runtime_down_during_start)
     source = {:extension, name}
     parent = self()
@@ -1323,13 +1323,8 @@ defmodule Minga.Extension.LifecycleContractTest do
     first_start = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
     assert_receive {:runtime_child_started, runtime}, 5_000
     authority = instance(ctx, name)
-    authority_pid = instance_pid(ctx, name)
 
-    assert {:starting,
-            %{
-              runtime: %{pid: ^runtime},
-              worker: %Worker{id: transition_id, pid: start_worker}
-            }} =
+    assert {:starting, %{runtime: %{pid: ^runtime}, worker: %Worker{pid: start_worker}}} =
              eventually(fn ->
                case Instance.phase(authority) do
                  {:starting, %{runtime: %{pid: ^runtime}, worker: %Worker{}}} = phase -> phase
@@ -1337,7 +1332,6 @@ defmodule Minga.Extension.LifecycleContractTest do
                end
              end)
 
-    stale_prepared = :sys.get_state(authority_pid)
     worker_ref = Process.monitor(start_worker)
     second_start = Task.async(fn -> Instance.start(authority) end)
     stop = Task.async(fn -> stop_extension(ctx, name, opts) end)
@@ -1366,12 +1360,6 @@ defmodule Minga.Extension.LifecycleContractTest do
              end)
 
     assert_receive {:DOWN, ^worker_ref, :process, ^start_worker, :killed}
-
-    send(
-      authority_pid,
-      {Worker, :done, transition_id, {:ok, {:ok, runtime, stale_prepared}}}
-    )
-
     assert {:stopping, _context} = Instance.phase(authority)
     :ok = :sys.resume(callback_registry)
 
@@ -1408,15 +1396,28 @@ defmodule Minga.Extension.LifecycleContractTest do
     callback_registry = Process.whereis(ctx.callback_registry)
     :ok = :sys.suspend(callback_registry)
 
-    opts = Keyword.put(ctx.opts, :transition_timeout_ms, 25)
+    timeout_ms = 5_000
+    opts = Keyword.put(ctx.opts, :transition_timeout_ms, timeout_ms)
     start_task = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
-    assert_receive {:runtime_child_started, runtime}, 5_000
+    assert_receive {:runtime_child_started, runtime}, 10_000
     runtime_ref = Process.monitor(runtime)
-    Process.send_after(self(), :resume_callback_registry, 50)
-    assert_receive :resume_callback_registry
+    authority = instance_pid(ctx, name)
+
+    worker_id =
+      eventually(fn ->
+        case :sys.get_state(authority) do
+          %{phase: {:starting, %{runtime: %{pid: ^runtime}, worker: %Worker{id: id}}}} -> id
+          _state -> nil
+        end
+      end)
+
+    send(authority, {Worker, :timeout, worker_id, :start})
+    _barrier = :sys.get_state(authority)
     :ok = :sys.resume(callback_registry)
 
-    assert {:error, {:transition_timeout, :start, 25}} = Task.await(start_task)
+    assert {:error, {:transition_timeout, :start, ^timeout_ms}} =
+             Task.await(start_task, timeout_ms + 1_000)
+
     assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, _reason}, 5_000
     assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
     assert :error = CommandRegistry.lookup(ctx.commands, :crash_contribution_command)
@@ -1467,10 +1468,6 @@ defmodule Minga.Extension.LifecycleContractTest do
     retry_task = Task.async(fn -> start_extension(ctx, name, entry) end)
     assert_receive {:retry_child_start_mfa, retry_runtime_supervisor}, 5_000
     refute Task.yield(retry_task, 50)
-
-    state = :sys.get_state(instance(ctx, name))
-
-    assert Minga.Extension.Instance.TransitionHandler.transition_timeout(state) == 120_000
 
     send(retry_runtime_supervisor, :release_retry_child_start)
     assert {:ok, runtime} = Task.await(retry_task)
@@ -1601,61 +1598,6 @@ defmodule Minga.Extension.LifecycleContractTest do
     assert_receive {:DOWN, ^runtime_ref, :process, ^runtime, _reason}, 5_000
     assert :error = ExtRegistry.get(ctx.registry, name)
     assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == :empty
-  end
-
-  test "replacement Instance reads the current redeclared config", ctx do
-    name = unique_name(:current_declaration)
-    original = register_module(ctx, name, [])
-    assert :ok = stop_extension(ctx, name, ctx.opts)
-    :ok = ExtRegistry.register_module(ctx.registry, name, RuntimeTwo, marker: :current)
-    {:ok, replacement} = ExtRegistry.get(ctx.registry, name)
-    assert :ok = Instance.declare(instance(ctx, name), replacement, ctx.registry, ctx.opts)
-
-    on_exit(fn ->
-      case InstanceRegistry.whereis(instance_registry(ctx), :root, name) do
-        pid when is_pid(pid) -> :sys.resume(pid)
-        nil -> :ok
-      end
-    end)
-
-    race = start_supervised!({Agent, fn -> :armed end})
-
-    after_located = fn ^name, _instance ->
-      case Agent.get_and_update(race, fn
-             :armed -> {:kill, :killed}
-             state -> {:skip, state}
-           end) do
-        :kill ->
-          root = InstanceRegistry.whereis(instance_registry(ctx), :root, name)
-          authority = instance_pid(ctx, name)
-          ref = Process.monitor(authority)
-          :ok = :sys.suspend(root)
-          Process.exit(authority, :kill)
-          assert_receive {:DOWN, ^ref, :process, ^authority, :killed}
-
-        :skip ->
-          :ok
-      end
-    end
-
-    before_retry = fn ^name ->
-      root = InstanceRegistry.whereis(instance_registry(ctx), :root, name)
-      :ok = :sys.resume(root)
-      Agent.update(race, fn :killed -> :retried end)
-    end
-
-    opts =
-      Keyword.put(ctx.opts, :test_hooks, %{
-        after_authority_located: after_located,
-        before_authority_retry: before_retry
-      })
-
-    assert {:ok, runtime} = start_extension(ctx, name, replacement, opts)
-    assert Agent.get(race, & &1) == :retried
-    assert Agent.get(runtime, & &1) == :runtime_two
-    refute_receive {:runtime_child_started, _duplicate}
-    assert RuntimeSupervisor.local_child(runtime_supervisor(ctx, name)) == {:ok, runtime}
-    refute replacement == original
   end
 
   test "restart policies cover normal shutdown tuple-shutdown and abnormal reasons", ctx do
@@ -1852,7 +1794,8 @@ defmodule Minga.Extension.LifecycleContractTest do
     assert {:ok, initial_pid} = start_extension(ctx, name, entry)
 
     assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: 0}, %{extension: ^name}}
+                    %{count: 0}, %{extension: ^name}},
+                   5_000
 
     final_pid =
       Enum.reduce([:normal, :shutdown, {:shutdown, :policy}, :abnormal], initial_pid, fn reason,
@@ -1884,7 +1827,8 @@ defmodule Minga.Extension.LifecycleContractTest do
         ) :: pid()
   defp assert_policy_transition(ctx, name, _entry, _reason, pid, true) do
     assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: _count}, %{extension: ^name}}
+                    %{count: _count}, %{extension: ^name}},
+                   5_000
 
     assert {:ok, replacement} = Instance.start(instance(ctx, name))
     refute replacement == pid
@@ -1893,17 +1837,20 @@ defmodule Minga.Extension.LifecycleContractTest do
 
   defp assert_policy_transition(ctx, name, entry, reason, _pid, false) do
     assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :stop],
-                    %{duration: _duration}, %{extension: ^name, phase: :cleanup, outcome: :ok}}
+                    %{duration: _duration}, %{extension: ^name, phase: :cleanup, outcome: :ok}},
+                   5_000
 
     expected_phase = terminal_policy_phase(reason)
 
     assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :terminal], %{count: 1},
-                    %{extension: ^name, phase: ^expected_phase}}
+                    %{extension: ^name, phase: ^expected_phase}},
+                   5_000
 
     assert {:ok, replacement} = start_extension(ctx, name, entry)
 
     assert_receive {:policy_telemetry, [:minga, :extension, :lifecycle, :crash_restart_count],
-                    %{count: _count}, %{extension: ^name}}
+                    %{count: _count}, %{extension: ^name}},
+                   5_000
 
     replacement
   end

--- a/test/minga/extension/sdk_contract_test.exs
+++ b/test/minga/extension/sdk_contract_test.exs
@@ -1,0 +1,93 @@
+defmodule Minga.Extension.SdkContractTest do
+  use ExUnit.Case, async: true
+
+  @dsl_pairs [
+    {"lib/minga/extension.ex", "sdk/lib/minga/extension.ex"},
+    {"lib/minga/extension/editor.ex", "sdk/lib/minga/extension/editor.ex"},
+    {"lib/minga/extension/agent.ex", "sdk/lib/minga/extension/agent.ex"},
+    {"lib/minga/extension/macros.ex", "sdk/lib/minga/extension/macros.ex"}
+  ]
+
+  test "runtime and SDK declaration DSLs have the same source contract" do
+    Enum.each(@dsl_pairs, fn {runtime, sdk} ->
+      assert normalized_ast(runtime) == normalized_ast(sdk),
+             "#{sdk} must mirror the declaration contract in #{runtime}"
+    end)
+  end
+
+  test "runtime and SDK callback families cannot drift" do
+    runtime_extension = "lib/minga/extension.ex"
+    runtime_handler = "lib/minga_editor/extension/event_handler.ex"
+    sdk_handler = "sdk/lib/minga_editor/extension/event_handler.ex"
+
+    expected_families = named_union_literals(runtime_extension, :editor_event_family)
+
+    assert named_union_literals(runtime_handler, :event_kind) == expected_families
+    assert named_union_literals(sdk_handler, :event_kind) == expected_families
+    assert callback_signatures(runtime_handler) == callback_signatures(sdk_handler)
+  end
+
+  @spec normalized_ast(String.t()) :: String.t()
+  defp normalized_ast(path) do
+    path
+    |> File.read!()
+    |> Code.string_to_quoted!(file: path)
+    |> Macro.to_string()
+  end
+
+  @spec callback_signatures(String.t()) :: [{atom(), non_neg_integer()}]
+  defp callback_signatures(path) do
+    ast = path |> File.read!() |> Code.string_to_quoted!(file: path)
+
+    {_ast, signatures} =
+      Macro.prewalk(ast, [], fn
+        {:@, _meta, [{:callback, _callback_meta, [{:"::", _spec_meta, [head, _result]}]}]} = node,
+        acc ->
+          {node, [callable_signature(head) | acc]}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    signatures |> Enum.reverse() |> Enum.sort()
+  end
+
+  @spec named_union_literals(String.t(), atom()) :: [atom()]
+  defp named_union_literals(path, type_name) do
+    ast = path |> File.read!() |> Code.string_to_quoted!(file: path)
+
+    {_ast, matches} =
+      Macro.prewalk(ast, [], fn
+        {:@, _meta,
+         [
+           {:type, _type_meta,
+            [{:"::", _spec_meta, [{^type_name, _name_meta, _arguments}, union]}]}
+         ]} = node,
+        acc ->
+          {node, [union_literals(union) | acc]}
+
+        node, acc ->
+          {node, acc}
+      end)
+
+    case matches do
+      [literals] -> Enum.sort(literals)
+      _ -> flunk("expected one @type #{type_name} in #{path}")
+    end
+  end
+
+  @spec callable_signature(Macro.t()) :: {atom(), non_neg_integer()}
+  defp callable_signature({:when, _meta, [head | _guards]}), do: callable_signature(head)
+
+  defp callable_signature({name, _meta, arguments}) when is_atom(name) and is_list(arguments),
+    do: {name, length(arguments)}
+
+  defp callable_signature({name, _meta, nil}) when is_atom(name), do: {name, 0}
+
+  @spec union_literals(Macro.t()) :: [atom()]
+  defp union_literals({:|, _meta, [left, right]}),
+    do: union_literals(left) ++ union_literals(right)
+
+  defp union_literals(literal) when is_atom(literal), do: [literal]
+  defp union_literals(other), do: flunk("expected an atom union, got: #{Macro.to_string(other)}")
+end

--- a/test/minga/extension/supervisor_test.exs
+++ b/test/minga/extension/supervisor_test.exs
@@ -180,56 +180,6 @@ defmodule Minga.Extension.SupervisorTest do
                {:ok, pid}
     end
 
-    test "restarts when registry has stale running pid outside supervisor", ctx do
-      {path, cleanup} =
-        make_extension("StaleRunningExt", """
-        defmodule Minga.TestExtensions.StaleRunningExt do
-          use Minga.Extension
-
-          @impl true
-          def name, do: :stale_running_ext
-
-          @impl true
-          def description, do: "Stale running test extension"
-
-          @impl true
-          def version, do: "1.0.0"
-
-          @impl true
-          def init(_config), do: {:ok, %{}}
-        end
-        """)
-
-      on_exit(fn ->
-        cleanup.()
-        :code.purge(Minga.TestExtensions.StaleRunningExt)
-        :code.delete(Minga.TestExtensions.StaleRunningExt)
-      end)
-
-      :ok = ExtRegistry.register(ctx.registry, :stale_running_ext, path, [])
-      {:ok, entry} = ExtRegistry.get(ctx.registry, :stale_running_ext)
-      stale_pid = self()
-
-      ExtRegistry.update(ctx.registry, :stale_running_ext,
-        status: :running,
-        pid: stale_pid,
-        module: Minga.TestExtensions.StaleRunningExt
-      )
-
-      assert {:ok, pid} =
-               ExtSupervisor.start_extension(
-                 ctx.supervisor,
-                 ctx.registry,
-                 :stale_running_ext,
-                 entry
-               )
-
-      assert pid != stale_pid
-      {:ok, updated} = ExtRegistry.get(ctx.registry, :stale_running_ext)
-      assert updated.status == :running
-      assert updated.pid == pid
-    end
-
     test "records load_error for nonexistent path", ctx do
       :ok =
         ExtRegistry.register(

--- a/test/minga_editor/config_reload_instance_deadlock_test.exs
+++ b/test/minga_editor/config_reload_instance_deadlock_test.exs
@@ -44,6 +44,27 @@ defmodule MingaEditor.ConfigReloadInstanceDeadlockTest do
     end
     """)
 
+    File.write!(Path.join(config_dir, "config.exs"), """
+    use Minga.Config
+    extension #{inspect(name)}, path: #{inspect(extension_dir)}
+    """)
+
+    previous_load_extensions = Application.get_env(:minga, :load_extensions)
+    # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
+    Application.put_env(:minga, :load_extensions, false)
+
+    on_exit(fn ->
+      case previous_load_extensions do
+        nil ->
+          # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
+          Application.delete_env(:minga, :load_extensions)
+
+        value ->
+          # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
+          Application.put_env(:minga, :load_extensions, value)
+      end
+    end)
+
     owner = :"reload_ack_artifacts_#{suffix}"
     persistence_key = {__MODULE__, suffix}
 
@@ -76,7 +97,6 @@ defmodule MingaEditor.ConfigReloadInstanceDeadlockTest do
         id: {Loader, suffix}
       )
 
-    :ok = ExtRegistry.register(name, extension_dir, [])
     {:ok, declaration} = ExtRegistry.get(name)
 
     opts = [
@@ -96,11 +116,6 @@ defmodule MingaEditor.ConfigReloadInstanceDeadlockTest do
              )
 
     runtime_ref = Process.monitor(runtime)
-
-    File.write!(Path.join(config_dir, "config.exs"), """
-    use Minga.Config
-    extension #{inspect(name)}, path: #{inspect(extension_dir)}
-    """)
 
     :sys.replace_state(
       ctx.editor,


### PR DESCRIPTION
# TL;DR
Finishes the extension lifecycle migration by removing superseded retry and polling paths, enforcing the fresh-process code-update contract before teardown, and making runtime and SDK declaration APIs drift-proof.

Closes #2937
Part of #2925

## Context
The earlier #2925 slices established `Minga.Extension.Instance` as the lifecycle authority, `EffectScheduler` as the asynchronous work owner, and `CallbackInvoker` as the dynamic trust boundary. This final convergence PR removes compatibility machinery left across those slices and verifies that config reload, supervision, documentation, and SDK contracts all describe one model.

## Changes
- Remove caller-side authority retries, restart-gap polling, lifecycle test hooks, and obsolete supervisor tests that preserved deleted coordination behavior.
- Keep replacement `Instance` state free of request-scoped callback and timeout overrides while preserving stable lifecycle collaborators.
- Reject changed user modules, changed admitted artifacts, and changed prospective extension declarations before config reload stops an active runtime.
- Track path, Git, Hex, and one- or two-argument module declarations across global, project, GUI settings, and after config sources, including newly created project config files.
- Reuse the current VM’s admitted modules during allowed config reloads and keep runtime disable separate from code replacement.
- Align runtime and SDK declaration modules byte-for-byte and add AST/type guardrails against future drift.
- Update architecture, configuration, extensibility, extension API, supervision, and SDK documentation to describe the final owner and ordering.
- Migrate the standalone Git Porcelain GUI diff test to the asynchronous extension callback contract introduced by #2962.

## Verification
- `make lint`, Credo clean across 2,164 files and Dialyzer with 0 errors.
- `mix test.llm`, 9,773 tests, 58 doctests, and 97 properties with 0 failures.
- Loader suite including heavy lifecycle tests, 50 passed.
- SDK suite, 14 passed.
- Standalone Git Porcelain suite, 109 passed.
- Runtime and SDK declaration files compare byte-identical.
- Generated Git Porcelain `_build`, `deps`, and `mix.lock` paths are absent.
- Epic intent audit, targeted lifecycle bug rechecks, and final acceptance review passed.

## Acceptance Criteria Addressed
- Every lifecycle transition has one documented owner and ordering. ✅
- Obsolete locks, polling, stale PID reconciliation, retry hooks, and duplicate worker paths are removed. ✅
- Registry, admission, finalization, cleanup, child termination, and artifact publication have no competing authority. ✅
- Update and reload paths enforce the fresh-process contract before teardown. ✅
- Runtime and SDK declaration contracts are aligned and guarded against drift. ✅
- Architecture and extension-author documentation match current behavior. ✅
- Tests cover public lifecycle behavior instead of removed timing hooks and private generations. ✅
- Root, SDK, and bundled-extension validation pass without generated artifacts. ✅
