### PR TITLE
fix(ui): preserve sidebar focus during git refresh

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1867,8 +1867,8 @@ Background Git status replacement updates the registered panel's visibility, bad
 
 #### Completion evidence
 
-- **PR URL:** Pending
-- **Commit SHA:** Pending
+- **PR URL:** https://github.com/jsmestad/minga/pull/3009
+- **Commit SHA:** `76ed51dde`
 - **Merge SHA:** Pending
 - **Focused tests:** 48 passed across the three locked test files.
 - **Broad validation:** `git diff --check`, `make lint`, and `mix test.llm --max-cases 4` passed; full non-heavy result: 58 doctests, 98 properties, 9,914 tests, 0 failures, 1 skipped, 578 excluded.

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1814,6 +1814,76 @@ When prettify symbols are disabled, scheduling for a buffer first cancels work o
 - **Discoveries affecting later work:** Canceling a task cannot retract an already-sent Buffer call. Effect workers that race cleanup must return data and defer mutation until scheduler claim.
 - **Completion date:** 2026-07-18
 
+### W014: Preserve sidebar focus during Git refresh
+
+- **Status:** ACTIVE
+- **Audit ID:** L14
+- **Roadmap unit:** W014, Preserve sidebar focus during Git refresh
+- **Ponytail verdict:** `ACCEPT/direct`
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness SHA:** `cea126bc0d520698c6ddb79ca6ae2fd0dc85aa7e`
+- **Freshness basis:** Current `HEAD` and `origin/main` contain the verified W013 lifecycle fix. A visible Git panel registration still marked itself focused during every background panel replacement.
+
+#### Observable outcome
+
+Background Git status replacement updates the registered panel's visibility, badge count, and content without changing the focused left sidebar. Explicit Git activation still selects and focuses Git Status. Closing Git Status clears its selected shell state and registered visibility and focus.
+
+#### Owners and failure path
+
+- `MingaEditor.Shell.Traditional.Sidebars.active_id` owns the selected left-sidebar identity.
+- `MingaEditor.Shell.Traditional.SidebarWorkflow.select/2` owns explicit selection and registry focus synchronization.
+- `MingaEditor.Sidebar.BuiltinSurfaces` projects shell panel state into `MingaEditor.Extension.Sidebar`; it does not own focus selection.
+- Before this unit, `FileEventHandler.handle_git_status_changed/2` replaced the panel through `SidebarWorkflow.replace_git_status/2`. The projection registered every visible Git panel with `focused?: true` and called `Sidebar.focus_left/2`, so a background refresh could steal focus from Observatory.
+
+#### Locked implementation
+
+1. Pass an explicit boolean focus projection through `BuiltinSurfaces.sync_git_status_panel/3`.
+2. Register a missing Git panel as invisible and unfocused with badge count zero.
+3. Register a visible Git panel with the passed focus and current entry count.
+4. Call `Sidebar.focus_left/2` only when the projected Git panel is both visible and focused.
+5. Derive the projection in `SidebarWorkflow.sync_git_status_sidebar/2` from `active_id(state) == "git_status"`.
+6. Keep `replace_git_status/2` as a data replacement. Keep `select/2` as the explicit focus transition.
+7. Preserve Observatory synchronization without changes.
+
+#### Required tests
+
+- `test/minga_editor/handlers/file_event_handler_test.exs`: a background Git refresh updates panel data, visibility, and badge count while Observatory remains selected and focused.
+- `test/minga_editor/handlers/gui_action_handler_test.exs`: a visible Git panel begins unfocused, then explicit activation selects Git and installs the Git keymap scope.
+- `test/minga_editor/shell/traditional/sidebars_test.exs`: closing Git clears shell selection and registered visibility, focus, and badge count.
+
+#### Validation
+
+- Focused: `mix test.debug test/minga_editor/handlers/file_event_handler_test.exs test/minga_editor/handlers/gui_action_handler_test.exs test/minga_editor/shell/traditional/sidebars_test.exs`
+- Broad: `git diff --check && make lint && mix test.llm --max-cases 4`
+
+#### Non-goals and budget
+
+- Do not add a process, registry, generic update API, wrapper, protocol, frontend change, or architecture migration.
+- Do not make `replace_git_status/2` select or focus a sidebar.
+- Do not change Observatory synchronization.
+- **Maximum production additions:** 40 lines.
+- **Maximum test additions:** 80 lines.
+
+#### Completion evidence
+
+- **PR URL:** Pending
+- **Commit SHA:** Pending
+- **Merge SHA:** Pending
+- **Focused tests:** 48 passed across the three locked test files.
+- **Broad validation:** `git diff --check`, `make lint`, and `mix test.llm --max-cases 4` passed; full non-heavy result: 58 doctests, 98 properties, 9,914 tests, 0 failures, 1 skipped, 578 excluded.
+- **Planner verdict:** `READY`; the selected-sidebar owner, projection boundary, focus transitions, tests, constraints, and validation are locked with no unresolved implementer question.
+- **Ponytail verdict:** `LEAN`; targeted review returned `Lean already. Ship.`
+- **Elixir verdict:** `PASS`; explicit clauses, boolean guards, owner-derived projection, and state flow are idiomatic and narrow.
+- **Bug-hunt verdict:** `PASS`; refresh, activation, and close paths preserve the authoritative focus transition.
+- **Final reviewer verdict:** `PASS`.
+- **Production lines added/removed:** 22 added / 13 removed, net +9.
+- **Test lines added/removed:** 53 added / 0 removed, net +53.
+- **Concepts added/removed:** One explicit focus projection replaces visibility-derived focus. No process, registry, abstraction, protocol, or frontend path is added.
+- **Findings resolved:** Pending merge.
+- **Discoveries affecting later work:** Registry projections must derive focus from shell-owned selection instead of inferring focus from visibility.
+- **Completion date:** Pending
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/lib/minga_editor/shell/traditional/sidebar_workflow.ex
+++ b/lib/minga_editor/shell/traditional/sidebar_workflow.ex
@@ -210,7 +210,13 @@ defmodule MingaEditor.Shell.Traditional.SidebarWorkflow do
 
   @spec sync_git_status_sidebar(state(), GitStatusPanel.t() | nil) :: :ok
   defp sync_git_status_sidebar(state, panel) do
