### PR TITLE
fix(ui): clear disabled prettify symbols

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1744,6 +1744,76 @@ Typing `#` at the start of File or Recent switches to Project Search without run
 - **Merge SHA:** `5c965962f31aa89f48b56f477c6d3373f2bb15a9`
 - **Completion date:** 2026-07-18
 
+### W013: Clear disabled prettify symbols safely
+
+- **Status:** ACTIVE
+- **Audit ID:** L13
+- **Roadmap unit:** W013, Clear disabled prettify symbols safely
+- **Ponytail verdict:** `ACCEPT/direct`
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness SHA:** `57a37139155812ca0f3e002916b948f17803ee47`
+- **Freshness basis:** Current `HEAD` and `origin/main` contain the verified W012 refinement. Disabled scheduling still skipped cleanup, and the effect worker still mutated the Buffer before scheduler claim.
+
+#### Observable outcome
+
+When prettify symbols are disabled, scheduling for a buffer first cancels work owned by `{:prettify_symbols, buffer}`, then synchronously removes only that buffer's `:prettify_symbols` conceal group. Repeated cleanup is idempotent, preserves other conceal groups, and does not increment the decoration version when the target group is already absent. Workers return prepared data; only the Editor's scheduler-claimed completed outcome may mutate the Buffer.
+
+#### Owners and failure path
+
+- `MingaEditor.UI.PrettifySymbolsEffect` owns domain scheduling, disabled cleanup, and domain outcome application.
+- `MingaEditor.EffectScheduler` owns admission, cancellation, candidate claim, and worker lifecycle.
+- `MingaEditor.UI.PrettifySymbols` owns conceal preparation and atomic update application.
+- `Minga.Buffer.Process` owns Buffer decoration mutation; `Minga.Core.Decorations.remove_conceal_group/2` owns idempotent group removal.
+- Before this unit, `PrettifySymbolsEffect.schedule/2` returned unchanged state when disabled, leaving installed conceals behind. `run/1` called the mutating `PrettifySymbols.apply/3`, so canceled or stale work could race cleanup.
+
+#### Locked implementation
+
+1. Keep scheduler resource identity `{:prettify_symbols, buffer}` and the existing latest-wins policy.
+2. Preserve the enabled path: snapshot highlight and filetype, require usable spans, and schedule through `EffectScheduler`.
+3. On the disabled path, call `EffectScheduler.cancel_resource/2` before `PrettifySymbols.clear/1`; treat scheduler unavailability as non-fatal.
+4. Split preparation from mutation: `prepare/3` returns `:clear | {:replace, conceals}`, while `apply_update/2` applies that update atomically.
+5. Make `run/1` return prepared data. Apply completed data only after the Editor claims the scheduler outcome.
+6. Route atomic group removal through `Minga.Buffer.remove_conceal_group/2` and `Minga.Buffer.Process`.
+7. Catch only expected stale/dead Buffer exits around cleanup and completed application.
+
+#### Required tests
+
+- `test/minga_editor/ui/prettify_symbols_effect_test.exs`: request identity and latest-wins policy; worker non-mutation; claimed outcome mutation; disabled cancellation before cleanup; group isolation; version idempotence; stale Buffer exit; failed, stale, and canceled outcome non-mutation.
+- Preserve rule and decoration contracts through `test/minga_editor/ui/prettify_symbols_test.exs` and `test/minga/buffer/conceal_range_test.exs`.
+
+#### Validation
+
+- Focused: `mix test.debug test/minga_editor/ui/prettify_symbols_effect_test.exs test/minga_editor/ui/prettify_symbols_test.exs test/minga/buffer/conceal_range_test.exs`
+- Broad: `git diff --check && make lint && mix test.llm --max-cases 4`
+
+#### Non-goals and budget
+
+- Do not add a config observer, process, registry, scheduler, protocol, frontend command, option-change event, wrapper, or dead-buffer abstraction.
+- Do not change capture rules, enabled scheduling, render scheduling, or unrelated empty-highlight behavior.
+- Do not remove or mutate conceal groups other than `:prettify_symbols`.
+- **Maximum production additions:** 200 lines.
+- **Maximum test additions:** 160 lines.
+
+#### Completion evidence
+
+- **PR URL:** Pending
+- **Commit SHA:** Pending
+- **Merge SHA:** Pending
+- **Focused tests:** 35 passed: 8 effect tests, 6 rule tests, and 21 conceal-range tests including 8 properties.
+- **Broad validation:** `git diff --check`, `make lint`, and `mix test.llm --max-cases 4` passed on current main; full non-heavy result: 58 doctests, 98 properties, 9,912 tests, 0 failures, 1 skipped, 578 excluded.
+- **Planner verdict:** `READY`; exact owners, transition order, worker/apply boundary, tests, constraints, and validation are locked with no unresolved implementer question.
+- **Ponytail verdict:** `LEAN` after deleting the obsolete test-only `PrettifySymbols.apply/3`; targeted recheck returned `Lean already. Ship.`
+- **Elixir verdict:** `PASS` after narrowing expected Buffer exits and making cleanup cancel admitted work before mutation.
+- **Bug-hunt verdict:** `PASS` after moving all Buffer mutation out of workers; canceled and stale candidates cannot re-add conceals.
+- **Final reviewer verdict:** `PASS` after a targeted correction narrowed worker and completed-apply catches to expected dead Buffer exits; behavior coverage proves unexpected exits propagate.
+- **Production lines added/removed:** 99 added / 58 removed, net +41.
+- **Test lines added/removed:** 160 added / 2 removed, net +158.
+- **Concepts added/removed:** Preparation and application are explicit phases of the existing effect; the obsolete combined `apply/3` entry point is removed. No process, scheduler, protocol, or wrapper is added.
+- **Findings resolved:** Pending merge.
+- **Discoveries affecting later work:** Pending
+- **Completion date:** Pending
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1797,8 +1797,8 @@ When prettify symbols are disabled, scheduling for a buffer first cancels work o
 
 #### Completion evidence
 
