### PR TITLE
fix(render): retain ack ownership for non-headless frames

### DIFF
--- a/lib/minga_editor/renderer.ex
+++ b/lib/minga_editor/renderer.ex
@@ -55,14 +55,7 @@ defmodule MingaEditor.Renderer do
     state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     if async_render?(state) do
-      {correlation, revision} =
-        MingaEditor.State.RenderCorrelation.submit(state.render.render_correlation)
-
-      state = %{
-        state
-        | render: MingaEditor.State.Render.accept_correlation(state.render, correlation)
-      }
-
+      {state, revision} = EditorState.submit_render_intent(state)
       {keyframe?, state} = EditorState.take_keyframe_request(state)
       intent = Intent.from_editor_state(state, revision)
       seq = System.unique_integer([:positive, :monotonic])
@@ -93,15 +86,7 @@ defmodule MingaEditor.Renderer do
 
   def reset_connection(%EditorState{frontend: %{backend: :headless}} = state) do
     {state, renderer} = ensure_synchronous_renderer(state)
-
-    {correlation, revision} =
-      MingaEditor.State.RenderCorrelation.submit(state.render.render_correlation)
-
-    state = %{
-      state
-      | render: MingaEditor.State.Render.accept_correlation(state.render, correlation)
-    }
-
+    {state, revision} = EditorState.submit_render_intent(state)
     {_keyframe?, state} = EditorState.take_keyframe_request(state)
     intent = Intent.from_editor_state(state, revision)
     seq = System.unique_integer([:positive, :monotonic])
@@ -116,14 +101,7 @@ defmodule MingaEditor.Renderer do
     state = MingaEditor.Shell.Workflow.ensure_available(state)
 
     if async_render?(state) do
-      {correlation, revision} =
-        MingaEditor.State.RenderCorrelation.submit(state.render.render_correlation)
-
-      state = %{
-        state
-        | render: MingaEditor.State.Render.accept_correlation(state.render, correlation)
-      }
-
+      {state, revision} = EditorState.submit_render_intent(state)
       {_keyframe?, state} = EditorState.take_keyframe_request(state)
       intent = Intent.from_editor_state(state, revision)
       seq = System.unique_integer([:positive, :monotonic])
@@ -143,7 +121,8 @@ defmodule MingaEditor.Renderer do
         continue_synchronous_render(state, renderer, RendererServer.rendering?(renderer))
 
       {true, state} ->
-        intent = Intent.from_editor_state(state)
+        {state, revision} = EditorState.submit_render_intent(state)
+        intent = Intent.from_editor_state(state, revision)
         seq = System.unique_integer([:positive, :monotonic])
         :ok = RendererServer.reset_connection(renderer, intent, seq)
         state
@@ -152,15 +131,14 @@ defmodule MingaEditor.Renderer do
 
   @spec continue_synchronous_render(state(), pid(), boolean()) :: state()
   defp continue_synchronous_render(state, renderer, true) do
-    intent = Intent.from_editor_state(state)
+    {state, revision} = EditorState.submit_render_intent(state)
+    intent = Intent.from_editor_state(state, revision)
     seq = System.unique_integer([:positive, :monotonic])
     RendererServer.cast_snapshot(renderer, intent, seq)
     state
   end
 
-  defp continue_synchronous_render(state, _renderer, false) do
-    render(state)
-  end
+  defp continue_synchronous_render(state, _renderer, false), do: render(state)
 
   @spec async_render?(state()) :: boolean()
   defp async_render?(state),
