### PR TITLE
refactor(agent): own touched files and simplify event log

### DIFF
--- a/lib/minga/extension/agent_api.ex
+++ b/lib/minga/extension/agent_api.ex
@@ -20,9 +20,11 @@ defmodule Minga.Extension.AgentAPI do
       Minga.Extension.AgentAPI.subscribe()
       # subscribes calling process to agent lifecycle events
   """
+  alias MingaAgent.EventLog
   alias MingaAgent.Session
 
   @default_manager MingaAgent.SessionManager
+  @default_event_log EventLog
 
   @typedoc "Agent session status."
   @type session_status :: :idle | :plan | :thinking | :tool_executing | :error
@@ -85,40 +87,43 @@ defmodule Minga.Extension.AgentAPI do
   @doc """
   Returns detailed info for a specific session by PID.
 
-  Includes cost, token usage, and turn count in addition to the
-  summary fields. Returns `{:error, :not_found}` if the PID is dead
-  or not a known session.
+  Includes cost, token usage, and turn count in addition to the summary fields.
+  Returns `{:error, :not_found}` if the PID is dead or not a known session, and
+  `{:error, :unavailable}` when the touched-file projection cannot be queried.
   """
-  @spec session_info(pid(), keyword()) :: {:ok, session_info()} | {:error, :not_found}
+  @spec session_info(pid(), keyword()) ::
+          {:ok, session_info()} | {:error, :not_found | :unavailable}
   def session_info(pid, opts \\ []) when is_pid(pid) do
     manager = Keyword.get(opts, :session_manager, @default_manager)
+    event_log = Keyword.get(opts, :event_log, @default_event_log)
 
     case MingaAgent.SessionManager.session_id_for_pid(manager, pid) do
       {:ok, id} ->
-        snapshot = Session.editor_snapshot(pid)
-        usage = Session.usage(pid)
-        metadata = Session.metadata(pid)
+        case EventLog.touched_files(id, event_log) do
+          {:ok, touched_files} ->
+            snapshot = Session.editor_snapshot(pid)
+            usage = Session.usage(pid)
+            metadata = Session.metadata(pid)
 
-        touched =
-          pid
-          |> Session.touched_files()
-          |> Enum.map(& &1.path)
+            {:ok,
+             %{
+               id: id,
+               pid: pid,
+               status: snapshot.status,
+               label: metadata.title || metadata.first_prompt || "agent",
+               model: metadata.model_name,
+               active_tool: snapshot.active_tool_name,
+               created_at: metadata.created_at,
+               cost: usage.cost,
+               input_tokens: usage.input,
+               output_tokens: usage.output,
+               turn_count: metadata.turn_count,
+               files_touched: Enum.map(touched_files, & &1.path)
+             }}
 
-        {:ok,
-         %{
-           id: id,
-           pid: pid,
-           status: snapshot.status,
-           label: metadata.title || metadata.first_prompt || "agent",
-           model: metadata.model_name,
-           active_tool: snapshot.active_tool_name,
-           created_at: metadata.created_at,
-           cost: usage.cost,
-           input_tokens: usage.input,
-           output_tokens: usage.output,
-           turn_count: metadata.turn_count,
-           files_touched: touched
-         }}
+          {:error, :unavailable} ->
+            {:error, :unavailable}
+        end
 
       {:error, :not_found} ->
         {:error, :not_found}

--- a/lib/minga_agent/event_log.ex
+++ b/lib/minga_agent/event_log.ex
@@ -9,8 +9,10 @@ defmodule MingaAgent.EventLog do
 
   use GenServer
 
+  alias MingaAgent.EventLog.Entry
   alias MingaAgent.EventLog.EventRecord
   alias MingaAgent.EventLog.State
+  alias MingaAgent.EventLog.Payload
   alias MingaAgent.EventLog.Store
   alias MingaAgent.EventLog.TouchedFiles
   alias MingaAgent.EventLog.Writer
@@ -19,8 +21,6 @@ defmodule MingaAgent.EventLog do
   @db_filename "agent_events.db"
   @default_max_queue_size 1_000
   @default_max_queue_bytes 8 * 1024 * 1024
-  @max_event_bytes 256 * 1024
-  @max_payload_depth 64
   @default_writer_restart_delay_ms 1_000
   @retention_sweep_interval_ms :timer.hours(1)
   @initial_retention_sweep_delay_ms :timer.seconds(5)
@@ -70,7 +70,7 @@ defmodule MingaAgent.EventLog do
           admission_result()
   def record(session_id, event_type, payload \\ %{}, server \\ __MODULE__)
       when is_binary(session_id) and is_atom(event_type) and is_map(payload) do
-    with {:ok, raw_bytes} <- bounded_raw_payload_size(payload) do
+    with {:ok, raw_bytes} <- Payload.external_size(payload) do
       GenServer.call(
         server,
         {:admit_payload, :critical, session_id, event_type, payload, raw_bytes},
@@ -90,7 +90,7 @@ defmodule MingaAgent.EventLog do
           best_effort_admission_result()
   def record_best_effort(session_id, event_type, payload \\ %{}, server \\ __MODULE__)
       when is_binary(session_id) and is_atom(event_type) and is_map(payload) do
-    with {:ok, raw_bytes} <- bounded_raw_payload_size(payload) do
+    with {:ok, raw_bytes} <- Payload.external_size(payload) do
       GenServer.call(
         server,
         {:admit_payload, :best_effort, session_id, event_type, payload, raw_bytes},
@@ -170,9 +170,7 @@ defmodule MingaAgent.EventLog do
   def handle_call(
         {:admit_payload, _kind, _session_id, _event_type, _payload, _raw_bytes},
         _from,
-        %State{
-          status: :unavailable
-        } = state
+        %State{writer: :unavailable} = state
       ) do
     {:reply, {:error, :unavailable}, state}
   end
@@ -182,38 +180,26 @@ defmodule MingaAgent.EventLog do
         from,
         state
       ) do
-    admit_payload(
-      kind,
-      session_id,
-      event_type,
-      payload,
-      raw_bytes,
-      from,
-      state,
-      State.admission_available?(state, raw_bytes)
-    )
+    admit_payload(kind, session_id, event_type, payload, raw_bytes, from, state)
   end
 
   def handle_call(
         {:admit, _kind, _record, _payload_bytes},
         _from,
-        %State{status: :unavailable} = state
+        %State{writer: :unavailable} = state
       ) do
     {:reply, {:error, :unavailable}, state}
   end
 
   def handle_call({:admit, kind, record, payload_bytes}, from, state) do
-    admit(
-      kind,
-      record,
-      payload_bytes,
-      from,
-      state,
-      State.admission_available?(state, payload_bytes)
-    )
+    admit(kind, record, payload_bytes, from, state)
   end
 
-  def handle_call({:touched_files, session_id}, _from, %State{status: :ready} = state) do
+  def handle_call(
+        {:touched_files, session_id},
+        _from,
+        %State{writer: {:ready, _writer, _ref}} = state
+      ) do
     {:reply, {:ok, State.touched_files(state, session_id)}, state}
   end
 
@@ -225,50 +211,57 @@ defmodule MingaAgent.EventLog do
     await_idle_reply(state, from, idle?(state))
   end
 
-  def handle_call(:restart_writer, _from, %State{status: :unavailable} = state) do
-    new_state = state |> State.clear_writer(:starting) |> start_writer()
-    reply = if new_state.status == :unavailable, do: {:error, :unavailable}, else: :ok
+  def handle_call(:restart_writer, _from, %State{writer: :unavailable} = state) do
+    new_state = state |> State.writer_restarting() |> start_writer()
+    reply = if is_pid(State.writer_pid(new_state)), do: :ok, else: {:error, :unavailable}
     {:reply, reply, new_state}
   end
 
   def handle_call(:restart_writer, _from, state), do: {:reply, :ok, state}
-  def handle_call(:writer_pid, _from, state), do: {:reply, state.writer, state}
+  def handle_call(:writer_pid, _from, state), do: {:reply, State.writer_pid(state), state}
 
   @impl GenServer
   @spec handle_info(term(), State.t()) :: {:noreply, State.t()}
-  def handle_info({:event_log_writer_ready, writer, events}, %{writer: writer} = state) do
+  def handle_info(
+        {:event_log_writer_ready, writer, events},
+        %State{writer: {:opening, writer, _ref}} = state
+      ) do
     {:noreply, complete_writer_start(state, events)}
   end
 
-  def handle_info({:event_log_writer_unavailable, writer, reason}, %{writer: writer} = state) do
+  def handle_info(
+        {:event_log_writer_unavailable, writer, reason},
+        %State{writer: {:opening, writer, _ref}} = state
+      ) do
     {:noreply, mark_writer_unavailable(state, reason)}
   end
 
   def handle_info(
         {:event_log_writer_result, writer, token, event_type, result},
-        %{writer: writer, in_flight: {:event, token, entry}} = state
+        %State{writer: {:ready, writer, _ref}, in_flight: {:event, token, entry}} = state
       ) do
     {:noreply, finish_event(state, entry, event_type, result)}
   end
 
   def handle_info(
         {:event_log_retention_result, writer, token, result},
-        %{writer: writer, in_flight: {:retention, token, cutoff}} = state
+        %State{writer: {:ready, writer, _ref}, in_flight: {:retention, token}} = state
       ) do
-    {:noreply, finish_retention(state, cutoff, result)}
+    {:noreply, finish_retention(state, result)}
   end
 
   def handle_info(
         {:DOWN, ref, :process, writer, reason},
-        %{writer_ref: ref, writer: writer} = state
-      ) do
+        %State{writer: {phase, writer, ref}} = state
+      )
+      when phase in [:opening, :ready] do
     {:noreply, handle_writer_down(state, reason)}
   end
 
   def handle_info({:EXIT, _writer, _reason}, state), do: {:noreply, state}
 
-  def handle_info(:restart_writer, %State{status: :unavailable} = state) do
-    {:noreply, state |> State.clear_writer(:starting) |> start_writer()}
+  def handle_info(:restart_writer, %State{writer: :unavailable} = state) do
+    {:noreply, state |> State.writer_restarting() |> start_writer()}
   end
 
   def handle_info(:restart_writer, state), do: {:noreply, state}
@@ -290,7 +283,7 @@ defmodule MingaAgent.EventLog do
   @spec terminate(term(), State.t()) :: :ok
   def terminate(_reason, state) do
     cancel_timer(state.sweep_ref)
-    stop_writer(state.writer)
+    stop_writer(State.writer_pid(state))
     :ok
   end
 
@@ -327,28 +320,14 @@ defmodule MingaAgent.EventLog do
           map(),
           non_neg_integer(),
           GenServer.from(),
-          State.t(),
-          boolean()
+          State.t()
         ) :: {:reply, admission_result() | best_effort_admission_result(), State.t()}
-  defp admit_payload(
-         _kind,
-         _session_id,
-         _event_type,
-         _payload,
-         _raw_bytes,
-         _from,
-         state,
-         false
-       ),
-       do: {:reply, {:error, :overloaded}, state}
-
-  defp admit_payload(kind, session_id, event_type, payload, _raw_bytes, from, state, true) do
-    with {:ok, sanitized, payload_bytes} <- prepare_payload(payload),
-         true <- State.admission_available?(state, payload_bytes) do
+  defp admit_payload(kind, session_id, event_type, payload, raw_bytes, from, state) do
+    with :ok <- State.ensure_capacity(state, raw_bytes),
+         {:ok, sanitized, payload_bytes} <- Payload.prepare(payload) do
       record = EventRecord.new(session_id, event_type, sanitized)
-      admit(kind, record, payload_bytes, from, state, true)
+      admit(kind, record, payload_bytes, from, state)
     else
-      false -> {:reply, {:error, :overloaded}, state}
       {:error, reason} -> {:reply, {:error, reason}, state}
     end
   end
@@ -358,21 +337,16 @@ defmodule MingaAgent.EventLog do
           EventRecord.t(),
           non_neg_integer(),
           GenServer.from(),
-          State.t(),
-          boolean()
+          State.t()
         ) :: {:reply, admission_result() | best_effort_admission_result(), State.t()}
-  defp admit(_kind, _record, _payload_bytes, _from, state, false),
-    do: {:reply, {:error, :overloaded}, state}
-
-  defp admit(kind, record, payload_bytes, from, state, true) do
-    admit_validated(
-      kind,
-      record,
-      payload_bytes,
-      from,
-      state,
-      TouchedFiles.validate(record)
-    )
+  defp admit(kind, record, payload_bytes, from, state) do
+    with :ok <- State.ensure_capacity(state, payload_bytes),
+         :ok <- TouchedFiles.validate(record) do
+      admit_validated(kind, record, payload_bytes, from, state)
+    else
+      {:error, :overloaded} -> {:reply, {:error, :overloaded}, state}
+      {:error, {:invalid_file_edit, _field}} -> {:reply, {:error, :invalid_payload}, state}
+    end
   end
 
   @spec admit_validated(
@@ -380,62 +354,55 @@ defmodule MingaAgent.EventLog do
           EventRecord.t(),
           non_neg_integer(),
           GenServer.from(),
-          State.t(),
-          :ok | {:error, TouchedFiles.rejection()}
+          State.t()
         ) :: {:reply, admission_result() | best_effort_admission_result(), State.t()}
-  defp admit_validated(_kind, _record, _payload_bytes, _from, state, {:error, _reason}) do
-    {:reply, {:error, :invalid_payload}, state}
-  end
-
-  defp admit_validated(:critical, record, payload_bytes, {caller, _tag}, state, :ok) do
+  defp admit_validated(:critical, record, payload_bytes, {caller, _tag}, state) do
     receipt = make_ref()
-    entry = {:critical, receipt, caller, record.event_type, payload_bytes, record}
+    entry = Entry.critical(record, payload_bytes, receipt, caller)
     state = state |> State.enqueue(entry) |> dispatch_next()
     {:reply, {:queued, receipt}, state}
   end
 
-  defp admit_validated(:best_effort, record, payload_bytes, _from, state, :ok) do
-    entry = {:best_effort, record.event_type, payload_bytes, record}
+  defp admit_validated(:best_effort, record, payload_bytes, _from, state) do
+    entry = Entry.best_effort(record, payload_bytes)
     state = state |> State.enqueue(entry) |> dispatch_next()
     {:reply, :queued, state}
   end
 
   @spec dispatch_next(State.t()) :: State.t()
-  defp dispatch_next(%State{status: :ready, in_flight: nil} = state) do
-    dispatch_queued_entry(State.dequeue(state))
+  defp dispatch_next(%State{writer: {:ready, writer, _ref}, in_flight: nil} = state) do
+    dispatch_queued_entry(State.dequeue(state), writer)
   end
 
   defp dispatch_next(state), do: state
 
-  @spec dispatch_queued_entry({:empty, State.t()} | {:ok, State.entry(), State.t()}) :: State.t()
-  defp dispatch_queued_entry({:empty, state}) do
-    dispatch_retention(state, state.pending_retention)
+  @spec dispatch_queued_entry(
+          {:empty, State.t()} | {:ok, State.entry(), State.t()},
+          pid()
+        ) :: State.t()
+  defp dispatch_queued_entry({:empty, state}, writer) do
+    dispatch_retention(state, state.pending_retention, writer)
   end
 
-  defp dispatch_queued_entry({:ok, entry, state}) do
+  defp dispatch_queued_entry({:ok, entry, state}, writer) do
     token = make_ref()
-    record = entry_record(entry)
-    send(state.writer, {:write_event, token, record})
+    send(writer, {:write_event, token, entry.record})
     State.start_event(state, token, entry)
   end
 
-  @spec dispatch_retention(State.t(), boolean()) :: State.t()
-  defp dispatch_retention(state, false), do: notify_idle_waiters(state)
+  @spec dispatch_retention(State.t(), boolean(), pid()) :: State.t()
+  defp dispatch_retention(state, false, _writer), do: notify_idle_waiters(state)
 
-  defp dispatch_retention(state, true) do
+  defp dispatch_retention(state, true, writer) do
     cutoff = DateTime.add(DateTime.utc_now(), -state.retention_days, :day)
     token = make_ref()
-    send(state.writer, {:delete_before, token, cutoff})
-    State.start_retention(state, token, cutoff)
+    send(writer, {:delete_before, token, cutoff})
+    State.start_retention(state, token)
   end
 
-  @spec entry_record(State.entry()) :: EventRecord.t()
-  defp entry_record({:critical, _receipt, _caller, _event_type, _bytes, record}), do: record
-  defp entry_record({:best_effort, _event_type, _bytes, record}), do: record
-
-  @spec acknowledge_entry(State.entry(), EventRecord.event_type(), term()) :: :ok
+  @spec acknowledge_entry(Entry.t(), EventRecord.event_type(), term()) :: :ok
   defp acknowledge_entry(
-         {:critical, receipt, caller, _type, _bytes, _record},
+         %Entry{delivery: {:critical, receipt, caller}},
          event_type,
          {:ok, id}
        ) do
@@ -444,22 +411,21 @@ defmodule MingaAgent.EventLog do
   end
 
   defp acknowledge_entry(
-         {:critical, receipt, caller, _type, _bytes, _record},
+         %Entry{delivery: {:critical, receipt, caller}},
          event_type,
          {:error, reason}
        ) do
     send_persistence_failure(caller, receipt, event_type, reason)
   end
 
-  defp acknowledge_entry({:best_effort, _type, _bytes, _record}, event_type, {:error, reason}) do
+  defp acknowledge_entry(%Entry{delivery: :best_effort}, event_type, {:error, reason}) do
     Minga.Log.warning(
       :agent,
       "[AgentEventLog] best-effort #{event_type} persistence failed: #{inspect(reason)}"
     )
   end
 
-  defp acknowledge_entry({:best_effort, _type, _bytes, _record}, _event_type, {:ok, _id}),
-    do: :ok
+  defp acknowledge_entry(%Entry{delivery: :best_effort}, _event_type, {:ok, _id}), do: :ok
 
   @spec send_persistence_failure(pid(), receipt(), EventRecord.event_type(), term()) :: :ok
   defp send_persistence_failure(caller, receipt, event_type, reason) do
@@ -479,26 +445,27 @@ defmodule MingaAgent.EventLog do
         state |> State.writer_ready() |> dispatch_next()
 
       {:error, reason} ->
-        stop_writer(state.writer)
+        stop_writer(State.writer_pid(state))
         mark_writer_unavailable(state, {:reconstruction_failed, reason})
     end
   end
 
   @spec mark_writer_unavailable(State.t(), term()) :: State.t()
-  defp mark_writer_unavailable(state, reason) do
+  defp mark_writer_unavailable(%State{writer: {phase, _writer, writer_ref}} = state, reason)
+       when phase in [:opening, :ready] do
     Minga.Log.warning(:agent, "[AgentEventLog] failed to open database: #{inspect(reason)}")
-    Process.demonitor(state.writer_ref, [:flush])
+    Process.demonitor(writer_ref, [:flush])
 
     state
     |> fail_all_events({:writer_start_failed, reason})
-    |> State.clear_writer(:unavailable)
+    |> State.writer_unavailable()
     |> schedule_writer_restart()
     |> notify_idle_waiters()
   end
 
   @spec finish_event(State.t(), State.entry(), EventRecord.event_type(), term()) :: State.t()
   defp finish_event(state, entry, event_type, {:ok, event_id}) do
-    case State.record_persisted(state, entry_record(entry), event_id) do
+    case State.record_persisted(state, entry.record, event_id) do
       {:ok, state} ->
         acknowledge_entry(entry, event_type, {:ok, event_id})
         state |> State.finish_in_flight() |> dispatch_next()
@@ -507,7 +474,7 @@ defmodule MingaAgent.EventLog do
         acknowledge_entry(entry, event_type, {:error, {:projection_failed, reason}})
         Minga.Log.error(:agent, "[AgentEventLog] projection failed: #{inspect(reason)}")
         state = State.finish_in_flight(state)
-        stop_writer(state.writer)
+        stop_writer(State.writer_pid(state))
         mark_writer_unavailable(state, {:projection_failed, reason})
     end
   end
@@ -517,8 +484,8 @@ defmodule MingaAgent.EventLog do
     state |> State.finish_in_flight() |> dispatch_next()
   end
 
-  @spec finish_retention(State.t(), DateTime.t(), term()) :: State.t()
-  defp finish_retention(state, _cutoff, {:ok, deleted_count, events}) do
+  @spec finish_retention(State.t(), term()) :: State.t()
+  defp finish_retention(state, {:ok, deleted_count, events}) do
     log_retention_result({:ok, deleted_count})
 
     case State.rebuild_touched_files(state, events) do
@@ -527,12 +494,12 @@ defmodule MingaAgent.EventLog do
     end
   end
 
-  defp finish_retention(state, _cutoff, {:error, {:delete_failed, reason}}) do
+  defp finish_retention(state, {:error, {:delete_failed, reason}}) do
     log_retention_result({:error, reason})
     complete_retention(state)
   end
 
-  defp finish_retention(state, _cutoff, {:error, {:reload_failed, reason}}) do
+  defp finish_retention(state, {:error, {:reload_failed, reason}}) do
     fail_retention_projection(state, {:reload_failed, reason})
   end
 
@@ -547,7 +514,7 @@ defmodule MingaAgent.EventLog do
   @spec fail_retention_projection(State.t(), term()) :: State.t()
   defp fail_retention_projection(state, reason) do
     Minga.Log.error(:agent, "[AgentEventLog] retention projection failed: #{inspect(reason)}")
-    stop_writer(state.writer)
+    stop_writer(State.writer_pid(state))
 
     state
     |> State.finish_in_flight()
@@ -556,26 +523,24 @@ defmodule MingaAgent.EventLog do
   end
 
   @spec handle_writer_down(State.t(), term()) :: State.t()
-  defp handle_writer_down(%State{status: :ready} = state, reason) do
+  defp handle_writer_down(%State{writer: {:ready, _writer, _ref}} = state, reason) do
     Minga.Log.warning(:agent, "[AgentEventLog] writer terminated: #{inspect(reason)}")
 
     state
     |> State.requeue_in_flight()
-    |> State.clear_writer(:starting)
+    |> State.writer_restarting()
     |> start_writer()
   end
 
-  defp handle_writer_down(%State{status: :starting} = state, reason) do
+  defp handle_writer_down(%State{writer: {:opening, _writer, _ref}} = state, reason) do
     Minga.Log.warning(:agent, "[AgentEventLog] writer failed to start: #{inspect(reason)}")
 
     state
     |> fail_all_events({:writer_start_failed, reason})
-    |> State.clear_writer(:unavailable)
+    |> State.writer_unavailable()
     |> schedule_writer_restart()
     |> notify_idle_waiters()
   end
-
-  defp handle_writer_down(state, _reason), do: State.clear_writer(state, :unavailable)
 
   @spec fail_all_events(State.t(), term()) :: State.t()
   defp fail_all_events(state, reason) do
@@ -590,12 +555,15 @@ defmodule MingaAgent.EventLog do
 
   defp outstanding_entries(state), do: :queue.to_list(state.queue)
 
-  @spec fail_entry(State.entry(), term()) :: :ok
-  defp fail_entry({:critical, receipt, caller, event_type, _bytes, _record}, reason) do
-    send_persistence_failure(caller, receipt, event_type, reason)
+  @spec fail_entry(Entry.t(), term()) :: :ok
+  defp fail_entry(
+         %Entry{delivery: {:critical, receipt, caller}, record: record},
+         reason
+       ) do
+    send_persistence_failure(caller, receipt, record.event_type, reason)
   end
 
-  defp fail_entry({:best_effort, _event_type, _bytes, _record}, _reason), do: :ok
+  defp fail_entry(%Entry{delivery: :best_effort}, _reason), do: :ok
 
   @spec start_writer(State.t()) :: State.t()
   defp start_writer(state) do
@@ -610,7 +578,7 @@ defmodule MingaAgent.EventLog do
 
         state
         |> fail_all_events({:writer_start_failed, reason})
-        |> State.clear_writer(:unavailable)
+        |> State.writer_unavailable()
         |> schedule_writer_restart()
     end
   end
@@ -715,137 +683,5 @@ defmodule MingaAgent.EventLog do
   defp stop_writer(writer) do
     Process.exit(writer, :shutdown)
     :ok
-  end
-
-  @secret_keys MapSet.new(
-                 ~w(api_key apikey token access_token refresh_token secret password credential credentials authorization remote_token)
-               )
-
-  @spec bounded_raw_payload_size(map()) ::
-          {:ok, non_neg_integer()} | {:error, :payload_too_large | :invalid_payload}
-  defp bounded_raw_payload_size(payload) do
-    with {:ok, raw_bytes} <- external_payload_size(payload),
-         :ok <- enforce_event_size(raw_bytes) do
-      {:ok, raw_bytes}
-    else
-      {:error, :payload_too_large} = error -> error
-      {:error, _reason} -> {:error, :invalid_payload}
-    end
-  end
-
-  @spec prepare_payload(map()) ::
-          {:ok, map(), non_neg_integer()} | {:error, :payload_too_large | :invalid_payload}
-  defp prepare_payload(payload) do
-    with {:ok, sanitized} <- sanitize_payload(payload, 0),
-         {:ok, encoded_bytes} <- encoded_payload_size(sanitized),
-         :ok <- enforce_event_size(encoded_bytes) do
-      {:ok, sanitized, encoded_bytes}
-    else
-      {:error, :payload_too_large} = error -> error
-      {:error, _reason} -> {:error, :invalid_payload}
-    end
-  end
-
-  @spec external_payload_size(term()) :: {:ok, non_neg_integer()} | {:error, term()}
-  defp external_payload_size(payload) do
-    {:ok, :erlang.external_size(payload)}
-  rescue
-    _exception -> {:error, :invalid_external_term}
-  end
-
-  @spec encoded_payload_size(map()) :: {:ok, non_neg_integer()} | {:error, term()}
-  defp encoded_payload_size(payload) do
-    {:ok, payload |> JSON.encode!() |> byte_size()}
-  rescue
-    _exception -> {:error, :not_json_encodable}
-  end
-
-  @spec enforce_event_size(non_neg_integer()) :: :ok | {:error, :payload_too_large}
-  defp enforce_event_size(bytes) when bytes <= @max_event_bytes, do: :ok
-  defp enforce_event_size(_bytes), do: {:error, :payload_too_large}
-
-  @spec sanitize_payload(term(), non_neg_integer()) :: {:ok, term()} | {:error, term()}
-  defp sanitize_payload(_payload, depth) when depth > @max_payload_depth,
-    do: {:error, :payload_too_deep}
-
-  defp sanitize_payload(%_{} = struct, depth),
-    do: sanitize_payload(Map.from_struct(struct), depth + 1)
-
-  defp sanitize_payload(map, depth) when is_map(map) do
-    Enum.reduce_while(map, {:ok, %{}}, fn {key, value}, {:ok, sanitized_map} ->
-      with {:ok, string_key} <- sanitize_key(key),
-           {:ok, sanitized} <- sanitize_value(string_key, value, depth) do
-        {:cont, {:ok, Map.put(sanitized_map, string_key, sanitized)}}
-      else
-        {:error, _reason} = error -> {:halt, error}
-      end
-    end)
-  end
-
-  defp sanitize_payload(list, depth) when is_list(list), do: sanitize_list(list, depth, [])
-  defp sanitize_payload(pid, _depth) when is_pid(pid), do: {:ok, "[PID]"}
-  defp sanitize_payload(ref, _depth) when is_reference(ref), do: {:ok, "[REFERENCE]"}
-  defp sanitize_payload(boolean, _depth) when is_boolean(boolean), do: {:ok, boolean}
-  defp sanitize_payload(nil, _depth), do: {:ok, nil}
-  defp sanitize_payload(atom, _depth) when is_atom(atom), do: {:ok, Atom.to_string(atom)}
-
-  defp sanitize_payload(binary, _depth) when is_binary(binary) do
-    if String.valid?(binary), do: {:ok, binary}, else: {:error, :invalid_utf8}
-  end
-
-  defp sanitize_payload(number, _depth) when is_number(number), do: {:ok, number}
-  defp sanitize_payload(_other, _depth), do: {:error, :unsupported_payload_type}
-
-  @spec sanitize_list(term(), non_neg_integer(), [term()]) ::
-          {:ok, [term()]} | {:error, term()}
-  defp sanitize_list([], _depth, acc), do: {:ok, Enum.reverse(acc)}
-
-  defp sanitize_list([value | rest], depth, acc) do
-    case sanitize_payload(value, depth + 1) do
-      {:ok, sanitized} -> sanitize_list(rest, depth, [sanitized | acc])
-      {:error, _reason} = error -> error
-    end
-  end
-
-  defp sanitize_list(_improper_tail, _depth, _acc), do: {:error, :improper_list}
-
-  @spec sanitize_key(term()) :: {:ok, String.t()} | {:error, term()}
-  defp sanitize_key(key) when is_binary(key) do
-    if String.valid?(key), do: {:ok, key}, else: {:error, :invalid_utf8_key}
-  end
-
-  defp sanitize_key(key) when is_atom(key) or is_number(key), do: {:ok, to_string(key)}
-  defp sanitize_key(_key), do: {:error, :unsupported_map_key}
-
-  @spec sanitize_value(String.t(), term(), non_neg_integer()) ::
-          {:ok, term()} | {:error, term()}
-  defp sanitize_value(key, value, depth) do
-    if secret_key?(key) do
-      {:ok, "[REDACTED]"}
-    else
-      sanitize_payload(value, depth + 1)
-    end
-  end
-
-  @spec secret_key?(String.t()) :: boolean()
-  defp secret_key?(key) do
-    normalized = normalize_secret_key(key)
-
-    MapSet.member?(@secret_keys, normalized) or
-      String.ends_with?(normalized, "_token") or
-      String.ends_with?(normalized, "_secret") or
-      String.contains?(normalized, "api_key") or
-      String.contains?(normalized, "password") or
-      String.contains?(normalized, "credential") or
-      String.contains?(normalized, "authorization")
-  end
-
-  @spec normalize_secret_key(String.t()) :: String.t()
-  defp normalize_secret_key(key) do
-    key
-    |> Macro.underscore()
-    |> String.downcase()
-    |> String.replace(~r/[^a-z0-9]+/, "_")
-    |> String.trim("_")
   end
 end

--- a/lib/minga_agent/event_log.ex
+++ b/lib/minga_agent/event_log.ex
@@ -12,6 +12,7 @@ defmodule MingaAgent.EventLog do
   alias MingaAgent.EventLog.EventRecord
   alias MingaAgent.EventLog.State
   alias MingaAgent.EventLog.Store
+  alias MingaAgent.EventLog.TouchedFiles
   alias MingaAgent.EventLog.Writer
 
   @default_db_dir Path.expand("~/.local/share/minga")
@@ -131,6 +132,15 @@ defmodule MingaAgent.EventLog do
   @spec writer_pid(GenServer.server()) :: pid() | nil
   def writer_pid(server \\ __MODULE__), do: GenServer.call(server, :writer_pid)
 
+  @doc "Returns one session's durably admitted file touches, most recent first."
+  @spec touched_files(String.t(), GenServer.server()) ::
+          {:ok, [TouchedFiles.touch()]} | {:error, :unavailable}
+  def touched_files(session_id, server \\ __MODULE__) when is_binary(session_id) do
+    GenServer.call(server, {:touched_files, session_id})
+  catch
+    :exit, _reason -> {:error, :unavailable}
+  end
+
   @doc "Queries events for a session after the given cursor."
   @spec events_after(Store.db(), String.t(), non_neg_integer(), pos_integer()) ::
           {:ok, [EventRecord.t()]} | {:error, term()}
@@ -203,6 +213,14 @@ defmodule MingaAgent.EventLog do
     )
   end
 
+  def handle_call({:touched_files, session_id}, _from, %State{status: :ready} = state) do
+    {:reply, {:ok, State.touched_files(state, session_id)}, state}
+  end
+
+  def handle_call({:touched_files, _session_id}, _from, state) do
+    {:reply, {:error, :unavailable}, state}
+  end
+
   def handle_call(:await_idle, from, state) do
     await_idle_reply(state, from, idle?(state))
   end
@@ -218,44 +236,26 @@ defmodule MingaAgent.EventLog do
 
   @impl GenServer
   @spec handle_info(term(), State.t()) :: {:noreply, State.t()}
-  def handle_info({:event_log_writer_ready, writer}, %{writer: writer} = state) do
-    Minga.Log.info(:agent, "[AgentEventLog] started, logging to #{state.path}")
-    {:noreply, state |> State.writer_ready() |> dispatch_next()}
+  def handle_info({:event_log_writer_ready, writer, events}, %{writer: writer} = state) do
+    {:noreply, complete_writer_start(state, events)}
   end
 
   def handle_info({:event_log_writer_unavailable, writer, reason}, %{writer: writer} = state) do
-    Minga.Log.warning(:agent, "[AgentEventLog] failed to open database: #{inspect(reason)}")
-    Process.demonitor(state.writer_ref, [:flush])
-
-    state =
-      state
-      |> fail_all_events({:writer_start_failed, reason})
-      |> State.clear_writer(:unavailable)
-      |> schedule_writer_restart()
-      |> notify_idle_waiters()
-
-    {:noreply, state}
+    {:noreply, mark_writer_unavailable(state, reason)}
   end
 
   def handle_info(
         {:event_log_writer_result, writer, token, event_type, result},
         %{writer: writer, in_flight: {:event, token, entry}} = state
       ) do
-    acknowledge_entry(entry, event_type, result)
-    {:noreply, state |> State.finish_in_flight() |> dispatch_next()}
+    {:noreply, finish_event(state, entry, event_type, result)}
   end
 
   def handle_info(
         {:event_log_retention_result, writer, token, result},
-        %{writer: writer, in_flight: {:retention, token, _cutoff}} = state
+        %{writer: writer, in_flight: {:retention, token, cutoff}} = state
       ) do
-    log_retention_result(result)
-
-    {:noreply,
-     state
-     |> State.finish_in_flight()
-     |> State.schedule_sweep(schedule_retention_sweep())
-     |> dispatch_next()}
+    {:noreply, finish_retention(state, cutoff, result)}
   end
 
   def handle_info(
@@ -364,14 +364,37 @@ defmodule MingaAgent.EventLog do
   defp admit(_kind, _record, _payload_bytes, _from, state, false),
     do: {:reply, {:error, :overloaded}, state}
 
-  defp admit(:critical, record, payload_bytes, {caller, _tag}, state, true) do
+  defp admit(kind, record, payload_bytes, from, state, true) do
+    admit_validated(
+      kind,
+      record,
+      payload_bytes,
+      from,
+      state,
+      TouchedFiles.validate(record)
+    )
+  end
+
+  @spec admit_validated(
+          :critical | :best_effort,
+          EventRecord.t(),
+          non_neg_integer(),
+          GenServer.from(),
+          State.t(),
+          :ok | {:error, TouchedFiles.rejection()}
+        ) :: {:reply, admission_result() | best_effort_admission_result(), State.t()}
+  defp admit_validated(_kind, _record, _payload_bytes, _from, state, {:error, _reason}) do
+    {:reply, {:error, :invalid_payload}, state}
+  end
+
+  defp admit_validated(:critical, record, payload_bytes, {caller, _tag}, state, :ok) do
     receipt = make_ref()
     entry = {:critical, receipt, caller, record.event_type, payload_bytes, record}
     state = state |> State.enqueue(entry) |> dispatch_next()
     {:reply, {:queued, receipt}, state}
   end
 
-  defp admit(:best_effort, record, payload_bytes, _from, state, true) do
+  defp admit_validated(:best_effort, record, payload_bytes, _from, state, :ok) do
     entry = {:best_effort, record.event_type, payload_bytes, record}
     state = state |> State.enqueue(entry) |> dispatch_next()
     {:reply, :queued, state}
@@ -446,6 +469,90 @@ defmodule MingaAgent.EventLog do
     )
 
     :ok
+  end
+
+  @spec complete_writer_start(State.t(), [EventRecord.t()]) :: State.t()
+  defp complete_writer_start(state, events) do
+    case State.rebuild_touched_files(state, events) do
+      {:ok, state} ->
+        Minga.Log.info(:agent, "[AgentEventLog] started, logging to #{state.path}")
+        state |> State.writer_ready() |> dispatch_next()
+
+      {:error, reason} ->
+        stop_writer(state.writer)
+        mark_writer_unavailable(state, {:reconstruction_failed, reason})
+    end
+  end
+
+  @spec mark_writer_unavailable(State.t(), term()) :: State.t()
+  defp mark_writer_unavailable(state, reason) do
+    Minga.Log.warning(:agent, "[AgentEventLog] failed to open database: #{inspect(reason)}")
+    Process.demonitor(state.writer_ref, [:flush])
+
+    state
+    |> fail_all_events({:writer_start_failed, reason})
+    |> State.clear_writer(:unavailable)
+    |> schedule_writer_restart()
+    |> notify_idle_waiters()
+  end
+
+  @spec finish_event(State.t(), State.entry(), EventRecord.event_type(), term()) :: State.t()
+  defp finish_event(state, entry, event_type, {:ok, event_id}) do
+    case State.record_persisted(state, entry_record(entry), event_id) do
+      {:ok, state} ->
+        acknowledge_entry(entry, event_type, {:ok, event_id})
+        state |> State.finish_in_flight() |> dispatch_next()
+
+      {:error, reason} ->
+        acknowledge_entry(entry, event_type, {:error, {:projection_failed, reason}})
+        Minga.Log.error(:agent, "[AgentEventLog] projection failed: #{inspect(reason)}")
+        state = State.finish_in_flight(state)
+        stop_writer(state.writer)
+        mark_writer_unavailable(state, {:projection_failed, reason})
+    end
+  end
+
+  defp finish_event(state, entry, event_type, {:error, _reason} = result) do
+    acknowledge_entry(entry, event_type, result)
+    state |> State.finish_in_flight() |> dispatch_next()
+  end
+
+  @spec finish_retention(State.t(), DateTime.t(), term()) :: State.t()
+  defp finish_retention(state, _cutoff, {:ok, deleted_count, events}) do
+    log_retention_result({:ok, deleted_count})
+
+    case State.rebuild_touched_files(state, events) do
+      {:ok, state} -> complete_retention(state)
+      {:error, reason} -> fail_retention_projection(state, {:rebuild_failed, reason})
+    end
+  end
+
+  defp finish_retention(state, _cutoff, {:error, {:delete_failed, reason}}) do
+    log_retention_result({:error, reason})
+    complete_retention(state)
+  end
+
+  defp finish_retention(state, _cutoff, {:error, {:reload_failed, reason}}) do
+    fail_retention_projection(state, {:reload_failed, reason})
+  end
+
+  @spec complete_retention(State.t()) :: State.t()
+  defp complete_retention(state) do
+    state
+    |> State.finish_in_flight()
+    |> State.schedule_sweep(schedule_retention_sweep())
+    |> dispatch_next()
+  end
+
+  @spec fail_retention_projection(State.t(), term()) :: State.t()
+  defp fail_retention_projection(state, reason) do
+    Minga.Log.error(:agent, "[AgentEventLog] retention projection failed: #{inspect(reason)}")
+    stop_writer(state.writer)
+
+    state
+    |> State.finish_in_flight()
+    |> mark_writer_unavailable({:retention_projection_failed, reason})
+    |> State.schedule_sweep(schedule_retention_sweep())
   end
 
   @spec handle_writer_down(State.t(), term()) :: State.t()

--- a/lib/minga_agent/event_log/entry.ex
+++ b/lib/minga_agent/event_log/entry.ex
@@ -1,0 +1,39 @@
+defmodule MingaAgent.EventLog.Entry do
+  @moduledoc """
+  One admitted EventLog item and its delivery contract.
+
+  Critical entries carry the receipt and caller that receive the later durability result. Best-effort entries share ordering and backpressure without requesting an acknowledgment.
+  """
+
+  alias MingaAgent.EventLog.EventRecord
+
+  @type delivery :: :best_effort | {:critical, receipt :: reference(), caller :: pid()}
+
+  @enforce_keys [:delivery, :payload_bytes, :record]
+  defstruct [:delivery, :payload_bytes, :record]
+
+  @type t :: %__MODULE__{
+          delivery: delivery(),
+          payload_bytes: non_neg_integer(),
+          record: EventRecord.t()
+        }
+
+  @doc "Builds a durability-critical queue entry."
+  @spec critical(EventRecord.t(), non_neg_integer(), reference(), pid()) :: t()
+  def critical(%EventRecord{} = record, payload_bytes, receipt, caller)
+      when is_integer(payload_bytes) and payload_bytes >= 0 and is_reference(receipt) and
+             is_pid(caller) do
+    %__MODULE__{
+      delivery: {:critical, receipt, caller},
+      payload_bytes: payload_bytes,
+      record: record
+    }
+  end
+
+  @doc "Builds a best-effort queue entry."
+  @spec best_effort(EventRecord.t(), non_neg_integer()) :: t()
+  def best_effort(%EventRecord{} = record, payload_bytes)
+      when is_integer(payload_bytes) and payload_bytes >= 0 do
+    %__MODULE__{delivery: :best_effort, payload_bytes: payload_bytes, record: record}
+  end
+end

--- a/lib/minga_agent/event_log/payload.ex
+++ b/lib/minga_agent/event_log/payload.ex
@@ -1,0 +1,135 @@
+defmodule MingaAgent.EventLog.Payload do
+  @moduledoc """
+  Normalizes event payloads and enforces their serialized size boundary.
+
+  External-term sizing protects admission before a payload enters the EventLog mailbox. Preparation sanitizes the payload and measures the JSON bytes charged to bounded outstanding work.
+  """
+
+  @max_event_bytes 256 * 1024
+  @max_depth 64
+  @secret_keys MapSet.new(
+                 ~w(api_key apikey token access_token refresh_token secret password credential credentials authorization remote_token)
+               )
+
+  @type error :: :payload_too_large | :invalid_payload
+
+  @doc "Returns the bounded external-term size used for pre-mailbox admission."
+  @spec external_size(map()) :: {:ok, non_neg_integer()} | {:error, error()}
+  def external_size(payload) when is_map(payload) do
+    with {:ok, bytes} <- measure_external(payload),
+         :ok <- enforce_size(bytes) do
+      {:ok, bytes}
+    else
+      {:error, :payload_too_large} = error -> error
+      {:error, _reason} -> {:error, :invalid_payload}
+    end
+  end
+
+  @doc "Sanitizes a payload and returns the exact JSON byte size charged to admission."
+  @spec prepare(map()) :: {:ok, map(), non_neg_integer()} | {:error, error()}
+  def prepare(payload) when is_map(payload) do
+    with {:ok, sanitized} <- sanitize(payload, 0),
+         {:ok, bytes} <- measure_encoded(sanitized),
+         :ok <- enforce_size(bytes) do
+      {:ok, sanitized, bytes}
+    else
+      {:error, :payload_too_large} = error -> error
+      {:error, _reason} -> {:error, :invalid_payload}
+    end
+  end
+
+  @spec measure_external(term()) :: {:ok, non_neg_integer()} | {:error, term()}
+  defp measure_external(payload) do
+    {:ok, :erlang.external_size(payload)}
+  rescue
+    _exception -> {:error, :invalid_external_term}
+  end
+
+  @spec measure_encoded(map()) :: {:ok, non_neg_integer()} | {:error, term()}
+  defp measure_encoded(payload) do
+    {:ok, payload |> JSON.encode!() |> byte_size()}
+  rescue
+    _exception -> {:error, :not_json_encodable}
+  end
+
+  @spec enforce_size(non_neg_integer()) :: :ok | {:error, :payload_too_large}
+  defp enforce_size(bytes) when bytes <= @max_event_bytes, do: :ok
+  defp enforce_size(_bytes), do: {:error, :payload_too_large}
+
+  @spec sanitize(term(), non_neg_integer()) :: {:ok, term()} | {:error, term()}
+  defp sanitize(_payload, depth) when depth > @max_depth, do: {:error, :payload_too_deep}
+  defp sanitize(%_{} = struct, depth), do: sanitize(Map.from_struct(struct), depth + 1)
+
+  defp sanitize(map, depth) when is_map(map) do
+    Enum.reduce_while(map, {:ok, %{}}, fn {key, value}, {:ok, sanitized_map} ->
+      with {:ok, string_key} <- sanitize_key(key),
+           {:ok, sanitized} <- sanitize_value(string_key, value, depth) do
+        {:cont, {:ok, Map.put(sanitized_map, string_key, sanitized)}}
+      else
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  defp sanitize(list, depth) when is_list(list), do: sanitize_list(list, depth, [])
+  defp sanitize(pid, _depth) when is_pid(pid), do: {:ok, "[PID]"}
+  defp sanitize(ref, _depth) when is_reference(ref), do: {:ok, "[REFERENCE]"}
+  defp sanitize(boolean, _depth) when is_boolean(boolean), do: {:ok, boolean}
+  defp sanitize(nil, _depth), do: {:ok, nil}
+  defp sanitize(atom, _depth) when is_atom(atom), do: {:ok, Atom.to_string(atom)}
+
+  defp sanitize(binary, _depth) when is_binary(binary) do
+    if String.valid?(binary), do: {:ok, binary}, else: {:error, :invalid_utf8}
+  end
+
+  defp sanitize(number, _depth) when is_number(number), do: {:ok, number}
+  defp sanitize(_other, _depth), do: {:error, :unsupported_payload_type}
+
+  @spec sanitize_list(term(), non_neg_integer(), [term()]) ::
+          {:ok, [term()]} | {:error, term()}
+  defp sanitize_list([], _depth, acc), do: {:ok, Enum.reverse(acc)}
+
+  defp sanitize_list([value | rest], depth, acc) do
+    case sanitize(value, depth + 1) do
+      {:ok, sanitized} -> sanitize_list(rest, depth, [sanitized | acc])
+      {:error, _reason} = error -> error
+    end
+  end
+
+  defp sanitize_list(_improper_tail, _depth, _acc), do: {:error, :improper_list}
+
+  @spec sanitize_key(term()) :: {:ok, String.t()} | {:error, term()}
+  defp sanitize_key(key) when is_binary(key) do
+    if String.valid?(key), do: {:ok, key}, else: {:error, :invalid_utf8_key}
+  end
+
+  defp sanitize_key(key) when is_atom(key) or is_number(key), do: {:ok, to_string(key)}
+  defp sanitize_key(_key), do: {:error, :unsupported_map_key}
+
+  @spec sanitize_value(String.t(), term(), non_neg_integer()) :: {:ok, term()} | {:error, term()}
+  defp sanitize_value(key, value, depth) do
+    if secret_key?(key), do: {:ok, "[REDACTED]"}, else: sanitize(value, depth + 1)
+  end
+
+  @spec secret_key?(String.t()) :: boolean()
+  defp secret_key?(key) do
+    normalized = normalize_secret_key(key)
+
+    MapSet.member?(@secret_keys, normalized) or
+      String.ends_with?(normalized, "_token") or
+      String.ends_with?(normalized, "_secret") or
+      String.contains?(normalized, "api_key") or
+      String.contains?(normalized, "password") or
+      String.contains?(normalized, "credential") or
+      String.contains?(normalized, "authorization")
+  end
+
+  @spec normalize_secret_key(String.t()) :: String.t()
+  defp normalize_secret_key(key) do
+    key
+    |> Macro.underscore()
+    |> String.downcase()
+    |> String.replace(~r/[^a-z0-9]+/, "_")
+    |> String.trim("_")
+  end
+end

--- a/lib/minga_agent/event_log/state.ex
+++ b/lib/minga_agent/event_log/state.ex
@@ -1,20 +1,18 @@
 defmodule MingaAgent.EventLog.State do
   @moduledoc "Owned runtime state and transitions for `MingaAgent.EventLog`."
 
+  alias MingaAgent.EventLog.Entry
   alias MingaAgent.EventLog.EventRecord
   alias MingaAgent.EventLog.Limits
   alias MingaAgent.EventLog.TouchedFiles
 
-  @type receipt :: reference()
-  @type critical_entry ::
-          {:critical, receipt(), pid(), EventRecord.event_type(), non_neg_integer(),
-           EventRecord.t()}
-  @type best_effort_entry ::
-          {:best_effort, EventRecord.event_type(), non_neg_integer(), EventRecord.t()}
-  @type entry :: critical_entry() | best_effort_entry()
-  @type in_flight ::
-          {:event, reference(), entry()}
-          | {:retention, reference(), DateTime.t()}
+  @type entry :: Entry.t()
+  @type writer_lifecycle ::
+          :starting
+          | :unavailable
+          | {:opening, pid(), reference()}
+          | {:ready, pid(), reference()}
+  @type in_flight :: {:event, reference(), entry()} | {:retention, reference()}
 
   @enforce_keys [
     :path,
@@ -31,9 +29,7 @@ defmodule MingaAgent.EventLog.State do
             writer_opts: [],
             restart_delay_ms: nil,
             queue: :queue.new(),
-            writer: nil,
-            writer_ref: nil,
-            status: :starting,
+            writer: :starting,
             in_flight: nil,
             pending_retention: false,
             sweep_ref: nil,
@@ -48,9 +44,7 @@ defmodule MingaAgent.EventLog.State do
           writer_opts: keyword(),
           restart_delay_ms: non_neg_integer(),
           queue: term(),
-          writer: pid() | nil,
-          writer_ref: reference() | nil,
-          status: :starting | :ready | :unavailable,
+          writer: writer_lifecycle(),
           in_flight: in_flight() | nil,
           pending_retention: boolean(),
           sweep_ref: reference() | nil,
@@ -113,25 +107,39 @@ defmodule MingaAgent.EventLog.State do
   @spec touched_files(t(), String.t()) :: [TouchedFiles.touch()]
   def touched_files(state, session_id), do: TouchedFiles.list(state.touched_files, session_id)
 
-  @doc "Marks a writer process as starting."
+  @doc "Stores an opening writer and its monitor as one lifecycle value."
   @spec writer_started(t(), pid(), reference()) :: t()
   def writer_started(state, writer, writer_ref) do
-    %{state | writer: writer, writer_ref: writer_ref, status: :starting}
+    %{state | writer: {:opening, writer, writer_ref}}
   end
 
-  @doc "Marks the current writer as ready."
+  @doc "Marks the opening writer as ready."
   @spec writer_ready(t()) :: t()
-  def writer_ready(state), do: %{state | status: :ready}
-
-  @doc "Clears writer identity and sets its availability state."
-  @spec clear_writer(t(), :starting | :unavailable) :: t()
-  def clear_writer(state, status) do
-    %{state | writer: nil, writer_ref: nil, status: status}
+  def writer_ready(%__MODULE__{writer: {:opening, writer, writer_ref}} = state) do
+    %{state | writer: {:ready, writer, writer_ref}}
   end
 
-  @doc "Returns whether one event of the given serialized size fits the outstanding-work bounds."
-  @spec admission_available?(t(), non_neg_integer()) :: boolean()
-  def admission_available?(state, bytes), do: Limits.available?(state.limits, bytes)
+  @doc "Transitions writer lifecycle into a fresh start attempt."
+  @spec writer_restarting(t()) :: t()
+  def writer_restarting(state), do: %{state | writer: :starting}
+
+  @doc "Transitions writer lifecycle into explicit unavailability."
+  @spec writer_unavailable(t()) :: t()
+  def writer_unavailable(state), do: %{state | writer: :unavailable}
+
+  @doc "Returns the writer process when opening or ready."
+  @spec writer_pid(t()) :: pid() | nil
+  def writer_pid(%__MODULE__{writer: {phase, writer, _ref}})
+      when phase in [:opening, :ready],
+      do: writer
+
+  def writer_pid(%__MODULE__{}), do: nil
+
+  @doc "Reports whether one serialized event fits the outstanding-work bounds."
+  @spec ensure_capacity(t(), non_neg_integer()) :: :ok | {:error, :overloaded}
+  def ensure_capacity(state, bytes) do
+    if Limits.available?(state.limits, bytes), do: :ok, else: {:error, :overloaded}
+  end
 
   @doc "Enqueues an admitted event at the back of the ordered queue."
   @spec enqueue(t(), entry()) :: t()
@@ -159,9 +167,9 @@ defmodule MingaAgent.EventLog.State do
   end
 
   @doc "Marks a retention sweep as the writer's single in-flight operation."
-  @spec start_retention(t(), reference(), DateTime.t()) :: t()
-  def start_retention(state, token, cutoff) do
-    %{state | pending_retention: false, in_flight: {:retention, token, cutoff}}
+  @spec start_retention(t(), reference()) :: t()
+  def start_retention(state, token) do
+    %{state | pending_retention: false, in_flight: {:retention, token}}
   end
 
   @doc "Clears the completed in-flight operation and releases completed event bytes."
@@ -178,7 +186,7 @@ defmodule MingaAgent.EventLog.State do
     %{state | queue: :queue.in_r(entry, state.queue), in_flight: nil}
   end
 
-  def requeue_in_flight(%__MODULE__{in_flight: {:retention, _token, _cutoff}} = state) do
+  def requeue_in_flight(%__MODULE__{in_flight: {:retention, _token}} = state) do
     %{state | in_flight: nil, pending_retention: true}
   end
 
@@ -188,7 +196,7 @@ defmodule MingaAgent.EventLog.State do
   @spec clear_event_work(t()) :: t()
   def clear_event_work(state) do
     pending_retention =
-      state.pending_retention or match?({:retention, _token, _cutoff}, state.in_flight)
+      state.pending_retention or match?({:retention, _token}, state.in_flight)
 
     %{
       state
@@ -216,6 +224,5 @@ defmodule MingaAgent.EventLog.State do
   def clear_idle_waiters(state), do: %{state | idle_waiters: []}
 
   @spec entry_bytes(entry()) :: non_neg_integer()
-  defp entry_bytes({:critical, _receipt, _caller, _event_type, bytes, _record}), do: bytes
-  defp entry_bytes({:best_effort, _event_type, bytes, _record}), do: bytes
+  defp entry_bytes(%Entry{payload_bytes: bytes}), do: bytes
 end

--- a/lib/minga_agent/event_log/state.ex
+++ b/lib/minga_agent/event_log/state.ex
@@ -3,6 +3,7 @@ defmodule MingaAgent.EventLog.State do
 
   alias MingaAgent.EventLog.EventRecord
   alias MingaAgent.EventLog.Limits
+  alias MingaAgent.EventLog.TouchedFiles
 
   @type receipt :: reference()
   @type critical_entry ::
@@ -36,7 +37,8 @@ defmodule MingaAgent.EventLog.State do
             in_flight: nil,
             pending_retention: false,
             sweep_ref: nil,
-            idle_waiters: []
+            idle_waiters: [],
+            touched_files: %TouchedFiles{}
 
   @type t :: %__MODULE__{
           path: String.t(),
@@ -52,7 +54,8 @@ defmodule MingaAgent.EventLog.State do
           in_flight: in_flight() | nil,
           pending_retention: boolean(),
           sweep_ref: reference() | nil,
-          idle_waiters: [GenServer.from()]
+          idle_waiters: [GenServer.from()],
+          touched_files: TouchedFiles.t()
         }
 
   @doc "Builds initial EventLog state from validated values."
@@ -87,6 +90,28 @@ defmodule MingaAgent.EventLog.State do
       restart_delay_ms: restart_delay_ms
     }
   end
+
+  @doc "Rebuilds the canonical touched-file projection from persisted events."
+  @spec rebuild_touched_files(t(), [EventRecord.t()]) ::
+          {:ok, t()} | {:error, TouchedFiles.rejection()}
+  def rebuild_touched_files(state, events) do
+    with {:ok, touched_files} <- TouchedFiles.rebuild(events) do
+      {:ok, %{state | touched_files: touched_files}}
+    end
+  end
+
+  @doc "Projects one event after its durable insert succeeds."
+  @spec record_persisted(t(), EventRecord.t(), pos_integer()) ::
+          {:ok, t()} | {:error, TouchedFiles.rejection()}
+  def record_persisted(state, event, event_id) do
+    with {:ok, touched_files} <- TouchedFiles.record(state.touched_files, event, event_id) do
+      {:ok, %{state | touched_files: touched_files}}
+    end
+  end
+
+  @doc "Returns one session's touched files in most-recent-first order."
+  @spec touched_files(t(), String.t()) :: [TouchedFiles.touch()]
+  def touched_files(state, session_id), do: TouchedFiles.list(state.touched_files, session_id)
 
   @doc "Marks a writer process as starting."
   @spec writer_started(t(), pid(), reference()) :: t()

--- a/lib/minga_agent/event_log/store.ex
+++ b/lib/minga_agent/event_log/store.ex
@@ -76,6 +76,20 @@ defmodule MingaAgent.EventLog.Store do
     query_events(db, sql, [session_id, last_id, limit])
   end
 
+  @doc "Returns every persisted file-edit event in durable order."
+  @impl MingaAgent.EventLog.StoreBackend
+  @spec file_edit_events(db()) :: {:ok, [EventRecord.t()]} | {:error, term()}
+  def file_edit_events(db) do
+    sql = """
+    SELECT id, event_key, session_id, event_type, payload, wall_clock, monotonic_ts
+    FROM events
+    WHERE event_type = 'file_edit_proposed'
+    ORDER BY id ASC
+    """
+
+    query_events(db, sql, [])
+  end
+
   @doc "Returns the latest event id for a session, or 0 when it has no events."
   @spec latest_id(db(), String.t()) :: {:ok, non_neg_integer()} | {:error, term()}
   def latest_id(db, session_id) when is_binary(session_id) do

--- a/lib/minga_agent/event_log/store_backend.ex
+++ b/lib/minga_agent/event_log/store_backend.ex
@@ -15,6 +15,9 @@ defmodule MingaAgent.EventLog.StoreBackend do
   @doc "Closes the writer-owned database connection."
   @callback close(db()) :: :ok | {:error, term()}
 
+  @doc "Loads persisted file-edit events in durable order for projection reconstruction."
+  @callback file_edit_events(db()) :: {:ok, [EventRecord.t()]} | {:error, term()}
+
   @doc "Inserts one event and returns its committed id."
   @callback insert(db(), EventRecord.t()) :: {:ok, pos_integer()} | {:error, term()}
 

--- a/lib/minga_agent/event_log/touched_files.ex
+++ b/lib/minga_agent/event_log/touched_files.ex
@@ -1,0 +1,125 @@
+defmodule MingaAgent.EventLog.TouchedFiles do
+  @moduledoc """
+  Projects the latest admitted file edit for each path in an agent session.
+
+  Durable event ids define recency. Replaying the same event or an older event
+  cannot replace a newer touch for the same path.
+  """
+
+  alias MingaAgent.EventLog.EventRecord
+
+  @typedoc "How the latest admitted edit changed a file."
+  @type action :: :created | :modified | :deleted
+
+  @typedoc "Extension-facing summary of one touched file."
+  @type touch :: %{path: String.t(), action: action(), timestamp: integer()}
+
+  @typedoc "Why a file-edit event cannot enter the projection."
+  @type rejection ::
+          {:invalid_file_edit, :event_id | :path | :before_content | :after_content}
+
+  @typep entry ::
+           {event_id :: pos_integer(), action(), timestamp :: integer(),
+            wall_clock :: DateTime.t()}
+  @typep session_entries :: %{String.t() => entry()}
+
+  @type t :: %__MODULE__{by_session: %{String.t() => session_entries()}}
+
+  defstruct by_session: %{}
+
+  @doc "Creates an empty touched-file projection."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Validates fields required to project a file-edit event."
+  @spec validate(EventRecord.t()) :: :ok | {:error, rejection()}
+  def validate(%EventRecord{event_type: event_type}) when event_type != :file_edit_proposed,
+    do: :ok
+
+  def validate(%EventRecord{payload: payload}) do
+    with :ok <- validate_binary(payload, "path", :path),
+         :ok <- validate_binary(payload, "before_content", :before_content) do
+      validate_binary(payload, "after_content", :after_content)
+    end
+  end
+
+  @doc "Applies one durably identified event to the projection."
+  @spec record(t(), EventRecord.t(), pos_integer()) :: {:ok, t()} | {:error, rejection()}
+  def record(%__MODULE__{} = projection, %EventRecord{event_type: event_type}, _event_id)
+      when event_type != :file_edit_proposed,
+      do: {:ok, projection}
+
+  def record(%__MODULE__{}, %EventRecord{}, event_id)
+      when not is_integer(event_id) or event_id <= 0,
+      do: {:error, {:invalid_file_edit, :event_id}}
+
+  def record(%__MODULE__{} = projection, %EventRecord{} = event, event_id) do
+    with :ok <- validate(event) do
+      {:ok, put_latest(projection, event, event_id)}
+    end
+  end
+
+  @doc "Rebuilds the projection from persisted events in durable order."
+  @spec rebuild([EventRecord.t()]) :: {:ok, t()} | {:error, rejection()}
+  def rebuild(events) when is_list(events) do
+    Enum.reduce_while(events, {:ok, new()}, fn event, {:ok, projection} ->
+      case record(projection, event, event.id) do
+        {:ok, next} -> {:cont, {:ok, next}}
+        {:error, _reason} = error -> {:halt, error}
+      end
+    end)
+  end
+
+  @doc "Lists one session's latest file touches, most recent first."
+  @spec list(t(), String.t()) :: [touch()]
+  def list(%__MODULE__{} = projection, session_id) when is_binary(session_id) do
+    projection.by_session
+    |> Map.get(session_id, %{})
+    |> Enum.sort_by(
+      fn {_path, {event_id, _action, _timestamp, _wall_clock}} -> event_id end,
+      :desc
+    )
+    |> Enum.map(fn {path, {_event_id, action, timestamp, _wall_clock}} ->
+      %{path: path, action: action, timestamp: timestamp}
+    end)
+  end
+
+  @spec validate_binary(map(), String.t(), :path | :before_content | :after_content) ::
+          :ok | {:error, rejection()}
+  defp validate_binary(payload, key, field) do
+    case Map.get(payload, key) do
+      value when is_binary(value) -> :ok
+      _other -> {:error, {:invalid_file_edit, field}}
+    end
+  end
+
+  @spec put_latest(t(), EventRecord.t(), pos_integer()) :: t()
+  defp put_latest(projection, event, event_id) do
+    path = event.payload["path"]
+    entries = Map.get(projection.by_session, event.session_id, %{})
+
+    case Map.get(entries, path) do
+      {current_id, _action, _timestamp, _wall_clock} when current_id >= event_id ->
+        projection
+
+      _current ->
+        entry = {event_id, action(event.payload), event.monotonic_ts, event.wall_clock}
+
+        by_session =
+          Map.put(projection.by_session, event.session_id, Map.put(entries, path, entry))
+
+        %{projection | by_session: by_session}
+    end
+  end
+
+  @spec action(map()) :: action()
+  defp action(%{"before_content" => "", "after_content" => after_content})
+       when byte_size(after_content) > 0,
+       do: :created
+
+  defp action(%{"before_content" => before_content, "after_content" => ""})
+       when byte_size(before_content) > 0,
+       do: :deleted
+
+  defp action(_payload), do: :modified
+end

--- a/lib/minga_agent/event_log/touched_files.ex
+++ b/lib/minga_agent/event_log/touched_files.ex
@@ -18,9 +18,7 @@ defmodule MingaAgent.EventLog.TouchedFiles do
   @type rejection ::
           {:invalid_file_edit, :event_id | :path | :before_content | :after_content}
 
-  @typep entry ::
-           {event_id :: pos_integer(), action(), timestamp :: integer(),
-            wall_clock :: DateTime.t()}
+  @typep entry :: {event_id :: pos_integer(), action(), timestamp :: integer()}
   @typep session_entries :: %{String.t() => entry()}
 
   @type t :: %__MODULE__{by_session: %{String.t() => session_entries()}}
@@ -33,31 +31,36 @@ defmodule MingaAgent.EventLog.TouchedFiles do
 
   @doc "Validates fields required to project a file-edit event."
   @spec validate(EventRecord.t()) :: :ok | {:error, rejection()}
-  def validate(%EventRecord{event_type: event_type}) when event_type != :file_edit_proposed,
-    do: :ok
-
-  def validate(%EventRecord{payload: payload}) do
+  def validate(%EventRecord{event_type: :file_edit_proposed, payload: payload}) do
     with :ok <- validate_binary(payload, "path", :path),
          :ok <- validate_binary(payload, "before_content", :before_content) do
       validate_binary(payload, "after_content", :after_content)
     end
   end
 
+  def validate(%EventRecord{}), do: :ok
+
   @doc "Applies one durably identified event to the projection."
   @spec record(t(), EventRecord.t(), pos_integer()) :: {:ok, t()} | {:error, rejection()}
-  def record(%__MODULE__{} = projection, %EventRecord{event_type: event_type}, _event_id)
-      when event_type != :file_edit_proposed,
-      do: {:ok, projection}
-
-  def record(%__MODULE__{}, %EventRecord{}, event_id)
+  def record(
+        %__MODULE__{},
+        %EventRecord{event_type: :file_edit_proposed},
+        event_id
+      )
       when not is_integer(event_id) or event_id <= 0,
       do: {:error, {:invalid_file_edit, :event_id}}
 
-  def record(%__MODULE__{} = projection, %EventRecord{} = event, event_id) do
+  def record(
+        %__MODULE__{} = projection,
+        %EventRecord{event_type: :file_edit_proposed} = event,
+        event_id
+      ) do
     with :ok <- validate(event) do
       {:ok, put_latest(projection, event, event_id)}
     end
   end
+
+  def record(%__MODULE__{} = projection, %EventRecord{}, _event_id), do: {:ok, projection}
 
   @doc "Rebuilds the projection from persisted events in durable order."
   @spec rebuild([EventRecord.t()]) :: {:ok, t()} | {:error, rejection()}
@@ -75,11 +78,8 @@ defmodule MingaAgent.EventLog.TouchedFiles do
   def list(%__MODULE__{} = projection, session_id) when is_binary(session_id) do
     projection.by_session
     |> Map.get(session_id, %{})
-    |> Enum.sort_by(
-      fn {_path, {event_id, _action, _timestamp, _wall_clock}} -> event_id end,
-      :desc
-    )
-    |> Enum.map(fn {path, {_event_id, action, timestamp, _wall_clock}} ->
+    |> Enum.sort_by(fn {_path, {event_id, _action, _timestamp}} -> event_id end, :desc)
+    |> Enum.map(fn {path, {_event_id, action, timestamp}} ->
       %{path: path, action: action, timestamp: timestamp}
     end)
   end
@@ -99,11 +99,11 @@ defmodule MingaAgent.EventLog.TouchedFiles do
     entries = Map.get(projection.by_session, event.session_id, %{})
 
     case Map.get(entries, path) do
-      {current_id, _action, _timestamp, _wall_clock} when current_id >= event_id ->
+      {current_id, _action, _timestamp} when current_id >= event_id ->
         projection
 
       _current ->
-        entry = {event_id, action(event.payload), event.monotonic_ts, event.wall_clock}
+        entry = {event_id, action(event.payload), event.monotonic_ts}
 
         by_session =
           Map.put(projection.by_session, event.session_id, Map.put(entries, path, entry))

--- a/lib/minga_agent/event_log/writer.ex
+++ b/lib/minga_agent/event_log/writer.ex
@@ -9,6 +9,7 @@ defmodule MingaAgent.EventLog.Writer do
 
   alias MingaAgent.EventLog.EventRecord
   alias MingaAgent.EventLog.WriterState
+  alias MingaAgent.EventLog.WriterWorkflow
 
   @doc "Starts an unlinked writer monitored by its EventLog owner."
   @spec start(pid(), keyword()) :: GenServer.on_start()
@@ -35,67 +36,24 @@ defmodule MingaAgent.EventLog.Writer do
   @impl GenServer
   @spec handle_continue(:open, WriterState.t()) ::
           {:noreply, WriterState.t()} | {:stop, term(), WriterState.t()}
-  def handle_continue(:open, state) do
-    case state.backend.open_writer(state.path, state.backend_opts) do
-      {:ok, db} -> finish_open(state, db, state.backend.file_edit_events(db))
-      {:error, reason} -> report_unavailable(state, reason)
-    end
-  end
-
-  @spec finish_open(WriterState.t(), term(), {:ok, [EventRecord.t()]} | {:error, term()}) ::
-          {:noreply, WriterState.t()} | {:stop, term(), WriterState.t()}
-  defp finish_open(state, db, {:ok, events}) do
-    send(state.owner, {:event_log_writer_ready, self(), events})
-    {:noreply, WriterState.opened(state, db)}
-  end
-
-  defp finish_open(state, db, {:error, reason}) do
-    _ = state.backend.close(db)
-    report_unavailable(state, {:reconstruction_failed, reason})
-  end
-
-  @spec report_unavailable(WriterState.t(), term()) :: {:stop, term(), WriterState.t()}
-  defp report_unavailable(state, reason) do
-    send(state.owner, {:event_log_writer_unavailable, self(), reason})
-    {:stop, {:shutdown, {:open_failed, reason}}, state}
-  end
+  def handle_continue(:open, state), do: WriterWorkflow.open(state)
 
   @impl GenServer
   @spec handle_info(term(), WriterState.t()) ::
           {:noreply, WriterState.t()} | {:stop, term(), WriterState.t()}
   def handle_info({:write_event, token, %EventRecord{} = record}, state) do
-    result = state.backend.insert(state.db, record)
-    send(state.owner, {:event_log_writer_result, self(), token, record.event_type, result})
-    {:noreply, state}
+    WriterWorkflow.write_event(state, token, record)
   end
 
   def handle_info({:delete_before, token, %DateTime{} = cutoff}, state) do
-    result =
-      case state.backend.delete_before(state.db, cutoff) do
-        {:ok, deleted_count} ->
-          case state.backend.file_edit_events(state.db) do
-            {:ok, events} -> {:ok, deleted_count, events}
-            {:error, reason} -> {:error, {:reload_failed, reason}}
-          end
-
-        {:error, reason} ->
-          {:error, {:delete_failed, reason}}
-      end
-
-    send(state.owner, {:event_log_retention_result, self(), token, result})
-    {:noreply, state}
+    WriterWorkflow.delete_before(state, token, cutoff)
   end
 
   def handle_info({:DOWN, ref, :process, owner, reason}, %{owner_ref: ref, owner: owner} = state) do
-    {:stop, {:owner_terminated, reason}, state}
+    WriterWorkflow.owner_down(state, reason)
   end
 
   @impl GenServer
   @spec terminate(term(), WriterState.t()) :: :ok
-  def terminate(_reason, %{db: nil}), do: :ok
-
-  def terminate(_reason, state) do
-    _ = state.backend.close(state.db)
-    :ok
-  end
+  def terminate(_reason, state), do: WriterWorkflow.terminate(state)
 end

--- a/lib/minga_agent/event_log/writer.ex
+++ b/lib/minga_agent/event_log/writer.ex
@@ -37,14 +37,27 @@ defmodule MingaAgent.EventLog.Writer do
           {:noreply, WriterState.t()} | {:stop, term(), WriterState.t()}
   def handle_continue(:open, state) do
     case state.backend.open_writer(state.path, state.backend_opts) do
-      {:ok, db} ->
-        send(state.owner, {:event_log_writer_ready, self()})
-        {:noreply, WriterState.opened(state, db)}
-
-      {:error, reason} ->
-        send(state.owner, {:event_log_writer_unavailable, self(), reason})
-        {:stop, {:shutdown, {:open_failed, reason}}, state}
+      {:ok, db} -> finish_open(state, db, state.backend.file_edit_events(db))
+      {:error, reason} -> report_unavailable(state, reason)
     end
+  end
+
+  @spec finish_open(WriterState.t(), term(), {:ok, [EventRecord.t()]} | {:error, term()}) ::
+          {:noreply, WriterState.t()} | {:stop, term(), WriterState.t()}
+  defp finish_open(state, db, {:ok, events}) do
+    send(state.owner, {:event_log_writer_ready, self(), events})
+    {:noreply, WriterState.opened(state, db)}
+  end
+
+  defp finish_open(state, db, {:error, reason}) do
+    _ = state.backend.close(db)
+    report_unavailable(state, {:reconstruction_failed, reason})
+  end
+
+  @spec report_unavailable(WriterState.t(), term()) :: {:stop, term(), WriterState.t()}
+  defp report_unavailable(state, reason) do
+    send(state.owner, {:event_log_writer_unavailable, self(), reason})
+    {:stop, {:shutdown, {:open_failed, reason}}, state}
   end
 
   @impl GenServer
@@ -57,7 +70,18 @@ defmodule MingaAgent.EventLog.Writer do
   end
 
   def handle_info({:delete_before, token, %DateTime{} = cutoff}, state) do
-    result = state.backend.delete_before(state.db, cutoff)
+    result =
+      case state.backend.delete_before(state.db, cutoff) do
+        {:ok, deleted_count} ->
+          case state.backend.file_edit_events(state.db) do
+            {:ok, events} -> {:ok, deleted_count, events}
+            {:error, reason} -> {:error, {:reload_failed, reason}}
+          end
+
+        {:error, reason} ->
+          {:error, {:delete_failed, reason}}
+      end
+
     send(state.owner, {:event_log_retention_result, self(), token, result})
     {:noreply, state}
   end

--- a/lib/minga_agent/event_log/writer_workflow.ex
+++ b/lib/minga_agent/event_log/writer_workflow.ex
@@ -1,0 +1,88 @@
+defmodule MingaAgent.EventLog.WriterWorkflow do
+  @moduledoc """
+  Performs the ordered database workflows requested of the EventLog writer.
+
+  `MingaAgent.EventLog.Writer` remains the process boundary. This module owns the effectful open, insert, retention, and shutdown sequences so each GenServer callback only routes a message.
+  """
+
+  alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.WriterState
+
+  @type callback_result ::
+          {:noreply, WriterState.t()} | {:stop, term(), WriterState.t()}
+
+  @doc "Opens the writer connection and reconstructs durable file-edit events."
+  @spec open(WriterState.t()) :: callback_result()
+  def open(state) do
+    case state.backend.open_writer(state.path, state.backend_opts) do
+      {:ok, db} -> finish_open(state, db, state.backend.file_edit_events(db))
+      {:error, reason} -> report_unavailable(state, reason)
+    end
+  end
+
+  @doc "Persists one event and reports its correlated result to the EventLog owner."
+  @spec write_event(WriterState.t(), reference(), EventRecord.t()) :: callback_result()
+  def write_event(state, token, %EventRecord{} = record) when is_reference(token) do
+    result = state.backend.insert(state.db, record)
+    send(state.owner, {:event_log_writer_result, self(), token, record.event_type, result})
+    {:noreply, state}
+  end
+
+  @doc "Deletes expired events, reloads the projection source, and reports one correlated result."
+  @spec delete_before(WriterState.t(), reference(), DateTime.t()) :: callback_result()
+  def delete_before(state, token, %DateTime{} = cutoff) when is_reference(token) do
+    result = retention_result(state, cutoff)
+    send(state.owner, {:event_log_retention_result, self(), token, result})
+    {:noreply, state}
+  end
+
+  @doc "Stops the writer after its EventLog owner terminates."
+  @spec owner_down(WriterState.t(), term()) :: callback_result()
+  def owner_down(state, reason), do: {:stop, {:owner_terminated, reason}, state}
+
+  @doc "Closes the writer-owned database connection when one was opened."
+  @spec terminate(WriterState.t()) :: :ok
+  def terminate(%WriterState{db: nil}), do: :ok
+
+  def terminate(state) do
+    _ = state.backend.close(state.db)
+    :ok
+  end
+
+  @spec finish_open(WriterState.t(), term(), {:ok, [EventRecord.t()]} | {:error, term()}) ::
+          callback_result()
+  defp finish_open(state, db, {:ok, events}) do
+    send(state.owner, {:event_log_writer_ready, self(), events})
+    {:noreply, WriterState.opened(state, db)}
+  end
+
+  defp finish_open(state, db, {:error, reason}) do
+    _ = state.backend.close(db)
+    report_unavailable(state, {:reconstruction_failed, reason})
+  end
+
+  @spec report_unavailable(WriterState.t(), term()) :: callback_result()
+  defp report_unavailable(state, reason) do
+    send(state.owner, {:event_log_writer_unavailable, self(), reason})
+    {:stop, {:shutdown, {:open_failed, reason}}, state}
+  end
+
+  @spec retention_result(WriterState.t(), DateTime.t()) ::
+          {:ok, non_neg_integer(), [EventRecord.t()]}
+          | {:error, {:delete_failed | :reload_failed, term()}}
+  defp retention_result(state, cutoff) do
+    case state.backend.delete_before(state.db, cutoff) do
+      {:ok, deleted_count} -> reload_file_edits(state, deleted_count)
+      {:error, reason} -> {:error, {:delete_failed, reason}}
+    end
+  end
+
+  @spec reload_file_edits(WriterState.t(), non_neg_integer()) ::
+          {:ok, non_neg_integer(), [EventRecord.t()]} | {:error, {:reload_failed, term()}}
+  defp reload_file_edits(state, deleted_count) do
+    case state.backend.file_edit_events(state.db) do
+      {:ok, events} -> {:ok, deleted_count, events}
+      {:error, reason} -> {:error, {:reload_failed, reason}}
+    end
+  end
+end

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -58,13 +58,6 @@ defmodule MingaAgent.Session do
   @typedoc "Tool trust lifetime."
   @type trust_scope :: :session | :turn
 
-  @typedoc "File touch record."
-  @type file_touch :: %{
-          path: String.t(),
-          action: :created | :modified | :deleted,
-          timestamp: integer()
-        }
-
   @typedoc "Context inherited by child subagent sessions."
   @type subagent_context :: SubagentContext.t()
 
@@ -118,7 +111,6 @@ defmodule MingaAgent.Session do
           created_at: DateTime.t(),
           steering_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
           follow_up_queue: [String.t() | [ReqLLM.Message.ContentPart.t()]],
-          touched_files: %{String.t() => file_touch()},
           boundaries: %{String.t() => EditBoundary.t()},
           credentials_configured: boolean()
         }
@@ -530,21 +522,6 @@ defmodule MingaAgent.Session do
   end
 
   @doc """
