### PR TITLE
fix(ui): size popups from frontend viewport

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1930,8 +1930,8 @@ New split and float popup windows initialize their viewport metadata from `state
 
 #### Completion evidence
 
-- **PR URL:** Pending
-- **Commit SHA:** Pending
+- **PR URL:** https://github.com/jsmestad/minga/pull/3011
+- **Commit SHA:** `90ba545eb`
 - **Merge SHA:** Pending
 - **Focused tests:** 30 popup lifecycle tests passed.
 - **Broad validation:** `git diff --check`, `make lint`, and `mix test.llm --max-cases 4` passed; full non-heavy result: 58 doctests, 98 properties, 9,915 tests, 0 failures, 1 skipped, 578 excluded.

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1884,6 +1884,69 @@ Background Git status replacement updates the registered panel's visibility, bad
 - **Discoveries affecting later work:** Registry projections must derive focus from shell-owned selection instead of inferring focus from visibility.
 - **Completion date:** 2026-07-18
 
+### W015: Size popup metadata from the frontend viewport
+
+- **Status:** ACTIVE
+- **Audit ID:** L15
+- **Roadmap unit:** W015, Size popup metadata from the frontend viewport
+- **Ponytail verdict:** `ACCEPT/direct`
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `medium`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness SHA:** `57d4e10bba0d5825164b20ca032544cac95baace`
+- **Freshness basis:** Current `HEAD` and `origin/main` contain verified W014. Popup lifecycle still matched a nonexistent top-level viewport and fell back to 24 by 80.
+
+#### Observable outcome
+
+New split and float popup windows initialize their viewport metadata from `state.frontend.terminal_viewport`, including dimensions reported after a frontend resize.
+
+#### Owner and failure path
+
+- `MingaEditor.State.Frontend` owns the terminal viewport and its resize transition.
+- `MingaEditor.UI.Popup.Lifecycle` owns popup Window construction.
+- Before this unit, both popup creation branches called `viewport_size/1`. That helper looked for `state.viewport`, which is not an `EditorState` field, then returned `{24, 80}`.
+
+#### Locked implementation
+
+1. Read `state.frontend.terminal_viewport.rows` and `.cols` directly in split popup construction.
+2. Read the same frontend-owned dimensions in float popup construction.
+3. Delete the stale helper, hardcoded fallback, and unused `Viewport` alias.
+4. Do not retain a compatibility path for a nonexistent state shape.
+
+#### Required test
+
+- `test/minga_editor/ui/popup/lifecycle_test.exs`: keep workspace viewport at 24 by 80, resize only the frontend viewport to 40 by 120, open one split and one float popup, and assert both Window viewports use 40 by 120.
+
+#### Validation
+
+- Focused: `mix test.debug test/minga_editor/ui/popup/lifecycle_test.exs`
+- Broad: `git diff --check && make lint && mix test.llm --max-cases 4`
+
+#### Non-goals and budget
+
+- Do not change layout geometry, split sizing, popup rules, protocols, rendering, or frontend resize ownership.
+- Do not add a helper, fallback, abstraction, module, or compatibility path.
+- **Maximum production additions:** 40 lines.
+- **Maximum test additions:** 40 lines.
+
+#### Completion evidence
+
+- **PR URL:** Pending
+- **Commit SHA:** Pending
+- **Merge SHA:** Pending
+- **Focused tests:** 30 popup lifecycle tests passed.
+- **Broad validation:** `git diff --check`, `make lint`, and `mix test.llm --max-cases 4` passed; full non-heavy result: 58 doctests, 98 properties, 9,915 tests, 0 failures, 1 skipped, 578 excluded.
+- **Planner verdict:** `READY`; source owner, both construction branches, regression assertion, constraints, and validation are locked.
+- **Ponytail verdict:** `LEAN`; targeted review returned `Lean already. Ship.`
+- **Elixir verdict:** `PASS`; direct frontend field access and stale helper deletion match existing Elixir conventions.
+- **Bug-hunt verdict:** `PASS`; both popup creation branches and the resize owner are covered.
+- **Final reviewer verdict:** `PASS`.
+- **Production lines added/removed:** 4 added / 7 removed, net -3.
+- **Test lines added/removed:** 33 added / 0 removed, net +33.
+- **Concepts added/removed:** The invalid state-shape fallback is removed; no concept is added.
+- **Findings resolved:** Pending merge.
+- **Discoveries affecting later work:** Frontend-reported row fit and terminal dimensions must be read from `State.Frontend`, not a workspace or top-level fallback.
+- **Completion date:** Pending
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/lib/minga_editor/ui/popup/lifecycle.ex
+++ b/lib/minga_editor/ui/popup/lifecycle.ex
@@ -34,7 +34,6 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   alias MingaEditor.Layout
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Windows
-  alias MingaEditor.Viewport
   alias MingaEditor.Window
   alias MingaEditor.WindowTree
   alias MingaEditor.UI.Popup.Active, as: PopupActive
@@ -179,7 +178,8 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
     previous_active = ws.active
 
     {next_id, ws} = Windows.allocate_id(ws)
-    {rows, cols} = viewport_size(state)
+    rows = state.frontend.terminal_viewport.rows
+    cols = state.frontend.terminal_viewport.cols
     popup_window = Window.new(next_id, buffer_pid, rows, cols)
 
     # Determine split direction from the rule's side
@@ -223,7 +223,8 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
 
     # Create the popup window (not added to the tree, only the map)
     {next_id, ws} = Windows.allocate_id(ws)
-    {rows, cols} = viewport_size(state)
+    rows = state.frontend.terminal_viewport.rows
+    cols = state.frontend.terminal_viewport.cols
     popup_window = Window.new(next_id, buffer_pid, rows, cols)
 
     # Attach popup metadata
@@ -386,10 +387,6 @@ defmodule MingaEditor.UI.Popup.Lifecycle do
   defp compute_popup_size({:percent, pct}, total), do: max(div(total * pct, 100), 1)
   defp compute_popup_size({:rows, n}, _total), do: max(n, 1)
   defp compute_popup_size({:cols, n}, _total), do: max(n, 1)
-
-  @spec viewport_size(state()) :: {pos_integer(), pos_integer()}
-  defp viewport_size(%{viewport: %Viewport{rows: r, cols: c}}), do: {r, c}
-  defp viewport_size(_state), do: {24, 80}
 
   @spec remove_popup_window(Windows.t(), Window.id(), PopupActive.t()) :: Windows.t()
   defp remove_popup_window(ws, window_id, %PopupActive{rule: %Rule{display: :float}}) do

--- a/test/minga_editor/ui/popup/lifecycle_test.exs
+++ b/test/minga_editor/ui/popup/lifecycle_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.UI.Popup.LifecycleTest do
 
   alias MingaEditor.Layout
   alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State.Frontend, as: FrontendState
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.Windows
@@ -146,6 +147,38 @@ defmodule MingaEditor.UI.Popup.LifecycleTest do
 
       assert {:ok, new_state} = Lifecycle.open_popup(state, "*Warnings*", popup_buf, registry: t)
       assert is_nil(new_state.render.layout)
+    end
+
+    test "uses frontend terminal viewport for split and float popup windows", %{
+      state: state,
+      popup_buf: popup_buf,
+      table: table
+    } do
+      float_buf = fake_pid()
+      on_exit(fn -> Process.exit(float_buf, :kill) end)
+
+      frontend = FrontendState.resize_terminal(state.frontend, Viewport.new(40, 120))
+      state = %{state | frontend: frontend}
+
+      assert state.workspace.viewport.rows == 24
+      assert state.workspace.viewport.cols == 80
+
+      PopupRegistry.register(Rule.new("*Split*", focus: false), table)
+      PopupRegistry.register(Rule.new("*Float*", display: :float, focus: false), table)
+
+      assert {:ok, with_split} =
+               Lifecycle.open_popup(state, "*Split*", popup_buf, registry: table)
+
+      assert {:ok, with_float} =
+               Lifecycle.open_popup(with_split, "*Float*", float_buf, registry: table)
+
+      split_window = Map.fetch!(with_float.workspace.windows.map, 2)
+      float_window = Map.fetch!(with_float.workspace.windows.map, 3)
+
+      assert split_window.viewport.rows == 40
+      assert split_window.viewport.cols == 120
+      assert float_window.viewport.rows == 40
+      assert float_window.viewport.cols == 120
     end
   end
 


### PR DESCRIPTION
# TL;DR

Split and float popup windows now initialize viewport metadata from the frontend-reported terminal dimensions instead of a hardcoded 24 by 80 fallback.

## Context

Popup lifecycle looked for a nonexistent top-level viewport field. Every new popup therefore used fallback dimensions even after the frontend reported a resize.

This is W015 in the editor lifecycle roadmap and resolves audit finding L15.

## Changes

- Read terminal rows and columns from `state.frontend.terminal_viewport` in both popup creation branches.
- Delete the invalid state-shape matcher and hardcoded fallback.
- Cover split and float popup creation after a frontend-only resize.
- Record the locked plan and review evidence in the lifecycle roadmap.

## Verification

- `mix test.debug test/minga_editor/ui/popup/lifecycle_test.exs` (30 passed)
- `make lint`
- `mix test.llm --max-cases 4` (58 doctests, 98 properties, 9,915 tests, 0 failures, 1 skipped, 578 excluded)
- Correctness review: PASS
- Ponytail review: `Lean already. Ship.`
- Elixir craftsmanship review: PASS
- Final acceptance review: PASS

## Acceptance Criteria Addressed

- Split popup Window metadata uses frontend dimensions.
- Float popup Window metadata uses frontend dimensions.
- The stale 24 by 80 fallback is removed without a replacement abstraction.
