### PR TITLE
fix(agent): bound subagent startup wait

### DIFF
--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -307,6 +307,13 @@ defmodule MingaAgent.Session do
     GenServer.call(session, {:subscribe, pid, opts})
   end
 
+  @doc "Subscribes the given process, allowing callers to bound startup waits explicitly."
+  @spec subscribe(GenServer.server(), pid(), keyword(), timeout()) ::
+          :ok | {:error, :invalid_role}
+  def subscribe(session, pid, opts, timeout) when is_pid(pid) do
+    GenServer.call(session, {:subscribe, pid, opts}, timeout)
+  end
+
   @doc "Returns the current remote attachment role for a subscriber."
   @spec subscriber_role(GenServer.server(), pid()) :: attachment_role() | nil
   def subscriber_role(session, pid) when is_pid(pid) do

--- a/lib/minga_agent/tools/subagent.ex
+++ b/lib/minga_agent/tools/subagent.ex
@@ -39,7 +39,8 @@ defmodule MingaAgent.Tools.Subagent do
           worktree_backend: module(),
           worktree_backend_opts: keyword(),
           session_manager: GenServer.server(),
-          notifier: module() | {module(), term()}
+          notifier: module() | {module(), term()},
+          startup_timeout_ms: pos_integer()
         ]
 
   @subagent_timeout_ms 300_000
@@ -125,7 +126,8 @@ defmodule MingaAgent.Tools.Subagent do
   defp do_start_foreground(task, opts) do
     with {:ok, session_opts} <- session_opts(opts),
          {:ok, session_pid} <- AgentSupervisor.start_session(session_opts) do
-      run_subagent(session_pid, task)
+      timeout = Keyword.get(opts, :startup_timeout_ms, @subagent_timeout_ms)
+      run_subagent(session_pid, task, timeout)
     else
       {:error, {:provider_resolution_failed, reason}} ->
         {:error, "Failed to resolve subagent provider: #{reason}"}
@@ -158,20 +160,19 @@ defmodule MingaAgent.Tools.Subagent do
     end
   end
 
-  @spec run_subagent(pid(), String.t()) :: {:ok, String.t()} | {:error, String.t()}
-  defp run_subagent(session_pid, task) do
-    :ok = Session.subscribe(session_pid)
+  @spec run_subagent(pid(), String.t(), pos_integer()) :: {:ok, String.t()} | {:error, String.t()}
+  defp run_subagent(session_pid, task, timeout) do
+    :ok = Session.subscribe(session_pid, self(), [], timeout)
 
     case send_prompt_when_ready(session_pid, task, 0) do
-      :ok ->
-        result = collect_response(session_pid)
-        cleanup(session_pid)
-        result
-
-      {:error, reason} ->
-        cleanup(session_pid)
-        {:error, "Subagent failed to start: #{inspect(reason)}"}
+      :ok -> collect_response(session_pid)
+      {:error, reason} -> {:error, "Subagent failed to start: #{inspect(reason)}"}
     end
+  catch
+    :exit, {:timeout, {GenServer, :call, [^session_pid, {:subscribe, _pid, _opts}, ^timeout]}} ->
+      {:error, "Subagent timed out while starting"}
+  after
+    AgentSupervisor.stop_session(session_pid)
   end
 
   @spec send_prompt_when_ready(pid(), String.t(), non_neg_integer()) :: :ok | {:error, term()}
@@ -221,17 +222,6 @@ defmodule MingaAgent.Tools.Subagent do
       timeout ->
         {:error, "Subagent timed out after #{div(@subagent_timeout_ms, 1000)} seconds"}
     end
-  end
-
-  @spec cleanup(pid()) :: :ok
-  defp cleanup(session_pid) do
-    Session.unsubscribe(session_pid)
-    AgentSupervisor.stop_session(session_pid)
-    :ok
-  rescue
-    ArgumentError -> :ok
-  catch
-    :exit, _ -> :ok
   end
 
   # ── Worktree isolation ─────────────────────────────────────────────────────

--- a/test/minga_agent/tools/subagent_test.exs
+++ b/test/minga_agent/tools/subagent_test.exs
@@ -56,6 +56,27 @@ defmodule MingaAgent.Tools.SubagentTest do
     assert {:ok, "foreground done"} = Task.await(task, @event_timeout)
   end
 
+  test "foreground startup timeout returns an error and stops the child session" do
+    test_pid = self()
+    ref = make_ref()
+
+    task =
+      Task.async(fn ->
+        Subagent.execute("blocked startup",
+          provider: GatedProvider,
+          provider_opts: [test_pid: test_pid, startup_gate: {test_pid, ref}],
+          startup_timeout_ms: 10
+        )
+      end)
+
+    assert_receive {:provider_starting, ^ref, provider_pid, session_pid}, @event_timeout
+    Process.send_after(provider_pid, {ref, :continue}, 50)
+    monitor = Process.monitor(session_pid)
+
+    assert {:error, "Subagent timed out while starting"} = Task.await(task, @event_timeout)
+    assert_receive {:DOWN, ^monitor, :process, ^session_pid, _reason}, @event_timeout
+  end
+
   test "inherits parent provider context by default", %{tmp_dir: dir} do
     ref = make_ref()
     parent = start_parent_session(dir, ref)

--- a/test/support/minga_agent/subagent_gated_provider.ex
+++ b/test/support/minga_agent/subagent_gated_provider.ex
@@ -39,8 +39,25 @@ defmodule Minga.Test.SubagentGatedProvider do
   @spec init(keyword()) :: {:ok, state()}
   @impl GenServer
   def init(opts) do
+    await_startup_gate(opts)
+
     {:ok,
      %{subscriber: Keyword.fetch!(opts, :subscriber), test_pid: Keyword.fetch!(opts, :test_pid)}}
+  end
+
+  @spec await_startup_gate(keyword()) :: :ok
+  defp await_startup_gate(opts) do
+    case Keyword.get(opts, :startup_gate) do
+      {test_pid, ref} ->
+        send(test_pid, {:provider_starting, ref, self(), Keyword.fetch!(opts, :subscriber)})
+
+        receive do
+          {^ref, :continue} -> :ok
+        end
+
+      nil ->
+        :ok
+    end
   end
 
   @spec handle_call(term(), GenServer.from(), state()) :: {:reply, :ok, state()}


### PR DESCRIPTION
## Summary

- let foreground subagent subscription use the existing five-minute subagent timeout instead of `GenServer.call/2`'s five-second default
- return a targeted startup-timeout error while always terminating the child session
- preserve existing subscription callers and response-timeout behavior
- add a deterministic blocked-provider regression that verifies both the error and child teardown

## Validation

- `mix test.debug test/minga_agent/tools/subagent_test.exs test/minga_agent/tools/subagent_receive_loop_test.exs` (9 passed)
- `make lint`
- `mix test.llm --max-cases 4` (9,916 tests, 0 failures, 1 skipped)
- correctness review: PASS
- Elixir craftsmanship review: PASS
- Ponytail review: `Lean already. Ship.`
- final reviewer: PASS