-  Returns files touched by this agent session, ordered by most recent first.
-
-  Each entry contains:
-  - `path`: relative file path
-  - `action`: `:created`, `:modified`, or `:deleted`
-  - `timestamp`: monotonic timestamp of the last touch
-
-  Derived from tool call history (file_write, file_edit, multi_edit_file, apply_diff).
-  """
-  @spec touched_files(GenServer.server()) :: [file_touch()]
-  def touched_files(session) do
-    GenServer.call(session, :touched_files)
-  end
-
-  @doc """
   Sets an edit boundary for the agent on the given file path.
 
   The agent will be restricted to editing within the specified line range
@@ -751,7 +728,6 @@ defmodule MingaAgent.Session do
       created_at: now,
       steering_queue: [],
       follow_up_queue: [],
-      touched_files: %{},
       boundaries: %{},
       credentials_configured: credentials_configured?
     }
@@ -865,15 +841,6 @@ defmodule MingaAgent.Session do
     {:reply, {state.steering_queue, state.follow_up_queue}, state}
   end
 
-  def handle_call(:touched_files, _from, state) do
-    files =
-      state.touched_files
-      |> Map.values()
-      |> Enum.sort_by(& &1.timestamp, :desc)
-
-    {:reply, files, state}
-  end
-
   def handle_call({:set_boundary, path, start_line, end_line}, _from, state) do
     abs_path = Path.expand(path)
 
