### PR TITLE
fix(editor): prevent shutdown after failed saves

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -687,8 +687,8 @@ None. The implementer must return `NEEDS_REPLAN` rather than choose a different 
 
 #### Completion evidence
 
-- **PR URL:** Pending
-- **Commit SHA:** Pending
+- **PR URL:** https://github.com/jsmestad/minga/pull/2980
+- **Commit SHA:** `e3a981b04`
 - **Merge SHA:** Pending
 - **Focused tests:** `mix test.debug test/minga_editor/commands/buffer_management_save_quit_test.exs test/minga_editor/input/handler_test.exs test/minga_editor/input/router_test.exs test/minga/buffer/mtime_test.exs` — 47 passed
 - **Broad validation:** `make lint` passed; `ERL_FLAGS='+S 8:8' mix test.llm` passed — 58 doctests, 98 properties, 9,845 tests, 0 failures, 1 skipped, 574 excluded

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -307,14 +307,401 @@ No Swift, Go, Zig, protocol generation, or snapshot validation is required becau
 
 ### W002: Failed saves prevent shutdown
 
-- **Status:** CANDIDATE
+#### Status and provenance
+
+- **Status:** ACTIVE
 - **Audit ID:** L02
+- **Roadmap unit:** W002, Failed saves prevent shutdown
 - **Ponytail verdict:** `ACCEPT/direct`