-    case BuiltinSurfaces.sync_git_status_panel(panel, state.extension_surfaces.sidebar_registry) do
+    focused? = active_id(state) == "git_status"
+
+    case BuiltinSurfaces.sync_git_status_panel(
+           panel,
+           state.extension_surfaces.sidebar_registry,
+           focused?
+         ) do
       :ok ->
         :ok
 

--- a/lib/minga_editor/sidebar/builtin_surfaces.ex
+++ b/lib/minga_editor/sidebar/builtin_surfaces.ex
@@ -29,19 +29,20 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
   end
 
   @doc "Synchronizes Git Status sidebar surface metadata from shell panel state."
-  @spec sync_git_status_panel(GitStatusPanel.t() | map() | nil, Sidebar.table()) ::
+  @spec sync_git_status_panel(GitStatusPanel.t() | map() | nil, Sidebar.table(), boolean()) ::
           :ok | {:error, term()}
-  def sync_git_status_panel(panel, sidebar_registry \\ Sidebar.default_table())
+  def sync_git_status_panel(panel, sidebar_registry \\ Sidebar.default_table(), focused? \\ false)
 
-  def sync_git_status_panel(nil, sidebar_registry),
-    do: register_git_status(false, 0, sidebar_registry)
+  def sync_git_status_panel(nil, sidebar_registry, focused?) when is_boolean(focused?),
+    do: register_git_status(false, false, 0, sidebar_registry)
 