@@ -954,7 +921,6 @@ defmodule MingaAgent.Session do
         created_at: now,
         steering_queue: [],
         follow_up_queue: [],
-        touched_files: %{},
         boundaries: %{},
         trust_levels: %{},
         pending_auto_approvals: %{}
@@ -1790,7 +1756,6 @@ defmodule MingaAgent.Session do
        tool_name}
     )
 
-    state = record_file_touch(state, event.path, event.before_content, event.after_content)
     state = record_tool_file_preview(state, event)
     notify_messages_changed(state)
   end
@@ -3635,7 +3600,6 @@ defmodule MingaAgent.Session do
             created_at: loaded_at,
             steering_queue: [],
             follow_up_queue: [],
-            touched_files: %{},
             boundaries: %{},
             trust_levels: %{},
             pending_auto_approvals: %{}
@@ -3805,33 +3769,6 @@ defmodule MingaAgent.Session do
       {first, rest} = String.split_at(word, 1)
       String.upcase(first) <> rest
     end)
-  end
-
-  # Records a file touch from a ToolFileChanged event.
-  @spec record_file_touch(state(), String.t(), String.t(), String.t()) :: state()
-  defp record_file_touch(state, path, "", after_content) when byte_size(after_content) > 0 do
-    record_file_touch_with_action(state, path, :created)
-  end
-
-  defp record_file_touch(state, path, before_content, "") when byte_size(before_content) > 0 do
-    record_file_touch_with_action(state, path, :deleted)
-  end
-
-  defp record_file_touch(state, path, _before, _after) do
-    record_file_touch_with_action(state, path, :modified)
-  end
-
-  @spec record_file_touch_with_action(state(), String.t(), :created | :modified | :deleted) ::
-          state()
-  defp record_file_touch_with_action(state, path, action) do
-    touch = %{
-      path: path,
-      action: action,
-      timestamp: System.monotonic_time()
-    }
-
-    touched_files = Map.put(state.touched_files, path, touch)
-    %{state | touched_files: touched_files}
   end
 
   @impl GenServer

