### PR TITLE
test(extension): allow blocked start signal under load

### DIFF
--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -1453,7 +1453,7 @@ defmodule Minga.Extension.LifecycleContractTest do
       |> Keyword.put(:runtime_query_timeout_ms, 10)
 
     start_task = Task.async(fn -> start_extension(ctx, name, entry, opts) end)
-    assert_receive {:blocked_child_start_mfa, old_runtime_supervisor}
+    assert_receive {:blocked_child_start_mfa, old_runtime_supervisor}, 1_000
     old_instance = instance_pid(ctx, name)
     supervisor_ref = Process.monitor(old_runtime_supervisor)
 


### PR DESCRIPTION
## TL;DR

Give the blocked child-start fixture signal a bounded 1-second receive window so the lifecycle contract test remains reliable under CI scheduler load.

## What changed

- Replaced ExUnit's default 100ms `assert_receive` timeout with an explicit 1,000ms timeout for `{:blocked_child_start_mfa, pid}`.
- Kept the wait event-driven and bounded. No production lifecycle timeout or behavior changed.

## Why

The Test (Elixir) job timed out before the fixture reached `RuntimeSupervisor.ensure_child/4`. The same test completed the authoritative transition in 302.8ms locally, which exceeds ExUnit's default mailbox wait but remains within the lifecycle's intended timing.

## Validation

- `mix test.debug test/minga/extension/lifecycle_contract_test.exs:1435`
- `make lint`
- `mix test.llm --max-cases 4`: 58 doctests, 98 properties, 9,889 tests, 0 failures, 1 skipped, 578 excluded
- Final reviewer: PASS