### PR TITLE
refactor(agent): own subscriber lifecycle state

### DIFF
--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -41,6 +41,8 @@ defmodule MingaAgent.Session do
   alias MingaAgent.SessionMetadata
   alias MingaAgent.Session.ProviderLifecycle
   alias MingaAgent.Session.Persistence
+  alias MingaAgent.Session.SubscriberAttachment
+  alias MingaAgent.Session.SubscriberLifecycle
   alias MingaAgent.Session.Transcript
   alias MingaAgent.Session.TurnExecution
   require ProviderLifecycle
@@ -65,7 +67,7 @@ defmodule MingaAgent.Session do
   @type credentials_configured_fn :: (-> boolean())
 
   @typedoc "Remote attachment role."
-  @type attachment_role :: :driver | :viewer
+  @type attachment_role :: SubscriberLifecycle.role()
 
   @typedoc "Latest EventLog admission or persistence failure retained for reconnecting subscribers."
   @type event_log_failure :: Failure.t()
@@ -84,13 +86,9 @@ defmodule MingaAgent.Session do
           credentials_configured_fn: credentials_configured_fn(),
           turn_execution: TurnExecution.t(),
           transcript: Transcript.t(),
-          subscribers: MapSet.t(pid()),
-          subscriber_roles: %{pid() => attachment_role()},
-          driver: pid() | nil,
+          subscriber_lifecycle: SubscriberLifecycle.t(),
           tool_approval_policy: tool_approval_policy(),
           idle_gc_timeout_ms: non_neg_integer(),
-          idle_gc_timer: {timer_ref :: reference(), token :: reference()} | nil,
-          idle_gc_token_fn: (-> reference()),
           persistence: Persistence.t(),
           pending_thinking_level: String.t() | nil,
           notifier: module() | {module(), term()},
@@ -691,13 +689,9 @@ defmodule MingaAgent.Session do
           [Message.system(initial_system_message(timestamp, Keyword.get(opts, :startup_notice)))],
           now
         ),
-      subscribers: MapSet.new(),
-      subscriber_roles: %{},
-      driver: nil,
+      subscriber_lifecycle: SubscriberLifecycle.new(),
       tool_approval_policy: Keyword.get(opts, :tool_approval_policy, :interactive),
       idle_gc_timeout_ms: Keyword.get_lazy(opts, :idle_gc_timeout_ms, &idle_gc_timeout_ms/0),
-      idle_gc_timer: nil,
-      idle_gc_token_fn: Keyword.get(opts, :idle_gc_token_fn, &make_ref/0),
       persistence: Persistence.new(Keyword.get(opts, :persist?, true)),
       pending_thinking_level: initial_thinking_level,
       notifier: Keyword.get(opts, :notifier, Notifier),
@@ -724,7 +718,7 @@ defmodule MingaAgent.Session do
       send(self(), :start_provider)
     end
 
-    {:ok, schedule_idle_gc(state, state.idle_gc_timeout_ms > 0, nil, state.idle_gc_timeout_ms)}
+    {:ok, maybe_schedule_idle_gc(state)}
   end
 
   @impl GenServer
@@ -1014,32 +1008,20 @@ defmodule MingaAgent.Session do
   end
 
   def handle_call({:subscribe, pid, opts}, _from, state) do
-    role = Keyword.get(opts, :role, default_subscriber_role(state))
-
-    if valid_subscriber_role?(role) do
-      Process.monitor(pid)
-      state = state |> cancel_idle_gc_timer() |> put_subscriber(pid, role)
-      send(pid, {:agent_event, self(), {:credentials_status, state.credentials_configured}})
-      notify_retained_event_log_failure(pid, state.event_log_failure)
-      {:reply, :ok, state}
-    else
-      {:reply, {:error, :invalid_role}, state}
-    end
+    role = Keyword.get(opts, :role, SubscriberLifecycle.default_role(state.subscriber_lifecycle))
+    reply_to_subscribe(state, pid, role)
   end
 
   def handle_call({:subscriber_role, pid}, _from, state) do
-    {:reply, Map.get(state.subscriber_roles, pid), state}
+    {:reply, SubscriberLifecycle.role(state.subscriber_lifecycle, pid), state}
   end
 
   def handle_call({:claim_driver, pid}, _from, state) do
-    case claim_driver_role(state, pid) do
-      {:ok, state} -> {:reply, :ok, state}
-      {:error, reason} -> {:reply, {:error, reason}, state}
-    end
+    reply_to_claim_driver(state, pid)
   end
 
   def handle_call({:unsubscribe, pid}, _from, state) do
-    {:reply, :ok, remove_subscriber(state, pid, :detached)}
+    {:reply, :ok, detach_subscriber(state, pid, :detached)}
   end
 
   def handle_call(:compact, _from, %{provider: provider} = state)
@@ -1378,36 +1360,12 @@ defmodule MingaAgent.Session do
     {:noreply, state}
   end
 
-  def handle_info({:DOWN, _ref, :process, pid, reason}, state) do
-    {:noreply, remove_subscriber(state, pid, reason)}
+  def handle_info({:DOWN, ref, :process, pid, reason}, state) do
+    {:noreply, handle_subscriber_down(state, pid, ref, reason)}
   end
 
-  def handle_info({:idle_gc_timeout, token}, %{idle_gc_timer: {_timer_ref, token}} = state) do
-    if idle_gc_reclaimable?(state) do
-      Minga.Log.info(
-        :agent,
-        "[Agent.Session] reclaiming idle detached session #{state.session_id}"
-      )
-
-      case save_to_disk(state) do
-        :ok ->
-          {:stop, :normal, %{state | idle_gc_timer: nil}}
-
-        {:error, reason} ->
-          Minga.Log.error(
-            :agent,
-            "[Agent.Session] failed to reclaim idle detached session #{state.session_id}: #{inspect(reason)}"
-          )
-
-          {:noreply, maybe_schedule_idle_gc(%{state | idle_gc_timer: nil})}
-      end
-    else
-      {:noreply, maybe_schedule_idle_gc(%{state | idle_gc_timer: nil})}
-    end
-  end
-
-  def handle_info({:idle_gc_timeout, _token}, state) do
-    {:noreply, state}
+  def handle_info({:timeout, timer_ref, :idle_gc}, state) do
+    handle_reclaim_timeout(state, timer_ref)
   end
 
   def handle_info(:save_session, %{persistence: %Persistence{timer: {token, _timer_ref}}} = state) do
@@ -1611,11 +1569,7 @@ defmodule MingaAgent.Session do
         |> maybe_schedule_idle_gc(execution)
 
       :plan ->
-        if TurnExecution.reclaimable?(execution) do
-          maybe_schedule_idle_gc(state, execution)
-        else
-          state
-        end
+        maybe_schedule_idle_gc(state, execution)
     end
   end
 
@@ -2153,93 +2107,117 @@ defmodule MingaAgent.Session do
     "Execution mode enabled. Destructive tools can run again after normal approval checks. Use /plan to return to planning."
   end
 
-  # ── Remote attachment roles ────────────────────────────────────────────────
+  # ── Subscriber lifecycle ──────────────────────────────────────────────────
 
-  @spec default_subscriber_role(state()) :: attachment_role()
-  defp default_subscriber_role(%{driver: nil}), do: :driver
-  defp default_subscriber_role(_state), do: :viewer
+  @spec reply_to_subscribe(state(), pid(), term()) ::
+          {:reply, :ok | {:error, :invalid_role}, state()}
+  defp reply_to_subscribe(state, pid, role) do
+    case SubscriberLifecycle.prepare_subscribe(state.subscriber_lifecycle, pid, role) do
+      {:monitor, preparation} ->
+        monitor_subscriber(state, pid, preparation)
 
-  @spec valid_subscriber_role?(term()) :: boolean()
-  defp valid_subscriber_role?(role), do: role in [:driver, :viewer]
+      {:already_attached, lifecycle} ->
+        notify_subscriber_connected(pid, state)
+        {:reply, :ok, %{state | subscriber_lifecycle: lifecycle}}
 
-  @spec put_subscriber(state(), pid(), attachment_role()) :: state()
-  defp put_subscriber(state, pid, :driver) do
-    state = %{state | subscribers: MapSet.put(state.subscribers, pid)}
-
-    case state.driver do
-      nil -> set_driver(state, pid)
-      ^pid -> set_driver(state, pid)
-      _other -> put_subscriber(state, pid, :viewer)
+      {:error, :invalid_role} ->
+        {:reply, {:error, :invalid_role}, state}
     end
   end
 