-- **Candidate outcome:** `:wq` and `:wqa` close or shut down only after every required save succeeds.
-- **Existing direction:** Factor one internal tagged save result and short-circuit close or shutdown on failure. Reuse the existing save workflow rather than adding a service, behaviour, or generic result framework.
-- **Readiness gap:** A fresh planner must reproduce current save sequencing, name the save-result owner and exact tagged shape, lock all callers and failure assertions, and separate L02 from the routed cross-tab inventory finding L03.
-- **Allowed concepts before planning:** None.
-- **Completion evidence:** Pending.
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.6-sol`, `xhigh`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.6-luna`, `high`
+- **Freshness SHA:** `1134ddaa7a25052546ef23789fa926d1685ebb44`
+- **Freshness basis:** Current `HEAD` and `origin/main` both resolve to the freshness SHA. The failure was reproduced by tracing the current source. No build or test was run, as required by the read-only constraint.
+
+#### Observable outcome
+
+For ordinary buffer-backed saves:
+
+- `:wq` closes the current tab or quits only when the active save succeeds.
+- `:wqa` invokes the existing shutdown path only when every dirty buffer in `state.workspace.buffers.list` saves successfully.
+- A save error or process exit returns the current Editor state without closing or shutting down.
+- Active-save failure feedback remains in the returned state.
+- Save-all stops at the first failure. Saves completed before that failure remain committed; there is no rollback.
+- Successful behavior remains unchanged: `:wq` saves and delegates to `close_tab_or_quit/1`; `:wqa` saves all currently enumerated dirty buffers and delegates to `shutdown_editor/1`.
+
+This outcome intentionally covers only the active workspace inventory already used by `save_all_buffers/1`.
+
+#### Current producer-to-consumer failure path
+
+The path remains present at the freshness SHA:
+
+1. `Minga.Command.Parser` produces `{:save_quit, []}` for `wq` and `{:save_quit_all, []}` for `wqa`.
+2. `MingaEditor.Commands.execute/2` routes both ex tuples directly to `MingaEditor.Commands.BufferManagement.execute/2`.
+3. `execute(state, :save)` applies pre-save transforms and calls `Minga.Buffer.save/1`.
+4. `Buffer.save/1` produces `:ok` or `{:error, reason}`. `BufferManagement` converts either result into an `EditorState` with the corresponding notice or conflict presentation, losing the success tag.
+5. `execute/2` for `{:save_quit, []}` pipes that state directly into `close_tab_or_quit/1`, including states produced by `:no_file_path`, `:file_changed`, or another save error.
+6. `save_all_buffers/1` uses `Enum.each/2`, ignores every `Buffer.save/1` return value, catches process exits as `:ok`, and returns the input state.
+7. `execute/2` for `{:save_quit_all, []}` pipes that state unconditionally into `shutdown_editor/1`.
+8. `shutdown_editor/1` resolves wait requests and calls the configured `:shutdown_fn`, defaulting to `System.stop/1`.
+
+#### Authoritative owners
+
+- **Write outcome and buffer dirty state:** `Minga.Buffer.Process`, exposed through `Minga.Buffer.save/1`.
+- **Save, close, and shutdown sequencing:** `MingaEditor.Commands.BufferManagement`. This is the workflow owner under ADR-0002 because it coordinates Buffer process calls, notice state, tab transitions, wait requests, and shutdown effects.
+- **Notice and conflict presentation:** Existing `MingaEditor.Shell.Traditional.NoticeWorkflow`, `handle_file_changed_on_save/2`, and remote conflict picker workflow.
+- **Tab closing:** Existing `close_tab_or_quit/1` and its current Tab/TabBar workflows.
+- **Process shutdown:** Existing `shutdown_editor/1`.
+- **Wait-request disposition:** Existing close and shutdown functions. The save workflow must not duplicate or move this responsibility.
+
+No root state, Buffer owner, lifecycle owner, or persistence owner changes.
+
+#### Exact return shape
+
+Add exactly one private tagged result:
+
+```elixir
+@typep save_result :: {:ok, state()} | {:error, state()}
+```
+
+Semantics:
+
+- `{:ok, state}` means the required save or save set succeeded and the caller may close or shut down.
+- `{:error, state}` means at least one required save failed or exited and the caller must return that state unchanged by close or shutdown.
+- Active-save errors carry the existing notice, warning, or conflict UI state.
+- Save-all retains its current notice behavior and does not introduce a new per-buffer notice.
+- The result does not carry a reason. No consumer needs it, and adding `{:error, reason, state}` would duplicate information already projected for active saves.
+- `execute/2` continues to return only `EditorState.t()`. The tagged result remains private to this module.
+
+#### Exact files, symbols, producers, and consumers
+
+##### Production change
+
+`lib/minga_editor/commands/buffer_management.ex`
+
+Changed or added symbols:
+
+- `@typep save_result`
+- `execute/2`, ordinary `:save` clause
+- `execute/2`, `{:execute_ex_command, {:save_quit, []}}` clause
+- `execute/2`, `{:execute_ex_command, {:save_quit_all, []}}` clause
+- New private `save_active_buffer/1`
+- Existing private `save_all_buffers/1`
+- New private recursive `save_all_buffers/2`
+
+Retained, unchanged consumers:
+
+- `close_tab_or_quit/1`
+- `shutdown_editor/1`
+- `complete_active_wait_on_close/1`
+- `cancel_active_wait_request/2`
+- `Minga.Frontend.WaitRequests`
+
+Retained, unchanged producers:
+
+- `Minga.Buffer.save/1`
+- `Minga.Buffer.Process.handle_call(:save, ...)`
+- `Minga.Command.Parser`
+- `MingaEditor.Commands.execute/2`
+
+##### Test change
+
+Create:
+
+`test/minga_editor/commands/buffer_management_save_quit_test.exs`
+
+A separate file is required because shutdown observation mutates `Application` environment. The existing `buffer_management_frontend_test.exs` is `async: true`; changing it to serialized execution would unnecessarily slow unrelated tests and violate the separate-file rule for global-state tests.
+
+##### Roadmap change
+
+`docs/workstreams/editor-lifecycle-roadmap.md`
+
+Replace the W002 candidate block with this READY specification. Implementation completion evidence remains pending until the PR merges.
+
+##### Contract sources that must not change
+
+- `FINDINGS.md`
+- `lib/minga/buffer.ex`
+- `lib/minga/buffer/process.ex`
+- `lib/minga/api.ex`, including `Minga.API.save/1`
+- `lib/minga/command/parser.ex`
+- `lib/minga_editor/commands.ex`
+- `lib/minga_editor/state.ex`
+- `lib/minga_editor/state/tab/context.ex`
+- `lib/minga_editor/commands/dired.ex`
+- `Minga.Buffer.save_all_dirty/0` and `test/minga/buffer/save_all_dirty_test.exs`
+
+#### Locked implementation shape
+
+##### Active save
+
+1. Keep the existing Dired `execute(state, :save)` clause unchanged.
+2. Move the ordinary active-buffer save workflow into `save_active_buffer/1`.
+3. The regular helper must preserve this exact order:
+   1. `apply_pre_save_transforms/2`
+   2. `Buffer.save/1`
+   3. Existing success notice, file-changed handling, no-path notice, or generic failure notice
+   4. Wrap the resulting state in `{:ok, state}` or `{:error, state}`
+4. Catch only process exits from the ordinary active-save workflow. Convert an exit to:
+   ```elixir
+   {:error, NoticeWorkflow.publish(state, "Save failed: #{inspect(reason)}")}
+   ```
+   Do not catch exceptions or throws.
+5. Add a Dired-specific `save_active_buffer/1` clause that invokes the existing `:dired_apply_changes` command and returns `{:ok, returned_state}`. Dired has no save-success contract, so this preserves current Dired `:wq` behavior rather than inventing one.
+6. The public ordinary `execute(state, :save)` clause unwraps either tag and returns only the state:
+   ```elixir
+   {_status, state} = save_active_buffer(state)
+   state
+   ```
+7. `:wq` calls `save_active_buffer/1` directly:
+   ```elixir
+   case save_active_buffer(state) do
+     {:ok, state} -> close_tab_or_quit(state)
+     {:error, state} -> state
+   end
+   ```
+
+##### Save-all
+
+`save_all_buffers/1` must return `save_result()` and delegate to a private recursive `save_all_buffers/2` over the exact current list:
+
+```elixir
+state.workspace.buffers.list
+```
+
+The recursive contract is locked:
+
+- Empty list returns `{:ok, state}`.
+- A clean live buffer is skipped.
+- A dirty buffer returning `:ok` advances to the next buffer.
+- A dirty buffer returning `{:error, _reason}` immediately returns `{:error, state}`.
+- An exit from either `Buffer.dirty?/1` or `Buffer.save/1` immediately returns `{:error, state}`.
+- The traversal does not attempt later buffers after a failure.
+- Previously saved buffers remain saved.
+- No pre-save transforms, conflict UI, save notice, force-save, deduplication, or alternate inventory is introduced.
+
+`:wqa` branches only on that result:
+
+```elixir
+case save_all_buffers(state) do
+  {:ok, state} -> shutdown_editor(state)
+  {:error, state} -> state
+end
+```
+
+##### Shared-helper decision
+
+One workflow helper must **not** serve both active save and save-all.
+
+Active save owns pre-save transforms, notices, local and remote conflict presentation, and Dired dispatch. Save-all intentionally performs raw dirty-buffer writes without those behaviors. Sharing one workflow helper would require mode flags or would change existing behavior.
+
+The two paths share only:
+
+- The private `save_result` contract
+- Existing `Buffer.dirty?/1` and `Buffer.save/1`
+- Existing close and shutdown owners
+
+No generic save wrapper or result framework is allowed.
+
+#### Ordered implementation steps
+
+1. Add the private `save_result` type.
+2. Extract the current ordinary `:save` body into tagged `save_active_buffer/1`, preserving branch order and exact notice strings.
+3. Add the Dired-specific `save_active_buffer/1` clause that classifies current Dired behavior as successful without changing it.
+4. Make public `execute(state, :save)` unwrap the private result and retain its `EditorState.t()` return contract.
+5. Replace the `:wq` pipeline with the exact success/error case split.
+6. Replace side-effect-only `save_all_buffers/1` with the ordered, first-failure-stopping tagged traversal.
+7. Replace the `:wqa` pipeline with the exact success/error case split.
+8. Add the dedicated serialized regression test file.
+9. Run focused and broad validation.
+10. Update W002 completion evidence only after validation and review. Do not alter L03 or claim it resolved.
+
+#### Required tests
+
+##### File and layer
+
+`test/minga_editor/commands/buffer_management_save_quit_test.exs`
+
+Use `Minga.Test.EditorCase` with rendering disabled. This is the cheapest deterministic layer that exercises real Buffer processes, command workflow state, tab closing, notices, and the configured shutdown function.
+
+The module header must include the mandated explanation:
+
+```elixir
+# Mutates Application env (:minga, :shutdown_fn); must not run concurrently with other tests.
+use Minga.Test.EditorCase, async: false, rendering: :disabled
+```
+
+Use `@moduletag :tmp_dir`.
+
+Setup must:
+
+1. Save the previous `Application.get_env(:minga, :shutdown_fn)`.
+2. Install a function that synchronously sends `{:shutdown, status}` to the test process.
+3. Restore the exact previous value in `on_exit/1`, deleting the key when it was previously absent.
+4. Follow the existing `NoGlobalStateInTestCheck` suppression pattern from `test/minga/chaos/editor_fuzzer_test.exs`.
+
+Use no sleeps, polling, `Process.alive?/1`, or foreign struct updates.
+
+##### Assertions
+
+1. **`"failed :wq keeps the active tab open and preserves the save notice"`**
+   - Start an editor with a scratch buffer.
+   - Add a second unnamed buffer through the existing command API so closing would visibly remove a tab.
+   - Execute `{:execute_ex_command, {:save_quit, []}}`.
+   - Assert the active buffer PID is unchanged.
+   - Assert tab labels are unchanged.
+   - Assert the notice is exactly `"No file name — use :w <filename>"`.
+   - `refute_received {:shutdown, 0}`.
+
+2. **`"successful :wq saves and closes the active tab"`**
+   - Start with one file-backed buffer and open a second file through `MingaEditor.open_file/2`.
+   - Edit the second buffer through `Buffer.insert_text/2`.
+   - Execute `:wq`.
+   - Assert the second file contains the edit.
+   - Assert exactly one file tab remains and the closed tab is absent.
+   - `refute_received {:shutdown, 0}` because another tab remains.
+
+3. **`"failed :wqa does not shut down and stops before later buffers"`**
+   - Make the first buffer in `workspace.buffers.list` a dirty unnamed buffer.
+   - Open a writable file-backed buffer second and make it dirty.
+   - Execute `:wqa`.
+   - `refute_received {:shutdown, 0}`.
+   - Assert the later buffer remains dirty.
+   - Assert its on-disk content is unchanged.
+   - This proves first-failure termination rather than merely suppressing shutdown after continuing all saves.
+
+4. **`"successful :wqa saves every current-workspace dirty buffer and invokes shutdown"`**
+   - Use two writable file-backed buffers in the active workspace.
+   - Make both dirty through Buffer APIs.
+   - Execute `:wqa`.
+   - Assert both files contain their edits.
+   - Assert both buffers are clean.
+   - `assert_received {:shutdown, 0}`.
+
+5. **`"active buffer exit is a failed :wq"`**
+   - Capture an owner-created Editor state.
+   - Monitor and stop its active Buffer process, then assert the matching `:DOWN`.
+   - Call `BufferManagement.execute/2` directly with the captured state and `:wq`.
+   - Assert it returns an `EditorState`.
+   - Assert the returned notice starts with `"Save failed:"`.
+   - `refute_received {:shutdown, 0}`.
+   - Do not mutate the captured state.
+
+6. **`"buffer exit stops :wqa without shutdown"`**
+   - Capture an owner-created Editor state containing the Buffer PID.
+   - Monitor and stop that Buffer, then assert the matching `:DOWN`.
+   - Call `BufferManagement.execute/2` directly with the captured state and `:wqa`.
+   - Assert it returns an `EditorState` without raising.
+   - `refute_received {:shutdown, 0}`.
+   - This deterministically exercises the exit path without racing the Editor’s buffer monitor.
+
+Existing `:file_changed`, no-path notice, and input-routing tests remain in place. No snapshot test is required because the rendered model does not change.
+
+#### Validation
+
+Focused:
+
+```bash
+mix test.debug test/minga_editor/commands/buffer_management_save_quit_test.exs test/minga_editor/input/handler_test.exs test/minga_editor/input/router_test.exs test/minga/buffer/mtime_test.exs
+```
+
+Broad:
+
+```bash
+make lint
+mix test.llm
+```
+
+No Swift, Go, Zig, protocol generation, or snapshot validation is required because the wire format and frontend behavior do not change.
+
+#### Non-goals
+
+- Do not implement L03.
+- Do not enumerate buffers from inactive tab contexts, stashed shell state, other workspaces, or root lifecycle monitors.
+- Do not add root-level buffer inventory, deduplication, retirement logic, or new ownership APIs.
+- Do not change which buffers `:wqa` considers.
+- Do not change `:quit`, `:quit_all`, force-quit, or quit-confirmation behavior.
+- Do not change `Minga.API.save/1`.
+- Do not change `Minga.Buffer.save_all_dirty/0`, whose continue-after-error behavior is a separate contract.
+- Do not add transactional save rollback.
+- Do not add save retries, telemetry, configuration, or error aggregation.
+- Do not introduce new notices for save-all failures.
+- Do not change file persistence or Buffer dirty tracking.
+
+#### Retained constraints
+
+- Active `:save` and `:wq` apply pre-save transforms exactly once.
+- `:wqa` does not apply pre-save transforms, matching current behavior.
+- Local and remote file-conflict handling remains unchanged.
+- Existing save notice strings remain unchanged for all current `Buffer.save/1` return values.
+- Dired `:save`, Dired `:wq`, and Dired confirmation behavior remain unchanged.
+- `:force_save` and Dired force-save behavior remain unchanged.
+- Failed save-and-quit paths do not close, cancel, accept, or otherwise resolve wait requests.
+- Successful close and shutdown paths retain their existing wait-request behavior.
+- `close_tab_or_quit/1` remains the sole close-or-quit decision point.
+- `shutdown_editor/1` remains the sole normal shutdown effect owner.
+- Save-all retains `state.workspace.buffers.list` order and stops on the first error or exit.
+- Inactive-tab-only buffers remain ignored. L03 stays `ROUTE/archie`.
+
+#### Dependencies
+
+- W001 is `VERIFIED`.
+- W003 through W006 remain `CANDIDATE`.
+- No W002 owner area is currently `READY` or `ACTIVE`.
+- Current `HEAD` equals current `origin/main`.
+- L03 is not a dependency because this specification explicitly preserves its current behavior and architecture gap.
+- No architecture, protocol, frontend, or persistence dependency remains.
+
+#### Line and concept budget
+
+- **Maximum production files:** 1
+- **Authorized target net production delta:** `<= +25`
+- **Absolute roadmap ceiling:** `+40`; exceeding `+25` requires replanning rather than compressing code, and exceeding `+40` is blocked.
+- **Expected production delta:** `[INFERENCE]` Between `+10` and `+25`, primarily the private result type, active-save extraction, and short-circuit branches.
+- **Maximum test delta:** `+180`
+- **Documentation lines:** Count separately; only the W002 roadmap block changes.
+- **New concepts:** Exactly one private `save_result` contract.
+- **Reused concepts:** `Buffer.save/1`, `Buffer.dirty?/1`, current notice/conflict workflows, Dired command dispatch, `close_tab_or_quit/1`, `shutdown_editor/1`, WaitRequests, and current active-workspace buffer order.
+- **Removed concepts:** State-only implicit save success, unconditional `:wq` close pipeline, side-effect-only `save_all_buffers/1`, ignored save errors, and catch-and-continue save-all exits.
+- **Forbidden additions:** New module, process, dependency, behaviour, protocol, registry, public API, configuration, persistence shape, owner, generic wrapper, compatibility shim, or parallel result framework.
+- **Review scope:** `[INFERENCE]` One production file, one dedicated test file, and one roadmap update fit one reviewable PR.
+
+#### Definition of Ready
+
+1. The Ponytail verdict is `ACCEPT`.
+2. The finding remains reproducible on current main.
+3. One independently verifiable outcome is locked.
+4. The authoritative state, process, protocol, or persistence owner is known.
+5. The exact target return shape, struct, tagged state, tuple, or transition contract is specified.
+6. Expected files, symbols, producers, and consumers are named.
+7. The exact test layer, test file, assertions, and edge cases are specified.
+8. Non-goals and retained constraints are explicit.
+9. Dependencies are merged and no overlapping-owner work is active.
+10. Exact focused and broad validation commands are listed.
+11. The production-line and concept budgets are locked.
+12. No unresolved question remains for the implementer.
+13. The work fits in one reviewable PR.
+
+#### Implementer-question status
+
+None. The implementer must return `NEEDS_REPLAN` rather than choose a different result shape, inventory, notice policy, helper abstraction, or production budget.
+
+#### Completion evidence
+
+- **PR URL:** Pending
+- **Commit SHA:** Pending
+- **Merge SHA:** Pending
+- **Focused tests:** `mix test.debug test/minga_editor/commands/buffer_management_save_quit_test.exs test/minga_editor/input/handler_test.exs test/minga_editor/input/router_test.exs test/minga/buffer/mtime_test.exs` — 47 passed
+- **Broad validation:** `make lint` passed; `ERL_FLAGS='+S 8:8' mix test.llm` passed — 58 doctests, 98 properties, 9,845 tests, 0 failures, 1 skipped, 574 excluded
+- **Ponytail verdict:** LEAN
+- **Bug-hunt verdict:** PASS
+- **Elixir craftsmanship verdict:** IDIOMATIC
+- **Final reviewer verdict:** PASS
+- **Production lines added/removed:** 60 added / 37 removed, net +23
+- **Test lines added/removed:** 140 added / 0 removed, net +140
+- **Concepts added/removed:** One private `save_result` contract added; removed implicit state-only save success, unconditional save-and-quit close/shutdown, ignored save errors, and catch-and-continue save-all exits
+- **Findings resolved:** L02, failed saves no longer close the active tab or shut down the editor
+- **Discoveries affecting later work:** Silent-failure review: PASS. Default-concurrency `mix test.llm` hit five unrelated MingaAgent timeout failures after 8,155 tests; untouched current `main` reproduced the known suite-instability class with an unrelated extension timeout and `erl_child_setup` EPIPE after 9,839 tests. The already-established reduced scheduler count produced a clean full pass. No later-work contract discovery; L03 remains out of scope and W003-W006 were not changed
+- **Completion date:** Pending
 
 ### W003: Dirty buffers require explicit destruction
 

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -48,6 +48,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias MingaEditor.WorkspaceWorkflow
 
   @type state :: EditorState.t()
