### PR TITLE
refactor(ui): clarify picker source transitions

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1739,8 +1739,8 @@ Typing `#` at the start of File or Recent switches to Project Search without run
 - **Test lines added/removed:** 88 added / 17 removed, net +71.
 - **Concepts added/removed:** One tagged `source_switch` field replaces two nullable/sentinel fields and removes invalid combinations; no new process, protocol, scheduler, or wrapper module.
 - **Final reviewer verdict:** `PASS`; the owner transition preserves restoration, context, layout, native correlation, fetch state, prefix behavior, latest-wins rejection, and semantic projection without new architecture or exceeding the production budget.
-- **PR URL:** Pending
-- **Commit SHA:** Pending
+- **PR URL:** https://github.com/jsmestad/minga/pull/3005
+- **Commit SHA:** `a2f432d40`
 - **Merge SHA:** Pending
 - **Completion date:** Pending
 

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1660,7 +1660,7 @@ Remove only the unreachable Tool Manager footer-overlay producer. Footer placeme
 
 ### W012: Route picker prefix switching through async lifecycle
 
-- **Status:** ACTIVE
+- **Status:** VERIFIED
 - **Audit ID:** L11
 - **Roadmap unit:** W012, Route picker prefix switching through async lifecycle
 - **Ponytail verdict:** `ACCEPT/direct`
@@ -1712,7 +1712,7 @@ Typing `#` at the start of File or Recent switches to Project Search without run
 
 - **PR URL:** https://github.com/jsmestad/minga/pull/2998
 - **Commit SHA:** `b3d700b971ced9ed9d8b421984e415132235fe6c`
-- **Merge SHA:** Pending
+- **Merge SHA:** `422ed731c8d4ae984bf78181ec392ed9ca233320`
 - **Focused tests:** 40 passed across `picker_ui_test.exs`, `fetch_effect_test.exs`, and `search_async_test.exs`.
 - **Broad validation:** `git diff --check` passed; `make lint` passed (Credo, compile, incremental Dialyzer: 0 errors); `ERL_FLAGS='+S 2:2' mix test.llm` passed on the final base (58 doctests, 98 properties, 9,891 tests, 0 failures, 1 skipped, 578 excluded).
 - **Ponytail and Elixir verdict:** `LEAN` after a targeted correction; source switching uses local helpers and existing lifecycle primitives, preserves picker-open ownership, clears stale sync-return fetch state, and stays within 76 production additions.
@@ -1722,8 +1722,27 @@ Typing `#` at the start of File or Recent switches to Project Search without run
 - **Test lines added/removed:** 64 added / 1 removed, net +63
 - **Concepts added/removed:** No concepts added or removed; prefix switching now reuses the existing async lifecycle.
 - **Findings resolved:** Project Search prefix switching no longer executes synchronous search on the Editor input loop or bypasses async lifecycle ownership.
-- **Discoveries affecting later work:** Source switching must preserve picker-open restoration and context independently from per-source query and fetch state.
+- **Discoveries affecting later work:** Source switching must preserve picker-open restoration and context independently from per-source query and fetch state. Post-merge Elixir review found that rebuilding through `open_loading/3` and repairing five fields left the transition represented by positional arguments and two independent sentinel fields.
 - **Completion date:** 2026-07-18