--- a/sdk/lib/minga/extension/agent_api.ex
+++ b/sdk/lib/minga/extension/agent_api.ex
@@ -34,7 +34,7 @@ defmodule Minga.Extension.AgentAPI do
   @spec list_sessions() :: [session_summary()]
   def list_sessions, do: raise("minga_sdk is compile-time only")
 
-  @spec session_info(pid()) :: {:ok, session_info()} | {:error, :not_found}
+  @spec session_info(pid()) :: {:ok, session_info()} | {:error, :not_found | :unavailable}
   def session_info(_pid), do: raise("minga_sdk is compile-time only")
 
   @spec subscribe() :: :ok

--- a/test/minga/extension/agent_api_test.exs
+++ b/test/minga/extension/agent_api_test.exs
@@ -1,13 +1,28 @@
 defmodule Minga.Extension.AgentAPITest do
-  use ExUnit.Case, async: true
+  # SessionManager starts sessions under the process-global MingaAgent.Supervisor.
+  use ExUnit.Case, async: false
 
   alias Minga.Extension.AgentAPI
+  alias MingaAgent.EventLog
   alias MingaAgent.SessionManager
 
-  setup do
-    name = :"agent_api_mgr_#{System.unique_integer([:positive])}"
-    _manager = start_supervised!({SessionManager, name: name}, id: name)
-    %{opts: [session_manager: name], manager: name}
+  @moduletag :tmp_dir
+  setup %{tmp_dir: tmp_dir} do
+    manager = :"agent_api_mgr_#{System.unique_integer([:positive])}"
+    event_log = :"agent_api_log_#{System.unique_integer([:positive])}"
+    _manager = start_supervised!({SessionManager, name: manager}, id: manager)
+
+    start_supervised!(
+      {EventLog, name: event_log, db_dir: tmp_dir, retention_sweep?: false, health_check: :none},
+      id: event_log
+    )
+
+    assert {:queued, receipt} =
+             EventLog.record("agent-api-setup", :status_changed, %{status: :idle}, event_log)
+
+    assert {:persisted, _event_id} = EventLog.await(receipt)
+
+    %{opts: [session_manager: manager, event_log: event_log], manager: manager}
   end
 
   describe "list_sessions/1" do
