### PR TITLE
docs(editor): verify W001 completion

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -156,7 +156,7 @@ Every unit reserves these fields:
 
 ### W001: Frame rejection reaches renderer recovery
 
-- **Status:** ACTIVE
+- **Status:** VERIFIED
 - **Audit ID:** L01
 - **Ponytail verdict:** `ACCEPT/direct`
 - **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.6-sol`, `xhigh`, read-only
@@ -291,9 +291,9 @@ No Swift, Go, Zig, protocol generation, or snapshot validation is required becau
 
 - **PR URL:** https://github.com/jsmestad/minga/pull/2978
 - **Commit SHA:** `db9163c5c`
-- **Merge SHA:** Pending
+- **Merge SHA:** `e902f97844570e1525424bfa8d3243ae550ea6d4`
 - **Focused tests:** `mix test.debug test/minga_editor/frontend/protocol_test.exs test/minga_editor/renderer/server_test.exs` — 179 passed
-- **Broad validation:** `make lint` passed (Credo: 3 changed source files, no issues; compile and incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 8:8' mix test.llm` passed (58 doctests, 98 properties, 9,839 tests, 0 failures, 1 skipped, 574 excluded; max_cases 16)
+- **Broad validation:** `make lint` passed (Credo: 3 changed source files, no issues; compile and incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 8:8' mix test.llm` passed (58 doctests, 98 properties, 9,839 tests, 0 failures, 1 skipped, 574 excluded; max_cases 16); all required PR checks passed
 - **Ponytail verdict:** LEAN, including targeted helper recheck
 - **Bug-hunt verdict:** PASS, correctness including targeted helper recheck
 - **Elixir craftsmanship verdict:** IDIOMATIC, including targeted helper recheck
@@ -303,7 +303,7 @@ No Swift, Go, Zig, protocol generation, or snapshot validation is required becau
 - **Concepts added/removed:** None added; removed five-element runtime `:frame_rejected` compatibility
 - **Findings resolved:** L01 routed canonical correlated frame rejection from `MingaEditor` to renderer recovery without Editor state mutation
 - **Discoveries affecting later work:** Silent-failure review: PASS. Default-concurrency broad runs exposed pre-existing unrelated suite races; seed 30291 reproduced the extension timeout on untouched `origin/main` with 9,838 tests passing, and another run got `:noproc` where an unrelated lifecycle test expected `:killed`; reduced scheduler count produced a clean full pass. No later-work contract discovery
-- **Completion date:** Pending
+- **Completion date:** 2026-07-18
 
 ### W002: Failed saves prevent shutdown
 


### PR DESCRIPTION
## Why

W001 merged in #2978. The living editor lifecycle ledger marks work VERIFIED only after merge and records the merge commit as evidence.

## What changed

- Mark W001 VERIFIED.
- Record merge commit `e902f97844570e1525424bfa8d3243ae550ea6d4` and completion date.
- Record that all required implementation PR checks passed.

No implementation code or later work-unit status changed.

## Verification

- `git diff --check`
- `make lint`: passed; no changed Credo source files, compile and incremental Dialyzer completed with 0 errors
