### PR TITLE
test(project): serialize OS process fixtures

### DIFF
--- a/test/minga/project_test.exs
+++ b/test/minga/project_test.exs
@@ -1,12 +1,19 @@
 defmodule Minga.ProjectTest do
-  use ExUnit.Case, async: true
+  # Serializes because git-backed fixtures spawn real OS processes.
+  use ExUnit.Case, async: false
   use ExUnitProperties
 
+  alias Minga.Config.Options
   alias Minga.Project
   alias Minga.Project.Root
   alias Minga.Project.WorkspaceSnapshot
 
   @moduletag :tmp_dir
+  setup_all do
+    Options.set(:persist_known_projects, false)
+    Options.set(:persist_recent_files, false)
+    :ok
+  end
 
   # Start a private Project GenServer for each test to avoid global state.
   defp start_project!(opts \\ []) do

--- a/test/minga_agent/tools/path_ignore_test.exs
+++ b/test/minga_agent/tools/path_ignore_test.exs
@@ -1,5 +1,6 @@
 defmodule MingaAgent.Tools.PathIgnoreTest do
-  use ExUnit.Case, async: true
+  # Serializes because git-backed filter tests spawn real OS processes.
+  use ExUnit.Case, async: false
 
   alias MingaAgent.Tools.PathIgnore
 

--- a/test/minga_editor/effects/todo_search_port_test.exs
+++ b/test/minga_editor/effects/todo_search_port_test.exs
@@ -46,7 +46,6 @@ defmodule MingaEditor.Effects.TodoSearch.PortTest do
     os_pid = read_probed_pid(probe)
     assert_receive {:DOWN, ^probe_ref, :port, ^probe, _reason}, 1_000
     drain_probe_messages(probe)
-    assert process_alive?(os_pid)
     {task, os_pid}
   end
 


### PR DESCRIPTION
## Summary

- Serialize two test modules that spawn real git OS processes.
- Reassert the test-suite persistence policy before serialized Project tests run.
- Remove an intermediate TodoSearch child-liveness assertion that races with the byte-limit kill it is testing.

## Why

Documentation-only PR #2985 exposed `erl_child_setup: failed with error 32` plus a TodoSearch child that completed before its intermediate liveness assertion. The affected modules either violated the project OS-process serialization rule or asserted timing instead of the final kill contract.

## Validation

- Focused three-file run: 38 passed
- Project isolation rerun: 32 passed
- `ERL_FLAGS='+S 2:2' mix test.llm`: 9,864 tests, 0 failures
- `make lint`: passed
- Final reviewer: PASS, confidence 0.99