-  defp put_subscriber(state, pid, :viewer) do
-    %{
-      state
-      | subscribers: MapSet.put(state.subscribers, pid),
-        subscriber_roles: Map.put(state.subscriber_roles, pid, :viewer)
-    }
-  end
+  @spec monitor_subscriber(state(), pid(), SubscriberLifecycle.subscription_preparation()) ::
+          {:reply, :ok, state()}
+  defp monitor_subscriber(state, pid, preparation) do
+    monitor_ref = Process.monitor(pid)
 
-  @spec claim_driver_role(state(), pid()) ::
-          {:ok, state()} | {:error, :driver_taken | :not_subscribed}
-  defp claim_driver_role(state, pid) do
-    claim_driver_role(state, pid, MapSet.member?(state.subscribers, pid), state.driver)
-  end
+    case SubscriberLifecycle.complete_subscribe(
+           state.subscriber_lifecycle,
+           preparation,
+           monitor_ref
+         ) do
+      {:ok, lifecycle, subscription_change, timer_ref} ->
+        cancel_reclaim_timer(timer_ref)
 
-  @spec claim_driver_role(state(), pid(), boolean(), pid() | nil) ::
-          {:ok, state()} | {:error, :driver_taken | :not_subscribed}
-  defp claim_driver_role(_state, _pid, false, _driver), do: {:error, :not_subscribed}
-  defp claim_driver_role(state, pid, true, nil), do: {:ok, set_driver(state, pid)}
-  defp claim_driver_role(state, pid, true, pid), do: {:ok, set_driver(state, pid)}
-  defp claim_driver_role(_state, _pid, true, _driver), do: {:error, :driver_taken}
+        state =
+          state
+          |> Map.put(:subscriber_lifecycle, lifecycle)
+          |> announce_subscription_change(pid, subscription_change)
 
-  @spec set_driver(state(), pid()) :: state()
-  defp set_driver(%{driver: nil, subscriber_roles: roles} = state, pid)
-       when map_size(roles) == 0 do
-    %{
-      state
-      | driver: pid,
-        subscriber_roles: Map.put(state.subscriber_roles, pid, :driver)
-    }
-  end
+        notify_subscriber_connected(pid, state)
+        {:reply, :ok, state}
 
-  defp set_driver(%{driver: pid} = state, pid) do
-    %{state | subscriber_roles: Map.put(state.subscriber_roles, pid, :driver)}
-  end
-
-  defp set_driver(state, pid) do
-    state = %{
-      state
-      | driver: pid,
-        subscriber_roles: Map.put(state.subscriber_roles, pid, :driver)
-    }
-
-    broadcast(state, {:driver_changed, pid})
-    state
-  end
-
-  @spec remove_subscriber(state(), pid(), term()) :: state()
-  defp remove_subscriber(state, pid, reason) do
-    was_subscribed? = MapSet.member?(state.subscribers, pid)
-    role = Map.get(state.subscriber_roles, pid)
-    driver = if state.driver == pid, do: nil, else: state.driver
-
-    state = %{
-      state
-      | subscribers: MapSet.delete(state.subscribers, pid),
-        subscriber_roles: Map.delete(state.subscriber_roles, pid),
-        driver: driver
-    }
-
-    if was_subscribed? do
-      record_user_disconnected(state, pid, role, reason)
+      {:error, reason} ->
+        Process.demonitor(monitor_ref, [:flush])
+        raise "subscriber monitor installation failed: #{inspect(reason)}"
     end
-
-    maybe_schedule_idle_gc(state)
   end
 
