### PR TITLE
fix(render): hand off keyframe recovery to renderer

### DIFF
--- a/lib/minga_editor/render_pipeline/input.ex
+++ b/lib/minga_editor/render_pipeline/input.ex
@@ -57,7 +57,6 @@ defmodule MingaEditor.RenderPipeline.Input do
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.LSP, as: LSPState
-  alias MingaEditor.State.RenderCorrelation
   alias MingaEditor.StatusBar.Data, as: StatusBarData
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Shell.Runtime
@@ -210,7 +209,6 @@ defmodule MingaEditor.RenderPipeline.Input do
       highlighting: state.parser.highlighting,
       terminal_viewport: state.frontend.terminal_viewport,
       last_input_seq: state.frontend.last_input_seq,
-      force_keyframe?: RenderCorrelation.force_keyframe?(state.render.render_correlation),
       line_spacing:
         Minga.Config.Options.get(state.interaction.options_server, :line_spacing) || 1.0,
       cursor_animate: Minga.Config.Options.get(state.interaction.options_server, :cursor_animate),

--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -63,12 +63,19 @@ defmodule MingaEditor.Renderer do
         | render: MingaEditor.State.Render.accept_correlation(state.render, correlation)
       }
 
+      {keyframe?, state} = EditorState.take_keyframe_request(state)
       intent = Intent.from_editor_state(state, revision)
       seq = System.unique_integer([:positive, :monotonic])
-      RendererServer.cast_snapshot(pid, intent, seq)
+
+      if keyframe? do
+        :ok = RendererServer.reset_connection(pid, intent, seq)
+      else
+        RendererServer.cast_snapshot(pid, intent, seq)
+      end
+
       state
     else
-      render(state)
+      render_synchronously_or_reset(state, pid)
     end
   end
 
@@ -95,6 +102,7 @@ defmodule MingaEditor.Renderer do
       | render: MingaEditor.State.Render.accept_correlation(state.render, correlation)
     }
 
+    {_keyframe?, state} = EditorState.take_keyframe_request(state)
     intent = Intent.from_editor_state(state, revision)
     seq = System.unique_integer([:positive, :monotonic])
 
@@ -116,6 +124,7 @@ defmodule MingaEditor.Renderer do
         | render: MingaEditor.State.Render.accept_correlation(state.render, correlation)
       }
 
+      {_keyframe?, state} = EditorState.take_keyframe_request(state)
       intent = Intent.from_editor_state(state, revision)
       seq = System.unique_integer([:positive, :monotonic])
       :ok = RendererServer.reset_connection(pid, intent, seq)
@@ -126,6 +135,32 @@ defmodule MingaEditor.Renderer do
   end
 
   def reset_connection(state), do: render(state)
+
+  @spec render_synchronously_or_reset(state(), pid()) :: state()
+  defp render_synchronously_or_reset(state, renderer) do
+    case EditorState.take_keyframe_request(state) do
+      {false, state} ->
+        continue_synchronous_render(state, renderer, RendererServer.rendering?(renderer))
+
+      {true, state} ->
+        intent = Intent.from_editor_state(state)
+        seq = System.unique_integer([:positive, :monotonic])
+        :ok = RendererServer.reset_connection(renderer, intent, seq)
+        state
+    end
+  end
+
+  @spec continue_synchronous_render(state(), pid(), boolean()) :: state()
+  defp continue_synchronous_render(state, renderer, true) do
+    intent = Intent.from_editor_state(state)
+    seq = System.unique_integer([:positive, :monotonic])
+    RendererServer.cast_snapshot(renderer, intent, seq)
+    state
+  end
+
+  defp continue_synchronous_render(state, _renderer, false) do
+    render(state)
+  end
 
   @spec async_render?(state()) :: boolean()
   defp async_render?(state),
@@ -139,14 +174,51 @@ defmodule MingaEditor.Renderer do
   @spec render_buffer(state()) :: state()
   def render_buffer(state) do
     {state, renderer} = ensure_synchronous_renderer(state)
+    {keyframe?, state} = EditorState.take_keyframe_request(state)
     seq = System.unique_integer([:positive, :monotonic])
     intent = Intent.from_editor_state(state)
 
-    case RendererServer.render_sync(renderer, intent, seq) do
+    case dispatch_render_buffer(renderer, intent, seq, keyframe?, state.frontend.backend) do
+      :async -> state
       {:ok, receipt} -> EditorState.integrate_synchronous_renderer_receipt(state, receipt)
       {:error, error} -> log_synchronous_error(state, seq, error)
     end
   end
