### PR TITLE
fix(editor): route frame rejections to recovery

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -156,7 +156,7 @@ Every unit reserves these fields:
 
 ### W001: Frame rejection reaches renderer recovery
 
-- **Status:** READY
+- **Status:** ACTIVE
 - **Audit ID:** L01
 - **Ponytail verdict:** `ACCEPT/direct`
 - **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.6-sol`, `xhigh`, read-only
@@ -292,17 +292,17 @@ No Swift, Go, Zig, protocol generation, or snapshot validation is required becau
 - **PR URL:** Pending
 - **Commit SHA:** Pending
 - **Merge SHA:** Pending
-- **Focused tests:** Pending
-- **Broad validation:** Pending
-- **Ponytail verdict:** Pending
-- **Bug-hunt verdict:** Pending
-- **Elixir craftsmanship verdict:** Pending
-- **Final reviewer verdict:** Pending
-- **Production lines added/removed:** Pending
-- **Test lines added/removed:** Pending
-- **Concepts added/removed:** Pending
-- **Findings resolved:** Pending
-- **Discoveries affecting later work:** Pending
+- **Focused tests:** `mix test.debug test/minga_editor/frontend/protocol_test.exs test/minga_editor/renderer/server_test.exs` — 179 passed
+- **Broad validation:** `make lint` passed (Credo: 3 changed source files, no issues; compile and incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 8:8' mix test.llm` passed (58 doctests, 98 properties, 9,839 tests, 0 failures, 1 skipped, 574 excluded; max_cases 16)
+- **Ponytail verdict:** LEAN, including targeted helper recheck
+- **Bug-hunt verdict:** PASS, correctness including targeted helper recheck
+- **Elixir craftsmanship verdict:** IDIOMATIC, including targeted helper recheck
+- **Final reviewer verdict:** PASS
+- **Production lines added/removed:** 11 added / 10 removed, net +1
+- **Test lines added/removed:** 32 added / 8 removed, net +24
+- **Concepts added/removed:** None added; removed five-element runtime `:frame_rejected` compatibility
+- **Findings resolved:** L01 routed canonical correlated frame rejection from `MingaEditor` to renderer recovery without Editor state mutation
+- **Discoveries affecting later work:** Silent-failure review: PASS. Default-concurrency broad runs exposed pre-existing unrelated suite races; seed 30291 reproduced the extension timeout on untouched `origin/main` with 9,838 tests passing, and another run got `:noproc` where an unrelated lifecycle test expected `:killed`; reduced scheduler count produced a clean full pass. No later-work contract discovery
 - **Completion date:** Pending
 
 ### W002: Failed saves prevent shutdown

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -289,8 +289,8 @@ No Swift, Go, Zig, protocol generation, or snapshot validation is required becau
 
 #### Completion evidence
 
