### PR TITLE
refactor(agent): centralize remote session tokens

### DIFF
--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -86,7 +86,6 @@ defmodule MingaAgent.Session do
   @typedoc "Internal session state."
   @type state :: %{
           session_id: String.t(),
-          remote_token: String.t() | nil,
           workdir: String.t() | nil,
           event_log_server: GenServer.server(),
           event_log_failure: event_log_failure() | nil,
@@ -723,7 +722,6 @@ defmodule MingaAgent.Session do
 
     state = %{
       session_id: session_id,
-      remote_token: Keyword.get(opts, :remote_token),
       workdir: Keyword.get(opts, :workdir),
       event_log_server: Keyword.get(opts, :event_log_server, EventLog),
       event_log_failure: nil,
@@ -3632,7 +3630,6 @@ defmodule MingaAgent.Session do
 
     data = %{
       id: state.session_id,
-      remote_token: state.remote_token,
       timestamp: now,
       last_message_at: last_message_at,
       title:
@@ -3691,7 +3688,6 @@ defmodule MingaAgent.Session do
         state = %{
           state
           | session_id: data.id,
-            remote_token: Map.get(data, :remote_token, state.remote_token),
             total_usage: data.usage,
             provider: lifecycle,
             status: :idle,

--- a/lib/minga_agent/session_manager.ex
+++ b/lib/minga_agent/session_manager.ex
@@ -499,30 +499,31 @@ defmodule MingaAgent.SessionManager do
   @spec do_start_managed_session(state(), keyword(), String.t()) ::
           {:ok, String.t(), pid(), state()} | {:error, term()}
   defp do_start_managed_session(state, opts, session_id) do
-    token = session_token_for_start(session_id, opts)
-    opts = Keyword.put(opts, :remote_token, token)
+    {supplied_token, session_opts} = Keyword.pop(opts, :remote_token)
 
-    case MingaAgent.Supervisor.start_session(opts) do
-      {:ok, pid} ->
-        ref = Process.monitor(pid)
+    with {:ok, token} <-
+           session_token_for_start(session_id, supplied_token, session_opts),
+         {:ok, pid} <- MingaAgent.Supervisor.start_session(session_opts) do
+      ref = Process.monitor(pid)
 
-        entry = %{
-          pid: pid,
-          monitor_ref: ref,
-          token: token,
-          restart_opts: opts,
-          restart_state: nil
-        }
+      entry = %{
+        pid: pid,
+        monitor_ref: ref,
+        token: token,
+        restart_opts: session_opts,
+        restart_state: nil
+      }
 
-        sessions = Map.put(state.sessions, session_id, entry)
-        next_id = next_id_after_start(state, session_id)
-        new_state = %{state | sessions: sessions, next_id: next_id}
+      sessions = Map.put(state.sessions, session_id, entry)
+      next_id = next_id_after_start(state, session_id)
+      new_state = %{state | sessions: sessions, next_id: next_id}
 
-        Minga.Log.info(:agent, "[SessionManager] Started session #{session_id} (#{inspect(pid)})")
-        {:ok, session_id, pid, new_state}
+      Minga.Log.info(
+        :agent,
+        "[SessionManager] Started session #{session_id} (#{inspect(pid)})"
+      )
 
-      {:error, reason} ->
-        {:error, reason}
+      {:ok, session_id, pid, new_state}
     end
   end
 
@@ -552,58 +553,31 @@ defmodule MingaAgent.SessionManager do
   defp next_id_after_start(state, "session-" <> _suffix), do: state.next_id + 1
   defp next_id_after_start(state, _session_id), do: state.next_id
 
-  @spec session_token_for_start(String.t(), keyword()) :: String.t()
-  defp session_token_for_start(session_id, opts) do
-    case Keyword.get(opts, :remote_token) do
-      token when is_binary(token) ->
-        token
+  @spec session_token_for_start(String.t(), term(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  defp session_token_for_start(session_id, supplied_token, opts) do
+    candidate =
+      case supplied_token do
+        token when is_binary(token) -> token
+        _ -> generate_token()
+      end
 
-      _ ->
-        case stored_session_token(session_id, opts) do
-          {:ok, token} ->
-            token
-
-          :missing ->
-            generate_token()
-
-          {:error, reason} ->
-            log_session_store_load_error(session_id, resolved_session_store_dir(opts), reason)
-            generate_token()
-        end
+    if Keyword.get(opts, :persist?, true) do
+      establish_persisted_token(session_id, candidate, opts)
+    else
+      {:ok, candidate}
     end
   end
 
-  @spec stored_session_token(String.t(), keyword()) ::
-          {:ok, String.t()} | :missing | {:error, term()}
-  defp stored_session_token(session_id, opts) do
+  @spec establish_persisted_token(String.t(), String.t(), keyword()) ::
+          {:ok, String.t()} | {:error, term()}
+  defp establish_persisted_token(session_id, candidate, opts) do
     session_store_dir = Keyword.get(opts, :session_store_dir)
 
-    case SessionStore.load(session_id, session_store_dir) do
-      {:ok, data} ->
-        case Map.get(data, :remote_token) do
-          token when is_binary(token) -> {:ok, token}
-          _ -> :missing
-        end
-
-      {:error, :enoent} ->
-        :missing
-
-      {:error, reason} ->
-        {:error, reason}
+    case SessionStore.establish_remote_token(session_id, candidate, session_store_dir) do
+      {:ok, token} -> {:ok, token}
+      {:error, reason} -> {:error, {:remote_token_persistence_failed, reason}}
     end
-  end
-
-  @spec log_session_store_load_error(String.t(), String.t() | nil, term()) :: :ok
-  defp log_session_store_load_error(session_id, session_store_dir, reason) do
-    message =
-      "[SessionManager] Failed to load persisted remote token for session #{session_id} from #{inspect(session_store_dir)}: #{inspect(reason)}"
-
-    case reason do
-      :enoent -> Minga.Log.warning(:agent, message)
-      _ -> Minga.Log.error(:agent, message)
-    end
-
-    :ok
   end
 
   @spec generate_token() :: String.t()

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -5,6 +5,7 @@ defmodule MingaAgent.SessionStore do
   Each session is saved as `{session_id}.json` in the sessions directory
   (`~/.config/minga/agent/sessions/` by default). Files are written
   atomically via a temp file + rename to avoid corruption on crash.
+  Manager-owned remote identity is stored separately under `.remote_tokens/`.
 
   The store is stateless: all functions operate directly on the filesystem.
   The `Session` GenServer calls `save/2` on a debounced timer, and the
@@ -37,13 +38,14 @@ defmodule MingaAgent.SessionStore do
           required(:usage) => MingaAgent.TurnUsage.t(),
           optional(:last_message_at) => String.t(),
           optional(:title) => String.t(),
-          optional(:remote_token) => String.t() | nil,
           optional(:provider_name) => String.t(),
           optional(:branches) => [MingaAgent.Branch.t()],
           optional(:message_ids) => [pos_integer()],
           optional(:pinned_ids) => MapSet.t(pos_integer()),
           optional(:memory) => String.t() | nil
         }
+
+  @typep remote_token_result :: {:ok, String.t()} | :missing | {:error, term()}
 
   @doc "Returns the sessions directory path."
   @spec sessions_dir(String.t() | nil) :: String.t()
@@ -64,25 +66,87 @@ defmodule MingaAgent.SessionStore do
   """
   @spec save(session_data(), String.t() | nil) :: :ok | {:error, term()}
   def save(%{id: id} = data, config_dir \\ nil) when is_binary(id) do
-    dir = sessions_dir(config_dir)
-    path = Path.join(dir, "#{id}.json")
-    tmp_path = path <> ".tmp"
+    path = Path.join(sessions_dir(config_dir), "#{id}.json")
     json = JSON.encode!(serialize(data))
 
-    with :ok <- ensure_private_dir(dir),
-         :ok <- write_private_file(tmp_path, json),
-         :ok <- File.rename(tmp_path, path) do
-      :ok
-    else
+    case atomic_write_private(path, json) do
+      :ok ->
+        :ok
+
       {:error, reason} ->
-        File.rm(tmp_path)
         Minga.Log.warning(:agent, "[SessionStore] failed to save #{id}: #{reason}")
         {:error, reason}
     end
   end
 
   @doc """
-  Loads a session from disk.
+  Establishes manager-owned remote session identity.
+
+  Existing canonical identity wins over legacy transcript identity and the candidate. A new identity is persisted before it is returned.
+  """
+  @spec establish_remote_token(String.t(), String.t(), String.t() | nil) ::
+          {:ok, String.t()} | {:error, term()}
+  def establish_remote_token(session_id, candidate, config_dir \\ nil)
+      when is_binary(session_id) and is_binary(candidate) do
+    path = Path.join(remote_tokens_dir(config_dir), "#{session_id}.json")
+
+    case read_remote_token(path, {:error, :invalid_remote_token_record}) do
+      {:ok, token} -> {:ok, token}
+      :missing -> establish_missing_remote_token(path, session_id, candidate, config_dir)
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec establish_missing_remote_token(String.t(), String.t(), String.t(), String.t() | nil) ::
+          {:ok, String.t()} | {:error, term()}
+  defp establish_missing_remote_token(path, session_id, candidate, config_dir) do
+    with {:ok, token} <- new_remote_token(session_id, candidate, config_dir),
+         :ok <- atomic_write_private(path, encode_remote_token(token)) do
+      {:ok, token}
+    end
+  end
+
+  @spec new_remote_token(String.t(), String.t(), String.t() | nil) ::
+          {:ok, String.t()} | {:error, term()}
+  defp new_remote_token(session_id, candidate, config_dir) do
+    case load_legacy_remote_token(session_id, config_dir) do
+      {:ok, token} -> {:ok, token}
+      :missing -> {:ok, candidate}
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec remote_tokens_dir(String.t() | nil) :: String.t()
+  defp remote_tokens_dir(config_dir) do
+    Path.join(sessions_dir(config_dir), ".remote_tokens")
+  end
+
+  @spec load_legacy_remote_token(String.t(), String.t() | nil) :: remote_token_result()
+  defp load_legacy_remote_token(session_id, config_dir) do
+    path = Path.join(sessions_dir(config_dir), "#{session_id}.json")
+    read_remote_token(path, :missing)
+  end
+
+  @spec read_remote_token(String.t(), :missing | {:error, term()}) :: remote_token_result()
+  defp read_remote_token(path, missing_record) do
+    with {:ok, json} <- File.read(path),
+         {:ok, data} when is_map(data) <- decode_json(json) do
+      case data["remote_token"] do
+        token when is_binary(token) -> {:ok, token}
+        _ -> missing_record
+      end
+    else
+      {:ok, _other} -> missing_record
+      {:error, :enoent} -> :missing
+      {:error, reason} -> {:error, reason}
+    end
+  end
+
+  @spec encode_remote_token(String.t()) :: String.t()
+  defp encode_remote_token(token), do: JSON.encode!(%{"remote_token" => token})
+
+  @doc """
+  Loads a persisted session transcript.
 
   Returns `{:ok, session_data}` or `{:error, reason}`.
   """
@@ -91,8 +155,11 @@ defmodule MingaAgent.SessionStore do
     path = Path.join(sessions_dir(config_dir), "#{session_id}.json")
 
     with {:ok, json} <- File.read(path),
-         {:ok, data} <- decode_json(json) do
+         {:ok, data} when is_map(data) <- decode_json(json) do
       {:ok, deserialize(data)}
+    else
+      {:ok, _other} -> {:error, :invalid_session_record}
+      {:error, reason} -> {:error, reason}
     end
   end
 
@@ -139,14 +206,29 @@ defmodule MingaAgent.SessionStore do
     end
   end
 
-  @doc "Deletes a saved session."
+  @spec atomic_write_private(String.t(), String.t()) :: :ok | {:error, term()}
+  defp atomic_write_private(path, contents) do
+    tmp_path = path <> ".tmp"
+
+    with :ok <- ensure_private_dir(Path.dirname(path)),
+         :ok <- write_private_file(tmp_path, contents),
+         :ok <- File.rename(tmp_path, path) do
+      :ok
+    else
+      {:error, _reason} = error ->
+        File.rm(tmp_path)
+        error
+    end
+  end
+
+  @doc "Deletes a saved session transcript. Durable remote identity is retained."
   @spec delete(String.t(), String.t() | nil) :: :ok | {:error, term()}
   def delete(session_id, config_dir \\ nil) when is_binary(session_id) do
     path = Path.join(sessions_dir(config_dir), "#{session_id}.json")
     File.rm(path)
   end
 
-  @doc "Deletes all saved sessions."
+  @doc "Deletes all saved session transcripts. Durable remote identities are retained."
   @spec clear_all(String.t() | nil) :: :ok
   def clear_all(config_dir \\ nil) do
     dir = sessions_dir(config_dir)
@@ -163,9 +245,9 @@ defmodule MingaAgent.SessionStore do
   end
 
   @doc """
-  Prunes sessions older than `days` days.
+  Prunes session transcripts older than `days` days.
 
-  Returns the number of sessions deleted.
+  Returns the number of transcripts deleted. Durable remote identities are retained.
   """
   @spec prune(non_neg_integer(), String.t() | nil) :: non_neg_integer()
   def prune(days, config_dir \\ nil) when is_integer(days) and days > 0 do
@@ -189,7 +271,6 @@ defmodule MingaAgent.SessionStore do
 
     %{
       "id" => data.id,
-      "remote_token" => Map.get(data, :remote_token),
       "timestamp" => timestamp,
       "last_message_at" => Map.get(data, :last_message_at, timestamp),
       "title" => Map.get(data, :title) || title_from_messages(messages),
@@ -262,7 +343,6 @@ defmodule MingaAgent.SessionStore do
 
     session = %{
       id: data["id"],
-      remote_token: data["remote_token"],
       timestamp: timestamp,
       last_message_at: data["last_message_at"] || timestamp,
       title: data["title"] || title_from_messages(messages),
@@ -439,7 +519,7 @@ defmodule MingaAgent.SessionStore do
   @spec load_meta(String.t()) :: session_meta() | nil
   defp load_meta(path) do
     with {:ok, json} <- File.read(path),
-         {:ok, data} <- decode_json(json) do
+         {:ok, data} when is_map(data) <- decode_json(json) do
       messages = data["messages"] || []
       preview = first_user_preview(messages)
       timestamp = data["timestamp"] || ""
@@ -534,7 +614,7 @@ defmodule MingaAgent.SessionStore do
     end
   end
 
-  @spec decode_json(String.t()) :: {:ok, map()} | {:error, term()}
+  @spec decode_json(String.t()) :: {:ok, term()} | {:error, term()}
   defp decode_json(json) do
     {:ok, JSON.decode!(json)}
   rescue

--- a/test/minga_agent/remote_api_test.exs
+++ b/test/minga_agent/remote_api_test.exs
@@ -1,0 +1,21 @@
+defmodule MingaAgent.RemoteAPITest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.RemoteAPI
+  alias MingaAgent.SessionManager
+
+  @moduletag :tmp_dir
+
+  test "authorization accepts only the manager-owned session token", %{tmp_dir: dir} do
+    session_id = "remote-api-auth-#{System.unique_integer([:positive])}"
+
+    assert {:ok, ^session_id, _pid} =
+             SessionManager.start_session(session_id: session_id, session_store_dir: dir)
+
+    on_exit(fn -> SessionManager.stop_session(session_id) end)
+
+    assert {:ok, token} = SessionManager.session_token(session_id)
+    assert :ok = RemoteAPI.authorize(session_id, token)
+    assert {:error, :unauthorized} = RemoteAPI.authorize(session_id, "invalid-token")
+  end
+end

--- a/test/minga_agent/session_manager_test.exs
+++ b/test/minga_agent/session_manager_test.exs
@@ -4,6 +4,7 @@ defmodule MingaAgent.SessionManagerTest do
   import ExUnit.CaptureLog
 
   alias MingaAgent.Providers.RecordingProvider
+  alias MingaAgent.Session
   alias MingaAgent.SessionManager
   alias MingaAgent.SessionManager.SessionRestartedEvent
   alias MingaAgent.SessionManager.SessionStoppedEvent
@@ -18,11 +19,13 @@ defmodule MingaAgent.SessionManagerTest do
     Process.unlink(manager)
 
     on_exit(fn ->
-      for {session_id, _pid, _metadata} <- SessionManager.list_sessions(manager) do
-        SessionManager.stop_session(manager, session_id)
-      end
+      if Process.alive?(manager) do
+        for {session_id, _pid, _metadata} <- SessionManager.list_sessions(manager) do
+          SessionManager.stop_session(manager, session_id)
+        end
 
-      GenServer.stop(manager)
+        GenServer.stop(manager)
+      end
     end)
 
     %{manager: manager}
@@ -75,73 +78,135 @@ defmodule MingaAgent.SessionManagerTest do
       assert String.starts_with?(id, "workdir-")
     end
 
-    test "mints a token for brokered remote control", %{manager: manager} do
-      {:ok, session_id, _pid} = SessionManager.start_session(manager, [])
+    @tag :tmp_dir
+    test "mints and persists a token before returning the session", %{
+      manager: manager,
+      tmp_dir: dir
+    } do
+      {:ok, session_id, pid} =
+        SessionManager.start_session(manager, session_store_dir: dir)
+
       assert {:ok, token} = SessionManager.session_token(manager, session_id)
       assert is_binary(token)
       assert byte_size(token) > 20
+
+      assert {:ok, ^token} =
+               SessionStore.establish_remote_token(session_id, "replacement-token", dir)
+
+      refute Map.has_key?(:sys.get_state(pid), :remote_token)
     end
 
-    test "reuses a persisted remote token for a stable session", %{manager: manager} do
-      dir =
-        Path.join(
-          System.tmp_dir!(),
-          "session-manager-token-#{System.unique_integer([:positive])}"
-        )
-
-      on_exit(fn -> File.rm_rf(dir) end)
-
-      :ok =
-        MingaAgent.SessionStore.save(
-          %{
-            id: "workdir-stable",
-            remote_token: "persisted-token",
-            timestamp: DateTime.to_iso8601(DateTime.utc_now()),
-            model_name: "test",
-            messages: [],
-            usage: MingaAgent.TurnUsage.new()
-          },
-          dir
-        )
-
-      {:ok, "workdir-stable", _pid} =
-        SessionManager.start_or_get_session(manager, "workdir-stable", session_store_dir: dir)
-
-      assert {:ok, "persisted-token"} = SessionManager.session_token(manager, "workdir-stable")
-    end
-
-    test "logs and mints a new token when persisted remote token file is corrupt", %{
-      manager: manager
+    @tag :tmp_dir
+    test "keeps the existing remote_token option at the manager boundary", %{
+      manager: manager,
+      tmp_dir: dir
     } do
-      dir =
-        Path.join(
-          System.tmp_dir!(),
-          "session-manager-token-corrupt-#{System.unique_integer([:positive])}"
-        )
+      session_id = "supplied-token"
 
-      session_id = "token-corrupt-#{System.unique_integer([:positive])}"
+      assert {:ok, ^session_id, pid} =
+               SessionManager.start_session(manager,
+                 session_id: session_id,
+                 remote_token: "caller-token",
+                 session_store_dir: dir
+               )
+
+      assert {:ok, "caller-token"} = SessionManager.session_token(manager, session_id)
+
+      assert {:ok, "caller-token"} =
+               SessionStore.establish_remote_token(session_id, "replacement-token", dir)
+
+      refute Map.has_key?(:sys.get_state(pid), :remote_token)
+    end
+
+    @tag :tmp_dir
+    test "does not publish a token when durable identity cannot be established", %{
+      manager: manager,
+      tmp_dir: dir
+    } do
+      session_id = "blocked-token-store"
       sessions_dir = SessionStore.sessions_dir(dir)
       File.mkdir_p!(sessions_dir)
-      File.write!(Path.join(sessions_dir, "#{session_id}.json"), "{not json")
+      File.write!(Path.join(sessions_dir, ".remote_tokens"), "blocks token directory")
 
-      on_exit(fn -> File.rm_rf(dir) end)
+      assert {:error, {:remote_token_persistence_failed, _reason}} =
+               SessionManager.start_session(manager,
+                 session_id: session_id,
+                 session_store_dir: dir
+               )
 
-      log =
-        capture_log(fn ->
-          assert {:ok, ^session_id, pid} =
-                   SessionManager.start_session(manager,
-                     session_id: session_id,
-                     session_store_dir: dir
-                   )
+      assert {:error, :not_found} = SessionManager.get_session(manager, session_id)
+    end
 
-          assert {:ok, token} = SessionManager.session_token(manager, session_id)
-          assert is_binary(token)
-          assert Process.alive?(pid)
-        end)
+    @tag :tmp_dir
+    test "migrates a legacy token and preserves it across transcript saves and manager recovery",
+         %{
+           manager: manager,
+           tmp_dir: dir
+         } do
+      session_id = "workdir-stable"
+      write_legacy_session(session_id, "persisted-token", dir)
 
-      assert log =~ "Failed to load persisted remote token"
-      assert log =~ session_id
-      assert log =~ dir
+      {:ok, ^session_id, pid} =
+        SessionManager.start_or_get_session(manager, session_id, session_store_dir: dir)
+
+      assert {:ok, "persisted-token"} = SessionManager.session_token(manager, session_id)
+
+      assert {:ok, "persisted-token"} =
+               SessionStore.establish_remote_token(session_id, "replacement-token", dir)
+
+      :ok = Session.add_system_message(pid, "persist transcript without broker identity", :info)
+      send(pid, :save_session)
+      :sys.get_state(pid)
+
+      assert {:ok, transcript} = SessionStore.load(session_id, dir)
+      refute Map.has_key?(transcript, :remote_token)
+
+      assert {:system, "persist transcript without broker identity", :info} in transcript.messages
+      refute File.read!(session_path(session_id, dir)) =~ "remote_token"
+
+      :ok = SessionManager.stop_session(manager, session_id)
+      GenServer.stop(manager)
+
+      replacement_name = :"replacement_manager_#{System.unique_integer([:positive])}"
+      {:ok, replacement_manager} = SessionManager.start_link(name: replacement_name)
+      Process.unlink(replacement_manager)
+
+      on_exit(fn ->
+        if Process.alive?(replacement_manager) do
+          SessionManager.stop_session(replacement_manager, session_id)
+          GenServer.stop(replacement_manager)
+        end
+      end)
+
+      assert {:ok, ^session_id, replacement_pid} =
+               SessionManager.start_or_get_session(replacement_manager, session_id,
+                 session_store_dir: dir
+               )
+
+      assert replacement_pid != pid
+
+      assert {:ok, "persisted-token"} =
+               SessionManager.session_token(replacement_manager, session_id)
+    end
+
+    @tag :tmp_dir
+    test "fails closed when canonical remote identity is corrupt", %{
+      manager: manager,
+      tmp_dir: dir
+    } do
+      session_id = "token-corrupt-#{System.unique_integer([:positive])}"
+      token_path = remote_token_path(session_id, dir)
+      File.mkdir_p!(Path.dirname(token_path))
+      File.write!(token_path, "42")
+
+      assert {:error, {:remote_token_persistence_failed, _reason}} =
+               SessionManager.start_session(manager,
+                 session_id: session_id,
+                 session_store_dir: dir
+               )
+
+      assert {:error, :not_found} = SessionManager.get_session(manager, session_id)
+      assert File.read!(token_path) == "42"
     end
   end
 
@@ -603,6 +668,32 @@ defmodule MingaAgent.SessionManagerTest do
       assert log =~ "after 101 attempts"
       assert log =~ "failed to accept prompt"
     end
+  end
+
+  @spec write_legacy_session(String.t(), String.t(), String.t()) :: :ok
+  defp write_legacy_session(session_id, token, dir) do
+    data = %{
+      id: session_id,
+      timestamp: DateTime.to_iso8601(DateTime.utc_now()),
+      model_name: "test",
+      messages: [],
+      usage: MingaAgent.TurnUsage.new()
+    }
+
+    :ok = SessionStore.save(data, dir)
+    path = session_path(session_id, dir)
+    payload = path |> File.read!() |> JSON.decode!() |> Map.put("remote_token", token)
+    File.write!(path, JSON.encode!(payload))
+  end
+
+  @spec session_path(String.t(), String.t()) :: String.t()
+  defp session_path(session_id, dir) do
+    Path.join(SessionStore.sessions_dir(dir), "#{session_id}.json")
+  end
+
+  @spec remote_token_path(String.t(), String.t()) :: String.t()
+  defp remote_token_path(session_id, dir) do
+    Path.join([SessionStore.sessions_dir(dir), ".remote_tokens", "#{session_id}.json"])
   end
 
   @spec crash_and_wait_for_restart(GenServer.server(), String.t(), pid()) :: pid()

--- a/test/minga_agent/session_store_test.exs
+++ b/test/minga_agent/session_store_test.exs
@@ -222,15 +222,22 @@ defmodule MingaAgent.SessionStoreTest do
       assert loaded.memory =~ "Use concise answers"
     end
 
-    test "writes session directory and files with private permissions", %{tmp_dir: dir} do
-      data = Map.put(sample_data("private-session"), :remote_token, "remote-token")
+    test "writes transcript and remote token files with private permissions", %{tmp_dir: dir} do
+      data = sample_data("private-session")
       assert :ok = SessionStore.save(data, dir)
+
+      assert {:ok, "remote-token"} =
+               SessionStore.establish_remote_token(data.id, "remote-token", dir)
 
       sessions_dir = SessionStore.sessions_dir(dir)
       session_path = Path.join(sessions_dir, "private-session.json")
+      token_dir = Path.join(sessions_dir, ".remote_tokens")
+      token_path = Path.join(token_dir, "private-session.json")
 
       assert private_mode?(File.stat!(sessions_dir).mode, 0o077)
       assert private_mode?(File.stat!(session_path).mode, 0o077)
+      assert private_mode?(File.stat!(token_dir).mode, 0o077)
+      assert private_mode?(File.stat!(token_path).mode, 0o077)
     end
 
     test "returns error for nonexistent session" do
@@ -242,6 +249,107 @@ defmodule MingaAgent.SessionStoreTest do
       File.write!(blocked_base, "file blocks mkdir")
 
       assert {:error, _reason} = SessionStore.save(sample_data("blocked"), blocked_base)
+    end
+  end
+
+  describe "remote token identity" do
+    test "persists manager identity outside the transcript", %{tmp_dir: dir} do
+      data = sample_data("separate-identity")
+
+      assert {:ok, "stable-token"} =
+               SessionStore.establish_remote_token(data.id, "stable-token", dir)
+
+      assert :ok = SessionStore.save(data, dir)
+
+      assert {:ok, "stable-token"} =
+               SessionStore.establish_remote_token(data.id, "replacement-token", dir)
+
+      assert {:ok, transcript} = SessionStore.load(data.id, dir)
+      refute Map.has_key?(transcript, :remote_token)
+
+      refute File.read!(Path.join(SessionStore.sessions_dir(dir), "#{data.id}.json")) =~
+               "remote_token"
+    end
+
+    test "existing canonical identity wins over a new candidate", %{tmp_dir: dir} do
+      session_id = "first-creator-wins"
+
+      assert {:ok, "first-token"} =
+               SessionStore.establish_remote_token(session_id, "first-token", dir)
+
+      assert {:ok, "first-token"} =
+               SessionStore.establish_remote_token(session_id, "second-token", dir)
+    end
+
+    test "migrates identity from a legacy transcript", %{tmp_dir: dir} do
+      data = sample_data("legacy-identity")
+      assert :ok = SessionStore.save(data, dir)
+
+      path = Path.join(SessionStore.sessions_dir(dir), "#{data.id}.json")
+      payload = path |> File.read!() |> JSON.decode!() |> Map.put("remote_token", "legacy-token")
+      File.write!(path, JSON.encode!(payload))
+
+      assert {:ok, "legacy-token"} =
+               SessionStore.establish_remote_token(data.id, "candidate-token", dir)
+
+      assert :ok = SessionStore.save(data, dir)
+      refute File.read!(path) =~ "remote_token"
+
+      assert {:ok, "legacy-token"} =
+               SessionStore.establish_remote_token(data.id, "replacement-token", dir)
+    end
+
+    test "concurrent transcript and identity writes preserve both owners", %{tmp_dir: dir} do
+      data = sample_data("concurrent-identity")
+      parent = self()
+
+      transcript_task =
+        Task.async(fn ->
+          send(parent, {:writer_ready, self()})
+          receive do: (:write -> SessionStore.save(data, dir))
+        end)
+
+      token_task =
+        Task.async(fn ->
+          send(parent, {:writer_ready, self()})
+
+          receive do
+            :write ->
+              SessionStore.establish_remote_token(data.id, "concurrent-token", dir)
+          end
+        end)
+
+      writer_pids =
+        for _ <- 1..2 do
+          assert_receive {:writer_ready, pid}
+          pid
+        end
+
+      Enum.each(writer_pids, &send(&1, :write))
+      assert :ok = Task.await(transcript_task)
+      assert {:ok, "concurrent-token"} = Task.await(token_task)
+
+      assert {:ok, transcript} = SessionStore.load(data.id, dir)
+      assert transcript.messages == data.messages
+      refute Map.has_key?(transcript, :remote_token)
+
+      assert {:ok, "concurrent-token"} =
+               SessionStore.establish_remote_token(data.id, "replacement-token", dir)
+    end
+
+    test "failed transcript writes leave durable identity unchanged", %{tmp_dir: dir} do
+      data = sample_data("failed-transcript")
+
+      assert {:ok, "surviving-token"} =
+               SessionStore.establish_remote_token(data.id, "surviving-token", dir)
+
+      transcript_path = Path.join(SessionStore.sessions_dir(dir), "#{data.id}.json")
+      File.mkdir_p!(transcript_path)
+
+      assert {:error, _reason} = SessionStore.save(data, dir)
+
+      assert {:ok, "surviving-token"} =
+               SessionStore.establish_remote_token(data.id, "replacement-token", dir)
     end
   end
 
@@ -394,6 +502,23 @@ defmodule MingaAgent.SessionStoreTest do
       pruned = SessionStore.prune(30)
       assert pruned == 0
       assert {:ok, _} = SessionStore.load("recent-session")
+    end
+
+    test "pruning a transcript does not revoke its durable identity", %{tmp_dir: dir} do
+      session_id = "old-transcript-stable-token"
+      old_timestamp = DateTime.to_iso8601(DateTime.add(DateTime.utc_now(), -40, :day))
+      data = %{sample_data(session_id) | timestamp: old_timestamp}
+
+      assert :ok = SessionStore.save(data, dir)
+
+      assert {:ok, "stable-token"} =
+               SessionStore.establish_remote_token(session_id, "stable-token", dir)
+
+      assert SessionStore.prune(30, dir) == 1
+      assert {:error, _reason} = SessionStore.load(session_id, dir)
+
+      assert {:ok, "stable-token"} =
+               SessionStore.establish_remote_token(session_id, "replacement-token", dir)
     end
   end
 


### PR DESCRIPTION
## Summary

- make `SessionManager` the sole live owner and publisher of remote session tokens
- persist manager-owned identity in an inert private sidecar before starting a `Session`
- migrate legacy transcript tokens on first managed start without returning token state to `Session`
- keep transcript save, delete, and retention behavior independent from authorization identity
- fail closed for missing, unwritable, malformed, or non-object canonical identity records

Closes #2966

## Context

A token previously lived in both each `SessionManager` entry and the child `Session` transcript state. That split ownership let transcript persistence drift from the token used by `RemoteAPI`. The new boundary is direct: the locally registered `SessionManager` serializes token establishment through its mailbox, publishes a child only after durable identity exists, and supplies authorization from its live entry. `Session` never receives, stores, restores, persists, or returns the token.

The sidecar is intentionally inert storage, not a second lifecycle owner. Transcript pruning does not revoke remote identity. Canonical sidecar identity wins over legacy transcript data and caller candidates. Legacy transcript tokens remain readable only for one-time migration.

## Verification

- `mix test.debug test/minga_agent/session_store_test.exs test/minga_agent/session_manager_test.exs test/minga_agent/remote_api_test.exs test/minga_agent/session_persistence_test.exs test/minga_agent/session_recovery_test.exs test/minga_agent/session_lifecycle_test.exs test/minga_agent/session_provider_error_test.exs` (117 passed)
- `make lint`
- `mix test.llm` (9,807 tests, 0 failures, 1 skipped)
- final reviewer: PASS after one blocker fix for non-object canonical JSON sidecars

## Review Notes

Focus on the ownership boundary in `SessionManager.do_start_managed_session/3`, the canonical-read and legacy-migration order in `SessionStore.establish_remote_token/3`, and the guarantee that `Session` options and transcript projections contain no remote token.