### PR TITLE
fix(editor): retire remote buffer registrations

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1947,6 +1947,39 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Discoveries affecting later work:** Frontend-reported row fit and terminal dimensions must be read from `State.Frontend`, not a workspace or top-level fallback.
 - **Completion date:** 2026-07-18
 
+### W016: Retire remote buffer registrations with root buffers
+
+- **Status:** ACTIVE
+- **Decision:** ACCEPT/direct
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness commit SHA:** `0f67b113ddd6e08c511528d2c306ed12a2d5810b`
+- **Observable outcome:** After `MingaEditor.State.remove_buffer(state, retired_pid)`, every `{server, path} => retired_pid` entry is removed from `state.remote`; entries for other PIDs remain.
+- **Failure path:** Root buffer retirement removed parser, lifecycle, workspace, shell runtime, and git state references but left `MingaEditor.State.Remote.buffers` registrations pointing at retired buffer PIDs.
+- **Locked implementation:** Add owner-local `Remote.retire_buffer/2` with a pid guard and `Map.reject/2`, call it from root `State.remove_buffer/2`, and install the returned remote state in the root struct.
+- **Focused validation:** `mix test.debug test/minga_editor/state_test.exs:502` passed 1 regression with 10 excluded; full `state_test.exs` passed 11 tests; `buffer_lifecycle_test.exs` passed 10 tests.
+- **Broad validation:** `make lint` passed; `mix test.llm --max-cases 4` passed 58 doctests, 98 properties, and 9,916 tests with 0 failures, 1 skipped, and 578 excluded.
+- **Non-goals:** No workflow changes, liveness probes, catches, wrappers, new process, module, dependency, behaviour, protocol, registry, config, data shape, root forwarding API, or changes to existing Remote read contracts.
+- **Maximum production additions:** 15 lines.
+- **Maximum test additions:** 25 lines.
+
+#### Completion evidence
+
+- **PR URL:** Pending
+- **Commit SHA:** Pending
+- **Merge SHA:** Pending
+- **Planner verdict:** `READY`; owner, exact filter, root installation, assertions, constraints, and validation were locked.
+- **Ponytail verdict:** `LEAN`; targeted review returned `Lean already. Ship.`
+- **Elixir verdict:** `PASS`; the owner-local transition and `Map.reject/2` are the idiomatic immutable update.
+- **Bug-hunt verdict:** `PASS`; the sole documentation command mismatch was corrected from line 501 to 502 and the exact regression passed.
+- **Final reviewer verdict:** `PASS`; the owner transition, atomic root installation, regression, budgets, evidence, and merge safety are accepted.
+- **Production lines added/removed:** 9 added / 1 removed, net +8.
+- **Test lines added/removed:** 20 added / 0 removed, net +20.
+- **Concepts added/removed:** Added one owner-local `Remote.retire_buffer/2` transition; no new process, module, dependency, protocol, registry, config, or data shape.
+- **Findings resolved:** Pending merge.
+- **Discoveries affecting later work:** Buffer retirement invariants span root owners; each owner must expose its own transition and root removal must install every returned owner value atomically.
+- **Completion date:** Pending
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/lib/minga_editor/state.ex
+++ b/lib/minga_editor/state.ex
@@ -280,6 +280,7 @@ defmodule MingaEditor.State do
 
     runtime = ShellRuntime.retire_buffer(state.shell_runtime, pid)
     git = GitState.retire_buffer(state.git, pid)
+    remote = Remote.retire_buffer(state.remote, pid)
 
     %{
       state
@@ -287,7 +288,8 @@ defmodule MingaEditor.State do
         buffer_lifecycle: lifecycle,
         workspace: workspace,
         shell_runtime: runtime,
-        git: git
+        git: git,
+        remote: remote
     }
   end
 

--- a/lib/minga_editor/state/remote.ex
+++ b/lib/minga_editor/state/remote.ex
@@ -48,6 +48,12 @@ defmodule MingaEditor.State.Remote do
     %{remote | buffers: Map.put(remote.buffers, {server_name, path}, buffer)}
   end
 