-  @spec record_user_disconnected(state(), pid(), attachment_role() | nil, term()) ::
+  @spec announce_subscription_change(
+          state(),
+          pid(),
+          SubscriberLifecycle.subscription_change()
+        ) :: state()
+  defp announce_subscription_change(state, pid, :driver_changed),
+    do: broadcast(state, {:driver_changed, pid})
+
+  defp announce_subscription_change(state, _pid, :driver_initialized), do: state
+
+  defp announce_subscription_change(state, _pid, :viewer_attached), do: state
+
+  @spec notify_subscriber_connected(pid(), state()) :: :ok
+  defp notify_subscriber_connected(pid, state) do
+    send(pid, {:agent_event, self(), {:credentials_status, state.credentials_configured}})
+    notify_retained_event_log_failure(pid, state.event_log_failure)
+  end
+
+  @spec reply_to_claim_driver(state(), pid()) ::
+          {:reply, :ok | {:error, :driver_taken | :not_subscribed}, state()}
+  defp reply_to_claim_driver(state, pid) do
+    case SubscriberLifecycle.claim_driver(state.subscriber_lifecycle, pid) do
+      {:changed, lifecycle} ->
+        state = %{state | subscriber_lifecycle: lifecycle}
+        {:reply, :ok, broadcast(state, {:driver_changed, pid})}
+
+      :unchanged ->
+        {:reply, :ok, state}
+
+      {:error, reason} ->
+        {:reply, {:error, reason}, state}
+    end
+  end
+
+  @spec detach_subscriber(state(), pid(), term()) :: state()
+  defp detach_subscriber(state, pid, reason) do
+    case SubscriberLifecycle.detach(state.subscriber_lifecycle, pid) do
+      {:removed, lifecycle, %SubscriberAttachment{} = attachment} ->
+        Process.demonitor(attachment.monitor_ref, [:flush])
+        state = %{state | subscriber_lifecycle: lifecycle}
+        record_user_disconnected(state, pid, attachment.role, reason)
+        maybe_schedule_idle_gc(state)
+
+      :unchanged ->
+        state
+    end
+  end
+
+  @spec handle_subscriber_down(state(), pid(), reference(), term()) :: state()
+  defp handle_subscriber_down(state, pid, monitor_ref, reason) do
+    case SubscriberLifecycle.subscriber_down(
+           state.subscriber_lifecycle,
+           pid,
+           monitor_ref
+         ) do
+      {:removed, lifecycle, %SubscriberAttachment{} = attachment} ->
+        state = %{state | subscriber_lifecycle: lifecycle}
+        record_user_disconnected(state, pid, attachment.role, reason)
+        maybe_schedule_idle_gc(state)
+
+      {:error, :stale_monitor} ->
+        state
+    end
+  end
+
+  @spec record_user_disconnected(state(), pid(), attachment_role(), term()) ::
           EventLog.admission_result()
   defp record_user_disconnected(state, pid, role, reason) do
     record_critical_event(state, :user_disconnected, %{
@@ -2255,45 +2233,93 @@ defmodule MingaAgent.Session do
 
   @spec maybe_schedule_idle_gc(state(), TurnExecution.t()) :: state()
   defp maybe_schedule_idle_gc(state, execution) do
-    schedule_idle_gc(
-      state,
-      idle_gc_reclaimable?(state, execution),
-      state.idle_gc_timer,
-      state.idle_gc_timeout_ms
+    enabled? = state.idle_gc_timeout_ms > 0
+    turn_reclaimable? = TurnExecution.reclaimable?(execution)
+
+    case SubscriberLifecycle.reconcile_reclaim(
+           state.subscriber_lifecycle,
+           enabled?,
+           turn_reclaimable?
+         ) do
+      {:start_timer, preparation} ->
+        start_reclaim_timer(state, preparation)
+
+      {:cancel_timer, timer_ref, lifecycle} ->
+        cancel_reclaim_timer(timer_ref)
+        %{state | subscriber_lifecycle: lifecycle}
+
+      :unchanged ->
+        state
+    end
+  end
+
+  @spec start_reclaim_timer(state(), SubscriberLifecycle.reclaim_preparation()) :: state()
+  defp start_reclaim_timer(state, preparation) do
+    timer_ref = :erlang.start_timer(state.idle_gc_timeout_ms, self(), :idle_gc)
+
+    case SubscriberLifecycle.complete_reclaim_schedule(
+           state.subscriber_lifecycle,
+           preparation,
+           timer_ref
+         ) do
+      {:ok, lifecycle} ->
+        %{state | subscriber_lifecycle: lifecycle}
+
+      {:error, reason} ->
+        Process.cancel_timer(timer_ref)
+        raise "subscriber reclaim timer installation failed: #{inspect(reason)}"
+    end
+  end
+
+  @spec handle_reclaim_timeout(state(), reference()) ::
+          {:noreply, state()} | {:stop, :normal, state()}
+  defp handle_reclaim_timeout(state, timer_ref) do
+    turn_reclaimable? = TurnExecution.reclaimable?(state.turn_execution)
+
+    case SubscriberLifecycle.reclaim_timeout(
+           state.subscriber_lifecycle,
+           timer_ref,
+           turn_reclaimable?
+         ) do
+      {:reclaim, lifecycle} ->
+        reclaim_idle_session(%{state | subscriber_lifecycle: lifecycle})
+
+      {:keep, lifecycle} ->
+        state = %{state | subscriber_lifecycle: lifecycle}
+        {:noreply, maybe_schedule_idle_gc(state)}
+
+      {:error, :stale_timer} ->
+        {:noreply, state}
+    end
+  end
+
+  @spec reclaim_idle_session(state()) :: {:noreply, state()} | {:stop, :normal, state()}
+  defp reclaim_idle_session(state) do
+    Minga.Log.info(
+      :agent,
+      "[Agent.Session] reclaiming idle detached session #{state.session_id}"
     )
+
+    case save_to_disk(state) do
+      :ok ->
+        {:stop, :normal, state}
+
+      {:error, reason} ->
+        Minga.Log.error(
+          :agent,
+          "[Agent.Session] failed to reclaim idle detached session #{state.session_id}: #{inspect(reason)}"
+        )
+
+        {:noreply, maybe_schedule_idle_gc(state)}
+    end
   end
 
-  @spec schedule_idle_gc(
-          map(),
-          boolean(),
-          {timer_ref :: reference(), token :: reference()} | nil,
-          non_neg_integer()
-        ) :: map()
-  defp schedule_idle_gc(state, true, nil, timeout_ms) when timeout_ms > 0 do
-    token = state.idle_gc_token_fn.()
-    timer_ref = Process.send_after(self(), {:idle_gc_timeout, token}, timeout_ms)
-    %{state | idle_gc_timer: {timer_ref, token}}
-  end
+  @spec cancel_reclaim_timer(reference() | nil) :: :ok
+  defp cancel_reclaim_timer(nil), do: :ok
 
-  defp schedule_idle_gc(state, true, _timer, _timeout_ms), do: state
-  defp schedule_idle_gc(state, false, _timer, _timeout_ms), do: cancel_idle_gc_timer(state)
-
-  @spec cancel_idle_gc_timer(map()) :: map()
-  defp cancel_idle_gc_timer(%{idle_gc_timer: nil} = state), do: state
-
-  defp cancel_idle_gc_timer(state) do
-    {timer_ref, _token} = state.idle_gc_timer
+  defp cancel_reclaim_timer(timer_ref) when is_reference(timer_ref) do
     Process.cancel_timer(timer_ref)
-    %{state | idle_gc_timer: nil}
-  end
-
-  @spec idle_gc_reclaimable?(state()) :: boolean()
-  defp idle_gc_reclaimable?(state),
-    do: idle_gc_reclaimable?(state, state.turn_execution)
-
-  @spec idle_gc_reclaimable?(state(), TurnExecution.t()) :: boolean()
-  defp idle_gc_reclaimable?(state, execution) do
-    MapSet.size(state.subscribers) == 0 and TurnExecution.reclaimable?(execution)
+    :ok
   end
 
   @spec idle_gc_timeout_ms() :: non_neg_integer()
@@ -2302,8 +2328,8 @@ defmodule MingaAgent.Session do
   end
 
   @spec driver_allowed?(state(), pid()) :: boolean()
-  defp driver_allowed?(%{driver: pid}, pid) when is_pid(pid), do: true
-  defp driver_allowed?(_state, _pid), do: false
+  defp driver_allowed?(state, pid),
+    do: SubscriberLifecycle.driver?(state.subscriber_lifecycle, pid)
 
   # ── Broadcasting ────────────────────────────────────────────────────────────
 
@@ -2312,7 +2338,7 @@ defmodule MingaAgent.Session do
     record_broadcast_event(state, event)
     session_pid = self()
 
-    Enum.each(state.subscribers, fn pid ->
+    Enum.each(SubscriberLifecycle.subscribers(state.subscriber_lifecycle), fn pid ->
       send(pid, {:agent_event, session_pid, event})
     end)
 
@@ -2323,7 +2349,7 @@ defmodule MingaAgent.Session do
   defp notify_event_log_failure(state, failure) do
     session_pid = self()
 
-    Enum.each(state.subscribers, fn pid ->
+    Enum.each(SubscriberLifecycle.subscribers(state.subscriber_lifecycle), fn pid ->
       send(pid, {:agent_event, session_pid, failure})
     end)
   end
@@ -3796,6 +3822,7 @@ defmodule MingaAgent.Session do
     })
 
     dispatch_session_end(state, reason)
+    state = release_subscriber_lifecycle(state)
     _stopped_state = stop_provider_lifecycle(state)
 
     case reason do
@@ -3814,6 +3841,14 @@ defmodule MingaAgent.Session do
           "[Agent.Session] crashed: #{inspect(reason, pretty: true, limit: 1000)}"
         )
     end
+  end
+
+  @spec release_subscriber_lifecycle(state()) :: state()
+  defp release_subscriber_lifecycle(state) do
+    {lifecycle, timer_ref, monitor_refs} = SubscriberLifecycle.stop(state.subscriber_lifecycle)
+    cancel_reclaim_timer(timer_ref)
+    Enum.each(monitor_refs, &Process.demonitor(&1, [:flush]))
+    %{state | subscriber_lifecycle: lifecycle}
   end
 
   # ── Hook dispatching ──────────────────────────────────────────────────────

--- a/lib/minga_agent/session/subscriber_attachment.ex
+++ b/lib/minga_agent/session/subscriber_attachment.ex
@@ -1,0 +1,32 @@
+defmodule MingaAgent.Session.SubscriberAttachment do
+  @moduledoc """
+  Canonical identity for one process attached to an agent session.
+
+  The role and monitor reference travel with the PID so subscriber membership cannot exist without its OTP monitor identity.
+  """
+
+  @typedoc "Remote attachment role."
+  @type role :: :driver | :viewer
+
+  @enforce_keys [:pid, :role, :monitor_ref]
+  defstruct [:pid, :role, :monitor_ref]
+
+  @type t :: %__MODULE__{
+          pid: pid(),
+          role: role(),
+          monitor_ref: reference()
+        }
+
+  @doc "Builds a monitored subscriber attachment."
+  @spec new(pid(), role(), reference()) :: t()
+  def new(pid, role, monitor_ref)
+      when is_pid(pid) and role in [:driver, :viewer] and is_reference(monitor_ref) do
+    %__MODULE__{pid: pid, role: role, monitor_ref: monitor_ref}
+  end
+
+  @doc "Assigns a new role while preserving subscriber and monitor identity."
+  @spec assign_role(t(), role()) :: t()
+  def assign_role(%__MODULE__{} = attachment, role) when role in [:driver, :viewer] do
+    %{attachment | role: role}
+  end
+end

--- a/lib/minga_agent/session/subscriber_lifecycle.ex
+++ b/lib/minga_agent/session/subscriber_lifecycle.ex
@@ -1,0 +1,324 @@
+defmodule MingaAgent.Session.SubscriberLifecycle do
+  @moduledoc """
+  Owns subscriber roles, monitor identity, and detached-session reclamation.
+
+  Session performs every process and timer effect. This value validates the operation, returns the next lifecycle or a named preparation, and accepts the resulting OTP reference through a completion transition.
+
+  ## Transition table
+
+  | Command | Valid source | Result |
+  |---|---|---|
+  | subscribe | valid role, PID absent | monitor preparation |
+  | complete subscribe | unchanged preparation source | attachment installed, prior timer returned for cancellation |
+  | claim driver | attached PID, driver vacant or same PID | role transition |
+  | detach | attached PID | attachment removed with monitor cleanup identity |
+  | DOWN | matching PID and monitor reference | attachment removed |
+  | reconcile reclaim | detached and turn reclaimable | timer preparation or unchanged |
+  | complete reclaim schedule | unchanged preparation source | exact OTP timer reference installed |
+  | reclaim timeout | matching timer, detached, turn reclaimable | reclaim accepted |
+  | stop | any | empty lifecycle plus ordered timer and monitor cleanup identity |
+  """
+
+  alias MingaAgent.Session.SubscriberAttachment
+
+  @typedoc "Remote attachment role."
+  @type role :: SubscriberAttachment.role()
+
+  @typedoc "Subscriber lifecycle state."
+  @type t :: %__MODULE__{
+          attachments: %{pid() => SubscriberAttachment.t()},
+          reclaim_timer: reference() | nil
+        }
+
+  @typedoc "A validated subscription awaiting monitor creation."
+  @type subscription_preparation :: {source :: t(), pid(), role()}
+
+  @typedoc "Role outcome produced by installing a new subscriber."
+  @type subscription_change :: :driver_initialized | :driver_changed | :viewer_attached
+
+  @typedoc "A validated reclaim schedule awaiting timer creation."
+  @type reclaim_preparation :: t()
+
+  defstruct attachments: %{}, reclaim_timer: nil
+
+  @doc "Builds an empty detached lifecycle."
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @doc "Returns all attached subscriber PIDs."
+  @spec subscribers(t()) :: [pid()]
+  def subscribers(%__MODULE__{attachments: attachments}), do: Map.keys(attachments)
+
+  @doc "Returns the role for an attached subscriber."
+  @spec role(t(), pid()) :: role() | nil
+  def role(%__MODULE__{attachments: attachments}, pid) when is_pid(pid) do
+    case Map.get(attachments, pid) do
+      %SubscriberAttachment{role: role} -> role
+      nil -> nil
+    end
+  end
+
+  @doc "Returns the active driver derived from canonical attachment roles."
+  @spec driver(t()) :: pid() | nil
+  def driver(%__MODULE__{attachments: attachments}) do
+    Enum.find_value(attachments, fn
+      {pid, %SubscriberAttachment{role: :driver}} -> pid
+      {_pid, %SubscriberAttachment{role: :viewer}} -> nil
+    end)
+  end
+
+  @doc "Returns the default role for a new subscriber."
+  @spec default_role(t()) :: role()
+  def default_role(%__MODULE__{} = lifecycle) do
+    case driver(lifecycle) do
+      nil -> :driver
+      _pid -> :viewer
+    end
+  end
+
+  @doc "Returns true when the PID owns the driver role."
+  @spec driver?(t(), pid()) :: boolean()
+  def driver?(%__MODULE__{} = lifecycle, pid) when is_pid(pid), do: driver(lifecycle) == pid
+
+  @doc "Returns the installed reclaim timer reference."
+  @spec reclaim_timer(t()) :: reference() | nil
+  def reclaim_timer(%__MODULE__{reclaim_timer: timer_ref}), do: timer_ref
+
+  @doc "Validates a subscription before Session creates its process monitor."
+  @spec prepare_subscribe(t(), pid(), term()) ::
+          {:monitor, subscription_preparation()}
+          | {:already_attached, t()}
+          | {:error, :invalid_role}
+  def prepare_subscribe(%__MODULE__{} = lifecycle, pid, role)
+      when is_pid(pid) and role in [:driver, :viewer] do
+    prepare_subscribe(lifecycle, pid, role, Map.has_key?(lifecycle.attachments, pid))
+  end
+
+  def prepare_subscribe(%__MODULE__{}, pid, _role) when is_pid(pid),
+    do: {:error, :invalid_role}
+
+  @doc "Installs a subscription monitor when the validated source is still current."
+  @spec complete_subscribe(t(), subscription_preparation(), reference()) ::
+          {:ok, t(), subscription_change(), timer_to_cancel :: reference() | nil}
+          | {:error, :stale_preparation | :already_attached | :driver_taken}
+  def complete_subscribe(
+        %__MODULE__{} = lifecycle,
+        {%__MODULE__{} = source, pid, role},
+        monitor_ref
+      )
+      when is_pid(pid) and role in [:driver, :viewer] and is_reference(monitor_ref) do
+    complete_subscribe(lifecycle, source, pid, role, monitor_ref)
+  end
+
+  @doc "Claims a vacant driver role for an attached subscriber."
+  @spec claim_driver(t(), pid()) ::
+          {:changed, t()} | :unchanged | {:error, :driver_taken | :not_subscribed}
+  def claim_driver(%__MODULE__{} = lifecycle, pid) when is_pid(pid) do
+    case Map.get(lifecycle.attachments, pid) do
+      nil ->
+        {:error, :not_subscribed}
+
+      %SubscriberAttachment{role: :driver} ->
+        :unchanged
+
+      %SubscriberAttachment{} = attachment ->
+        claim_vacant_driver(lifecycle, pid, attachment, driver(lifecycle))
+    end
+  end
+
+  @doc "Detaches a subscriber and returns its monitor identity for cleanup."
+  @spec detach(t(), pid()) :: {:removed, t(), SubscriberAttachment.t()} | :unchanged
+  def detach(%__MODULE__{} = lifecycle, pid) when is_pid(pid) do
+    case Map.pop(lifecycle.attachments, pid) do
+      {nil, _attachments} ->
+        :unchanged
+
+      {%SubscriberAttachment{} = attachment, attachments} ->
+        {:removed, %{lifecycle | attachments: attachments}, attachment}
+    end
+  end
+
+  @doc "Consumes a subscriber DOWN only when both PID and monitor identity match."
+  @spec subscriber_down(t(), pid(), reference()) ::
+          {:removed, t(), SubscriberAttachment.t()} | {:error, :stale_monitor}
+  def subscriber_down(%__MODULE__{} = lifecycle, pid, monitor_ref)
+      when is_pid(pid) and is_reference(monitor_ref) do
+    case Map.get(lifecycle.attachments, pid) do
+      %SubscriberAttachment{monitor_ref: ^monitor_ref} = attachment ->
+        {:removed, next} = remove_attachment(lifecycle, pid)
+        {:removed, next, attachment}
+
+      %SubscriberAttachment{} ->
+        {:error, :stale_monitor}
+
+      nil ->
+        {:error, :stale_monitor}
+    end
+  end
+
+  @doc "Reconciles the installed reclaim timer with attachment and turn eligibility."
+  @spec reconcile_reclaim(t(), boolean(), boolean()) ::
+          {:start_timer, reclaim_preparation()}
+          | {:cancel_timer, reference(), t()}
+          | :unchanged
+  def reconcile_reclaim(%__MODULE__{} = lifecycle, enabled?, turn_reclaimable?)
+      when is_boolean(enabled?) and is_boolean(turn_reclaimable?) do
+    reconcile_reclaim(lifecycle, reclaim_eligible?(lifecycle, enabled?, turn_reclaimable?))
+  end
+
+  @doc "Installs an OTP reclaim timer when the validated source is still current."
+  @spec complete_reclaim_schedule(t(), reclaim_preparation(), reference()) ::
+          {:ok, t()}
+          | {:error, :stale_preparation | :timer_already_installed | :subscriber_attached}
+  def complete_reclaim_schedule(
+        %__MODULE__{} = lifecycle,
+        %__MODULE__{} = source,
+        timer_ref
+      )
+      when is_reference(timer_ref) do
+    complete_reclaim_schedule(lifecycle, source, timer_ref, lifecycle == source)
+  end
+
+  @doc "Accepts only the installed timer identity and rechecks reclaim eligibility."
+  @spec reclaim_timeout(t(), reference(), boolean()) ::
+          {:reclaim, t()} | {:keep, t()} | {:error, :stale_timer}
+  def reclaim_timeout(
+        %__MODULE__{reclaim_timer: timer_ref} = lifecycle,
+        timer_ref,
+        turn_reclaimable?
+      )
+      when is_reference(timer_ref) and is_boolean(turn_reclaimable?) do
+    next = %{lifecycle | reclaim_timer: nil}
+    reclaim_after_timeout(next, map_size(lifecycle.attachments) == 0 and turn_reclaimable?)
+  end
+
+  def reclaim_timeout(%__MODULE__{}, timer_ref, turn_reclaimable?)
+      when is_reference(timer_ref) and is_boolean(turn_reclaimable?),
+      do: {:error, :stale_timer}
+
+  @doc "Clears lifecycle ownership and returns timer then monitor cleanup identities."
+  @spec stop(t()) :: {t(), timer_ref :: reference() | nil, monitor_refs :: [reference()]}
+  def stop(%__MODULE__{} = lifecycle) do
+    monitor_refs =
+      Enum.map(lifecycle.attachments, fn {_pid, attachment} -> attachment.monitor_ref end)
+
+    {new(), lifecycle.reclaim_timer, monitor_refs}
+  end
+
+  @spec prepare_subscribe(t(), pid(), role(), boolean()) ::
+          {:monitor, subscription_preparation()} | {:already_attached, t()}
+  defp prepare_subscribe(lifecycle, _pid, _role, true),
+    do: {:already_attached, lifecycle}
+
+  defp prepare_subscribe(lifecycle, pid, role, false),
+    do: {:monitor, {lifecycle, pid, effective_role(lifecycle, role)}}
+
+  @spec reclaim_after_timeout(t(), boolean()) :: {:reclaim, t()} | {:keep, t()}
+  defp reclaim_after_timeout(lifecycle, true), do: {:reclaim, lifecycle}
+  defp reclaim_after_timeout(lifecycle, false), do: {:keep, lifecycle}
+
+  @spec effective_role(t(), role()) :: role()
+  defp effective_role(lifecycle, :driver) do
+    case driver(lifecycle) do
+      nil -> :driver
+      _pid -> :viewer
+    end
+  end
+
+  defp effective_role(_lifecycle, :viewer), do: :viewer
+
+  @spec complete_subscribe(t(), t(), pid(), role(), reference()) ::
+          {:ok, t(), subscription_change(), reference() | nil}
+          | {:error, :stale_preparation | :already_attached | :driver_taken}
+  defp complete_subscribe(lifecycle, source, _pid, _role, _monitor_ref)
+       when lifecycle != source,
+       do: {:error, :stale_preparation}
+
+  defp complete_subscribe(%{attachments: attachments}, _source, pid, _role, _monitor_ref)
+       when is_map_key(attachments, pid),
+       do: {:error, :already_attached}
+
+  defp complete_subscribe(lifecycle, _source, pid, :driver, monitor_ref) do
+    case driver(lifecycle) do
+      nil -> install_attachment(lifecycle, pid, :driver, monitor_ref)
+      _pid -> {:error, :driver_taken}
+    end
+  end
+
+  defp complete_subscribe(lifecycle, _source, pid, :viewer, monitor_ref),
+    do: install_attachment(lifecycle, pid, :viewer, monitor_ref)
+
+  @spec install_attachment(t(), pid(), role(), reference()) ::
+          {:ok, t(), subscription_change(), reference() | nil}
+  defp install_attachment(lifecycle, pid, role, monitor_ref) do
+    attachment = SubscriberAttachment.new(pid, role, monitor_ref)
+
+    next = %{
+      lifecycle
+      | attachments: Map.put(lifecycle.attachments, pid, attachment),
+        reclaim_timer: nil
+    }
+
+    {:ok, next, subscription_change(lifecycle, role), lifecycle.reclaim_timer}
+  end
+
+  @spec subscription_change(t(), role()) :: subscription_change()
+  defp subscription_change(%{attachments: attachments}, :driver)
+       when map_size(attachments) == 0,
+       do: :driver_initialized
+
+  defp subscription_change(_lifecycle, :driver), do: :driver_changed
+  defp subscription_change(_lifecycle, :viewer), do: :viewer_attached
+
+  @spec claim_vacant_driver(t(), pid(), SubscriberAttachment.t(), pid() | nil) ::
+          {:changed, t()} | {:error, :driver_taken}
+  defp claim_vacant_driver(lifecycle, pid, attachment, nil) do
+    attachments =
+      Map.put(lifecycle.attachments, pid, SubscriberAttachment.assign_role(attachment, :driver))
+
+    {:changed, %{lifecycle | attachments: attachments}}
+  end
+
+  defp claim_vacant_driver(_lifecycle, _pid, _attachment, _driver),
+    do: {:error, :driver_taken}
+
+  @spec remove_attachment(t(), pid()) :: {:removed, t()}
+  defp remove_attachment(lifecycle, pid) do
+    {:removed, %{lifecycle | attachments: Map.delete(lifecycle.attachments, pid)}}
+  end
+
+  @spec reconcile_reclaim(t(), boolean()) ::
+          {:start_timer, reclaim_preparation()}
+          | {:cancel_timer, reference(), t()}
+          | :unchanged
+  defp reconcile_reclaim(%{reclaim_timer: nil} = lifecycle, true),
+    do: {:start_timer, lifecycle}
+
+  defp reconcile_reclaim(%{reclaim_timer: timer_ref} = lifecycle, false)
+       when is_reference(timer_ref),
+       do: {:cancel_timer, timer_ref, %{lifecycle | reclaim_timer: nil}}
+
+  defp reconcile_reclaim(_lifecycle, _eligible?), do: :unchanged
+
+  @spec reclaim_eligible?(t(), boolean(), boolean()) :: boolean()
+  defp reclaim_eligible?(lifecycle, enabled?, turn_reclaimable?) do
+    enabled? and map_size(lifecycle.attachments) == 0 and turn_reclaimable?
+  end
+
+  @spec complete_reclaim_schedule(t(), t(), reference(), boolean()) ::
+          {:ok, t()}
+          | {:error, :stale_preparation | :timer_already_installed | :subscriber_attached}
+  defp complete_reclaim_schedule(_lifecycle, _source, _timer_ref, false),
+    do: {:error, :stale_preparation}
+
+  defp complete_reclaim_schedule(%{reclaim_timer: timer_ref}, _source, _new_ref, true)
+       when is_reference(timer_ref),
+       do: {:error, :timer_already_installed}
+
+  defp complete_reclaim_schedule(%{attachments: attachments}, _source, _timer_ref, true)
+       when map_size(attachments) > 0,
+       do: {:error, :subscriber_attached}
+
+  defp complete_reclaim_schedule(lifecycle, _source, timer_ref, true),
+    do: {:ok, %{lifecycle | reclaim_timer: timer_ref}}
+end

--- a/test/minga/distribution/remote_session_e2e_test.exs
+++ b/test/minga/distribution/remote_session_e2e_test.exs
@@ -106,17 +106,10 @@ defmodule Minga.Distribution.RemoteSessionE2ETest do
     Session.add_system_message(remote_pid, "work done while you were away")
 
     # Simulate a GUI that subscribes, then dies (laptop closed / wifi lost).
-    test_pid = self()
-
-    subscriber =
-      spawn(fn ->
-        Session.subscribe(remote_pid, self())
-        send(test_pid, :subscribed)
-        Process.sleep(:infinity)
-      end)
-
-    assert_receive :subscribed, 1_000
+    subscriber = spawn(fn -> receive do: (:stop -> :ok) end)
     ref = Process.monitor(subscriber)
+
+    assert :ok = Session.subscribe(remote_pid, subscriber)
     Process.exit(subscriber, :kill)
     assert_receive {:DOWN, ^ref, :process, ^subscriber, _}, 1_000
 
@@ -139,16 +132,25 @@ defmodule Minga.Distribution.RemoteSessionE2ETest do
 
     viewer =
       spawn(fn ->
-        :erpc.call(server, RemoteAPI, :attach, [session_id, token, self(), [role: :driver]])
-        send(test_pid, :viewer_attached)
+        attach_result =
+          :erpc.call(server, RemoteAPI, :attach, [
+            session_id,
+            token,
+            self(),
+            [role: :driver]
+          ])
+
+        receive do
+          {:agent_event, ^remote_pid, {:credentials_status, _configured?}} ->
+            send(test_pid, {:viewer_attached, attach_result})
+        end
 
         receive do
           {:agent_event, ^remote_pid, event} -> send(test_pid, {:viewer_event, event})
-          :stop -> :ok
         end
       end)
 
-    assert_receive :viewer_attached, 1_000
+    assert_receive {:viewer_attached, {:ok, %{role: :viewer}}}, 1_000
 
     assert {:error, :not_driver} =
              :erpc.call(server, RemoteAPI, :send_prompt, [

--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -1679,7 +1679,15 @@ defmodule Minga.Extension.LifecycleContractTest do
 
     Process.exit(old_runtime_supervisor, :kill)
     new_instance = await_new_instance(ctx, name, old_instance)
-    assert {:ok, replacement} = eventually(fn -> Instance.start(new_instance) end)
+
+    assert {:ok, replacement} =
+             eventually(fn ->
+               case Instance.start(new_instance) do
+                 {:ok, _pid} = started -> started
+                 {:error, _reason} -> nil
+               end
+             end)
+
     refute replacement == runtime
     refute runtime_supervisor_pid(ctx, name) == old_runtime_supervisor
   end

--- a/test/minga_agent/session/subscriber_lifecycle_test.exs
+++ b/test/minga_agent/session/subscriber_lifecycle_test.exs
@@ -1,0 +1,284 @@
+defmodule MingaAgent.Session.SubscriberLifecycleTest do
+  use ExUnit.Case, async: true
+
+  alias MingaAgent.Session.SubscriberAttachment
+  alias MingaAgent.Session.SubscriberLifecycle
+
+  test "canonical attachments derive subscriber membership and one driver" do
+    driver = self()
+    viewer = Process.whereis(:init)
+    requested_driver = Process.whereis(:code_server)
+
+    lifecycle =
+      SubscriberLifecycle.new()
+      |> attach(driver, :driver, make_ref())
+      |> attach(viewer, :viewer, make_ref())
+      |> attach(requested_driver, :driver, make_ref())
+
+    assert MapSet.new(SubscriberLifecycle.subscribers(lifecycle)) ==
+             MapSet.new([driver, viewer, requested_driver])
+
+    assert SubscriberLifecycle.driver(lifecycle) == driver
+    assert SubscriberLifecycle.role(lifecycle, driver) == :driver
+    assert SubscriberLifecycle.role(lifecycle, viewer) == :viewer
+    assert SubscriberLifecycle.role(lifecycle, requested_driver) == :viewer
+    assert SubscriberLifecycle.default_role(lifecycle) == :viewer
+    assert SubscriberLifecycle.driver?(lifecycle, driver)
+  end
+
+  test "subscription completion distinguishes initial, viewer, and replacement roles" do
+    initial = SubscriberLifecycle.new()
+
+    assert {:monitor, initial_driver} =
+             SubscriberLifecycle.prepare_subscribe(initial, self(), :driver)
+
+    assert {:ok, _with_driver, :driver_initialized, nil} =
+             SubscriberLifecycle.complete_subscribe(initial, initial_driver, make_ref())
+
+    viewer = Process.whereis(:init)
+
+    assert {:monitor, initial_viewer} =
+             SubscriberLifecycle.prepare_subscribe(initial, viewer, :viewer)
+
+    assert {:ok, viewer_only, :viewer_attached, nil} =
+             SubscriberLifecycle.complete_subscribe(initial, initial_viewer, make_ref())
+
+    assert {:monitor, replacement_driver} =
+             SubscriberLifecycle.prepare_subscribe(viewer_only, self(), :driver)
+
+    assert {:ok, _with_replacement, :driver_changed, nil} =
+             SubscriberLifecycle.complete_subscribe(
+               viewer_only,
+               replacement_driver,
+               make_ref()
+             )
+  end
+
+  test "subscription preparation rejects invalid roles and preserves an existing attachment" do
+    driver = self()
+    lifecycle = attach(SubscriberLifecycle.new(), driver, :driver, make_ref())
+
+    assert {:error, :invalid_role} =
+             SubscriberLifecycle.prepare_subscribe(lifecycle, Process.whereis(:init), :owner)
+
+    assert {:already_attached, ^lifecycle} =
+             SubscriberLifecycle.prepare_subscribe(lifecycle, driver, :viewer)
+
+    assert SubscriberLifecycle.role(lifecycle, driver) == :driver
+  end
+
+  test "monitor completion rejects a stale preparation and leaves the acquired reference unowned" do
+    lifecycle = SubscriberLifecycle.new()
+    subscriber = self()
+    other = Process.whereis(:init)
+    monitor_ref = make_ref()
+
+    assert {:monitor, preparation} =
+             SubscriberLifecycle.prepare_subscribe(lifecycle, subscriber, :driver)
+
+    changed = attach(lifecycle, other, :viewer, make_ref())
+
+    assert {:error, :stale_preparation} =
+             SubscriberLifecycle.complete_subscribe(changed, preparation, monitor_ref)
+
+    refute monitor_ref in monitor_refs(changed)
+  end
+
+  test "driver claims are exhaustive across absent, occupied, vacant, and unchanged states" do
+    driver = self()
+    viewer = Process.whereis(:init)
+
+    states = [
+      {:empty, SubscriberLifecycle.new(), {:error, :not_subscribed}},
+      {:viewer_only, attach(SubscriberLifecycle.new(), viewer, :viewer, make_ref()),
+       {:changed, :viewer}},
+      {:driver_occupied,
+       SubscriberLifecycle.new()
+       |> attach(driver, :driver, make_ref())
+       |> attach(viewer, :viewer, make_ref()), {:error, :driver_taken}}
+    ]
+
+    for {name, lifecycle, expected} <- states do
+      case {name, SubscriberLifecycle.claim_driver(lifecycle, viewer), expected} do
+        {:viewer_only, {:changed, next}, {:changed, :viewer}} ->
+          assert SubscriberLifecycle.driver(next) == viewer
+          assert SubscriberLifecycle.role(next, viewer) == :driver
+
+        {_name, actual, expected} ->
+          assert actual == expected
+      end
+    end
+
+    occupied = attach(SubscriberLifecycle.new(), driver, :driver, make_ref())
+    assert :unchanged = SubscriberLifecycle.claim_driver(occupied, driver)
+  end
+
+  test "driver DOWN leaves viewers attached without automatic promotion" do
+    driver = self()
+    viewer = Process.whereis(:init)
+    driver_ref = make_ref()
+    viewer_ref = make_ref()
+
+    lifecycle =
+      SubscriberLifecycle.new()
+      |> attach(driver, :driver, driver_ref)
+      |> attach(viewer, :viewer, viewer_ref)
+
+    assert {:error, :stale_monitor} =
+             SubscriberLifecycle.subscriber_down(lifecycle, driver, make_ref())
+
+    assert {:removed, without_driver, %SubscriberAttachment{monitor_ref: ^driver_ref}} =
+             SubscriberLifecycle.subscriber_down(lifecycle, driver, driver_ref)
+
+    assert SubscriberLifecycle.driver(without_driver) == nil
+    assert SubscriberLifecycle.role(without_driver, viewer) == :viewer
+    assert {:changed, claimed} = SubscriberLifecycle.claim_driver(without_driver, viewer)
+    assert SubscriberLifecycle.driver(claimed) == viewer
+  end
+
+  test "viewer DOWN does not affect the current driver" do
+    driver = self()
+    viewer = Process.whereis(:init)
+    viewer_ref = make_ref()
+
+    lifecycle =
+      SubscriberLifecycle.new()
+      |> attach(driver, :driver, make_ref())
+      |> attach(viewer, :viewer, viewer_ref)
+
+    assert {:removed, next, %SubscriberAttachment{pid: ^viewer}} =
+             SubscriberLifecycle.subscriber_down(lifecycle, viewer, viewer_ref)
+
+    assert SubscriberLifecycle.driver(next) == driver
+    assert SubscriberLifecycle.role(next, viewer) == nil
+  end
+
+  test "detach returns the exact monitor identity once" do
+    subscriber = self()
+    monitor_ref = make_ref()
+    lifecycle = attach(SubscriberLifecycle.new(), subscriber, :driver, monitor_ref)
+
+    assert {:removed, detached, %SubscriberAttachment{monitor_ref: ^monitor_ref}} =
+             SubscriberLifecycle.detach(lifecycle, subscriber)
+
+    assert SubscriberLifecycle.subscribers(detached) == []
+    assert :unchanged = SubscriberLifecycle.detach(detached, subscriber)
+
+    assert {:error, :stale_monitor} =
+             SubscriberLifecycle.subscriber_down(detached, subscriber, monitor_ref)
+  end
+
+  test "reclaim scheduling installs and cancels exact OTP timer identity" do
+    lifecycle = SubscriberLifecycle.new()
+    timer_ref = make_ref()
+
+    assert {:start_timer, preparation} =
+             SubscriberLifecycle.reconcile_reclaim(lifecycle, true, true)
+
+    assert {:ok, scheduled} =
+             SubscriberLifecycle.complete_reclaim_schedule(lifecycle, preparation, timer_ref)
+
+    assert SubscriberLifecycle.reclaim_timer(scheduled) == timer_ref
+    assert :unchanged = SubscriberLifecycle.reconcile_reclaim(scheduled, true, true)
+
+    assert {:cancel_timer, ^timer_ref, cancelled} =
+             SubscriberLifecycle.reconcile_reclaim(scheduled, true, false)
+
+    assert SubscriberLifecycle.reclaim_timer(cancelled) == nil
+  end
+
+  test "timer completion rejects stale, occupied, and already scheduled lifecycle states" do
+    lifecycle = SubscriberLifecycle.new()
+    subscriber = self()
+
+    assert {:start_timer, preparation} =
+             SubscriberLifecycle.reconcile_reclaim(lifecycle, true, true)
+
+    attached = attach(lifecycle, subscriber, :driver, make_ref())
+
+    assert {:error, :stale_preparation} =
+             SubscriberLifecycle.complete_reclaim_schedule(attached, preparation, make_ref())
+
+    assert {:error, :subscriber_attached} =
+             SubscriberLifecycle.complete_reclaim_schedule(attached, attached, make_ref())
+
+    scheduled = install_timer(lifecycle, make_ref())
+
+    assert {:error, :timer_already_installed} =
+             SubscriberLifecycle.complete_reclaim_schedule(scheduled, scheduled, make_ref())
+  end
+
+  test "reattach invalidates the prior timer before stale timeout delivery" do
+    timer_ref = make_ref()
+    scheduled = install_timer(SubscriberLifecycle.new(), timer_ref)
+    subscriber = self()
+
+    assert {:monitor, preparation} =
+             SubscriberLifecycle.prepare_subscribe(scheduled, subscriber, :driver)
+
+    assert {:ok, attached, :driver_initialized, ^timer_ref} =
+             SubscriberLifecycle.complete_subscribe(scheduled, preparation, make_ref())
+
+    assert SubscriberLifecycle.reclaim_timer(attached) == nil
+    assert {:error, :stale_timer} = SubscriberLifecycle.reclaim_timeout(attached, timer_ref, true)
+  end
+
+  test "timeout accepts only the installed timer and rechecks turn activity" do
+    timer_ref = make_ref()
+    scheduled = install_timer(SubscriberLifecycle.new(), timer_ref)
+
+    assert {:error, :stale_timer} =
+             SubscriberLifecycle.reclaim_timeout(scheduled, make_ref(), true)
+
+    assert {:keep, kept} = SubscriberLifecycle.reclaim_timeout(scheduled, timer_ref, false)
+    assert SubscriberLifecycle.reclaim_timer(kept) == nil
+
+    scheduled = install_timer(SubscriberLifecycle.new(), timer_ref)
+    assert {:reclaim, reclaimed} = SubscriberLifecycle.reclaim_timeout(scheduled, timer_ref, true)
+    assert SubscriberLifecycle.reclaim_timer(reclaimed) == nil
+  end
+
+  test "stop returns every owned cleanup identity and clears lifecycle" do
+    first_ref = make_ref()
+    second_ref = make_ref()
+
+    attached =
+      SubscriberLifecycle.new()
+      |> attach(self(), :driver, first_ref)
+      |> attach(Process.whereis(:init), :viewer, second_ref)
+
+    {stopped, nil, monitor_refs} = SubscriberLifecycle.stop(attached)
+
+    assert MapSet.new(monitor_refs) == MapSet.new([first_ref, second_ref])
+    assert SubscriberLifecycle.subscribers(stopped) == []
+
+    timer_ref = make_ref()
+    scheduled = install_timer(SubscriberLifecycle.new(), timer_ref)
+    {stopped, ^timer_ref, []} = SubscriberLifecycle.stop(scheduled)
+    assert SubscriberLifecycle.reclaim_timer(stopped) == nil
+  end
+
+  defp attach(lifecycle, pid, role, monitor_ref) do
+    assert {:monitor, preparation} = SubscriberLifecycle.prepare_subscribe(lifecycle, pid, role)
+
+    assert {:ok, next, _subscription_change, _timer_ref} =
+             SubscriberLifecycle.complete_subscribe(lifecycle, preparation, monitor_ref)
+
+    next
+  end
+
+  defp install_timer(lifecycle, timer_ref) do
+    assert {:start_timer, preparation} =
+             SubscriberLifecycle.reconcile_reclaim(lifecycle, true, true)
+
+    assert {:ok, next} =
+             SubscriberLifecycle.complete_reclaim_schedule(lifecycle, preparation, timer_ref)
+
+    next
+  end
+
+  defp monitor_refs(lifecycle) do
+    {_stopped, _timer_ref, monitor_refs} = SubscriberLifecycle.stop(lifecycle)
+    monitor_refs
+  end
+end

--- a/test/minga_agent/session_lifecycle_test.exs
+++ b/test/minga_agent/session_lifecycle_test.exs
@@ -1,6 +1,8 @@
 defmodule MingaAgent.SessionLifecycleTest do
   use Minga.Test.SessionCase, async: true
 
+  alias MingaAgent.Session.SubscriberLifecycle
+
   describe "initial state" do
     test "starts idle with a system message and zero usage" do
       session = start_subscribed_session()
@@ -92,6 +94,26 @@ defmodule MingaAgent.SessionLifecycleTest do
       assert :ok = Session.claim_driver(session, viewer)
       assert Session.subscriber_role(session, viewer) == :driver
     end
+
+    test "a driver attaching to a viewer-only session broadcasts the role change" do
+      session = start_test_session(provider: Minga.Test.SessionMockProvider, provider_opts: [])
+      old_driver = idle_process()
+      new_driver = idle_process()
+
+      on_exit(fn -> Process.exit(new_driver, :kill) end)
+
+      assert :ok = Session.subscribe(session, old_driver, role: :driver)
+      assert :ok = Session.subscribe(session, self(), role: :viewer)
+
+      ref = Process.monitor(old_driver)
+      Process.exit(old_driver, :kill)
+      assert_receive {:DOWN, ^ref, :process, ^old_driver, :killed}, @event_timeout
+      wait_until_subscriber_role(session, old_driver, nil)
+
+      assert :ok = Session.subscribe(session, new_driver, role: :driver)
+      assert_receive {:agent_event, ^session, {:driver_changed, ^new_driver}}, @event_timeout
+      assert Session.subscriber_role(session, new_driver) == :driver
+    end
   end
 
   describe "detached session lifecycle" do
@@ -102,14 +124,11 @@ defmodule MingaAgent.SessionLifecycleTest do
     end
 
     test "idle detached sessions are reclaimed after the configured timeout" do
-      idle_gc_token = make_ref()
-
       session =
         start_test_session(
           provider: Minga.Test.SessionMockProvider,
           provider_opts: [],
-          idle_gc_timeout_ms: 60_000,
-          idle_gc_token_fn: fn -> idle_gc_token end
+          idle_gc_timeout_ms: 60_000
         )
 
       client = idle_process()
@@ -120,7 +139,8 @@ defmodule MingaAgent.SessionLifecycleTest do
 
       ref = Process.monitor(session)
       assert :ok = Session.unsubscribe(session, client)
-      send(session, {:idle_gc_timeout, idle_gc_token})
+      timer_ref = reclaim_timer(session)
+      send(session, {:timeout, timer_ref, :idle_gc})
       assert_receive {:DOWN, ^ref, :process, ^session, :normal}, @event_timeout
     end
 
@@ -130,7 +150,6 @@ defmodule MingaAgent.SessionLifecycleTest do
     } do
       bad_store_dir = Path.join(dir, "blocked-store")
       File.write!(bad_store_dir, "not a directory")
-      idle_gc_token = make_ref()
 
       session =
         start_test_session(
@@ -138,8 +157,7 @@ defmodule MingaAgent.SessionLifecycleTest do
           provider_opts: [],
           persist?: false,
           session_store_dir: bad_store_dir,
-          idle_gc_timeout_ms: 60_000,
-          idle_gc_token_fn: fn -> idle_gc_token end
+          idle_gc_timeout_ms: 60_000
         )
 
       client = idle_process()
@@ -150,7 +168,8 @@ defmodule MingaAgent.SessionLifecycleTest do
 
       ref = Process.monitor(session)
       assert :ok = Session.unsubscribe(session, client)
-      send(session, {:idle_gc_timeout, idle_gc_token})
+      timer_ref = reclaim_timer(session)
+      send(session, {:timeout, timer_ref, :idle_gc})
       assert_receive {:DOWN, ^ref, :process, ^session, :normal}, @event_timeout
       assert File.read!(bad_store_dir) == "not a directory"
     end
@@ -161,15 +180,12 @@ defmodule MingaAgent.SessionLifecycleTest do
     } do
       session_store_dir = Path.join(dir, "idle-race")
 
-      idle_gc_token = make_ref()
-
       session =
         start_test_session(
           provider: Minga.Test.SessionDeferredMockProvider,
           provider_opts: [test_pid: self()],
           session_store_dir: session_store_dir,
-          idle_gc_timeout_ms: 60_000,
-          idle_gc_token_fn: fn -> idle_gc_token end
+          idle_gc_timeout_ms: 60_000
         )
 
       client = idle_process()
@@ -178,6 +194,7 @@ defmodule MingaAgent.SessionLifecycleTest do
 
       assert :ok = Session.subscribe(session, client)
       assert :ok = Session.unsubscribe(session, client)
+      timer_ref = reclaim_timer(session)
       ref = Process.monitor(session)
 
       assert :ok = Session.send_prompt(session, "keep working")
@@ -186,7 +203,7 @@ defmodule MingaAgent.SessionLifecycleTest do
       assert_receive {:deferred_provider_prompt_received, ^provider, "keep working"},
                      @event_timeout
 
-      send(session, {:idle_gc_timeout, idle_gc_token})
+      send(session, {:timeout, timer_ref, :idle_gc})
       assert Session.status(session) == :idle
       refute_receive {:DOWN, ^ref, :process, ^session, :normal}, 50
 
@@ -199,17 +216,15 @@ defmodule MingaAgent.SessionLifecycleTest do
     end
 
     test "active plan-mode turns reschedule idle GC after finishing" do
-      initial_token = make_ref()
-      finished_token = make_ref()
-
       session =
         start_test_session(
           provider: Minga.Test.StubProvider,
           provider_opts: [],
           persist?: false,
-          idle_gc_timeout_ms: 60_000,
-          idle_gc_token_fn: idle_gc_token_fn([initial_token, finished_token])
+          idle_gc_timeout_ms: 60_000
         )
+
+      initial_timer = reclaim_timer(session)
 
       ref = Process.monitor(session)
 
@@ -217,14 +232,15 @@ defmodule MingaAgent.SessionLifecycleTest do
       assert :ok = Session.send_prompt(session, "start plan turn")
       send_provider_event(session, %Event.AgentStart{})
 
-      send(session, {:idle_gc_timeout, initial_token})
+      send(session, {:timeout, initial_timer, :idle_gc})
       assert Session.status(session) == :plan
       refute_receive {:DOWN, ^ref, :process, ^session, :normal}, 50
 
       send_provider_event(session, %Event.AgentEnd{usage: nil})
 
       assert Session.status(session) == :plan
-      send(session, {:idle_gc_timeout, finished_token})
+      finished_timer = reclaim_timer(session)
+      send(session, {:timeout, finished_timer, :idle_gc})
       assert_receive {:DOWN, ^ref, :process, ^session, :normal}, @event_timeout
     end
 
@@ -236,14 +252,14 @@ defmodule MingaAgent.SessionLifecycleTest do
           idle_gc_timeout_ms: 60_000
         )
 
-      {_timer_ref, stale_token} = :sys.get_state(session).idle_gc_timer
+      stale_timer = reclaim_timer(session)
 
       assert :ok = Session.subscribe(session)
       assert :ok = Session.send_prompt(session, "keep working")
       assert_receive {:agent_event, _, {:status_changed, :thinking}}, @event_timeout
       assert :ok = Session.unsubscribe(session)
 
-      send(session, {:idle_gc_timeout, stale_token})
+      send(session, {:timeout, stale_timer, :idle_gc})
       assert Session.status(session) == :thinking
     end
 
@@ -255,15 +271,17 @@ defmodule MingaAgent.SessionLifecycleTest do
           idle_gc_timeout_ms: 60_000
         )
 