+
+  @spec dispatch_render_buffer(
+          pid(),
+          Intent.t(),
+          non_neg_integer(),
+          boolean(),
+          EditorState.backend()
+        ) ::
+          :async
+          | {:ok, MingaEditor.Renderer.RenderReceipt.t()}
+          | {:error, Exception.t()}
+  defp dispatch_render_buffer(renderer, intent, seq, true, :headless),
+    do: RendererServer.reset_sync(renderer, intent, seq)
+
+  defp dispatch_render_buffer(renderer, intent, seq, true, _backend) do
+    :ok = RendererServer.reset_connection(renderer, intent, seq)
+    :async
+  end
+
+  defp dispatch_render_buffer(renderer, intent, seq, false, :headless),
+    do: RendererServer.render_sync(renderer, intent, seq)
+
+  defp dispatch_render_buffer(renderer, intent, seq, false, _backend) do
+    dispatch_non_headless_render(renderer, intent, seq, RendererServer.rendering?(renderer))
+  end
+
+  @spec dispatch_non_headless_render(pid(), Intent.t(), non_neg_integer(), boolean()) ::
+          :async | {:ok, MingaEditor.Renderer.RenderReceipt.t()} | {:error, Exception.t()}
+  defp dispatch_non_headless_render(renderer, intent, seq, true) do
+    RendererServer.cast_snapshot(renderer, intent, seq)
+    :async
+  end
+
+  defp dispatch_non_headless_render(renderer, intent, seq, false),
+    do: RendererServer.render_sync(renderer, intent, seq)
 
   @spec ensure_synchronous_renderer(state()) :: {state(), pid()}
   defp ensure_synchronous_renderer(%EditorState{render: %{renderer: renderer}} = state)

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -155,8 +155,7 @@ defmodule MingaEditor.State do
       RenderCorrelation.accept_synchronous_receipt(
         state.render.render_correlation,
         receipt.intent_revision,
-        receipt.frame_seq,
-        receipt.keyframe?
+        receipt.frame_seq
       )
 
     commit_renderer_receipt(state, receipt, correlation)
@@ -197,6 +196,16 @@ defmodule MingaEditor.State do
     workspace = SessionState.set_viewport(state.workspace, viewport)
     frontend = FrontendState.resize_terminal(state.frontend, viewport)
     %{state | workspace: workspace, frontend: frontend}
+  end
+
+  @doc "Transfers one queued keyframe request to the renderer boundary."
+  @spec take_keyframe_request(t()) :: {boolean(), t()}
+  def take_keyframe_request(%__MODULE__{} = state) do
+    {keyframe?, correlation} =
+      RenderCorrelation.take_keyframe_request(state.render.render_correlation)
+
+    render = RenderState.accept_correlation(state.render, correlation)
+    {keyframe?, %{state | render: render}}
   end
 
   @doc "Clears workspace and render observations after frontend state loss."
@@ -336,8 +345,7 @@ defmodule MingaEditor.State do
         RenderCorrelation.accept_receipt(
           state.render.render_correlation,
           receipt.intent_revision,
-          receipt.frame_seq,
-          receipt.keyframe?
+          receipt.frame_seq
         )
 
       {commit_renderer_receipt(state, receipt, correlation), :applied}

--- a/lib/minga_editor/state/render_correlation.ex
+++ b/lib/minga_editor/state/render_correlation.ex
@@ -85,22 +85,25 @@ defmodule MingaEditor.State.RenderCorrelation do
       when is_integer(sequence) and sequence > 0,
       do: {:stale, correlation}
 
-  @doc "Marks the next completed render as requiring a keyframe."
+  @doc "Queues a keyframe request for one handoff to the renderer process."
   @spec request_keyframe(t()) :: t()
   def request_keyframe(%__MODULE__{} = correlation),
     do: %{correlation | keyframe_pending?: true}
+
+  @doc "Takes a queued keyframe request so the renderer becomes its sole durable owner."
+  @spec take_keyframe_request(t()) :: {boolean(), t()}
+  def take_keyframe_request(%__MODULE__{keyframe_pending?: true} = correlation),
+    do: {true, %{correlation | keyframe_pending?: false}}
+
+  def take_keyframe_request(%__MODULE__{} = correlation), do: {false, correlation}
 
   @doc "Resets frontend correlation without making an older receipt fresh again."
   @spec reset(t()) :: t()
   def reset(%__MODULE__{} = correlation), do: request_keyframe(correlation)
 
-  @doc "Marks a newly ready frontend as requiring a correlated keyframe."
+  @doc "Marks a newly ready frontend as requiring a renderer-owned keyframe reset."
   @spec frontend_ready(t()) :: t()
   def frontend_ready(%__MODULE__{} = correlation), do: reset(correlation)