-  def sync_git_status_panel(%GitStatusPanel{} = panel, sidebar_registry) do
-    register_git_status(true, Enum.count(panel.entries), sidebar_registry)
+  def sync_git_status_panel(%GitStatusPanel{} = panel, sidebar_registry, focused?)
+      when is_boolean(focused?) do
+    register_git_status(true, focused?, Enum.count(panel.entries), sidebar_registry)
   end
 
-  def sync_git_status_panel(%{} = panel, sidebar_registry) do
-    panel |> GitStatusPanel.new() |> sync_git_status_panel(sidebar_registry)
+  def sync_git_status_panel(%{} = panel, sidebar_registry, focused?) when is_boolean(focused?) do
+    panel |> GitStatusPanel.new() |> sync_git_status_panel(sidebar_registry, focused?)
   end
 
   @doc "Synchronizes BEAM Observatory sidebar surface metadata from shell visibility state."
@@ -102,9 +103,11 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
 
   def handle_observatory_action(%EditorState{} = state, _action, _context), do: state
 
-  @spec register_git_status(boolean(), non_neg_integer(), Sidebar.table()) ::
+  @spec register_git_status(boolean(), boolean(), non_neg_integer(), Sidebar.table()) ::
           :ok | {:error, term()}
-  defp register_git_status(visible?, badge_count, sidebar_registry) do
+  defp register_git_status(visible?, focused?, badge_count, sidebar_registry) do
+    focused? = visible? and focused?
+
     result =
       Sidebar.register(sidebar_registry, @builtin_source, %{
         id: @git_status_id,
@@ -114,14 +117,14 @@ defmodule MingaEditor.Sidebar.BuiltinSurfaces do
         priority: 20,
         preferred_width: 30,
         visible?: visible?,
-        focused?: visible?,
+        focused?: focused?,
         semantic_kind: "git_status",
         icon: "point.3.filled.connected.trianglepath.dotted",
         badge_count: badge_count,
         action_handler: {__MODULE__, :handle_git_status_action}
       })
 
-    focus_if_visible(result, visible?, @git_status_id, sidebar_registry)
+    focus_if_visible(result, focused?, @git_status_id, sidebar_registry)
   end
 
   @spec focus_if_visible(:ok | {:error, term()}, boolean(), String.t(), Sidebar.table()) ::

--- a/test/minga_editor/handlers/file_event_handler_test.exs
+++ b/test/minga_editor/handlers/file_event_handler_test.exs
@@ -15,6 +15,7 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
   alias Minga.Project.FileRef
   alias Minga.Project.FileTree
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
+  alias MingaEditor.Extension.Sidebar
   alias MingaEditor.Handlers.FileEventHandler
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.SidebarWorkflow
@@ -65,6 +66,38 @@ defmodule MingaEditor.Handlers.FileEventHandlerTest do
       assert panel.ahead == 1
       assert panel.last_commit_message == "feat: previous subject"
       assert panel.stash_count == 2
+      assert {:render, 16} in effects
+    end
+
+    test "background git refresh updates visible Git panel without stealing Observatory focus" do
+      state =
+        base_state()
+        |> SidebarWorkflow.open_observatory(nil)
+        |> SidebarWorkflow.select("observatory")
+        |> SidebarWorkflow.replace_git_status(GitStatusPanel.new(%{entries: []}))
+
+      table = state.extension_surfaces.sidebar_registry
+      assert Sidebar.get(table, "observatory").focused?
+      refute Sidebar.get(table, "git_status").focused?
+
+      entry = %StatusEntry{path: "foo.ex", status: :modified, staged: false}
+
+      event =
+        {:minga_event, :git_status_changed,
+         %Minga.Events.GitStatusEvent{
+           git_root: "/tmp/repo",
+           entries: [entry],
+           branch: "develop",
+           ahead: 1,
+           behind: 0
+         }}
+
+      {new_state, effects} = FileEventHandler.handle(state, event)
+
+      assert SidebarWorkflow.active_id(new_state) == "observatory"
+      assert SidebarWorkflow.git_status_panel(new_state).entries == [entry]
+      assert %{visible?: true, focused?: false, badge_count: 1} = Sidebar.get(table, "git_status")
+      assert Sidebar.get(table, "observatory").focused?
       assert {:render, 16} in effects
     end
 

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -183,6 +183,8 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
     git_state = SidebarWorkflow.replace_git_status(state, GitStatusPanel.new(%{entries: []}))
 
