### PR TITLE
fix(ui): hide launchpad behind agent chat

### DIFF
--- a/lib/minga_editor/render_model/ui/empty_state_builder.ex
+++ b/lib/minga_editor/render_model/ui/empty_state_builder.ex
@@ -17,6 +17,8 @@ defmodule MingaEditor.RenderModel.UI.EmptyStateBuilder do
   alias Minga.RenderModel.UI.EmptyState.Section
   alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.State.Launchpad
+  alias MingaEditor.State.Windows
+  alias MingaEditor.Window.Content
 
   # {item id, label, leader-bound command} for the start section, in order.
   @actions [
@@ -26,14 +28,19 @@ defmodule MingaEditor.RenderModel.UI.EmptyStateBuilder do
   ]
 
   @spec build(Context.t()) :: EmptyState.t()
-  def build(%Context{launchpad: %Launchpad{} = lp}) do
-    %EmptyState{
-      visible?: true,
-      crashed?: lp.crashed?,
-      focused_id: lp.focused_id,
-      version: version(),
-      sections: sections(lp)
-    }
+  def build(%Context{launchpad: %Launchpad{} = lp, windows: %Windows{} = windows}) do
+    with %{content: content} <- Windows.active_struct(windows),
+         true <- Content.empty?(content) do
+      %EmptyState{
+        visible?: true,
+        crashed?: lp.crashed?,
+        focused_id: lp.focused_id,
+        version: version(),
+        sections: sections(lp)
+      }
+    else
+      _other -> %EmptyState{visible?: false}
+    end
   end
 
   def build(%Context{}), do: %EmptyState{visible?: false}

--- a/test/minga_editor/render_model/ui/empty_state_builder_test.exs
+++ b/test/minga_editor/render_model/ui/empty_state_builder_test.exs
@@ -3,17 +3,17 @@ defmodule MingaEditor.RenderModel.UI.EmptyStateBuilderTest do
 
   alias Minga.RenderModel.UI.EmptyState
   alias MingaEditor.RenderModel.UI.EmptyStateBuilder
+  alias MingaEditor.Renderer.RenderWindow
   alias MingaEditor.State.Launchpad
+  alias MingaEditor.State.Windows
 
-  defp ctx(launchpad) do
-    # The builder only reads ctx.launchpad; a bare struct-shaped map keeps
-    # the test at the cheapest layer.
+  defp ctx(launchpad, window \\ RenderWindow.new_empty_state(1, 24, 80)) do
     %MingaEditor.Frontend.Emit.Context{
       port_manager: nil,
       capabilities: nil,
       theme: nil,
       font_registry: nil,
-      windows: nil,
+      windows: %Windows{tree: {:leaf, 1}, map: %{1 => window}, active: 1, next_id: 2},
       layout: nil,
       shell: nil,
       launchpad: launchpad
@@ -29,6 +29,13 @@ defmodule MingaEditor.RenderModel.UI.EmptyStateBuilderTest do
 
   test "hidden when the workspace has no launchpad" do
     assert %EmptyState{visible?: false} = EmptyStateBuilder.build(ctx(nil))
+  end
+
+  test "hidden when the active render window is agent chat" do
+    agent_window = RenderWindow.new_agent_chat(1, 24, 80)
+
+    assert %EmptyState{visible?: false} =
+             EmptyStateBuilder.build(ctx(launchpad([]), agent_window))
   end
 
   test "returning user gets a resume card, recents, actions, and footer" do


### PR DESCRIPTION
# TL;DR

Hide the launchpad whenever the active window is not the semantic empty-state surface. This prevents the retained zero-buffer launchpad from covering Agent chat after `SPC a n`.

## Context

Opening Agent chat from a zero-buffer startup correctly switched tabs and started the session, but the launchpad snapshot remained present so both semantic models were emitted as visible. Swift rendered the later launchpad layer over the chat.

## Changes

- Gate launchpad visibility on the active window using the existing `Window.Content.empty?/1` predicate.
- Preserve the launchpad snapshot so returning to the empty workspace still restores it.
- Add regression coverage for an active Agent chat window with retained launchpad state.

## Verification

- Focused EmptyStateBuilder and AgentChatBuilder tests: 21 passed
- `make lint`
- `PATH="/private/tmp/minga-test-bin:$PATH" TMPDIR=/private/tmp mix test.llm` (9,802 tests, 0 failures)
- Final reviewer gate: PASS