+  @typep save_result :: {:ok, state()} | {:error, state()}
 
   @spec execute(state(), Mode.command()) :: state()
 
@@ -61,30 +62,9 @@ defmodule MingaEditor.Commands.BufferManagement do
     MingaEditor.Commands.Dired.execute(state, :dired_apply_changes)
   end
 
-  def execute(%{workspace: %{buffers: %{active: buf}}} = state, :save) do
-    state = apply_pre_save_transforms(state, buf)
-
-    case Buffer.save(buf) do
-      :ok ->
-        name = Helpers.buffer_display_name(buf)
-
-        NoticeWorkflow.publish(state, "Wrote #{name}")
-
-      {:error, :file_changed} ->
-        handle_file_changed_on_save(state, buf)
-
-      {:error, :no_file_path} ->
-        NoticeWorkflow.publish(
-          state,
-          "No file name — use :w <filename>"
-        )
-
-      {:error, reason} ->
-        NoticeWorkflow.publish(
-          state,
-          "Save failed: #{inspect(reason)}"
-        )
-    end
+  def execute(%{workspace: %{buffers: %{active: _}}} = state, :save) do
+    {_status, state} = save_active_buffer(state)
+    state
   end
 
   def execute(%{workspace: %{buffers: %{active: buf}}} = state, :force_save) do
