### PR TITLE
fix(extension): accept repeated artifact observations

### DIFF
--- a/lib/minga/extension/isolated_compiler.ex
+++ b/lib/minga/extension/isolated_compiler.ex
@@ -281,13 +281,7 @@ defmodule Minga.Extension.IsolatedCompiler do
     module_name = Atom.to_string(module)
 
     if valid_artifact_name?(module_name) do
-      path = Path.join(directory, module_name <> ".beam")
-
-      case File.write(path, bytecode, [:binary, :exclusive]) do
-        :ok -> errors
-        {:error, :eexist} -> ["duplicate compiler output" | errors]
-        {:error, _reason} -> ["runtime artifact write failed" | errors]
-      end
+      observe_named_loaded_artifact(directory, module_name, bytecode, errors)
     else
       ["invalid runtime artifact name" | errors]
     end


### PR DESCRIPTION
## TL;DR

Accept repeated observations of identical isolated compiler bytecode while still rejecting conflicting duplicate output.

## Problem

The isolated compiler can observe one BEAM artifact through runtime tracing before the compiler tracer reports the same bytes. The second event used an exclusive write and intermittently failed valid extension compilation with `duplicate compiler output`.

## Changes

- Reuse the existing compare-or-write artifact path for compiler emissions.
- Treat identical bytecode as the same observation.
- Preserve rejection when the module path contains different bytecode.

## Verification

- Focused artifact inventory, duplicate compiler emission, and duplicate runtime emission tests passed.
- The previously failing artifact inventory test passed 200 consecutive repetitions with seed `271275`.
- `make lint`
- `mix test.llm --max-cases 4`: 58 doctests, 98 properties, 9,915 tests, 0 failures, 1 skipped, 578 excluded.
