### PR TITLE
refactor(agent): own session transcript lifecycle

### DIFF
--- a/credo/checks/dependency_direction_check.exs
+++ b/credo/checks/dependency_direction_check.exs
@@ -215,6 +215,7 @@ defmodule Minga.Credo.DependencyDirectionCheck do
     "MingaAgent.Tool.Spec",
     "MingaAgent.ToolApproval.Preview",
     "MingaAgent.ToolCall",
+    "MingaAgent.TranscriptEntry",
     "MingaAgent.TurnUsage",
     "MingaEditor.Agent.SlashCommand.Command"
   ]

--- a/lib/minga_agent/branch.ex
+++ b/lib/minga_agent/branch.ex
@@ -1,76 +1,48 @@
 defmodule MingaAgent.Branch do
   @moduledoc """
-  Conversation branching for the agent session.
+  An immutable snapshot of identified transcript entries.
 
-  Allows rewinding to an earlier turn and trying a different prompt,
-  creating a branch. Previous branches are preserved and can be revisited.
-  This enables "what if" exploration without losing prior work.
+  Branch creation and switching are aggregate transcript transitions owned by
+  `MingaAgent.Session.Transcript`. This value stores only the frozen snapshot
+  and its presentation metadata.
   """
 
-  alias MingaAgent.Message
+  alias MingaAgent.TranscriptEntry
 
-  @typedoc "A named conversation branch."
+  @typedoc "A named conversation branch snapshot."
   @type t :: %__MODULE__{
           name: String.t(),
-          messages: [Message.t()],
+          entries: [TranscriptEntry.t()],
           created_at: DateTime.t()
         }
 
-  @enforce_keys [:name, :messages, :created_at]
-  defstruct [:name, :messages, :created_at]
+  @enforce_keys [:name, :entries, :created_at]
+  defstruct [:name, :entries, :created_at]
 
-  @doc "Creates a new branch from the given messages."
-  @spec new(String.t(), [Message.t()]) :: t()
-  def new(name, messages) when is_binary(name) and is_list(messages) do
-    %__MODULE__{
-      name: name,
-      messages: messages,
-      created_at: DateTime.utc_now()
-    }
+  @doc "Creates a branch snapshot from identified entries."
+  @spec new(String.t(), [TranscriptEntry.t()], DateTime.t()) :: t()
+  def new(name, entries, %DateTime{} = created_at) when is_binary(name) and is_list(entries) do
+    %__MODULE__{name: name, entries: entries, created_at: created_at}
   end
 
-  @doc """
-  Branches at the given turn index, saving the current messages
-  as a named branch and returning the truncated message list.
+  @doc "Returns the branch messages in transcript order."
+  @spec messages(t()) :: [MingaAgent.Message.t()]
+  def messages(%__MODULE__{} = branch), do: Enum.map(branch.entries, & &1.message)
 
-  Turn index is 0-based. Messages from index 0 to `turn_index` (inclusive)
-  are kept; the rest become the branch.
-  """
-  @spec branch_at(
-          [Message.t()],
-          non_neg_integer(),
-          String.t(),
-          [t()]
-        ) :: {:ok, [Message.t()], [t()]} | {:error, String.t()}
-  def branch_at(messages, turn_index, branch_name, existing_branches)
-      when is_integer(turn_index) and turn_index >= 0 do
-    if turn_index >= Enum.count(messages) do
-      {:error,
-       "Turn index #{turn_index} is beyond the conversation length (#{Enum.count(messages)})"}
-    else
-      # Save current messages as a branch
-      branch = new(branch_name, messages)
-      branches = Enum.concat(existing_branches, [branch])
+  @doc "Returns the stable entry IDs in branch order."
+  @spec entry_ids(t()) :: [pos_integer()]
+  def entry_ids(%__MODULE__{} = branch), do: Enum.map(branch.entries, & &1.id)
 
-      # Truncate to the branch point
-      truncated = Enum.take(messages, turn_index + 1)
-
-      {:ok, truncated, branches}
-    end
-  end
-
-  @doc "Lists all branches with their names and message counts."
+  @doc "Lists branches with their names and message counts."
   @spec list([t()]) :: String.t()
-  def list([]) do
-    "No branches. Use /branch <turn_number> to create one."
-  end
+  def list([]), do: "No branches. Use /branch <turn_number> to create one."
 
   def list(branches) do
     branches
     |> Enum.with_index(1)
-    |> Enum.map_join("\n", fn {b, idx} ->
-      time = Calendar.strftime(b.created_at, "%H:%M:%S UTC")
-      "  #{idx}. #{b.name} (#{Enum.count(b.messages)} messages, created #{time})"
+    |> Enum.map_join("\n", fn {branch, index} ->
+      time = Calendar.strftime(branch.created_at, "%H:%M:%S UTC")
+      "  #{index}. #{branch.name} (#{Enum.count(branch.entries)} messages, created #{time})"
     end)
   end
 end

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -40,13 +40,14 @@ defmodule MingaAgent.Session do
   alias MingaAgent.ProviderResolver
   alias MingaAgent.SessionMetadata
   alias MingaAgent.Session.ProviderLifecycle
+  alias MingaAgent.Session.Persistence
+  alias MingaAgent.Session.Transcript
   require ProviderLifecycle
   alias MingaAgent.SessionStore
   alias MingaAgent.EditBoundary
   alias MingaAgent.SubagentContext
   alias MingaAgent.ToolApproval
   alias MingaAgent.ToolCall
-  alias MingaAgent.TurnUsage
 
   @typedoc "Agent session status."
   @type status :: :idle | :plan | :thinking | :tool_executing | :error
@@ -92,9 +93,7 @@ defmodule MingaAgent.Session do
           provider: ProviderLifecycle.t(),
           credentials_configured_fn: credentials_configured_fn(),
           status: status(),
-          messages: [Message.t()],
-          message_ids: [pos_integer()],
-          next_message_id: pos_integer(),
+          transcript: Transcript.t(),
           subscribers: MapSet.t(pid()),
           subscriber_roles: %{pid() => attachment_role()},
           driver: pid() | nil,
@@ -102,7 +101,7 @@ defmodule MingaAgent.Session do
           idle_gc_timeout_ms: non_neg_integer(),
           idle_gc_timer: {timer_ref :: reference(), token :: reference()} | nil,
           idle_gc_token_fn: (-> reference()),
-          total_usage: Event.token_usage(),
+          persistence: Persistence.t(),
           error_message: String.t() | nil,
           pending_thinking_level: String.t() | nil,
           pending_approval: pending_approval() | nil,
@@ -113,20 +112,14 @@ defmodule MingaAgent.Session do
           pending_auto_approvals: %{String.t() => trust_scope()},
           notifier: module() | {module(), term()},
           background_subagent: boolean(),
-          persist?: boolean(),
           hooks_enabled?: boolean(),
           session_start_hook_enabled?: boolean(),
-          save_timer: reference() | nil,
-          save_retry_count: non_neg_integer(),
           session_store_dir: String.t() | nil,
           created_at: DateTime.t(),
-          last_message_at: DateTime.t(),
-          branches: [Branch.t()],
           steering_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
           follow_up_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
           touched_files: %{String.t() => file_touch()},
           boundaries: %{String.t() => EditBoundary.t()},
-          pinned_ids: MapSet.t(pos_integer()),
           credentials_configured: boolean()
         }
 
@@ -728,11 +721,11 @@ defmodule MingaAgent.Session do
       provider: provider,
       credentials_configured_fn: credentials_configured_fn,
       status: :idle,
-      messages: [
-        Message.system(initial_system_message(timestamp, Keyword.get(opts, :startup_notice)))
-      ],
-      message_ids: [1],
-      next_message_id: 2,
+      transcript:
+        Transcript.new(
+          [Message.system(initial_system_message(timestamp, Keyword.get(opts, :startup_notice)))],
+          now
+        ),
       subscribers: MapSet.new(),
       subscriber_roles: %{},
       driver: nil,
@@ -740,7 +733,7 @@ defmodule MingaAgent.Session do
       idle_gc_timeout_ms: Keyword.get_lazy(opts, :idle_gc_timeout_ms, &idle_gc_timeout_ms/0),
       idle_gc_timer: nil,
       idle_gc_token_fn: Keyword.get(opts, :idle_gc_token_fn, &make_ref/0),
-      total_usage: TurnUsage.new(),
+      persistence: Persistence.new(Keyword.get(opts, :persist?, true)),
       error_message: nil,
       pending_thinking_level: initial_thinking_level,
       pending_approval: nil,
@@ -751,21 +744,15 @@ defmodule MingaAgent.Session do
       pending_auto_approvals: %{},
       notifier: Keyword.get(opts, :notifier, Notifier),
       background_subagent: Keyword.get(opts, :background_subagent, false),
-      persist?: Keyword.get(opts, :persist?, true),
       hooks_enabled?: Keyword.get(opts, :hooks_enabled?, true),
       session_start_hook_enabled?:
         Keyword.get(opts, :session_start_hook_enabled?, Keyword.get(opts, :hooks_enabled?, true)),
-      save_timer: nil,
-      save_retry_count: 0,
       session_store_dir: Keyword.get(opts, :session_store_dir),
       created_at: now,
-      last_message_at: now,
-      branches: [],
       steering_queue: [],
       follow_up_queue: [],
       touched_files: %{},
       boundaries: %{},
-      pinned_ids: MapSet.new(),
       credentials_configured: credentials_configured?
     }
 
@@ -929,14 +916,14 @@ defmodule MingaAgent.Session do
     state.provider.module.abort(ProviderLifecycle.pid(state.provider))
 
     # Mark any running tool calls as aborted
-    messages =
-      Enum.map(state.messages, fn
-        {:tool_call, %ToolCall{} = tc} -> {:tool_call, ToolCall.abort(tc)}
+    transcript =
+      Transcript.transform_messages(state.transcript, fn
+        {:tool_call, %ToolCall{} = tool_call} -> {:tool_call, ToolCall.abort(tool_call)}
         other -> other
       end)
 
     # Append "Aborted" system message, clear any pending approval
-    state = %{state | messages: messages, pending_approval: nil}
+    state = %{state | transcript: transcript, pending_approval: nil}
     state = append_system_message(state, "Aborted", :info)
     state = notify_messages_changed(state)
     state = set_idle_or_plan(state)
@@ -959,14 +946,12 @@ defmodule MingaAgent.Session do
       state
       | session_id: generate_session_id(),
         status: :idle,
-        total_usage: TurnUsage.new(),
         error_message: nil,
         pending_approval: nil,
         active_tool_calls: [],
         active_tool_name: nil,
         turn_active?: false,
         created_at: now,
-        last_message_at: now,
         steering_queue: [],
         follow_up_queue: [],
         touched_files: %{},
@@ -975,7 +960,12 @@ defmodule MingaAgent.Session do
         pending_auto_approvals: %{}
     }
 