+
+#### Post-merge ownership refinement
+
+- **Status:** ACTIVE
+- **Reason:** User review and a focused `elixir-architect` audit found that `switch_async_source/6` reopened a fresh picker and repaired session-owned fields instead of expressing one owner transition.
+- **Owned shape:** `MingaEditor.State.Picker` replaces `original_source` plus `mode_prefix` with `source_switch: :original | {:switched, original_source, prefix}` and owns retargeting through `retarget/4`. `PickerUI` retains callback, cancellation, scheduler, and candidate orchestration.
+- **Deletion outcome:** Async and sync switching update the existing picker state through the same transition. The async reopen-and-repair block, six-argument helper, duplicate picker/query arguments, foreign picker-state writes, and invalid sentinel combinations are removed without a new process, protocol, scheduler, or wrapper module.
+- **Preserve:** Prefix mappings, synchronous `>` and `@`, asynchronous `#`, query correlation, fetch revisions, scheduler cancellation, stale-result rejection, picker restoration, context, layout, and semantic mode-prefix rendering.
+- **Focused tests:** 55 passed across `state/picker_test.exs`, `picker_ui_test.exs`, `picker_builder_test.exs`, `fetch_effect_test.exs`, and `search_async_test.exs`.
+- **Broad validation:** `git diff --check`, `make lint`, and `mix test.llm --max-cases 4` passed on current main; full non-heavy result: 58 doctests, 98 properties, 9,906 tests, 0 failures, 1 skipped, 578 excluded.
+- **Ponytail verdict:** `LEAN`; after rebasing removed an apparent unrelated diff and `Context.from_editor_state(loading_state)` made the retargeted state the single context owner, the targeted recheck returned `Lean already. Ship.`
+- **Production lines added/removed:** 147 added / 118 removed, net +29. Production additions remain below the 200-line slice ceiling.
+- **Test lines added/removed:** 88 added / 17 removed, net +71.
+- **Concepts added/removed:** One tagged `source_switch` field replaces two nullable/sentinel fields and removes invalid combinations; no new process, protocol, scheduler, or wrapper module.
+- **Final reviewer verdict:** `PASS`; the owner transition preserves restoration, context, layout, native correlation, fetch state, prefix behavior, latest-wins rejection, and semantic projection without new architecture or exceeding the production budget.
+- **PR URL:** Pending
+- **Commit SHA:** Pending
+- **Merge SHA:** Pending
+- **Completion date:** Pending
 
 ## Follow-on simplifications
 

--- a/lib/minga_editor/picker_ui.ex
+++ b/lib/minga_editor/picker_ui.ex
@@ -53,6 +53,9 @@ defmodule MingaEditor.PickerUI do
           {:ok, [Picker.item()], [MingaEditor.UI.Picker.Candidate.t()], Source.fetch_meta()}
           | {:error, String.t()}
 
+  @typep source_target :: PickerState.source_target()
+  @typep source_transition :: PickerState.source_transition()
+
   # Mode-switching prefix map: first character → source module.
   # When a prefix character is typed as the first query char in a switchable
   # source (file picker, recent files), the picker swaps to the mapped source
@@ -296,7 +299,7 @@ defmodule MingaEditor.PickerUI do
               modal:
                 {:picker,
                  %{
-                   picker_ui: %PickerState{picker: %Picker{} = picker} = picker_state
+                   picker_ui: %PickerState{picker: %Picker{}} = picker_state
                  }}
             }
           }
@@ -307,7 +310,7 @@ defmodule MingaEditor.PickerUI do
       )
       when is_binary(query) do
     if PickerState.current_query_edit?(picker_state, generation, edit_seq) do
-      replace_current_query(state, picker_state, picker, query, edit_seq)
+      replace_current_query(state, picker_state, query, edit_seq)
     else
       state
     end
@@ -315,29 +318,30 @@ defmodule MingaEditor.PickerUI do
 
   def replace_query(state, _generation, _edit_seq, _query), do: state
 
-  @spec replace_current_query(
-          state(),
-          PickerState.t(),
-          Picker.t(),
-          String.t(),
-          non_neg_integer()
-        ) :: state()
+  @spec replace_current_query(state(), PickerState.t(), String.t(), non_neg_integer()) ::
+          state()
   defp replace_current_query(
          state,
-         %PickerState{mode_prefix: mode_prefix},
-         picker,
+         %PickerState{
+           picker: %Picker{} = picker,
+           source_switch: {:switched, _original_source, mode_prefix}
+         },
          query,
          edit_seq
-       )
-       when mode_prefix != "" do
+       ) do
     normalized_query = String.replace_prefix(query, mode_prefix, "")
     install_query_edit(state, picker, normalized_query, edit_seq)
   end
 
-  defp replace_current_query(state, %PickerState{}, picker, query, edit_seq) do
+  defp replace_current_query(
+         state,
+         %PickerState{picker: %Picker{} = picker} = picker_state,
+         query,
+         edit_seq
+       ) do
     case String.next_grapheme(query) do
       {prefix, remaining_query} ->