-- **PR URL:** Pending
-- **Commit SHA:** Pending
+- **PR URL:** https://github.com/jsmestad/minga/pull/3007
+- **Commit SHA:** `d55840281`
 - **Merge SHA:** Pending
 - **Focused tests:** 35 passed: 8 effect tests, 6 rule tests, and 21 conceal-range tests including 8 properties.
 - **Broad validation:** `git diff --check`, `make lint`, and `mix test.llm --max-cases 4` passed on current main; full non-heavy result: 58 doctests, 98 properties, 9,912 tests, 0 failures, 1 skipped, 578 excluded.

--- a/lib/minga/buffer.ex
+++ b/lib/minga/buffer.ex
@@ -481,6 +481,10 @@ defmodule Minga.Buffer do
   @spec decorations_version(t()) :: non_neg_integer()
   defdelegate decorations_version(server), to: BufferProcess
 
+  @doc "Removes every conceal range in a group atomically."
+  @spec remove_conceal_group(t(), atom()) :: :ok
+  defdelegate remove_conceal_group(server, group), to: BufferProcess
+
   @doc "Apply a batch of decoration changes atomically."
   @spec batch_decorations(t(), (Minga.Core.Decorations.t() -> Minga.Core.Decorations.t())) ::
           :ok

--- a/lib/minga/buffer/process.ex
+++ b/lib/minga/buffer/process.ex
@@ -792,6 +792,12 @@ defmodule Minga.Buffer.Process do
     GenServer.call(server, {:remove_highlight_group, group})
   end
 