-
-  @doc "Returns whether render intent construction must force a keyframe."
-  @spec force_keyframe?(t()) :: boolean()
-  def force_keyframe?(%__MODULE__{keyframe_pending?: pending?}), do: pending?
 
   @doc "Advances the Editor-owned semantic intent revision."
   @spec submit(t()) :: {t(), pos_integer()}
@@ -130,28 +133,24 @@ defmodule MingaEditor.State.RenderCorrelation do
     classify_normalized(correlation, revision, frame_seq)
   end
 
-  @doc "Records one accepted asynchronous receipt and clears a fulfilled keyframe request."
-  @spec accept_receipt(t(), non_neg_integer(), non_neg_integer(), boolean()) :: t()
-  def accept_receipt(%__MODULE__{} = correlation, revision, frame_seq, keyframe?)
-      when is_integer(revision) and revision >= 0 and is_integer(frame_seq) and frame_seq >= 0 and
-             is_boolean(keyframe?) do
+  @doc "Records one accepted asynchronous receipt."
+  @spec accept_receipt(t(), non_neg_integer(), non_neg_integer()) :: t()
+  def accept_receipt(%__MODULE__{} = correlation, revision, frame_seq)
+      when is_integer(revision) and revision >= 0 and is_integer(frame_seq) and frame_seq >= 0 do
     %{
       correlation
-      | keyframe_pending?: pending_after_receipt?(correlation, keyframe?),
-        last_receipt_revision: revision,
+      | last_receipt_revision: revision,
         last_receipt_seq: frame_seq
     }
   end
 
   @doc "Records a synchronous receipt while preserving monotonic ordering evidence."
-  @spec accept_synchronous_receipt(t(), non_neg_integer(), non_neg_integer(), boolean()) :: t()
-  def accept_synchronous_receipt(%__MODULE__{} = correlation, revision, frame_seq, keyframe?)
-      when is_integer(revision) and revision >= 0 and is_integer(frame_seq) and frame_seq >= 0 and
-             is_boolean(keyframe?) do
+  @spec accept_synchronous_receipt(t(), non_neg_integer(), non_neg_integer()) :: t()
+  def accept_synchronous_receipt(%__MODULE__{} = correlation, revision, frame_seq)
+      when is_integer(revision) and revision >= 0 and is_integer(frame_seq) and frame_seq >= 0 do
     %{
       correlation
-      | keyframe_pending?: pending_after_receipt?(correlation, keyframe?),
-        last_receipt_revision: max(correlation.last_receipt_revision, revision),
+      | last_receipt_revision: max(correlation.last_receipt_revision, revision),
         last_receipt_seq: max(correlation.last_receipt_seq, frame_seq)
     }
   end
@@ -174,8 +173,4 @@ defmodule MingaEditor.State.RenderCorrelation do
        do: {:stale, :stale_sequence}
 
   defp classify_normalized(_correlation, revision, _frame_seq), do: {:fresh, revision}
-
-  @spec pending_after_receipt?(t(), boolean()) :: boolean()
-  defp pending_after_receipt?(%__MODULE__{keyframe_pending?: false}, _keyframe?), do: false
-  defp pending_after_receipt?(%__MODULE__{keyframe_pending?: true}, keyframe?), do: not keyframe?
 end

--- a/test/minga_editor/render_pipeline/input_test.exs
+++ b/test/minga_editor/render_pipeline/input_test.exs
@@ -314,7 +314,7 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       assert integrate_receipt(switched, stale) == switched
     end
 
-    test "only an applied keyframe receipt clears a pending keyframe request", %{state: state} do
+    test "renderer receipts do not consume a keyframe request before handoff", %{state: state} do
       input = Input.from_editor_state(state)
 
       state = %{
@@ -329,10 +329,8 @@ defmodule MingaEditor.RenderPipeline.InputTest do
       }
 
       state = integrate_receipt(state, receipt(input, 10, false))
-      assert state.render.render_correlation.keyframe_pending?
-
       state = integrate_receipt(state, receipt(input, 11, true))
-      refute state.render.render_correlation.keyframe_pending?
+      assert state.render.render_correlation.keyframe_pending?
     end
   end
 

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -19,6 +19,8 @@ defmodule MingaEditor.Renderer.ServerTest do
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Renderer.RenderReceipt
   alias MingaEditor.Renderer.Server, as: RendererServer