-        case maybe_switch_mode(state, prefix, "") do
+        case maybe_switch_mode(state, picker_state, prefix) do
           {:switched, new_state} ->
             install_switched_query_edit(new_state, remaining_query, edit_seq)
 
@@ -676,14 +680,13 @@ defmodule MingaEditor.PickerUI do
     end
   end
 
-  # Backspace (with mode-switch detection: if query becomes empty and we're in a switched mode, switch back)
+  # Backspace returns to the original source when it empties a switched picker.
   def handle_key(
         %{
           shell_runtime: %{
             state: %{
               modal:
-                {:picker,
-                 %{picker_ui: %{picker: picker, mode_prefix: prefix, original_source: orig}}}
+                {:picker, %{picker_ui: %PickerState{picker: %Picker{} = picker} = picker_state}}
             }
           }
         } = state,
@@ -691,20 +694,23 @@ defmodule MingaEditor.PickerUI do
         _mods
       )
       when cp in [8, 127] do
-    new_picker = Picker.backspace(picker)
+    case {Picker.backspace(picker), picker_state.source_switch} do
+      {%Picker{query: ""}, {:switched, _original_source, _prefix}} ->
+        switch_back_to_original(state)
 
-    # If query is now empty and we had mode-switched, switch back to original source
-    if new_picker.query == "" and prefix != "" and orig != nil do
-      switch_back_to_original(state)
-    else
-      state = update_picker(state, &%{&1 | picker: new_picker})
-      maybe_preview_selection(state)
+      {%Picker{} = new_picker, _source_switch} ->
+        state = update_picker(state, &PickerState.update_picker(&1, new_picker))
+        maybe_preview_selection(state)
     end
   end
 
   # Printable characters → filter (with mode-switch detection)
   def handle_key(
-        %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{picker: picker}}}}}} = state,
+        %{
+          shell_runtime: %{
+            state: %{modal: {:picker, %{picker_ui: %PickerState{} = picker_state}}}
+          }
+        } = state,
         codepoint,
         0
       )
@@ -721,7 +727,7 @@ defmodule MingaEditor.PickerUI do
         state
 
       c ->
-        type_printable_char(state, picker, c)
+        type_printable_char(state, picker_state, c)
     end
   end
 
@@ -736,15 +742,15 @@ defmodule MingaEditor.PickerUI do
     run_action(source, action_id, item, new_state, callback_source)
   end
 
-  @spec type_printable_char(EditorState.t(), Picker.t(), String.t()) :: EditorState.t()
-  defp type_printable_char(state, picker, char) do
-    case maybe_switch_mode(state, char, picker.query) do
+  @spec type_printable_char(EditorState.t(), PickerState.t(), String.t()) :: EditorState.t()
+  defp type_printable_char(state, %PickerState{picker: picker} = picker_state, char) do
+    case maybe_switch_mode(state, picker_state, char) do
       {:switched, new_state} ->
         new_state
 
       :no_switch ->
         new_picker = Picker.type_char(picker, char)
-        state = update_picker(state, &%{&1 | picker: new_picker})
+        state = update_picker(state, &PickerState.update_picker(&1, new_picker))
         maybe_preview_selection(state)
     end
   end
@@ -1015,119 +1021,88 @@ defmodule MingaEditor.PickerUI do
 
   # ── Mode switching ──────────────────────────────────────────────────────────
 
-  # Check if typing a character should trigger a mode switch.
-  # Only triggers on the first character in an empty query, for switchable sources.
-  @spec maybe_switch_mode(state(), String.t(), String.t()) ::
+  # Check whether the first character in an empty query retargets the picker.
+  @spec maybe_switch_mode(state(), PickerState.t(), String.t()) ::
           {:switched, state()} | :no_switch
   defp maybe_switch_mode(
-         %{shell_runtime: %{state: %{modal: {:picker, %{picker_ui: %{source: source}}}}}} = state,
-         char,
-         query
+         state,
+         %PickerState{picker: %Picker{query: ""}, source: source},
+         char
        ) do
-    source_prefixes = Map.get(@mode_prefixes, source, %{})
+    case @mode_prefixes do
+      %{^source => %{^char => target_source}} ->
+        {:switched, switch_to_source(state, target_source, char)}
 