+      stale_timer = reclaim_timer(session)
+
       assert :ok = Session.enter_plan(session)
       assert :ok = Session.send_prompt(session, "start plan turn")
       send(session, {:agent_provider_event, %Event.AgentStart{}})
       :sys.get_state(session)
 
-      {_timer_ref, token} = :sys.get_state(session).idle_gc_timer
+      assert reclaim_timer(session) == nil
       ref = Process.monitor(session)
 
-      send(session, {:idle_gc_timeout, token})
+      send(session, {:timeout, stale_timer, :idle_gc})
       assert Session.status(session) == :plan
       refute_receive {:DOWN, ^ref, :process, ^session, :normal}, 50
     end
@@ -278,10 +296,10 @@ defmodule MingaAgent.SessionLifecycleTest do
 
       assert :ok = Session.subscribe(session)
       assert :ok = Session.unsubscribe(session)
-      {_timer_ref, stale_token} = :sys.get_state(session).idle_gc_timer
+      stale_timer = reclaim_timer(session)
       assert :ok = Session.subscribe(session)
 
-      send(session, {:idle_gc_timeout, stale_token})
+      send(session, {:timeout, stale_timer, :idle_gc})
       assert Session.status(session) == :idle
     end
 
@@ -323,13 +341,11 @@ defmodule MingaAgent.SessionLifecycleTest do
           idle_gc_timeout_ms: 60_000
         )
 