@@ -306,11 +286,17 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   def execute(state, {:execute_ex_command, {:save_quit, []}}) do
-    state |> execute(:save) |> close_tab_or_quit()
+    case save_active_buffer(state) do
+      {:ok, state} -> close_tab_or_quit(state)
+      {:error, state} -> state
+    end
   end
 
   def execute(state, {:execute_ex_command, {:save_quit_all, []}}) do
-    state |> save_all_buffers() |> shutdown_editor()
+    case save_all_buffers(state) do
+      {:ok, state} -> shutdown_editor(state)
+      {:error, state} -> state
+    end
   end
 
   def execute(state, {:execute_ex_command, {:dired, nil}}) do
@@ -2093,19 +2079,56 @@ defmodule MingaEditor.Commands.BufferManagement do
     end)
   end
 
-  # Saves all dirty buffers in the buffer list. Called by :wqa before
-  # shutting down. Returns state unchanged (side-effectual only).
-  @spec save_all_buffers(state()) :: state()
-  defp save_all_buffers(state) do
-    Enum.each(state.workspace.buffers.list, fn buf ->
-      try do
-        if Buffer.dirty?(buf), do: Buffer.save(buf)
-      catch
-        :exit, _ -> :ok
-      end
-    end)
+  @spec save_active_buffer(state()) :: save_result()
+  defp save_active_buffer(%{workspace: %{dired: %{active?: true}}} = state) do
+    {:ok, MingaEditor.Commands.Dired.execute(state, :dired_apply_changes)}
+  end
 