-    if query == "" and Map.has_key?(source_prefixes, char) do
-      target_source = Map.fetch!(source_prefixes, char)
-      {:switched, switch_to_source(state, target_source, char)}
-    else
-      :no_switch
+      _prefixes ->
+        :no_switch
     end
   end
 
-  # Switch the picker to a new source module, preserving the original source for switch-back.
+  defp maybe_switch_mode(_state, %PickerState{}, _char), do: :no_switch
+
   @spec switch_to_source(state(), module(), String.t()) :: state()
   defp switch_to_source(state, new_source, prefix) do
     current = picker_state(state)
-    switch_source(state, new_source, current.original_source || current.source, prefix, current)
+    switch_source(state, current, new_source, {:switch, prefix})
   end
 
-  # Switch back to the original source after the prefix is deleted.
   @spec switch_back_to_original(state()) :: state()
   defp switch_back_to_original(state) do
-    current = picker_state(state)
-    switch_source(state, current.original_source, nil, "", current)
+    %PickerState{source_switch: {:switched, original_source, _prefix}} =
+      current =
+      picker_state(state)
+
+    switch_source(state, current, original_source, :restore)
   end
 
-  @spec switch_source(state(), module(), module() | nil, String.t(), PickerState.t()) :: state()
-  defp switch_source(state, source, original_source, mode_prefix, current) do
+  @spec switch_source(state(), PickerState.t(), module(), source_transition()) :: state()
+  defp switch_source(state, current, source, transition) do
     callback_source = Source.source_identity(source)
+    target = {source, callback_source, Source.layout(source, callback_source)}
 
     if Source.async?(source, callback_source) do
-      switch_async_source(state, source, callback_source, original_source, mode_prefix, current)
+      switch_async_source(state, current, target, transition)
     else
-      switch_sync_source(state, source, callback_source, original_source, mode_prefix)
+      switch_sync_source(state, current, target, transition)
     end
   end
 
-  @spec switch_async_source(
-          state(),
-          module(),
-          PickerState.callback_source(),
-          module() | nil,
-          String.t(),
-          PickerState.t()
-        ) :: state()
+  @spec switch_async_source(state(), PickerState.t(), source_target(), source_transition()) ::
+          state()
   defp switch_async_source(
          state,
-         source,
-         callback_source,
-         original_source,
-         mode_prefix,
-         current
+         current,
+         {source, callback_source, _layout} = target,
+         transition
        ) do
-    {loading_state, revision} = open_loading(state, source)
-
-    loading_state =
-      update_picker(loading_state, fn loading ->
-        %{
-          loading
-          | restore: current.restore,
-            restore_theme: current.restore_theme,
-            context: current.context,
-            original_source: original_source,
-            mode_prefix: mode_prefix
-        }
-      end)
+    state = cancel_current_fetch(state)
+    max_vis = max(state.frontend.terminal_viewport.rows - 3, 5)
+    picker = Picker.new([], title: Source.title(source, callback_source), max_visible: max_vis)
+    switched = PickerState.retarget(current, picker, target, transition)
+    {loading, revision} = PickerState.begin_fetch(switched)
+    loading_state = update_picker(state, fn _current -> loading end)
 
     request =
       FetchEffect.request(
         source,
         callback_source,
-        Context.from_editor_state(loading_state, current.context),
+        Context.from_editor_state(loading_state),
         revision
       )
 
     schedule_fetch(loading_state, request, source, revision)
   end
 
-  @spec switch_sync_source(
-          state(),
-          module(),
-          PickerState.callback_source(),
-          module() | nil,
-          String.t()
-        ) :: state()
-  defp switch_sync_source(state, source, callback_source, original_source, mode_prefix) do
+  @spec switch_sync_source(state(), PickerState.t(), source_target(), source_transition()) ::
+          state()
+  defp switch_sync_source(state, current, {source, callback_source, _layout} = target, transition) do
     state = cancel_current_fetch(state)
     items = Source.candidates(source, Context.from_editor_state(state), callback_source)
     max_vis = max(state.frontend.terminal_viewport.rows - 3, 5)
     picker = Picker.new(items, title: Source.title(source, callback_source), max_visible: max_vis)
