### PR TITLE
fix(ui): remove unreachable tool manager footer placement

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1643,8 +1643,8 @@ Remove only the unreachable Tool Manager footer-overlay producer. Footer placeme
 
 #### Completion evidence
 
-- **PR URL:** Pending
-- **Commit SHA:** Pending
+- **PR URL:** https://github.com/jsmestad/minga/pull/2997
+- **Commit SHA:** `7dcd23c20ffd9368e341ce64fa435ea9391cea23`
 - **Merge SHA:** Pending
 - **Focused tests:** `mix test.debug test/minga_editor/layout/footer_band_overlays_test.exs` passed, 18 tests.
 - **Broad validation:** `git diff --check` passed; `make lint` passed (Credo, compile, incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 2:2' mix test.llm` passed (58 doctests, 98 properties, 9,854 tests, 0 failures, 1 skipped, 578 excluded).

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1521,7 +1521,7 @@ Live renderer behavior is owned by the renderer pipeline, frontend capabilities,
 
 ### W010: Remove duplicate Diagnostics LSP Info branch
 
-- **Status:** ACTIVE
+- **Status:** VERIFIED
 - **Audit ID:** D29
 - **Roadmap unit:** W010, Remove duplicate Diagnostics LSP Info branch
 - **Ponytail verdict:** `ACCEPT/delete`
@@ -1576,7 +1576,7 @@ Remove the unreachable Diagnostics-owned `:lsp_info` branch and its unused alias
 
 - **PR URL:** https://github.com/jsmestad/minga/pull/2996
 - **Commit SHA:** `8a050efa3fabf0dfce0a02e1b8de19a54a7bceae`
-- **Merge SHA:** Pending
+- **Merge SHA:** `38451d7cf696987d86a5d100ad20c0e308693f7e`
 - **Focused tests:** `mix test.debug test/minga_editor/commands/diagnostics_picker_test.exs test/minga_editor/commands/lsp_test.exs` passed, 9 tests.
 - **Broad validation:** `git diff --check` passed; `make lint` passed (Credo, compile, incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 2:2' mix test.llm` passed (58 doctests, 98 properties, 9,853 tests, 0 failures, 1 skipped, 578 excluded).
 - **Ponytail and Elixir verdict:** `LEAN`; the one-file cut removes a duplicate unreachable branch while leaving the explicit registered owner intact.
@@ -1587,6 +1587,75 @@ Remove the unreachable Diagnostics-owned `:lsp_info` branch and its unused alias
 - **Concepts added/removed:** No concepts added; one duplicate command implementation removed.
 - **Findings resolved:** Diagnostics no longer carries an unreachable alternate LSP Info implementation.
 - **Discoveries affecting later work:** None.
+- **Completion date:** 2026-07-18
+
+### W011: Remove unreachable Tool Manager footer placement
+
+- **Status:** ACTIVE
+- **Audit ID:** D36
+- **Roadmap unit:** W011, Remove unreachable Tool Manager footer placement
+- **Ponytail verdict:** `ACCEPT/delete`
+- **Freshness profile:** `editor-lifecycle-freshness`, `openai-codex/gpt-5.5`, `medium`, read-only
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness SHA:** `38451d7cf696987d86a5d100ad20c0e308693f7e`
+- **Freshness basis:** Freshly rebased `HEAD` and `origin/main` include W010. The footer placement list still contains Tool Manager behind a private predicate that always returns false. SurfaceRegistry identity, numeric ID 21, GUI action handling, frontend decoder state, service ownership, and picker behavior remain live and must be preserved.
+- **Implementer questions:** None.
+
+#### Observable outcome
+
+Remove only the unreachable Tool Manager footer-overlay producer. Footer placement APIs report the seven active producers and never return a Tool Manager rect, while Tool Manager protocol identity and live frontend/service/picker behavior remain unchanged.
+
+#### Authoritative owner and locked shape
+
+`MingaEditor.Layout.FooterOverlays` owns footer placement production. `MingaEditor.Layout.SurfaceRegistry` separately owns stable surface identity, numeric protocol ID, z order, and hit kind. Delete the dormant producer from the former without changing the latter.
+
+#### Exact files, symbols, producers, and consumers
+
+- `lib/minga_editor/layout/footer_overlays.ex`: remove the `:tool_manager` visibility entry and private `tool_manager_visible?/1`; document seven active producers
+- `lib/minga_editor/focus_tree.ex`: update exact active footer-overlay count wording
+- `lib/minga_editor/layout/overlay_band.ex`: remove Tool Manager from the active footer-band surface list and retain the seven real surfaces
+- `test/minga_editor/layout/footer_band_overlays_test.exs`: assert Tool Manager retains registry identity and ID 21 but has no placement or rect
+- Preserve `MingaEditor.Layout.SurfaceRegistry.surface_id/1`, `surface_id_u16/1`, z/hit mappings, protocol encoders/decoders, Tool Manager service, commands, picker sources, and native frontend state
+
+#### Locked implementation
+
+1. Delete `{:tool_manager, tool_manager_visible?(state), :max}` from `FooterOverlays.visible/1`.
+2. Delete the private hardcoded-false predicate.
+3. Update active-producer documentation from eight to seven and remove Tool Manager from the list.
+4. Add a focused regression asserting `surface_id(:tool_manager) == :tool_manager`, `surface_id_u16(:tool_manager) == 21`, no placement ID equals `:tool_manager`, and `rect_for(state, :tool_manager) == nil`.
+5. Change no registry, protocol, frontend, service, command, picker, or Tool Manager state code.
+
+#### Validation
+
+- Focused: `mix test.debug test/minga_editor/layout/footer_band_overlays_test.exs`
+- Broad: `make lint`
+- Full non-heavy: `ERL_FLAGS='+S 2:2' mix test.llm`
+
+#### Non-goals and budget
+
+- Do not delete or redesign Tool Manager, reclaim ID 21, alter SurfaceRegistry, change footer geometry, or modify any live producer.
+- Do not add a process, module, dependency, abstraction, behaviour, protocol, cache, compatibility path, or replacement.
+- **Expected production delta:** net non-positive.
+- **Expected test delta:** at most +12 net lines.
+- **Maximum production-line increase:** 0 net.
+- **Maximum test-line increase:** +12 net.
+
+#### Completion evidence
+
+- **PR URL:** Pending
+- **Commit SHA:** Pending
+- **Merge SHA:** Pending
+- **Focused tests:** `mix test.debug test/minga_editor/layout/footer_band_overlays_test.exs` passed, 18 tests.
+- **Broad validation:** `git diff --check` passed; `make lint` passed (Credo, compile, incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 2:2' mix test.llm` passed (58 doctests, 98 properties, 9,854 tests, 0 failures, 1 skipped, 578 excluded).
+- **Ponytail and Elixir verdict:** `LEAN` after one targeted correction; stale eight-surface wording was corrected to the same seven active producers implemented by `FooterOverlays`.
+- **Bug-hunt verdict:** `PASS`; Tool Manager registry ID 21, z/hit mapping, GUI actions, frontend decoder state, service, and picker behavior remain live and untouched.
+- **Final reviewer verdict:** `PASS`; the staged diff removes only the false placement producer, preserves Tool Manager compatibility boundaries and all live overlays, matches budgets, and carries final-base validation.
+- **Production lines added/removed:** 26 added / 36 removed, net -10
+- **Test lines added/removed:** 12 added / 2 removed, net +10
+- **Concepts added/removed:** No concepts added; one permanently false placement branch removed.
+- **Findings resolved:** Tool Manager no longer appears as an unreachable footer-overlay producer.
+- **Discoveries affecting later work:** SurfaceRegistry identity is a protocol compatibility boundary independent from footer placement production.
 - **Completion date:** 2026-07-18
 
 ## Follow-on simplifications

--- a/lib/minga_editor/focus_tree.ex
+++ b/lib/minga_editor/focus_tree.ex
@@ -352,9 +352,9 @@ defmodule MingaEditor.FocusTree do
 
   # ── Footer-band overlay builders ──────────────────────────────────────────
   #
-  # The eight secondary overlays (float popup, agent context, tool manager,
-  # extension panel, observatory, edit timeline, notifications, extension
-  # overlay) the owner ruled mouse-driven (#2330). `FooterOverlays.visible/1`
+  # The seven active secondary overlay producers (float popup, agent context,
+  # extension panel, observatory, edit timeline, notifications, extension overlay)
+  # the owner ruled mouse-driven (#2330). `FooterOverlays.visible/1`
   # decides which are live this frame (single-active model still holds, but the
   # tree expresses each visible one so the registry/emitter carry their rect/z;
   # Go composites the single highest-z winner). Each gets a bottom-anchored band

--- a/lib/minga_editor/layout/footer_overlays.ex
+++ b/lib/minga_editor/layout/footer_overlays.ex
@@ -1,17 +1,17 @@
 defmodule MingaEditor.Layout.FooterOverlays do
   @moduledoc """
-  BEAM visibility source for the eight footer-band secondary overlays (#2281).
+  BEAM visibility source for the seven active footer-band secondary overlay producers (#2281).
 
-  These surfaces (float popup, agent context, tool manager, extension panel,
-  observatory, edit timeline, notifications, extension overlay) historically had
-  no BEAM rect: the Go compositor footer-appended one of them, sizing it
-  frontend-side. The owner ruled them mouse-driven (#2330), so the BEAM now owns
-  their semantic footer-band z and conservative cell containment. Native GUI
-  frontends still own final rich-content measurement inside those bands. This
-  module is the single place that decides which of the eight is visible this
-  frame and how tall its conservative band is, reading the SAME underlying state
-  the render-model builders read (so visibility never drifts from what the
-  frontend actually renders).
+  These surfaces (float popup, agent context, extension panel, observatory, edit
+  timeline, notifications, extension overlay) historically had no BEAM rect: the
+  Go compositor footer-appended one of them, sizing it frontend-side. The owner
+  ruled them mouse-driven (#2330), so the BEAM now owns their semantic footer-band
+  z and conservative cell containment. Native GUI frontends still own final
+  rich-content measurement inside those bands. This module is the single place
+  that decides which active producer is visible this frame and how tall its
+  conservative band is, reading the SAME underlying state the render-model
+  builders read (so visibility never drifts from what the frontend actually
+  renders).
 
   `visible/1` returns the visible footer overlays as `{surface_id, content_height}`
   pairs. `MingaEditor.FocusTree` turns each into an overlay node via
@@ -51,17 +51,13 @@ defmodule MingaEditor.Layout.FooterOverlays do
       renders a title plus up to two blocks per visible panel until it fills the
       band, so its phantom zone shrinks as panels are added.
 
-  ## Live vs dormant sources (honesty, #2281)
+  ## Live sources (honesty, #2281)
 
   Seven surfaces have a live BEAM content source in the render-model path and so
   can actually become visible here: float popup, extension panel, observatory,
-  edit timeline, notifications, extension overlay, and agent context. One is
-  dormant on that path: the tool manager is not in the render-model UI at all (it
-  ships only via the legacy `protocol/gui.ex` path). Their predicates here are
-  wired to the same future sources, so they are placement-ready and will light up
-  automatically when an epic child gives them a BEAM render-model source. Today
-  the tool manager predicate never fires, which is correct: an overlay the BEAM
-  never renders must not claim a footer band.
+  edit timeline, notifications, extension overlay, and agent context. The Tool
+  Manager registry identity is preserved elsewhere for compatibility, but it has
+  no footer-overlay producer here because it is not in the render-model UI.
   """
 
   alias MingaEditor.RenderModel.UI.AgentContextBuilder
@@ -98,7 +94,6 @@ defmodule MingaEditor.Layout.FooterOverlays do
       {:edit_timeline, edit_timeline_visible?(state), content_height_edit_timeline(state)},
       {:observatory, observatory_visible?(state), content_height_observatory(state)},
       {:extension_panel, extension_panel_visible?(), :max},
-      {:tool_manager, tool_manager_visible?(state), :max},
       {:agent_context, agent_context_visible?(state), :max},
       {:float_popup, float_popup_visible?(state), :max}
     ]
@@ -218,11 +213,6 @@ defmodule MingaEditor.Layout.FooterOverlays do
   defp agent_context_visible?(state) do
     AgentContextBuilder.visible?(state)
   end
-
-  # Tool manager: not in the render-model UI; no BEAM content source on this path.
-  # Dormant until an epic child adds a render-model builder for it.
-  @spec tool_manager_visible?(map()) :: boolean()
-  defp tool_manager_visible?(_state), do: false
 
   # Extension panel: any visible extension or semantic panel.
   # Mirrors MingaEditor.RenderModel.UI.ExtensionPanelBuilder.

--- a/lib/minga_editor/layout/overlay_band.ex
+++ b/lib/minga_editor/layout/overlay_band.ex
@@ -5,10 +5,10 @@ defmodule MingaEditor.Layout.OverlayBand do
   The Go compositor historically footer-appended one secondary overlay at the
   bottom of the screen, sizing its height with `maxOverlayHeight()`
   (`go/tui/internal/ui/model.go`: `min(max(height/3, 4), 12)`) and spanning the
-  full terminal width. These eight surfaces (float popup, agent context, tool
-  manager, extension panel, observatory, edit timeline, notifications, extension
-  overlay) are identical footer-band shapes, so the BEAM owns one rect helper for
-  all of them instead of eight copies.
+  full terminal width. These seven surfaces (float popup, agent context, extension
+  panel, observatory, edit timeline, notifications, and extension overlay) are
+  identical footer-band shapes, so the BEAM owns one rect helper for all of them
+  instead of seven copies.
 
   `rect/2` ports that exact clamp. `content_height` is the surface's content line
   count (BEAM-derivable from the chrome/UI models) or `:max` for a surface whose
@@ -20,9 +20,9 @@ defmodule MingaEditor.Layout.OverlayBand do
   Only one overlay shows at a time in that band (single-active model, #2268 AC-4).
   For the count-derivable surfaces (notifications, observatory, edit_timeline,
   extension_overlay) the caller passes a real `content_height` so the band shrinks
-  to the content and the overlay hugs the screen bottom. For the wrap-dependent
-  surfaces (float_popup, extension_panel, and the dormant agent_context/tool_manager)
-  the caller passes `:max` (the clamp ceiling); the frontend bottom-aligns the
+  to the content and the overlay hugs the screen bottom. For wrap-dependent
+  active surfaces (float_popup, extension_panel, and agent_context) the caller
+  passes `:max` (the clamp ceiling); the frontend bottom-aligns the
   rendered content inside that band, so a short overlay still hugs the bottom and
   the residual phantom rows sit ABOVE it (see `MingaEditor.Layout.FooterOverlays`).
   Either way the rect only needs to CONTAIN the overlay so clicks over it are

--- a/test/minga_editor/layout/footer_band_overlays_test.exs
+++ b/test/minga_editor/layout/footer_band_overlays_test.exs
@@ -1,7 +1,7 @@
 defmodule MingaEditor.Layout.FooterBandOverlaysTest do
   @moduledoc """
-  Promotion of the eight footer-band secondary overlays to registry-placed
-  FocusTree nodes (#2281), plus the click-containment safety floor (AC-2).
+  Promotion of active footer-band secondary overlays to registry-placed FocusTree
+  nodes (#2281), plus the click-containment safety floor (AC-2).
 
   Covers four things:
 
@@ -228,6 +228,16 @@ defmodule MingaEditor.Layout.FooterBandOverlaysTest do
       refute :notifications in ids
       refute :float_popup in ids
       refute :observatory in ids
+    end
+
+    test "tool manager registry identity remains without a footer placement" do
+      state = base_state()
+      ids = state |> SurfaceRegistry.placements() |> Enum.map(& &1.surface_id)
+
+      assert SurfaceRegistry.surface_id(:tool_manager) == :tool_manager
+      assert SurfaceRegistry.surface_id_u16(:tool_manager) == 21
+      refute :tool_manager in ids
+      assert SurfaceRegistry.rect_for(state, :tool_manager) == nil
     end
 
     test "the notifications focus node routes to the swallow-by-default sink" do


### PR DESCRIPTION
## TL;DR

Remove a permanently false Tool Manager footer-placement branch while preserving Tool Manager's stable protocol identity and all live behavior.

## Context

Audit finding D36 identified a footer producer guarded by a private predicate that always returned false. Tool Manager itself remains live through SurfaceRegistry ID 21, GUI actions, frontend state, its service, and picker commands. Those boundaries are intentionally untouched.

## Changes

- Remove the unreachable Tool Manager entry from `FooterOverlays.visible/1`
- Remove the hardcoded-false predicate
- Correct footer-overlay documentation to the seven active producers
- Add regression coverage that preserves Tool Manager identity and ID 21 while proving it has no footer rect
- Record W010 merge evidence and the locked W011 scope in the lifecycle roadmap

## Preserved

- SurfaceRegistry identity, numeric ID 21, z order, and hit kind
- GUI actions, protocol/frontend decoder state, service, and picker behavior
- Footer geometry and all seven live overlay producers

## Verification

- Focused footer overlay tests: 18 passed
- `git diff --check`: passed
- `make lint`: passed
- `ERL_FLAGS='+S 2:2' mix test.llm`: 9,854 tests, 0 failures
- Ponytail and Elixir review: LEAN after stale wording correction
- Bug hunt: PASS
- Final acceptance review: PASS