-      {_timer_ref, token} = :sys.get_state(session).idle_gc_timer
+      timer_ref = reclaim_timer(session)
       ref = Process.monitor(session)
 
-      send(session, {:idle_gc_timeout, token})
-      state = :sys.get_state(session)
-
-      assert state.idle_gc_timer != nil
+      send(session, {:timeout, timer_ref, :idle_gc})
+      assert is_reference(reclaim_timer(session))
       assert Session.status(session) == :idle
       assert is_pid(Session.get_provider(session))
       refute_receive {:DOWN, ^ref, :process, ^session, _}, 50
@@ -660,4 +676,10 @@ defmodule MingaAgent.SessionLifecycleTest do
   end
 
   # ── Queue API ──────────────────────────────────────────────────────────────
+  defp reclaim_timer(session) do
+    session
+    |> :sys.get_state()
+    |> Map.fetch!(:subscriber_lifecycle)
+    |> SubscriberLifecycle.reclaim_timer()
+  end
 end

--- a/test/minga_agent/session_manager_test.exs
+++ b/test/minga_agent/session_manager_test.exs
@@ -5,6 +5,7 @@ defmodule MingaAgent.SessionManagerTest do
 
   alias MingaAgent.Providers.RecordingProvider
   alias MingaAgent.Session