-    layout = MingaEditor.UI.Picker.Source.layout(source, callback_source)
+    switched = PickerState.retarget(current, picker, target, transition)
 
-    update_picker(
-      state,
-      &%{
-        &1
-        | picker: picker,
-          source: source,
-          callback_source: callback_source,
-          layout: layout,
-          original_source: original_source,
-          mode_prefix: mode_prefix,
-          load_status: :ready,
-          fetch_revision: nil
-      }
-    )
+    update_picker(state, fn _current -> switched end)
   end
 
   # ── Private helpers ──────────────────────────────────────────────────────────

--- a/lib/minga_editor/render_model/ui/picker_builder.ex
+++ b/lib/minga_editor/render_model/ui/picker_builder.ex
@@ -7,6 +7,7 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
   alias Minga.RenderModel.UI.Picker, as: PickerModel
   alias Minga.RenderModel.UI.Picker.ActionMenu
   alias MingaEditor.Frontend.Emit.Context
+  alias MingaEditor.State.Picker, as: PickerState
   alias MingaEditor.UI.Picker
   alias MingaEditor.UI.Picker.FileSource
   alias MingaEditor.UI.Picker.ProjectFileCandidate
@@ -21,20 +22,20 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilder do
       {:picker,
        %{
          picker_ui:
-           picker_ui = %{
-             picker: picker,
-             source: source,
-             callback_source: callback_source,
-             action_menu: action_menu
-           }
+           picker_ui =
+               %PickerState{
+                 picker: picker,
+                 source: source,
+                 callback_source: callback_source,
+                 action_menu: action_menu,
+                 load_status: load_status,
+                 query_generation: query_generation,
+                 acknowledged_query_edit_seq: acknowledged_query_edit_seq
+               }
        }}
       when picker != nil ->