-- **PR URL:** Pending
-- **Commit SHA:** Pending
+- **PR URL:** https://github.com/jsmestad/minga/pull/2978
+- **Commit SHA:** `db9163c5c`
 - **Merge SHA:** Pending
 - **Focused tests:** `mix test.debug test/minga_editor/frontend/protocol_test.exs test/minga_editor/renderer/server_test.exs` — 179 passed
 - **Broad validation:** `make lint` passed (Credo: 3 changed source files, no issues; compile and incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 8:8' mix test.llm` passed (58 doctests, 98 properties, 9,839 tests, 0 failures, 1 skipped, 574 excluded; max_cases 16)

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -742,10 +742,19 @@ defmodule MingaEditor do
   end
 
   def handle_info(
-        {:minga_input, {kind, _, _, _, _} = status},
+        {:minga_input, {:frame_rejected, _, _, _, _, _} = status},
         %{render: %{renderer: renderer}} = state
       )
-      when kind in [:frame_rejected, :window_ref_miss] and is_pid(renderer) do
+      when is_pid(renderer) do
+    MingaEditor.Renderer.Server.frame_status(renderer, status)
+    {:noreply, state}
+  end
+
+  def handle_info(
+        {:minga_input, {:window_ref_miss, _, _, _, _} = status},
+        %{render: %{renderer: renderer}} = state
+      )
+      when is_pid(renderer) do
     MingaEditor.Renderer.Server.frame_status(renderer, status)
     {:noreply, state}
   end

--- a/lib/minga_editor/renderer/ack_handler.ex
+++ b/lib/minga_editor/renderer/ack_handler.ex
@@ -57,14 +57,6 @@ defmodule MingaEditor.Renderer.AckHandler do
     terminal(state, last_applied, reason, disposition)
   end
 
-  # Keep direct callers from the protocol-version-11 contract retryable.
-  def handle(state, {:frame_rejected, generation, seq, last_applied, reason}) do
-    handle(
-      state,
-      {:frame_rejected, generation, seq, last_applied, reason, :retryable_recovery}
-    )
-  end
-
   def handle(
         %State{
           awaiting_ack: %{generation: generation, seq: seq, intent: intent, pushed_at: pushed_at}

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -200,8 +200,7 @@ defmodule MingaEditor.Renderer.ServerTest do
     :ok = Minga.Buffer.Process.move_to(buffer, {0, 0})
     :ok = Minga.Buffer.Process.insert_text(buffer, "new\n")
     RendererServer.cast_snapshot(renderer, snapshot, 81)
-    RendererServer.frame_status(renderer, {:frame_rejected, 1, 80, 0, :base_sequence_mismatch})
-
+    reject_base_sequence_mismatch(renderer, 1, 80, 0)
     assert_receive {:lineage_probe, 81, nil, 0, [0, 1, 2], 1}, @async_render_timeout
     RendererServer.frame_status(renderer, {:frame_applied, 2, 81})
   end
@@ -291,7 +290,7 @@ defmodule MingaEditor.Renderer.ServerTest do
 
       RendererServer.frame_status(renderer, {:frame_applied, 2, 10})
       RendererServer.frame_status(renderer, {:frame_applied, 1, 9})
-      RendererServer.frame_status(renderer, {:frame_rejected, 1, 10, 99, :base_sequence_mismatch})
+      reject_base_sequence_mismatch(renderer, 1, 10, 99)
       assert RendererServer.acknowledgement_state(renderer) == {1, 0}
       refute_receive {:ack_pipeline, _, _, _, _}, 50
 
@@ -304,7 +303,7 @@ defmodule MingaEditor.Renderer.ServerTest do
       assert RendererServer.acknowledgement_state(renderer) == {1, 10}
 
       RendererServer.frame_status(renderer, {:frame_applied, 1, 10})
-      RendererServer.frame_status(renderer, {:frame_rejected, 0, 12, 10, :base_sequence_mismatch})
+      reject_base_sequence_mismatch(renderer, 0, 12, 10)
       assert RendererServer.acknowledgement_state(renderer) == {1, 10}
       refute_receive {:render_done, %RenderReceipt{frame_seq: 12}}, 50
     end
@@ -373,6 +372,26 @@ defmodule MingaEditor.Renderer.ServerTest do
       assert_receive {:ack_pipeline, 21, 2, 0, true}, @async_render_timeout
       assert RendererServer.acknowledgement_state(renderer) == {2, 0}
       refute_receive {:ack_pipeline, _, 3, _, _}, 50
+      refute_receive {:render_done, %RenderReceipt{frame_seq: 20}}, 50
+    end
+
+    test "decoded retryable frame rejection reaches renderer recovery" do
+      renderer = start_ack_renderer(self())
+
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 20)
+      assert_receive {:ack_pipeline, 20, 1, 0, true}, @async_render_timeout
+      RendererServer.cast_snapshot(renderer, stub_snapshot(), 21)
+
+      assert {:ok, decoded} =
+               MingaEditor.Frontend.Protocol.decode_event(<<0x0B, 1::32, 20::32, 0::32, 4, 1>>)
+
+      assert decoded ==
+               {:frame_rejected, 1, 20, 0, :base_sequence_mismatch, :retryable_recovery}
+
+      state = build_editor_state(:tui, renderer)
+      assert {:noreply, ^state} = MingaEditor.handle_info({:minga_input, decoded}, state)
+
+      assert_receive {:ack_pipeline, 21, 2, 0, true}, @async_render_timeout
       refute_receive {:render_done, %RenderReceipt{frame_seq: 20}}, 50
     end
 
@@ -710,10 +729,7 @@ defmodule MingaEditor.Renderer.ServerTest do
       assert_receive {:resident_probe, 20, 1, false, 0, [], ^epoch}, @async_render_timeout
       assert_receive {:line_fetch, %{lines_fetched: 24}, %{full_residence?: true}}
 
-      RendererServer.frame_status(
-        renderer,
-        {:frame_rejected, 1, 20, 3, :base_sequence_mismatch}
-      )
+      reject_base_sequence_mismatch(renderer, 1, 20, 3)
 
       assert_receive {:resident_probe, retry_seq, 2, true, 130, nil, fresh_epoch},
                      @async_render_timeout
@@ -1291,6 +1307,14 @@ defmodule MingaEditor.Renderer.ServerTest do
     else
       false
     end
+  end
+
+  defp reject_base_sequence_mismatch(renderer, generation, frame_seq, last_applied) do
+    RendererServer.frame_status(
+      renderer,
+      {:frame_rejected, generation, frame_seq, last_applied, :base_sequence_mismatch,
+       :retryable_recovery}
+    )
   end
 
   defp stub_snapshot do


### PR DESCRIPTION
## Why

Protocol v12 decodes frontend frame rejections as six-field tuples, but `MingaEditor.handle_info/2` still matched the obsolete five-field shape. Current rejection events therefore fell through generic input handling instead of reaching renderer acknowledgement recovery.

This is W001, audit finding L01, from the [editor lifecycle execution roadmap](docs/workstreams/editor-lifecycle-roadmap.md).

## What changed

- Route canonical six-field `:frame_rejected` events directly to `Renderer.Server.frame_status/2` when the renderer PID is present.
- Keep five-field `:window_ref_miss` handling separate.
- Remove the obsolete five-field rejection normalization in `AckHandler`.
- Migrate direct renderer tests to the canonical tuple and add a decoder-to-Editor-to-renderer regression that observes the recovery keyframe while preserving Editor state identity.
- Record W001 implementation and review evidence in the living roadmap.

Production delta: `+11/-10`, net `+1`. Test delta: `+32/-8`, net `+24`. No new production concept was introduced; the obsolete compatibility shape was removed.

## Verification

- `mix test.debug test/minga_editor/frontend/protocol_test.exs test/minga_editor/renderer/server_test.exs`: 179 passed
- `make lint`: passed, including Credo, compile, and incremental Dialyzer with 0 errors
- `ERL_FLAGS='+S 8:8' mix test.llm`: 58 doctests, 98 properties, 9,839 tests, 0 failures, 1 skipped, 574 excluded
- Ponytail review: LEAN
- Correctness review: PASS
- Silent-failure review: PASS
- Elixir craftsmanship review: IDIOMATIC

Default-concurrency broad runs also exposed unrelated baseline synchronization races. Seed 30291 reproduced the extension timeout on untouched `origin/main`; reducing only the BEAM scheduler count produced the clean full-suite result above.