+  alias MingaAgent.Session.SubscriberLifecycle
   alias MingaAgent.SessionManager
   alias MingaAgent.SessionManager.SessionRestartedEvent
   alias MingaAgent.SessionManager.SessionStoppedEvent
@@ -387,18 +388,17 @@ defmodule MingaAgent.SessionManagerTest do
 
   test "idle GC shutdown stops a managed session without restart", %{manager: manager} do
     Minga.Events.subscribe(:agent_session_stopped)
-    idle_gc_token = make_ref()
 
     {:ok, session_id, pid} =
       SessionManager.start_session(manager,
         persist?: false,
-        idle_gc_timeout_ms: 60_000,
-        idle_gc_token_fn: fn -> idle_gc_token end
+        idle_gc_timeout_ms: 60_000
       )
 
     assert :ok = MingaAgent.Session.subscribe(pid)
     assert :ok = MingaAgent.Session.unsubscribe(pid)
-    send(pid, {:idle_gc_timeout, idle_gc_token})
+    timer_ref = :sys.get_state(pid).subscriber_lifecycle |> SubscriberLifecycle.reclaim_timer()
+    send(pid, {:timeout, timer_ref, :idle_gc})
 
     assert_receive {
                      :minga_event,

--- a/test/support/minga_agent/session_case.ex
+++ b/test/support/minga_agent/session_case.ex
@@ -38,18 +38,6 @@ defmodule Minga.Test.SessionCase do
     :ok
   end
 
-  @spec idle_gc_token_fn([reference()]) :: (-> reference())
-  def idle_gc_token_fn(tokens) do
-    token_source = start_supervised!({Agent, fn -> tokens end})
-
-    fn ->
-      Agent.get_and_update(token_source, fn
-        [token | rest] -> {token, rest}
-        [] -> raise "idle_gc_token_fn called more times than expected"
-      end)
-    end
-  end
-
   @spec start_test_session(keyword()) :: pid()
   def start_test_session(opts) do
     opts = Keyword.put_new(opts, :persist?, false)


### PR DESCRIPTION
# TL;DR
Session now owns subscriber roles, monitor identity, driver ownership, and idle reclaim timer identity through one pure lifecycle value. This removes overlapping state and custom timer tokens while preserving local, remote, and SessionManager behavior.

Closes #2853
Part of #2850

## Context
Remote attach and multi-client behavior previously depended on separate subscriber, role, monitor, driver, and idle-GC fields. This PR gives those transitions one canonical owner without adding another process or moving effects out of Session.

## Changes
- Add `SubscriberAttachment` to structurally pair each PID with its role and OTP monitor reference.
- Add `SubscriberLifecycle` with pure prepare/complete transitions for subscribe and reclaim effects, derived subscriber and driver queries, typed stale-identity rejection, and ordered cleanup identities.
- Keep monitoring, demonitoring, timer creation, cancellation, broadcasts, persistence, and termination in Session, then install the lifecycle returned by each transition.
- Replace custom idle-GC tokens with exact OTP timer references and reject stale timeout messages after cancellation or reconnect.
- Preserve explicit driver claims after driver death and the existing `driver_changed` event when a new driver fills a viewer-only vacancy.
- Add pure transition coverage plus local, SessionManager, RemoteAPI, reconnect, and distributed lifecycle regression coverage.
- Retry transient replacement-start errors in the extension lifecycle contract test after its runtime supervisor is intentionally killed.

## Verification
- `make lint`: passed with no Credo issues and zero Dialyzer errors.
- `mix test.llm --max-cases 1`: 9,903 tests, 58 doctests, and 98 properties passed; zero failures.
- `mix test.llm --include distributed --max-cases 1 test/minga/distribution/remote_session_e2e_test.exs`: 5 distributed lifecycle tests passed.
- `mix test.llm --max-cases 8 test/minga/extension/lifecycle_contract_test.exs`: 42 concurrent lifecycle contract tests passed.
- Focused lifecycle, SessionManager, and RemoteAPI suites: 76 tests passed.
- Focused bug hunt: PASS.
- Final acceptance review and targeted blocker re-review: PASS.

## Acceptance Criteria Addressed
- Canonical lifecycle owns attachment role and monitor identity, with subscriber membership and active driver derived from it. [OK]
- Pure transitions cover subscribe, monitor completion, transfer, DOWN, detach, reconnect, reclaim scheduling, cancellation, and stale identities. [OK]
- Session performs effects, installs returned lifecycle state, and consumes ordered cleanup identities. [OK]
- Idle reclamation uses exact OTP timer identity and removes custom token generation. [OK]
- Local, remote, authorization, driver, SessionManager, and restart behavior remain compatible. [OK]
- Transition and integration tests cover the required normal, active-turn, failure, reconnect, and stale-message paths. [OK]

---
**Updated after CI:** The extension lifecycle replacement test now retries the transient `:noproc` result that can occur while its intentionally killed runtime supervisor is restarting. The production lifecycle implementation is unchanged.