+  alias MingaEditor.State.Render
+  alias MingaEditor.State.RenderCorrelation
   alias MingaEditor.UI.Panel.MessageStore
   alias MingaEditor.Viewport
   alias MingaEditor.Renderer.RenderWindow, as: Window
@@ -750,6 +752,32 @@ defmodule MingaEditor.Renderer.ServerTest do
                      @async_render_timeout
     end
 
+    test "keyframe handoff survives a superseding intent without forcing another keyframe" do
+      renderer = start_ack_renderer(self())
+      state = build_editor_state(:tui, renderer)
+      correlation = RenderCorrelation.request_keyframe(state.render.render_correlation)
+      state = %{state | render: Render.accept_correlation(state.render, correlation)}
+
+      recovered = MingaEditor.Renderer.render_or_async(state)
+      refute recovered.render.render_correlation.keyframe_pending?
+
+      assert_receive {:ack_pipeline, first_seq, 2, 0, true}, @async_render_timeout
+
+      superseding = MingaEditor.Renderer.render_or_async(recovered)
+      refute superseding.render.render_correlation.keyframe_pending?
+
+      RendererServer.frame_status(renderer, {:frame_applied, 2, first_seq})
+
+      assert_receive {:render_done, %RenderReceipt{frame_seq: ^first_seq, keyframe?: true}},
+                     @async_render_timeout
+
+      assert_receive {:ack_pipeline, second_seq, 2, ^first_seq, false}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 2, second_seq})
+
+      assert_receive {:render_done, %RenderReceipt{frame_seq: ^second_seq, keyframe?: false}},
+                     @async_render_timeout
+    end
+
     test "consecutive headless renders reuse renderer-process cache and consume targeted deltas" do
       state = build_editor_state(:headless, nil)
 
@@ -811,6 +839,33 @@ defmodule MingaEditor.Renderer.ServerTest do
       assert confirmed.render.renderer == edited.render.renderer
       assert [row] = frontend_window.rows
       assert row.text == "Ztest"
+    end
+
+    test "non-headless synchronous shells retain acknowledgement ownership during keyframe reset" do
+      renderer = start_ack_renderer(self())
+      state = build_sync_shell_state(renderer)
+      correlation = RenderCorrelation.request_keyframe(state.render.render_correlation)
+      state = %{state | render: Render.accept_correlation(state.render, correlation)}
+
+      result = MingaEditor.Renderer.render_or_async(state)
+      refute result.render.render_correlation.keyframe_pending?
+
+      assert_receive {:ack_pipeline, frame_seq, 2, 0, true}, @async_render_timeout
+
+      superseding = MingaEditor.Renderer.render_or_async(result)
+      refute superseding.render.render_correlation.keyframe_pending?
+      refute_receive {:render_done, _receipt}, 50
+
+      RendererServer.frame_status(renderer, {:frame_applied, 2, frame_seq})
+
+      assert_receive {:render_done, %RenderReceipt{frame_seq: ^frame_seq, keyframe?: true}},
+                     @async_render_timeout
+
+      assert_receive {:ack_pipeline, next_seq, 2, ^frame_seq, false}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 2, next_seq})
+
+      assert_receive {:render_done, %RenderReceipt{frame_seq: ^next_seq, keyframe?: false}},
+                     @async_render_timeout
     end
 
     test "shells that opt out of async rendering render synchronously even when a renderer pid is present" do

--- a/test/minga_editor/state/render_correlation_test.exs
+++ b/test/minga_editor/state/render_correlation_test.exs
@@ -91,7 +91,7 @@ defmodule MingaEditor.State.RenderCorrelationTest do
     refute RenderCorrelation.scheduled?(delivered.render.render_correlation)
   end
 
-  test "frontend readiness and reset require a keyframe without resetting ordering evidence" do
+  test "frontend readiness queues one renderer handoff without resetting ordering evidence" do
     correlation = %RenderCorrelation{
       latest_intent_revision: 8,
       last_receipt_revision: 7,
@@ -99,10 +99,11 @@ defmodule MingaEditor.State.RenderCorrelationTest do
     }
 
     ready = RenderCorrelation.frontend_ready(correlation)
-    assert RenderCorrelation.force_keyframe?(ready)
-    assert RenderCorrelation.latest_intent_revision(ready) == 8
-    assert RenderCorrelation.last_receipt_revision(ready) == 7
-    assert RenderCorrelation.last_receipt_sequence(ready) == 41
+    assert {true, handed_off} = RenderCorrelation.take_keyframe_request(ready)
+    assert {false, ^handed_off} = RenderCorrelation.take_keyframe_request(handed_off)
+    assert RenderCorrelation.latest_intent_revision(handed_off) == 8
+    assert RenderCorrelation.last_receipt_revision(handed_off) == 7
+    assert RenderCorrelation.last_receipt_sequence(handed_off) == 41
 
     reset = RenderCorrelation.reset(correlation)
     assert reset == ready