@@ -20,7 +35,8 @@ defmodule Minga.Extension.AgentAPITest do
     end
 
     test "returns summaries with the documented keys", %{opts: opts, manager: manager} do
-      {:ok, _id, _pid} = SessionManager.start_session(manager, [])
+      {:ok, _id, _pid} =
+        SessionManager.start_session(manager, provider: Minga.Test.StubProvider)
 
       summaries = AgentAPI.list_sessions(opts)
       assert Enum.count(summaries) == 1
@@ -33,7 +49,8 @@ defmodule Minga.Extension.AgentAPITest do
     end
 
     test "summary fields have correct types", %{opts: opts, manager: manager} do
-      {:ok, _id, session_pid} = SessionManager.start_session(manager, [])
+      {:ok, _id, session_pid} =
+        SessionManager.start_session(manager, provider: Minga.Test.StubProvider)
 
       [summary] = AgentAPI.list_sessions(opts)
 
@@ -65,7 +82,8 @@ defmodule Minga.Extension.AgentAPITest do
       opts: opts,
       manager: manager
     } do
-      {:ok, _id, session_pid} = SessionManager.start_session(manager, [])
+      {:ok, _id, session_pid} =
+        SessionManager.start_session(manager, provider: Minga.Test.StubProvider)
 
       assert {:ok, info} = AgentAPI.session_info(session_pid, opts)
 
