### PR TITLE
test(editor): synchronize scheduler monitor

### DIFF
--- a/test/minga_editor/effect_scheduler_test.exs
+++ b/test/minga_editor/effect_scheduler_test.exs
@@ -875,6 +875,7 @@ defmodule MingaEditor.EffectSchedulerTest do
 
     worker_monitor = Process.monitor(worker)
     scheduler_monitor = Process.monitor(first_scheduler)
+    :sys.get_state(first_scheduler)
     Process.exit(first_owner, :kill)
 
     request_id = request.id


### PR DESCRIPTION
# TL;DR

Make the EffectScheduler generation-restart test establish its scheduler monitor before triggering owner teardown. This removes a CI race where the monitor could report `:noproc` instead of the scheduler's actual `:shutdown` reason.

## Changes

- Add a scheduler-side `:sys.get_state/1` synchronization barrier after `Process.monitor/1`.
- Keep production code and lifecycle assertions unchanged.

## Verification

- Focused CI-seed test passed 100 consecutive repetitions.
- `make lint`
- `mix test.llm --max-cases 4` (9,914 tests, 0 failures)
- Correctness, Ponytail, Elixir craftsmanship, and final acceptance reviews: PASS