@@ -172,11 +150,18 @@ defmodule MingaEditor.Renderer do
   Called by Shell.Traditional.render for normal buffer rendering.
   """
   @spec render_buffer(state()) :: state()
+  def render_buffer(%EditorState{frontend: %{backend: backend}, render: %{renderer: nil}} = state)
+      when backend != :headless do
+    Minga.Log.warning(:render, "Skipped non-headless render without Renderer.Server")
+    state
+  end
+
   def render_buffer(state) do
     {state, renderer} = ensure_synchronous_renderer(state)
+    {state, revision} = EditorState.submit_render_intent(state)
     {keyframe?, state} = EditorState.take_keyframe_request(state)
     seq = System.unique_integer([:positive, :monotonic])
-    intent = Intent.from_editor_state(state)
+    intent = Intent.from_editor_state(state, revision)
 
     case dispatch_render_buffer(renderer, intent, seq, keyframe?, state.frontend.backend) do
       :async -> state
@@ -207,25 +192,16 @@ defmodule MingaEditor.Renderer do
     do: RendererServer.render_sync(renderer, intent, seq)
 
   defp dispatch_render_buffer(renderer, intent, seq, false, _backend) do
-    dispatch_non_headless_render(renderer, intent, seq, RendererServer.rendering?(renderer))
-  end
-
-  @spec dispatch_non_headless_render(pid(), Intent.t(), non_neg_integer(), boolean()) ::
-          :async | {:ok, MingaEditor.Renderer.RenderReceipt.t()} | {:error, Exception.t()}
-  defp dispatch_non_headless_render(renderer, intent, seq, true) do
     RendererServer.cast_snapshot(renderer, intent, seq)
     :async
   end
-
-  defp dispatch_non_headless_render(renderer, intent, seq, false),
-    do: RendererServer.render_sync(renderer, intent, seq)
 
   @spec ensure_synchronous_renderer(state()) :: {state(), pid()}
   defp ensure_synchronous_renderer(%EditorState{render: %{renderer: renderer}} = state)
        when is_pid(renderer),
        do: {state, renderer}
 
-  defp ensure_synchronous_renderer(%EditorState{} = state) do
+  defp ensure_synchronous_renderer(%EditorState{frontend: %{backend: :headless}} = state) do
     {:ok, renderer} =
       RendererServer.start_link(name: nil, editor_pid: nil, require_ack?: false)
 

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -198,6 +198,14 @@ defmodule MingaEditor.State do
     %{state | workspace: workspace, frontend: frontend}
   end
 
+  @doc "Advances the semantic render revision and installs it through the Render owner."
+  @spec submit_render_intent(t()) :: {t(), pos_integer()}
+  def submit_render_intent(%__MODULE__{} = state) do
+    {correlation, revision} = RenderCorrelation.submit(state.render.render_correlation)
+    render = RenderState.accept_correlation(state.render, correlation)
+    {%{state | render: render}, revision}
+  end
+
   @doc "Transfers one queued keyframe request to the renderer boundary."
   @spec take_keyframe_request(t()) :: {boolean(), t()}
   def take_keyframe_request(%__MODULE__{} = state) do

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -737,6 +737,17 @@ defmodule MingaEditor.Renderer.ServerTest do
   end
 
   describe "render_or_async dispatch" do
+    test "non-headless render without Renderer.Server fails closed" do
+      state = build_editor_state(:tui, nil)
+      assert Minga.Test.HeadlessPort.frame_count(state.frontend.port_manager) == 0
+
+      result = MingaEditor.Renderer.render_buffer(state)
+
+      assert result == state
+      assert result.render.renderer == nil
+      assert Minga.Test.HeadlessPort.frame_count(state.frontend.port_manager) == 0
+    end
+
     test "non-headless backend with renderer dispatches asynchronously" do
       renderer = start_renderer(self(), pipeline: & &1)
       state = build_editor_state(:tui, renderer)
@@ -750,6 +761,88 @@ defmodule MingaEditor.Renderer.ServerTest do
 
       assert_receive {:render_done, %RenderReceipt{}},
                      @async_render_timeout
+    end
+
+    test "traditional launchpad render correlates before a normal async render" do
+      renderer = start_ack_renderer(self())
+      state = build_editor_state(:tui, renderer)
+      launchpad = MingaEditor.State.enter_empty_state(state)
+      assert launchpad.workspace.buffers.active == nil
+
+      rendered_launchpad = MingaEditor.Renderer.render_or_async(launchpad)
+      assert rendered_launchpad.render.render_correlation.latest_intent_revision == 1
+
+      assert_receive {:ack_pipeline, launchpad_seq, 1, 0, true}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 1, launchpad_seq})
+
+      assert_receive {:render_done,
+                      %RenderReceipt{frame_seq: ^launchpad_seq, intent_revision: 1} = receipt},
+                     @async_render_timeout
+
+      assert {integrated_launchpad, :applied} =
+               MingaEditor.State.integrate_renderer_receipt(rendered_launchpad, receipt)
+
+      normal = %{state | render: integrated_launchpad.render}
+      rendered_normal = MingaEditor.Renderer.render_or_async(normal)
+      assert rendered_normal.render.render_correlation.latest_intent_revision == 2
+
+      assert_receive {:ack_pipeline, normal_seq, 1, ^launchpad_seq, false},
+                     @async_render_timeout
+
+      RendererServer.frame_status(renderer, {:frame_applied, 1, normal_seq})
+
+      assert_receive {:render_done,
+                      %RenderReceipt{frame_seq: ^normal_seq, intent_revision: 2} = normal_receipt},
+                     @async_render_timeout
+
+      assert {_integrated_normal, :applied} =
+               MingaEditor.State.integrate_renderer_receipt(rendered_normal, normal_receipt)
+    end
+
+    test "direct non-headless render keeps delta-base advancement behind frontend acknowledgement" do
+      renderer = start_ack_renderer(self())
+      state = build_editor_state(:tui, renderer)
+      intent = Intent.from_editor_state(state)
+
+      RendererServer.cast_snapshot(renderer, intent, 13)
+      assert_receive {:ack_pipeline, 13, 1, 0, true}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 1, 13})
+
+      assert_receive {:render_done, %RenderReceipt{frame_seq: 13, keyframe?: true}},
+                     @async_render_timeout
+
+      result = MingaEditor.Renderer.render_buffer(state)
+      assert result.render.render_correlation.latest_intent_revision == 1
+
+      assert_receive {:ack_pipeline, direct_seq, 1, 13, false}, @async_render_timeout
+      assert RendererServer.rendering?(renderer)
+      refute_receive {:render_done, %RenderReceipt{frame_seq: ^direct_seq}}, 50
+
+      RendererServer.frame_status(renderer, {:frame_applied, 1, direct_seq})
+
+      assert_receive {:render_done,
+                      %RenderReceipt{
+                        frame_seq: ^direct_seq,
+                        keyframe?: false,
+                        intent_revision: 1
+                      } = direct_receipt},
+                     @async_render_timeout
+
+      assert {integrated, :applied} =
+               MingaEditor.State.integrate_renderer_receipt(result, direct_receipt)
+
+      next = MingaEditor.Renderer.render_or_async(integrated)
+      assert_receive {:ack_pipeline, next_seq, 1, ^direct_seq, false}, @async_render_timeout
+      RendererServer.frame_status(renderer, {:frame_applied, 1, next_seq})
+
+      assert_receive {:render_done,
+                      %RenderReceipt{frame_seq: ^next_seq, intent_revision: 2} = next_receipt},
+                     @async_render_timeout
+
+      assert {_integrated, :applied} =
+               MingaEditor.State.integrate_renderer_receipt(next, next_receipt)
+
+      assert next.render.render_correlation.latest_intent_revision == 2
     end
 
     test "keyframe handoff survives a superseding intent without forcing another keyframe" do


### PR DESCRIPTION
# TL;DR

Ensure every non-headless frame remains owned by `Renderer.Server` until the frontend acknowledges it. This closes a synchronous publication path that could leave Swift one committed frame ahead of the BEAM and trigger a permanent resync loop.

Follow-up to #2968.

## Context

#2968 fixed the startup keyframe storm by transferring recovery ownership to the renderer. A second sequence divergence remained: direct rendering, including parser highlight updates and the Traditional launchpad path, could call `render_sync` while the GUI renderer was idle.

That path emitted and committed a frame without an acknowledgement lease. The frontend could commit frame 14 while the BEAM still tracked frame 13, causing every later delta based on 13 to be rejected.

## Changes

- Route every non-headless render through asynchronous `Renderer.Server` publication, even when the renderer is idle.
- Keep `render_sync` and its no-ACK fallback exclusive to headless rendering.
- Fail closed when a non-headless state lacks its supervised renderer instead of silently creating a no-ACK renderer.
- Submit a correlated render revision for direct, launchpad, keyframe-reset, and queued synchronous-shell intents.
- Add regressions proving delta bases advance only after frontend acknowledgement and launchpad revision 1 transitions cleanly to normal async revision 2.

## Verification

- `make lint`
- `PATH="/private/tmp/minga-test-bin:$PATH" TMPDIR=/private/tmp mix test.llm` (9,801 tests, 0 failures)
- Focused renderer/state/input tests
- Final acceptance review: PASS

## Acceptance Criteria Addressed

- Non-headless frames cannot advance renderer caches without a matching frontend ACK. ✅
- Direct highlight and launchpad renders participate in normal receipt correlation. ✅
- Missing non-headless renderer state fails closed rather than weakening ACK guarantees. ✅
- Headless rendering remains synchronous. ✅