+    assert %{visible?: true, focused?: false} = Sidebar.get(table, "git_status")
+
     git_active =
       GuiActionHandler.dispatch(
         git_state,
@@ -191,6 +193,7 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
 
     assert git_active.workspace.keymap_scope == :git_status
     assert SidebarWorkflow.active_id(git_active) == "git_status"
+    assert Sidebar.get(table, "git_status").focused?
 
     observatory_state =
       state

--- a/test/minga_editor/shell/traditional/sidebars_test.exs
+++ b/test/minga_editor/shell/traditional/sidebars_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.Shell.Traditional.SidebarsTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.GitStatus.Panel
+  alias MingaEditor.Extension.Sidebar
   alias MingaEditor.GitStatus.TUIState
   alias MingaEditor.Observatory.Data
   alias MingaEditor.Observatory.Inspection
@@ -22,6 +23,22 @@ defmodule MingaEditor.Shell.Traditional.SidebarsTest do
     assert Sidebars.active_id(closed) == nil
     assert Sidebars.git_status_panel(closed) == nil
     assert Sidebars.git_status_tui_state(closed) == nil
+  end
+
+  test "Git status workflow close clears shell state and registered visibility" do
+    state =
+      MingaEditor.RenderPipeline.TestHelpers.base_state()
+      |> SidebarWorkflow.replace_git_status(Panel.new(%{entries: []}))
+      |> SidebarWorkflow.select("git_status")
+
+    table = state.extension_surfaces.sidebar_registry
+    assert %{visible?: true, focused?: true} = Sidebar.get(table, "git_status")
+
+    closed = SidebarWorkflow.close_git_status(state)
+
+    assert SidebarWorkflow.git_status_panel(closed) == nil
+    assert SidebarWorkflow.active_id(closed) == nil
+    assert %{visible?: false, focused?: false, badge_count: 0} = Sidebar.get(table, "git_status")
   end
 
   test "Git status replacement rejects legacy map-shaped panel and TUI state" do


### PR DESCRIPTION
# TL;DR

Background Git status refreshes now preserve the currently focused left sidebar. Git Status still gains focus on explicit activation and clears its registry projection when closed.

## Context

The Git status sidebar projection previously inferred focus from visibility. Replacing visible panel data during a background refresh therefore called the registry's left-focus transition and could steal focus from Observatory.

This is W014 in the editor lifecycle roadmap and resolves audit finding L14.

## Changes

- Derive projected Git sidebar focus from the Traditional shell's selected sidebar identity.
- Keep Git panel replacement as a data-only transition.
- Register visible Git metadata without focusing it unless Git is already selected.
- Cover background refresh, explicit activation, and close behavior.
- Record the locked plan, validation, and review evidence in the lifecycle roadmap.

## Verification

- `mix test.debug test/minga_editor/handlers/file_event_handler_test.exs test/minga_editor/handlers/gui_action_handler_test.exs test/minga_editor/shell/traditional/sidebars_test.exs` (48 passed)
- `make lint`
- `mix test.llm --max-cases 4` (58 doctests, 98 properties, 9,914 tests, 0 failures, 1 skipped, 578 excluded)
- Correctness review: PASS
- Ponytail review: `Lean already. Ship.`
- Elixir craftsmanship review: PASS
- Final acceptance review: PASS

## Acceptance Criteria Addressed

- Background Git refresh updates visible panel metadata without changing sidebar focus.
- Explicit Git activation selects Git Status and installs its keyboard scope.
- Closing Git Status clears shell selection and registered visibility and focus.
- No new process, registry, abstraction, protocol, or frontend path is introduced.