-        mode_prefix = Map.get(picker_ui, :mode_prefix, "")
-        load_status = Map.get(picker_ui, :load_status, :ready)
-
-        query_correlation =
-          {Map.get(picker_ui, :query_generation, 0),
-           Map.get(picker_ui, :acknowledged_query_edit_seq, 0)}
+        mode_prefix = PickerState.mode_prefix(picker_ui)
+        query_correlation = {query_generation, acknowledged_query_edit_seq}
 
         build_open(
           ctx,

--- a/lib/minga_editor/state/picker.ex
+++ b/lib/minga_editor/state/picker.ex
@@ -16,6 +16,14 @@ defmodule MingaEditor.State.Picker do
   @typedoc "Contribution source semantically authorized to provide picker candidates."
   @type callback_source :: Minga.Extension.ContributionCleanup.contribution_source() | nil
 
+  @typedoc "Source-switch state for the picker currently shown."
+  @type source_switch :: :original | {:switched, module(), String.t()}
+  @type source_transition :: {:switch, String.t()} | :restore
+
+  @typedoc "Source metadata installed by a picker source transition."
+  @type source_target ::
+          {module(), callback_source(), MingaEditor.UI.Picker.Source.layout()}
+
   @typedoc "Correlation generation for native full-query editing."
   @type query_generation :: non_neg_integer()
 
@@ -39,8 +47,7 @@ defmodule MingaEditor.State.Picker do
           action_menu: action_menu(),
           context: map() | nil,
           layout: MingaEditor.UI.Picker.Source.layout(),
-          original_source: module() | nil,
-          mode_prefix: String.t(),
+          source_switch: source_switch(),
           load_status: load_status(),
           fetch_revision: fetch_revision(),
           query_generation: query_generation(),
@@ -55,8 +62,7 @@ defmodule MingaEditor.State.Picker do
             action_menu: nil,
             context: nil,
             layout: :bottom,
-            original_source: nil,
-            mode_prefix: "",
+            source_switch: :original,
             load_status: :ready,
             fetch_revision: nil,
             query_generation: 0,
@@ -143,6 +149,53 @@ defmodule MingaEditor.State.Picker do
   @spec update_picker(t(), MingaEditor.UI.Picker.t()) :: t()
   def update_picker(%__MODULE__{} = ps, picker) do
     %{ps | picker: picker}
+  end
+
+  @doc "Returns the visible prefix for a switched source."
+  @spec mode_prefix(t()) :: String.t()
+  def mode_prefix(%__MODULE__{source_switch: {:switched, _original_source, prefix}}), do: prefix
+  def mode_prefix(%__MODULE__{}), do: ""
+
+  @doc "Retargets an open picker while retaining its session-owned fields."
+  @spec retarget(t(), MingaEditor.UI.Picker.t(), source_target(), source_transition()) :: t()
+  def retarget(
+        %__MODULE__{source: original_source, source_switch: :original} = ps,
+        picker,
+        target,
+        {:switch, prefix}
+      )
+      when is_atom(original_source) and is_binary(prefix),
+      do: put_source(ps, picker, target, {:switched, original_source, prefix})
+
+  def retarget(
+        %__MODULE__{source_switch: {:switched, original_source, _old_prefix}} = ps,
+        picker,
+        target,
+        {:switch, prefix}
+      )
+      when is_binary(prefix),
+      do: put_source(ps, picker, target, {:switched, original_source, prefix})
+
+  def retarget(
+        %__MODULE__{source_switch: {:switched, original_source, _prefix}} = ps,
+        picker,
+        {original_source, _callback_source, _layout} = target,
+        :restore
+      ),
+      do: put_source(ps, picker, target, :original)
+
+  @spec put_source(t(), MingaEditor.UI.Picker.t(), source_target(), source_switch()) :: t()
+  defp put_source(ps, picker, {source, callback_source, layout}, source_switch) do
+    %{
+      ps
+      | picker: picker,
+        source: source,
+        callback_source: callback_source,
+        layout: layout,
+        source_switch: source_switch,
+        load_status: :ready,
+        fetch_revision: nil
+    }
   end
 
   @doc """

--- a/test/minga_editor/picker_ui_test.exs
+++ b/test/minga_editor/picker_ui_test.exs
@@ -450,14 +450,14 @@ defmodule MingaEditor.PickerUITest do
       switched_state = PickerUI.handle_key(state, ?>, 0)
       {:picker, %{picker_ui: switched_pui}} = switched_state.shell_runtime.state.modal
       assert switched_pui.source == MingaEditor.UI.Picker.CommandSource
-      assert switched_pui.original_source == MingaEditor.UI.Picker.FileSource
-      assert switched_pui.mode_prefix == ">"
+
+      assert switched_pui.source_switch ==
+               {:switched, MingaEditor.UI.Picker.FileSource, ">"}
 
       reverted_state = PickerUI.handle_key(switched_state, 127, 0)
       {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_runtime.state.modal
       assert reverted_pui.source == MingaEditor.UI.Picker.FileSource
-      assert reverted_pui.original_source == nil
-      assert reverted_pui.mode_prefix == ""
+      assert reverted_pui.source_switch == :original
     end
 
     test "hash mode switches from file to project search through async loading" do
@@ -471,8 +471,10 @@ defmodule MingaEditor.PickerUITest do
       {:picker, %{picker_ui: switched_pui}} = switched_state.shell_runtime.state.modal
 
       assert switched_pui.source == MingaEditor.UI.Picker.ProjectSearchSource
-      assert switched_pui.original_source == MingaEditor.UI.Picker.FileSource
-      assert switched_pui.mode_prefix == "#"
+
+      assert switched_pui.source_switch ==
+               {:switched, MingaEditor.UI.Picker.FileSource, "#"}
+
       assert switched_pui.restore == 0
       assert switched_pui.load_status == :loading
       assert is_reference(switched_pui.fetch_revision)
@@ -494,8 +496,7 @@ defmodule MingaEditor.PickerUITest do
       reverted_state = PickerUI.handle_key(switched_state, 127, 0)
       {:picker, %{picker_ui: reverted_pui}} = reverted_state.shell_runtime.state.modal
       assert reverted_pui.source == MingaEditor.UI.Picker.FileSource
-      assert reverted_pui.original_source == nil
-      assert reverted_pui.mode_prefix == ""
+      assert reverted_pui.source_switch == :original
       assert reverted_pui.restore == 0
       refute PickerState.current_fetch?(reverted_pui, old_revision)
 
@@ -553,8 +554,10 @@ defmodule MingaEditor.PickerUITest do
       {:picker, %{picker_ui: picker_ui}} = switched.shell_runtime.state.modal
 
       assert picker_ui.source == MingaEditor.UI.Picker.CommandSource
-      assert picker_ui.original_source == MingaEditor.UI.Picker.FileSource
-      assert picker_ui.mode_prefix == ">"
+
+      assert picker_ui.source_switch ==
+               {:switched, MingaEditor.UI.Picker.FileSource, ">"}
+
       assert picker_ui.picker.query == ""
       assert picker_ui.acknowledged_query_edit_seq == 1
     end
@@ -569,8 +572,10 @@ defmodule MingaEditor.PickerUITest do
       {:picker, %{picker_ui: picker_ui}} = switched.shell_runtime.state.modal
 
       assert picker_ui.source == MingaEditor.UI.Picker.ProjectSearchSource
-      assert picker_ui.original_source == MingaEditor.UI.Picker.FileSource
-      assert picker_ui.mode_prefix == "#"
+
+      assert picker_ui.source_switch ==
+               {:switched, MingaEditor.UI.Picker.FileSource, "#"}
+
       assert picker_ui.picker.query == "needle"
       assert picker_ui.acknowledged_query_edit_seq == 1
       assert picker_ui.load_status == :loading
@@ -586,7 +591,10 @@ defmodule MingaEditor.PickerUITest do
       {:picker, %{picker_ui: picker_ui}} = switched.shell_runtime.state.modal
 
       assert picker_ui.source == MingaEditor.UI.Picker.CommandSource
-      assert picker_ui.mode_prefix == ">"
+
+      assert picker_ui.source_switch ==
+               {:switched, MingaEditor.UI.Picker.FileSource, ">"}
+
       assert picker_ui.picker.query == "open"
       assert picker_ui.acknowledged_query_edit_seq == 1
     end
@@ -728,8 +736,7 @@ defmodule MingaEditor.PickerUITest do
       {:picker, %{picker_ui: pui}} = switched.shell_runtime.state.modal
 
       assert pui.source == MingaEditor.UI.Picker.CommandSource
-      assert pui.original_source == MingaEditor.UI.Picker.FileSource
-      assert pui.mode_prefix == ">"
+      assert pui.source_switch == {:switched, MingaEditor.UI.Picker.FileSource, ">"}
     end
 
     defp large_file_picker_state(item_count) do

--- a/test/minga_editor/render_model/ui/picker_builder_test.exs
+++ b/test/minga_editor/render_model/ui/picker_builder_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilderTest do
   alias Minga.RenderModel.UI.Picker
   alias MingaEditor.RenderModel.UI.PickerBuilder
   alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Picker, as: PickerUIState
   alias MingaEditor.UI.Picker, as: PickerState
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.ProjectFileCandidate
@@ -164,18 +165,22 @@ defmodule MingaEditor.RenderModel.UI.PickerBuilderTest do
   defp picker_modal(picker, source, action_menu, mode_prefix, load_status) do
     {:picker,
      %{
-       picker_ui: %{
+       picker_ui: %PickerUIState{
          picker: picker,
          source: source,
          callback_source: nil,
          action_menu: action_menu,
-         mode_prefix: mode_prefix,
+         source_switch: source_switch(mode_prefix, source),
          load_status: load_status,
          query_generation: 7,
          acknowledged_query_edit_seq: 11
        }
      }}
   end
+
+  @spec source_switch(String.t(), module()) :: PickerUIState.source_switch()
+  defp source_switch("", _source), do: :original
+  defp source_switch(prefix, source), do: {:switched, source, prefix}
 
   @spec build_context(term()) :: MingaEditor.Frontend.Emit.Context.t()
   defp build_context(modal) do

--- a/test/minga_editor/state/picker_test.exs
+++ b/test/minga_editor/state/picker_test.exs
@@ -2,6 +2,8 @@ defmodule MingaEditor.State.PickerTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.State.Picker, as: PickerState
+  alias MingaEditor.UI.Picker
+  alias MingaEditor.UI.Theme
 
   describe "begin_fetch/1 and current_fetch?/2" do
     test "marks the picker loading and mints a fresh revision" do
@@ -55,6 +57,63 @@ defmodule MingaEditor.State.PickerTest do
       assert accepted.picker == picker
       assert accepted.acknowledged_query_edit_seq == 3
       assert PickerState.accept_query_edit(accepted, nil, 2) == accepted
+    end
+  end
+
+  describe "source switching" do
+    test "retarget and restore preserve picker-session state as one owned transition" do
+      original_picker = Picker.new([], title: "Files")
+      target_picker = Picker.new([], title: "Search")
+      theme = Theme.get!(Theme.default())
+      stale_revision = make_ref()
+
+      state = %PickerState{
+        picker: original_picker,
+        source: MingaEditor.UI.Picker.FileSource,
+        restore: 3,
+        restore_theme: theme,
+        context: %{query: "needle"},
+        query_generation: 7,
+        acknowledged_query_edit_seq: 2,
+        load_status: {:error, "old"},
+        fetch_revision: stale_revision
+      }
+
+      switched =
+        PickerState.retarget(
+          state,
+          target_picker,
+          {MingaEditor.UI.Picker.ProjectSearchSource, nil, :top},
+          {:switch, "#"}
+        )
+
+      assert switched.source == MingaEditor.UI.Picker.ProjectSearchSource
+      assert switched.source_switch == {:switched, MingaEditor.UI.Picker.FileSource, "#"}
+      assert PickerState.mode_prefix(switched) == "#"
+      assert switched.load_status == :ready
+      assert switched.fetch_revision == nil
+      assert switched.restore == 3
+      assert switched.restore_theme == theme
+      assert switched.context == %{query: "needle"}
+      assert switched.query_generation == 7
+      assert switched.acknowledged_query_edit_seq == 2
+
+      restored =
+        PickerState.retarget(
+          switched,
+          original_picker,
+          {MingaEditor.UI.Picker.FileSource, nil, :bottom},
+          :restore
+        )
+
+      assert restored.source == MingaEditor.UI.Picker.FileSource
+      assert restored.source_switch == :original
+      assert PickerState.mode_prefix(restored) == ""
+      assert restored.restore == 3
+      assert restored.restore_theme == theme
+      assert restored.context == %{query: "needle"}
+      assert restored.query_generation == 7
+      assert restored.acknowledged_query_edit_seq == 2
     end
   end
 


### PR DESCRIPTION
# TL;DR

Picker source switching now uses one state-owner transition instead of reopening a picker and repairing its fields afterward. This removes invalid source-prefix state combinations while preserving synchronous and asynchronous prefix behavior.

## Context

The async Project Search prefix path was correct after #2998, but its state shape remained harder to reason about than necessary. Source switching threaded six positional arguments through `PickerUI`, rebuilt a fresh picker, and manually restored session-owned state.

## Changes

- Replace `original_source` plus `mode_prefix` sentinel fields with one tagged `source_switch` field.
- Add `MingaEditor.State.Picker.retarget/4` as the single owner transition for source switching and restoration.
- Route synchronous and asynchronous prefix changes through the same transition while leaving callback, scheduler, cancellation, and stale-result orchestration in `PickerUI`.
- Project the semantic mode prefix from the tagged state in `PickerBuilder`.
- Record the post-merge refinement and validation evidence in the lifecycle roadmap.

## Verification

- `mix test.debug test/minga_editor/state/picker_test.exs test/minga_editor/picker_ui_test.exs test/minga_editor/render_model/ui/picker_builder_test.exs test/minga_editor/ui/picker/fetch_effect_test.exs test/minga_editor/commands/search_async_test.exs` (55 passed)
- `git diff --check`
- `make lint`
- `mix test.llm --max-cases 4` (58 doctests, 98 properties, 9,906 tests, 0 failures, 1 skipped, 578 excluded)
- Ponytail targeted review: `Lean already. Ship.`
- Final acceptance review: `PASS`

## Acceptance Criteria Addressed

- Source retargeting and restoration are one explicit owner transition.
- Prefix switching preserves restore buffer/theme, context, layout, native query correlation, fetch lifecycle, and stale-result rejection.
- No new process, protocol, scheduler, wrapper, or compatibility path is introduced.
- Production additions remain below the 200-line slice ceiling.