+  @doc "Removes every conceal range in a group atomically."
+  @spec remove_conceal_group(GenServer.server(), atom()) :: :ok
+  def remove_conceal_group(server, group) when is_atom(group) do
+    GenServer.call(server, {:remove_conceal_group, group})
+  end
+
   @doc """
   Executes a batch of decoration operations. The function receives and
   returns a `Decorations` struct. All operations are applied with a
@@ -1776,6 +1782,11 @@ defmodule Minga.Buffer.Process do
 
   def handle_call({:remove_highlight_group, group}, _from, state) do
     decs = Decorations.remove_group(state.decorations, group)
+    {:reply, :ok, %{state | decorations: decs}}
+  end
+
+  def handle_call({:remove_conceal_group, group}, _from, state) do
+    decs = Decorations.remove_conceal_group(state.decorations, group)
     {:reply, :ok, %{state | decorations: decs}}
   end
 

--- a/lib/minga_editor/ui/prettify_symbols.ex
+++ b/lib/minga_editor/ui/prettify_symbols.ex
@@ -38,6 +38,10 @@ defmodule MingaEditor.UI.PrettifySymbols do
           captures: [String.t()]
         }
 
+  @type position :: {non_neg_integer(), non_neg_integer()}
+  @type conceal :: {position(), position(), String.t()}
+  @type update :: :clear | {:replace, [conceal()]}
+
   @doc """
   Returns the substitution rules for a filetype.
 
@@ -116,56 +120,38 @@ defmodule MingaEditor.UI.PrettifySymbols do
     ]
   end
 
-  @doc """
-  Applies prettify-symbol conceals to a buffer based on its highlight spans.
-
-  Clears any previous `:prettify_symbols` conceal group, then scans
-  highlight spans against the substitution rules for the buffer's filetype.
-  Only applies when the `prettify_symbols` config option is enabled.
-
-  Returns `:ok`. Decorations are applied directly to the buffer via
-  `Buffer.batch_decorations/2`.
-  """
-  @spec apply(pid(), Highlight.t(), atom()) :: :ok
-  def apply(buf, %Highlight{} = hl, filetype) do
-    if enabled?() do
-      apply_conceals(buf, hl, filetype)
-    else
-      clear_conceals(buf)
-    end
+  @doc "Builds the decoration update for the current buffer content and highlights."
+  @spec prepare(pid(), Highlight.t(), atom()) :: update()
+  def prepare(buf, %Highlight{} = hl, filetype) when is_pid(buf) and is_atom(filetype) do
+    build_update(buf, hl, rules_for(filetype))
   end
 
-  @spec clear_conceals(pid()) :: :ok
-  defp clear_conceals(buf) do
+  @doc "Applies a prepared prettify-symbol update atomically."
+  @spec apply_update(pid(), update()) :: :ok
+  def apply_update(buf, :clear) when is_pid(buf), do: clear(buf)
+
+  def apply_update(buf, {:replace, conceals}) when is_pid(buf) and is_list(conceals) do
     Buffer.batch_decorations(buf, fn decs ->
-      Decorations.remove_conceal_group(decs, :prettify_symbols)
+      decs
+      |> Decorations.remove_conceal_group(:prettify_symbols)
+      |> add_all_conceals(conceals)
     end)
-
-    :ok
   end
 
-  @spec apply_conceals(pid(), Highlight.t(), atom()) :: :ok
-  defp apply_conceals(buf, hl, filetype) do
-    rules = rules_for(filetype)
+  @doc "Clears the `:prettify_symbols` conceal group from a buffer."
+  @spec clear(pid()) :: :ok
+  def clear(buf), do: Buffer.remove_conceal_group(buf, :prettify_symbols)
 
-    if rules == [] do
-      clear_conceals(buf)
-    else
-      content = Buffer.content(buf)
-      lines = String.split(content, "\n")
-      capture_names = Tuple.to_list(hl.capture_names)
-      spans = Tuple.to_list(hl.spans)
+  @spec build_update(pid(), Highlight.t(), [rule()]) :: update()
+  defp build_update(_buf, %Highlight{}, []), do: :clear
 
-      conceals = find_conceals(spans, rules, capture_names, content, lines)
+  defp build_update(buf, %Highlight{} = hl, rules) do
+    content = Buffer.content(buf)
+    lines = String.split(content, "\n")
+    capture_names = Tuple.to_list(hl.capture_names)
+    spans = Tuple.to_list(hl.spans)
 