@@ -131,7 +132,7 @@ defmodule MingaEditor.State.RenderCorrelationTest do
     assert RenderCorrelation.classify_receipt(correlation, 3, 20) ==
              {:stale, :stale_sequence}
 
-    accepted = RenderCorrelation.accept_receipt(correlation, 3, 21, false)
+    accepted = RenderCorrelation.accept_receipt(correlation, 3, 21)
 
     assert RenderCorrelation.classify_receipt(accepted, 3, 22) ==
              {:stale, :stale_receipt_revision}
@@ -146,26 +147,23 @@ defmodule MingaEditor.State.RenderCorrelationTest do
     correlation = RenderCorrelation.new()
     assert RenderCorrelation.classify_receipt(correlation, 0, 12) == {:fresh, 12}
 
-    correlation = RenderCorrelation.accept_receipt(correlation, 12, 12, false)
+    correlation = RenderCorrelation.accept_receipt(correlation, 12, 12)
 
     assert RenderCorrelation.classify_receipt(correlation, 0, 12) ==
              {:stale, :stale_receipt_revision}
   end
 
-  test "only an accepted keyframe fulfills a pending keyframe request" do
+  test "receipts do not consume a keyframe request before renderer handoff" do
     correlation = RenderCorrelation.request_keyframe(RenderCorrelation.new())
-    assert RenderCorrelation.force_keyframe?(correlation)
+    correlation = RenderCorrelation.accept_receipt(correlation, 1, 1)
 
-    delta = RenderCorrelation.accept_receipt(correlation, 1, 1, false)
-    assert RenderCorrelation.force_keyframe?(delta)
-
-    keyframe = RenderCorrelation.accept_receipt(delta, 2, 2, true)
-    refute RenderCorrelation.force_keyframe?(keyframe)
+    assert {true, handed_off} = RenderCorrelation.take_keyframe_request(correlation)
+    assert {false, ^handed_off} = RenderCorrelation.take_keyframe_request(handed_off)
   end
 
   test "synchronous receipts preserve monotonic revision and sequence evidence" do
     correlation = %RenderCorrelation{last_receipt_revision: 10, last_receipt_seq: 20}
-    correlation = RenderCorrelation.accept_synchronous_receipt(correlation, 8, 19, false)
+    correlation = RenderCorrelation.accept_synchronous_receipt(correlation, 8, 19)
 
     assert RenderCorrelation.last_receipt_revision(correlation) == 10
     assert RenderCorrelation.last_receipt_sequence(correlation) == 20


### PR DESCRIPTION
# TL;DR

Stop repeated keyframe recovery from overwhelming the frontend and eventually desynchronizing frame sequences. Keyframe requests now transfer once from Editor state to `Renderer.Server`, which owns recovery until the frontend acknowledges the reset frame.

## Context

Rapidly superseded render intents could make an acknowledged keyframe receipt stale for semantic projection. Because Editor state also used that receipt to clear its keyframe request, the request stayed active and forced every later frame to be another full keyframe. Under output pressure, this could end in a persistent `base_frame_seq != last committed` recovery badge whose Retry action only added another keyframe.

## Changes

- Treat the Editor keyframe flag as a one-shot request waiting for renderer handoff, not durable recovery state.
- Use the renderer's existing connection reset, generation, acknowledgement lease, and cache state as the sole durable recovery owner.
- Keep stale semantic receipts separate from transport recovery.
- Preserve synchronous headless rendering while retaining ACK ownership for non-headless recovery.
- Queue superseding non-headless intents behind an outstanding recovery lease so they resume from the acknowledged reset frame.
- Add regression coverage for rapid supersession and the non-headless synchronous-shell ACK race.

## Verification

- `make lint`
- `PATH="/private/tmp/minga-test-bin:$PATH" TMPDIR=/private/tmp mix test.llm` (9,790 tests, 0 failures)
- Focused renderer, attach-keyframe, and frontend-manager tests
- `mix swift.build`
- `xcodebuild test -scheme Minga -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO` (1,231 tests)

## Acceptance Criteria Addressed

- Recovery requests stop forcing full keyframes after renderer handoff. ✅
- Superseding intents wait for the recovery frame acknowledgement and resume from its committed base. ✅
- Existing macOS rejection and Retry behavior works without a Swift protocol change. ✅