@@ -93,6 +111,65 @@ defmodule Minga.Extension.AgentAPITest do
       assert is_integer(info.output_tokens) and info.output_tokens >= 0
       assert is_integer(info.turn_count) and info.turn_count >= 0
       assert is_list(info.files_touched)
+    end
+
+    test "reads touched files from the EventLog projection in durable order", %{
+      manager: manager,
+      opts: opts,
+      tmp_dir: tmp_dir
+    } do
+      event_log = Keyword.fetch!(opts, :event_log)
+      session_id = "agent-api-touched-files-#{System.unique_integer([:positive])}"
+
+      {:ok, ^session_id, session} =
+        SessionManager.start_session(manager,
+          session_id: session_id,
+          provider: Minga.Test.StubProvider,
+          session_store_dir: tmp_dir
+        )
+
+      assert {:queued, first_receipt} =
+               EventLog.record(
+                 session_id,
+                 :file_edit_proposed,
+                 %{
+                   path: "lib/first.ex",
+                   before_content: "",
+                   after_content: "created"
+                 },
+                 event_log
+               )
+
+      assert {:persisted, _first_id} = EventLog.await(first_receipt)
+
+      assert {:queued, second_receipt} =
+               EventLog.record(
+                 session_id,
+                 :file_edit_proposed,
+                 %{
+                   path: "lib/second.ex",
+                   before_content: "before",
+                   after_content: "after"
+                 },
+                 event_log
+               )
+
+      assert {:persisted, _second_id} = EventLog.await(second_receipt)
+      assert {:ok, info} = AgentAPI.session_info(session, opts)
+      assert info.files_touched == ["lib/second.ex", "lib/first.ex"]
+    end
+
+    test "reports unavailable when the EventLog projection cannot be queried", %{
+      manager: manager
+    } do
+      {:ok, _id, session} =
+        SessionManager.start_session(manager, provider: Minga.Test.StubProvider)
+
+      assert {:error, :unavailable} =
+               AgentAPI.session_info(session,
+                 event_log: :missing_event_log,
+                 session_manager: manager
+               )
     end
   end
 