-      Buffer.batch_decorations(buf, fn decs ->
-        decs
-        |> Decorations.remove_conceal_group(:prettify_symbols)
-        |> add_all_conceals(conceals)
-      end)
-
-      :ok
-    end
+    {:replace, find_conceals(spans, rules, capture_names, content, lines)}
   end
 
   @doc "Returns true if prettify-symbols is enabled in config."
@@ -173,8 +159,6 @@ defmodule MingaEditor.UI.PrettifySymbols do
   def enabled? do
     Config.get(:prettify_symbols)
   end
-
-  @typep position :: {non_neg_integer(), non_neg_integer()}
 
   @spec add_all_conceals(Decorations.t(), [{position(), position(), String.t()}]) ::
           Decorations.t()

--- a/lib/minga_editor/ui/prettify_symbols_effect.ex
+++ b/lib/minga_editor/ui/prettify_symbols_effect.ex
@@ -7,9 +7,9 @@ defmodule MingaEditor.UI.PrettifySymbolsEffect do
   that buffer cancels the older worker/candidate instead of building a queue.
   The generation-owned scheduler starts workers under its `Task.Supervisor`.
 
-  Scheduler supersession provides request correlation and cancellation. Since
-  prettification writes only the addressed Buffer's decoration store and does
-  not mutate EditorState, canceled/stale outcomes require no state rollback.
+  Scheduler supersession provides request correlation and cancellation. Workers
+  return prepared decoration data without mutating the Buffer. The Editor applies
+  only a scheduler-claimed outcome, so canceled and stale work cannot write.
   Worker or admission failures are logged and remain non-rendering; successful
   Buffer decoration notifications retain the existing render behavior.
   """
@@ -47,27 +47,34 @@ defmodule MingaEditor.UI.PrettifySymbolsEffect do
     )
   end
 
-  @doc "Snapshots and schedules prettification for a highlighted Buffer."
+  @doc "Snapshots and schedules prettification, or synchronously clears disabled prettify conceals."
   @spec schedule(EditorState.t(), pid()) :: EditorState.t()
   def schedule(%EditorState{} = state, buffer) when is_pid(buffer) do
-    highlight = HighlightSync.get_highlight(state, buffer)
+    if PrettifySymbols.enabled?() do
+      highlight = HighlightSync.get_highlight(state, buffer)
 
-    if PrettifySymbols.enabled?() and highlight.capture_names != {} and
-         tuple_size(highlight.spans) > 0 do
-      filetype = buffer |> Buffer.file_path() |> Language.detect_filetype()
-      schedule_request(state, request(buffer, highlight, filetype))
+      if highlight.capture_names != {} and tuple_size(highlight.spans) > 0 do
+        filetype = buffer |> Buffer.file_path() |> Language.detect_filetype()
+        schedule_request(state, request(buffer, highlight, filetype))
+      else
+        state
+      end
     else
-      state
+      clear_disabled(state, buffer)
     end
   end
 
   @impl true
-  @spec run(t()) :: {:ok, :applied} | {:error, term()}
+  @spec run(t()) :: {:ok, PrettifySymbols.update()} | {:error, term()}
   def run(%__MODULE__{buffer: buffer, highlight: highlight, filetype: filetype}) do
-    :ok = PrettifySymbols.apply(buffer, highlight, filetype)
-    {:ok, :applied}
+    {:ok, PrettifySymbols.prepare(buffer, highlight, filetype)}
   catch
-    :exit, reason -> {:error, {:buffer_exit, reason}}
+    :exit, {reason, {GenServer, :call, [^buffer | _args]}}
+    when reason in [:noproc, :normal, :shutdown, :killed] ->
+      {:error, {:buffer_exit, reason}}
+
+    :exit, {{:shutdown, reason}, {GenServer, :call, [^buffer | _args]}} ->
+      {:error, {:buffer_exit, {:shutdown, reason}}}
   end
 
   @impl true
@@ -76,6 +83,25 @@ defmodule MingaEditor.UI.PrettifySymbolsEffect do
 
   @impl true
   @spec apply(EditorState.t(), Outcome.t()) :: {EditorState.t(), Outcome.t()}
+  def apply(
+        %EditorState{} = state,
+        %Outcome{
+          request: %Request{effect: %__MODULE__{buffer: buffer}},
+          status: :completed,
+          result: update
+        } = outcome
+      ) do
+    :ok = PrettifySymbols.apply_update(buffer, update)
+    {state, outcome}
+  catch
+    :exit, {reason, {GenServer, :call, [^buffer | _args]}}
+    when reason in [:noproc, :normal, :shutdown, :killed] ->
+      {state, Outcome.failed(outcome.request, {:buffer_exit, reason})}
+
+    :exit, {{:shutdown, reason}, {GenServer, :call, [^buffer | _args]}} ->
+      {state, Outcome.failed(outcome.request, {:buffer_exit, {:shutdown, reason}})}
+  end
+
   def apply(%EditorState{} = state, %Outcome{status: :failed, reason: reason} = outcome) do
     Minga.Log.warning(:editor, "Prettify symbols failed: #{inspect(reason)}")
     {state, outcome}
@@ -86,6 +112,22 @@ defmodule MingaEditor.UI.PrettifySymbolsEffect do
   @impl true
   @spec render?(Outcome.t()) :: boolean()
   def render?(%Outcome{}), do: false
+
+  @spec clear_disabled(EditorState.t(), pid()) :: EditorState.t()
+  defp clear_disabled(%EditorState{} = state, buffer) when is_pid(buffer) do
+    _cancel_result =
+      EffectScheduler.cancel_resource(state.effect_scheduler, {:prettify_symbols, buffer})
+
+    :ok = PrettifySymbols.clear(buffer)
+    state
+  catch
+    :exit, {reason, {GenServer, :call, [^buffer | _args]}}
+    when reason in [:noproc, :normal, :shutdown, :killed] ->
+      state
+
+    :exit, {{:shutdown, _reason}, {GenServer, :call, [^buffer | _args]}} ->
+      state
+  end
 
   @spec schedule_request(EditorState.t(), Request.t()) :: EditorState.t()
   defp schedule_request(%EditorState{effect_scheduler: nil} = state, _request) do

--- a/test/minga_editor/ui/prettify_symbols_effect_test.exs
+++ b/test/minga_editor/ui/prettify_symbols_effect_test.exs
@@ -3,11 +3,35 @@ defmodule MingaEditor.UI.PrettifySymbolsEffectTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Buffer
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Config
+  alias Minga.Config.Options
+  alias Minga.Core.Decorations
+  alias Minga.Test.EffectProbe
+  alias MingaEditor.Effect.Policy
+  alias MingaEditor.EffectScheduler
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.UI.Highlight
+  alias MingaEditor.UI.PrettifySymbols
   alias MingaEditor.UI.PrettifySymbolsEffect
 
   import MingaEditor.RenderPipeline.TestHelpers
+
+  setup do
+    options = start_supervised!({Options, name: nil})
+    previous_options = Process.put(:minga_config_options, options)
+
+    on_exit(fn ->
+      if is_nil(previous_options) do
+        Process.delete(:minga_config_options)
+      else
+        Process.put(:minga_config_options, previous_options)
+      end
+    end)
+
+    %{options: options}
+  end
 
   test "request uses Buffer identity, latest-wins policy, and immutable parser input" do
     buffer = fake_buffer()
@@ -26,13 +50,12 @@ defmodule MingaEditor.UI.PrettifySymbolsEffectTest do
     assert request.effect.filetype == :elixir
   end
 
-  test "completed, failed, stale, and canceled outcomes do not mutate EditorState" do
+  test "failed, stale, and canceled outcomes do not mutate EditorState" do
     buffer = fake_buffer()
     request = PrettifySymbolsEffect.request(buffer, Highlight.new(), :text)
     state = base_state()
 
     outcomes = [
-      Outcome.completed(request, :applied),
       Outcome.failed(request, :buffer_closed),
       Outcome.stale(Outcome.completed(request, :applied), :superseded),
       Outcome.canceled(request, :superseded)
@@ -42,6 +65,133 @@ defmodule MingaEditor.UI.PrettifySymbolsEffectTest do
       assert {^state, ^outcome} = PrettifySymbolsEffect.apply(state, outcome)
       refute PrettifySymbolsEffect.render?(outcome)
     end)
+  end
+
+  test "worker returns data and outcome application mutates the buffer" do
+    state = base_state(content: "->", filetype: :elixir)
+    buffer = state.workspace.buffers.active
+    request = PrettifySymbolsEffect.request(buffer, operator_highlight(), :elixir)
+
+    assert {:ok, {:replace, [_conceal]}} = PrettifySymbolsEffect.run(request.effect)
+    assert conceal_groups(buffer) == []
+
+    outcome = Outcome.completed(request, {:replace, [{{0, 0}, {0, 2}, "→"}]})
+    assert {^state, ^outcome} = PrettifySymbolsEffect.apply(state, outcome)
+    assert conceal_groups(buffer) == [:prettify_symbols]
+  end
+
+  test "enable apply then disabled schedule clears only prettify conceals" do
+    state = base_state(content: "->", filetype: :elixir)
+    buffer = state.workspace.buffers.active
+    highlight = operator_highlight()
+
+    Config.set(:prettify_symbols, true)
+
+    :ok = apply_prettify(buffer, highlight)
+
+    assert conceal_groups(buffer) == [:prettify_symbols]
+
+    Config.set(:prettify_symbols, false)
+    assert ^state = PrettifySymbolsEffect.schedule(state, buffer)
+    assert conceal_groups(buffer) == []
+  end
+
+  test "disabled cleanup cancels admitted work before clearing conceals" do
+    task_supervisor = start_supervised!({Task.Supervisor, name: nil})
+
+    scheduler =
+      start_supervised!({EffectScheduler, task_supervisor: task_supervisor, owner: self()})
+
+    :ok = EffectScheduler.attach(scheduler, self())
+    state = base_state(content: "->", filetype: :elixir, effect_scheduler: scheduler)
+    buffer = state.workspace.buffers.active
+
+    Config.set(:prettify_symbols, true)
+
+    :ok = apply_prettify(buffer, operator_highlight())
+
+    request =
+      EffectProbe.request(
+        self(),
+        :stale_prettify,
+        {:prettify_symbols, buffer},
+        Policy.latest_wins()
+      )
+
+    assert {:ok, _request_id, :running} = EffectScheduler.schedule(scheduler, request)
+    assert_receive {:effect_started, :stale_prettify, _worker, _payloads}
+
+    Config.set(:prettify_symbols, false)
+
+    assert ^state = PrettifySymbolsEffect.schedule(state, buffer)
+    refute EffectScheduler.active?(scheduler, EffectProbe)
+    assert conceal_groups(buffer) == []
+  end
+
+  test "repeated disabled cleanup is idempotent and preserves other conceals and version" do
+    state = base_state(content: "other", filetype: :elixir)
+    buffer = state.workspace.buffers.active
+
+    :ok =
+      Buffer.batch_decorations(buffer, fn decs ->
+        {_id, decs} = Decorations.add_conceal(decs, {0, 0}, {0, 1}, group: :other)
+        decs
+      end)
+
+    Config.set(:prettify_symbols, false)
+    version = Buffer.decorations_version(buffer)
+
+    assert ^state = PrettifySymbolsEffect.schedule(state, buffer)
+    assert ^state = PrettifySymbolsEffect.schedule(state, buffer)
+    assert Buffer.decorations_version(buffer) == version
+    assert conceal_groups(buffer) == [:other]
+  end
+
+  test "disabled cleanup ignores stale buffer exits and returns state" do
+    state = base_state()
+    {:ok, buffer} = BufferProcess.start_link(content: "->", filetype: :elixir)
+    :ok = GenServer.stop(buffer)
+
+    Config.set(:prettify_symbols, false)
+
+    assert ^state = PrettifySymbolsEffect.schedule(state, buffer)
+  end
+
+  test "unexpected buffer exits propagate from worker and claimed application" do
+    worker_buffer = crashing_buffer(:unexpected_worker_exit)
+
+    effect = %PrettifySymbolsEffect{
+      buffer: worker_buffer,
+      highlight: operator_highlight(),
+      filetype: :elixir
+    }
+
+    assert {:unexpected_worker_exit, {GenServer, :call, [^worker_buffer | _args]}} =
+             catch_exit(PrettifySymbolsEffect.run(effect))
+
+    apply_buffer = crashing_buffer(:unexpected_apply_exit)
+    request = PrettifySymbolsEffect.request(apply_buffer, operator_highlight(), :elixir)
+    outcome = Outcome.completed(request, :clear)
+
+    assert {:unexpected_apply_exit, {GenServer, :call, [^apply_buffer | _args]}} =
+             catch_exit(PrettifySymbolsEffect.apply(base_state(), outcome))
+  end
+
+  defp apply_prettify(buffer, highlight),
+    do: PrettifySymbols.apply_update(buffer, PrettifySymbols.prepare(buffer, highlight, :elixir))
+
+  defp operator_highlight do
+    Highlight.new()
+    |> Highlight.put_names(["operator"])
+    |> Highlight.put_spans(1, [%{start_byte: 0, end_byte: 2, capture_id: 0}])
+  end
+
+  defp conceal_groups(buffer) do
+    buffer
+    |> Buffer.decorations()
+    |> Map.fetch!(:conceal_ranges)
+    |> Enum.map(& &1.group)
+    |> Enum.sort()
   end
 
   defp fake_buffer do
@@ -54,5 +204,13 @@ defmodule MingaEditor.UI.PrettifySymbolsEffectTest do
 
     on_exit(fn -> send(pid, :stop) end)
     pid
+  end
+
+  defp crashing_buffer(reason) do
+    spawn(fn ->
+      receive do
+        {:"$gen_call", _from, _request} -> exit(reason)
+      end
+    end)
   end
 end


### PR DESCRIPTION
# TL;DR

Disabling prettify symbols now cancels pending work and removes only the affected buffer's prettify conceals. Workers prepare data without mutating buffers, so canceled or stale results cannot race cleanup and reinstall decorations.

## Context

The disabled path previously returned without removing installed conceals. The effect worker also wrote directly to the Buffer before the scheduler-owned result was claimed, which made cancellation insufficient as a cleanup boundary.

## Changes

- Cancel buffer-keyed prettify work before disabled cleanup.
- Remove `:prettify_symbols` conceals atomically through the Buffer owner while preserving other groups and no-op decoration versions.
- Split conceal preparation from application so workers return data and only claimed completed outcomes mutate the Buffer.
- Narrow dead Buffer handling to expected shutdown exits; unexpected worker or apply failures still propagate.
- Record the locked W013 plan, review evidence, validation, and line budgets in the lifecycle roadmap.

## Verification

- `mix test.debug test/minga_editor/ui/prettify_symbols_effect_test.exs test/minga_editor/ui/prettify_symbols_test.exs test/minga/buffer/conceal_range_test.exs` (35 passed, including 8 properties)
- `git diff --check`
- `make lint`
- `mix test.llm --max-cases 4` (58 doctests, 98 properties, 9,912 tests, 0 failures, 1 skipped, 578 excluded)
- Planner: `READY`
- Ponytail: `Lean already. Ship.` after deleting an obsolete combined entry point
- Elixir and bug-hunt rechecks: `PASS`
- Final acceptance review: `PASS` after narrowing Buffer exit catches

## Acceptance Criteria Addressed

- Disabled scheduling removes stale prettify conceals and returns the existing Editor state.
- Cleanup cancels admitted work first and cannot be undone by stale worker mutation.
- Other conceal groups survive; repeated no-op cleanup preserves decoration version.
- Expected dead Buffer cleanup is contained; unexpected exits propagate.
- Production and test additions remain within the locked 200 and 160 line ceilings.
