### PR TITLE
fix(ui): preserve async picker prefix lifecycle

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1591,7 +1591,7 @@ Remove the unreachable Diagnostics-owned `:lsp_info` branch and its unused alias
 
 ### W011: Remove unreachable Tool Manager footer placement
 
-- **Status:** ACTIVE
+- **Status:** VERIFIED
 - **Audit ID:** D36
 - **Roadmap unit:** W011, Remove unreachable Tool Manager footer placement
 - **Ponytail verdict:** `ACCEPT/delete`
@@ -1645,7 +1645,7 @@ Remove only the unreachable Tool Manager footer-overlay producer. Footer placeme
 
 - **PR URL:** https://github.com/jsmestad/minga/pull/2997
 - **Commit SHA:** `7dcd23c20ffd9368e341ce64fa435ea9391cea23`
-- **Merge SHA:** Pending
+- **Merge SHA:** `943382f155a13abebec53951a30e5b4c0d1ce9df`
 - **Focused tests:** `mix test.debug test/minga_editor/layout/footer_band_overlays_test.exs` passed, 18 tests.
 - **Broad validation:** `git diff --check` passed; `make lint` passed (Credo, compile, incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 2:2' mix test.llm` passed (58 doctests, 98 properties, 9,854 tests, 0 failures, 1 skipped, 578 excluded).
 - **Ponytail and Elixir verdict:** `LEAN` after one targeted correction; stale eight-surface wording was corrected to the same seven active producers implemented by `FooterOverlays`.
@@ -1656,6 +1656,73 @@ Remove only the unreachable Tool Manager footer-overlay producer. Footer placeme
 - **Concepts added/removed:** No concepts added; one permanently false placement branch removed.
 - **Findings resolved:** Tool Manager no longer appears as an unreachable footer-overlay producer.
 - **Discoveries affecting later work:** SurfaceRegistry identity is a protocol compatibility boundary independent from footer placement production.
+- **Completion date:** 2026-07-18
+
+### W012: Route picker prefix switching through async lifecycle
+
+- **Status:** ACTIVE
+- **Audit ID:** L11
+- **Roadmap unit:** W012, Route picker prefix switching through async lifecycle
+- **Ponytail verdict:** `ACCEPT/direct`
+- **Freshness profile:** direct just-in-time source check against current main
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness SHA:** `74f0bf29f1212b2036ceff3ad7a6323d81dcef6b`
+- **Freshness basis:** Current `HEAD` and `origin/main` include W011. Prefix switching still called source callbacks synchronously, while initial async picker opening already owned loading state, fetch revision, scheduler admission, latest-wins replacement, cancellation, errors, and stale-result rejection.
+- **Implementer questions:** None.
+
+#### Observable outcome
+
+Typing `#` at the start of File or Recent switches to Project Search without running search on the Editor input loop. The picker enters loading state with a fresh revision and scheduler-owned fetch. Backspacing through `#` cancels that resource, restores the original source and picker-open ownership fields, and rejects delayed Project Search results as stale. Synchronous `>` and `@` switching remains immediate.
+
+#### Authoritative owner and locked shape
+
+`MingaEditor.PickerUI` owns source switching and orchestrates the existing `PickerState`, `FetchEffect`, and `EffectScheduler` lifecycle. Async prefix targets must use `open_loading/3`, `FetchEffect.request/4`, and `schedule_fetch/4`; sync targets continue to rebuild candidates directly. Source switches preserve the picker-open `restore`, `restore_theme`, and `context` fields. Returning to a sync source clears the former async fetch revision and loading status.
+
+#### Exact files, symbols, producers, and consumers
+
+- `lib/minga_editor/picker_ui.ex`: `switch_to_source/3`, `switch_back_to_original/1`, local source-switch helpers, `open_loading/3`, `schedule_fetch/4`, `cancel_current_fetch/1`, and `apply_fetch_result/4`
+- `test/minga_editor/picker_ui_test.exs`: prefix switching, native full-query edits, loading/revision state, restoration, cancellation, and stale-result rejection
+- Existing collaborators remain unchanged: `MingaEditor.State.Picker`, `MingaEditor.UI.Picker.FetchEffect`, `MingaEditor.EffectScheduler`, `MingaEditor.UI.Picker.Source`, and `ProjectSearchSource`
+
+#### Locked implementation
+
+1. Derive the target callback source and select async or sync handling in one local switch path.
+2. For async targets, cancel the current resource through `open_loading/3`, retain picker-open ownership fields, mint a revision, build the existing `FetchEffect`, and submit it through `schedule_fetch/4`.
+3. For sync targets, cancel any current fetch, rebuild candidates immediately, update source/layout/prefix fields, and clear stale async loading/revision state.
+4. Preserve `original_source` while switched and clear it only when returning.
+5. Keep native full-query edit acknowledgement and post-prefix query installation unchanged.
+6. Add regressions for `#` loading, full `#needle` query handling, restore-index preservation, backspace cancellation, and delayed-result rejection. Preserve existing `>` coverage.
+
+#### Validation
+
+- Focused: `mix test.debug test/minga_editor/picker_ui_test.exs test/minga_editor/ui/picker/fetch_effect_test.exs test/minga_editor/commands/search_async_test.exs`
+- Broad: `make lint`
+- Full non-heavy: `ERL_FLAGS='+S 2:2' mix test.llm`
+
+#### Non-goals and budget
+
+- Do not remove prefix switching or change prefix mappings.
+- Do not add a process, scheduler, fetch abstraction, parallel picker state, compatibility path, retry policy, or new protocol.
+- Do not change project-search semantics, filtering, rendering, source callbacks, Editor scheduling, or extension behavior.
+- **Maximum production additions:** 80 lines.
+- **Maximum test additions:** 120 lines.
+
+#### Completion evidence
+
+- **PR URL:** Pending
+- **Commit SHA:** Pending
+- **Merge SHA:** Pending
+- **Focused tests:** 40 passed across `picker_ui_test.exs`, `fetch_effect_test.exs`, and `search_async_test.exs`.
+- **Broad validation:** `git diff --check` passed; `make lint` passed (Credo, compile, incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 2:2' mix test.llm` passed on the final base (58 doctests, 98 properties, 9,891 tests, 0 failures, 1 skipped, 578 excluded).
+- **Ponytail and Elixir verdict:** `LEAN` after a targeted correction; source switching uses local helpers and existing lifecycle primitives, preserves picker-open ownership, clears stale sync-return fetch state, and stays within 76 production additions.
+- **Bug-hunt verdict:** Initial review found a lost live-preview restore index; the correction preserves `restore`, `restore_theme`, and `context`, with a targeted recheck confirming callback identity, query correlation, cancellation key, and stale-result guards.
+- **Final reviewer verdict:** `PASS`; the staged three-file diff routes `#` through existing async ownership, preserves synchronous prefixes and picker-open state, matches budgets, and carries behavior-level regressions plus final-base validation.
+- **Production lines added/removed:** 76 added / 56 removed, net +20
+- **Test lines added/removed:** 64 added / 1 removed, net +63
+- **Concepts added/removed:** No concepts added or removed; prefix switching now reuses the existing async lifecycle.
+- **Findings resolved:** Project Search prefix switching no longer executes synchronous search on the Editor input loop or bypasses async lifecycle ownership.
+- **Discoveries affecting later work:** Source switching must preserve picker-open restoration and context independently from per-source query and fetch state.
 - **Completion date:** 2026-07-18
 
 ## Follow-on simplifications

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1710,8 +1710,8 @@ Typing `#` at the start of File or Recent switches to Project Search without run
 
 #### Completion evidence
 
-- **PR URL:** Pending
-- **Commit SHA:** Pending
+- **PR URL:** https://github.com/jsmestad/minga/pull/2998
+- **Commit SHA:** `b3d700b971ced9ed9d8b421984e415132235fe6c`
 - **Merge SHA:** Pending
 - **Focused tests:** 40 passed across `picker_ui_test.exs`, `fetch_effect_test.exs`, and `search_async_test.exs`.
 - **Broad validation:** `git diff --check` passed; `make lint` passed (Credo, compile, incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 2:2' mix test.llm` passed on the final base (58 doctests, 98 properties, 9,891 tests, 0 failures, 1 skipped, 578 excluded).

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -1036,76 +1036,96 @@ defmodule MingaEditor.PickerUI do
 
   # Switch the picker to a new source module, preserving the original source for switch-back.
   @spec switch_to_source(state(), module(), String.t()) :: state()
-  defp switch_to_source(
-         %{
-           shell_runtime: %{
-             state: %{
-               modal:
-                 {:picker,
-                  %{
-                    picker_ui: %{
-                      source: current_source,
-                      original_source: orig_src,
-                      callback_source: callback_source
-                    }
-                  }}
-             }
-           }
-         } = state,
-         new_source,
-         prefix
-       ) do
-    ctx = Context.from_editor_state(state)
-    items = Source.candidates(new_source, ctx, callback_source)
-    max_vis = max(state.frontend.terminal_viewport.rows - 3, 5)
-
-    picker =
-      Picker.new(items, title: Source.title(new_source, callback_source), max_visible: max_vis)
-
-    layout = MingaEditor.UI.Picker.Source.layout(new_source, callback_source)
-    original = orig_src || current_source
-
-    update_picker(
-      state,
-      &%{
-        &1
-        | picker: picker,
-          source: new_source,
-          layout: layout,
-          original_source: original,
-          mode_prefix: prefix
-      }
-    )
+  defp switch_to_source(state, new_source, prefix) do
+    current = picker_state(state)
+    switch_source(state, new_source, current.original_source || current.source, prefix, current)
   end
 
   # Switch back to the original source after the prefix is deleted.
   @spec switch_back_to_original(state()) :: state()
-  defp switch_back_to_original(
-         %{
-           shell_runtime: %{
-             state: %{
-               modal:
-                 {:picker,
-                  %{picker_ui: %{original_source: orig, callback_source: callback_source}}}
-             }
-           }
-         } = state
+  defp switch_back_to_original(state) do
+    current = picker_state(state)
+    switch_source(state, current.original_source, nil, "", current)
+  end
+
+  @spec switch_source(state(), module(), module() | nil, String.t(), PickerState.t()) :: state()
+  defp switch_source(state, source, original_source, mode_prefix, current) do
+    callback_source = Source.source_identity(source)
+
+    if Source.async?(source, callback_source) do
+      switch_async_source(state, source, callback_source, original_source, mode_prefix, current)
+    else
+      switch_sync_source(state, source, callback_source, original_source, mode_prefix)
+    end
+  end
+
+  @spec switch_async_source(
+          state(),
+          module(),
+          PickerState.callback_source(),
+          module() | nil,
+          String.t(),
+          PickerState.t()
+        ) :: state()
+  defp switch_async_source(
+         state,
+         source,
+         callback_source,
+         original_source,
+         mode_prefix,
+         current
        ) do
-    ctx = Context.from_editor_state(state)
-    items = Source.candidates(orig, ctx, callback_source)
+    {loading_state, revision} = open_loading(state, source)
+
+    loading_state =
+      update_picker(loading_state, fn loading ->
+        %{
+          loading
+          | restore: current.restore,
+            restore_theme: current.restore_theme,
+            context: current.context,
+            original_source: original_source,
+            mode_prefix: mode_prefix
+        }
+      end)
+
+    request =
+      FetchEffect.request(
+        source,
+        callback_source,
+        Context.from_editor_state(loading_state, current.context),
+        revision
+      )
+
+    schedule_fetch(loading_state, request, source, revision)
+  end
+
+  @spec switch_sync_source(
+          state(),
+          module(),
+          PickerState.callback_source(),
+          module() | nil,
+          String.t()
+        ) :: state()
+  defp switch_sync_source(state, source, callback_source, original_source, mode_prefix) do
+    state = cancel_current_fetch(state)
+    items = Source.candidates(source, Context.from_editor_state(state), callback_source)
     max_vis = max(state.frontend.terminal_viewport.rows - 3, 5)
-    picker = Picker.new(items, title: Source.title(orig, callback_source), max_visible: max_vis)
-    layout = MingaEditor.UI.Picker.Source.layout(orig, callback_source)
+    picker = Picker.new(items, title: Source.title(source, callback_source), max_visible: max_vis)
+    layout = MingaEditor.UI.Picker.Source.layout(source, callback_source)
 
     update_picker(
       state,
       &%{
         &1
         | picker: picker,
-          source: orig,
+          source: source,
+          callback_source: callback_source,
           layout: layout,
-          original_source: nil,
-          mode_prefix: ""
+          original_source: original_source,
+          mode_prefix: mode_prefix,
+          load_status: :ready,
+          fetch_revision: nil
       }
     )
   end

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -9,6 +9,9 @@ defmodule MingaEditor.PickerUITest do
   alias MingaEditor.Handlers.GuiActionHandler
   alias MingaEditor.PickerUI
   alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.UI.Picker.Candidate
+  alias MingaEditor.UI.Picker.Context
+  alias MingaEditor.UI.Picker.FetchEffect
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
@@ -216,6 +219,11 @@ defmodule MingaEditor.PickerUITest do
 
     :ok = EffectScheduler.attach(scheduler, self())
     %{TestHelpers.base_state(rendering: :disabled) | effect_scheduler: scheduler}
+  end
+
+  defp with_project_query(state, query) do
+    search = MingaEditor.State.Search.set_project_query(state.workspace.search, query)
+    %{state | workspace: SessionState.set_search(state.workspace, search)}
   end
 
   defp picker_state_for_source(state, source, items) do
@@ -452,20 +460,57 @@ defmodule MingaEditor.PickerUITest do
       assert reverted_pui.mode_prefix == ""
     end
 
-    test "hash mode switches to project search and backspaces to the original source" do
+    test "hash mode switches from file to project search through async loading" do
       {state, _original_buf, _preview_buf} = preview_promotion_state()
+      scheduled = state_with_scheduler()
+
+      state =
+        %{state | effect_scheduler: scheduled.effect_scheduler} |> with_project_query("needle")
 
       switched_state = PickerUI.handle_key(state, ?#, 0)
       {:picker, %{picker_ui: switched_pui}} = switched_state.shell_runtime.state.modal
+
       assert switched_pui.source == MingaEditor.UI.Picker.ProjectSearchSource
       assert switched_pui.original_source == MingaEditor.UI.Picker.FileSource
       assert switched_pui.mode_prefix == "#"
+      assert switched_pui.restore == 0
+      assert switched_pui.load_status == :loading
+      assert is_reference(switched_pui.fetch_revision)
+      assert switched_pui.picker.items == []
+      assert EffectScheduler.active?(switched_state.effect_scheduler, FetchEffect)
+    end
+
+    test "backspace from hash mode restores file and makes old project search results stale" do
+      {state, _original_buf, _preview_buf} = preview_promotion_state()
+      scheduled = state_with_scheduler()
+
+      state =
+        %{state | effect_scheduler: scheduled.effect_scheduler} |> with_project_query("needle")
+
+      switched_state = PickerUI.handle_key(state, ?#, 0)
+      {:picker, %{picker_ui: switched_pui}} = switched_state.shell_runtime.state.modal
+      old_revision = switched_pui.fetch_revision
 
       reverted_state = PickerUI.handle_key(switched_state, 127, 0)
       {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_runtime.state.modal
       assert reverted_pui.source == MingaEditor.UI.Picker.FileSource
       assert reverted_pui.original_source == nil
       assert reverted_pui.mode_prefix == ""
+      assert reverted_pui.restore == 0
+      refute PickerState.current_fetch?(reverted_pui, old_revision)
+
+      sentinel_items = [%Item{id: :sentinel, label: "sentinel"}]
+
+      stale_outcome =
+        MingaEditor.UI.Picker.ProjectSearchSource
+        |> FetchEffect.request(nil, Context.from_editor_state(switched_state), old_revision)
+        |> Outcome.completed({:ok, sentinel_items, Candidate.from_items(sentinel_items), %{}})
+
+      assert {^reverted_state, %Outcome{status: :stale}} =
+               FetchEffect.apply(reverted_state, stale_outcome)
+
+      {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_runtime.state.modal
+      refute Enum.any?(reverted_pui.picker.items, &(&1.id == :sentinel))
     end
 
     test "typing fix in git log stays in the fuzzy query" do
@@ -512,6 +557,24 @@ defmodule MingaEditor.PickerUITest do
       assert picker_ui.mode_prefix == ">"
       assert picker_ui.picker.query == ""
       assert picker_ui.acknowledged_query_edit_seq == 1
+    end
+
+    test "native hash query switches to project search and keeps the pasted query loading" do
+      {state, _original_buf, _preview_buf} = preview_promotion_state()
+      scheduled = state_with_scheduler()
+      state = %{state | effect_scheduler: scheduled.effect_scheduler}
+      {:picker, %{picker_ui: initial_pui}} = state.shell_runtime.state.modal
+
+      switched = PickerUI.replace_query(state, initial_pui.query_generation, 1, "#needle")
+      {:picker, %{picker_ui: picker_ui}} = switched.shell_runtime.state.modal
+
+      assert picker_ui.source == MingaEditor.UI.Picker.ProjectSearchSource
+      assert picker_ui.original_source == MingaEditor.UI.Picker.FileSource
+      assert picker_ui.mode_prefix == "#"
+      assert picker_ui.picker.query == "needle"
+      assert picker_ui.acknowledged_query_edit_seq == 1
+      assert picker_ui.load_status == :loading
+      assert is_reference(picker_ui.fetch_revision)
     end
 
     test "applies text pasted after a source prefix to the switched picker" do


### PR DESCRIPTION
## TL;DR

Route Project Search prefix switching through the existing async picker lifecycle so `#` never runs search synchronously on the Editor input loop.

## Context

Audit L11 found that prefix switching called source callbacks directly. That bypassed loading and error state, fetch revisions, scheduler admission, latest-wins replacement, cancellation, and stale-result rejection.

## Changes

- Select async or synchronous handling through one local source-switch path
- Route `#` through `open_loading/3`, `FetchEffect.request/4`, and `schedule_fetch/4`
- Preserve picker-open restore index, theme, and context across source changes
- Cancel Project Search and clear its revision/loading state when backspacing to the original sync source
- Keep `>` and `@` synchronous and immediate
- Add regressions for loading state, native `#needle`, restore ownership, cancellation, and stale results
- Record W011 merge evidence and W012 completion evidence in the roadmap

## Verification

- Focused picker/effect/search suites: 40 passed
- `git diff --check`: passed
- `make lint`: passed
- Full non-heavy suite on final base: 9,891 tests, 0 failures
- Ponytail and Elixir recheck: LEAN
- Bug hunt: initial restore-index defect found, fixed, targeted recheck passed
- Final acceptance review: PASS