--- a/test/minga_agent/event_log/touched_files_test.exs
+++ b/test/minga_agent/event_log/touched_files_test.exs
@@ -1,0 +1,92 @@
+defmodule MingaAgent.EventLog.TouchedFilesTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.EventLog.EventRecord
+  alias MingaAgent.EventLog.TouchedFiles
+
+  @earlier ~U[2026-07-17 12:00:00Z]
+  @later ~U[2026-07-17 12:01:00Z]
+
+  test "classifies every admitted file-change shape" do
+    cases = [
+      {"", "created", :created},
+      {"before", "after", :modified},
+      {"deleted", "", :deleted},
+      {"", "", :modified}
+    ]
+
+    for {before_content, after_content, expected_action} <- cases do
+      event = file_event("session", "lib/example.ex", before_content, after_content, 10, @earlier)
+      assert {:ok, projection} = TouchedFiles.record(TouchedFiles.new(), event, 1)
+
+      assert TouchedFiles.list(projection, "session") == [
+               %{path: "lib/example.ex", action: expected_action, timestamp: 10}
+             ]
+    end
+  end
+
+  test "latest durable event controls action and most-recent-first ordering" do
+    events = [
+      {file_event("session", "lib/a.ex", "", "one", 10, @earlier), 1},
+      {file_event("session", "lib/b.ex", "old", "new", 20, @earlier), 2},
+      {file_event("session", "lib/a.ex", "one", "", 30, @later), 3}
+    ]
+
+    projection =
+      Enum.reduce(events, TouchedFiles.new(), fn {event, id}, projection ->
+        {:ok, projection} = TouchedFiles.record(projection, event, id)
+        projection
+      end)
+
+    assert TouchedFiles.list(projection, "session") == [
+             %{path: "lib/a.ex", action: :deleted, timestamp: 30},
+             %{path: "lib/b.ex", action: :modified, timestamp: 20}
+           ]
+  end
+
+  test "duplicate and older replay cannot duplicate or regress a path" do
+    created = file_event("session", "lib/a.ex", "", "one", 10, @earlier)
+    deleted = file_event("session", "lib/a.ex", "one", "", 30, @later)
+
+    assert {:ok, projection} = TouchedFiles.record(TouchedFiles.new(), created, 1)
+    assert {:ok, projection} = TouchedFiles.record(projection, deleted, 3)
+    assert {:ok, projection} = TouchedFiles.record(projection, deleted, 3)
+    assert {:ok, projection} = TouchedFiles.record(projection, created, 1)
+
+    assert TouchedFiles.list(projection, "session") == [
+             %{path: "lib/a.ex", action: :deleted, timestamp: 30}
+           ]
+  end
+
+  test "rebuild uses the same transition as live admission" do
+    first = %{file_event("session", "lib/a.ex", "", "one", 10, @earlier) | id: 1}
+    second = %{file_event("session", "lib/a.ex", "one", "two", 20, @later) | id: 2}
+
+    assert {:ok, rebuilt} = TouchedFiles.rebuild([first, second, first])
+
+    assert TouchedFiles.list(rebuilt, "session") == [
+             %{path: "lib/a.ex", action: :modified, timestamp: 20}
+           ]
+  end
+
+  test "malformed file-edit events return a typed rejection" do
+    event = EventRecord.new("session", :file_edit_proposed, %{"path" => "lib/a.ex"})
+
+    assert TouchedFiles.record(TouchedFiles.new(), event, 1) ==
+             {:error, {:invalid_file_edit, :before_content}}
+  end
+
+  defp file_event(session_id, path, before_content, after_content, monotonic_ts, wall_clock) do
+    EventRecord.new(
+      session_id,
+      :file_edit_proposed,
+      %{
+        "path" => path,
+        "before_content" => before_content,
+        "after_content" => after_content
+      },
+      monotonic_ts: monotonic_ts,
+      wall_clock: wall_clock
+    )
+  end
+end

--- a/test/minga_agent/event_log_test.exs
+++ b/test/minga_agent/event_log_test.exs
@@ -291,7 +291,7 @@ defmodule MingaAgent.EventLogTest do
     second_ref = Process.monitor(second_writer)
     send(second_writer, {:event_log_store_open_result, {:error, :permission_denied}})
     assert_receive {:DOWN, ^second_ref, :process, ^second_writer, _reason}
-    assert %{status: :unavailable, pending_retention: true} = :sys.get_state(log)
+    assert %{writer: :unavailable, pending_retention: true} = :sys.get_state(log)
 
     assert :ok = EventLog.restart_writer(name)
     third_writer = open_controlled_writer()
@@ -508,7 +508,7 @@ defmodule MingaAgent.EventLogTest do
     assert_receive {:event_log_store_file_edit_events, ^writer}
     send(writer, {:event_log_store_file_edit_events_result, {:ok, []}})
     :sys.get_state(writer)
-    assert %{status: :ready} = :sys.get_state(name)
+    assert %{writer: {:ready, ^writer, _ref}} = :sys.get_state(name)
 
     send(name, :retention_sweep)
     assert_receive {:event_log_store_delete_before, ^writer, _cutoff}
@@ -519,7 +519,7 @@ defmodule MingaAgent.EventLogTest do
     send(writer, {:event_log_store_file_edit_events_result, {:error, :disk_read_failed}})
 
     assert_receive {:DOWN, ^writer_ref, :process, ^writer, _reason}, @event_timeout
-    assert %{status: :unavailable} = :sys.get_state(name)
+    assert %{writer: :unavailable} = :sys.get_state(name)
     assert EventLog.touched_files("session", name) == {:error, :unavailable}
   end
 