+  @doc "Retires every remote file registration that points at `buffer`."
+  @spec retire_buffer(t(), pid()) :: t()
+  def retire_buffer(%__MODULE__{} = remote, buffer) when is_pid(buffer) do
+    %{remote | buffers: Map.reject(remote.buffers, fn {_key, pid} -> pid == buffer end)}
+  end
+
   @doc "Finds an open buffer for a remote file."
   @spec buffer(t(), String.t(), String.t()) :: pid() | nil
   def buffer(%__MODULE__{} = remote, server_name, path)

--- a/test/minga_editor/state_test.exs
+++ b/test/minga_editor/state_test.exs
@@ -9,6 +9,7 @@ defmodule MingaEditor.StateTest do
   alias MingaEditor.State.Buffers
   alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.Frontend, as: FrontendState
+  alias MingaEditor.State.Remote
   alias MingaEditor.State.Workspace, as: WorkspaceModel
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
@@ -509,15 +510,34 @@ defmodule MingaEditor.StateTest do
         |> MingaEditor.Handlers.BufferRegistry.monitor_buffer(buf1)
         |> MingaEditor.Handlers.BufferRegistry.monitor_buffer(buf2)
 
+      state = %{
+        state
+        | remote:
+            state.remote
+            |> Remote.put_buffer("server-a", "/remote/one.ex", buf1)
+            |> Remote.put_buffer("server-b", "/remote/one.ex", buf1)
+            |> Remote.put_buffer("server-a", "/remote/two.ex", buf2)
+      }
+
       removed_inactive = EditorState.remove_buffer(state, buf1)
       refute buf1 in removed_inactive.workspace.buffers.list
       assert buf2 in removed_inactive.workspace.buffers.list
       refute Map.has_key?(removed_inactive.buffer_lifecycle.buffer_monitors, buf1)
       assert Map.has_key?(removed_inactive.buffer_lifecycle.buffer_monitors, buf2)
+      refute Remote.buffer(removed_inactive.remote, "server-a", "/remote/one.ex")
+      refute Remote.buffer(removed_inactive.remote, "server-b", "/remote/one.ex")
+      assert Remote.buffer(removed_inactive.remote, "server-a", "/remote/two.ex") == buf2
+
+      refute Enum.any?(Remote.all_buffers(removed_inactive.remote), fn {_server, _path, pid} ->
+               pid == buf1
+             end)
 
       removed_active = EditorState.remove_buffer(state, buf2)
       assert removed_active.workspace.buffers.active == buf1
       assert removed_active.workspace.buffers.list == [buf1]
+      assert Remote.buffer(removed_active.remote, "server-a", "/remote/one.ex") == buf1
+      assert Remote.buffer(removed_active.remote, "server-b", "/remote/one.ex") == buf1
+      refute Remote.buffer(removed_active.remote, "server-a", "/remote/two.ex")
     end
   end
 


### PR DESCRIPTION
## Summary

- add an owner-local `Remote.retire_buffer/2` transition
- remove every remote registration for a retired buffer during root buffer removal
- preserve registrations for other buffer PIDs and all other Remote state
- record W016 implementation and validation evidence in the lifecycle roadmap

## Validation

- `mix test.debug test/minga_editor/state_test.exs:502` (1 passed, 10 excluded)
- `mix test.debug test/minga_editor/state_test.exs` (11 passed)
- `mix test.debug test/minga_editor/state/buffer_lifecycle_test.exs` (10 passed)
- `make lint`
- `mix test.llm --max-cases 4` (9,916 tests, 0 failures, 1 skipped)
- correctness review: PASS
- Elixir craftsmanship review: PASS
- Ponytail review: `Lean already. Ship.`
- final reviewer: PASS

## Scope

Resolves audit finding L16. Production change is 9 additions and 1 removal. Test change is 20 additions. No process, module, dependency, protocol, registry, config, data-shape, or Remote read-contract changes.