-    state
+  defp save_active_buffer(%{workspace: %{buffers: %{active: buf}}} = state) do
+    try do
+      state = apply_pre_save_transforms(state, buf)
+
+      case Buffer.save(buf) do
+        :ok ->
+          name = Helpers.buffer_display_name(buf)
+          {:ok, NoticeWorkflow.publish(state, "Wrote #{name}")}
+
+        {:error, :file_changed} ->
+          {:error, handle_file_changed_on_save(state, buf)}
+
+        {:error, :no_file_path} ->
+          {:error, NoticeWorkflow.publish(state, "No file name — use :w <filename>")}
+
+        {:error, reason} ->
+          {:error, NoticeWorkflow.publish(state, "Save failed: #{inspect(reason)}")}
+      end
+    catch
+      :exit, reason ->
+        {:error, NoticeWorkflow.publish(state, "Save failed: #{inspect(reason)}")}
+    end
+  end
+
+  @spec save_all_buffers(state()) :: save_result()
+  defp save_all_buffers(state), do: save_all_buffers(state, state.workspace.buffers.list)
+
+  @spec save_all_buffers(state(), [pid()]) :: save_result()
+  defp save_all_buffers(state, []), do: {:ok, state}
+
+  defp save_all_buffers(state, [buf | rest]) do
+    try do
+      case Buffer.dirty?(buf) do
+        true ->
+          case Buffer.save(buf) do
+            :ok -> save_all_buffers(state, rest)
+            {:error, _reason} -> {:error, state}
+          end
+
+        false ->
+          save_all_buffers(state, rest)
+      end
+    catch
+      :exit, _reason -> {:error, state}
+    end
   end
 
   @spec complete_wait_requests_for_tabs([Tab.t()]) :: :ok