-    state = reset_messages(state, [Message.system("Session cleared · #{timestamp}")])
+    transcript =
+      state.transcript
+      |> Transcript.reset([Message.system("Session cleared · #{timestamp}")])
+      |> Transcript.touch(now)
+
+    state = %{state | transcript: transcript}
 
     record_critical_event(state, :session_started, %{
       model: state.provider.model_name,
@@ -1034,29 +1024,24 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call(:messages, _from, state) do
-    {:reply, state.messages, state}
+    {:reply, Transcript.messages(state.transcript), state}
   end
 
   def handle_call(:messages_with_ids, _from, state) do
-    paired = Enum.zip(state.message_ids, state.messages)
-    {:reply, paired, state}
+    {:reply, Transcript.messages_with_ids(state.transcript), state}
   end
 
   def handle_call(:usage, _from, state) do
-    {:reply, state.total_usage, state}
+    {:reply, Transcript.usage(state.transcript), state}
   end
 
   def handle_call(:pinned_ids, _from, state) do
-    {:reply, state.pinned_ids, state}
+    {:reply, Transcript.pinned_ids(state.transcript), state}
   end
 
   def handle_call({:toggle_pin, message_id}, _from, state) do
-    pinned =
-      if MapSet.member?(state.pinned_ids, message_id),
-        do: MapSet.delete(state.pinned_ids, message_id),
-        else: MapSet.put(state.pinned_ids, message_id)
-
-    state = %{state | pinned_ids: pinned}
+    transcript = Transcript.toggle_pin(state.transcript, message_id)
+    state = %{state | transcript: transcript}
     broadcast(state, :messages_changed)
     {:reply, :ok, schedule_save(state)}
   end
@@ -1066,7 +1051,7 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call(:persist?, _from, state) do
-    {:reply, state.persist?, state}
+    {:reply, Persistence.enabled?(state.persistence), state}
   end
 
   def handle_call(:hooks_enabled?, _from, state) do
@@ -1086,8 +1071,11 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call(:metadata, _from, state) do
-    first_prompt = first_user_prompt(state.messages)
-    title = readable_title(first_assistant_text(state.messages)) || readable_title(first_prompt)
+    first_prompt = first_user_prompt(Transcript.messages(state.transcript))
+
+    title =
+      readable_title(first_assistant_text(Transcript.messages(state.transcript))) ||
+        readable_title(first_prompt)
 
     meta = %SessionMetadata{
       id: state.session_id,
@@ -1095,11 +1083,11 @@ defmodule MingaAgent.Session do
       model_name: state.provider.model_name,
       provider_name: state.provider.provider_name,
       created_at: state.created_at,
-      last_message_at: state.last_message_at,
-      message_count: Enum.count(state.messages),
-      turn_count: count_user_turns(state.messages),
+      last_message_at: Transcript.last_changed_at(state.transcript),
+      message_count: Enum.count(Transcript.messages(state.transcript)),
+      turn_count: count_user_turns(Transcript.messages(state.transcript)),
       first_prompt: first_prompt,
-      cost: state.total_usage.cost,
+      cost: Transcript.usage(state.transcript).cost,
       status: state.status,
       workdir: state.workdir
     }
@@ -1360,14 +1348,19 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call({:toggle_tool_collapse, index}, _from, state) do
-    messages =
-      List.update_at(state.messages, index, fn
-        {:tool_call, %ToolCall{} = tc} -> {:tool_call, ToolCall.toggle_collapsed(tc)}
-        {:thinking, text, collapsed} -> {:thinking, text, !collapsed}
-        other -> other
+    transcript =
+      Transcript.update_at(state.transcript, index, fn
+        {:tool_call, %ToolCall{} = tool_call} ->
+          {:tool_call, ToolCall.toggle_collapsed(tool_call)}
+
+        {:thinking, text, collapsed} ->
+          {:thinking, text, !collapsed}
+
+        other ->
+          other
       end)
 
-    state = %{state | messages: messages}
+    state = %{state | transcript: transcript}
     state = notify_messages_changed(state)
     {:reply, :ok, state}
   end
@@ -1375,7 +1368,7 @@ defmodule MingaAgent.Session do
   def handle_call(:toggle_all_tool_collapses, _from, state) do
     # If any tool call is collapsed, expand all; otherwise collapse all.
     any_collapsed =
-      Enum.any?(state.messages, fn
+      Enum.any?(Transcript.messages(state.transcript), fn
         {:tool_call, %ToolCall{collapsed: true}} -> true
         {:thinking, _, true} -> true
         _ -> false
@@ -1383,28 +1376,30 @@ defmodule MingaAgent.Session do
 
     target = !any_collapsed
 
-    messages =
-      Enum.map(state.messages, fn
-        {:tool_call, %ToolCall{} = tc} -> {:tool_call, ToolCall.set_collapsed(tc, target)}
-        {:thinking, text, _} -> {:thinking, text, target}
-        other -> other
+    transcript =
+      Transcript.transform_messages(state.transcript, fn
+        {:tool_call, %ToolCall{} = tool_call} ->
+          {:tool_call, ToolCall.set_collapsed(tool_call, target)}
+
+        {:thinking, text, _collapsed} ->
+          {:thinking, text, target}
+
+        other ->
+          other
       end)
 
-    state = %{state | messages: messages}
+    state = %{state | transcript: transcript}
     state = notify_messages_changed(state)
     {:reply, :ok, state}
   end
 
   def handle_call({:branch_at, turn_index}, _from, state) do
-    branch_name = "branch-#{Enum.count(state.branches) + 1}"
-
-    case Branch.branch_at(state.messages, turn_index, branch_name, state.branches) do
-      {:ok, truncated, branches} ->
-        truncated_ids = Enum.take(state.message_ids, Enum.count(truncated))
-        state = %{state | messages: truncated, message_ids: truncated_ids, branches: branches}
+    case Transcript.branch_at(state.transcript, turn_index, DateTime.utc_now()) do
+      {:ok, transcript, branch} ->
+        state = %{state | transcript: transcript}
         state = notify_messages_changed(state)
 
-        {:reply, {:ok, "Branched at turn #{turn_index}. Branch saved as '#{branch_name}'."},
+        {:reply, {:ok, "Branched at turn #{turn_index}. Branch saved as '#{branch.name}'."},
          state}
 
       {:error, reason} ->
@@ -1413,20 +1408,18 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call(:list_branches, _from, state) do
-    {:reply, {:ok, Branch.list(state.branches)}, state}
+    {:reply, {:ok, Branch.list(Transcript.branches(state.transcript))}, state}
   end
 
   def handle_call({:switch_branch, branch_index}, _from, state) do
-    idx = branch_index - 1
-
-    case Enum.at(state.branches, idx) do
-      nil ->
-        {:reply, {:error, "Branch #{branch_index} not found. Use /branches to list."}, state}
-
-      branch ->
-        state = reset_messages(state, branch.messages)
+    case Transcript.switch_branch(state.transcript, branch_index) do
+      {:ok, transcript} ->
+        state = %{state | transcript: transcript}
         state = notify_messages_changed(state)
         {:reply, :ok, state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
     end
   end
 
@@ -1545,20 +1538,40 @@ defmodule MingaAgent.Session do
     {:noreply, state}
   end
 
+  def handle_info(:save_session, %{persistence: %Persistence{timer: {token, _timer_ref}}} = state) do
+    handle_info({:save_session, token}, state)
+  end
+
   def handle_info(:save_session, state) do
-    state = %{state | save_timer: nil}
+    {persistence, timer_to_cancel} = Persistence.changed(state.persistence)
 
-    case save_to_disk(state) do
-      :ok ->
-        {:noreply, %{state | save_retry_count: 0}}
+    cancel_runtime_timer(timer_to_cancel)
 
-      {:error, reason} ->
-        Minga.Log.error(
-          :agent,
-          "[Agent.Session] failed to save session #{state.session_id} to disk: #{inspect(reason)}"
-        )
+    token = make_ref()
+    persistence = Persistence.scheduled(persistence, token, make_ref())
+    handle_info({:save_session, token}, %{state | persistence: persistence})
+  end
 
-        {:noreply, schedule_save_retry(state)}
+  def handle_info({:save_session, token}, state) do
+    case Persistence.save_due(state.persistence, token) do
+      :stale ->
+        {:noreply, state}
+
+      {:save, persistence} ->
+        state = %{state | persistence: persistence}
+
+        case save_to_disk(state) do
+          :ok ->
+            {:noreply, %{state | persistence: Persistence.saved(persistence)}}
+
+          {:error, reason} ->
+            Minga.Log.error(
+              :agent,
+              "[Agent.Session] failed to save session #{state.session_id} to disk: #{inspect(reason)}"
+            )
+
+            {:noreply, schedule_save_retry(state)}
+        end
     end
   end
 
@@ -1677,13 +1690,13 @@ defmodule MingaAgent.Session do
     notify(state, :complete, completion_notification(state))
 
     # Collapse thinking blocks now that the turn is complete.
-    state = %{state | messages: collapse_thinking_blocks(state.messages)}
+    state = %{state | transcript: Transcript.collapse_thinking(state.transcript)}
 
     state =
       if usage do
         log_turn_usage(usage, state)
 
-        state = %{state | total_usage: TurnUsage.add(state.total_usage, usage)}
+        state = %{state | transcript: Transcript.add_usage(state.transcript, usage)}
 
         state
         |> append_msg(Message.usage(usage))
@@ -1731,29 +1744,15 @@ defmodule MingaAgent.Session do
   end
 
   defp handle_provider_event(%Event.TextDelta{delta: delta}, state) do
-    state =
-      case append_to_last_assistant(state.messages, delta) do
-        {:updated, updated_messages} ->
-          %{state | messages: updated_messages}
-
-        {:appended, new_msg} ->
-          append_msg(state, new_msg)
-      end
-
+    transcript = Transcript.append_stream_tail(state.transcript, :assistant, [delta])
+    state = %{state | transcript: transcript}
     broadcast(state, {:text_delta, delta})
     state
   end
 
   defp handle_provider_event(%Event.ThinkingDelta{delta: delta}, state) do
-    state =
-      case append_to_last_thinking(state.messages, delta) do
-        {:updated, updated_messages} ->
-          %{state | messages: updated_messages}
-
-        {:appended, new_msg} ->
-          append_msg(state, new_msg)
-      end
-
+    transcript = Transcript.append_stream_tail(state.transcript, :thinking, [delta])
+    state = %{state | transcript: transcript}
     broadcast(state, {:thinking_delta, delta})
     state
   end
@@ -1817,29 +1816,29 @@ defmodule MingaAgent.Session do
   end
 
   defp handle_provider_event(%Event.ToolUpdate{} = event, state) do
-    messages =
-      update_tool_call(state.messages, event.tool_call_id, fn tc ->
-        ToolCall.update_partial(tc, event.partial_result)
+    transcript =
+      Transcript.update_tool_call(state.transcript, event.tool_call_id, fn tool_call ->
+        ToolCall.update_partial(tool_call, event.partial_result)
       end)
 
-    state = %{state | messages: messages}
+    state = %{state | transcript: transcript}
     broadcast(state, {:tool_update, event.tool_call_id, event.name, event.partial_result})
     state
   end
 
   defp handle_provider_event(%Event.ToolEnd{} = event, state) do
-    messages =
-      update_tool_call(state.messages, event.tool_call_id, fn tc ->
+    transcript =
+      Transcript.update_tool_call(state.transcript, event.tool_call_id, fn tool_call ->
         if event.is_error do
-          ToolCall.error(tc, event.result)
+          ToolCall.error(tool_call, event.result)
         else
-          ToolCall.complete(tc, event.result)
+          ToolCall.complete(tool_call, event.result)
         end
       end)
 
     state = %{
       state
-      | messages: messages,
+      | transcript: transcript,
         pending_auto_approvals: Map.delete(state.pending_auto_approvals, event.tool_call_id)
     }
 
@@ -1881,8 +1880,8 @@ defmodule MingaAgent.Session do
   end
 
   @spec append_error_message_once(state(), String.t()) :: state()
-  defp append_error_message_once(%{messages: messages} = state, message) do
-    case Enum.at(messages, -1) do
+  defp append_error_message_once(state, message) do
+    case Transcript.last_message(state.transcript) do
       {:system, ^message, :error} -> state
       _other -> append_system_message(state, message, :error)
     end
@@ -1922,12 +1921,17 @@ defmodule MingaAgent.Session do
 
     pending_auto_approvals = Map.put(state.pending_auto_approvals, event.tool_call_id, scope)
 
-    messages =
-      update_tool_call(state.messages, event.tool_call_id, fn tc ->
-        ToolCall.set_auto_approved_scope(tc, scope)
+    transcript =
+      Transcript.update_tool_call(state.transcript, event.tool_call_id, fn tool_call ->
+        ToolCall.set_auto_approved_scope(tool_call, scope)
       end)
 
-    state = %{state | messages: messages, pending_auto_approvals: pending_auto_approvals}
+    state = %{
+      state
+      | transcript: transcript,
+        pending_auto_approvals: pending_auto_approvals
+    }
+
     broadcast(state, {:tool_auto_approved, event.tool_call_id, event.name, scope})
     notify_messages_changed(state)
   end
@@ -1954,64 +1958,14 @@ defmodule MingaAgent.Session do
 
   # Appends a message and assigns it a new stable ID.
   @spec append_msg(state(), Message.t()) :: state()
-  defp append_msg(state, msg) do
-    id = state.next_message_id
-
-    %{
-      state
-      | messages: Enum.concat(state.messages, [msg]),
-        message_ids: Enum.concat(state.message_ids, [id]),
-        next_message_id: id + 1
-    }
+  defp append_msg(state, message) do
+    %{state | transcript: Transcript.append(state.transcript, message)}
   end
 
   # Appends multiple messages, assigning each a new stable ID.
   @spec append_msgs(state(), [Message.t()]) :: state()
-  defp append_msgs(state, []), do: state
-
-  defp append_msgs(state, msgs) do
-    count = Enum.count(msgs)
-    base_id = state.next_message_id
-    new_ids = Enum.to_list(base_id..(base_id + count - 1))
-
-    %{
-      state
-      | messages: state.messages ++ msgs,
-        message_ids: state.message_ids ++ new_ids,
-        next_message_id: base_id + count
-    }
-  end
-
-  @spec restore_messages_with_ids(state(), SessionStore.session_data()) :: state()
-  defp restore_messages_with_ids(state, data) do
-    case Map.get(data, :message_ids) do
-      ids when is_list(ids) and ids != [] ->
-        count = Enum.count(data.messages)
-
-        %{
-          state
-          | messages: data.messages,
-            message_ids: Enum.take(ids, count),
-            next_message_id: Enum.max(ids, fn -> 0 end) + 1
-        }
-
-      _ ->
-        reset_messages(state, data.messages)
-    end
-  end
-
-  # Replaces all messages and resets IDs (used by new_session, load_session, switch_branch).
-  @spec reset_messages(state(), [Message.t()]) :: state()
-  defp reset_messages(state, msgs) do
-    count = Enum.count(msgs)
-    ids = Enum.to_list(1..max(count, 1))
-
-    %{
-      state
-      | messages: msgs,
-        message_ids: Enum.take(ids, count),
-        next_message_id: count + 1
-    }
+  defp append_msgs(state, messages) do
+    %{state | transcript: Transcript.append_many(state.transcript, messages)}
   end
 
   @spec append_system_message(state(), String.t(), Message.system_level()) :: state()
@@ -2101,60 +2055,17 @@ defmodule MingaAgent.Session do
   defp public_pending_approval(%MingaAgent.ToolApproval{} = approval),
     do: MingaAgent.ToolApproval.public(approval)
 
-  @spec append_to_last_assistant([Message.t()], String.t()) ::
-          {:updated, [Message.t()]} | {:appended, Message.t()}
-  defp append_to_last_assistant(messages, delta) do
-    case Enum.at(messages, -1) do
-      {:assistant, text} ->
-        {:updated,
-         List.replace_at(messages, Enum.count(messages) - 1, {:assistant, text <> delta})}
-
-      _ ->
-        {:appended, Message.assistant(delta)}
-    end
-  end
-
-  @spec collapse_thinking_blocks([Message.t()]) :: [Message.t()]
-  defp collapse_thinking_blocks(messages) do
-    Enum.map(messages, fn
-      {:thinking, text, false} -> {:thinking, text, true}
-      other -> other
-    end)
-  end
-
-  @spec append_to_last_thinking([Message.t()], String.t()) ::
-          {:updated, [Message.t()]} | {:appended, Message.t()}
-  defp append_to_last_thinking(messages, delta) do
-    case Enum.at(messages, -1) do
-      {:thinking, text, _collapsed} ->
-        {:updated,
-         List.replace_at(messages, Enum.count(messages) - 1, {:thinking, text <> delta, false})}
-
-      _ ->
-        {:appended, Message.thinking(delta)}
-    end
-  end
-
-  @spec update_tool_call([Message.t()], String.t(), (ToolCall.t() -> ToolCall.t())) ::
-          [Message.t()]
-  defp update_tool_call(messages, tool_call_id, updater) do
-    Enum.map(messages, fn
-      {:tool_call, %ToolCall{id: ^tool_call_id} = tc} -> {:tool_call, updater.(tc)}
-      other -> other
-    end)
-  end
-
   @spec record_tool_file_preview(state(), Event.ToolFileChanged.t()) :: state()
   defp record_tool_file_preview(state, %Event.ToolFileChanged{} = event) do
     preview =
       ToolApproval.build_file_diff_preview(event.path, event.before_content, event.after_content)
 
-    messages =
-      update_tool_call(state.messages, event.tool_call_id, fn tc ->
-        ToolCall.set_preview(tc, preview)
+    transcript =
+      Transcript.update_tool_call(state.transcript, event.tool_call_id, fn tool_call ->
+        ToolCall.set_preview(tool_call, preview)
       end)
 
-    %{state | messages: messages}
+    %{state | transcript: transcript}
   end
 
   # ── Status management ──────────────────────────────────────────────────────
@@ -2755,7 +2666,8 @@ defmodule MingaAgent.Session do
   @doc false
   @spec notify_messages_changed(state()) :: state()
   defp notify_messages_changed(state) do
-    state = %{state | last_message_at: DateTime.utc_now()}
+    transcript = Transcript.touch(state.transcript, DateTime.utc_now())
+    state = %{state | transcript: transcript}
     broadcast(state, :messages_changed)
     schedule_save(state)
   end
@@ -3205,7 +3117,7 @@ defmodule MingaAgent.Session do
     state = install_provider_transition(state, lifecycle, effects)
     state = clear_provider_start_error(state)
 
-    state = seed_provider_messages(state, state.messages)
+    state = seed_provider_messages(state, Transcript.messages(state.transcript))
     state = apply_pending_thinking_level(state)
     state = maybe_show_auth_onboarding(state)
     dispatch_session_start(state)
@@ -3602,66 +3514,76 @@ defmodule MingaAgent.Session do
   @save_debounce_ms 500
 
   @spec schedule_save(state()) :: state()
-  defp schedule_save(%{persist?: false} = state), do: state
-
   defp schedule_save(state) do
-    state = cancel_save_timer(state)
-    ref = Process.send_after(self(), :save_session, @save_debounce_ms)
-    %{state | save_timer: ref, save_retry_count: 0}
+    {persistence, timer_to_cancel} = Persistence.changed(state.persistence)
+
+    cancel_runtime_timer(timer_to_cancel)
+
+    persistence =
+      if Persistence.dirty?(persistence) do
+        token = make_ref()
+        timer_ref = Process.send_after(self(), {:save_session, token}, @save_debounce_ms)
+        Persistence.scheduled(persistence, token, timer_ref)
+      else
+        persistence
+      end
+
+    %{state | persistence: persistence}
   end
 
   @spec cancel_save_timer(state()) :: state()
-  defp cancel_save_timer(%{save_timer: nil} = state), do: state
-
-  defp cancel_save_timer(%{save_timer: ref} = state) do
-    Process.cancel_timer(ref)
-    %{state | save_timer: nil}
+  defp cancel_save_timer(state) do
+    {persistence, timer_to_cancel} = Persistence.cancel(state.persistence)
+    cancel_runtime_timer(timer_to_cancel)
+    %{state | persistence: persistence}
   end
 
-  @save_retry_base_ms 5_000
-  @save_retry_max_ms 60_000
+  @spec cancel_runtime_timer({reference(), reference()} | nil) :: :ok
+  defp cancel_runtime_timer(nil), do: :ok
+
+  defp cancel_runtime_timer({_token, timer_ref}) do
+    Process.cancel_timer(timer_ref)
+    :ok
+  end
 
   @spec save_to_disk(state()) :: :ok | {:error, term()}
-  defp save_to_disk(%{persist?: false}), do: :ok
-
   defp save_to_disk(state) do
-    now = DateTime.to_iso8601(DateTime.utc_now())
-    last_message_at = DateTime.to_iso8601(state.last_message_at)
+    if Persistence.enabled?(state.persistence) do
+      now = DateTime.to_iso8601(DateTime.utc_now())
+      last_message_at = DateTime.to_iso8601(Transcript.last_changed_at(state.transcript))
 
-    data = %{
-      id: state.session_id,
-      timestamp: now,
-      last_message_at: last_message_at,
-      title:
-        readable_title(first_assistant_text(state.messages)) ||
-          readable_title(first_user_prompt(state.messages)),
-      model_name: state.provider.model_name,
-      provider_name: state.provider.provider_name,
-      messages: state.messages,
-      message_ids: state.message_ids,
-      pinned_ids: state.pinned_ids,
-      usage: state.total_usage,
-      branches: state.branches,
-      memory: Memory.read(state.session_store_dir)
-    }
+      data = %{
+        id: state.session_id,
+        timestamp: now,
+        last_message_at: last_message_at,
+        title:
+          readable_title(first_assistant_text(Transcript.messages(state.transcript))) ||
+            readable_title(first_user_prompt(Transcript.messages(state.transcript))),
+        model_name: state.provider.model_name,
+        provider_name: state.provider.provider_name,
+        messages: Transcript.messages(state.transcript),
+        message_ids:
+          state.transcript
+          |> Transcript.messages_with_ids()
+          |> Enum.map(&elem(&1, 0)),
+        pinned_ids: Transcript.pinned_ids(state.transcript),
+        usage: Transcript.usage(state.transcript),
+        branches: Transcript.branches(state.transcript),
+        memory: Memory.read(state.session_store_dir)
+      }
 
-    SessionStore.save(data, state.session_store_dir)
+      SessionStore.save(data, state.session_store_dir)
+    else
+      :ok
+    end
   end
 
   @spec schedule_save_retry(state()) :: state()
   defp schedule_save_retry(state) do
-    retry_count = state.save_retry_count + 1
-    delay_ms = retry_delay_ms(retry_count)
-    ref = Process.send_after(self(), :save_session, delay_ms)
-    %{state | save_timer: ref, save_retry_count: retry_count}
-  end
-
-  @spec retry_delay_ms(non_neg_integer()) :: non_neg_integer()
-  defp retry_delay_ms(retry_count) when retry_count <= 1, do: @save_retry_base_ms
-
-  defp retry_delay_ms(retry_count) do
-    exponential = @save_retry_base_ms * round(:math.pow(2, retry_count - 1))
-    min(exponential, @save_retry_max_ms)
+    {persistence, delay_ms} = Persistence.failed(state.persistence)
+    token = make_ref()
+    timer_ref = Process.send_after(self(), {:save_session, token}, delay_ms)
+    %{state | persistence: Persistence.scheduled(persistence, token, timer_ref)}
   end
 
   @spec restore_loaded_session(state(), SessionStore.session_data()) ::
@@ -3685,10 +3607,25 @@ defmodule MingaAgent.Session do
             provider_opts
           )
 
+        transcript =
+          Transcript.restore(
+            data.messages,
+            data.message_ids,
+            Map.get(data, :branches, []),
+            data.usage,
+            Map.get(data, :pinned_ids, MapSet.new()),
+            loaded_at
+          )
+
+        {persistence, timer_to_cancel} = Persistence.restored(state.persistence)
+
+        cancel_runtime_timer(timer_to_cancel)
+
         state = %{
           state
           | session_id: data.id,
-            total_usage: data.usage,
+            transcript: transcript,
+            persistence: persistence,
             provider: lifecycle,
             status: :idle,
             error_message: nil,
@@ -3696,9 +3633,6 @@ defmodule MingaAgent.Session do
             active_tool_calls: [],
             active_tool_name: nil,
             created_at: loaded_at,
-            last_message_at: loaded_at,
-            branches: Map.get(data, :branches, []),
-            pinned_ids: Map.get(data, :pinned_ids, MapSet.new()),
             steering_queue: [],
             follow_up_queue: [],
             touched_files: %{},
@@ -3721,9 +3655,7 @@ defmodule MingaAgent.Session do
     case restore_memory_snapshot_if_recorded(state, data) do
       :ok ->
         state =
-          state
-          |> restore_messages_with_ids(data)
-          |> seed_provider_messages(data.messages)
+          seed_provider_messages(state, Transcript.messages(state.transcript))
 
         broadcast(state, {:status_changed, :idle})
         broadcast(state, :messages_changed)
@@ -3977,7 +3909,7 @@ defmodule MingaAgent.Session do
   defp dispatch_stop(%{hooks_enabled?: false}), do: :ok
 
   defp dispatch_stop(state) do
-    last_message = extract_last_assistant_text(state.messages)
+    last_message = extract_last_assistant_text(Transcript.messages(state.transcript))
     payload = StopPayload.new(state.session_id, :end_turn, last_message)
     HookDispatcher.stop(AgentConfig.resolve().agent_hooks, StopPayload.to_map(payload))
   rescue

--- a/lib/minga_agent/session/persistence.ex
+++ b/lib/minga_agent/session/persistence.ex
@@ -1,0 +1,93 @@
+defmodule MingaAgent.Session.Persistence do
+  @moduledoc """
+  Owns transcript save intent, timer correlation, and retry state.
+
+  Session performs each write synchronously, so a dirty flag is sufficient:
+  no transcript change can overtake an in-flight write. Session owns timer and
+  storage effects; this value only calculates bookkeeping transitions.
+  """
+
+  @retry_delays {5_000, 10_000, 20_000, 40_000, 60_000}
+
+  @typedoc "A semantic timer token paired with the runtime timer reference."
+  @type timer :: {token :: reference(), timer_ref :: reference()}
+
+  @typedoc "Focused transcript persistence bookkeeping."
+  @type t :: %__MODULE__{
+          enabled?: boolean(),
+          timer: timer() | nil,
+          dirty?: boolean(),
+          retry_count: non_neg_integer()
+        }
+
+  @enforce_keys [:enabled?]
+  defstruct enabled?: true, timer: nil, dirty?: false, retry_count: 0
+
+  @doc "Creates persistence bookkeeping for one Session."
+  @spec new(boolean()) :: t()
+  def new(enabled?) when is_boolean(enabled?), do: %__MODULE__{enabled?: enabled?}
+
+  @doc "Returns whether transcript persistence is enabled."
+  @spec enabled?(t()) :: boolean()
+  def enabled?(%__MODULE__{} = persistence), do: persistence.enabled?
+
+  @doc "Returns whether the transcript has unsaved changes."
+  @spec dirty?(t()) :: boolean()
+  def dirty?(%__MODULE__{} = persistence), do: persistence.dirty?
+
+  @doc "Marks the transcript dirty and returns the timer Session must cancel."
+  @spec changed(t()) :: {t(), timer() | nil}
+  def changed(%__MODULE__{enabled?: false} = persistence), do: {persistence, nil}
+
+  def changed(%__MODULE__{} = persistence) do
+    next = %__MODULE__{persistence | timer: nil, dirty?: true, retry_count: 0}
+    {next, persistence.timer}
+  end
+
+  @doc "Installs a runtime timer under its semantic delivery token."
+  @spec scheduled(t(), reference(), reference()) :: t()
+  def scheduled(%__MODULE__{} = persistence, token, timer_ref)
+      when is_reference(token) and is_reference(timer_ref) do
+    %__MODULE__{persistence | timer: {token, timer_ref}}
+  end
+
+  @doc "Consumes a due save token or rejects stale timer delivery."
+  @spec save_due(t(), reference()) :: {:save, t()} | :stale
+  def save_due(%__MODULE__{timer: {token, _timer_ref}} = persistence, token) do
+    {:save, %__MODULE__{persistence | timer: nil}}
+  end
+
+  def save_due(%__MODULE__{}, _token), do: :stale
+
+  @doc "Records a successful synchronous write."
+  @spec saved(t()) :: t()
+  def saved(%__MODULE__{} = persistence) do
+    %__MODULE__{persistence | dirty?: false, retry_count: 0}
+  end
+
+  @doc "Records a failed write and returns the next retry delay."
+  @spec failed(t()) :: {t(), pos_integer()}
+  def failed(%__MODULE__{} = persistence) do
+    retry_count = persistence.retry_count + 1
+    {%__MODULE__{persistence | retry_count: retry_count}, retry_delay_ms(retry_count)}
+  end
+
+  @doc "Cancels bookkeeping for the current timer and returns its runtime effect handle."
+  @spec cancel(t()) :: {t(), timer() | nil}
+  def cancel(%__MODULE__{} = persistence) do
+    {%__MODULE__{persistence | timer: nil}, persistence.timer}
+  end
+
+  @doc "Marks a restored transcript as already persisted."
+  @spec restored(t()) :: {t(), timer() | nil}
+  def restored(%__MODULE__{} = persistence) do
+    next = %__MODULE__{persistence | timer: nil, dirty?: false, retry_count: 0}
+    {next, persistence.timer}
+  end
+
+  @spec retry_delay_ms(pos_integer()) :: pos_integer()
+  defp retry_delay_ms(retry_count) do
+    index = min(retry_count, tuple_size(@retry_delays)) - 1
+    elem(@retry_delays, index)
+  end
+end

--- a/lib/minga_agent/session/transcript.ex
+++ b/lib/minga_agent/session/transcript.ex
@@ -1,0 +1,484 @@
+defmodule MingaAgent.Session.Transcript do
+  @moduledoc """
+  Owns the ordered, identified agent transcript and its branch snapshots.
+
+  Every active message is carried by a `TranscriptEntry`, so message content and
+  identity cannot be reordered independently. Branches freeze those same entry
+  values. The identity high-water mark includes active and branched entries, so
+  truncation and branch switching never permit ID reuse.
+
+  ## Transition contract
+
+  Total transitions return the next transcript directly. Rejectable branch
+  operations return `{:ok, next}` or `{:error, reason}`. All transitions are
+  pure: callers provide timestamps, and this module performs no persistence,
+  timer, broadcast, provider, or tool effects.
+
+  Compaction keeps the requested active entry IDs in their existing order and
+  preserves every branch snapshot and pin relationship unchanged. Retained
+  entries and every branch entry keep their IDs.
+  """
+
+  alias MingaAgent.Branch
+  alias MingaAgent.Message
+  alias MingaAgent.TranscriptEntry
+  alias MingaAgent.ToolCall
+  alias MingaAgent.TurnUsage
+
+  @typedoc "The streaming message kind that may replace the active tail."
+  @type stream_kind :: :assistant | :thinking
+
+  @typedoc "Decoded branch fields accepted by the canonical restore transition."
+  @type restore_branch ::
+          {name :: String.t(), messages :: [Message.t()], message_ids :: [term()],
+           created_at :: DateTime.t()}
+
+  @typedoc "Canonical transcript state owned by one Session process."
+  @type t :: %__MODULE__{
+          entries: [TranscriptEntry.t()],
+          next_id: pos_integer(),
+          branches: [Branch.t()],
+          usage: TurnUsage.t(),
+          pinned_ids: MapSet.t(pos_integer()),
+          revision: non_neg_integer(),
+          last_changed_at: DateTime.t()
+        }
+
+  @enforce_keys [
+    :entries,
+    :next_id,
+    :branches,
+    :usage,
+    :pinned_ids,
+    :revision,
+    :last_changed_at
+  ]
+  defstruct @enforce_keys
+
+  @doc "Creates a live transcript with freshly allocated stable IDs."
+  @spec new([Message.t()], DateTime.t()) :: t()
+  def new(messages, %DateTime{} = changed_at) when is_list(messages) do
+    entries = identified(messages, 1)
+
+    %__MODULE__{
+      entries: entries,
+      next_id: Enum.count(entries) + 1,
+      branches: [],
+      usage: TurnUsage.new(),
+      pinned_ids: MapSet.new(),
+      revision: 0,
+      last_changed_at: changed_at
+    }
+  end
+
+  @doc "Restores active and branched entries through the canonical identity allocator."
+  @spec restore(
+          [Message.t()],
+          term(),
+          [Branch.t() | restore_branch()],
+          TurnUsage.t(),
+          MapSet.t(pos_integer()),
+          DateTime.t()
+        ) :: t()
+  def restore(
+        messages,
+        message_ids,
+        branches,
+        %TurnUsage{} = usage,
+        %MapSet{} = pinned_ids,
+        %DateTime{} = changed_at
+      )
+      when is_list(messages) and is_list(branches) do
+    message_ids = restore_legacy_message_ids(messages, message_ids)
+    branches = restore_legacy_branch_ids(branches)
+
+    {entries, next_id} =
+      normalize_messages(messages, message_ids, highest_candidate_id(message_ids, branches) + 1)
+
+    {branches, next_id} = normalize_branches(branches, next_id)
+
+    %__MODULE__{
+      entries: entries,
+      next_id: next_id,
+      branches: branches,
+      usage: usage,
+      pinned_ids: pinned_ids,
+      revision: 0,
+      last_changed_at: changed_at
+    }
+  end
+
+  @doc "Returns active messages in transcript order."
+  @spec messages(t()) :: [Message.t()]
+  def messages(%__MODULE__{} = transcript), do: Enum.map(transcript.entries, & &1.message)
+
+  @doc "Returns the active tail message, or nil for an empty transcript."
+  @spec last_message(t()) :: Message.t() | nil
+  def last_message(%__MODULE__{} = transcript), do: last_entry_message(transcript.entries)
+
+  @doc "Returns active stable-ID/message pairs in transcript order."
+  @spec messages_with_ids(t()) :: [{pos_integer(), Message.t()}]
+  def messages_with_ids(%__MODULE__{} = transcript) do
+    Enum.map(transcript.entries, &{&1.id, &1.message})
+  end
+
+  @doc "Returns the immutable branch snapshots."
+  @spec branches(t()) :: [Branch.t()]
+  def branches(%__MODULE__{} = transcript), do: transcript.branches
+
+  @doc "Returns cumulative transcript usage."
+  @spec usage(t()) :: TurnUsage.t()
+  def usage(%__MODULE__{} = transcript), do: transcript.usage
+
+  @doc "Returns pinned active entry IDs."
+  @spec pinned_ids(t()) :: MapSet.t(pos_integer())
+  def pinned_ids(%__MODULE__{} = transcript), do: transcript.pinned_ids
+
+  @doc "Returns the transcript mutation revision."
+  @spec revision(t()) :: non_neg_integer()
+  def revision(%__MODULE__{} = transcript), do: transcript.revision
+
+  @doc "Returns the last externally published transcript timestamp."
+  @spec last_changed_at(t()) :: DateTime.t()
+  def last_changed_at(%__MODULE__{} = transcript), do: transcript.last_changed_at
+
+  @doc "Appends one newly identified message."
+  @spec append(t(), Message.t()) :: t()
+  def append(%__MODULE__{} = transcript, message) do
+    entry = TranscriptEntry.new(transcript.next_id, message)
+
+    # Transcript entries stay in publication order and grow at human interaction speed.
+    # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
+    entries = transcript.entries ++ [entry]
+
+    %{
+      transcript
+      | entries: entries,
+        next_id: transcript.next_id + 1,
+        revision: transcript.revision + 1
+    }
+  end
+
+  @doc "Appends a batch of messages and allocates one stable ID per message."
+  @spec append_many(t(), [Message.t()]) :: t()
+  def append_many(%__MODULE__{} = transcript, []), do: transcript
+
+  def append_many(%__MODULE__{} = transcript, messages) when is_list(messages) do
+    entries = identified(messages, transcript.next_id)
+
+    %{
+      transcript
+      | entries: transcript.entries ++ entries,
+        next_id: transcript.next_id + Enum.count(entries),
+        revision: transcript.revision + 1
+    }
+  end
+
+  @doc "Replaces or appends one streaming tail from a whole batch of chunks."
+  @spec append_stream_tail(t(), stream_kind(), iodata()) :: t()
+  def append_stream_tail(%__MODULE__{} = transcript, kind, chunks)
+      when kind in [:assistant, :thinking] do
+    fragment = IO.iodata_to_binary(chunks)
+
+    case replace_stream_tail(transcript.entries, kind, fragment) do
+      {:ok, entries} -> %{transcript | entries: entries, revision: transcript.revision + 1}
+      :append -> append(transcript, stream_message(kind, fragment))
+    end
+  end
+
+  @doc "Transforms every message while preserving entry identity and order."
+  @spec transform_messages(t(), (Message.t() -> Message.t())) :: t()
+  def transform_messages(%__MODULE__{} = transcript, transform) when is_function(transform, 1) do
+    entries = Enum.map(transcript.entries, &TranscriptEntry.replace(&1, transform.(&1.message)))
+    replace_entries_if_changed(transcript, entries)
+  end
+
+  @doc "Transforms one message by active transcript index while preserving its identity."
+  @spec update_at(t(), integer(), (Message.t() -> Message.t())) :: t()
+  def update_at(%__MODULE__{} = transcript, index, transform)
+      when is_integer(index) and is_function(transform, 1) do
+    entries =
+      List.update_at(transcript.entries, index, fn entry ->
+        TranscriptEntry.replace(entry, transform.(entry.message))
+      end)
+
+    replace_entries_if_changed(transcript, entries)
+  end
+
+  @doc "Updates the matching tool-call entry while preserving its stable identity."
+  @spec update_tool_call(t(), String.t(), (ToolCall.t() -> ToolCall.t())) :: t()
+  def update_tool_call(%__MODULE__{} = transcript, tool_call_id, update)
+      when is_binary(tool_call_id) and is_function(update, 1) do
+    transform_messages(transcript, fn
+      {:tool_call, %ToolCall{id: ^tool_call_id} = tool_call} ->
+        {:tool_call, update.(tool_call)}
+
+      other ->
+        other
+    end)
+  end
+
+  @doc "Collapses every expanded thinking entry without changing identity."
+  @spec collapse_thinking(t()) :: t()
+  def collapse_thinking(%__MODULE__{} = transcript) do
+    transform_messages(transcript, fn
+      {:thinking, text, false} -> {:thinking, text, true}
+      other -> other
+    end)
+  end
+
+  @doc "Adds one turn's usage to the transcript aggregate."
+  @spec add_usage(t(), TurnUsage.t()) :: t()
+  def add_usage(%__MODULE__{} = transcript, %TurnUsage{} = usage) do
+    %{
+      transcript
+      | usage: TurnUsage.add(transcript.usage, usage),
+        revision: transcript.revision + 1
+    }
+  end
+
+  @doc "Toggles a pin relationship for one stable transcript ID."
+  @spec toggle_pin(t(), pos_integer()) :: t()
+  def toggle_pin(%__MODULE__{} = transcript, message_id)
+      when is_integer(message_id) and message_id > 0 do
+    pinned_ids = toggle_member(transcript.pinned_ids, message_id)
+    %{transcript | pinned_ids: pinned_ids, revision: transcript.revision + 1}
+  end
+
+  @doc "Creates a frozen branch snapshot and truncates the active transcript."
+  @spec branch_at(t(), integer(), DateTime.t()) ::
+          {:ok, t(), Branch.t()} | {:error, String.t()}
+  def branch_at(%__MODULE__{} = transcript, turn_index, %DateTime{} = created_at)
+      when is_integer(turn_index) and turn_index >= 0 do
+    if turn_index >= Enum.count(transcript.entries) do
+      {:error,
+       "Turn index #{turn_index} is beyond the conversation length (#{Enum.count(transcript.entries)})"}
+    else
+      branch =
+        Branch.new(
+          "branch-#{Enum.count(transcript.branches) + 1}",
+          transcript.entries,
+          created_at
+        )
+
+      entries = Enum.take(transcript.entries, turn_index + 1)
+
+      # Branches are immutable user-created checkpoints and remain in creation order.
+      # credo:disable-for-next-line Credo.Check.Refactor.AppendSingleItem
+      branches = transcript.branches ++ [branch]
+
+      next =
+        %{
+          transcript
+          | entries: entries,
+            branches: branches,
+            revision: transcript.revision + 1
+        }
+
+      {:ok, next, branch}
+    end
+  end
+
+  def branch_at(%__MODULE__{}, turn_index, %DateTime{})
+      when is_integer(turn_index) do
+    {:error, "Turn index #{turn_index} is invalid."}
+  end
+
+  @doc "Switches to a one-based branch snapshot without renumbering its entries."
+  @spec switch_branch(t(), integer()) :: {:ok, t()} | {:error, String.t()}
+  def switch_branch(%__MODULE__{} = transcript, branch_index)
+      when is_integer(branch_index) and branch_index >= 0 do
+    case Enum.at(transcript.branches, branch_index - 1) do
+      nil ->
+        {:error, "Branch #{branch_index} not found. Use /branches to list."}
+
+      %Branch{} = branch ->
+        {:ok,
+         %{
+           transcript
+           | entries: branch.entries,
+             revision: transcript.revision + 1
+         }}
+    end
+  end
+
+  def switch_branch(%__MODULE__{}, branch_index) when is_integer(branch_index) do
+    {:error, "Branch #{branch_index} not found. Use /branches to list."}
+  end
+
+  @doc "Compacts the active transcript to retained stable IDs and preserves branches."
+  @spec compact(t(), [pos_integer()]) :: t()
+  def compact(%__MODULE__{} = transcript, retained_ids) when is_list(retained_ids) do
+    retained = MapSet.new(retained_ids)
+    entries = Enum.filter(transcript.entries, &MapSet.member?(retained, &1.id))
+
+    if entries == transcript.entries do
+      transcript
+    else
+      %{transcript | entries: entries, revision: transcript.revision + 1}
+    end
+  end
+
+  @doc "Resets the active transcript and usage for a new logical session."
+  @spec reset(t(), [Message.t()]) :: t()
+  def reset(%__MODULE__{} = transcript, messages) when is_list(messages) do
+    entries = identified(messages, 1)
+
+    %{
+      transcript
+      | entries: entries,
+        next_id: Enum.count(entries) + 1,
+        branches: [],
+        usage: TurnUsage.new(),
+        pinned_ids: MapSet.new(),
+        revision: transcript.revision + 1
+    }
+  end
+
+  @doc "Records the timestamp at which Session published transcript changes."
+  @spec touch(t(), DateTime.t()) :: t()
+  def touch(%__MODULE__{} = transcript, %DateTime{} = changed_at) do
+    %{transcript | last_changed_at: changed_at}
+  end
+
+  @spec identified([Message.t()], pos_integer()) :: [TranscriptEntry.t()]
+  defp identified(messages, first_id) do
+    messages
+    |> Enum.with_index(first_id)
+    |> Enum.map(fn {message, id} -> TranscriptEntry.new(id, message) end)
+  end
+
+  @spec last_entry_message([TranscriptEntry.t()]) :: Message.t() | nil
+  defp last_entry_message([]), do: nil
+  defp last_entry_message([%TranscriptEntry{message: message}]), do: message
+  defp last_entry_message([_entry | rest]), do: last_entry_message(rest)
+
+  @spec replace_stream_tail([TranscriptEntry.t()], stream_kind(), String.t()) ::
+          {:ok, [TranscriptEntry.t()]} | :append
+  defp replace_stream_tail([], _kind, _fragment), do: :append
+
+  defp replace_stream_tail(
+         [%TranscriptEntry{message: {:assistant, text}} = entry],
+         :assistant,
+         fragment
+       ) do
+    {:ok, [TranscriptEntry.replace(entry, Message.assistant(text <> fragment))]}
+  end
+
+  defp replace_stream_tail(
+         [%TranscriptEntry{message: {:thinking, text, _collapsed}} = entry],
+         :thinking,
+         fragment
+       ) do
+    {:ok, [TranscriptEntry.replace(entry, Message.thinking(text <> fragment))]}
+  end
+
+  defp replace_stream_tail([_entry], _kind, _fragment), do: :append
+
+  defp replace_stream_tail([entry | rest], kind, fragment) do
+    case replace_stream_tail(rest, kind, fragment) do
+      {:ok, updated} -> {:ok, [entry | updated]}
+      :append -> :append
+    end
+  end
+
+  @spec replace_entries_if_changed(t(), [TranscriptEntry.t()]) :: t()
+  defp replace_entries_if_changed(%{entries: entries} = transcript, entries), do: transcript
+
+  defp replace_entries_if_changed(transcript, entries) do
+    %{transcript | entries: entries, revision: transcript.revision + 1}
+  end
+
+  @spec stream_message(stream_kind(), String.t()) :: Message.t()
+  defp stream_message(:assistant, text), do: Message.assistant(text)
+  defp stream_message(:thinking, text), do: Message.thinking(text)
+
+  @spec toggle_member(MapSet.t(pos_integer()), pos_integer()) :: MapSet.t(pos_integer())
+  defp toggle_member(set, id) do
+    if MapSet.member?(set, id), do: MapSet.delete(set, id), else: MapSet.put(set, id)
+  end
+
+  @spec restore_legacy_message_ids([Message.t()], term()) :: [term()]
+  defp restore_legacy_message_ids([], _ids), do: []
+  defp restore_legacy_message_ids(_messages, ids) when is_list(ids) and ids != [], do: ids
+
+  defp restore_legacy_message_ids(messages, _ids) do
+    messages |> Enum.with_index(1) |> Enum.map(&elem(&1, 1))
+  end
+
+  @spec restore_legacy_branch_ids([Branch.t() | restore_branch()]) ::
+          [Branch.t() | restore_branch()]
+  defp restore_legacy_branch_ids(branches) do
+    Enum.map(branches, fn
+      {name, messages, [], created_at} ->
+        ids = messages |> Enum.with_index(1) |> Enum.map(&elem(&1, 1))
+        {name, messages, ids, created_at}
+
+      branch ->
+        branch
+    end)
+  end
+
+  @spec highest_candidate_id([term()], [Branch.t() | restore_branch()]) ::
+          non_neg_integer()
+  defp highest_candidate_id(message_ids, branches) do
+    branch_ids =
+      Enum.flat_map(branches, fn
+        %Branch{} = branch -> Branch.entry_ids(branch)
+        {_name, _messages, ids, _created_at} -> ids
+      end)
+
+    message_ids
+    |> Enum.concat(branch_ids)
+    |> Enum.filter(&(is_integer(&1) and &1 > 0))
+    |> Enum.max(fn -> 0 end)
+  end
+
+  @spec normalize_messages([Message.t()], [term()], pos_integer()) ::
+          {[TranscriptEntry.t()], pos_integer()}
+  defp normalize_messages(messages, ids, next_id) do
+    messages
+    |> Enum.with_index()
+    |> Enum.map_reduce({next_id, MapSet.new()}, fn {message, index}, {next, local_ids} ->
+      {id, next} = normalize_id(Enum.at(ids, index), local_ids, next)
+      {TranscriptEntry.new(id, message), {next, MapSet.put(local_ids, id)}}
+    end)
+    |> then(fn {entries, {next, _local_ids}} -> {entries, next} end)
+  end
+
+  @spec normalize_branches([Branch.t() | restore_branch()], pos_integer()) ::
+          {[Branch.t()], pos_integer()}
+  defp normalize_branches(branches, next_id) do
+    Enum.map_reduce(branches, next_id, fn
+      %Branch{} = branch, next ->
+        normalize_branch(
+          branch.name,
+          Branch.messages(branch),
+          Branch.entry_ids(branch),
+          branch.created_at,
+          next
+        )
+
+      {name, messages, ids, created_at}, next ->
+        normalize_branch(name, messages, ids, created_at, next)
+    end)
+  end
+
+  @spec normalize_branch(String.t(), [Message.t()], [term()], DateTime.t(), pos_integer()) ::
+          {Branch.t(), pos_integer()}
+  defp normalize_branch(name, messages, ids, created_at, next_id) do
+    {entries, next_id} = normalize_messages(messages, ids, next_id)
+    {Branch.new(name, entries, created_at), next_id}
+  end
+
+  @spec normalize_id(term(), MapSet.t(pos_integer()), pos_integer()) ::
+          {pos_integer(), pos_integer()}
+  defp normalize_id(candidate, local_ids, next_id)
+       when is_integer(candidate) and candidate > 0 do
+    if MapSet.member?(local_ids, candidate),
+      do: {next_id, next_id + 1},
+      else: {candidate, next_id}
+  end
+
+  defp normalize_id(_candidate, _local_ids, next_id), do: {next_id, next_id + 1}
+end

--- a/lib/minga_agent/session_store.ex
+++ b/lib/minga_agent/session_store.ex
@@ -13,6 +13,7 @@ defmodule MingaAgent.SessionStore do
   """
 
   alias MingaAgent.ToolApproval.Preview
+  alias MingaAgent.Session.Transcript
 
   @typedoc "Session metadata for the picker (without full message content)."
   @type session_meta :: %{
@@ -338,10 +339,34 @@ defmodule MingaAgent.SessionStore do
 
   @spec deserialize(map()) :: session_data()
   defp deserialize(data) do
-    messages = Enum.map(data["messages"] || [], &deserialize_message/1)
     timestamp = data["timestamp"] || ""
+    transcript = deserialize_transcript(data, timestamp)
+    session = deserialize_session(data, timestamp, transcript)
 
-    session = %{
+    if Map.has_key?(data, "memory"), do: Map.put(session, :memory, data["memory"]), else: session
+  end
+
+  @spec deserialize_transcript(map(), String.t()) :: Transcript.t()
+  defp deserialize_transcript(data, timestamp) do
+    messages = Enum.map(data["messages"] || [], &deserialize_message/1)
+    message_ids = data["message_ids"]
+    branches = Enum.map(data["branches"] || [], &deserialize_branch/1)
+
+    Transcript.restore(
+      messages,
+      message_ids,
+      branches,
+      deserialize_turn_usage(data["usage"] || %{}),
+      deserialize_pinned_ids(data["pinned_ids"]),
+      parse_datetime(timestamp)
+    )
+  end
+
+  @spec deserialize_session(map(), String.t(), Transcript.t()) :: session_data()
+  defp deserialize_session(data, timestamp, transcript) do
+    messages = Transcript.messages(transcript)
+
+    %{
       id: data["id"],
       timestamp: timestamp,
       last_message_at: data["last_message_at"] || timestamp,
@@ -349,18 +374,12 @@ defmodule MingaAgent.SessionStore do
       model_name: data["model_name"] || "unknown",
       provider_name: data["provider_name"] || "unknown",
       messages: messages,
-      message_ids: deserialize_message_ids(data["message_ids"], Enum.count(messages)),
-      pinned_ids: deserialize_pinned_ids(data["pinned_ids"]),
-      usage: deserialize_turn_usage(data["usage"] || %{}),
-      branches: Enum.map(data["branches"] || [], &deserialize_branch/1)
+      message_ids: Enum.map(Transcript.messages_with_ids(transcript), &elem(&1, 0)),
+      pinned_ids: Transcript.pinned_ids(transcript),
+      usage: Transcript.usage(transcript),
+      branches: Transcript.branches(transcript)
     }
-
-    if Map.has_key?(data, "memory"), do: Map.put(session, :memory, data["memory"]), else: session
   end
-
-  @spec deserialize_message_ids(term(), non_neg_integer()) :: [pos_integer()]
-  defp deserialize_message_ids(ids, _msg_count) when is_list(ids) and ids != [], do: ids
-  defp deserialize_message_ids(_, msg_count), do: Enum.to_list(1..max(msg_count, 1))
 
   @spec deserialize_pinned_ids(term()) :: MapSet.t()
   defp deserialize_pinned_ids(ids) when is_list(ids), do: MapSet.new(ids)
@@ -479,18 +498,18 @@ defmodule MingaAgent.SessionStore do
   defp serialize_branch(%MingaAgent.Branch{} = branch) do
     %{
       "name" => branch.name,
-      "messages" => Enum.map(branch.messages, &serialize_message/1),
+      "messages" => branch |> MingaAgent.Branch.messages() |> Enum.map(&serialize_message/1),
+      "message_ids" => MingaAgent.Branch.entry_ids(branch),
       "created_at" => DateTime.to_iso8601(branch.created_at)
     }
   end
 
-  @spec deserialize_branch(map()) :: MingaAgent.Branch.t()
+  @spec deserialize_branch(map()) :: Transcript.restore_branch()
   defp deserialize_branch(data) do
-    %MingaAgent.Branch{
-      name: data["name"] || "branch",
-      messages: Enum.map(data["messages"] || [], &deserialize_message/1),
-      created_at: parse_datetime(data["created_at"])
-    }
+    messages = Enum.map(data["messages"] || [], &deserialize_message/1)
+    ids = if is_list(data["message_ids"]), do: data["message_ids"], else: []
+
+    {data["name"] || "branch", messages, ids, parse_datetime(data["created_at"])}
   end
 
   @spec deserialize_turn_usage(map()) :: MingaAgent.TurnUsage.t()

--- a/lib/minga_agent/transcript_entry.ex
+++ b/lib/minga_agent/transcript_entry.ex
@@ -1,0 +1,29 @@
+defmodule MingaAgent.TranscriptEntry do
+  @moduledoc """
+  Couples one transcript message to its stable identity.
+
+  A message can change while it is streaming or while tool state is updated, but
+  its identity never changes. Keeping both values in this struct makes it
+  impossible to reorder content independently from its ID.
+  """
+
+  alias MingaAgent.Message
+
+  @enforce_keys [:id, :message]
+  defstruct [:id, :message]
+
+  @type t :: %__MODULE__{
+          id: pos_integer(),
+          message: Message.t()
+        }
+
+  @doc "Creates an identified transcript entry."
+  @spec new(pos_integer(), Message.t()) :: t()
+  def new(id, message) when is_integer(id) and id > 0 do
+    %__MODULE__{id: id, message: message}
+  end
+
+  @doc "Replaces an entry's content while preserving its stable identity."
+  @spec replace(t(), Message.t()) :: t()
+  def replace(%__MODULE__{} = entry, message), do: %__MODULE__{entry | message: message}
+end

--- a/test/minga_agent/branch_test.exs
+++ b/test/minga_agent/branch_test.exs
@@ -2,70 +2,44 @@ defmodule MingaAgent.BranchTest do
   use ExUnit.Case, async: true
 
   alias MingaAgent.Branch
+  alias MingaAgent.TranscriptEntry
 
-  defp make_messages(count) do
-    for i <- 1..count do
-      {:user, "message #{i}"}
-    end
+  @created_at ~U[2026-07-17 12:00:00Z]
+
+  test "stores an immutable snapshot of identified entries" do
+    entries = [
+      TranscriptEntry.new(7, {:user, "question"}),
+      TranscriptEntry.new(11, {:assistant, "answer"})
+    ]
+
+    branch = Branch.new("experiment", entries, @created_at)
+
+    assert branch.name == "experiment"
+    assert Branch.messages(branch) == [{:user, "question"}, {:assistant, "answer"}]
+    assert Branch.entry_ids(branch) == [7, 11]
+    assert branch.created_at == @created_at
   end
 
-  describe "new/2" do
-    test "creates a branch with name and messages" do
-      msgs = make_messages(3)
-      branch = Branch.new("test-branch", msgs)
+  test "lists branch names and message counts" do
+    branches = [
+      branch("first", [{1, {:user, "one"}}]),
+      branch("second", [{2, {:user, "two"}}, {3, {:assistant, "three"}}])
+    ]
 
-      assert branch.name == "test-branch"
-      assert Enum.count(branch.messages) == 3
-      assert %DateTime{} = branch.created_at
-    end
+    result = Branch.list(branches)
+
+    assert result =~ "first"
+    assert result =~ "1 messages"
+    assert result =~ "second"
+    assert result =~ "2 messages"
   end
 
-  describe "branch_at/4" do
-    test "saves current messages and truncates" do
-      msgs = make_messages(5)
-
-      {:ok, truncated, branches} = Branch.branch_at(msgs, 2, "b1", [])
-
-      assert Enum.count(truncated) == 3
-      assert Enum.count(branches) == 1
-      assert hd(branches).name == "b1"
-      assert Enum.count(hd(branches).messages) == 5
-    end
-
-    test "returns error for out-of-bounds index" do
-      msgs = make_messages(3)
-      {:error, reason} = Branch.branch_at(msgs, 10, "b1", [])
-      assert reason =~ "beyond"
-    end
-
-    test "appends to existing branches" do
-      msgs = make_messages(5)
-      existing = [Branch.new("b0", make_messages(2))]
-
-      {:ok, _truncated, branches} = Branch.branch_at(msgs, 1, "b1", existing)
-
-      assert Enum.count(branches) == 2
-      assert Enum.at(branches, 0).name == "b0"
-      assert Enum.at(branches, 1).name == "b1"
-    end
+  test "lists help when no branches exist" do
+    assert Branch.list([]) =~ "No branches"
   end
 
-  describe "list/1" do
-    test "shows help when empty" do
-      assert Branch.list([]) =~ "No branches"
-    end
-
-    test "shows branches with counts" do
-      branches = [
-        Branch.new("b1", make_messages(3)),
-        Branch.new("b2", make_messages(5))
-      ]
-
-      result = Branch.list(branches)
-      assert result =~ "b1"
-      assert result =~ "3 messages"
-      assert result =~ "b2"
-      assert result =~ "5 messages"
-    end
+  defp branch(name, pairs) do
+    entries = Enum.map(pairs, fn {id, message} -> TranscriptEntry.new(id, message) end)
+    Branch.new(name, entries, @created_at)
   end
 end

--- a/test/minga_agent/session/persistence_test.exs
+++ b/test/minga_agent/session/persistence_test.exs
@@ -1,0 +1,85 @@
+defmodule MingaAgent.Session.PersistenceTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Session.Persistence
+
+  test "disabled persistence ignores transcript changes" do
+    persistence = Persistence.new(false)
+
+    assert {^persistence, nil} = Persistence.changed(persistence)
+    refute Persistence.dirty?(persistence)
+    refute Persistence.enabled?(persistence)
+  end
+
+  test "change, schedule, due, and success handle one correlated save" do
+    token = make_ref()
+    timer_ref = make_ref()
+
+    {changed, nil} = Persistence.new(true) |> Persistence.changed()
+    scheduled = Persistence.scheduled(changed, token, timer_ref)
+
+    assert Persistence.dirty?(scheduled)
+    assert scheduled.timer == {token, timer_ref}
+    assert :stale = Persistence.save_due(scheduled, make_ref())
+    assert {:save, saving} = Persistence.save_due(scheduled, token)
+    assert saving.timer == nil
+
+    saved = Persistence.saved(saving)
+    refute Persistence.dirty?(saved)
+    assert saved.retry_count == 0
+  end
+
+  test "failed saves remain dirty and use capped retry delays" do
+    {persistence, nil} = Persistence.new(true) |> Persistence.changed()
+
+    {persistence, first_delay} = Persistence.failed(persistence)
+    {persistence, second_delay} = Persistence.failed(persistence)
+    {persistence, third_delay} = Persistence.failed(persistence)
+
+    assert [first_delay, second_delay, third_delay] == [5_000, 10_000, 20_000]
+    assert Persistence.dirty?(persistence)
+    assert persistence.retry_count == 3
+
+    {capped, _persistence} =
+      Enum.map_reduce(1..8, Persistence.new(true), fn _attempt, current ->
+        {next, delay} = Persistence.failed(current)
+        {delay, next}
+      end)
+
+    assert Enum.at(capped, -1) == 60_000
+    assert Enum.max(capped) == 60_000
+  end
+
+  test "a newer change cancels the installed retry timer and resets retry count" do
+    token = make_ref()
+    timer_ref = make_ref()
+
+    persistence = Persistence.new(true)
+    {persistence, nil} = Persistence.changed(persistence)
+    {persistence, _delay} = Persistence.failed(persistence)
+    persistence = Persistence.scheduled(persistence, token, timer_ref)
+
+    assert {changed, {^token, ^timer_ref}} = Persistence.changed(persistence)
+    assert changed.retry_count == 0
+    assert Persistence.dirty?(changed)
+    assert changed.timer == nil
+  end
+
+  test "cancel and restore return timer effects while installing pure bookkeeping" do
+    token = make_ref()
+    timer_ref = make_ref()
+
+    persistence = Persistence.new(true)
+    {persistence, nil} = Persistence.changed(persistence)
+    persistence = Persistence.scheduled(persistence, token, timer_ref)
+
+    assert {canceled, {^token, ^timer_ref}} = Persistence.cancel(persistence)
+    assert canceled.timer == nil
+    assert Persistence.dirty?(canceled)
+
+    rescheduled = Persistence.scheduled(canceled, token, timer_ref)
+    assert {restored, {^token, ^timer_ref}} = Persistence.restored(rescheduled)
+    refute Persistence.dirty?(restored)
+    assert restored.timer == nil
+  end
+end

--- a/test/minga_agent/session/transcript_test.exs
+++ b/test/minga_agent/session/transcript_test.exs
@@ -1,0 +1,278 @@
+defmodule MingaAgent.Session.TranscriptTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias MingaAgent.Branch
+  alias MingaAgent.Session.Transcript
+  alias MingaAgent.TranscriptEntry
+  alias MingaAgent.ToolCall
+  alias MingaAgent.TurnUsage
+
+  @now ~U[2026-07-17 12:00:00Z]
+  @later ~U[2026-07-17 12:01:00Z]
+
+  test "streaming replaces the matching tail without changing its identity" do
+    transcript =
+      Transcript.new([{:system, "started", :info}], @now)
+      |> Transcript.append_stream_tail(:thinking, ["plan"])
+      |> Transcript.append_stream_tail(:thinking, [" more"])
+      |> Transcript.append_stream_tail(:assistant, ["answer"])
+      |> Transcript.append_stream_tail(:assistant, [" continued"])
+
+    assert Transcript.messages_with_ids(transcript) == [
+             {1, {:system, "started", :info}},
+             {2, {:thinking, "plan more", false}},
+             {3, {:assistant, "answer continued"}}
+           ]
+
+    assert Transcript.revision(transcript) == 4
+  end
+
+  test "message transforms preserve identity and advance revisions only when content changes" do
+    tool_call = %ToolCall{id: "tool-1", name: "shell", status: :running, collapsed: true}
+
+    transcript =
+      Transcript.new([{:thinking, "reason", false}, {:tool_call, tool_call}], @now)
+
+    original_ids = entry_ids(transcript)
+    original_revision = Transcript.revision(transcript)
+
+    unchanged = Transcript.update_tool_call(transcript, "missing", & &1)
+    assert unchanged == transcript
+
+    changed =
+      transcript
+      |> Transcript.collapse_thinking()
+      |> Transcript.update_tool_call("tool-1", &ToolCall.set_collapsed(&1, false))
+
+    assert entry_ids(changed) == original_ids
+    assert Transcript.revision(changed) == original_revision + 2
+
+    assert [{:thinking, "reason", true}, {:tool_call, %{collapsed: false}}] =
+             Transcript.messages(changed)
+  end
+
+  test "branching freezes identified entries and switching restores them without ID reuse" do
+    transcript =
+      Transcript.new(
+        [
+          {:system, "started", :info},
+          {:user, "question"},
+          {:assistant, "answer"},
+          {:user, "follow-up"}
+        ],
+        @now
+      )
+      |> Transcript.toggle_pin(4)
+
+    assert {:ok, branched, %Branch{} = branch} = Transcript.branch_at(transcript, 1, @later)
+    assert entry_ids(branched) == [1, 2]
+    assert Branch.entry_ids(branch) == [1, 2, 3, 4]
+    assert Transcript.pinned_ids(branched) == MapSet.new([4])
+
+    compacted = Transcript.compact(branched, [1])
+    assert Branch.entry_ids(hd(Transcript.branches(compacted))) == [1, 2, 3, 4]
+
+    assert {:ok, zero_switched} = Transcript.switch_branch(compacted, 0)
+    assert entry_ids(zero_switched) == [1, 2, 3, 4]
+    assert Transcript.pinned_ids(zero_switched) == MapSet.new([4])
+
+    assert {:ok, switched} = Transcript.switch_branch(compacted, 1)
+    assert entry_ids(switched) == [1, 2, 3, 4]
+    assert Transcript.pinned_ids(switched) == MapSet.new([4])
+
+    appended = Transcript.append(switched, {:assistant, "new path"})
+    assert entry_ids(appended) == [1, 2, 3, 4, 5]
+  end
+
+  test "branch and switch reject invalid indexes without changing the value" do
+    transcript = Transcript.new([{:user, "question"}], @now)
+
+    assert {:error, message} = Transcript.branch_at(transcript, 1, @later)
+    assert message =~ "beyond"
+    assert {:error, "Branch 1 not found" <> _rest} = Transcript.switch_branch(transcript, 1)
+    assert {:error, "Turn index -1 is invalid."} = Transcript.branch_at(transcript, -1, @later)
+    assert {:error, "Branch -1 not found" <> _rest} = Transcript.switch_branch(transcript, -1)
+    assert entry_ids(transcript) == [1]
+  end
+
+  test "compaction preserves retained order, branches, and pin relationships" do
+    transcript = Transcript.new([{:user, "one"}, {:user, "two"}, {:user, "three"}], @now)
+    assert {:ok, transcript, _branch} = Transcript.branch_at(transcript, 2, @later)
+
+    transcript =
+      transcript
+      |> Transcript.toggle_pin(1)
+      |> Transcript.toggle_pin(2)
+      |> Transcript.compact([3, 1])
+
+    assert entry_ids(transcript) == [1, 3]
+    assert Transcript.pinned_ids(transcript) == MapSet.new([1, 2])
+    assert Branch.entry_ids(hd(Transcript.branches(transcript))) == [1, 2, 3]
+  end
+
+  test "restore keeps valid identities and normalizes invalid or duplicate identities once" do
+    transcript =
+      Transcript.restore(
+        [{:user, "one"}, {:assistant, "two"}, {:user, "three"}],
+        [9, 9, -1],
+        [],
+        TurnUsage.new(),
+        MapSet.new([9, 999]),
+        @now
+      )
+
+    assert entry_ids(transcript) == [9, 10, 11]
+    assert Transcript.pinned_ids(transcript) == MapSet.new([9, 999])
+
+    appended = Transcript.append(transcript, {:assistant, "four"})
+    assert entry_ids(appended) == [9, 10, 11, 12]
+  end
+
+  test "restore infers structural identities for legacy active messages" do
+    transcript =
+      Transcript.restore(
+        [{:user, "one"}, {:assistant, "two"}],
+        nil,
+        [],
+        TurnUsage.new(),
+        MapSet.new([2]),
+        @now
+      )
+
+    assert entry_ids(transcript) == [1, 2]
+    assert Transcript.pinned_ids(transcript) == MapSet.new([2])
+  end
+
+  test "restore keeps branch identities in the allocation high-water mark" do
+    branch =
+      Branch.new(
+        "saved",
+        [TranscriptEntry.new(40, {:assistant, "archived"})],
+        @later
+      )
+
+    transcript =
+      Transcript.restore(
+        [{:user, "active"}],
+        [3],
+        [branch],
+        TurnUsage.new(),
+        MapSet.new(),
+        @now
+      )
+
+    appended = Transcript.append(transcript, {:assistant, "new"})
+    assert entry_ids(appended) == [3, 41]
+    assert Branch.entry_ids(hd(Transcript.branches(appended))) == [40]
+  end
+
+  test "reset starts a fresh logical transcript" do
+    usage = %TurnUsage{input: 10, output: 5, cache_read: 1, cache_write: 2, cost: 0.25}
+
+    transcript = Transcript.new([{:user, "old"}, {:assistant, "reply"}], @now)
+    assert {:ok, transcript, _branch} = Transcript.branch_at(transcript, 0, @later)
+
+    reset =
+      transcript
+      |> Transcript.add_usage(usage)
+      |> Transcript.toggle_pin(1)
+      |> Transcript.reset([{:system, "new", :info}])
+
+    assert Transcript.messages_with_ids(reset) == [{1, {:system, "new", :info}}]
+    assert Transcript.branches(reset) == []
+    assert Transcript.pinned_ids(reset) == MapSet.new()
+    assert Transcript.usage(reset) == TurnUsage.new()
+  end
+
+  property "arbitrary transition sequences keep active IDs unique and allocation monotonic" do
+    check all(
+            initial <- list_of(message_generator(), min_length: 1, max_length: 12),
+            operations <- list_of(operation_generator(), max_length: 60)
+          ) do
+      initial
+      |> Transcript.new(@now)
+      |> apply_operations(operations)
+    end
+  end
+
+  defp apply_operations(transcript, operations) do
+    Enum.reduce(operations, transcript, fn operation, current ->
+      next = apply_operation(current, operation)
+      assert_invariants(current, next)
+      next
+    end)
+  end
+
+  defp apply_operation(transcript, {:append, text}) do
+    Transcript.append(transcript, {:user, text})
+  end
+
+  defp apply_operation(transcript, {:stream, text}) do
+    Transcript.append_stream_tail(transcript, :assistant, [text])
+  end
+
+  defp apply_operation(transcript, {:branch, raw_index}) do
+    count = Enum.count(Transcript.messages(transcript))
+
+    case Transcript.branch_at(transcript, rem(raw_index, count + 1), @later) do
+      {:ok, next, _branch} -> next
+      {:error, _reason} -> transcript
+    end
+  end
+
+  defp apply_operation(transcript, {:switch, raw_index}) do
+    count = Enum.count(Transcript.branches(transcript))
+
+    case Transcript.switch_branch(transcript, rem(raw_index, count + 1) + 1) do
+      {:ok, next} -> next
+      {:error, _reason} -> transcript
+    end
+  end
+
+  defp apply_operation(transcript, {:compact, divisor}) do
+    retained_ids =
+      transcript
+      |> entry_ids()
+      |> Enum.filter(&(rem(&1, divisor) != 0))
+
+    Transcript.compact(transcript, retained_ids)
+  end
+
+  defp assert_invariants(previous, transcript) do
+    active_ids = entry_ids(transcript)
+    branch_ids = Enum.flat_map(Transcript.branches(transcript), &Branch.entry_ids/1)
+
+    assert active_ids == Enum.uniq(active_ids)
+    assert Enum.all?(active_ids, &(&1 > 0))
+
+    assert Enum.all?(Transcript.branches(transcript), fn branch ->
+             ids = Branch.entry_ids(branch)
+             ids == Enum.uniq(ids) and Enum.all?(ids, &(&1 > 0))
+           end)
+
+    assert transcript.next_id >= previous.next_id
+    assert transcript.next_id > Enum.max(active_ids ++ branch_ids, fn -> 0 end)
+
+    assert Enum.take(Transcript.branches(transcript), Enum.count(Transcript.branches(previous))) ==
+             Transcript.branches(previous)
+  end
+
+  defp entry_ids(transcript) do
+    Enum.map(Transcript.messages_with_ids(transcript), &elem(&1, 0))
+  end
+
+  defp message_generator do
+    map(string(:alphanumeric, min_length: 1, max_length: 30), &{:user, &1})
+  end
+
+  defp operation_generator do
+    one_of([
+      map(string(:alphanumeric, min_length: 1, max_length: 20), &{:append, &1}),
+      map(string(:alphanumeric, min_length: 1, max_length: 20), &{:stream, &1}),
+      map(non_negative_integer(), &{:branch, &1}),
+      map(non_negative_integer(), &{:switch, &1}),
+      map(integer(2..7), &{:compact, &1})
+    ])
+  end
+end

--- a/test/minga_agent/session_lifecycle_test.exs
+++ b/test/minga_agent/session_lifecycle_test.exs
@@ -266,8 +266,8 @@ defmodule MingaAgent.SessionLifecycleTest do
       send(session, :save_session)
       state = :sys.get_state(session)
 
-      assert state.save_timer != nil
-      assert state.save_retry_count == 1
+      assert state.persistence.timer != nil
+      assert state.persistence.retry_count == 1
       refute_receive {:DOWN, ^ref, :process, ^session, _}, 50
     end
 

--- a/test/minga_agent/session_persistence_test.exs
+++ b/test/minga_agent/session_persistence_test.exs
@@ -1,5 +1,7 @@
 defmodule MingaAgent.SessionPersistenceTest do
   use Minga.Test.SessionCase, async: true
+  alias MingaAgent.Branch
+  alias MingaAgent.TranscriptEntry
 
   describe "session persistence" do
     test "session has a unique ID" do
@@ -84,6 +86,8 @@ defmodule MingaAgent.SessionPersistenceTest do
           model_name: "anthropic:claude-sonnet-4",
           provider_name: "native",
           messages: [{:user, "Restore me"}, {:assistant, "Restored reply"}],
+          message_ids: [7, 13],
+          pinned_ids: MapSet.new([13]),
           usage: %MingaAgent.TurnUsage{
             input: 20,
             output: 10,
@@ -92,7 +96,14 @@ defmodule MingaAgent.SessionPersistenceTest do
             cost: 0.02
           },
           branches: [
-            Branch.new("branch-1", [{:user, "branched prompt"}, {:assistant, "branched reply"}])
+            Branch.new(
+              "branch-1",
+              [
+                TranscriptEntry.new(1, {:user, "branched prompt"}),
+                TranscriptEntry.new(2, {:assistant, "branched reply"})
+              ],
+              ~U[2026-01-01 00:00:00Z]
+            )
           ],
           memory: "- [2026-01-01 00:00 UTC] Prefer direct answers\n"
         },
@@ -103,6 +114,13 @@ defmodule MingaAgent.SessionPersistenceTest do
       assert Session.session_id(session) == "resumable-session"
       assert Session.messages(session) == [{:user, "Restore me"}, {:assistant, "Restored reply"}]
 
+      assert Session.messages_with_ids(session) == [
+               {7, {:user, "Restore me"}},
+               {13, {:assistant, "Restored reply"}}
+             ]
+
+      assert Session.pinned_ids(session) == MapSet.new([13])
+
       meta = Session.metadata(session)
       assert meta.model_name == "anthropic:claude-sonnet-4"
       assert meta.provider_name == "native"
@@ -112,6 +130,13 @@ defmodule MingaAgent.SessionPersistenceTest do
 
       assert {:ok, branches} = Session.list_branches(session)
       assert branches =~ "branch-1"
+      assert :ok = Session.switch_branch(session, 0)
+
+      assert Session.messages(session) == [
+               {:user, "branched prompt"},
+               {:assistant, "branched reply"}
+             ]
+
       assert :ok = Session.switch_branch(session, 1)
 
       assert Session.messages(session) == [

--- a/test/minga_agent/session_store_test.exs
+++ b/test/minga_agent/session_store_test.exs
@@ -3,6 +3,7 @@ defmodule MingaAgent.SessionStoreTest do
 
   alias MingaAgent.Branch
   alias MingaAgent.SessionStore
+  alias MingaAgent.TranscriptEntry
   alias MingaAgent.ToolCall
   alias MingaAgent.TurnUsage
 
@@ -36,8 +37,16 @@ defmodule MingaAgent.SessionStoreTest do
         {:thinking, "Let me think about this...", true},
         {:usage, %TurnUsage{input: 100, output: 50, cache_read: 200, cache_write: 0, cost: 0.003}}
       ],
+      message_ids: [10, 20, 30, 40, 50, 60],
+      pinned_ids: MapSet.new([20, 50]),
       usage: %TurnUsage{input: 100, output: 50, cache_read: 200, cache_write: 0, cost: 0.003},
-      branches: [Branch.new("branch-1", [{:user, "branch prompt"}])],
+      branches: [
+        Branch.new(
+          "branch-1",
+          [TranscriptEntry.new(8, {:user, "branch prompt"})],
+          ~U[2026-01-01 00:00:00Z]
+        )
+      ],
       memory: "- [2026-01-01 00:00 UTC] Use concise answers\n"
     }
   end
@@ -218,8 +227,85 @@ defmodule MingaAgent.SessionStoreTest do
       {:ok, loaded} = SessionStore.load(data.id, dir)
       assert loaded.title == "Hello, how are you?"
       assert loaded.provider_name == "native"
-      assert [%Branch{name: "branch-1", messages: [{:user, "branch prompt"}]}] = loaded.branches
+      assert [%Branch{name: "branch-1"} = branch] = loaded.branches
+      assert Branch.messages(branch) == [{:user, "branch prompt"}]
+      assert Branch.entry_ids(branch) == [8]
+      assert loaded.message_ids == [10, 20, 30, 40, 50, 60]
+      assert loaded.pinned_ids == MapSet.new([20, 50])
       assert loaded.memory =~ "Use concise answers"
+    end
+
+    test "loads legacy branch snapshots that predate structural message IDs", %{tmp_dir: dir} do
+      sessions_dir = SessionStore.sessions_dir(dir)
+      File.mkdir_p!(sessions_dir)
+
+      File.write!(
+        Path.join(sessions_dir, "legacy-branch.json"),
+        JSON.encode!(%{
+          "id" => "legacy-branch",
+          "timestamp" => "2026-01-01T00:00:00Z",
+          "model_name" => "test-model",
+          "messages" => [
+            %{"type" => "user", "text" => "question"},
+            %{"type" => "assistant", "text" => "answer"}
+          ],
+          "message_ids" => [1, 2],
+          "pinned_ids" => [2],
+          "branches" => [
+            %{
+              "name" => "old-shape",
+              "messages" => [
+                %{"type" => "user", "text" => "question"},
+                %{"type" => "assistant", "text" => "answer"}
+              ],
+              "created_at" => "2026-01-01T00:00:00Z"
+            }
+          ],
+          "usage" => %{}
+        })
+      )
+
+      assert {:ok, %{branches: [branch], message_ids: [1, 2], pinned_ids: pinned_ids}} =
+               SessionStore.load("legacy-branch", dir)
+
+      assert Branch.messages(branch) == [{:user, "question"}, {:assistant, "answer"}]
+      assert Branch.entry_ids(branch) == [1, 2]
+      assert pinned_ids == MapSet.new([2])
+    end
+
+    test "normalizes invalid persisted branch identity candidates without raising", %{
+      tmp_dir: dir
+    } do
+      sessions_dir = SessionStore.sessions_dir(dir)
+      File.mkdir_p!(sessions_dir)
+
+      File.write!(
+        Path.join(sessions_dir, "invalid-branch-ids.json"),
+        JSON.encode!(%{
+          "id" => "invalid-branch-ids",
+          "timestamp" => "2026-01-01T00:00:00Z",
+          "model_name" => "test-model",
+          "messages" => [%{"type" => "user", "text" => "active"}],
+          "message_ids" => [10],
+          "branches" => [
+            %{
+              "name" => "invalid-identities",
+              "messages" => [
+                %{"type" => "user", "text" => "one"},
+                %{"type" => "assistant", "text" => "two"},
+                %{"type" => "user", "text" => "three"}
+              ],
+              "message_ids" => [0, "bad", 2],
+              "created_at" => "2026-01-01T00:00:00Z"
+            }
+          ],
+          "usage" => %{}
+        })
+      )
+
+      assert {:ok, %{branches: [branch]}} = SessionStore.load("invalid-branch-ids", dir)
+      assert Branch.entry_ids(branch) == [11, 12, 2]
+      assert Branch.messages(branch) == [{:user, "one"}, {:assistant, "two"}, {:user, "three"}]
     end
 
     test "writes transcript and remote token files with private permissions", %{tmp_dir: dir} do


### PR DESCRIPTION
# TL;DR
Session now owns transcript state through one focused value with structural message identity, immutable branch snapshots, usage, pins, and revision tracking. Persistence retry bookkeeping is also a pure value, while Session remains the sole owner of timers, disk writes, broadcasts, and provider effects.

Closes #2852

## Context
This is part of #2850, which decomposes independently mutable Session state into explicit owned values without adding processes or changing public behavior.

The prior transcript representation kept message content, message IDs, branches, usage, pins, save timers, and retry counters in parallel Session fields. This made multi-field transitions depend on callback convention rather than a single invariant-preserving API.

## Changes
- Add `MingaAgent.Session.Transcript`, backed by structural `MingaAgent.TranscriptEntry` values, as the canonical owner of active entries, immutable branch snapshots, usage, pins, stable ID allocation, revision, and last-change time.
- Route append, batch append, streaming-tail replacement, message transforms, tool-call updates, branching, switching, compaction, restore, and reset through pure transcript transitions.
- Change `MingaAgent.Branch` from a parallel message list to an immutable snapshot of identified transcript entries while preserving its message projection and legacy serialization shape.
- Add `MingaAgent.Session.Persistence` for correlated save tokens, dirty and persisted revisions, retry counts, and capped backoff. Session still creates and cancels timers, writes through `SessionStore`, and logs failures.
- Preserve persisted compatibility for active and branch `message_ids`, including legacy branches without IDs and invalid persisted branch ID candidates that must not crash restore.
- Preserve historical branch-index and pin behavior, including `switch_branch(session, 0)` selecting the last branch and pin relationships surviving branch truncation, compaction, switching, and restore.
- Classify `MingaAgent.TranscriptEntry` as an Agent Level 0 pure value so `MingaAgent.Branch` can depend on it without crossing the enforced dependency boundary.

## Verification
- `make lint`: full Credo clean, compile clean, incremental Dialyzer clean.
- `mix test.llm`: 58 doctests, 98 properties, 9,823 tests, 0 failures, 1 skipped.
- `mix test.debug test/minga_agent/providers/native_test.exs:546 test/minga_editor/agent/concurrent_sessions_test.exs`: 14 passed, including provider streaming and concurrent-session transcript cache behavior.
- Focused transcript, persistence, Session restore, SessionStore, recovery, export, event-log, and branch suites passed.
- Focused bug hunter found three compatibility defects during development. The fixes for zero-index branch switching, pin survival, and invalid persisted branch IDs passed a targeted recheck.
- Final acceptance reviewer: PASS, confidence 0.97, remaining merge risk none.

## Acceptance Criteria Addressed
- Transcript entries carry stable identity structurally. ✅
- Branches, usage, and persistence invariants are represented by focused owned values with no authentication or remote-token ownership. ✅
- Append, replacement, streaming, branch, switch, restore, compact, and persistence success or failure transitions are pure and exhaustive. ✅
- Identity uniqueness, order, branch references, pin relationships, and checkpoint behavior hold through arbitrary operation sequences. ✅
- Public events, snapshots, recovery, compaction, provider behavior, tool behavior, and persisted compatibility remain unchanged. ✅
- Pure transitions, failure sequences, legacy persistence, and arbitrary operation sequences have focused example and property coverage. ✅

## Updated after review
- Simplified synchronous persistence bookkeeping from dirty/persisted revision checkpoints to one dirty flag, retained timer correlation, and an explicit capped retry schedule.
- Simplified persistence loading so `SessionStore` only decodes persisted branch fields and `Transcript.restore/6` solely owns identity normalization and allocation.
- Added a legacy regression proving a full branch snapshot without IDs preserves active IDs and pin relationships.