--- a/test/minga_agent/event_log_test.exs
+++ b/test/minga_agent/event_log_test.exs
@@ -329,7 +329,8 @@ defmodule MingaAgent.EventLogTest do
 
     second_boundaries = [
       {:approval_resolved, %{approval_id: "approval-1", sequence: 4}},
-      {:file_edit_proposed, %{path: "lib/example.ex", sequence: 5}},
+      {:file_edit_proposed,
+       %{path: "lib/example.ex", before_content: "old", after_content: "new", sequence: 5}},
       {:waiting_for_input, %{status: :idle, sequence: 6}}
     ]
 
@@ -380,6 +381,184 @@ defmodule MingaAgent.EventLogTest do
 
     assert_receive {:DOWN, ^writer_ref, :process, ^writer, _reason}
     assert_receive {:DOWN, ^log_ref, :process, ^log, :shutdown}
+  end
+
+  test "touched-file query updates after durable commits and reconstructs identically", %{
+    tmp_dir: tmp_dir
+  } do
+    first_name = unique_name("touched-files-log")
+    first_child = unique_name("touched-files-child")
+    start_event_log(first_name, [db_dir: tmp_dir], first_child)
+
+    first_receipt = record_file_edit(first_name, "session", "lib/a.ex", "", "created")
+    second_receipt = record_file_edit(first_name, "session", "lib/b.ex", "before", "after")
+    third_receipt = record_file_edit(first_name, "session", "lib/a.ex", "created", "")
+
+    assert {:persisted, _first_id} = EventLog.await(first_receipt)
+    assert {:persisted, _second_id} = EventLog.await(second_receipt)
+    assert {:persisted, _third_id} = EventLog.await(third_receipt)
+
+    assert {:ok, live} = EventLog.touched_files("session", first_name)
+
+    assert Enum.map(live, &{&1.path, &1.action}) == [
+             {"lib/a.ex", :deleted},
+             {"lib/b.ex", :modified}
+           ]
+
+    stop_supervised(first_child)
+
+    second_name = unique_name("touched-files-log")
+    start_event_log(second_name, db_dir: tmp_dir)
+    record_and_await(second_name, :status_changed, %{status: :idle})
+
+    assert EventLog.touched_files("session", second_name) == {:ok, live}
+  end
+
+  test "retention rebuilds from remaining durable events when wall clocks regress", %{
+    tmp_dir: tmp_dir
+  } do
+    now = DateTime.utc_now()
+    path = EventLog.db_path(db_dir: tmp_dir)
+    {:ok, db} = Store.open(path)
+
+    retained =
+      EventRecord.new(
+        "session",
+        :file_edit_proposed,
+        %{
+          "path" => "lib/a.ex",
+          "before_content" => "",
+          "after_content" => "created"
+        },
+        wall_clock: now,
+        monotonic_ts: 10
+      )
+
+    expired =
+      EventRecord.new(
+        "session",
+        :file_edit_proposed,
+        %{
+          "path" => "lib/a.ex",
+          "before_content" => "created",
+          "after_content" => ""
+        },
+        wall_clock: DateTime.add(now, -3, :day),
+        monotonic_ts: 20
+      )
+
+    assert {:ok, 1} = Store.insert(db, retained)
+    assert {:ok, 2} = Store.insert(db, expired)
+    assert :ok = Store.close(db)
+
+    name = unique_name("retention-projection-log")
+    start_event_log(name, db_dir: tmp_dir, retention_days: 1)
+    record_and_await(name, :status_changed, %{status: :idle})
+
+    assert {:ok, [%{action: :deleted, timestamp: 20}]} =
+             EventLog.touched_files("session", name)
+
+    send(name, :retention_sweep)
+    assert :ok = EventLog.await_idle(name)
+
+    assert {:ok, [%{action: :created, timestamp: 10}]} =
+             EventLog.touched_files("session", name)
+  end
+
+  test "failed admission and persistence never enter the touched-file projection" do
+    name = unique_name("failed-touch-log")
+    start_controlled_event_log(name)
+    writer = open_controlled_writer()
+
+    assert {:error, :invalid_payload} =
+             EventLog.record("session", :file_edit_proposed, %{path: "lib/invalid.ex"}, name)
+
+    assert {:queued, receipt} =
+             EventLog.record(
+               "session",
+               :file_edit_proposed,
+               %{
+                 path: "lib/failed.ex",
+                 before_content: "before",
+                 after_content: "after"
+               },
+               name
+             )
+
+    assert_receive {:event_log_store_insert, ^writer, _record}
+    send(writer, {:event_log_store_insert_result, {:error, :disk_full}})
+
+    assert {:error, {:persistence_failed, :disk_full}} = EventLog.await(receipt)
+    assert EventLog.touched_files("session", name) == {:ok, []}
+  end
+
+  test "retention reload failure makes the projection unavailable" do
+    name = unique_name("failed-retention-reload-log")
+
+    start_event_log(name,
+      store_backend: ControllableStore,
+      store_backend_opts: [
+        controller: self(),
+        reconstruction_result: :controlled
+      ],
+      writer_restart_delay_ms: 60_000
+    )
+
+    writer = open_controlled_writer()
+    assert_receive {:event_log_store_file_edit_events, ^writer}
+    send(writer, {:event_log_store_file_edit_events_result, {:ok, []}})
+    :sys.get_state(writer)
+    assert %{status: :ready} = :sys.get_state(name)
+
+    send(name, :retention_sweep)
+    assert_receive {:event_log_store_delete_before, ^writer, _cutoff}
+    send(writer, {:event_log_store_delete_before_result, {:ok, 0}})
+    assert_receive {:event_log_store_file_edit_events, ^writer}
+
+    writer_ref = Process.monitor(writer)
+    send(writer, {:event_log_store_file_edit_events_result, {:error, :disk_read_failed}})
+
+    assert_receive {:DOWN, ^writer_ref, :process, ^writer, _reason}, @event_timeout
+    assert %{status: :unavailable} = :sys.get_state(name)
+    assert EventLog.touched_files("session", name) == {:error, :unavailable}
+  end
+
+  test "reconstruction failure leaves touched-file queries explicitly unavailable" do
+    name = unique_name("failed-reconstruction-log")
+
+    start_event_log(name,
+      store_backend: ControllableStore,
+      store_backend_opts: [
+        controller: self(),
+        reconstruction_result: {:error, :corrupt_projection_event}
+      ],
+      writer_restart_delay_ms: 60_000
+    )
+
+    writer = open_controlled_writer()
+    writer_ref = Process.monitor(writer)
+    assert_receive {:DOWN, ^writer_ref, :process, ^writer, _reason}, @event_timeout
+    :sys.get_state(name)
+
+    assert EventLog.touched_files("session", name) == {:error, :unavailable}
+  end
+
+  @spec record_file_edit(atom(), String.t(), String.t(), String.t(), String.t()) ::
+          EventLog.receipt()
+  defp record_file_edit(server, session_id, path, before_content, after_content) do
+    assert {:queued, receipt} =
+             EventLog.record(
+               session_id,
+               :file_edit_proposed,
+               %{
+                 path: path,
+                 before_content: before_content,
+                 after_content: after_content
+               },
+               server
+             )
+
+    receipt
   end
 
   @spec record_and_await(atom(), MingaAgent.EventLog.EventRecord.event_type(), map()) ::

--- a/test/minga_agent/remote_api_test.exs
+++ b/test/minga_agent/remote_api_test.exs
@@ -1,5 +1,6 @@
 defmodule MingaAgent.RemoteAPITest do
-  use ExUnit.Case, async: true
+  # RemoteAPI is fixed to the global SessionManager, so this test cannot isolate manager state.
+  use ExUnit.Case, async: false
 
   alias MingaAgent.RemoteAPI
   alias MingaAgent.SessionManager

--- a/test/support/minga_agent/event_log_controllable_store.ex
+++ b/test/support/minga_agent/event_log_controllable_store.ex
@@ -13,9 +13,22 @@ defmodule MingaAgent.EventLog.ControllableStore do
     send(controller, {:event_log_store_open, self(), path})
 
     receive do
-      {:event_log_store_open_result, result} -> normalize_open_result(result, controller)
+      {:event_log_store_open_result, result} -> normalize_open_result(result, controller, opts)
     end
   end
+
+  @doc "Returns the configured reconstruction result without another synchronization exchange."
+  @impl MingaAgent.EventLog.StoreBackend
+  @spec file_edit_events(map()) :: {:ok, [EventRecord.t()]} | {:error, term()}
+  def file_edit_events(%{controller: controller, reconstruction_result: :controlled}) do
+    send(controller, {:event_log_store_file_edit_events, self()})
+
+    receive do
+      {:event_log_store_file_edit_events_result, result} -> result
+    end
+  end
+
+  def file_edit_events(%{reconstruction_result: result}), do: result
 
   @doc "Reports that the controlled connection closed."
   @impl MingaAgent.EventLog.StoreBackend
@@ -61,8 +74,15 @@ defmodule MingaAgent.EventLog.ControllableStore do
     end
   end
 
-  @spec normalize_open_result(:ok | {:error, term()}, pid()) ::
+  @spec normalize_open_result(:ok | {:error, term()}, pid(), keyword()) ::
           {:ok, map()} | {:error, term()}
-  defp normalize_open_result(:ok, controller), do: {:ok, %{controller: controller}}
-  defp normalize_open_result({:error, _reason} = error, _controller), do: error
+  defp normalize_open_result(:ok, controller, opts) do
+    {:ok,
+     %{
+       controller: controller,
+       reconstruction_result: Keyword.get(opts, :reconstruction_result, {:ok, []})
+     }}
+  end
+
+  defp normalize_open_result({:error, _reason} = error, _controller, _opts), do: error
 end


### PR DESCRIPTION
# TL;DR
EventLog now owns the canonical per-session touched-file projection and rebuilds it from durable `file_edit_proposed` events. The same process now uses focused payload, queue-entry, writer-lifecycle, and writer-workflow values instead of positional tuples and correlated fields. Session no longer keeps a parallel touched-file cache, while extension callers retain the same path, action, ordering, durability, and error behavior.

Closes #2967

## Context
Issue #2967 is part of #2850's Session state ownership cleanup. Every admitted file change was already durable in EventLog, but Session also tracked an in-memory summary that could diverge after recovery or persistence failure. The follow-up refactor keeps EventLog's required durability state machine while making its Elixir data shapes and transitions explicit.

## Changes
- Add a pure `MingaAgent.EventLog.TouchedFiles` reducer keyed by session and path. Durable event identity controls replacement, action classification, and most-recent-first ordering.
- Install projection updates only after SQLite reports a successful commit. Rebuild the same projection during EventLog startup and retention reloads, and mark queries unavailable when reconstruction fails.
- Extend the EventLog store backend with a session-scoped `file_edit_events/1` query so reconstruction uses the existing indexed event stream instead of scanning history on every request.
- Remove Session's touched-file field, mutation helpers, reset logic, and public query.
- Route `Minga.Extension.AgentAPI.session_info/2` through EventLog while preserving `files_touched` values and returning explicit `:unavailable` when the projection cannot be queried. Update the compile-time SDK contract accordingly.
- Extract pure payload normalization, redaction, validation, and exact serialized-size accounting into `MingaAgent.EventLog.Payload` while preserving the pre-mailbox size guard.
- Replace positional queue tuples with `MingaAgent.EventLog.Entry`, keeping critical receipt ownership and best-effort delivery semantics explicit.
- Replace independent writer PID, monitor, and status fields with one tagged lifecycle value covering `:starting`, `:unavailable`, `{:opening, pid, ref}`, and `{:ready, pid, ref}`.
- Return tagged capacity results from the state owner and route writer callbacks through `MingaAgent.EventLog.WriterWorkflow`.
- Remove unused touched-file projection fields and retention cutoff bookkeeping without weakening durable-ID ordering or restart behavior.

## Verification
- Final SHA: `8588caeb6`.
- `make lint` passed on the final SHA: changed-file Credo, warnings-as-errors compile, and incremental Dialyzer reported no errors.
- `mix test.llm --max-cases 1` passed on the final SHA: 58 doctests, 98 properties, 9,837 tests, 0 failures, 1 skipped.
- Focused EventLog, touched-file, session integration, store, and Extension Agent API suites passed: 51 tests, 0 failures.
- Focused stateful bug hunt: PASS after tracing admission bounds, FIFO dispatch, uncertain-write replay, acknowledgments, retention, reconstruction, payload handling, and shutdown.
- Final acceptance reviewer: PASS with 0.99 confidence and no findings.

## Acceptance Criteria Addressed
- Extension and agent introspection preserve path, action, and most-recent-first behavior. ✅
- Created, modified, and deleted classifications remain correct across repeated and changing actions. ✅
- Live summaries and durable restart reconstruction use the same projection transition. ✅
- EventLog owns an indexed latest-record-per-session-and-path projection. ✅
- Session no longer owns or falls back to touched-file state. ✅
- File-change broadcasts, records, previews, edit boundaries, failure reporting, and Extension Agent API behavior remain intact. ✅
- Payload policy, queue entries, writer lifecycle, capacity decisions, and writer effects now have focused data or workflow owners. ✅
- Durable acknowledgments, bounded FIFO work, uncertain-write replay, retention synchronization, and availability-safe queries remain unchanged. ✅