--- a/test/minga_editor/commands/buffer_management_save_quit_test.exs
+++ b/test/minga_editor/commands/buffer_management_save_quit_test.exs
@@ -1,0 +1,140 @@
+defmodule MingaEditor.Commands.BufferManagementSaveQuitTest do
+  @moduledoc false
+
+  # Mutates Application env (:minga, :shutdown_fn); must not run concurrently with other tests.
+  use Minga.Test.EditorCase, async: false, rendering: :disabled
+
+  alias Minga.Buffer
+  alias MingaEditor.Commands.BufferManagement
+  alias MingaEditor.State, as: EditorState
+
+  @moduletag :tmp_dir
+
+  setup do
+    previous_shutdown_fn = Application.get_env(:minga, :shutdown_fn)
+    test_pid = self()
+
+    # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
+    Application.put_env(:minga, :shutdown_fn, fn status -> send(test_pid, {:shutdown, status}) end)
+
+    on_exit(fn ->
+      case previous_shutdown_fn do
+        # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
+        nil -> Application.delete_env(:minga, :shutdown_fn)
+        # credo:disable-for-next-line Minga.Credo.NoGlobalStateInTestCheck
+        shutdown_fn -> Application.put_env(:minga, :shutdown_fn, shutdown_fn)
+      end
+    end)
+
+    :ok
+  end
+
+  test "failed :wq keeps the active tab open and preserves the save notice" do
+    ctx = start_editor("")
+    send_ex_sync(ctx, "new")
+    active_before = active_buffer(ctx)
+    labels_before = tab_labels(ctx)
+
+    send_ex_sync(ctx, "wq")
+
+    assert active_buffer(ctx) == active_before
+    assert tab_labels(ctx) == labels_before
+    assert notice_message(ctx) == "No file name — use :w <filename>"
+    refute_received {:shutdown, 0}
+  end
+
+  test "successful :wq saves and closes the active tab", %{tmp_dir: root} do
+    first_path = Path.join(root, "first.txt")
+    second_path = Path.join(root, "second.txt")
+    File.write!(first_path, "first")
+    File.write!(second_path, "second")
+
+    ctx = start_editor("first", file_path: first_path)
+    :ok = MingaEditor.open_file(ctx.editor, second_path)
+    second_buffer = active_buffer(ctx)
+    :ok = Buffer.insert_text(second_buffer, " edited")
+
+    send_ex_sync(ctx, "wq")
+
+    assert File.read!(second_path) == " editedsecond"
+    assert length(visible_file_tabs(ctx, active_workspace_id(ctx))) == 1
+    refute "second.txt" in tab_labels(ctx)
+    refute_received {:shutdown, 0}
+  end
+
+  test "failed :wqa does not shut down and stops before later buffers", %{tmp_dir: root} do
+    later_path = Path.join(root, "later.txt")
+    File.write!(later_path, "later")
+
+    ctx = start_editor("")
+    first_buffer = active_buffer(ctx)
+    :ok = Buffer.insert_text(first_buffer, "first")
+    :ok = MingaEditor.open_file(ctx.editor, later_path)
+    later_buffer = active_buffer(ctx)
+    :ok = Buffer.insert_text(later_buffer, " changed")
+
+    send_ex_sync(ctx, "wqa")
+
+    refute_received {:shutdown, 0}
+    assert Buffer.dirty?(later_buffer)
+    assert File.read!(later_path) == "later"
+  end
+
+  test "successful :wqa saves every current-workspace dirty buffer and invokes shutdown", %{
+    tmp_dir: root
+  } do
+    first_path = Path.join(root, "first.txt")
+    second_path = Path.join(root, "second.txt")
+    File.write!(first_path, "first")
+    File.write!(second_path, "second")
+
+    ctx = start_editor("first", file_path: first_path)
+    first_buffer = active_buffer(ctx)
+    :ok = MingaEditor.open_file(ctx.editor, second_path)
+    second_buffer = active_buffer(ctx)
+    :ok = Buffer.insert_text(first_buffer, " edited")
+    :ok = Buffer.insert_text(second_buffer, " edited")
+
+    send_ex_sync(ctx, "wqa")
+
+    assert File.read!(first_path) == " editedfirst"
+    assert File.read!(second_path) == " editedsecond"
+    refute Buffer.dirty?(first_buffer)
+    refute Buffer.dirty?(second_buffer)
+    assert_received {:shutdown, 0}
+  end
+
+  test "active buffer exit is a failed :wq" do
+    ctx = start_editor("")
+    state = editor_state(ctx)
+    buffer = state.workspace.buffers.active
+    monitor_ref = Process.monitor(buffer)
+    :ok = GenServer.stop(buffer)
+    assert_receive {:DOWN, ^monitor_ref, :process, ^buffer, _reason}
+
+    result = BufferManagement.execute(state, {:execute_ex_command, {:save_quit, []}})
+
+    assert %EditorState{} = result
+
+    assert String.starts_with?(
+             MingaEditor.Shell.Traditional.NoticeWorkflow.message(result),
+             "Save failed:"
+           )
+
+    refute_received {:shutdown, 0}
+  end
+
+  test "buffer exit stops :wqa without shutdown" do
+    ctx = start_editor("")
+    state = editor_state(ctx)
+    buffer = state.workspace.buffers.active
+    monitor_ref = Process.monitor(buffer)
+    :ok = GenServer.stop(buffer)
+    assert_receive {:DOWN, ^monitor_ref, :process, ^buffer, _reason}
+
+    result = BufferManagement.execute(state, {:execute_ex_command, {:save_quit_all, []}})
+
+    assert %EditorState{} = result
+    refute_received {:shutdown, 0}
+  end
+end


### PR DESCRIPTION
# TL;DR

Save-and-quit now closes the active tab or shuts down the editor only after the required saves succeed. Save failures preserve the current editor state, and `:wqa` stops at the first failed or exited buffer process.

## Context

This is W002 from the repository-local editor lifecycle roadmap and resolves audit finding L02. It deliberately preserves the current active-workspace buffer inventory; the separate root inventory decision in L03 remains out of scope.

## Changes

- Add one private tagged save result around the existing active-buffer save workflow while preserving pre-save transforms, conflict handling, notices, and Dired dispatch.
- Make `:wq` close only on `{:ok, state}` and make `:wqa` shut down only after every dirty buffer in the existing ordered inventory saves successfully.
- Treat Buffer process exits as save failures without adding retries, rollback, error aggregation, or new save-all notices.
- Add six command-boundary regression tests for failed and successful `:wq`, first-failure and successful `:wqa`, and dead-buffer behavior.
- Promote W002 in the living roadmap and record scope, budgets, reviews, and validation evidence.

## Compatibility

Public command shapes, Buffer APIs, Dired behavior, wait-request behavior, file-conflict handling, frontend protocols, and persistence formats are unchanged. Ordinary `:save` still returns Editor state through the existing command boundary.

## Verification

- `mix test.debug test/minga_editor/commands/buffer_management_save_quit_test.exs test/minga_editor/input/handler_test.exs test/minga_editor/input/router_test.exs test/minga/buffer/mtime_test.exs` — 47 passed
- `make lint` — passed
- `ERL_FLAGS='+S 8:8' mix test.llm` — 58 doctests, 98 properties, 9,845 tests, 0 failures, 1 skipped, 574 excluded
- LSP diagnostics for the changed production and test files — no diagnostics
- `git diff --check` — passed

The default 64-way broad run hit unrelated MingaAgent timeouts. Untouched current `main` independently reproduced the existing suite-instability class with an unrelated extension timeout and `erl_child_setup` EPIPE; the reduced-scheduler full run above was clean.

## Acceptance Criteria Addressed

- Failed `:wq` keeps the active tab open and preserves existing save feedback.
- Successful `:wq` saves and closes through the existing close-or-quit owner.
- Failed `:wqa` does not shut down and does not continue to later buffers.
- Successful `:wqa` saves every dirty buffer in the existing current-workspace inventory and invokes shutdown.
- Active and save-all Buffer process exits return safely without closing or shutting down.
- L02 is resolved without implementing or obscuring L03.
