### PR TITLE
fix(macos): unify editor presentation snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,10 +93,8 @@ jobs:
       - name: Check cross-language golden manifest is committed
         run: MIX_ENV=test mix protocol.golden --check
       - run: mix native.build.support
-      - name: Run non-heavy Elixir tests
-        run: mix test --warnings-as-errors --exclude system_clipboard --exclude conformance --exclude heavy --exclude extension_compile_cache
-      - name: Run heavy Elixir tests
-        run: mix test --warnings-as-errors --max-cases 1 --exclude system_clipboard --exclude conformance --only heavy --exclude extension_compile_cache
+      - name: Run Elixir tests except the isolated compile-cache suite
+        run: mix test --warnings-as-errors --exclude system_clipboard --exclude conformance --exclude extension_compile_cache
       - name: Run extension compile-cache tests in an isolated BEAM
         run: mix test --warnings-as-errors test/minga/extension/compile_cache_test.exs
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -337,6 +337,7 @@ jobs:
           path: |
             native_render_performance.json
             native_render_performance_metrics.txt
+            minga-native-render-performance*.ips
           if-no-files-found: error
 
       - name: Cache DerivedData

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,12 @@ jobs:
       - name: Check cross-language golden manifest is committed
         run: MIX_ENV=test mix protocol.golden --check
       - run: mix native.build.support
-      - run: mix test --warnings-as-errors --exclude system_clipboard --exclude conformance
+      - name: Run non-heavy Elixir tests
+        run: mix test --warnings-as-errors --exclude system_clipboard --exclude conformance --exclude heavy --exclude extension_compile_cache
+      - name: Run heavy Elixir tests
+        run: mix test --warnings-as-errors --max-cases 1 --exclude system_clipboard --exclude conformance --only heavy --exclude extension_compile_cache
+      - name: Run extension compile-cache tests in an isolated BEAM
+        run: mix test --warnings-as-errors test/minga/extension/compile_cache_test.exs
 
   keystroke-latency-baseline:
     name: Keystroke Latency Baseline

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -309,6 +309,9 @@ jobs:
       - run: mix deps.get
       - run: mix protocol.gen
 
+      - name: Install pinned XcodeGen
+        run: echo "$(scripts/install_xcodegen "$RUNNER_TEMP/xcodegen")" >> "$GITHUB_PATH"
+
       - name: Gate optimized native render preparation
         run: |
           HEAD_REF=$(git rev-parse HEAD)
@@ -320,15 +323,32 @@ jobs:
             bash scripts/bench_render_performance_ab --head-only "$HEAD_REF"
           fi
 
+      - name: Gate native Metal completion path
+        run: |
+          HEAD_REF=$(git rev-parse HEAD)
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE_SHA=$(git merge-base origin/main "$HEAD_REF")
+            bash scripts/bench_native_render_performance_ab "$BASE_SHA" "$HEAD_REF"
+          else
+            bash scripts/bench_native_render_performance_ab --head-only "$HEAD_REF"
+          fi
+
+      - name: Upload native Metal performance evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-render-performance
+          path: |
+            native_render_performance.json
+            native_render_performance_metrics.txt
+          if-no-files-found: error
+
       - name: Cache DerivedData
         uses: actions/cache@v4
         with:
           path: macos/DerivedData
           key: xcode-${{ runner.os }}-${{ hashFiles('macos/Sources/**/*.swift', 'macos/Sources/**/*.metal', 'macos/project.yml') }}
           restore-keys: xcode-${{ runner.os }}-
-
-      - name: Install pinned XcodeGen
-        run: echo "$(scripts/install_xcodegen "$RUNNER_TEMP/xcodegen")" >> "$GITHUB_PATH"
 
       - name: Generate Xcode project
         run: cd macos && xcodegen generate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -325,13 +325,9 @@ jobs:
 
       - name: Gate native Metal completion path
         run: |
+          # Hosted macOS GPU scheduling is not a stable baseline environment, and the known-old renderer can trap before producing measurements. CI gates HEAD's absolute budgets; paired A/B evidence is captured separately on stable same-machine hardware.
           HEAD_REF=$(git rev-parse HEAD)
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
-            BASE_SHA=$(git merge-base origin/main "$HEAD_REF")
-            bash scripts/bench_native_render_performance_ab "$BASE_SHA" "$HEAD_REF"
-          else
-            bash scripts/bench_native_render_performance_ab --head-only "$HEAD_REF"
-          fi
+          bash scripts/bench_native_render_performance_ab --head-only "$HEAD_REF"
 
       - name: Upload native Metal performance evidence
         if: always()

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -12,8 +12,11 @@
 		021E5E13E2F6CA9FEEA6D175 /* GUIFramePresentationMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18683C638D0F417500DAF924 /* GUIFramePresentationMetrics.swift */; };
 		03C97AFD225BCEA6E7A8E0BF /* PreparedFrameTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */; };
 		058481A528AFB6C7225A067D /* MouseInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA65B90C0347C6496C7FA986 /* MouseInputTests.swift */; };
+		05A024F8BFA924976FB7D68D /* PreparedFrameTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */; };
 		05EC70C811170EE160C5E4D9 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
+		0636EFFAF2BE90489D553917 /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A733EF649EF21A761608D75 /* MingaWindow.swift */; };
 		067369CB702835E93D254606 /* PipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */; };
+		06D741E1FB11DDFC35EC3B18 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
 		077AF22C34E2851B1F975C78 /* PreviewHostApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9978FBBB4E1BC671AF1C49F5 /* PreviewHostApp.swift */; };
 		07C32C28178AE5675ACF4539 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
 		07C6F28E3CD1A55ABD5344AA /* SlotAllocatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F8372175FF223C9260B00C4 /* SlotAllocatorTests.swift */; };
@@ -24,16 +27,21 @@
 		0C0F3AF675E0AA401FEC648F /* LiveResizeDebounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */; };
 		0C218A1F0FFE238D8B2CD7E5 /* ActivityBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA105569D96F7654005293B2 /* ActivityBar.swift */; };
 		0E41F92F8E0358C4847E871E /* LatencyHUDState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4B4CB36A83E4FEBF0B58397 /* LatencyHUDState.swift */; };
+		0E7636FCDD5DA74E56E49EA9 /* PresentationScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */; };
 		1042F0D41E737771D9D00FB5 /* TextHighlighting.swift in Sources */ = {isa = PBXBuildFile; fileRef = A87246A39436BB38B41100F9 /* TextHighlighting.swift */; };
+		10A82EBF290447A56787873C /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
+		111AC046FBBCDCCEB7E02F27 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		11B3954DAF033C87DD94828E /* RendererComplexityGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816B39C0D25C2A0CBEA4F93F /* RendererComplexityGate.swift */; };
 		121E3F11034FFD88D07A62E9 /* AgentToolCallCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EBF8F752B40004FCD33C6F /* AgentToolCallCard.swift */; };
 		123999564C3B1FE9804B13B0 /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		1549A4ECD1BD124BF8241ADF /* ThumbDragSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AEAD1E631064BE3B13E42C /* ThumbDragSession.swift */; };
+		15F65BBF4297D723F7C47A28 /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		16116567DD7218A82575360A /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
 		1631D7B76B33CD897C48F263 /* IMECompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6C3196976BC934B3112EF96 /* IMECompositionTests.swift */; };
 		172D7B7EC516CC0CA76797AC /* WorkspaceHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D0D4C9BE8CA9DC30BCE6ED49 /* WorkspaceHeaderView.swift */; };
 		18F0DDA03D08C0B4302DCCF4 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
 		1936219891B87FD4AB49795B /* StatusBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 575815EBAD4E1DFE0BE3DE57 /* StatusBarState.swift */; };
+		199BEA8FC7B5C8696014027F /* DecodedFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */; };
 		19E561E5F7841B2CF1ABB085 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		1A2DA0CD8DD4B1C1F30C9098 /* MingaProtocol.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; };
 		1A7BC027E152504B67F6F418 /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
@@ -44,19 +52,24 @@
 		21860F09B105F23D5F5F9623 /* ExtensionPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20D36FDE455CBEE50349F675 /* ExtensionPanelState.swift */; };
 		2189892352237ED1153E70F2 /* MingaUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		2198A76504E5C0A41209CF57 /* EditTimelineView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE173FAAAC37ACFF47EE03B8 /* EditTimelineView.swift */; };
+		21D2F006D7D827CA7E024F84 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		22EFBD4416697A01FDC9C2AD /* ProtocolCommandSize.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762CD389E04B0DE6A86CDBF2 /* ProtocolCommandSize.generated.swift */; };
 		2388D1CC8878556958DA4A0D /* EditorGeometry+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */; };
 		23DA463A92D1EC2F7BFA5B5A /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
+		245180E7A0626A8C48245493 /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */; };
 		25B21FDC79D3F65CAA270C99 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		25D865A5AD887E5F31FA162D /* LatencyHUDStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA53378E05335BC93B342123 /* LatencyHUDStateTests.swift */; };
 		26DAAF2C2CCC2713AD30C539 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
 		281A9531103F9E962B3F31A7 /* EditorScrollTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44800E8F274B5EC453CAE7EB /* EditorScrollTrack.swift */; };
 		2850DD6D3A2061ECEE89C81F /* AgentPromptView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 46CACE8313B301092C88666E /* AgentPromptView.swift */; };
+		286916557519E9A3B7EDA241 /* RendererSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F37BEAA7D7267D29882A632 /* RendererSignposts.swift */; };
 		28E5444432A6B3AF05FE9762 /* PreviewRegistry+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6904499C06BDDEDCECC5D364 /* PreviewRegistry+AgentChat.swift */; };
 		28F3D7BFADCE4A2509D66C2B /* CommandDispatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 470991E7B3850B1AADFD46FD /* CommandDispatcherTests.swift */; };
+		29C378441427D0BCE64A68AE /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		2C176B25F957ABFA236A1F31 /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
 		2CF1DDA2F81F9387EFADE135 /* SignatureHelpOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F8CC95C21F56C815C87A3C9 /* SignatureHelpOverlay.swift */; };
 		2CFB39859AC1E448147D8C31 /* EditTimelineState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BB45C5B630FDEDFD0BD6BE0 /* EditTimelineState.swift */; };
+		2DC7C337561B2DD304BD22D0 /* EditorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD617770357D4F3C286BBFF /* EditorPresentation.swift */; };
 		2DFDA6E32CE61E6D89341423 /* AppearanceSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 912C5F808709BABFF3126DEE /* AppearanceSettingsView.swift */; };
 		2F0A0D75FA309989C48B32EF /* WindowContent.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790F7E20F30FEEFC552B3685 /* WindowContent.swift */; };
 		2FE07FE013FC3DE8FD01DF39 /* BottomPanelState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A583EB0DCE480D1A5FC7E440 /* BottomPanelState.swift */; };
@@ -68,11 +81,14 @@
 		332992D8BDA62035A5B57A41 /* PointingHandModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA51F390E49935563AB0AEB6 /* PointingHandModifier.swift */; };
 		346A7206B13063768245AC96 /* ThumbDragSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AEAD1E631064BE3B13E42C /* ThumbDragSession.swift */; };
 		34F2E7C171D777C4CE7F0978 /* NativeTextCommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF00AA30A3F2887F49DA9E90 /* NativeTextCommandRouter.swift */; };
+		3535A85D824D23299BA91A86 /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
 		364C48575BB95C9CA535A9C8 /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
 		384AC3273F54DFE9E87177C6 /* ResidentRowStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D7FFB77269C17AB9036BC17B /* ResidentRowStoreTests.swift */; };
 		3A23159F3A6631F0AD99A702 /* ExtensionViewsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA6F5FC902DD40A54F100FF /* ExtensionViewsTests.swift */; };
 		3A296C1AF0FDD2A0FDF83E7A /* PresentationScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */; };
 		3B03245A5A6EFA39B99B37F8 /* InputEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 92E717A483EC2E50C536785C /* InputEncoder.swift */; };
+		3B65693EFE431AD00660D754 /* MingaProtocol.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; };
+		3CA33261F251A71830F618AA /* TemporalOffscreenMetalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 51F0B55F4608ACA6BDB7CB3E /* TemporalOffscreenMetalTests.swift */; };
 		3CD15ED81AE384C93557B0C0 /* CompletionOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCA8938E70ED0123ACECD921 /* CompletionOverlay.swift */; };
 		41DCC27275D0E8E903EAA061 /* SidebarViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */; };
 		41FF9FC432F155FBCAA0A3C2 /* FrameResourcePolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDA4AE7E853248477810B52C /* FrameResourcePolicy.swift */; };
@@ -88,6 +104,7 @@
 		45B91273836C8DFA73205995 /* MingaProtocol.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; };
 		465E423FE68C2E64731164C3 /* ResyncOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = FCFB66F7BCD7E565FACECF70 /* ResyncOverlay.swift */; };
 		465F1FEF8EBEBBC62B1D3339 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65B982679577E3DBD4E7A69D /* SettingsView.swift */; };
+		48D002490916CE1B42DCA825 /* CachedLineTexture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C9F6C86861307AE9524E8F5 /* CachedLineTexture.swift */; };
 		4A2ED658D250B02BE89A6A56 /* CompletionStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEA19E7E243EB130E1969551 /* CompletionStateTests.swift */; };
 		4A3BE630EECDBD2A557A4027 /* WorkspaceIconPicker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 671A222860B90E08D7975099 /* WorkspaceIconPicker.swift */; };
 		4ADE54090FEEF5AA2A6C86A0 /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
@@ -99,9 +116,11 @@
 		4F42D3504D3606AAC6950FA0 /* BreadcrumbBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD9F43E781BA11616C52373E /* BreadcrumbBar.swift */; };
 		50C327D61ECA2C35142198D7 /* ProtocolCommandSize.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762CD389E04B0DE6A86CDBF2 /* ProtocolCommandSize.generated.swift */; };
 		51666BAFCCF8E47DA25B6E80 /* HoverPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D068C9707F3A44D03F7C3222 /* HoverPopupState.swift */; };
+		521052DC241D93D8C4AA8CA3 /* WindowContentRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */; };
 		527C7DB557EFD09B3161BC20 /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		52C10A4F60138FF6E0939286 /* AgentChatView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31DA375DF5D4047E01761926 /* AgentChatView.swift */; };
 		537AA754C723E8F02ED14D32 /* ExtensionOverlayState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C85068F0199E155E5349C53 /* ExtensionOverlayState.swift */; };
+		53EDC20DDE726C337975B053 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
 		5589E3C37EC68A39756A9591 /* SettingsState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 77BBC8154E1D48CE215F2F25 /* SettingsState.swift */; };
 		569B5AC209C6D76E75E30A62 /* PickerQueryReconciler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CCBC56FFB1C80D5AE32755F /* PickerQueryReconciler.swift */; };
 		581390BB65F36B77E59F6D9F /* GUIColorSlots.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6154F8ABA71694035D38ED2 /* GUIColorSlots.swift */; };
@@ -112,16 +131,19 @@
 		5DE70D2369F1CB92DD8D5000 /* PreviewSnapshotPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1D0E05FBEEC550591460C7 /* PreviewSnapshotPolicy.swift */; };
 		604EA0D182B756909D021DC6 /* PreviewRegistry+GitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB5DAD0EAB1AE583E45AF5C /* PreviewRegistry+GitStatus.swift */; };
 		615049EC1AF720C119D63438 /* ExtensionPanelView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C089C5163F2C513D3DC21E7C /* ExtensionPanelView.swift */; };
+		6184BD99497BC7DED163F04F /* ProtocolSemanticDecode.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B639BCE7660087F70778E839 /* ProtocolSemanticDecode.generated.swift */; };
 		619712AD984E8EA2ED68AE2C /* PreviewRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = D17B2A4D2BADE64E249073E1 /* PreviewRegistry.swift */; };
 		61CF67858355FFF4962D9D99 /* ThemeColorsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */; };
 		61D00C1763BF9CE0587A9A5F /* PreparedFrameTransaction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F23F8D48BE810AB3FD81B5A /* PreparedFrameTransaction.swift */; };
 		62628D5EAC0BCF980D2C59A3 /* PreviewRegistry+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6904499C06BDDEDCECC5D364 /* PreviewRegistry+AgentChat.swift */; };
 		63244435D2C9F3DCFB5E199F /* ContentViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D69D36DE216362078A88571E /* ContentViewTests.swift */; };
+		634A3C578E804955D95008BC /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		637E93B9C1D6B5DBF0E29F05 /* MessagesContentStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4867C8EE01AF6ACFB27DB7C /* MessagesContentStateTests.swift */; };
 		63F3CF3A4746901FDF1C3356 /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
 		647346FE3161B2C2FC4A5436 /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
 		64A5A16E02B3E2694060F1A1 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
 		64F4537439FC69C8D9094419 /* LiveResizeDebounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */; };
+		65C137EB08F6E784742D5B68 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
 		66314FC85298ED8BA412C02F /* ProtocolCommandSizeTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB492F643770698E3E7F419 /* ProtocolCommandSizeTests.swift */; };
 		66FAAD91BF8CF5B72C187D02 /* KeybindingsSettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C50661EF3472E892F77AF9C2 /* KeybindingsSettingsView.swift */; };
 		6700C63C4B7070D3388A7BD4 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
@@ -138,7 +160,9 @@
 		6DC89F81DBC022B3FCBA39BB /* EditorGeometry+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */; };
 		6EE7C16703E92B31CC9CE9C0 /* NonBlockingEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B3DDF1EB804D4E31EDFA519 /* NonBlockingEncoderTests.swift */; };
 		6EE844B0AA477984A99FF81A /* MingaUI.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		6F13186CB83B8FF2870F9D49 /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
 		6F4588B8EB30D91E05176E9E /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25503C21E0D55E1515A38C7D /* ScrollAccumulator.swift */; };
+		6F9C2C373304BAEF0F5BB93F /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
 		6FFA15B975A574EB4D11A804 /* NativeTextCommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF00AA30A3F2887F49DA9E90 /* NativeTextCommandRouter.swift */; };
 		712BB689EB52A507311BC1B0 /* RendererSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F37BEAA7D7267D29882A632 /* RendererSignposts.swift */; };
 		71384FFD82964586B710BD94 /* PreviewRegistry+FileTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305F0E7D9158C236803224AA /* PreviewRegistry+FileTree.swift */; };
@@ -164,6 +188,7 @@
 		7C9B7CB6670412D9F4DE60BB /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		7D7B070451AD0F32911A133B /* EditorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD617770357D4F3C286BBFF /* EditorPresentation.swift */; };
 		7FE374C007A79192530A6B26 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
+		8064EA19AD10D1790AECC0A9 /* PreviewSnapshotPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1D0E05FBEEC550591460C7 /* PreviewSnapshotPolicy.swift */; };
 		83ACC5A2A0BF5F5F3BA34894 /* HoverPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38E8668FFBC3522674AE29C /* HoverPopupOverlay.swift */; };
 		842F37A4A6D1D95F63E41E2A /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
 		86526CCD268BB390F0C14C53 /* AgentSurfaceTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 483AA21EF140F07296D1E16A /* AgentSurfaceTypes.swift */; };
@@ -181,6 +206,7 @@
 		8AB3B55F301192FA4F4A4E41 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		8B1190F4059EAA56BEC3954D /* NativeSidebarRegistry.swift in Sources */ = {isa = PBXBuildFile; fileRef = F7689397379CF6F761E34E67 /* NativeSidebarRegistry.swift */; };
 		8DBD574DB36A054FBCFC5DD8 /* MingaWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A733EF649EF21A761608D75 /* MingaWindow.swift */; };
+		8F2A7EB63F4884FF1C486874 /* ProtocolDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */; };
 		8FB0DF76DEB5112AD590BB11 /* CoreTextMetalRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */; };
 		91B8BE371D5CA58EC153394A /* WhichKeyOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 10FA7BF770B3453A402B9F78 /* WhichKeyOverlay.swift */; };
 		932C189ED218AC16620D8C19 /* BitmapRasterizer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 42375D2D8B25AF31BEB11AB5 /* BitmapRasterizer.swift */; };
@@ -193,6 +219,7 @@
 		95F6DCD24E2D261CF64EC8EB /* FontFace.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BC98120D82BD7548347875E /* FontFace.swift */; };
 		9758BF46BB0EC7FEEB14FBA3 /* SwiftUIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86478D5660213F165B7E1E35 /* SwiftUIViewTests.swift */; };
 		986CED792328DA9C1B22BF84 /* PreviewRegistry+GitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB5DAD0EAB1AE583E45AF5C /* PreviewRegistry+GitStatus.swift */; };
+		98B18D9FDEF20AFA62901108 /* Instrumentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */; };
 		9916B58B1B3AA32F063D2901 /* EmptyStateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6F41F2EB3E50F072FC68B88 /* EmptyStateView.swift */; };
 		9AA31CF152E2CD33E4BD2098 /* MingaProtocol.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		9B328F29A48C7C7EC810CB1B /* AgentApprovalCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492285F3371798B69478BF13 /* AgentApprovalCard.swift */; };
@@ -204,6 +231,7 @@
 		9F615B0B1750281E84BD25C1 /* GitStatusView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3ECFA1BAF013281143087097 /* GitStatusView.swift */; };
 		9F7CBB6787243AC4F0F1E8B7 /* ProtocolEventHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */; };
 		A07B320CE2B623ADBA433732 /* PreviewRegistry+Chrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF40BCB1722FAD446E1E6E52 /* PreviewRegistry+Chrome.swift */; };
+		A12056DE54484A143D4293AF /* ByteCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E609A9FCD637B39DD56497B /* ByteCursor.swift */; };
 		A17019B3C14044971571A5F1 /* ProtocolCommandSize.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762CD389E04B0DE6A86CDBF2 /* ProtocolCommandSize.generated.swift */; };
 		A23A42248D022DE42E122D0B /* WorkspaceIndicatorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B59BD32DD25D2C6C5A90D898 /* WorkspaceIndicatorView.swift */; };
 		A29BB96B8F84AA489CBA0C5F /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
@@ -211,6 +239,7 @@
 		A3B27DBFF9C2D200BEEE3B89 /* RenderPerformanceGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D563A97B0CB496D7906B53D /* RenderPerformanceGate.swift */; };
 		A409AE210CBAE48D4DCE47F7 /* ProtocolConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = C441427A427E23B912F70092 /* ProtocolConstants.swift */; };
 		A4329C17518FA82F5049A8EF /* PresentationScrollAnimatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 09DADB6D964450D692B37217 /* PresentationScrollAnimatorTests.swift */; };
+		A4737D68FB6735F26D2B54CB /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25503C21E0D55E1515A38C7D /* ScrollAccumulator.swift */; };
 		A4E838B0B19ED0B8F9CC4654 /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		A4F18CE5271CF85A08AFB06F /* ObservatoryState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67B23834E6FEB75E891AAFE2 /* ObservatoryState.swift */; };
 		A4F2EB67F3AC15AD8F8DAB32 /* SearchState.swift in Sources */ = {isa = PBXBuildFile; fileRef = F6104336F33C41EBE21B10F6 /* SearchState.swift */; };
@@ -236,15 +265,18 @@
 		B0A5712B943D48F8F72C1DDA /* KeyboardInputTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E4E980D53CCCE228BA59BD5 /* KeyboardInputTests.swift */; };
 		B0ED5B46A4F6317344D58C88 /* ByteCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E609A9FCD637B39DD56497B /* ByteCursor.swift */; };
 		B12FA22E8F25CE3E5F55366F /* WindowContentRendererTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */; };
+		B1744D1172F401BB1649EC96 /* NativeRenderPerformanceMain.swift in Sources */ = {isa = PBXBuildFile; fileRef = C96967ED4DCCC7465EC07D8B /* NativeRenderPerformanceMain.swift */; };
 		B21401DDB10E990350A3FB3F /* FrameMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */; };
 		B215CFD8C30AA26BAA9C5448 /* PickerOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3947E679EE2D80E4D8FED9E /* PickerOverlay.swift */; };
 		B280588DFCED52C9B2E0655C /* MingaUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; };
 		B308ADA08963E550E47FCDED /* EditorScrollTrackTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE2E468DA824CDB99FCEF94A /* EditorScrollTrackTests.swift */; };
 		B36F6632677AC067B8A7A2A4 /* FileTreeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 568352180EC6FAF208830660 /* FileTreeView.swift */; };
 		B3B08F3C63B5A5D2605C8611 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5647A59C841B3C408994CC7 /* Assets.xcassets */; };
+		B48BC4542B423D422705314A /* NativeTextCommandRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF00AA30A3F2887F49DA9E90 /* NativeTextCommandRouter.swift */; };
 		B4D102EA2208CBB90DB2D894 /* NativeRenderResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = E945E6E53217CEC4BAAECBDD /* NativeRenderResources.swift */; };
 		B4E3EC9A8E5388DF973D170F /* NativeRenderResourcesTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4819FED95BD6D1746F538DED /* NativeRenderResourcesTests.swift */; };
 		B5D79AA3EB89928091967F73 /* ProtocolEventHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */; };
+		B665502CAAED32DA5FBEC6CC /* PreviewRegistry+GitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB5DAD0EAB1AE583E45AF5C /* PreviewRegistry+GitStatus.swift */; };
 		B6F6BC02D79641B220329521 /* NativeRenderResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = E945E6E53217CEC4BAAECBDD /* NativeRenderResources.swift */; };
 		B7203DF9CF85663B0A266580 /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
 		B7EA51EE1C9145223251B68C /* ProtocolSemanticDecode.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = B639BCE7660087F70778E839 /* ProtocolSemanticDecode.generated.swift */; };
@@ -252,25 +284,33 @@
 		BA72343308BCD0E078452868 /* PowerThermalPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E27E6D9ACEB7DCD7F98FB0F /* PowerThermalPolicyTests.swift */; };
 		BA87497E73BB694BE1FCE77E /* GitStatusState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A68F78CBBEFBC90C5B5ED15 /* GitStatusState.swift */; };
 		BA9576ED247B43963BC588F2 /* MingaProtocol.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 848E04E4F242C861887769F3 /* MingaProtocol.framework */; };
+		BB5BB7400CA5B75887E7E5B1 /* MingaUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; };
 		BBFA84AD4053D2DDA336FBAF /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E89640A29C207B9040DC67 /* EditorView.swift */; };
+		BC7E4A33AC8A2DA8D861FB64 /* ThumbDragSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11AEAD1E631064BE3B13E42C /* ThumbDragSession.swift */; };
 		BCCC8F959EDD3B7C8525BA61 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DB822E0C8D06C7B45D329F /* EditorNSView.swift */; };
 		BF41C04B7AF7C400A4DC1474 /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
 		BF4E98B0BE647893CB5DA85C /* PipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */; };
 		BF89605C029E1F2F4EE328EA /* CoreTextMetalRendererCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5BA668E827BD6B77C72E9D6 /* CoreTextMetalRendererCursorTests.swift */; };
 		BFF766FB4240D9E306D3557E /* MingaApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A647814918768E62822D4A1 /* MingaApp.swift */; };
+		C0389E69F6B78917438E810C /* NativeRenderResources.swift in Sources */ = {isa = PBXBuildFile; fileRef = E945E6E53217CEC4BAAECBDD /* NativeRenderResources.swift */; };
+		C0EEC8AF693A8D2E47E7A8F3 /* PreviewRegistry+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6904499C06BDDEDCECC5D364 /* PreviewRegistry+AgentChat.swift */; };
 		C1EFCE9E5449DB7B04C386E3 /* PreviewRegistry+FileTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305F0E7D9158C236803224AA /* PreviewRegistry+FileTree.swift */; };
 		C2FC62BE435E26A8E579F8AD /* ProtocolTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08DE9CEF5C3D599B42635554 /* ProtocolTypes.swift */; };
 		C3FAE27B586C49B9172CD41A /* FrameMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */; };
 		C43DAF0776A77C3DE0EE6A90 /* ProtocolErrorState.swift in Sources */ = {isa = PBXBuildFile; fileRef = A915C3108F2370C753A1931B /* ProtocolErrorState.swift */; };
 		C44D9CF03C49E7BCA39A76A9 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
+		C4E49841C01BA2B55FF5DBE0 /* ProtocolEventHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */; };
 		C6BCAF6C4605DD682B8BC442 /* FloatPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37AA0E8F5D7D411B92E9E3FA /* FloatPopupOverlay.swift */; };
 		C6F817BD3BFBFA4C334DC229 /* FeedbackState.swift in Sources */ = {isa = PBXBuildFile; fileRef = EF185FF7AFC2D9E5430B6B65 /* FeedbackState.swift */; };
 		C715D937E8591D8BA46A29CD /* FontTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BD2DE335B00721CBB29329F9 /* FontTests.swift */; };
 		C9EE9DC782AEA94BAA0FC538 /* TabBarState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A2CBCDF99282365E723D45A /* TabBarState.swift */; };
 		CA07A054C4AD25FADA35DAF7 /* MinibufferState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7DCE12924B5A58CA615BA58 /* MinibufferState.swift */; };
+		CB84C04D898F6ADE2B2B0619 /* RendererComplexityGate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 816B39C0D25C2A0CBEA4F93F /* RendererComplexityGate.swift */; };
+		CC34849841451E9797F0FF8D /* EditorScrollTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44800E8F274B5EC453CAE7EB /* EditorScrollTrack.swift */; };
 		CCE118FC3021E69BB08F98BE /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E89640A29C207B9040DC67 /* EditorView.swift */; };
 		CD0AC714E46D3F95FE9AAE6F /* GUIFrameRoutingAndMetricsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 485DB41F09E703BBC203DBD0 /* GUIFrameRoutingAndMetricsTests.swift */; };
 		CD2952CCEB2FD594B269A75D /* GUIActionEncoderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2C629D58FF3305F579BA5E2 /* GUIActionEncoderTests.swift */; };
+		CD5139DFEABE5F0A2608FBB2 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DB822E0C8D06C7B45D329F /* EditorNSView.swift */; };
 		CE2F1915565DB90F4A7FC04C /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		CE65FF332E03ED47ADFBA48E /* EditorScrollTrack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 44800E8F274B5EC453CAE7EB /* EditorScrollTrack.swift */; };
 		CE8489B606217C3889536EBD /* PreviewRegistry+AgentChat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6904499C06BDDEDCECC5D364 /* PreviewRegistry+AgentChat.swift */; };
@@ -278,22 +318,28 @@
 		CF72EFC1EF2109055E2CE9F0 /* SearchToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7740BB367B27DD4B53FFB853 /* SearchToolbar.swift */; };
 		CF8B7220F4ECE08DAD597CD7 /* GUIFrameCorrelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C41D4B8B3DCF4A06CDF44 /* GUIFrameCorrelation.swift */; };
 		D016856873812B1D5433960E /* FloatPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B59F66E6260DE4B09FB563 /* FloatPopupState.swift */; };
+		D0221D782016237A28D9F356 /* CommandDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */; };
 		D201772572F4ECF891E73253 /* EditorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD617770357D4F3C286BBFF /* EditorPresentation.swift */; };
 		D394B6B62354CC4ADD76DB74 /* LatencyRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749F7E4A3595F1289002943E /* LatencyRecorder.swift */; };
+		D39F23DB142B71508F6DE03C /* RecoveryManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1A6769D066EC44A58791CFC /* RecoveryManager.swift */; };
 		D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */; };
+		D4557DCFEC94887B44D7D901 /* FrameMetrics.swift in Sources */ = {isa = PBXBuildFile; fileRef = FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */; };
 		D486A1CE007AF228798286B7 /* SidebarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34C34EC8FF8D20C141F2290 /* SidebarContainer.swift */; };
 		D4C960A3B32B98BE985C6ECA /* EditorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD617770357D4F3C286BBFF /* EditorPresentation.swift */; };
 		D52E7150799D94DC2204882A /* ByteCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E609A9FCD637B39DD56497B /* ByteCursor.swift */; };
 		D5F45455932847E76CA9A4E4 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA08D322A0BCE2491D4489D /* MessagesContentView.swift */; };
 		D916997E44A9619D08995FDA /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */; };
 		DA224DFB69915CFBFC50DDAE /* EditorGeometry+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */; };
+		DAA7EF98BE173F84E9F3E48E /* LiveResizeDebounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F60610CCB4E603ACBA360C1 /* LiveResizeDebounce.swift */; };
 		DAB6615DF756BFD9BFC420FF /* DecodedFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */; };
 		DB4EE4C9D35A3CCEA80442D6 /* WorkspaceState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D1EC68F918782FE2FCDB2413 /* WorkspaceState.swift */; };
 		DB83E9F1763A0D2E7BD7F7D3 /* ViewInspector in Frameworks */ = {isa = PBXBuildFile; productRef = BD2531C0969FD21CC18D2FDB /* ViewInspector */; };
 		DCCC540FD702D8D37013173F /* ScrollAccumulator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25503C21E0D55E1515A38C7D /* ScrollAccumulator.swift */; };
 		DD0B958D8ACEFFEF3C1A50AE /* ViewModelComputedTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 22420E1CC772DAFB9A5043C2 /* ViewModelComputedTests.swift */; };
+		DDA57E6CD5801C79E241BC90 /* ProtocolReader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4AF6BEBA233BA1169CF8C642 /* ProtocolReader.swift */; };
 		DF3B2A645C089F616B9DBD1B /* ProtocolEncoderDisconnectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19D226D16EF96375868F716D /* ProtocolEncoderDisconnectTests.swift */; };
 		DF3C7F2962B4563C54D82C8C /* PreviewSnapshotPolicyTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 100F1DE1D6A8C5A2065AC582 /* PreviewSnapshotPolicyTests.swift */; };
+		DF498FA4A0E14A495D35773F /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
 		E0F2C0021D714788A404E845 /* PresentationScrollAnimator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 29556A488CB8DABE4F7DBC51 /* PresentationScrollAnimator.swift */; };
 		E139B8F9FCA100EBDDC042AB /* ExtensionOverlayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AD9302C5E00767815DD10A7 /* ExtensionOverlayView.swift */; };
 		E1601C8BE90E7A7CB8F7F5DA /* ResyncState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 953A62EE436C9B1F73B97D07 /* ResyncState.swift */; };
@@ -309,21 +355,28 @@
 		E5D2C74777E92E16837B6846 /* AgentChatHeaderView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86A4DA796E10E4A7D98A18E1 /* AgentChatHeaderView.swift */; };
 		E6B945D114487F6BD18ADD31 /* FontManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79F5D551302873BE8F7240ED /* FontManager.swift */; };
 		E6F3BFAAB63F1108DFD81FBF /* RendererResidentSliceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7863B32F1CFA231CFB9F509B /* RendererResidentSliceTests.swift */; };
+		E7579240861B0DA10637C9A1 /* PreviewRegistry+Chrome.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF40BCB1722FAD446E1E6E52 /* PreviewRegistry+Chrome.swift */; };
 		E7A77B344139B5748EC8E4CC /* FeedbackStateTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E557E349097FF119EFE0F827 /* FeedbackStateTests.swift */; };
 		E8DAC5BD5013095E550BF4E8 /* CompletionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 124E376C3B8F6EC62765F5C1 /* CompletionState.swift */; };
 		E986DB2DA0989A52D16B1E69 /* PickerState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 60980E90FDD864409144BA5B /* PickerState.swift */; };
 		EA49ADC46692D8613D80EA2D /* NativeSidebarRegistryTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CA2269E199608D475AB34F10 /* NativeSidebarRegistryTests.swift */; };
+		ECE46C17B78255F1761E8DB0 /* ProtocolCommandSize.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 762CD389E04B0DE6A86CDBF2 /* ProtocolCommandSize.generated.swift */; };
 		ED8592B57E8A2A3EAAE24295 /* EditorNSView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98DB822E0C8D06C7B45D329F /* EditorNSView.swift */; };
 		EE84DA1BF4952359DD0DC343 /* LineTextureAtlas.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4742DDE225F256A140177301 /* LineTextureAtlas.swift */; };
+		EEA7BBE501D8F983046A091F /* PreviewRegistry+Overlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0D41B1D748FBFE7916342C /* PreviewRegistry+Overlays.swift */; };
 		EFB02B33864584C42AD0038E /* MingaUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */; };
 		F07A71D61F5E19EF77AD31D2 /* TabBarView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4CDC572B6F7D2CD90E07CA61 /* TabBarView.swift */; };
 		F0A2BCCA095F1CA4FBE9BE3F /* ProtocolSchemaTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */; };
+		F0B5BDD2F0982B527A05CDF8 /* BEAMProcessManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0EFEC421284D11AD2177113 /* BEAMProcessManager.swift */; };
 		F12D6284209D6D32037E6644 /* AppState.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9FC2118EA77254CBCAE7B0B /* AppState.swift */; };
+		F248E3D8C3ABC76F58955B6B /* EditorGeometry+App.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5F6F03841A5D97A688A35CC9 /* EditorGeometry+App.swift */; };
 		F3BB64E36F257BD7FACEA5D6 /* CoreTextShaders.metal in Sources */ = {isa = PBXBuildFile; fileRef = 48E21C30D142028698027567 /* CoreTextShaders.metal */; };
 		F3C4A9DABEF6FD369F8B1F45 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A84218125A9F97DBE87F349 /* ContentView.swift */; };
 		F47F466346CB7353AD5B4028 /* DecodedFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */; };
+		F5A14CECBF792E504031B38B /* PreviewRegistry+FileTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 305F0E7D9158C236803224AA /* PreviewRegistry+FileTree.swift */; };
 		F6774D86515DEFEFD0F3894B /* ProtocolEventHandoff.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB164EE3CF13E41E95FFD9AA /* ProtocolEventHandoff.swift */; };
 		F6F56719C285CB9C3EA62A57 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = F5647A59C841B3C408994CC7 /* Assets.xcassets */; };
+		F79A7BD26DFA628C643EB253 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13E89640A29C207B9040DC67 /* EditorView.swift */; };
 		F984C67E0F2861DE6A25DBD4 /* PreviewRegistry+GitStatus.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4BB5DAD0EAB1AE583E45AF5C /* PreviewRegistry+GitStatus.swift */; };
 		F986D696164E7D7483EF2DB4 /* PreviewRegistry+Overlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0D41B1D748FBFE7916342C /* PreviewRegistry+Overlays.swift */; };
 		F99ACADC9C8BF572A3E6115F /* PreviewSnapshotPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E1D0E05FBEEC550591460C7 /* PreviewSnapshotPolicy.swift */; };
@@ -337,11 +390,20 @@
 		FEA7FDF0B8C5551790872FCA /* WindowContentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FD7FC26DB745A436D50E3AA6 /* WindowContentTests.swift */; };
 		FEE7A22BC5E84F37E0054B6F /* DecodedFrame.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F42C05E1FECBE9422C61790 /* DecodedFrame.swift */; };
 		FEFCEFCDC21C5AA5456036D0 /* SystemColorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56B00002D020FED57D265C74 /* SystemColorTests.swift */; };
+		FF0739EA09327D30D5B6DD3B /* PipelineCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */; };
+		FF534047392CCD846A9D327D /* OffscreenMetalReadback.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3E755C715672C47760940CA7 /* OffscreenMetalReadback.swift */; };
 		FFA8B5D73FABC2792F4A3589 /* ProtocolDecoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 56750F0AAE58AF9A98BF5841 /* ProtocolDecoder.swift */; };
 		FFE9F4F1490B1937AD3AC129 /* PreviewRegistry+Overlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9A0D41B1D748FBFE7916342C /* PreviewRegistry+Overlays.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		11E7EF0AEA69376CA0D28F8F /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 408C02F1934F748B5B5586FC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 969B3EB40D6CCF3C8DC3F1F9;
+			remoteInfo = MingaUI;
+		};
 		3AA4E51F5469EEE2AA5A84CE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 408C02F1934F748B5B5586FC /* Project object */;
@@ -362,6 +424,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 969B3EB40D6CCF3C8DC3F1F9;
 			remoteInfo = MingaUI;
+		};
+		691BDA111CF818DC80D84171 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 408C02F1934F748B5B5586FC /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 853A7F20F3909F3BE071C5E6;
+			remoteInfo = MingaProtocol;
 		};
 		6CD45D78D9315C323464A999 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -487,6 +556,7 @@
 		3C85068F0199E155E5349C53 /* ExtensionOverlayState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExtensionOverlayState.swift; sourceTree = "<group>"; };
 		3DC281B7F9F7E4C0BA793B1E /* ProtocolSchemaTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolSchemaTests.swift; sourceTree = "<group>"; };
 		3E23DC6E0ACB156F21293E87 /* PortLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PortLogger.swift; sourceTree = "<group>"; };
+		3E755C715672C47760940CA7 /* OffscreenMetalReadback.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffscreenMetalReadback.swift; sourceTree = "<group>"; };
 		3ECFA1BAF013281143087097 /* GitStatusView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GitStatusView.swift; sourceTree = "<group>"; };
 		3EE75BA15B74A84B77B5B911 /* PipelineCache.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PipelineCache.swift; sourceTree = "<group>"; };
 		414C8FEBAF13F134A617D886 /* AgentChatState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AgentChatState.swift; sourceTree = "<group>"; };
@@ -512,6 +582,7 @@
 		4CDC572B6F7D2CD90E07CA61 /* TabBarView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabBarView.swift; sourceTree = "<group>"; };
 		510D1033E87B077777E8FD64 /* GUIFrameSwiftUIInvalidationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIFrameSwiftUIInvalidationTests.swift; sourceTree = "<group>"; };
 		51E88C12915EC4EBE96165AF /* FileTreeHeaderView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FileTreeHeaderView.swift; sourceTree = "<group>"; };
+		51F0B55F4608ACA6BDB7CB3E /* TemporalOffscreenMetalTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemporalOffscreenMetalTests.swift; sourceTree = "<group>"; };
 		53CEDDFB3856C44BA51C8A7B /* Instrumentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Instrumentation.swift; sourceTree = "<group>"; };
 		54D2036E3609EB1C3E575CFC /* BottomPanelView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BottomPanelView.swift; sourceTree = "<group>"; };
 		5634B25BE5BB945A83E30FAD /* StateLifecycleTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateLifecycleTests.swift; sourceTree = "<group>"; };
@@ -573,6 +644,7 @@
 		912C5F808709BABFF3126DEE /* AppearanceSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppearanceSettingsView.swift; sourceTree = "<group>"; };
 		92E717A483EC2E50C536785C /* InputEncoder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InputEncoder.swift; sourceTree = "<group>"; };
 		953A62EE436C9B1F73B97D07 /* ResyncState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ResyncState.swift; sourceTree = "<group>"; };
+		97BD64EBD5278692573ADEBA /* NativeRenderPerformance */ = {isa = PBXFileReference; includeInIndex = 0; path = NativeRenderPerformance; sourceTree = BUILT_PRODUCTS_DIR; };
 		98DB822E0C8D06C7B45D329F /* EditorNSView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorNSView.swift; sourceTree = "<group>"; };
 		9978FBBB4E1BC671AF1C49F5 /* PreviewHostApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PreviewHostApp.swift; sourceTree = "<group>"; };
 		9A0D41B1D748FBFE7916342C /* PreviewRegistry+Overlays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "PreviewRegistry+Overlays.swift"; sourceTree = "<group>"; };
@@ -612,6 +684,7 @@
 		C441427A427E23B912F70092 /* ProtocolConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolConstants.swift; sourceTree = "<group>"; };
 		C50661EF3472E892F77AF9C2 /* KeybindingsSettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeybindingsSettingsView.swift; sourceTree = "<group>"; };
 		C6154F8ABA71694035D38ED2 /* GUIColorSlots.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GUIColorSlots.swift; sourceTree = "<group>"; };
+		C96967ED4DCCC7465EC07D8B /* NativeRenderPerformanceMain.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeRenderPerformanceMain.swift; sourceTree = "<group>"; };
 		CA105569D96F7654005293B2 /* ActivityBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivityBar.swift; sourceTree = "<group>"; };
 		CA2269E199608D475AB34F10 /* NativeSidebarRegistryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NativeSidebarRegistryTests.swift; sourceTree = "<group>"; };
 		CC335D7973205BF8B7EDD8EA /* WindowContentRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowContentRenderer.swift; sourceTree = "<group>"; };
@@ -682,6 +755,15 @@
 			buildActionMask = 2147483647;
 			files = (
 				A5ABF2822747A306951D59AE /* MingaProtocol.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8C2817EBDB4990304CFE8923 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				3B65693EFE431AD00660D754 /* MingaProtocol.framework in Frameworks */,
+				BB5BB7400CA5B75887E7E5B1 /* MingaUI.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -859,6 +941,7 @@
 			isa = PBXGroup;
 			children = (
 				EF010AC81BF7F66D126A242B /* MingaTests */,
+				E21EB402C3CF337C600FBBEC /* NativePerformance */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -1022,6 +1105,14 @@
 			path = Agent;
 			sourceTree = "<group>";
 		};
+		E21EB402C3CF337C600FBBEC /* NativePerformance */ = {
+			isa = PBXGroup;
+			children = (
+				C96967ED4DCCC7465EC07D8B /* NativeRenderPerformanceMain.swift */,
+			);
+			path = NativePerformance;
+			sourceTree = "<group>";
+		};
 		E8CFD7B30DBBE5DA4A27BC1A /* EditorChrome */ = {
 			isa = PBXGroup;
 			children = (
@@ -1066,6 +1157,7 @@
 				848E04E4F242C861887769F3 /* MingaProtocol.framework */,
 				64CEFB02A774E5E8EF19029F /* MingaTests.xctest */,
 				7D941F158B53B4D4CF4AAA4F /* MingaUI.framework */,
+				97BD64EBD5278692573ADEBA /* NativeRenderPerformance */,
 				26134C841A15020D9C61E4F9 /* PreviewHost.app */,
 			);
 			name = Products;
@@ -1104,6 +1196,7 @@
 				4819FED95BD6D1746F538DED /* NativeRenderResourcesTests.swift */,
 				CA2269E199608D475AB34F10 /* NativeSidebarRegistryTests.swift */,
 				4B3DDF1EB804D4E31EDFA519 /* NonBlockingEncoderTests.swift */,
+				3E755C715672C47760940CA7 /* OffscreenMetalReadback.swift */,
 				E235842E924833B02390F375 /* PickerQueryFieldTests.swift */,
 				00EC9D6E3E77B85DF13841B4 /* PickerStateTests.swift */,
 				321E4E28F5F49F089CCE2E1D /* PipelineCacheTests.swift */,
@@ -1128,6 +1221,7 @@
 				5634B25BE5BB945A83E30FAD /* StateLifecycleTests.swift */,
 				86478D5660213F165B7E1E35 /* SwiftUIViewTests.swift */,
 				56B00002D020FED57D265C74 /* SystemColorTests.swift */,
+				51F0B55F4608ACA6BDB7CB3E /* TemporalOffscreenMetalTests.swift */,
 				F086ACF8E4F305C9DDAE24FF /* ThemeColorsTests.swift */,
 				22420E1CC772DAFB9A5043C2 /* ViewModelComputedTests.swift */,
 				620F7F967502D4F1F7AE8F03 /* WindowContentRendererTests.swift */,
@@ -1161,6 +1255,27 @@
 			productName = MingaTests;
 			productReference = 64CEFB02A774E5E8EF19029F /* MingaTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		5F0005CFBBE5B5BCF7C310E0 /* NativeRenderPerformance */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 14B2F9D1BCAAF186936F1567 /* Build configuration list for PBXNativeTarget "NativeRenderPerformance" */;
+			buildPhases = (
+				AB3377FF36C885204FE3C13A /* Generate protocol opcodes */,
+				37B95ECD09B57D0C0A26F4F5 /* Sources */,
+				8C2817EBDB4990304CFE8923 /* Frameworks */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				BDCD942BF64F4D653BF8DEFC /* PBXTargetDependency */,
+				22712CAAE127D0D4F23219FE /* PBXTargetDependency */,
+			);
+			name = NativeRenderPerformance;
+			packageProductDependencies = (
+			);
+			productName = NativeRenderPerformance;
+			productReference = 97BD64EBD5278692573ADEBA /* NativeRenderPerformance */;
+			productType = "com.apple.product-type.tool";
 		};
 		662577BE79F99FA071ADF484 /* MingaIPC */ = {
 			isa = PBXNativeTarget;
@@ -1292,11 +1407,12 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				D96277718552247F338DD197 /* Minga */,
-				662577BE79F99FA071ADF484 /* MingaIPC */,
 				853A7F20F3909F3BE071C5E6 /* MingaProtocol */,
-				2734C1C657DD572768745C3F /* MingaTests */,
 				969B3EB40D6CCF3C8DC3F1F9 /* MingaUI */,
+				662577BE79F99FA071ADF484 /* MingaIPC */,
+				D96277718552247F338DD197 /* Minga */,
+				2734C1C657DD572768745C3F /* MingaTests */,
+				5F0005CFBBE5B5BCF7C310E0 /* NativeRenderPerformance */,
 				AD057EA18D39D4B97E8AE743 /* PreviewHost */,
 			);
 		};
@@ -1386,6 +1502,25 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "cd \"${SRCROOT}/..\"\nif ! command -v mix >/dev/null 2>&1; then\n  if [ -f macos/.generated/protocol/ProtocolOpcodes.generated.swift ]; then\n    echo \"warning: mix not found; reusing existing generated protocol artifacts (e.g. Xcode Preview build sandbox)\"\n    exit 0\n  fi\n  echo \"error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen\"\n  exit 1\nfi\nmix protocol.gen\n";
+		};
+		AB3377FF36C885204FE3C13A /* Generate protocol opcodes */ = {
+			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Generate protocol opcodes";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "if [[ \"${MINGA_NATIVE_RENDER_SKIP_PROTOCOL_GEN:-0}\" == \"1\" ]]; then\n  exit 0\nfi\ncd \"${SRCROOT}/..\"\nmix protocol.gen\n";
 		};
 		DB4598C0910E3166689E6F1A /* Codesign */ = {
 			isa = PBXShellScriptBuildPhase;
@@ -1488,6 +1623,64 @@
 				CE2F1915565DB90F4A7FC04C /* SlotAllocator.swift in Sources */,
 				346A7206B13063768245AC96 /* ThumbDragSession.swift in Sources */,
 				4ADE54090FEEF5AA2A6C86A0 /* WindowContentRenderer.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		37B95ECD09B57D0C0A26F4F5 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				6F9C2C373304BAEF0F5BB93F /* AppState.swift in Sources */,
+				F0B5BDD2F0982B527A05CDF8 /* BEAMProcessManager.swift in Sources */,
+				53EDC20DDE726C337975B053 /* BitmapRasterizer.swift in Sources */,
+				A12056DE54484A143D4293AF /* ByteCursor.swift in Sources */,
+				48D002490916CE1B42DCA825 /* CachedLineTexture.swift in Sources */,
+				D0221D782016237A28D9F356 /* CommandDispatcher.swift in Sources */,
+				29C378441427D0BCE64A68AE /* CoreTextMetalRenderer.swift in Sources */,
+				6F13186CB83B8FF2870F9D49 /* CoreTextShaders.metal in Sources */,
+				199BEA8FC7B5C8696014027F /* DecodedFrame.swift in Sources */,
+				F248E3D8C3ABC76F58955B6B /* EditorGeometry+App.swift in Sources */,
+				CD5139DFEABE5F0A2608FBB2 /* EditorNSView.swift in Sources */,
+				2DC7C337561B2DD304BD22D0 /* EditorPresentation.swift in Sources */,
+				CC34849841451E9797F0FF8D /* EditorScrollTrack.swift in Sources */,
+				F79A7BD26DFA628C643EB253 /* EditorView.swift in Sources */,
+				15F65BBF4297D723F7C47A28 /* FontFace.swift in Sources */,
+				21D2F006D7D827CA7E024F84 /* FontManager.swift in Sources */,
+				D4557DCFEC94887B44D7D901 /* FrameMetrics.swift in Sources */,
+				DF498FA4A0E14A495D35773F /* FrameState.swift in Sources */,
+				245180E7A0626A8C48245493 /* IMEComposition.swift in Sources */,
+				98B18D9FDEF20AFA62901108 /* Instrumentation.swift in Sources */,
+				06D741E1FB11DDFC35EC3B18 /* LineTextureAtlas.swift in Sources */,
+				DAA7EF98BE173F84E9F3E48E /* LiveResizeDebounce.swift in Sources */,
+				0636EFFAF2BE90489D553917 /* MingaWindow.swift in Sources */,
+				B1744D1172F401BB1649EC96 /* NativeRenderPerformanceMain.swift in Sources */,
+				C0389E69F6B78917438E810C /* NativeRenderResources.swift in Sources */,
+				B48BC4542B423D422705314A /* NativeTextCommandRouter.swift in Sources */,
+				FF0739EA09327D30D5B6DD3B /* PipelineCache.swift in Sources */,
+				65C137EB08F6E784742D5B68 /* PowerThermalPolicy.swift in Sources */,
+				05A024F8BFA924976FB7D68D /* PreparedFrameTransaction.swift in Sources */,
+				0E7636FCDD5DA74E56E49EA9 /* PresentationScrollAnimator.swift in Sources */,
+				C0EEC8AF693A8D2E47E7A8F3 /* PreviewRegistry+AgentChat.swift in Sources */,
+				E7579240861B0DA10637C9A1 /* PreviewRegistry+Chrome.swift in Sources */,
+				F5A14CECBF792E504031B38B /* PreviewRegistry+FileTree.swift in Sources */,
+				B665502CAAED32DA5FBEC6CC /* PreviewRegistry+GitStatus.swift in Sources */,
+				EEA7BBE501D8F983046A091F /* PreviewRegistry+Overlays.swift in Sources */,
+				8064EA19AD10D1790AECC0A9 /* PreviewSnapshotPolicy.swift in Sources */,
+				ECE46C17B78255F1761E8DB0 /* ProtocolCommandSize.generated.swift in Sources */,
+				10A82EBF290447A56787873C /* ProtocolConstants.swift in Sources */,
+				8F2A7EB63F4884FF1C486874 /* ProtocolDecoder.swift in Sources */,
+				634A3C578E804955D95008BC /* ProtocolEncoder.swift in Sources */,
+				C4E49841C01BA2B55FF5DBE0 /* ProtocolEventHandoff.swift in Sources */,
+				3535A85D824D23299BA91A86 /* ProtocolOpcodes.generated.swift in Sources */,
+				DDA57E6CD5801C79E241BC90 /* ProtocolReader.swift in Sources */,
+				6184BD99497BC7DED163F04F /* ProtocolSemanticDecode.generated.swift in Sources */,
+				D39F23DB142B71508F6DE03C /* RecoveryManager.swift in Sources */,
+				CB84C04D898F6ADE2B2B0619 /* RendererComplexityGate.swift in Sources */,
+				286916557519E9A3B7EDA241 /* RendererSignposts.swift in Sources */,
+				A4737D68FB6735F26D2B54CB /* ScrollAccumulator.swift in Sources */,
+				111AC046FBBCDCCEB7E02F27 /* SlotAllocator.swift in Sources */,
+				BC7E4A33AC8A2DA8D861FB64 /* ThumbDragSession.swift in Sources */,
+				521052DC241D93D8C4AA8CA3 /* WindowContentRenderer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1733,6 +1926,7 @@
 				EA49ADC46692D8613D80EA2D /* NativeSidebarRegistryTests.swift in Sources */,
 				34F2E7C171D777C4CE7F0978 /* NativeTextCommandRouter.swift in Sources */,
 				6EE7C16703E92B31CC9CE9C0 /* NonBlockingEncoderTests.swift in Sources */,
+				FF534047392CCD846A9D327D /* OffscreenMetalReadback.swift in Sources */,
 				715BDC47F6D55E8C7765068C /* PickerQueryFieldTests.swift in Sources */,
 				798E677ABC34C730785559B4 /* PickerStateTests.swift in Sources */,
 				BF4E98B0BE647893CB5DA85C /* PipelineCache.swift in Sources */,
@@ -1780,6 +1974,7 @@
 				0BCDFB56E8397D739F52ED34 /* StateLifecycleTests.swift in Sources */,
 				9758BF46BB0EC7FEEB14FBA3 /* SwiftUIViewTests.swift in Sources */,
 				FEFCEFCDC21C5AA5456036D0 /* SystemColorTests.swift in Sources */,
+				3CA33261F251A71830F618AA /* TemporalOffscreenMetalTests.swift in Sources */,
 				61CF67858355FFF4962D9D99 /* ThemeColorsTests.swift in Sources */,
 				4400C2DBBACCF83790714235 /* ThumbDragSession.swift in Sources */,
 				DD0B958D8ACEFFEF3C1A50AE /* ViewModelComputedTests.swift in Sources */,
@@ -1807,6 +2002,11 @@
 			target = 853A7F20F3909F3BE071C5E6 /* MingaProtocol */;
 			targetProxy = 90C4F94B902B7ADD11FFE5E9 /* PBXContainerItemProxy */;
 		};
+		22712CAAE127D0D4F23219FE /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 969B3EB40D6CCF3C8DC3F1F9 /* MingaUI */;
+			targetProxy = 11E7EF0AEA69376CA0D28F8F /* PBXContainerItemProxy */;
+		};
 		54CBF20E3992D0B45F1B64AA /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 969B3EB40D6CCF3C8DC3F1F9 /* MingaUI */;
@@ -1832,9 +2032,31 @@
 			target = 662577BE79F99FA071ADF484 /* MingaIPC */;
 			targetProxy = 4045B01EC0CF76B0ABD127B2 /* PBXContainerItemProxy */;
 		};
+		BDCD942BF64F4D653BF8DEFC /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 853A7F20F3909F3BE071C5E6 /* MingaProtocol */;
+			targetProxy = 691BDA111CF818DC80D84171 /* PBXContainerItemProxy */;
+		};
 /* End PBXTargetDependency section */
 
 /* Begin XCBuildConfiguration section */
+		024AB834C8F8CAC92B0F85C2 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.minga.NativeRenderPerformance;
+				PRODUCT_NAME = "minga-native-render-performance";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) MINGA_SNAPSHOT_RENDERER";
+				TOOLCHAINS = com.apple.dt.toolchain.Metal.32023.864;
+			};
+			name = Debug;
+		};
 		03D1C4FA288798B824DB15EC /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1991,6 +2213,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.minga.MingaTests;
 				PRODUCT_NAME = MingaTests;
 				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) MINGA_SNAPSHOT_RENDERER";
 				TOOLCHAINS = com.apple.dt.toolchain.Metal.32023.864;
 			};
 			name = Release;
@@ -2049,6 +2272,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = com.minga.MingaTests;
 				PRODUCT_NAME = MingaTests;
 				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) MINGA_SNAPSHOT_RENDERER";
 				TOOLCHAINS = com.apple.dt.toolchain.Metal.32023.864;
 			};
 			name = Debug;
@@ -2066,6 +2290,23 @@
 				PRODUCT_NAME = "minga-ipc";
 				SDKROOT = macosx;
 				SWIFT_VERSION = 6.0;
+			};
+			name = Release;
+		};
+		A598EDF02D6326B2CC339BAE /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COMBINE_HIDPI_IMAGES = YES;
+				GENERATE_INFOPLIST_FILE = YES;
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/../Frameworks",
+				);
+				PRODUCT_BUNDLE_IDENTIFIER = com.minga.NativeRenderPerformance;
+				PRODUCT_NAME = "minga-native-render-performance";
+				SDKROOT = macosx;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) MINGA_SNAPSHOT_RENDERER";
+				TOOLCHAINS = com.apple.dt.toolchain.Metal.32023.864;
 			};
 			name = Release;
 		};
@@ -2208,6 +2449,15 @@
 			buildConfigurations = (
 				333BBE9DFB9A1207127F43FA /* Debug */,
 				03D1C4FA288798B824DB15EC /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Debug;
+		};
+		14B2F9D1BCAAF186936F1567 /* Build configuration list for PBXNativeTarget "NativeRenderPerformance" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				024AB834C8F8CAC92B0F85C2 /* Debug */,
+				A598EDF02D6326B2CC339BAE /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Debug;

--- a/macos/Minga.xcodeproj/project.pbxproj
+++ b/macos/Minga.xcodeproj/project.pbxproj
@@ -127,6 +127,7 @@
 		6700C63C4B7070D3388A7BD4 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		686DD6EB8AFDCAFC79EA100A /* ProtocolTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F220A60775A252A728477659 /* ProtocolTests.swift */; };
 		68886327B4EB9F0766EB7DCD /* PowerThermalPolicy.swift in Sources */ = {isa = PBXBuildFile; fileRef = B4D576456737CFE8706B66F5 /* PowerThermalPolicy.swift */; };
+		68AEF7AED091ADB42400AAFE /* RendererSnapshotTestSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = F4285AA8E914B2ECEF3DC5F3 /* RendererSnapshotTestSupport.swift */; };
 		6A2F6CEFE2775E2872C4759C /* PickerQueryField.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF9F40C96A90C86754F90D7C /* PickerQueryField.swift */; };
 		6A53A9D9731FD7CCDACEC9E5 /* RendererSignposts.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F37BEAA7D7267D29882A632 /* RendererSignposts.swift */; };
 		6AFA24DC3EE21023636C136A /* ProtocolOpcodes.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25B93E05D6126B3BC32280CA /* ProtocolOpcodes.generated.swift */; };
@@ -161,6 +162,7 @@
 		7BA75B36E9A9573C57571C53 /* AgentContextBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 63D118F59FBCA463A52B84FA /* AgentContextBar.swift */; };
 		7BCDF8E63FDADFCADFCA5276 /* ByteCursorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D220B640A214311083EE8B4 /* ByteCursorTests.swift */; };
 		7C9B7CB6670412D9F4DE60BB /* ProtocolEncoder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7CDC524DEAE5431F6B18A31B /* ProtocolEncoder.swift */; };
+		7D7B070451AD0F32911A133B /* EditorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD617770357D4F3C286BBFF /* EditorPresentation.swift */; };
 		7FE374C007A79192530A6B26 /* SlotAllocator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 371C61E78D4BB39467516BA7 /* SlotAllocator.swift */; };
 		83ACC5A2A0BF5F5F3BA34894 /* HoverPopupOverlay.swift in Sources */ = {isa = PBXBuildFile; fileRef = A38E8668FFBC3522674AE29C /* HoverPopupOverlay.swift */; };
 		842F37A4A6D1D95F63E41E2A /* FrameState.swift in Sources */ = {isa = PBXBuildFile; fileRef = D2D59D9EEB390C8DF351D595 /* FrameState.swift */; };
@@ -276,9 +278,11 @@
 		CF72EFC1EF2109055E2CE9F0 /* SearchToolbar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7740BB367B27DD4B53FFB853 /* SearchToolbar.swift */; };
 		CF8B7220F4ECE08DAD597CD7 /* GUIFrameCorrelation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A9C41D4B8B3DCF4A06CDF44 /* GUIFrameCorrelation.swift */; };
 		D016856873812B1D5433960E /* FloatPopupState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 07B59F66E6260DE4B09FB563 /* FloatPopupState.swift */; };
+		D201772572F4ECF891E73253 /* EditorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD617770357D4F3C286BBFF /* EditorPresentation.swift */; };
 		D394B6B62354CC4ADD76DB74 /* LatencyRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 749F7E4A3595F1289002943E /* LatencyRecorder.swift */; };
 		D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */; };
 		D486A1CE007AF228798286B7 /* SidebarContainer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E34C34EC8FF8D20C141F2290 /* SidebarContainer.swift */; };
+		D4C960A3B32B98BE985C6ECA /* EditorPresentation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DD617770357D4F3C286BBFF /* EditorPresentation.swift */; };
 		D52E7150799D94DC2204882A /* ByteCursor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E609A9FCD637B39DD56497B /* ByteCursor.swift */; };
 		D5F45455932847E76CA9A4E4 /* MessagesContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BA08D322A0BCE2491D4489D /* MessagesContentView.swift */; };
 		D916997E44A9619D08995FDA /* IMEComposition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 048C53BF025A1476EE8BC1A7 /* IMEComposition.swift */; };
@@ -458,6 +462,7 @@
 		1BB45C5B630FDEDFD0BD6BE0 /* EditTimelineState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditTimelineState.swift; sourceTree = "<group>"; };
 		1BD0DFA1F5211213E7AD6FA7 /* SidebarViewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SidebarViewTests.swift; sourceTree = "<group>"; };
 		1D563A97B0CB496D7906B53D /* RenderPerformanceGate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RenderPerformanceGate.swift; sourceTree = "<group>"; };
+		1DD617770357D4F3C286BBFF /* EditorPresentation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorPresentation.swift; sourceTree = "<group>"; };
 		1E1059DF5F524F5FC2B697EC /* LatencyHUDOverlay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyHUDOverlay.swift; sourceTree = "<group>"; };
 		1F2A06C5BA9E3F53A59E202F /* BEAMProcessManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BEAMProcessManagerTests.swift; sourceTree = "<group>"; };
 		1F37BEAA7D7267D29882A632 /* RendererSignposts.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RendererSignposts.swift; sourceTree = "<group>"; };
@@ -644,6 +649,7 @@
 		F1F77D3367DCC1BAD0BCC1BE /* TabIconColors.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TabIconColors.swift; sourceTree = "<group>"; };
 		F220A60775A252A728477659 /* ProtocolTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ProtocolTests.swift; sourceTree = "<group>"; };
 		F330603D06228BB2A18F71F5 /* FrontendExtensionRuntimeMessage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FrontendExtensionRuntimeMessage.swift; sourceTree = "<group>"; };
+		F4285AA8E914B2ECEF3DC5F3 /* RendererSnapshotTestSupport.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RendererSnapshotTestSupport.swift; sourceTree = "<group>"; };
 		F4B4CB36A83E4FEBF0B58397 /* LatencyHUDState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LatencyHUDState.swift; sourceTree = "<group>"; };
 		F5647A59C841B3C408994CC7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		F6104336F33C41EBE21B10F6 /* SearchState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchState.swift; sourceTree = "<group>"; };
@@ -770,6 +776,7 @@
 				C21AB9021A9BCB034C13109A /* CommandDispatcher.swift */,
 				5DDE4A535E0895090BF02EE8 /* CoreTextMetalRenderer.swift */,
 				48E21C30D142028698027567 /* CoreTextShaders.metal */,
+				1DD617770357D4F3C286BBFF /* EditorPresentation.swift */,
 				FA1B4D69D3277F2372A8F6F1 /* FrameMetrics.swift */,
 				D2D59D9EEB390C8DF351D595 /* FrameState.swift */,
 				4742DDE225F256A140177301 /* LineTextureAtlas.swift */,
@@ -1110,6 +1117,7 @@
 				F220A60775A252A728477659 /* ProtocolTests.swift */,
 				E1AF508EECAEFEA4ADC41409 /* RecoveryManagerTests.swift */,
 				7863B32F1CFA231CFB9F509B /* RendererResidentSliceTests.swift */,
+				F4285AA8E914B2ECEF3DC5F3 /* RendererSnapshotTestSupport.swift */,
 				31E6BD3E6A84E3117BD3C7AF /* RenderPerformanceGateTests.swift */,
 				D7FFB77269C17AB9036BC17B /* ResidentRowStoreTests.swift */,
 				211424F30BBE8A57852D5630 /* ScrollAccumulatorTests.swift */,
@@ -1440,6 +1448,7 @@
 				DAB6615DF756BFD9BFC420FF /* DecodedFrame.swift in Sources */,
 				DA224DFB69915CFBFC50DDAE /* EditorGeometry+App.swift in Sources */,
 				ED8592B57E8A2A3EAAE24295 /* EditorNSView.swift in Sources */,
+				7D7B070451AD0F32911A133B /* EditorPresentation.swift in Sources */,
 				281A9531103F9E962B3F31A7 /* EditorScrollTrack.swift in Sources */,
 				78621BB35169CCFF26C753DD /* EditorView.swift in Sources */,
 				95F6DCD24E2D261CF64EC8EB /* FontFace.swift in Sources */,
@@ -1497,6 +1506,7 @@
 				FEE7A22BC5E84F37E0054B6F /* DecodedFrame.swift in Sources */,
 				6DC89F81DBC022B3FCBA39BB /* EditorGeometry+App.swift in Sources */,
 				E27074789DFFC30C49DD40D0 /* EditorNSView.swift in Sources */,
+				D4C960A3B32B98BE985C6ECA /* EditorPresentation.swift in Sources */,
 				CE65FF332E03ED47ADFBA48E /* EditorScrollTrack.swift in Sources */,
 				BBFA84AD4053D2DDA336FBAF /* EditorView.swift in Sources */,
 				123999564C3B1FE9804B13B0 /* FontFace.swift in Sources */,
@@ -1689,6 +1699,7 @@
 				A6327C6FAB3DCFD57327FBF4 /* DecoderRobustnessTests.swift in Sources */,
 				2388D1CC8878556958DA4A0D /* EditorGeometry+App.swift in Sources */,
 				BCCC8F959EDD3B7C8525BA61 /* EditorNSView.swift in Sources */,
+				D201772572F4ECF891E73253 /* EditorPresentation.swift in Sources */,
 				9D1D5E11F9839F86F7A7BA70 /* EditorScrollTrack.swift in Sources */,
 				B308ADA08963E550E47FCDED /* EditorScrollTrackTests.swift in Sources */,
 				CCE118FC3021E69BB08F98BE /* EditorView.swift in Sources */,
@@ -1757,6 +1768,7 @@
 				11B3954DAF033C87DD94828E /* RendererComplexityGate.swift in Sources */,
 				E6F3BFAAB63F1108DFD81FBF /* RendererResidentSliceTests.swift in Sources */,
 				1BEBAB013862C0F8F1972209 /* RendererSignposts.swift in Sources */,
+				68AEF7AED091ADB42400AAFE /* RendererSnapshotTestSupport.swift in Sources */,
 				384AC3273F54DFE9E87177C6 /* ResidentRowStoreTests.swift in Sources */,
 				DCCC540FD702D8D37013173F /* ScrollAccumulator.swift in Sources */,
 				D42695D627BD38405475ECFF /* ScrollAccumulatorTests.swift in Sources */,

--- a/macos/Sources/EditorGeometry+App.swift
+++ b/macos/Sources/EditorGeometry+App.swift
@@ -16,7 +16,7 @@ extension EditorGeometry {
                 cellWidth: v.cellWidth,
                 cellHeight: v.cellHeight,
                 viewportWidth: v.bounds.width,
-                gutterCol: Int(v.dispatcher.frameState.gutterCol),
+                gutterCol: Int(v.dispatcher.committedEditorSnapshot?.gutterCol ?? 0),
                 gutterLeftMargin: CoreTextMetalRenderer.gutterLeftMarginPt,
                 gutterRightGap: CoreTextMetalRenderer.gutterRightGapPt
             )

--- a/macos/Sources/MingaApp.swift
+++ b/macos/Sources/MingaApp.swift
@@ -751,7 +751,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
 
         // Re-send ready event so the new BEAM knows our dimensions.
         if let nsView = editorNSView {
-            let gutterPad: CGFloat = nsView.dispatcher.frameState.gutterCol > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+            let gutterPad: CGFloat = (nsView.dispatcher.committedEditorSnapshot?.gutterCol ?? 0) > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
             let cols = UInt16(max((nsView.bounds.width - gutterPad) / CGFloat(nsView.cellWidth), 1))
             let rows = UInt16(nsView.bounds.height / CGFloat(nsView.cellHeight))
             enc.sendReady(cols: cols, rows: rows)

--- a/macos/Sources/PreviewRegistry.swift
+++ b/macos/Sources/PreviewRegistry.swift
@@ -299,30 +299,7 @@ enum PreviewRegistry {
     }
 
     private static func populateEditorFrame(dispatcher: CommandDispatcher, guiState: GUIState) {
-        dispatcher.frameState.defaultBg = 0x282C34
-        dispatcher.frameState.gutterCol = 4
-        dispatcher.frameState.gutterSeparatorColor = 0x3E4452
-        dispatcher.frameState.cursorRow = 5
-        dispatcher.frameState.cursorCol = 12
-        dispatcher.frameState.cursorShape = .beam
-        dispatcher.frameState.cursorlineRow = 5
-        dispatcher.frameState.cursorlineBg = 0x2C323C
-        dispatcher.frameState.totalLineCount = 1250
-        dispatcher.frameState.viewportTopLine = 38
-        dispatcher.frameState.scrollIndicatorColor = 0x5C6370
-        // Indent guides for the visible window, matching previewEditorRows()
-        // (2-space Elixir indent). The cursor's enclosing level (col 2) is the
-        // active guide. Exercises the same render path the BEAM drives via the
-        // gui_indent_guides (0x91) opcode so the snapshot reflects the real
-        // editor surface rather than underselling it.
-        dispatcher.frameState.windowIndentGuides[1] = IndentGuideData(
-            windowId: 1,
-            tabWidth: 2,
-            activeGuideCol: 2,
-            guideCols: [0, 2],
-            lineIndentLevels: [0, 1, 1, 1, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
-        )
-        dispatcher.frameState.windowGutters[1] = Wire.WindowGutter(
+        let gutter = Wire.WindowGutter(
             windowId: 1,
             contentRow: 1,
             contentCol: 0,
@@ -335,7 +312,19 @@ enum PreviewRegistry {
             signColWidth: 1,
             entries: previewGutterEntries()
         )
-        guiState.windowContents[1] = try GUIWindowContent(
+        // Indent guides for the visible window, matching previewEditorRows()
+        // (2-space Elixir indent). The cursor's enclosing level (col 2) is the
+        // active guide. Exercises the same render path the BEAM drives via the
+        // gui_indent_guides (0x91) opcode so the committed snapshot reflects the
+        // real editor surface rather than underselling it.
+        let indentGuides = IndentGuideData(
+            windowId: 1,
+            tabWidth: 2,
+            activeGuideCol: 2,
+            guideCols: [0, 2],
+            lineIndentLevels: [0, 1, 1, 1, 2, 2, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        )
+        let content = try GUIWindowContent(
             windowId: 1,
             fullRefresh: true,
             cursorVisible: true,
@@ -348,11 +337,93 @@ enum PreviewRegistry {
             diagnosticUnderlines: [GUIDiagnosticUnderline(startRow: 4, startCol: 20, endRow: 4, endCol: 31, severity: .warning)],
             documentHighlights: [GUIDocumentHighlight(startRow: 5, startCol: 4, endRow: 5, endCol: 10, kind: .read)],
             lineAnnotations: [],
+            paneGeometry: previewPaneGeometry(for: gutter, totalLineCount: 1250),
             // Current-line band on the cursor row. The renderer reads the
             // per-window cursorline (CoreTextMetalRenderer drawWindowedContent),
             // not frameState, so it must be set here to render.
             cursorline: GUICursorline(row: 5, bg: 0x2C323C)
         )
+        commitPreviewEditorFrame(
+            dispatcher: dispatcher,
+            defaultBg: 0x282C34,
+            gutterSeparatorColor: 0x3E4452,
+            cursorlineRow: 5,
+            cursorlineBg: 0x2C323C,
+            totalLineCount: 1250,
+            scrollIndicatorColor: 0x5C6370,
+            cursorShape: .beam,
+            content: content,
+            gutter: gutter,
+            indentGuides: indentGuides
+        )
+    }
+
+    /// Derives a committed pane geometry from a preview gutter so the snapshot
+    /// freeze accepts the surface. The editor authority (window content, gutter,
+    /// cursor shape, indent guides) now lives only on `CommittedEditorSnapshot`
+    /// (#2999 AC6), so previews must drive a real keyframe rather than mutating
+    /// removed `FrameState` fields.
+    private static func previewPaneGeometry(for gutter: Wire.WindowGutter, totalLineCount: UInt32) -> GUIPaneGeometry {
+        let gutterWidth = UInt16(gutter.lineNumberWidth) + UInt16(gutter.signColWidth)
+        let totalRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutter.contentWidth, height: gutter.contentHeight)
+        let textRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol + gutterWidth, width: gutter.contentWidth - gutterWidth, height: gutter.contentHeight)
+        let gutterRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutterWidth, height: gutter.contentHeight)
+        let totalLines = max(totalLineCount, UInt32(gutter.contentHeight))
+        return GUIPaneGeometry(
+            windowId: gutter.windowId,
+            totalRect: totalRect,
+            contentRect: totalRect,
+            textRect: textRect,
+            gutterRect: gutterRect,
+            clipRect: totalRect,
+            viewport: GUIViewportSummary(top: 0, left: 0, rows: gutter.contentHeight, cols: textRect.width, totalLines: totalLines, visualRowOffset: 0, totalVisualRows: totalLines),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: UInt16(gutter.lineNumberWidth), signColWidth: UInt16(gutter.signColWidth)),
+            hitRegions: gutterWidth == 0 ? [] : [GUIHitRegion(kind: .gutter, rect: gutterRect, windowId: gutter.windowId)]
+        )
+    }
+
+    /// Required theme slots painted a neutral grey. The snapshot freeze validates
+    /// only that every required slot is present; the committed `themeColors` are
+    /// frozen from the pre-apply defaults, so these values do not change preview
+    /// fidelity — they exist to satisfy the keyframe theme-completeness gate.
+    private static func previewThemeSlots() -> [(UInt8, UInt8, UInt8, UInt8)] {
+        CommandDispatcher.requiredThemeSlots.map { ($0, 0x99, 0x99, 0x99) }
+    }
+
+    /// Publishes a preview editor keyframe through the real begin/commit path so
+    /// `dispatcher.committedEditorSnapshot` is populated for `draw`. Chrome-only
+    /// `FrameState` fields (background, cursorline band, totals, scroll indicator)
+    /// are seeded directly because they still live on `FrameState`; editor
+    /// authority is carried by the dispatched commands (#2999 AC6).
+    private static func commitPreviewEditorFrame(
+        dispatcher: CommandDispatcher,
+        defaultBg: UInt32,
+        gutterSeparatorColor: UInt32,
+        cursorlineRow: UInt16,
+        cursorlineBg: UInt32,
+        totalLineCount: UInt32,
+        scrollIndicatorColor: UInt32,
+        cursorShape: CursorShape,
+        content: GUIWindowContent,
+        gutter: Wire.WindowGutter,
+        indentGuides: IndentGuideData?
+    ) {
+        dispatcher.frameState.defaultBg = defaultBg
+        dispatcher.frameState.gutterSeparatorColor = gutterSeparatorColor
+        dispatcher.frameState.cursorlineRow = cursorlineRow
+        dispatcher.frameState.cursorlineBg = cursorlineBg
+        dispatcher.frameState.totalLineCount = totalLineCount
+        dispatcher.frameState.scrollIndicatorColor = scrollIndicatorColor
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: previewThemeSlots()))
+        dispatcher.dispatch(.setCursorShape(cursorShape))
+        dispatcher.dispatch(.guiWindowContent(data: content))
+        dispatcher.dispatch(.guiGutter(data: gutter))
+        if let indentGuides {
+            dispatcher.dispatch(.guiIndentGuides(data: indentGuides))
+        }
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
     }
 
     private static func previewGutterEntries() -> [Wire.GutterEntry] {
@@ -455,18 +526,7 @@ enum PreviewRegistry {
     }
 
     private static func populateDiagnosticsEditorFrame(dispatcher: CommandDispatcher, guiState: GUIState) {
-        dispatcher.frameState.defaultBg = 0x282C34
-        dispatcher.frameState.gutterCol = 4
-        dispatcher.frameState.gutterSeparatorColor = 0x3E4452
-        dispatcher.frameState.cursorRow = 5
-        dispatcher.frameState.cursorCol = 12
-        dispatcher.frameState.cursorShape = .beam
-        dispatcher.frameState.cursorlineRow = 5
-        dispatcher.frameState.cursorlineBg = 0x2C323C
-        dispatcher.frameState.totalLineCount = 1250
-        dispatcher.frameState.viewportTopLine = 38
-        dispatcher.frameState.scrollIndicatorColor = 0x5C6370
-        dispatcher.frameState.windowGutters[1] = Wire.WindowGutter(
+        let gutter = Wire.WindowGutter(
             windowId: 1,
             contentRow: 1,
             contentCol: 0,
@@ -479,7 +539,7 @@ enum PreviewRegistry {
             signColWidth: 1,
             entries: previewDiagnosticsGutterEntries()
         )
-        guiState.windowContents[1] = try GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1,
             fullRefresh: true,
             cursorVisible: true,
@@ -495,7 +555,21 @@ enum PreviewRegistry {
                 GUIDiagnosticUnderline(startRow: 1, startCol: 8, endRow: 1, endCol: 20, severity: .info),
             ],
             documentHighlights: [],
-            lineAnnotations: []
+            lineAnnotations: [],
+            paneGeometry: previewPaneGeometry(for: gutter, totalLineCount: 1250)
+        )
+        commitPreviewEditorFrame(
+            dispatcher: dispatcher,
+            defaultBg: 0x282C34,
+            gutterSeparatorColor: 0x3E4452,
+            cursorlineRow: 5,
+            cursorlineBg: 0x2C323C,
+            totalLineCount: 1250,
+            scrollIndicatorColor: 0x5C6370,
+            cursorShape: .beam,
+            content: content,
+            gutter: gutter,
+            indentGuides: nil
         )
     }
 

--- a/macos/Sources/Protocol/RenderPerformanceGate.swift
+++ b/macos/Sources/Protocol/RenderPerformanceGate.swift
@@ -358,3 +358,221 @@ public enum RenderPerformanceGate {
 
     private static func format(_ value: Double) -> String { String(format: "%.2f", value) }
 }
+
+/// End-to-end Release measurement for one native editor rendering batch.
+public struct NativeRenderPerformanceMeasurement: Codable, Equatable, Sendable {
+    /// Median transaction-freeze plus publication duration.
+    public let freezePublicationP50Ms: Double
+    /// P95 transaction-freeze plus publication duration.
+    public let freezePublicationP95Ms: Double
+    /// Median CPU time spent preparing and encoding a warm native draw.
+    public let drawCPUP50Ms: Double
+    /// P95 CPU time spent preparing and encoding a warm native draw.
+    public let drawCPUP95Ms: Double
+    /// P99 CPU time spent preparing and encoding a warm native draw.
+    public let drawCPUP99Ms: Double
+    /// Median GPU time across render and drawable-copy command buffers.
+    public let gpuP50Ms: Double
+    /// P95 GPU time across render and drawable-copy command buffers.
+    public let gpuP95Ms: Double
+    /// Median wall time from committed snapshot handoff through completion of the drawable-copy command.
+    public let completionWallP50Ms: Double
+    /// P95 wall time from committed snapshot handoff through completion of the drawable-copy command.
+    public let completionWallP95Ms: Double
+    /// Largest number of bytes allocated by native draw resources in any measured warm frame.
+    public let maximumAllocatedBytesPerFrame: Int
+    /// Native buffer or texture allocation calls observed after warm-up.
+    public let allocationCountAfterWarmup: Int
+    /// Frames submitted to the measured native path.
+    public let attemptedFrameCount: Int
+    /// Frames that completed the drawable-copy command and requested presentation.
+    public let copyCompletedFrameCount: Int
+    /// Frames failed or discarded before drawable-copy completion.
+    public let failedOrDiscardedFrameCount: Int
+    /// Largest number of native presentation generations simultaneously in flight.
+    public let maximumInFlightGenerations: Int
+
+    /// Creates one complete native render measurement.
+    public init(
+        freezePublicationP50Ms: Double,
+        freezePublicationP95Ms: Double,
+        drawCPUP50Ms: Double,
+        drawCPUP95Ms: Double,
+        drawCPUP99Ms: Double,
+        gpuP50Ms: Double,
+        gpuP95Ms: Double,
+        completionWallP50Ms: Double,
+        completionWallP95Ms: Double,
+        maximumAllocatedBytesPerFrame: Int,
+        allocationCountAfterWarmup: Int,
+        attemptedFrameCount: Int,
+        copyCompletedFrameCount: Int,
+        failedOrDiscardedFrameCount: Int,
+        maximumInFlightGenerations: Int
+    ) {
+        self.freezePublicationP50Ms = freezePublicationP50Ms
+        self.freezePublicationP95Ms = freezePublicationP95Ms
+        self.drawCPUP50Ms = drawCPUP50Ms
+        self.drawCPUP95Ms = drawCPUP95Ms
+        self.drawCPUP99Ms = drawCPUP99Ms
+        self.gpuP50Ms = gpuP50Ms
+        self.gpuP95Ms = gpuP95Ms
+        self.completionWallP50Ms = completionWallP50Ms
+        self.completionWallP95Ms = completionWallP95Ms
+        self.maximumAllocatedBytesPerFrame = maximumAllocatedBytesPerFrame
+        self.allocationCountAfterWarmup = allocationCountAfterWarmup
+        self.attemptedFrameCount = attemptedFrameCount
+        self.copyCompletedFrameCount = copyCompletedFrameCount
+        self.failedOrDiscardedFrameCount = failedOrDiscardedFrameCount
+        self.maximumInFlightGenerations = maximumInFlightGenerations
+    }
+}
+
+/// Fail-closed budgets for the complete native editor presentation path.
+public enum NativeRenderPerformanceGate {
+    /// Ordinary snapshot freeze and publication p95 budget.
+    public static let freezePublicationP95BudgetMs = 1.0
+    /// Warm cursor and local-scroll draw CPU p95 budget.
+    public static let drawCPUP95BudgetMs = 2.5
+    /// Warm cursor and local-scroll draw CPU p99 budget.
+    public static let drawCPUP99BudgetMs = 4.0
+    /// GPU render plus drawable-copy active-time p95 budget for a 120 Hz refresh interval.
+    public static let gpuP95BudgetMs = 8.33
+    /// End-to-end handoff through drawable-copy completion p95 budget for a 120 Hz refresh interval.
+    public static let completionWallP95BudgetMs = 8.33
+    /// Largest supported number of native presentation generations in flight.
+    public static let maximumInFlightGenerations = 3
+    /// Largest permitted paired median regression for end-to-end presentation p50.
+    public static let maximumPairedRegressionRatio = 1.10
+
+    /// Returns every absolute native-render budget violation.
+    public static func absoluteFailures(_ measurement: NativeRenderPerformanceMeasurement) -> [String] {
+        var failures = validationFailures(measurement)
+        guard failures.isEmpty else { return failures }
+
+        check("freeze_publication p95", measurement.freezePublicationP95Ms,
+              freezePublicationP95BudgetMs, &failures)
+        check("draw_cpu p95", measurement.drawCPUP95Ms, drawCPUP95BudgetMs, &failures)
+        check("draw_cpu p99", measurement.drawCPUP99Ms, drawCPUP99BudgetMs, &failures)
+        check("gpu_active_time p95", measurement.gpuP95Ms, gpuP95BudgetMs, &failures)
+        check("handoff_to_copy_completion p95", measurement.completionWallP95Ms,
+              completionWallP95BudgetMs, &failures)
+        if measurement.maximumAllocatedBytesPerFrame != 0 {
+            failures.append("warm frames allocated up to \(measurement.maximumAllocatedBytesPerFrame) bytes")
+        }
+        if measurement.allocationCountAfterWarmup != 0 {
+            failures.append("warm frames performed \(measurement.allocationCountAfterWarmup) native allocations")
+        }
+        if measurement.failedOrDiscardedFrameCount != 0 {
+            failures.append("native rendering failed or discarded \(measurement.failedOrDiscardedFrameCount) frames")
+        }
+        if measurement.maximumInFlightGenerations > maximumInFlightGenerations {
+            failures.append("native presentation retained \(measurement.maximumInFlightGenerations) generations; limit is \(maximumInFlightGenerations)")
+        }
+        return failures
+    }
+
+    /// Returns absolute HEAD failures plus the paired end-to-end p50 regression failure.
+    public static func pairedFailures(
+        base: NativeRenderPerformanceMeasurement,
+        head: NativeRenderPerformanceMeasurement
+    ) -> [String] {
+        pairedFailures(
+            baseMeasurements: [base, base, base],
+            headMeasurements: [head, head, head]
+        )
+    }
+
+    /// Returns failures for an odd set of at least three adjacent same-runner base/HEAD pairs.
+    public static func pairedFailures(
+        baseMeasurements: [NativeRenderPerformanceMeasurement],
+        headMeasurements: [NativeRenderPerformanceMeasurement]
+    ) -> [String] {
+        guard baseMeasurements.count == headMeasurements.count else {
+            return ["native paired measurements have unequal counts"]
+        }
+        guard baseMeasurements.count >= 3, baseMeasurements.count.isMultiple(of: 2) == false else {
+            return ["native paired comparison requires an odd count of at least three"]
+        }
+        for measurement in baseMeasurements where !validationFailures(measurement).isEmpty {
+            return ["invalid native base measurement"]
+        }
+        for measurement in headMeasurements where !validationFailures(measurement).isEmpty {
+            return ["invalid native HEAD measurement"]
+        }
+
+        var failures = absoluteFailures(aggregate(headMeasurements))
+        let ratios = zip(baseMeasurements, headMeasurements).map { base, head in
+            head.completionWallP50Ms / base.completionWallP50Ms
+        }
+        let ratio = median(ratios)
+        if ratio > maximumPairedRegressionRatio {
+            failures.append(
+                "native handoff-to-copy-completion p50 paired median ratio \(format(ratio))x exceeds \(format(maximumPairedRegressionRatio))x"
+            )
+        }
+        return failures
+    }
+
+    private static func validationFailures(_ measurement: NativeRenderPerformanceMeasurement) -> [String] {
+        var failures: [String] = []
+        let durations = [
+            ("freeze_publication p50", measurement.freezePublicationP50Ms),
+            ("freeze_publication p95", measurement.freezePublicationP95Ms),
+            ("draw_cpu p50", measurement.drawCPUP50Ms),
+            ("draw_cpu p95", measurement.drawCPUP95Ms),
+            ("draw_cpu p99", measurement.drawCPUP99Ms),
+            ("gpu p50", measurement.gpuP50Ms),
+            ("gpu_active_time p95", measurement.gpuP95Ms),
+            ("handoff_to_copy_completion p50", measurement.completionWallP50Ms),
+            ("handoff_to_copy_completion p95", measurement.completionWallP95Ms)
+        ]
+        for (name, value) in durations where !value.isFinite || value <= 0 {
+            failures.append("\(name) must be finite and greater than zero")
+        }
+        if measurement.maximumAllocatedBytesPerFrame < 0 || measurement.allocationCountAfterWarmup < 0
+            || measurement.attemptedFrameCount <= 0 || measurement.copyCompletedFrameCount <= 0
+            || measurement.failedOrDiscardedFrameCount < 0 || measurement.maximumInFlightGenerations <= 0
+            || measurement.copyCompletedFrameCount + measurement.failedOrDiscardedFrameCount != measurement.attemptedFrameCount {
+            failures.append("native render counters are invalid or incomplete")
+        }
+        return failures
+    }
+
+    private static func aggregate(
+        _ measurements: [NativeRenderPerformanceMeasurement]
+    ) -> NativeRenderPerformanceMeasurement {
+        NativeRenderPerformanceMeasurement(
+            freezePublicationP50Ms: median(measurements.map(\.freezePublicationP50Ms)),
+            freezePublicationP95Ms: median(measurements.map(\.freezePublicationP95Ms)),
+            drawCPUP50Ms: median(measurements.map(\.drawCPUP50Ms)),
+            drawCPUP95Ms: median(measurements.map(\.drawCPUP95Ms)),
+            drawCPUP99Ms: median(measurements.map(\.drawCPUP99Ms)),
+            gpuP50Ms: median(measurements.map(\.gpuP50Ms)),
+            gpuP95Ms: median(measurements.map(\.gpuP95Ms)),
+            completionWallP50Ms: median(measurements.map(\.completionWallP50Ms)),
+            completionWallP95Ms: median(measurements.map(\.completionWallP95Ms)),
+            maximumAllocatedBytesPerFrame: measurements.map(\.maximumAllocatedBytesPerFrame).max() ?? 0,
+            allocationCountAfterWarmup: measurements.map(\.allocationCountAfterWarmup).max() ?? 0,
+            attemptedFrameCount: Int(median(measurements.map { Double($0.attemptedFrameCount) })),
+            copyCompletedFrameCount: Int(median(measurements.map { Double($0.copyCompletedFrameCount) })),
+            failedOrDiscardedFrameCount: measurements.map(\.failedOrDiscardedFrameCount).max() ?? 0,
+            maximumInFlightGenerations: measurements.map(\.maximumInFlightGenerations).max() ?? 0
+        )
+    }
+
+    private static func median(_ values: [Double]) -> Double { values.sorted()[values.count / 2] }
+
+    private static func check(
+        _ name: String,
+        _ measured: Double,
+        _ limit: Double,
+        _ failures: inout [String]
+    ) {
+        if measured > limit {
+            failures.append("\(name) \(format(measured))ms exceeds \(format(limit))ms")
+        }
+    }
+
+    private static func format(_ value: Double) -> String { String(format: "%.2f", value) }
+}

--- a/macos/Sources/Protocol/RenderPerformanceGate.swift
+++ b/macos/Sources/Protocol/RenderPerformanceGate.swift
@@ -143,7 +143,7 @@ public enum RenderPerformanceGate {
     /// Absolute p95 ceiling for the combined native preparation path.
     public static let combinedAbsoluteBudgetMs = 8.0
     /// Largest allowed ratio between a measurement and its checked-in reference.
-    public static let maximumRegressionRatio = 1.20
+    public static let maximumRegressionRatio = 1.10
     /// Minimum absolute allowance for sub-millisecond measurement variance.
     public static let minimumRegressionAllowanceMs = 0.05
     /// Number of independent batches required for the authoritative median aggregate.

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -151,8 +151,11 @@ final class CommandDispatcher {
     /// The newest complete committed editor snapshot available for Metal submission.
     private(set) var committedEditorSnapshot: CommittedEditorSnapshot?
 
-    /// The exact committed editor snapshot associated with the last successful Metal presentation.
-    private(set) var visibleEditorSnapshot: CommittedEditorSnapshot?
+    /// The exact editor presentation associated with the last successful Metal presentation.
+    private(set) var visibleEditorPresentation: VisibleEditorPresentation?
+
+    /// Backward-compatible view of the visible semantic snapshot.
+    var visibleEditorSnapshot: CommittedEditorSnapshot? { visibleEditorPresentation?.snapshot }
 
     /// The committed editor frame identity awaiting Metal presentation, owned by the editor lifecycle rather than telemetry.
     private var pendingEditorPresentationFrame: GUICommittedFrame?
@@ -169,26 +172,32 @@ final class CommandDispatcher {
         pendingEditorPresentationFrame
     }
 
-    /// Promotes the exact captured snapshot after its drawable presents successfully.
-    func promoteVisibleEditorSnapshot(_ snapshot: CommittedEditorSnapshot) {
-        let presentedFrame = GUICommittedFrame(generation: snapshot.generation, frameSeq: snapshot.frameSeq)
-        if let pendingFrame = pendingEditorPresentationFrame {
-            guard pendingFrame == presentedFrame else { return }
+    /// Promotes the exact captured presentation after its drawable presents successfully.
+    func promoteVisibleEditorPresentation(snapshot: CommittedEditorSnapshot, localTransform: EditorLocalPresentationTransform?) {
+        let presentedFrame = editorFrame(for: snapshot)
+        if let visibleFrame = visibleEditorSnapshot.map(editorFrame(for:)),
+           Self.isPresentedFrame(presentedFrame, olderThan: visibleFrame) {
+            return
+        }
+
+        visibleEditorPresentation = VisibleEditorPresentation(snapshot: snapshot, localTransform: localTransform)
+        if pendingEditorPresentationFrame == presentedFrame {
             pendingEditorPresentationFrame = nil
-            visibleEditorSnapshot = snapshot
-            return
         }
+    }
 
-        if let visibleFrame = visibleEditorSnapshot.map({ GUICommittedFrame(generation: $0.generation, frameSeq: $0.frameSeq) }), visibleFrame == presentedFrame {
-            visibleEditorSnapshot = snapshot
-            return
-        }
+    /// Test and compatibility seam for callers that have no frontend-local transform.
+    func promoteVisibleEditorSnapshot(_ snapshot: CommittedEditorSnapshot) {
+        promoteVisibleEditorPresentation(snapshot: snapshot, localTransform: nil)
+    }
 
-        if visibleEditorSnapshot == nil,
-           let committedFrame = committedEditorSnapshot.map({ GUICommittedFrame(generation: $0.generation, frameSeq: $0.frameSeq) }),
-           committedFrame == presentedFrame {
-            visibleEditorSnapshot = snapshot
-        }
+    private func editorFrame(for snapshot: CommittedEditorSnapshot) -> GUICommittedFrame {
+        GUICommittedFrame(generation: snapshot.generation, frameSeq: snapshot.frameSeq)
+    }
+
+    private static func isPresentedFrame(_ lhs: GUICommittedFrame, olderThan rhs: GUICommittedFrame) -> Bool {
+        if lhs.generation != rhs.generation { return lhs.generation < rhs.generation }
+        return lhs.frameSeq < rhs.frameSeq
     }
 
     /// Discards an applied frame that cannot acquire a drawable/presentation path.
@@ -381,6 +390,7 @@ final class CommandDispatcher {
             generation: generation,
             committedWindows: guiState.windowContents,
             committedGutters: frameState.windowGutters,
+            committedIndentGuides: frameState.windowIndentGuides,
             registeredFontIds: registeredFontIds,
             committedTranscript: guiState.agentChatState.transcriptSnapshot,
             stagingLimit: resourcePolicy.staging.weight,
@@ -440,7 +450,7 @@ final class CommandDispatcher {
             return
         }
 
-        switch transactionBuilder.freeze(requiredThemeSlots: Self.requiredThemeSlots) {
+        switch transactionBuilder.freeze(requiredThemeSlots: Self.requiredThemeSlots, frameState: frameState, themeColors: guiState.themeColors) {
         case .failure(let rejection):
             reject(rejection, frameSeq: frameSeq, logReason: rejection.logDescription)
             return
@@ -506,21 +516,10 @@ final class CommandDispatcher {
             for command in focus.commands { apply(command, effects: &effects) }
         }
         if clearsResync { guiState.resyncState.clear() }
-        if finalImpact.contains(.editor) || committedEditorSnapshot == nil {
-            switch CommittedEditorSnapshot.make(
-                generation: transaction.generation,
-                frameSeq: transaction.frameSeq,
-                frameState: frameState,
-                themeColors: guiState.themeColors,
-                windowContents: guiState.windowContents
-            ) {
-            case .success(let snapshot):
-                committedEditorSnapshot = snapshot
-                if finalImpact.contains(.editor) {
-                    pendingEditorPresentationFrame = committed
-                }
-            case .failure(let rejection):
-                PortLogger.error("Committed editor snapshot rejected after semantic apply: \(rejection.logDescription)")
+        if let snapshot = transaction.editorSnapshot {
+            committedEditorSnapshot = snapshot
+            if finalImpact.contains(.editor) {
+                pendingEditorPresentationFrame = committed
             }
         }
         replay(effects)

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -136,6 +136,13 @@ final class CommandDispatcher {
     /// Tracks the last mode to detect changes.
     private var lastMode: UInt8 = 0
 
+    /// Tracks the last emitted line spacing so the `lineSpacingChanged` effect is
+    /// detected against prior committed state. Publication installs the snapshot's
+    /// `frameState` (which already carries the staged line spacing) before the
+    /// prepared `gui_line_spacing` command replays, so a `frameState`-local delta
+    /// check would always miss the change (#2999 AC6 staging).
+    private var lastLineSpacing: Float = 1.0
+
     /// All GUI chrome sub-states. Injected at init from AppDelegate.
     /// Non-optional: forgetting to wire this is a compile-time error.
     let guiState: GUIState
@@ -384,13 +391,18 @@ final class CommandDispatcher {
         openBaseFrameSeq = baseFrameSeq
         openGeneration = generation
         openGenerationIsStale = hasCommitted && generation < lastCommittedGeneration
+        // Seed the builder from the prior committed editor snapshot — the single
+        // semantic authority — never from the resident-window backing or mutable
+        // FrameState mirrors (#2999 AC6). Base-0 keyframes start empty regardless.
+        let priorSnapshot = committedEditorSnapshot
         transactionBuilder = PreparedFrameTransactionBuilder(
             frameSeq: frameSeq,
             baseFrameSeq: baseFrameSeq,
             generation: generation,
-            committedWindows: guiState.windowContents,
-            committedGutters: frameState.windowGutters,
-            committedIndentGuides: frameState.windowIndentGuides,
+            committedWindows: priorSnapshot?.windowContents ?? [:],
+            committedGutters: priorSnapshot?.windowGutters ?? [:],
+            committedIndentGuides: priorSnapshot?.windowIndentGuides ?? [:],
+            committedMetadata: priorSnapshot?.metadata ?? .empty,
             registeredFontIds: registeredFontIds,
             committedTranscript: guiState.agentChatState.transcriptSnapshot,
             stagingLimit: resourcePolicy.staging.weight,
@@ -492,6 +504,7 @@ final class CommandDispatcher {
             generation: transaction.generation,
             frameSeq: transaction.frameSeq
         )
+        let priorSnapshot = committedEditorSnapshot
         var effects: [CommitEffect] = []
         if let theme = transaction.theme {
             apply(.guiTheme(slots: theme.slots), effects: &effects)
@@ -499,7 +512,26 @@ final class CommandDispatcher {
         if let resources = transaction.resources {
             for command in resources.commands { apply(command, effects: &effects) }
         }
-        if let windows = transaction.windows { apply(windows, effects: &effects) }
+        // Install the committed editor snapshot — the sole editor authority — before
+        // any derived projection. Editor window content/gutter/geometry/cursor/
+        // split/active-window state is never mirrored back into FrameState; the
+        // snapshot's own frameState carries only chrome/theme render metadata.
+        if let snapshot = transaction.editorSnapshot {
+            frameState = snapshot.frameState
+            committedEditorSnapshot = snapshot
+            if finalImpact.contains(.editor) {
+                pendingEditorPresentationFrame = committed
+            }
+            // The resident-window backing is a read-only projection of the snapshot consumed by extension overlays (chrome-only GUI state); it is never the seed for the next transaction. Metadata-only snapshots do not rewrite an identical observable projection.
+            if let changedWindowIds = transaction.residentProjectionWindowIds {
+                projectResidentWindows(
+                    from: snapshot,
+                    priorSnapshot: priorSnapshot,
+                    changedWindowIds: changedWindowIds,
+                    effects: &effects
+                )
+            }
+        }
         if let metadata = transaction.metadata {
             for command in metadata.commands { apply(command, effects: &effects) }
         }
@@ -516,13 +548,6 @@ final class CommandDispatcher {
             for command in focus.commands { apply(command, effects: &effects) }
         }
         if clearsResync { guiState.resyncState.clear() }
-        if let snapshot = transaction.editorSnapshot {
-            frameState = snapshot.frameState
-            committedEditorSnapshot = snapshot
-            if finalImpact.contains(.editor) {
-                pendingEditorPresentationFrame = committed
-            }
-        }
         replay(effects)
         guiState.presentationMetrics.beginCommitted(frame: committed, impact: finalImpact)
         publicationCount += 1
@@ -539,40 +564,26 @@ final class CommandDispatcher {
         replay(effects)
     }
 
-    private func apply(_ updates: PreparedWindowUpdates, effects: inout [CommitEffect]) {
-        for (windowId, content) in updates.replacements {
-            let previousScroll = guiState.windowContents[windowId]?.scrollPresentation
-            guiState.windowContents[windowId] = content
-            if shouldResetScrollPresentation(previous: previousScroll, next: content.scrollPresentation) {
-                effects.append(.scrollPresentationReset(windowID: windowId))
+    /// Projects the committed snapshot's window content into the resident-window
+    /// backing so extension overlays (chrome-only GUI state) observe it. This is
+    /// a one-way projection from the authority; the next transaction seeds from
+    /// the snapshot, never from this backing (#2999 AC6). Stale windows absent
+    /// from the snapshot are pruned, preserving keyframe prune behavior. Scroll
+    /// presentation resets are detected against the prior committed snapshot so
+    /// frontend-local scroll ownership is preserved.
+    private func projectResidentWindows(
+        from snapshot: CommittedEditorSnapshot,
+        priorSnapshot: CommittedEditorSnapshot?,
+        changedWindowIds: Set<UInt16>,
+        effects: inout [CommitEffect]
+    ) {
+        for surface in snapshot.surfaces where changedWindowIds.contains(surface.windowId) {
+            let previousScroll = priorSnapshot?.content(for: surface.windowId)?.scrollPresentation
+            if shouldResetScrollPresentation(previous: previousScroll, next: surface.content.scrollPresentation) {
+                effects.append(.scrollPresentationReset(windowID: surface.windowId))
             }
-            frameState.cursorVisible = content.cursorVisible
         }
-        for command in updates.commands { apply(command, effects: &effects) }
-        if let authoritativeWindowIds = updates.authoritativeWindowIds {
-            pruneAuthoritativeFrameState(liveWindowIds: authoritativeWindowIds)
-        }
-    }
-
-    private func pruneAuthoritativeFrameState(liveWindowIds: Set<UInt16>) {
-        guiState.windowContents = Dictionary(uniqueKeysWithValues: guiState.windowContents.filter { liveWindowIds.contains($0.key) })
-        frameState.windowGutters = Dictionary(uniqueKeysWithValues: frameState.windowGutters.filter { liveWindowIds.contains($0.key) })
-        frameState.windowIndentGuides = Dictionary(uniqueKeysWithValues: frameState.windowIndentGuides.filter { liveWindowIds.contains($0.key) })
-        if let activeWindowId = frameState.activeWindowId, !liveWindowIds.contains(activeWindowId) {
-            frameState.activeWindowId = nil
-        }
-        refreshDerivedGutterStateAfterPrune()
-    }
-
-    private func refreshDerivedGutterStateAfterPrune() {
-        guard let activeGutter = frameState.windowGutters.values.filter(\.isActive).sorted(by: { $0.windowId < $1.windowId }).first else {
-            frameState.gutterCol = 0
-            frameState.viewportTopLine = 0xFFFF_FFFF
-            return
-        }
-
-        frameState.gutterCol = UInt16(activeGutter.lineNumberWidth) + UInt16(activeGutter.signColWidth)
-        frameState.viewportTopLine = activeGutter.entries.first?.bufLine ?? 0xFFFF_FFFF
+        guiState.windowContents = snapshot.windowContents
     }
 
     /// Rejects one frame, leaves the last-good publication untouched, and emits
@@ -798,8 +809,11 @@ final class CommandDispatcher {
     /// in `dispatch`/`commitTransaction`, not the presented state.
     private func apply(_ command: RenderCommand, effects: inout [CommitEffect]) {
         switch command {
-        case .setCursorShape(let shape):
-            frameState.cursorShape = shape
+        case .setCursorShape:
+            // The editor-global cursor shape is frozen into the committed
+            // snapshot's metadata during freeze; publication does not mirror it
+            // back into FrameState (#2999 AC6).
+            break
 
         case .beginFrame, .commitFrame:
             // Frame markers drive the transaction state machine in `dispatch`,
@@ -883,14 +897,18 @@ final class CommandDispatcher {
             guiState.agentContextBarState.update(visible: visible, task: task, dispatchTimestamp: dispatchTimestamp,
                                                   status: status, canApprove: canApprove, progress: progress, todos: todos)
 
-        case .guiIndentGuides(let data):
-            frameState.windowIndentGuides[data.windowId] = data
+        case .guiIndentGuides:
+            // Indent guides are owned by the committed snapshot's surfaces; the
+            // freeze builds them from staged state and publication never mirrors
+            // them into FrameState (#2999 AC6).
+            break
 
         case .guiLineSpacing(let spacing):
-            let oldSpacing = frameState.lineSpacing
-            frameState.lineSpacing = max(spacing, 1.0)
-            if oldSpacing != frameState.lineSpacing {
-                effects.append(.lineSpacingChanged(frameState.lineSpacing))
+            let newSpacing = max(spacing, 1.0)
+            frameState.lineSpacing = newSpacing
+            if lastLineSpacing != newSpacing {
+                lastLineSpacing = newSpacing
+                effects.append(.lineSpacingChanged(newSpacing))
             }
 
         case .guiCursorAnimation(let enabled):
@@ -977,11 +995,11 @@ final class CommandDispatcher {
             // Reaching this path would bypass all-or-nothing transcript validation.
             assertionFailure("guiAgentTranscript must be prepared before publication")
 
-        case .guiGutterSeparator(let col, let r, let g, let b):
+        case .guiGutterSeparator(_, let r, let g, let b):
             let rgb: UInt32 = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
-            // Use the gutter fg color for the scroll indicator.
+            // Use the gutter fg color for the scroll indicator. The active gutter
+            // column now lives on the committed snapshot's metadata (#2999 AC6).
             frameState.scrollIndicatorColor = rgb
-            frameState.gutterCol = col
             frameState.gutterSeparatorColor = rgb
 
         case .guiCursorline(let row, let r, let g, let b):
@@ -989,16 +1007,11 @@ final class CommandDispatcher {
             frameState.cursorlineRow = row
             frameState.cursorlineBg = rgb
 
-        case .guiGutter(let data):
-            frameState.windowGutters[data.windowId] = data
-            if data.isActive {
-                frameState.activeWindowId = data.windowId
-                frameState.gutterCol = UInt16(data.lineNumberWidth) + UInt16(data.signColWidth)
-                // Derive viewport top from the first gutter entry's buffer line.
-                if let firstEntry = data.entries.first {
-                    frameState.viewportTopLine = firstEntry.bufLine
-                }
-            }
+        case .guiGutter:
+            // Gutter geometry and the active window are owned by the committed
+            // snapshot's surfaces and metadata; publication never mirrors them
+            // back into FrameState (#2999 AC6).
+            break
 
         case .guiWindowContent(let data):
             let previousScroll = guiState.windowContents[data.windowId]?.scrollPresentation
@@ -1006,13 +1019,11 @@ final class CommandDispatcher {
             if shouldResetScrollPresentation(previous: previousScroll, next: data.scrollPresentation) {
                 effects.append(.scrollPresentationReset(windowID: data.windowId))
             }
-            frameState.cursorVisible = data.cursorVisible
 
         case .guiWindowOverlayDelta(let delta):
             guard let current = guiState.windowContents[delta.windowId] else { break }
             guard let updated = current.applyingOverlayDelta(delta) else { break }
             guiState.windowContents[delta.windowId] = updated
-            frameState.cursorVisible = delta.cursorVisible
 
         case .guiWindowViewportDelta(let delta), .guiWindowRowsDelta(let delta):
             guard let current = guiState.windowContents[delta.windowId] else { break }
@@ -1026,7 +1037,6 @@ final class CommandDispatcher {
             if shouldResetScrollPresentation(previous: previousScroll, next: updated.scrollPresentation) {
                 effects.append(.scrollPresentationReset(windowID: delta.windowId))
             }
-            frameState.cursorVisible = delta.cursorVisible
 
         case .guiBottomPanel(let visible, let activeTabIndex, let heightPercent, let filterPreset, let tabs, let entries):
             if visible {
@@ -1092,10 +1102,11 @@ final class CommandDispatcher {
                 guiState.signatureHelpState.hide()
             }
 
-        case .guiSplitSeparators(let borderColor, let verticals, let horizontals):
-            frameState.splitBorderColor = borderColor
-            frameState.verticalSeparators = verticals
-            frameState.horizontalSeparators = horizontals
+        case .guiSplitSeparators:
+            // Split separator geometry is frozen into the committed snapshot's
+            // metadata during freeze; publication does not mirror it back into
+            // FrameState (#2999 AC6).
+            break
 
         case .guiFloatPopup(let visible, let width, let height, let title, let lines):
             if visible {

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -517,6 +517,7 @@ final class CommandDispatcher {
         }
         if clearsResync { guiState.resyncState.clear() }
         if let snapshot = transaction.editorSnapshot {
+            frameState = snapshot.frameState
             committedEditorSnapshot = snapshot
             if finalImpact.contains(.editor) {
                 pendingEditorPresentationFrame = committed

--- a/macos/Sources/Renderer/CommandDispatcher.swift
+++ b/macos/Sources/Renderer/CommandDispatcher.swift
@@ -148,6 +148,15 @@ final class CommandDispatcher {
     /// Input sequence attached to the newest applied frame awaiting a draw.
     private var pendingPresentationInputSeq: UInt32 = 0
 
+    /// The newest complete committed editor snapshot available for Metal submission.
+    private(set) var committedEditorSnapshot: CommittedEditorSnapshot?
+
+    /// The exact committed editor snapshot associated with the last successful Metal presentation.
+    private(set) var visibleEditorSnapshot: CommittedEditorSnapshot?
+
+    /// The committed editor frame identity awaiting Metal presentation, owned by the editor lifecycle rather than telemetry.
+    private var pendingEditorPresentationFrame: GUICommittedFrame?
+
     /// Claims the newest applied input sequence for one Metal submission.
     func takePresentationInputSeq() -> UInt32 {
         let seq = pendingPresentationInputSeq
@@ -157,7 +166,29 @@ final class CommandDispatcher {
 
     /// Returns the committed editor frame waiting for native Metal presentation.
     func pendingPresentationFrame() -> GUICommittedFrame? {
-        guiState.presentationMetrics.pendingEditorFrame()
+        pendingEditorPresentationFrame
+    }
+
+    /// Promotes the exact captured snapshot after its drawable presents successfully.
+    func promoteVisibleEditorSnapshot(_ snapshot: CommittedEditorSnapshot) {
+        let presentedFrame = GUICommittedFrame(generation: snapshot.generation, frameSeq: snapshot.frameSeq)
+        if let pendingFrame = pendingEditorPresentationFrame {
+            guard pendingFrame == presentedFrame else { return }
+            pendingEditorPresentationFrame = nil
+            visibleEditorSnapshot = snapshot
+            return
+        }
+
+        if let visibleFrame = visibleEditorSnapshot.map({ GUICommittedFrame(generation: $0.generation, frameSeq: $0.frameSeq) }), visibleFrame == presentedFrame {
+            visibleEditorSnapshot = snapshot
+            return
+        }
+
+        if visibleEditorSnapshot == nil,
+           let committedFrame = committedEditorSnapshot.map({ GUICommittedFrame(generation: $0.generation, frameSeq: $0.frameSeq) }),
+           committedFrame == presentedFrame {
+            visibleEditorSnapshot = snapshot
+        }
     }
 
     /// Discards an applied frame that cannot acquire a drawable/presentation path.
@@ -167,15 +198,9 @@ final class CommandDispatcher {
             pendingPresentationInputSeq = 0
         }
         let outcome: GUIFramePresentationMetrics.Outcome = reason == .hidden ? .hidden : .unavailable
-        guiState.presentationMetrics.discard(domain: .editor, outcome: outcome)
+        guiState.presentationMetrics.discard(domain: .editor, outcome: outcome, frame: pendingEditorPresentationFrame)
+        pendingEditorPresentationFrame = nil
     }
-
-    /// Window ids that arrived in the current frame batch. Used for input hit testing so stale
-    /// retained pane geometry can still render without being clickable.
-    // TODO(#2241-adjacent): no reset path since the cell-era clear opcode was
-    // retired; grows by distinct window ids seen this session (bounded, ids are
-    // reused). Reset at semantic frame start when frame lifecycle is reworked.
-    private(set) var currentFrameWindowIds: Set<UInt16> = []
 
     // MARK: - Frame transaction staging (#2219 child D)
 
@@ -355,6 +380,7 @@ final class CommandDispatcher {
             baseFrameSeq: baseFrameSeq,
             generation: generation,
             committedWindows: guiState.windowContents,
+            committedGutters: frameState.windowGutters,
             registeredFontIds: registeredFontIds,
             committedTranscript: guiState.agentChatState.transcriptSnapshot,
             stagingLimit: resourcePolicy.staging.weight,
@@ -480,6 +506,23 @@ final class CommandDispatcher {
             for command in focus.commands { apply(command, effects: &effects) }
         }
         if clearsResync { guiState.resyncState.clear() }
+        if finalImpact.contains(.editor) || committedEditorSnapshot == nil {
+            switch CommittedEditorSnapshot.make(
+                generation: transaction.generation,
+                frameSeq: transaction.frameSeq,
+                frameState: frameState,
+                themeColors: guiState.themeColors,
+                windowContents: guiState.windowContents
+            ) {
+            case .success(let snapshot):
+                committedEditorSnapshot = snapshot
+                if finalImpact.contains(.editor) {
+                    pendingEditorPresentationFrame = committed
+                }
+            case .failure(let rejection):
+                PortLogger.error("Committed editor snapshot rejected after semantic apply: \(rejection.logDescription)")
+            }
+        }
         replay(effects)
         guiState.presentationMetrics.beginCommitted(frame: committed, impact: finalImpact)
         publicationCount += 1
@@ -504,13 +547,10 @@ final class CommandDispatcher {
                 effects.append(.scrollPresentationReset(windowID: windowId))
             }
             frameState.cursorVisible = content.cursorVisible
-            frameState.dirty = true
         }
         for command in updates.commands { apply(command, effects: &effects) }
         if let authoritativeWindowIds = updates.authoritativeWindowIds {
             pruneAuthoritativeFrameState(liveWindowIds: authoritativeWindowIds)
-        } else {
-            currentFrameWindowIds.formUnion(updates.touchedWindowIds)
         }
     }
 
@@ -518,7 +558,9 @@ final class CommandDispatcher {
         guiState.windowContents = Dictionary(uniqueKeysWithValues: guiState.windowContents.filter { liveWindowIds.contains($0.key) })
         frameState.windowGutters = Dictionary(uniqueKeysWithValues: frameState.windowGutters.filter { liveWindowIds.contains($0.key) })
         frameState.windowIndentGuides = Dictionary(uniqueKeysWithValues: frameState.windowIndentGuides.filter { liveWindowIds.contains($0.key) })
-        currentFrameWindowIds = liveWindowIds
+        if let activeWindowId = frameState.activeWindowId, !liveWindowIds.contains(activeWindowId) {
+            frameState.activeWindowId = nil
+        }
         refreshDerivedGutterStateAfterPrune()
     }
 
@@ -689,13 +731,6 @@ final class CommandDispatcher {
         frameState.resize(newCols: newCols, newRows: newRows)
     }
 
-    /// Clears the dirty flag after the view has consumed the current
-    /// `FrameState` for a render. The view drives the render but does not own the
-    /// state, so it calls this instead of writing `frameState.dirty` directly.
-    func markRendered() {
-        frameState.dirty = false
-    }
-
     /// Applies a zero-latency local file-tree navigation preview when the BEAM marks the current tree model as eligible.
     /// The key still goes to the BEAM; this only moves the transient selection highlight until the next authoritative file-tree payload reconciles it.
     @discardableResult
@@ -850,13 +885,10 @@ final class CommandDispatcher {
 
         case .guiIndentGuides(let data):
             frameState.windowIndentGuides[data.windowId] = data
-            currentFrameWindowIds.insert(data.windowId)
-            frameState.dirty = true
 
         case .guiLineSpacing(let spacing):
             let oldSpacing = frameState.lineSpacing
             frameState.lineSpacing = max(spacing, 1.0)
-            frameState.dirty = true
             if oldSpacing != frameState.lineSpacing {
                 effects.append(.lineSpacingChanged(frameState.lineSpacing))
             }
@@ -951,17 +983,14 @@ final class CommandDispatcher {
             frameState.scrollIndicatorColor = rgb
             frameState.gutterCol = col
             frameState.gutterSeparatorColor = rgb
-            frameState.dirty = true
 
         case .guiCursorline(let row, let r, let g, let b):
             let rgb: UInt32 = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
             frameState.cursorlineRow = row
             frameState.cursorlineBg = rgb
-            frameState.dirty = true
 
         case .guiGutter(let data):
             frameState.windowGutters[data.windowId] = data
-            currentFrameWindowIds.insert(data.windowId)
             if data.isActive {
                 frameState.activeWindowId = data.windowId
                 frameState.gutterCol = UInt16(data.lineNumberWidth) + UInt16(data.signColWidth)
@@ -970,12 +999,10 @@ final class CommandDispatcher {
                     frameState.viewportTopLine = firstEntry.bufLine
                 }
             }
-            frameState.dirty = true
 
         case .guiWindowContent(let data):
             let previousScroll = guiState.windowContents[data.windowId]?.scrollPresentation
             guiState.windowContents[data.windowId] = data
-            currentFrameWindowIds.insert(data.windowId)
             if shouldResetScrollPresentation(previous: previousScroll, next: data.scrollPresentation) {
                 effects.append(.scrollPresentationReset(windowID: data.windowId))
             }
@@ -985,9 +1012,7 @@ final class CommandDispatcher {
             guard let current = guiState.windowContents[delta.windowId] else { break }
             guard let updated = current.applyingOverlayDelta(delta) else { break }
             guiState.windowContents[delta.windowId] = updated
-            currentFrameWindowIds.insert(delta.windowId)
             frameState.cursorVisible = delta.cursorVisible
-            frameState.dirty = true
 
         case .guiWindowViewportDelta(let delta), .guiWindowRowsDelta(let delta):
             guard let current = guiState.windowContents[delta.windowId] else { break }
@@ -998,12 +1023,10 @@ final class CommandDispatcher {
             }
             let previousScroll = current.scrollPresentation
             guiState.windowContents[delta.windowId] = updated
-            currentFrameWindowIds.insert(delta.windowId)
             if shouldResetScrollPresentation(previous: previousScroll, next: updated.scrollPresentation) {
                 effects.append(.scrollPresentationReset(windowID: delta.windowId))
             }
             frameState.cursorVisible = delta.cursorVisible
-            frameState.dirty = true
 
         case .guiBottomPanel(let visible, let activeTabIndex, let heightPercent, let filterPreset, let tabs, let entries):
             if visible {
@@ -1073,7 +1096,6 @@ final class CommandDispatcher {
             frameState.splitBorderColor = borderColor
             frameState.verticalSeparators = verticals
             frameState.horizontalSeparators = horizontals
-            frameState.dirty = true
 
         case .guiFloatPopup(let visible, let width, let height, let title, let lines):
             if visible {

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -403,6 +403,7 @@ final class CoreTextMetalRenderer {
         }
 
         let frameState = snapshot.frameState
+        let metadata = snapshot.metadata
         let themeColors = snapshot.themeColors
         let surfaces = snapshot.surfaces
         let presentationFrame = GUICommittedFrame(generation: snapshot.generation, frameSeq: snapshot.frameSeq)
@@ -444,7 +445,7 @@ final class CoreTextMetalRenderer {
         // Gutter spacing is also needed to derive the exact clipped command
         // viewport. Prepare each resident window once, then reuse that result
         // for metrics, atlas demand, gutters, and CoreText rendering.
-        let hasGutterChrome = frameState.gutterCol > 0 || surfaces.contains { surface in
+        let hasGutterChrome = metadata.gutterCol > 0 || surfaces.contains { surface in
             let gutter = surface.renderGutter
             return gutter.lineNumberWidth > 0 || gutter.signColWidth > 0 || !gutter.entries.isEmpty
         }
@@ -511,7 +512,7 @@ final class CoreTextMetalRenderer {
         let candidateWindowRenderer = activeWindowRenderer.makeCandidate(rasterizer: candidateRasterizer)
         let candidateAtlas = activeAtlas.makeCandidate()
         let neededSlots = CoreTextMetalRenderer.atlasSlotDemand(
-            frameState: frameState, preparedSurfaces: preparedSurfaces
+            frameState: frameState, metadata: metadata, preparedSurfaces: preparedSurfaces
         )
         let atlasPixelWidth = Int(ceil(CGFloat(frameState.cols) * CGFloat(cellW) * CGFloat(scale)))
         switch candidateAtlas.ensureCapacity(maxSlots: neededSlots, width: atlasPixelWidth,
@@ -576,7 +577,7 @@ final class CoreTextMetalRenderer {
         // This is a single-window lookup, not fragmented per-window joining.
         let cursorSurface: PresentedWindowSurface? = renderCursor?.windowId
             .flatMap { id in surfaces.first { $0.windowId == id } }
-        let activeSurface: PresentedWindowSurface? = frameState.activeWindowId
+        let activeSurface: PresentedWindowSurface? = snapshot.activeWindowId
             .flatMap { id in surfaces.first { $0.windowId == id } }
 
         // Build background quads and line texture instances.
@@ -924,7 +925,7 @@ final class CoreTextMetalRenderer {
         // Derive one exact aggregate buffer request before command creation. No
         // buffer is replaced or grown while a pass is being encoded.
         let gutterChromeQuads = CoreTextMetalRenderer.gutterChromeQuads(
-            frameState: frameState, surfaces: surfaces,
+            frameState: frameState, metadata: metadata, surfaces: surfaces,
             cellW: cellW, cellH: displayCellH, scale: scale,
             gutterLeftMarginPx: gutterLeftMarginPx, gutterPaddingPx: gutterPaddingPx,
             viewportHeight: Float(viewportSize.height), defaultBg: defaultBg,
@@ -1330,11 +1331,11 @@ final class CoreTextMetalRenderer {
 
         // Pass 5.5: Split separators (vertical lines between split panes,
         // horizontal bars with centered filenames for horizontal splits).
-        if frameState.splitBorderColor != 0 {
-            let sepColor = colorFromU24(frameState.splitBorderColor, default: SIMD3<Float>(0.3, 0.3, 0.3))
+        if metadata.splitBorderColor != 0 {
+            let sepColor = colorFromU24(metadata.splitBorderColor, default: SIMD3<Float>(0.3, 0.3, 0.3))
 
             // Vertical separators: 1px-wide lines spanning startRow..endRow
-            for vert in frameState.verticalSeparators {
+            for vert in metadata.verticalSeparators {
                 let sepX = Float(vert.col) * cellW * scale
                 let sepY = Float(vert.startRow) * displayCellH * scale
                 let sepH = Float(vert.endRow &- vert.startRow &+ 1) * displayCellH * scale
@@ -1352,7 +1353,7 @@ final class CoreTextMetalRenderer {
             }
 
             // Horizontal separators: 1px-high line + centered filename label
-            for (separatorIndex, horiz) in frameState.horizontalSeparators.enumerated() {
+            for (separatorIndex, horiz) in metadata.horizontalSeparators.enumerated() {
                 let hY = Float(horiz.row) * displayCellH * scale + (displayCellH * scale * 0.5) - 0.5
                 let hX = Float(horiz.col) * cellW * scale
                 let hW = Float(horiz.width) * cellW * scale
@@ -1371,9 +1372,9 @@ final class CoreTextMetalRenderer {
 
                 // Centered filename label rendered as a CoreText texture
                 if !horiz.filename.isEmpty, let atlas = atlas, let wcr = windowContentRenderer {
-                    let labelHash = horiz.filename.hashValue ^ Int(frameState.splitBorderColor)
+                    let labelHash = horiz.filename.hashValue ^ Int(metadata.splitBorderColor)
                     let labelKey = AtlasKey.splitLabel(row: horiz.row, subIndex: UInt16(min(separatorIndex, Int(UInt16.max))))
-                    if let entry = wcr.renderSimpleText(horiz.filename, fg: frameState.splitBorderColor,
+                    if let entry = wcr.renderSimpleText(horiz.filename, fg: metadata.splitBorderColor,
                                                          key: labelKey, contentHash: labelHash, atlas: atlas, metrics: &frameMetrics) {
                         // Center the label text within the separator width
                         let labelW = Float(entry.pixelWidth)
@@ -2271,6 +2272,7 @@ final class CoreTextMetalRenderer {
 
     nonisolated static func atlasSlotDemand(
         frameState: FrameState,
+        metadata: EditorSnapshotMetadata = .empty,
         preparedSurfaces: [PreparedPresentedSurface]
     ) -> Int {
         let bufferRows = preparedSurfaces.reduce(0) { $0 + $1.slice.rows.count }
@@ -2294,7 +2296,7 @@ final class CoreTextMetalRenderer {
             )
         }
 
-        let splitLabels = frameState.horizontalSeparators.reduce(0) { total, separator in
+        let splitLabels = metadata.horizontalSeparators.reduce(0) { total, separator in
             total + (separator.filename.isEmpty ? 0 : 1)
         }
 
@@ -2306,6 +2308,7 @@ final class CoreTextMetalRenderer {
     #if MINGA_SNAPSHOT_RENDERER
     nonisolated static func atlasSlotDemand(
         frameState: FrameState,
+        metadata: EditorSnapshotMetadata = .empty,
         windowContents: [UInt16: GUIWindowContent],
         gutters: [UInt16: Wire.WindowGutter],
         preparedRows: [UInt16: ResidentRenderPreparationResult]
@@ -2313,11 +2316,12 @@ final class CoreTextMetalRenderer {
         let slices = Dictionary(uniqueKeysWithValues: preparedRows.map { windowID, prepared in
             (windowID, RendererSignposts.rowSlice(for: prepared))
         })
-        return atlasSlotDemand(frameState: frameState, windowContents: windowContents, gutters: gutters, visibleSlices: slices)
+        return atlasSlotDemand(frameState: frameState, metadata: metadata, windowContents: windowContents, gutters: gutters, visibleSlices: slices)
     }
 
     nonisolated static func atlasSlotDemand(
         frameState: FrameState,
+        metadata: EditorSnapshotMetadata = .empty,
         windowContents: [UInt16: GUIWindowContent],
         gutters: [UInt16: Wire.WindowGutter],
         visibleSlices: [UInt16: RendererRowSlice]
@@ -2342,7 +2346,7 @@ final class CoreTextMetalRenderer {
             )
         }
 
-        let splitLabels = frameState.horizontalSeparators.reduce(0 as Int) { total, separator in
+        let splitLabels = metadata.horizontalSeparators.reduce(0 as Int) { total, separator in
             total + (separator.filename.isEmpty ? 0 : 1)
         }
 
@@ -2536,6 +2540,7 @@ final class CoreTextMetalRenderer {
     #if MINGA_SNAPSHOT_RENDERER
     nonisolated static func gutterChromeRects(
         frameState: FrameState,
+        metadata: EditorSnapshotMetadata = .empty,
         gutters: [UInt16: Wire.WindowGutter],
         cellW: Float,
         cellH: Float,
@@ -2571,15 +2576,15 @@ final class CoreTextMetalRenderer {
             return (leftFills, rightFills, separators)
         }
 
-        guard frameState.gutterCol > 0 else { return ([], [], []) }
+        guard metadata.gutterCol > 0 else { return ([], [], []) }
         if gutterLeftMarginPx > 0 {
             leftFills.append((x: 0, y: 0, width: gutterLeftMarginPx, height: viewportHeight))
         }
         if gutterPaddingPx > 0 {
-            rightFills.append((x: Float(frameState.gutterCol) * cellW * scale + gutterLeftMarginPx, y: 0, width: gutterPaddingPx, height: viewportHeight))
+            rightFills.append((x: Float(metadata.gutterCol) * cellW * scale + gutterLeftMarginPx, y: 0, width: gutterPaddingPx, height: viewportHeight))
         }
         if frameState.gutterSeparatorColor != 0 {
-            let gutterRightX = Float(frameState.gutterCol) * cellW * scale + gutterLeftMarginPx
+            let gutterRightX = Float(metadata.gutterCol) * cellW * scale + gutterLeftMarginPx
             separators.append((x: gutterRightX + gutterPaddingPx * 0.5, y: 0, width: 1.0, height: viewportHeight))
         }
         return (leftFills, rightFills, separators)
@@ -2589,6 +2594,7 @@ final class CoreTextMetalRenderer {
 
     nonisolated static func gutterChromeRects(
         frameState: FrameState,
+        metadata: EditorSnapshotMetadata = .empty,
         surfaces: [PresentedWindowSurface],
         cellW: Float,
         cellH: Float,
@@ -2625,15 +2631,15 @@ final class CoreTextMetalRenderer {
             return (leftFills, rightFills, separators)
         }
 
-        guard frameState.gutterCol > 0 else { return ([], [], []) }
+        guard metadata.gutterCol > 0 else { return ([], [], []) }
         if gutterLeftMarginPx > 0 {
             leftFills.append((x: 0, y: 0, width: gutterLeftMarginPx, height: viewportHeight))
         }
         if gutterPaddingPx > 0 {
-            rightFills.append((x: Float(frameState.gutterCol) * cellW * scale + gutterLeftMarginPx, y: 0, width: gutterPaddingPx, height: viewportHeight))
+            rightFills.append((x: Float(metadata.gutterCol) * cellW * scale + gutterLeftMarginPx, y: 0, width: gutterPaddingPx, height: viewportHeight))
         }
         if frameState.gutterSeparatorColor != 0 {
-            let gutterRightX = Float(frameState.gutterCol) * cellW * scale + gutterLeftMarginPx
+            let gutterRightX = Float(metadata.gutterCol) * cellW * scale + gutterLeftMarginPx
             separators.append((x: gutterRightX + gutterPaddingPx * 0.5, y: 0, width: 1.0, height: viewportHeight))
         }
         return (leftFills, rightFills, separators)
@@ -2641,6 +2647,7 @@ final class CoreTextMetalRenderer {
 
     nonisolated static func gutterChromeQuads(
         frameState: FrameState,
+        metadata: EditorSnapshotMetadata = .empty,
         surfaces: [PresentedWindowSurface],
         cellW: Float,
         cellH: Float,
@@ -2653,6 +2660,7 @@ final class CoreTextMetalRenderer {
     ) -> [QuadGPU] {
         let rects = gutterChromeRects(
             frameState: frameState,
+            metadata: metadata,
             surfaces: surfaces,
             cellW: cellW,
             cellH: cellH,

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -331,16 +331,11 @@ final class CoreTextMetalRenderer {
                                       policy: resourcePolicy, makeTexture: factories.makeTexture)
     }
 
-    /// Render the editor from FrameState metadata + semantic window content.
+    /// Render the editor from one complete committed snapshot.
     ///
-    /// Buffer windows with semantic content (from 0x80 opcode) are rendered
-    /// via `WindowContentRenderer`. Frame metadata (cursor, gutter, cursorline,
-    /// default bg) comes from FrameState. Content comes from WindowContentRenderer
-    /// via the gui_window_content (0x80) semantic rendering pipeline.
-    func render(frameState: FrameState, fontManager: FontManager,
+    /// Buffer windows with semantic content are rendered via their already-paired snapshot surfaces. The renderer must not accept independently read `FrameState` and window-content dictionaries from production call sites.
+    func render(snapshot: CommittedEditorSnapshot, fontManager: FontManager,
                 cursorBlinkVisible: Bool = true,
-                windowContents: [UInt16: GUIWindowContent] = [:],
-                themeColors: ThemeColors? = nil,
                 isMouseInGutter: Bool = false,
                 gutterHoverWindowId: UInt16? = nil,
                 gutterHoverRow: UInt16? = nil,
@@ -348,8 +343,16 @@ final class CoreTextMetalRenderer {
                 contentScale: Float, scrollOffset: SIMD2<Float> = .zero,
                 presentationWindowId: UInt16? = nil,
                 presentationInputSeq: UInt32 = 0,
-                presentationFrame: GUICommittedFrame? = nil,
-                latencyRecorder: LatencyRecorder? = nil) {
+                latencyRecorder: LatencyRecorder? = nil,
+                onPresented: @escaping @MainActor (CommittedEditorSnapshot) -> Void = { _ in }) {
+        let frameState = snapshot.frameState
+        let themeColors = snapshot.themeColors
+        let surfaces = snapshot.surfaces
+        let windowContents = Dictionary(uniqueKeysWithValues: surfaces.map { ($0.windowId, $0.content) })
+        let renderGutters = Dictionary(uniqueKeysWithValues: surfaces.map { ($0.windowId, $0.renderGutter) })
+        let indentGuides = Dictionary(uniqueKeysWithValues: surfaces.compactMap { surface in surface.indentGuides.map { (surface.windowId, $0) } })
+        let presentationFrame = GUICommittedFrame(generation: snapshot.generation, frameSeq: snapshot.frameSeq)
+        let presentedSnapshot = snapshot
         let renderSignpostID = OSSignpostID(log: renderLog)
         os_signpost(.begin, log: renderLog, name: "Frame", signpostID: renderSignpostID)
         defer {
@@ -387,7 +390,7 @@ final class CoreTextMetalRenderer {
         // Gutter spacing is also needed to derive the exact clipped command
         // viewport. Prepare each resident window once, then reuse that result
         // for metrics, atlas demand, gutters, and CoreText rendering.
-        let hasGutterChrome = frameState.gutterCol > 0 || !frameState.windowGutters.isEmpty
+        let hasGutterChrome = frameState.gutterCol > 0 || renderGutters.values.contains { $0.lineNumberWidth > 0 || $0.signColWidth > 0 || !$0.entries.isEmpty }
         let gutterLeftMarginPt: Float = hasGutterChrome ? round(Float(Self.gutterLeftMarginPt) * scale) / scale : 0
         let gutterLeftMarginPx = gutterLeftMarginPt * scale
         let gutterPaddingPt: Float = hasGutterChrome ? round(Float(Self.gutterRightGapPt) * scale) / scale : 0
@@ -395,24 +398,21 @@ final class CoreTextMetalRenderer {
 
         var preparedRowsByWindow: [UInt16: ResidentRenderPreparationResult] = [:]
         var visibleSlices: [UInt16: RendererRowSlice] = [:]
-        preparedRowsByWindow.reserveCapacity(windowContents.count)
-        visibleSlices.reserveCapacity(windowContents.count)
-        for content in windowContents.values {
-            let fallbackRows = Int(content.paneGeometry?.textRect.height
-                ?? frameState.windowGutters[content.windowId]?.contentHeight
-                ?? frameState.rows)
-            let gutter = frameState.windowGutters[content.windowId]
-            let contentCols = gutter.map {
-                CoreTextMetalRenderer.visibleTextCols(
-                    geometry: content.paneGeometry,
-                    gutter: $0,
-                    frameCols: frameState.cols,
-                    cellW: cellW,
-                    scale: scale,
-                    gutterLeftMarginPx: gutterLeftMarginPx,
-                    gutterPaddingPx: gutterPaddingPx
-                )
-            } ?? Int(frameState.cols)
+        preparedRowsByWindow.reserveCapacity(surfaces.count)
+        visibleSlices.reserveCapacity(surfaces.count)
+        for surface in surfaces {
+            let content = surface.content
+            let gutter = surface.renderGutter
+            let fallbackRows = Int(surface.paneGeometry.textRect.height)
+            let contentCols = CoreTextMetalRenderer.visibleTextCols(
+                geometry: surface.paneGeometry,
+                gutter: gutter,
+                frameCols: frameState.cols,
+                cellW: cellW,
+                scale: scale,
+                gutterLeftMarginPx: gutterLeftMarginPx,
+                gutterPaddingPx: gutterPaddingPx
+            )
             let scrollLeftInt = Int(content.scrollLeft)
             let localScrollInsetCols = scrollLeftInt > 0 ? 1 : 0
             let prepared = ResidentRenderPreparation.prepare(
@@ -454,7 +454,7 @@ final class CoreTextMetalRenderer {
         let candidateAtlas = activeAtlas.makeCandidate()
         let neededSlots = CoreTextMetalRenderer.atlasSlotDemand(
             frameState: frameState, windowContents: windowContents,
-            preparedRows: preparedRowsByWindow
+            gutters: renderGutters, preparedRows: preparedRowsByWindow
         )
         let atlasPixelWidth = Int(ceil(CGFloat(frameState.cols) * CGFloat(cellW) * CGFloat(scale)))
         switch candidateAtlas.ensureCapacity(maxSlots: neededSlots, width: atlasPixelWidth,
@@ -500,6 +500,7 @@ final class CoreTextMetalRenderer {
         let resolvedCursor = CoreTextMetalRenderer.resolveCursor(
             frameState: frameState,
             windowContents: windowContents,
+            gutters: renderGutters,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -520,27 +521,23 @@ final class CoreTextMetalRenderer {
         var diagnosticQuads: [QuadGPU] = []
 
         if let wcr = windowContentRenderer {
-            for (_, content) in windowContents {
-                // Match gutter data to semantic window content by windowId.
-                guard let gutter = frameState.windowGutters[content.windowId] else {
-                    continue
-                }
-
-                let paneGeometry = content.paneGeometry
+            for surface in surfaces {
+                let content = surface.content
+                let gutter = surface.renderGutter
+                let paneGeometry = surface.paneGeometry
                 let windowScrollOffsetPx = CoreTextMetalRenderer.smoothScrollOffset(
                     for: content.windowId,
                     targetWindowId: scrollTargetWindowId,
                     scrollOffsetPx: smoothScrollOffsetPx
                 )
-                let windowRowOffset = Float(paneGeometry?.textRect.row ?? gutter.contentRow) * displayCellH * scale
+                let windowRowOffset = Float(paneGeometry.textRect.row) * displayCellH * scale
                 let presentationScrollOffsetPx = CoreTextMetalRenderer.presentationScrollOffset(
                     scrollLeft: content.scrollLeft,
                     scrollOffsetPx: windowScrollOffsetPx
                 )
                 let scrollableWindowRowOffset = windowRowOffset - presentationScrollOffsetPx.y
                 let scrollableWindowColOffset = presentationScrollOffsetPx.x
-                let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
-                let textCol = Float(paneGeometry?.textRect.col ?? fallbackTextCol)
+                let textCol = Float(paneGeometry.textRect.col)
                 let contentColOffset = textCol * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
                 let windowBounds = CoreTextMetalRenderer.windowHorizontalBounds(
                     geometry: paneGeometry,
@@ -551,7 +548,7 @@ final class CoreTextMetalRenderer {
                     viewportWidth: Float(viewportSize.width)
                 )
                 let contentRightPx = windowBounds.x + windowBounds.width
-                let contentTopPx = Float(paneGeometry?.textRect.row ?? gutter.contentRow) * displayCellH * scale
+                let contentTopPx = Float(paneGeometry.textRect.row) * displayCellH * scale
                 guard let visibleSlice = visibleSlices[content.windowId] else { continue }
                 let overscanBeforeRows = visibleSlice.overscanBeforeRows
                 let committedVisibleRows = CoreTextMetalRenderer.committedVisibleRows(
@@ -577,7 +574,7 @@ final class CoreTextMetalRenderer {
                 // panes (including the agent panel edge) have no band above them.
                 if windowBounds.width > 0,
                    let fill = CoreTextMetalRenderer.windowBackgroundFillBounds(
-                       paneTopRow: Int(paneGeometry?.textRect.row ?? gutter.contentRow),
+                       paneTopRow: Int(paneGeometry.textRect.row),
                        paneRows: committedVisibleRows,
                        totalRows: Int(frameState.rows),
                        displayCellH: displayCellH,
@@ -818,7 +815,7 @@ final class CoreTextMetalRenderer {
 
         // Native gutter rendering from structured data.
         // One Wire.WindowGutter per editor window (split pane).
-        for (_, windowGutter) in frameState.windowGutters {
+        for windowGutter in renderGutters.values where windowGutter.lineNumberWidth > 0 || windowGutter.signColWidth > 0 || !windowGutter.entries.isEmpty {
             renderGutterEntries(
                 gutter: windowGutter,
                 frameState: frameState,
@@ -856,7 +853,8 @@ final class CoreTextMetalRenderer {
         // Derive one exact aggregate buffer request before command creation. No
         // buffer is replaced or grown while a pass is being encoded.
         let gutterChromeQuads = CoreTextMetalRenderer.gutterChromeQuads(
-            frameState: frameState, cellW: cellW, cellH: displayCellH, scale: scale,
+            frameState: frameState, gutters: renderGutters,
+            cellW: cellW, cellH: displayCellH, scale: scale,
             gutterLeftMarginPx: gutterLeftMarginPx, gutterPaddingPx: gutterPaddingPx,
             viewportHeight: Float(viewportSize.height), defaultBg: defaultBg,
             separatorColor: colorFromU24(frameState.gutterSeparatorColor,
@@ -864,6 +862,7 @@ final class CoreTextMetalRenderer {
         )
         let guidePassCounts = indentGuideQuadCounts(
             frameState: frameState, windowContents: windowContents,
+            gutters: renderGutters, indentGuides: indentGuides,
             cellW: cellW, displayCellH: displayCellH, scale: scale,
             gutterLeftMarginPx: gutterLeftMarginPx, gutterPaddingPx: gutterPaddingPx,
             viewportSize: viewportSize, scrollTargetWindowId: scrollTargetWindowId,
@@ -1046,13 +1045,12 @@ final class CoreTextMetalRenderer {
         // Drawn after bg fills but before text, cursor, and selection overlays.
         // When per-line indent levels are available, draw segments only in
         // leading whitespace so guides don't bleed through text content.
-        for (_, guideData) in frameState.windowIndentGuides {
+        for (_, guideData) in indentGuides {
             guard !guideData.guideCols.isEmpty else { continue }
 
-            guard let gutter = frameState.windowGutters[guideData.windowId] else { continue }
-            let paneGeometry = windowContents[guideData.windowId]?.paneGeometry
-            let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
-            let windowContentColOffset = Float(paneGeometry?.textRect.col ?? fallbackTextCol) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
+            guard let gutter = renderGutters[guideData.windowId],
+                  let paneGeometry = windowContents[guideData.windowId]?.paneGeometry else { continue }
+            let windowContentColOffset = Float(paneGeometry.textRect.col) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
             let windowBounds = CoreTextMetalRenderer.windowHorizontalBounds(
                 geometry: paneGeometry,
                 gutter: gutter,
@@ -1076,8 +1074,8 @@ final class CoreTextMetalRenderer {
             )
             let guideScrollOffsetY = guideScrollOffset.y
             let guideScrollOffsetX = guideScrollOffset.x
-            let guideTopY = Float(paneGeometry?.textRect.row ?? gutter.contentRow) * displayCellH * scale
-            let guideHeightPx = Float(max(Int(paneGeometry?.textRect.height ?? gutter.contentHeight), 0)) * lineCellH
+            let guideTopY = Float(paneGeometry.textRect.row) * displayCellH * scale
+            let guideHeightPx = Float(max(Int(paneGeometry.textRect.height), 0)) * lineCellH
             let guideBottomY = min(guideTopY + guideHeightPx, Float(viewportSize.height))
             let textRightPx = contentRightPx
 
@@ -1158,7 +1156,7 @@ final class CoreTextMetalRenderer {
             let cursorWidth = CoreTextMetalRenderer.snapToPixel(cellW * scale)
             let cursorHeight = CoreTextMetalRenderer.snapToPixel(displayCellH * scale)
             let cursorWindowBounds = renderCursor.windowId.flatMap { windowId -> (x: Float, width: Float)? in
-                guard let gutter = frameState.windowGutters[windowId] else { return nil }
+                guard let gutter = renderGutters[windowId] else { return nil }
                 return CoreTextMetalRenderer.cursorHorizontalBounds(
                     geometry: windowContents[windowId]?.paneGeometry,
                     gutter: gutter,
@@ -1173,7 +1171,7 @@ final class CoreTextMetalRenderer {
             let cursorBounds = CoreTextMetalRenderer.paneVerticalBounds(
                 for: renderCursor.windowId,
                 windowContents: windowContents,
-                gutters: frameState.windowGutters,
+                gutters: renderGutters,
                 displayCellH: displayCellH,
                 scale: scale,
                 viewportHeight: Float(viewportSize.height)
@@ -1336,7 +1334,7 @@ final class CoreTextMetalRenderer {
             let cursorX = renderCursor.x - cursorScrollOffsetPx.x
             let cursorY = renderCursor.y - cursorScrollOffsetPx.y
             let cursorWindowBounds = renderCursor.windowId.flatMap { windowId -> (x: Float, width: Float)? in
-                guard let gutter = frameState.windowGutters[windowId] else { return nil }
+                guard let gutter = renderGutters[windowId] else { return nil }
                 return CoreTextMetalRenderer.cursorHorizontalBounds(
                     geometry: windowContents[windowId]?.paneGeometry,
                     gutter: gutter,
@@ -1356,7 +1354,7 @@ final class CoreTextMetalRenderer {
             let cursorBounds = CoreTextMetalRenderer.paneVerticalBounds(
                 for: renderCursor.windowId,
                 windowContents: windowContents,
-                gutters: frameState.windowGutters,
+                gutters: renderGutters,
                 displayCellH: displayCellH,
                 scale: scale,
                 viewportHeight: Float(viewportSize.height)
@@ -1494,11 +1492,9 @@ final class CoreTextMetalRenderer {
             }
             guard self.configurationEpoch == candidateConfigurationEpoch else {
                 latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
-                if let presentationFrame {
-                    self.presentationMetrics?.discard(
-                        domain: .editor, outcome: .superseded, frame: presentationFrame
-                    )
-                }
+                self.presentationMetrics?.discard(
+                    domain: .editor, outcome: .superseded, frame: presentationFrame
+                )
                 return
             }
             guard let drawable = drawableProvider() else {
@@ -1579,11 +1575,9 @@ final class CoreTextMetalRenderer {
                 guard self.configurationEpoch == candidateConfigurationEpoch,
                       generation > self.presentationGeneration.completed else {
                     latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
-                    if let presentationFrame {
-                        self.presentationMetrics?.discard(
-                            domain: .editor, outcome: .superseded, frame: presentationFrame
-                        )
-                    }
+                    self.presentationMetrics?.discard(
+                        domain: .editor, outcome: .superseded, frame: presentationFrame
+                    )
                     return
                 }
                 do {
@@ -1597,11 +1591,9 @@ final class CoreTextMetalRenderer {
                 }
                 guard self.presentationGeneration.complete(generation) else {
                     latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
-                    if let presentationFrame {
-                        self.presentationMetrics?.discard(
-                            domain: .editor, outcome: .superseded, frame: presentationFrame
-                        )
-                    }
+                    self.presentationMetrics?.discard(
+                        domain: .editor, outcome: .superseded, frame: presentationFrame
+                    )
                     return
                 }
 
@@ -1614,20 +1606,17 @@ final class CoreTextMetalRenderer {
                 self.quadBufferCapacity = candidateQuadCapacity
                 self.lastCompletedPresentationGeneration = generation
                 latencyRecorder?.markPresented(seq: presentationInputSeq)
-                if let presentationFrame {
-                    self.presentationMetrics?.recordMetalPresented(presentationFrame: presentationFrame)
-                }
+                self.presentationMetrics?.recordMetalPresented(presentationFrame: presentationFrame)
+                onPresented(presentedSnapshot)
                 os_signpost(.event, log: renderLog, name: "PresentationComplete",
                             signpostID: renderSignpostID,
                             "input=%{public}u", presentationInputSeq)
             }
             presentationBuffer.commit()
-            if let presentationFrame {
-                self.presentationMetrics?.recordMetalSubmission(presentationFrame: presentationFrame)
-            }
+            self.presentationMetrics?.recordMetalSubmission(presentationFrame: presentationFrame)
             os_signpost(.event, log: renderLog, name: "MetalPresentationSubmit", signpostID: renderSignpostID,
                         "input=%{public}u frame=%{public}u", presentationInputSeq,
-                        presentationFrame?.frameSeq ?? 0)
+                        presentationFrame.frameSeq)
         }
         cmdBuf.commit()
         latencyRecorder?.markSubmitted(seq: presentationInputSeq)
@@ -1955,15 +1944,16 @@ final class CoreTextMetalRenderer {
 
     private func indentGuideQuadCounts(
         frameState: FrameState, windowContents: [UInt16: GUIWindowContent],
+        gutters: [UInt16: Wire.WindowGutter], indentGuides: [UInt16: IndentGuideData],
         cellW: Float, displayCellH: Float, scale: Float,
         gutterLeftMarginPx: Float, gutterPaddingPx: Float,
         viewportSize: CGSize, scrollTargetWindowId: UInt16?,
         smoothScrollOffsetPx: SIMD2<Float>
     ) -> [Int] {
         var counts: [Int] = []
-        for (_, guideData) in frameState.windowIndentGuides {
+        for (_, guideData) in indentGuides {
             guard !guideData.guideCols.isEmpty,
-                  let gutter = frameState.windowGutters[guideData.windowId] else { continue }
+                  let gutter = gutters[guideData.windowId] else { continue }
             let paneGeometry = windowContents[guideData.windowId]?.paneGeometry
             let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth)
                                          + Int(gutter.signColWidth))
@@ -2169,30 +2159,22 @@ final class CoreTextMetalRenderer {
         }
     }
 
-    nonisolated static func atlasSlotDemand(frameState: FrameState, windowContents: [UInt16: GUIWindowContent]) -> Int {
-        let slices = Dictionary(uniqueKeysWithValues: windowContents.values.map { content in
-            let fallback = Int(content.paneGeometry?.textRect.height
-                ?? frameState.windowGutters[content.windowId]?.contentHeight
-                ?? frameState.rows)
-            return (content.windowId, RendererSignposts.visibleSlice(for: content, fallbackVisibleRows: fallback))
-        })
-        return atlasSlotDemand(frameState: frameState, windowContents: windowContents, visibleSlices: slices)
-    }
-
     nonisolated static func atlasSlotDemand(
         frameState: FrameState,
         windowContents: [UInt16: GUIWindowContent],
+        gutters: [UInt16: Wire.WindowGutter],
         preparedRows: [UInt16: ResidentRenderPreparationResult]
     ) -> Int {
         let slices = Dictionary(uniqueKeysWithValues: preparedRows.map { windowID, prepared in
             (windowID, RendererSignposts.rowSlice(for: prepared))
         })
-        return atlasSlotDemand(frameState: frameState, windowContents: windowContents, visibleSlices: slices)
+        return atlasSlotDemand(frameState: frameState, windowContents: windowContents, gutters: gutters, visibleSlices: slices)
     }
 
     nonisolated static func atlasSlotDemand(
         frameState: FrameState,
         windowContents: [UInt16: GUIWindowContent],
+        gutters: [UInt16: Wire.WindowGutter],
         visibleSlices: [UInt16: RendererRowSlice]
     ) -> Int {
         let bufferRows = visibleSlices.values.reduce(0) { $0 + $1.rows.count }
@@ -2201,14 +2183,13 @@ final class CoreTextMetalRenderer {
             guard let slice = visibleSlices[content.windowId] else { return total }
             let fallback = max(slice.rows.count - slice.overscanBeforeRows, 0)
             let paneRows = Int(content.paneGeometry?.textRect.height ?? 0)
-            let gutterRows = Int(frameState.windowGutters[content.windowId]?.contentHeight ?? 0)
-            let visibleRows = paneRows > 0 ? paneRows : (gutterRows > 0 ? gutterRows : fallback)
+            let visibleRows = paneRows > 0 ? paneRows : fallback
             return total + content.lineAnnotations.filter {
                 $0.kind != .gutterIcon && Int($0.row) < visibleRows
             }.count
         }
 
-        let gutterTextures = frameState.windowGutters.values.reduce(0 as Int) { total, gutter in
+        let gutterTextures = gutters.values.reduce(0 as Int) { total, gutter in
             guard let slice = visibleSlices[gutter.windowId] else { return total }
             return total + gutterTextureDemand(
                 gutter,
@@ -2407,6 +2388,7 @@ final class CoreTextMetalRenderer {
 
     nonisolated static func gutterChromeRects(
         frameState: FrameState,
+        gutters: [UInt16: Wire.WindowGutter],
         cellW: Float,
         cellH: Float,
         scale: Float,
@@ -2419,8 +2401,8 @@ final class CoreTextMetalRenderer {
         var rightFills: [(x: Float, y: Float, width: Float, height: Float)] = []
         var separators: [(x: Float, y: Float, width: Float, height: Float)] = []
 
-        if !frameState.windowGutters.isEmpty {
-            for gutter in frameState.windowGutters.values.sorted(by: { $0.windowId < $1.windowId }) {
+        if !gutters.isEmpty {
+            for gutter in gutters.values.sorted(by: { $0.windowId < $1.windowId }) {
                 let gutterWidthCols = Int(gutter.lineNumberWidth) + Int(gutter.signColWidth)
                 guard gutterWidthCols > 0 else { continue }
                 let top = Float(gutter.contentRow) * cellH * scale
@@ -2457,6 +2439,7 @@ final class CoreTextMetalRenderer {
 
     nonisolated static func gutterChromeQuads(
         frameState: FrameState,
+        gutters: [UInt16: Wire.WindowGutter],
         cellW: Float,
         cellH: Float,
         scale: Float,
@@ -2468,6 +2451,7 @@ final class CoreTextMetalRenderer {
     ) -> [QuadGPU] {
         let rects = gutterChromeRects(
             frameState: frameState,
+            gutters: gutters,
             cellW: cellW,
             cellH: cellH,
             scale: scale,
@@ -2753,6 +2737,7 @@ final class CoreTextMetalRenderer {
     nonisolated static func resolveCursor(
         frameState: FrameState,
         windowContents: [UInt16: GUIWindowContent],
+        gutters: [UInt16: Wire.WindowGutter],
         cellW: Float,
         displayCellH: Float,
         scale: Float,
@@ -2760,8 +2745,8 @@ final class CoreTextMetalRenderer {
         gutterPaddingPx: Float
     ) -> RenderCursor? {
         var sawActiveSemanticCursorOwner = false
-        for windowId in semanticCursorWindowIds(frameState.windowGutters) {
-            guard let gutter = frameState.windowGutters[windowId], let content = windowContents[windowId] else { continue }
+        for windowId in semanticCursorWindowIds(gutters) {
+            guard let gutter = gutters[windowId], let content = windowContents[windowId] else { continue }
             sawActiveSemanticCursorOwner = true
             guard content.cursorVisible else { continue }
 

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -498,7 +498,6 @@ final class CoreTextMetalRenderer {
         }
 
         let resolvedCursor = CoreTextMetalRenderer.resolveCursor(
-            frameState: frameState,
             windowContents: windowContents,
             gutters: renderGutters,
             cellW: cellW,
@@ -818,8 +817,8 @@ final class CoreTextMetalRenderer {
         for windowGutter in renderGutters.values where windowGutter.lineNumberWidth > 0 || windowGutter.signColWidth > 0 || !windowGutter.entries.isEmpty {
             renderGutterEntries(
                 gutter: windowGutter,
-                frameState: frameState,
                 cellW: cellW, cellH: displayCellH, scale: scale,
+                frameState: frameState,
                 gutterLeftMarginPx: gutterLeftMarginPx,
                 gutterPaddingPx: gutterPaddingPx,
                 viewportWidthPx: Float(viewportSize.width),
@@ -1675,8 +1674,8 @@ final class CoreTextMetalRenderer {
     /// Diagnostic signs are rendered as CTLine textures.
     private func renderGutterEntries(
         gutter: Wire.WindowGutter,
-        frameState: FrameState,
         cellW: Float, cellH: Float, scale: Float,
+        frameState: FrameState,
         gutterLeftMarginPx: Float,
         gutterPaddingPx: Float,
         viewportWidthPx: Float,
@@ -1717,7 +1716,7 @@ final class CoreTextMetalRenderer {
                     frameState: frameState,
                     clipTop: clipTop, clipBottom: clipBottom,
                     atlas: atlas, windowRenderer: windowRenderer,
-                    bgQuads: &bgQuads, lineInstances: &lineInstances,
+                    bgQuads: &bgQuads, lineInstances: &lineInstances
                 )
             }
 
@@ -1728,12 +1727,12 @@ final class CoreTextMetalRenderer {
                     gutter: gutter, xOffset: xOffset,
                     signColWidth: signColWidth,
                     cellW: cellW, cellH: cellH, scale: scale,
+                    frameState: frameState,
                     gutterPaddingPx: gutterPaddingPx,
                     viewportWidthPx: viewportWidthPx,
                     gutterHoverWindowId: gutterHoverWindowId,
                     gutterHoverRow: gutterHoverRow,
-                    frameState: frameState,
-                    clipTop: clipTop, clipBottom: clipBottom,
+                            clipTop: clipTop, clipBottom: clipBottom,
                     bgQuads: &bgQuads,
                 )
 
@@ -1741,11 +1740,11 @@ final class CoreTextMetalRenderer {
                     entry: entry, yPos: yPos, xOffset: xOffset,
                     signColWidth: signColWidth,
                     cellW: cellW, cellH: cellH, scale: scale,
+                    frameState: frameState,
                     isMouseInGutter: isMouseInGutter,
                     gutterHoverWindowId: gutterHoverWindowId,
                     gutter: gutter,
-                    frameState: frameState,
-                    clipTop: clipTop, clipBottom: clipBottom,
+                            clipTop: clipTop, clipBottom: clipBottom,
                     bgQuads: &bgQuads,
                 )
             }
@@ -1756,9 +1755,9 @@ final class CoreTextMetalRenderer {
                     entry: entry, gutter: gutter,
                     atlasRow: atlasRow, yPos: yPos, xOffset: xOffset,
                     signColWidth: signColWidth,
-                    cellW: cellW, cellH: cellH, scale: scale,
-                    frameState: frameState,
-                    clipTop: clipTop, clipBottom: clipBottom,
+                            cellW: cellW, cellH: cellH, scale: scale,
+                            frameState: frameState,
+                            clipTop: clipTop, clipBottom: clipBottom,
                     atlas: atlas, windowRenderer: windowRenderer,
                     lineInstances: &lineInstances,
                 )
@@ -1811,7 +1810,7 @@ final class CoreTextMetalRenderer {
         atlas: LineTextureAtlas,
         windowRenderer: WindowContentRenderer,
         bgQuads: inout [QuadGPU],
-        lineInstances: inout [LineGPU],
+        lineInstances: inout [LineGPU]
     ) {
         switch entry.signType {
         case .gitAdded:
@@ -1859,11 +1858,11 @@ final class CoreTextMetalRenderer {
         gutter: Wire.WindowGutter, xOffset: Float,
         signColWidth: Int,
         cellW: Float, cellH: Float, scale: Float,
+        frameState: FrameState,
         gutterPaddingPx: Float,
         viewportWidthPx: Float,
         gutterHoverWindowId: UInt16?,
         gutterHoverRow: UInt16?,
-        frameState: FrameState,
         clipTop: Float, clipBottom: Float,
         bgQuads: inout [QuadGPU],
     ) {
@@ -1890,10 +1889,10 @@ final class CoreTextMetalRenderer {
         entry: Wire.GutterEntry, yPos: Float, xOffset: Float,
         signColWidth: Int,
         cellW: Float, cellH: Float, scale: Float,
+        frameState: FrameState,
         isMouseInGutter: Bool,
         gutterHoverWindowId: UInt16?,
         gutter: Wire.WindowGutter,
-        frameState: FrameState,
         clipTop: Float, clipBottom: Float,
         bgQuads: inout [QuadGPU],
     ) {
@@ -2733,9 +2732,8 @@ final class CoreTextMetalRenderer {
     }
 
     /// Resolve the cursor position in the same coordinate system as the text renderer.
-    /// Semantic GUI window content is preferred because it carries window-relative cursor coordinates and horizontal scroll. Legacy frameState cursor data remains the fallback for transition frames and non-semantic surfaces.
+    /// Cursor authority lives in the active presented window surface. There is no legacy `FrameState` fallback because drawing a cursor from a different semantic source would recreate the #2999 split-brain presentation bug.
     nonisolated static func resolveCursor(
-        frameState: FrameState,
         windowContents: [UInt16: GUIWindowContent],
         gutters: [UInt16: Wire.WindowGutter],
         cellW: Float,
@@ -2744,14 +2742,12 @@ final class CoreTextMetalRenderer {
         gutterLeftMarginPx: Float,
         gutterPaddingPx: Float
     ) -> RenderCursor? {
-        var sawActiveSemanticCursorOwner = false
         for windowId in semanticCursorWindowIds(gutters) {
             guard let gutter = gutters[windowId], let content = windowContents[windowId] else { continue }
-            sawActiveSemanticCursorOwner = true
             guard content.cursorVisible else { continue }
 
-            let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
-            let contentColOffset = Float(content.paneGeometry?.textRect.col ?? fallbackTextCol) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
+            let textCol = content.paneGeometry?.textRect.col ?? UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
+            let contentColOffset = Float(textCol) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
             let hScrollPx = Float(content.scrollLeft) * cellW * scale
             let cursorCol = resolvedSemanticCursorCol(content)
             let x = contentColOffset + Float(cursorCol) * cellW * scale - hScrollPx
@@ -2764,15 +2760,7 @@ final class CoreTextMetalRenderer {
             )
             return RenderCursor(x: x, y: y, shape: content.cursorShape, windowId: windowId)
         }
-
-        if sawActiveSemanticCursorOwner { return nil }
-        guard frameState.cursorVisible else { return nil }
-
-        let cursorPadding: Float = (frameState.gutterCol > 0 && frameState.cursorCol >= frameState.gutterCol)
-            ? gutterLeftMarginPx + gutterPaddingPx : 0
-        let x = Float(frameState.cursorCol) * cellW * scale + cursorPadding
-        let y = Float(frameState.cursorRow) * displayCellH * scale
-        return RenderCursor(x: x, y: y, shape: frameState.cursorShape)
+        return nil
     }
 
     /// Returns active semantic cursor owners in deterministic priority order. The agent prompt uses a reserved window id and must win over the retained chat content when both are active during focus transitions.

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -1802,9 +1802,7 @@ final class CoreTextMetalRenderer {
             let rowY = (Float(baseRow) + Float(presentationRow)) * cellH * scale - scrollOffsetY
             guard CoreTextMetalRenderer.clipVerticalQuad(y: rowY, height: cellH * scale, top: clipTop, bottom: clipBottom) != nil else { continue }
             let yPos = rowY
-            let gutterWidth = signColWidth + Int(gutter.lineNumberWidth)
-            let gutterCol = max(Int(baseCol) - gutterWidth, 0)
-            let xOffset = Float(gutterCol) * cellW * scale + gutterLeftMarginPx
+            let xOffset = Float(baseCol) * cellW * scale + gutterLeftMarginPx
 
             // Sign column (leftmost in gutter)
             if signColWidth > 0 {
@@ -2593,25 +2591,32 @@ final class CoreTextMetalRenderer {
         var rightFills: [(x: Float, y: Float, width: Float, height: Float)] = []
         var separators: [(x: Float, y: Float, width: Float, height: Float)] = []
 
-        for surface in surfaces.sorted(by: { $0.windowId < $1.windowId }) {
-            let gutter = surface.renderGutter
-            let gutterWidthCols = Int(gutter.lineNumberWidth) + Int(gutter.signColWidth)
-            guard gutterWidthCols > 0 else { continue }
-            let top = Float(gutter.contentRow) * cellH * scale
-            let height = Float(gutter.contentHeight) * cellH * scale
-            guard let vertical = clipVerticalQuad(y: top, height: height, top: 0, bottom: viewportHeight) else { continue }
-            let gutterLeftX = Float(gutter.contentCol) * cellW * scale
-            if gutterLeftMarginPx > 0 {
-                leftFills.append((x: gutterLeftX, y: vertical.y, width: gutterLeftMarginPx, height: vertical.height))
+        if !surfaces.isEmpty {
+            for surface in surfaces.sorted(by: { $0.windowId < $1.windowId }) {
+                let gutter = surface.renderGutter
+                let gutterWidthCols = Int(gutter.lineNumberWidth) + Int(gutter.signColWidth)
+                guard gutterWidthCols > 0 else { continue }
+                let top = Float(gutter.contentRow) * cellH * scale
+                let height = Float(gutter.contentHeight) * cellH * scale
+                guard let vertical = clipVerticalQuad(y: top, height: height, top: 0, bottom: viewportHeight) else { continue }
+                let gutterLeftX = Float(gutter.contentCol) * cellW * scale
+                if gutterLeftMarginPx > 0 {
+                    leftFills.append((x: gutterLeftX, y: vertical.y, width: gutterLeftMarginPx, height: vertical.height))
+                }
+                let gutterRightX = Float(Int(gutter.contentCol) + gutterWidthCols) * cellW * scale + gutterLeftMarginPx
+                if gutterPaddingPx > 0 {
+                    rightFills.append((x: gutterRightX, y: vertical.y, width: gutterPaddingPx, height: vertical.height))
+                }
+                if frameState.gutterSeparatorColor != 0 {
+                    separators.append((x: gutterRightX + gutterPaddingPx * 0.5, y: vertical.y, width: 1.0, height: vertical.height))
+                }
             }
-            let gutterRightX = Float(Int(gutter.contentCol) + gutterWidthCols) * cellW * scale + gutterLeftMarginPx
-            if gutterPaddingPx > 0 {
-                rightFills.append((x: gutterRightX, y: vertical.y, width: gutterPaddingPx, height: vertical.height))
-            }
+            return (leftFills, rightFills, separators)
         }
 
+        guard frameState.gutterCol > 0 else { return ([], [], []) }
         if gutterLeftMarginPx > 0 {
-            leftFills.append((x: Float(frameState.gutterCol) * cellW * scale, y: 0, width: gutterLeftMarginPx, height: viewportHeight))
+            leftFills.append((x: 0, y: 0, width: gutterLeftMarginPx, height: viewportHeight))
         }
         if gutterPaddingPx > 0 {
             rightFills.append((x: Float(frameState.gutterCol) * cellW * scale + gutterLeftMarginPx, y: 0, width: gutterPaddingPx, height: viewportHeight))

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -65,6 +65,32 @@ struct RenderCursor: Equatable {
     }
 }
 
+/// One presented editor surface bundled with the bounded row preparation the
+/// renderer computed for it in this frame.
+///
+/// This keeps the complete `PresentedWindowSurface` (content, gutter,
+/// pane geometry, indent guides) travelling with its `prepared`/`slice`
+/// products through metrics, atlas demand, content, gutter, indent-guide,
+/// cursor, and scroll-indicator passes. No pass rejoins per-window state from
+/// separate keyed collections after the transaction freeze.
+struct PreparedPresentedSurface {
+    let surface: PresentedWindowSurface
+    let prepared: ResidentRenderPreparationResult
+    let slice: RendererRowSlice
+
+    init(surface: PresentedWindowSurface, prepared: ResidentRenderPreparationResult) {
+        self.surface = surface
+        self.prepared = prepared
+        self.slice = RendererSignposts.rowSlice(for: prepared)
+    }
+
+    var content: GUIWindowContent { surface.content }
+    var renderGutter: Wire.WindowGutter { surface.renderGutter }
+    var paneGeometry: GUIPaneGeometry { surface.paneGeometry }
+    var indentGuides: IndentGuideData? { surface.indentGuides }
+    var windowId: UInt16 { surface.windowId }
+}
+
 /// Default background clear color (dark gray matching the default bg).
 /// Linear equivalents of sRGB (0.12, 0.12, 0.14).
 private let ctBgClearColorDefault = MTLClearColor(red: 0.01298, green: 0.01298, blue: 0.01681, alpha: 1.0)
@@ -292,6 +318,8 @@ final class CoreTextMetalRenderer {
     private var frameMetrics = FrameMetrics()
     /// Last immutable content value whose staging counters were reported.
     private var residentMetricContentIdentities: [UInt16: ObjectIdentifier] = [:]
+    /// Last successfully presented full-refresh value invalidated in each window's atlas namespace.
+    private var atlasFullRefreshIdentities: [UInt16: UUID] = [:]
 
     /// Metal buffer most recently promoted for line GPU instances (one instanced draw call).
     private var instanceBuffer: MTLBuffer?
@@ -372,9 +400,6 @@ final class CoreTextMetalRenderer {
         let frameState = snapshot.frameState
         let themeColors = snapshot.themeColors
         let surfaces = snapshot.surfaces
-        let windowContents = Dictionary(uniqueKeysWithValues: surfaces.map { ($0.windowId, $0.content) })
-        let renderGutters = Dictionary(uniqueKeysWithValues: surfaces.map { ($0.windowId, $0.renderGutter) })
-        let indentGuides = Dictionary(uniqueKeysWithValues: surfaces.compactMap { surface in surface.indentGuides.map { (surface.windowId, $0) } })
         let presentationFrame = GUICommittedFrame(generation: snapshot.generation, frameSeq: snapshot.frameSeq)
         let presentedSnapshot = snapshot
         let renderSignpostID = OSSignpostID(log: renderLog)
@@ -414,16 +439,21 @@ final class CoreTextMetalRenderer {
         // Gutter spacing is also needed to derive the exact clipped command
         // viewport. Prepare each resident window once, then reuse that result
         // for metrics, atlas demand, gutters, and CoreText rendering.
-        let hasGutterChrome = frameState.gutterCol > 0 || renderGutters.values.contains { $0.lineNumberWidth > 0 || $0.signColWidth > 0 || !$0.entries.isEmpty }
+        let hasGutterChrome = frameState.gutterCol > 0 || surfaces.contains { surface in
+            let gutter = surface.renderGutter
+            return gutter.lineNumberWidth > 0 || gutter.signColWidth > 0 || !gutter.entries.isEmpty
+        }
         let gutterLeftMarginPt: Float = hasGutterChrome ? round(Float(Self.gutterLeftMarginPt) * scale) / scale : 0
         let gutterLeftMarginPx = gutterLeftMarginPt * scale
         let gutterPaddingPt: Float = hasGutterChrome ? round(Float(Self.gutterRightGapPt) * scale) / scale : 0
         let gutterPaddingPx = gutterPaddingPt * scale
 
-        var preparedRowsByWindow: [UInt16: ResidentRenderPreparationResult] = [:]
-        var visibleSlices: [UInt16: RendererRowSlice] = [:]
-        preparedRowsByWindow.reserveCapacity(surfaces.count)
-        visibleSlices.reserveCapacity(surfaces.count)
+        // Each surface stays whole: its content, gutter, pane geometry, and
+        // indent guides ride alongside the bounded preparation/slice this frame
+        // computed for it. Every downstream pass reads this ordered array; no
+        // per-window state is rejoined from a separate keyed collection.
+        var preparedSurfaces: [PreparedPresentedSurface] = []
+        preparedSurfaces.reserveCapacity(surfaces.count)
         for surface in surfaces {
             let content = surface.content
             let gutter = surface.renderGutter
@@ -446,11 +476,10 @@ final class CoreTextMetalRenderer {
                 scrollLeft: max(scrollLeftInt - localScrollInsetCols, 0),
                 viewportCols: contentCols + 2
             )
-            preparedRowsByWindow[content.windowId] = prepared
-            let slice = RendererSignposts.rowSlice(for: prepared)
-            visibleSlices[content.windowId] = slice
+            let preparedSurface = PreparedPresentedSurface(surface: surface, prepared: prepared)
+            preparedSurfaces.append(preparedSurface)
             // This is the sole production resident traversal counter update.
-            RendererSignposts.recordVisibleSlice(slice, in: &frameMetrics)
+            RendererSignposts.recordVisibleSlice(preparedSurface.slice, in: &frameMetrics)
             frameMetrics.decorationsVisited += prepared.decorationsVisited
             RendererSignposts.recordOperation(
                 RendererSignposts.operationCounters(
@@ -477,8 +506,7 @@ final class CoreTextMetalRenderer {
         let candidateWindowRenderer = activeWindowRenderer.makeCandidate(rasterizer: candidateRasterizer)
         let candidateAtlas = activeAtlas.makeCandidate()
         let neededSlots = CoreTextMetalRenderer.atlasSlotDemand(
-            frameState: frameState, windowContents: windowContents,
-            gutters: renderGutters, preparedRows: preparedRowsByWindow
+            frameState: frameState, preparedSurfaces: preparedSurfaces
         )
         let atlasPixelWidth = Int(ceil(CGFloat(frameState.cols) * CGFloat(cellW) * CGFloat(scale)))
         switch candidateAtlas.ensureCapacity(maxSlots: neededSlots, width: atlasPixelWidth,
@@ -497,7 +525,15 @@ final class CoreTextMetalRenderer {
         candidateWindowRenderer.updateViewportWidth(cols: frameState.cols)
         if let tc = themeColors { candidateWindowRenderer.defaultFgRGB = tc.editorFgRGB }
         candidateAtlas.beginFrame()
-        Self.invalidateFullRefreshWindows(in: candidateAtlas, windowContents: windowContents)
+        let presentedWindowIDs = Set(surfaces.map(\.windowId))
+        var candidateFullRefreshIdentities = atlasFullRefreshIdentities.filter {
+            presentedWindowIDs.contains($0.key)
+        }
+        Self.invalidateFullRefreshWindows(
+            in: candidateAtlas,
+            surfaces: surfaces,
+            lastIdentities: &candidateFullRefreshIdentities
+        )
 
         // Default background color.
         let defaultBg = frameState.defaultBg != 0
@@ -522,8 +558,7 @@ final class CoreTextMetalRenderer {
         }
 
         let resolvedCursor = CoreTextMetalRenderer.resolveCursor(
-            windowContents: windowContents,
-            gutters: renderGutters,
+            surfaces: surfaces,
             activeWindowId: snapshot.activeSurface?.windowId,
             cellW: cellW,
             displayCellH: displayCellH,
@@ -532,6 +567,12 @@ final class CoreTextMetalRenderer {
             gutterPaddingPx: gutterPaddingPx
         )
         let renderCursor = animatedCursor(for: resolvedCursor, teleportLineThresholdPx: displayCellH * scale * 50.0)
+        // The cursor names exactly one window; select its complete surface once.
+        // This is a single-window lookup, not fragmented per-window joining.
+        let cursorSurface: PresentedWindowSurface? = renderCursor?.windowId
+            .flatMap { id in surfaces.first { $0.windowId == id } }
+        let activeSurface: PresentedWindowSurface? = frameState.activeWindowId
+            .flatMap { id in surfaces.first { $0.windowId == id } }
 
         // Build background quads and line texture instances.
         var bgQuads: [QuadGPU] = []
@@ -545,7 +586,8 @@ final class CoreTextMetalRenderer {
         var diagnosticQuads: [QuadGPU] = []
 
         if let wcr = windowContentRenderer {
-            for surface in surfaces {
+            for preparedSurface in preparedSurfaces {
+                let surface = preparedSurface.surface
                 let content = surface.content
                 let gutter = surface.renderGutter
                 let paneGeometry = surface.paneGeometry
@@ -573,7 +615,7 @@ final class CoreTextMetalRenderer {
                 )
                 let contentRightPx = windowBounds.x + windowBounds.width
                 let contentTopPx = Float(paneGeometry.textRect.row) * displayCellH * scale
-                guard let visibleSlice = visibleSlices[content.windowId] else { continue }
+                let visibleSlice = preparedSurface.slice
                 let overscanBeforeRows = visibleSlice.overscanBeforeRows
                 let committedVisibleRows = CoreTextMetalRenderer.committedVisibleRows(
                     paneGeometry: paneGeometry,
@@ -721,7 +763,7 @@ final class CoreTextMetalRenderer {
 
                 // Reuse the shared Metal-free CoreText commands prepared once
                 // at the start of this frame.
-                guard let preparedRows = preparedRowsByWindow[content.windowId] else { continue }
+                let preparedRows = preparedSurface.prepared
                 var visibleRowWidths: [UInt16: Int] = [:]
                 for command in preparedRows.commands {
                     let displayRow = command.displayRow
@@ -838,8 +880,12 @@ final class CoreTextMetalRenderer {
         }
 
         // Native gutter rendering from structured data.
-        // One Wire.WindowGutter per editor window (split pane).
-        for windowGutter in renderGutters.values where windowGutter.lineNumberWidth > 0 || windowGutter.signColWidth > 0 || !windowGutter.entries.isEmpty {
+        // One presented surface per editor window (split pane); its gutter and
+        // slice travel together, so no per-window state is rejoined here.
+        for preparedSurface in preparedSurfaces {
+            let windowGutter = preparedSurface.renderGutter
+            guard windowGutter.lineNumberWidth > 0 || windowGutter.signColWidth > 0 || !windowGutter.entries.isEmpty else { continue }
+            let slice = preparedSurface.slice
             renderGutterEntries(
                 gutter: windowGutter,
                 cellW: cellW, cellH: displayCellH, scale: scale,
@@ -855,12 +901,8 @@ final class CoreTextMetalRenderer {
                     targetWindowId: scrollTargetWindowId,
                     scrollOffsetPx: smoothScrollOffsetPx
                 ).y,
-                entryRange: visibleSlices[windowGutter.windowId].map {
-                    RendererSignposts.gutterRange(for: windowGutter, slice: $0)
-                } ?? 0..<min(Int(windowGutter.contentHeight), windowGutter.entries.count),
-                overscanBeforeRows: visibleSlices[windowGutter.windowId]?.overscanBeforeRows
-                    ?? windowContents[windowGutter.windowId].map(CoreTextMetalRenderer.presentationOverscanBeforeRows)
-                    ?? CoreTextMetalRenderer.scrollOverscanBefore(windowContents[windowGutter.windowId]?.scrollPresentation),
+                entryRange: RendererSignposts.gutterRange(for: windowGutter, slice: slice),
+                overscanBeforeRows: slice.overscanBeforeRows,
                 atlas: candidateAtlas,
                 windowRenderer: candidateWindowRenderer,
                 bgQuads: &bgQuads,
@@ -877,7 +919,7 @@ final class CoreTextMetalRenderer {
         // Derive one exact aggregate buffer request before command creation. No
         // buffer is replaced or grown while a pass is being encoded.
         let gutterChromeQuads = CoreTextMetalRenderer.gutterChromeQuads(
-            frameState: frameState, gutters: renderGutters,
+            frameState: frameState, surfaces: surfaces,
             cellW: cellW, cellH: displayCellH, scale: scale,
             gutterLeftMarginPx: gutterLeftMarginPx, gutterPaddingPx: gutterPaddingPx,
             viewportHeight: Float(viewportSize.height), defaultBg: defaultBg,
@@ -885,8 +927,7 @@ final class CoreTextMetalRenderer {
                                          default: SIMD3<Float>(0.3, 0.3, 0.3))
         )
         let guidePassCounts = indentGuideQuadCounts(
-            frameState: frameState, windowContents: windowContents,
-            gutters: renderGutters, indentGuides: indentGuides,
+            frameState: frameState, surfaces: surfaces,
             cellW: cellW, displayCellH: displayCellH, scale: scale,
             gutterLeftMarginPx: gutterLeftMarginPx, gutterPaddingPx: gutterPaddingPx,
             viewportSize: viewportSize, scrollTargetWindowId: scrollTargetWindowId,
@@ -1091,11 +1132,11 @@ final class CoreTextMetalRenderer {
         // Drawn after bg fills but before text, cursor, and selection overlays.
         // When per-line indent levels are available, draw segments only in
         // leading whitespace so guides don't bleed through text content.
-        for (_, guideData) in indentGuides {
-            guard !guideData.guideCols.isEmpty else { continue }
+        for surface in surfaces {
+            guard let guideData = surface.indentGuides, !guideData.guideCols.isEmpty else { continue }
 
-            guard let gutter = renderGutters[guideData.windowId],
-                  let paneGeometry = windowContents[guideData.windowId]?.paneGeometry else { continue }
+            let gutter = surface.renderGutter
+            let paneGeometry = surface.paneGeometry
             let windowContentColOffset = Float(paneGeometry.textRect.col) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
             let windowBounds = CoreTextMetalRenderer.windowHorizontalBounds(
                 geometry: paneGeometry,
@@ -1109,7 +1150,7 @@ final class CoreTextMetalRenderer {
             let lineCellH = displayCellH * scale
             let inactiveFg = colorFromU24(frameState.gutterColors.fg, default: SIMD3<Float>(0.33, 0.33, 0.33))
             let tabW = max(UInt16(guideData.tabWidth), 1)
-            let guideScrollLeft = windowContents[guideData.windowId]?.scrollLeft ?? 0
+            let guideScrollLeft = surface.content.scrollLeft
             let guideScrollOffset = CoreTextMetalRenderer.presentationScrollOffset(
                 scrollLeft: guideScrollLeft,
                 scrollOffsetPx: CoreTextMetalRenderer.smoothScrollOffset(
@@ -1187,7 +1228,7 @@ final class CoreTextMetalRenderer {
         // For block cursors, draw the cursor bg here so the text pass composites over it.
         // Beam and underline cursors are drawn AFTER text (pass 5).
         if let renderCursor, cursorBlinkVisible, renderCursor.shape == .block {
-            let cursorScrollLeft = renderCursor.windowId.flatMap { windowContents[$0]?.scrollLeft } ?? 0
+            let cursorScrollLeft = cursorSurface?.content.scrollLeft ?? 0
             let cursorScrollOffsetPx = CoreTextMetalRenderer.presentationScrollOffset(
                 scrollLeft: cursorScrollLeft,
                 scrollOffsetPx: CoreTextMetalRenderer.smoothScrollOffset(
@@ -1201,11 +1242,10 @@ final class CoreTextMetalRenderer {
             var cursorQuad = QuadGPU()
             let cursorWidth = CoreTextMetalRenderer.snapToPixel(cellW * scale)
             let cursorHeight = CoreTextMetalRenderer.snapToPixel(displayCellH * scale)
-            let cursorWindowBounds = renderCursor.windowId.flatMap { windowId -> (x: Float, width: Float)? in
-                guard let gutter = renderGutters[windowId] else { return nil }
-                return CoreTextMetalRenderer.cursorHorizontalBounds(
-                    geometry: windowContents[windowId]?.paneGeometry,
-                    gutter: gutter,
+            let cursorWindowBounds = cursorSurface.map { surface in
+                CoreTextMetalRenderer.cursorHorizontalBounds(
+                    geometry: surface.paneGeometry,
+                    gutter: surface.renderGutter,
                     frameCols: frameState.cols,
                     cellW: cellW,
                     scale: scale,
@@ -1214,14 +1254,14 @@ final class CoreTextMetalRenderer {
                     viewportWidth: Float(viewportSize.width)
                 )
             }
-            let cursorBounds = CoreTextMetalRenderer.paneVerticalBounds(
-                for: renderCursor.windowId,
-                windowContents: windowContents,
-                gutters: renderGutters,
-                displayCellH: displayCellH,
-                scale: scale,
-                viewportHeight: Float(viewportSize.height)
-            )
+            let cursorBounds = cursorSurface.flatMap { surface in
+                CoreTextMetalRenderer.paneVerticalBounds(
+                    geometry: surface.paneGeometry,
+                    displayCellH: displayCellH,
+                    scale: scale,
+                    viewportHeight: Float(viewportSize.height)
+                )
+            }
             var shouldDrawCursor = true
             if let cursorWindowBounds, let cursorBounds {
                 if let horizontal = CoreTextMetalRenderer.clipHorizontalRect(x: cursorX, width: cursorWidth, left: cursorWindowBounds.x, right: cursorWindowBounds.x + cursorWindowBounds.width), let clipped = CoreTextMetalRenderer.clipVerticalQuad(y: cursorY, height: cursorHeight, top: cursorBounds.top, bottom: cursorBounds.bottom) {
@@ -1368,7 +1408,7 @@ final class CoreTextMetalRenderer {
         // Block cursor is drawn in pass 2 (before text) so text shows on top.
         // Beam and underline are drawn AFTER text so they overlay it.
         if let renderCursor, cursorBlinkVisible, renderCursor.shape != .block {
-            let cursorScrollLeft = renderCursor.windowId.flatMap { windowContents[$0]?.scrollLeft } ?? 0
+            let cursorScrollLeft = cursorSurface?.content.scrollLeft ?? 0
             let cursorScrollOffsetPx = CoreTextMetalRenderer.presentationScrollOffset(
                 scrollLeft: cursorScrollLeft,
                 scrollOffsetPx: CoreTextMetalRenderer.smoothScrollOffset(
@@ -1379,11 +1419,10 @@ final class CoreTextMetalRenderer {
             )
             let cursorX = renderCursor.x - cursorScrollOffsetPx.x
             let cursorY = renderCursor.y - cursorScrollOffsetPx.y
-            let cursorWindowBounds = renderCursor.windowId.flatMap { windowId -> (x: Float, width: Float)? in
-                guard let gutter = renderGutters[windowId] else { return nil }
-                return CoreTextMetalRenderer.cursorHorizontalBounds(
-                    geometry: windowContents[windowId]?.paneGeometry,
-                    gutter: gutter,
+            let cursorWindowBounds = cursorSurface.map { surface in
+                CoreTextMetalRenderer.cursorHorizontalBounds(
+                    geometry: surface.paneGeometry,
+                    gutter: surface.renderGutter,
                     frameCols: frameState.cols,
                     cellW: cellW,
                     scale: scale,
@@ -1397,14 +1436,14 @@ final class CoreTextMetalRenderer {
             cursorQuad.alpha = 1.0
             var shouldDrawCursor = true
 
-            let cursorBounds = CoreTextMetalRenderer.paneVerticalBounds(
-                for: renderCursor.windowId,
-                windowContents: windowContents,
-                gutters: renderGutters,
-                displayCellH: displayCellH,
-                scale: scale,
-                viewportHeight: Float(viewportSize.height)
-            )
+            let cursorBounds = cursorSurface.flatMap { surface in
+                CoreTextMetalRenderer.paneVerticalBounds(
+                    geometry: surface.paneGeometry,
+                    displayCellH: displayCellH,
+                    scale: scale,
+                    viewportHeight: Float(viewportSize.height)
+                )
+            }
 
             switch renderCursor.shape {
             case .block:
@@ -1457,11 +1496,10 @@ final class CoreTextMetalRenderer {
         let viewportTop = frameState.viewportTopLine
 
         let scrollIndicatorResident: Bool = {
-            guard let wid = frameState.activeWindowId,
-                  let content = windowContents[wid],
-                  let sp = content.scrollPresentation else { return false }
-            let perWindowTotal = content.paneGeometry?.viewport.totalLines ?? totalLines
-            return perWindowTotal > 0 && sp.overscanStartLine == 0 && sp.overscanEndLine >= perWindowTotal
+            guard let activeSurface,
+                  let scrollPresentation = activeSurface.content.scrollPresentation else { return false }
+            let perWindowTotal = activeSurface.paneGeometry.viewport.totalLines
+            return perWindowTotal > 0 && scrollPresentation.overscanStartLine == 0 && scrollPresentation.overscanEndLine >= perWindowTotal
         }()
 
         if totalLines > visibleRows && viewportTop != 0xFFFF_FFFF && scrollIndicatorAlpha > 0 {
@@ -1479,6 +1517,17 @@ final class CoreTextMetalRenderer {
 
             let thumbX = Float(viewportSize.width) - indicatorWidth - indicatorMargin
 
+            var trackQuad = QuadGPU()
+            trackQuad.position = SIMD2<Float>(thumbX - indicatorMargin, 0)
+            trackQuad.size = SIMD2<Float>(indicatorWidth + indicatorMargin * 2, trackHeight)
+            trackQuad.color = defaultBg
+            trackQuad.alpha = scrollIndicatorAlpha
+
+            encoder.setRenderPipelineState(bgPipeline)
+            encoder.setVertexBytes(&trackQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
+            encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
+            encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
+
             var scrollQuad = QuadGPU()
             scrollQuad.position = SIMD2<Float>(thumbX, thumbY)
             scrollQuad.size = SIMD2<Float>(indicatorWidth, thumbHeight)
@@ -1486,7 +1535,6 @@ final class CoreTextMetalRenderer {
             scrollQuad.color = colorFromU24(frameState.scrollIndicatorColor, default: SIMD3<Float>(0.4, 0.4, 0.4))
             scrollQuad.alpha = 0.4 * scrollIndicatorAlpha
 
-            encoder.setRenderPipelineState(bgPipeline)
             encoder.setVertexBytes(&scrollQuad, length: MemoryLayout<QuadGPU>.stride, index: 0)
             encoder.setVertexBytes(&uniforms, length: MemoryLayout<CTUniformsGPU>.size, index: 1)
             encoder.drawPrimitives(type: .triangle, vertexStart: 0, vertexCount: 6, instanceCount: 1)
@@ -1646,6 +1694,7 @@ final class CoreTextMetalRenderer {
                 self.atlas = candidateAtlas
                 self.bitmapRasterizer = candidateRasterizer
                 self.windowContentRenderer = candidateWindowRenderer
+                self.atlasFullRefreshIdentities = candidateFullRefreshIdentities
                 self.instanceBuffer = candidateInstanceBuffer
                 self.maxInstanceSlots = candidateInstanceSlots
                 self.quadBuffers = candidateQuadBuffers
@@ -1753,7 +1802,9 @@ final class CoreTextMetalRenderer {
             let rowY = (Float(baseRow) + Float(presentationRow)) * cellH * scale - scrollOffsetY
             guard CoreTextMetalRenderer.clipVerticalQuad(y: rowY, height: cellH * scale, top: clipTop, bottom: clipBottom) != nil else { continue }
             let yPos = rowY
-            let xOffset = Float(baseCol) * cellW * scale + gutterLeftMarginPx
+            let gutterWidth = signColWidth + Int(gutter.lineNumberWidth)
+            let gutterCol = max(Int(baseCol) - gutterWidth, 0)
+            let xOffset = Float(gutterCol) * cellW * scale + gutterLeftMarginPx
 
             // Sign column (leftmost in gutter)
             if signColWidth > 0 {
@@ -1989,21 +2040,19 @@ final class CoreTextMetalRenderer {
     }
 
     private func indentGuideQuadCounts(
-        frameState: FrameState, windowContents: [UInt16: GUIWindowContent],
-        gutters: [UInt16: Wire.WindowGutter], indentGuides: [UInt16: IndentGuideData],
+        frameState: FrameState, surfaces: [PresentedWindowSurface],
         cellW: Float, displayCellH: Float, scale: Float,
         gutterLeftMarginPx: Float, gutterPaddingPx: Float,
         viewportSize: CGSize, scrollTargetWindowId: UInt16?,
         smoothScrollOffsetPx: SIMD2<Float>
     ) -> [Int] {
         var counts: [Int] = []
-        for (_, guideData) in indentGuides {
-            guard !guideData.guideCols.isEmpty,
-                  let gutter = gutters[guideData.windowId] else { continue }
-            let paneGeometry = windowContents[guideData.windowId]?.paneGeometry
-            let fallbackTextCol = UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth)
-                                         + Int(gutter.signColWidth))
-            let contentLeft = Float(paneGeometry?.textRect.col ?? fallbackTextCol) * cellW * scale
+        for surface in surfaces {
+            guard let guideData = surface.indentGuides,
+                  !guideData.guideCols.isEmpty else { continue }
+            let gutter = surface.renderGutter
+            let paneGeometry = surface.paneGeometry
+            let contentLeft = Float(paneGeometry.textRect.col) * cellW * scale
                 + gutterLeftMarginPx + gutterPaddingPx
             let bounds = Self.windowHorizontalBounds(
                 geometry: paneGeometry, gutter: gutter, frameCols: frameState.cols,
@@ -2011,16 +2060,15 @@ final class CoreTextMetalRenderer {
             )
             let contentRight = bounds.x + bounds.width
             let lineCellH = displayCellH * scale
-            let scrollLeft = windowContents[guideData.windowId]?.scrollLeft ?? 0
             let scroll = Self.presentationScrollOffset(
-                scrollLeft: scrollLeft,
+                scrollLeft: surface.content.scrollLeft,
                 scrollOffsetPx: Self.smoothScrollOffset(
-                    for: guideData.windowId, targetWindowId: scrollTargetWindowId,
+                    for: surface.windowId, targetWindowId: scrollTargetWindowId,
                     scrollOffsetPx: smoothScrollOffsetPx
                 )
             )
-            let top = Float(paneGeometry?.textRect.row ?? gutter.contentRow) * displayCellH * scale
-            let height = Float(max(Int(paneGeometry?.textRect.height ?? gutter.contentHeight), 0)) * lineCellH
+            let top = Float(paneGeometry.textRect.row) * displayCellH * scale
+            let height = Float(max(Int(paneGeometry.textRect.height), 0)) * lineCellH
             let bottom = min(top + height, Float(viewportSize.height))
             let tabWidth = max(UInt16(guideData.tabWidth), 1)
             var count = 0
@@ -2197,14 +2245,56 @@ final class CoreTextMetalRenderer {
         return hasher.finalize()
     }
 
-    /// Computes a conservative atlas slot count for all text textures that may be touched by the current frame.
+    /// Invalidates one newly presented full-refresh value once, not on every local redraw of the same immutable content.
     @MainActor
-    static func invalidateFullRefreshWindows(in atlas: LineTextureAtlas, windowContents: [UInt16: GUIWindowContent]) {
-        for content in windowContents.values where content.fullRefresh {
-            atlas.invalidateWindow(content.windowId)
+    static func invalidateFullRefreshWindows(
+        in atlas: LineTextureAtlas,
+        surfaces: [PresentedWindowSurface],
+        lastIdentities: inout [UInt16: UUID]
+    ) {
+        for surface in surfaces where surface.content.fullRefresh {
+            let identity = surface.content.renderIdentity
+            guard lastIdentities[surface.windowId] != identity else { continue }
+            atlas.invalidateWindow(surface.windowId)
+            lastIdentities[surface.windowId] = identity
         }
     }
 
+    nonisolated static func atlasSlotDemand(
+        frameState: FrameState,
+        preparedSurfaces: [PreparedPresentedSurface]
+    ) -> Int {
+        let bufferRows = preparedSurfaces.reduce(0) { $0 + $1.slice.rows.count }
+
+        let lineAnnotations = preparedSurfaces.reduce(0) { total, preparedSurface in
+            let content = preparedSurface.surface.content
+            let slice = preparedSurface.slice
+            let fallback = max(slice.rows.count - slice.overscanBeforeRows, 0)
+            let paneRows = Int(preparedSurface.surface.paneGeometry.textRect.height)
+            let visibleRows = paneRows > 0 ? paneRows : fallback
+            return total + content.lineAnnotations.filter {
+                $0.kind != .gutterIcon && Int($0.row) < visibleRows
+            }.count
+        }
+
+        let gutterTextures = preparedSurfaces.reduce(0) { total, preparedSurface in
+            let gutter = preparedSurface.surface.renderGutter
+            return total + gutterTextureDemand(
+                gutter,
+                range: RendererSignposts.gutterRange(for: gutter, slice: preparedSurface.slice)
+            )
+        }
+
+        let splitLabels = frameState.horizontalSeparators.reduce(0) { total, separator in
+            total + (separator.filename.isEmpty ? 0 : 1)
+        }
+
+        let demand = bufferRows + lineAnnotations + gutterTextures + splitLabels
+        let slack = max(Int(frameState.rows), 32)
+        return max(demand + slack, 1)
+    }
+
+    #if MINGA_SNAPSHOT_RENDERER
     nonisolated static func atlasSlotDemand(
         frameState: FrameState,
         windowContents: [UInt16: GUIWindowContent],
@@ -2251,6 +2341,8 @@ final class CoreTextMetalRenderer {
         let slack = max(Int(frameState.rows), 32)
         return max(demand + slack, 1)
     }
+
+    #endif
 
     private nonisolated static func gutterTextureDemand(
         _ gutter: Wire.WindowGutter,
@@ -2432,6 +2524,7 @@ final class CoreTextMetalRenderer {
         return low
     }
 
+    #if MINGA_SNAPSHOT_RENDERER
     nonisolated static func gutterChromeRects(
         frameState: FrameState,
         gutters: [UInt16: Wire.WindowGutter],
@@ -2483,9 +2576,56 @@ final class CoreTextMetalRenderer {
         return (leftFills, rightFills, separators)
     }
 
+    #endif
+
+    nonisolated static func gutterChromeRects(
+        frameState: FrameState,
+        surfaces: [PresentedWindowSurface],
+        cellW: Float,
+        cellH: Float,
+        scale: Float,
+        gutterLeftMarginPx: Float,
+        gutterPaddingPx: Float,
+        viewportHeight: Float
+    ) -> (leftFills: [(x: Float, y: Float, width: Float, height: Float)], rightFills: [(x: Float, y: Float, width: Float, height: Float)], separators: [(x: Float, y: Float, width: Float, height: Float)]) {
+        guard gutterLeftMarginPx > 0 || gutterPaddingPx > 0 || frameState.gutterSeparatorColor != 0 else { return ([], [], []) }
+        var leftFills: [(x: Float, y: Float, width: Float, height: Float)] = []
+        var rightFills: [(x: Float, y: Float, width: Float, height: Float)] = []
+        var separators: [(x: Float, y: Float, width: Float, height: Float)] = []
+
+        for surface in surfaces.sorted(by: { $0.windowId < $1.windowId }) {
+            let gutter = surface.renderGutter
+            let gutterWidthCols = Int(gutter.lineNumberWidth) + Int(gutter.signColWidth)
+            guard gutterWidthCols > 0 else { continue }
+            let top = Float(gutter.contentRow) * cellH * scale
+            let height = Float(gutter.contentHeight) * cellH * scale
+            guard let vertical = clipVerticalQuad(y: top, height: height, top: 0, bottom: viewportHeight) else { continue }
+            let gutterLeftX = Float(gutter.contentCol) * cellW * scale
+            if gutterLeftMarginPx > 0 {
+                leftFills.append((x: gutterLeftX, y: vertical.y, width: gutterLeftMarginPx, height: vertical.height))
+            }
+            let gutterRightX = Float(Int(gutter.contentCol) + gutterWidthCols) * cellW * scale + gutterLeftMarginPx
+            if gutterPaddingPx > 0 {
+                rightFills.append((x: gutterRightX, y: vertical.y, width: gutterPaddingPx, height: vertical.height))
+            }
+        }
+
+        if gutterLeftMarginPx > 0 {
+            leftFills.append((x: Float(frameState.gutterCol) * cellW * scale, y: 0, width: gutterLeftMarginPx, height: viewportHeight))
+        }
+        if gutterPaddingPx > 0 {
+            rightFills.append((x: Float(frameState.gutterCol) * cellW * scale + gutterLeftMarginPx, y: 0, width: gutterPaddingPx, height: viewportHeight))
+        }
+        if frameState.gutterSeparatorColor != 0 {
+            let gutterRightX = Float(frameState.gutterCol) * cellW * scale + gutterLeftMarginPx
+            separators.append((x: gutterRightX + gutterPaddingPx * 0.5, y: 0, width: 1.0, height: viewportHeight))
+        }
+        return (leftFills, rightFills, separators)
+    }
+
     nonisolated static func gutterChromeQuads(
         frameState: FrameState,
-        gutters: [UInt16: Wire.WindowGutter],
+        surfaces: [PresentedWindowSurface],
         cellW: Float,
         cellH: Float,
         scale: Float,
@@ -2497,7 +2637,7 @@ final class CoreTextMetalRenderer {
     ) -> [QuadGPU] {
         let rects = gutterChromeRects(
             frameState: frameState,
-            gutters: gutters,
+            surfaces: surfaces,
             cellW: cellW,
             cellH: cellH,
             scale: scale,
@@ -2547,6 +2687,19 @@ final class CoreTextMetalRenderer {
     }
 
     nonisolated static func paneVerticalBounds(
+        geometry: GUIPaneGeometry,
+        displayCellH: Float,
+        scale: Float,
+        viewportHeight: Float
+    ) -> (top: Float, bottom: Float)? {
+        let top = Float(geometry.textRect.row) * displayCellH * scale
+        let rows = max(Int(geometry.textRect.height), 0)
+        let bottom = min(top + Float(rows) * displayCellH * scale, viewportHeight)
+        return bottom > top ? (top, bottom) : nil
+    }
+
+    #if MINGA_SNAPSHOT_RENDERER
+    nonisolated static func paneVerticalBounds(
         for windowId: UInt16?,
         windowContents: [UInt16: GUIWindowContent],
         gutters: [UInt16: Wire.WindowGutter],
@@ -2556,10 +2709,12 @@ final class CoreTextMetalRenderer {
     ) -> (top: Float, bottom: Float)? {
         guard let windowId else { return nil }
         if let geometry = windowContents[windowId]?.paneGeometry {
-            let top = Float(geometry.textRect.row) * displayCellH * scale
-            let rows = max(Int(geometry.textRect.height), 0)
-            let bottom = min(top + Float(rows) * displayCellH * scale, viewportHeight)
-            return bottom > top ? (top, bottom) : nil
+            return paneVerticalBounds(
+                geometry: geometry,
+                displayCellH: displayCellH,
+                scale: scale,
+                viewportHeight: viewportHeight
+            )
         }
         if let gutter = gutters[windowId] {
             let top = Float(gutter.contentRow) * displayCellH * scale
@@ -2569,6 +2724,8 @@ final class CoreTextMetalRenderer {
         }
         return nil
     }
+
+    #endif
 
     /// Vertical span (in device pixels) of a window's editor-background fill.
     ///
@@ -2781,6 +2938,47 @@ final class CoreTextMetalRenderer {
     /// Resolve the cursor position in the same coordinate system as the text renderer.
     /// Cursor authority lives in the active presented window surface. There is no legacy `FrameState` fallback because drawing a cursor from a different semantic source would recreate the #2999 split-brain presentation bug.
     nonisolated static func resolveCursor(
+        surfaces: [PresentedWindowSurface],
+        activeWindowId: UInt16? = nil,
+        cellW: Float,
+        displayCellH: Float,
+        scale: Float,
+        gutterLeftMarginPx: Float,
+        gutterPaddingPx: Float
+    ) -> RenderCursor? {
+        let orderedSurfaces: [PresentedWindowSurface]
+        if let activeWindowId,
+           let activeSurface = surfaces.first(where: { $0.windowId == activeWindowId }) {
+            orderedSurfaces = [activeSurface]
+        } else {
+            let activeSurfaces = surfaces.filter(\.renderGutter.isActive).sorted {
+                let leftPriority = semanticCursorPriority(windowId: $0.windowId)
+                let rightPriority = semanticCursorPriority(windowId: $1.windowId)
+                return leftPriority == rightPriority ? $0.windowId < $1.windowId : leftPriority < rightPriority
+            }
+            orderedSurfaces = activeSurfaces.isEmpty ? surfaces.sorted { $0.windowId < $1.windowId } : activeSurfaces
+        }
+
+        for surface in orderedSurfaces where surface.content.cursorVisible {
+            let content = surface.content
+            let textCol = surface.paneGeometry.textRect.col
+            let contentColOffset = Float(textCol) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
+            let hScrollPx = Float(content.scrollLeft) * cellW * scale
+            let cursorCol = resolvedSemanticCursorCol(content)
+            let x = contentColOffset + Float(cursorCol) * cellW * scale - hScrollPx
+            let y = viewportLocalRowY(
+                localRow: Int(content.cursorRow),
+                origin: Float(surface.paneGeometry.textRect.row) * displayCellH * scale,
+                cellHeight: displayCellH,
+                scale: scale
+            )
+            return RenderCursor(x: x, y: y, shape: content.cursorShape, windowId: surface.windowId)
+        }
+        return nil
+    }
+
+    #if MINGA_SNAPSHOT_RENDERER
+    nonisolated static func resolveCursor(
         windowContents: [UInt16: GUIWindowContent],
         gutters: [UInt16: Wire.WindowGutter],
         activeWindowId: UInt16? = nil,
@@ -2836,6 +3034,8 @@ final class CoreTextMetalRenderer {
 
         return windowContents.keys.sorted()
     }
+
+    #endif
 
     nonisolated static func semanticCursorPriority(windowId: UInt16) -> Int {
         windowId == 65_534 ? 0 : 1

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -293,12 +293,21 @@ final class CoreTextMetalRenderer {
     /// Last immutable content value whose staging counters were reported.
     private var residentMetricContentIdentities: [UInt16: ObjectIdentifier] = [:]
 
-    /// Metal buffer for line GPU instances (one instanced draw call).
+    /// Metal buffer most recently promoted for line GPU instances (one instanced draw call).
     private var instanceBuffer: MTLBuffer?
     private var maxInstanceSlots: Int = 0
 
-    /// Number of in-flight frames for triple-buffered quad uploads.
-    private static let quadBufferFrameCount = 3
+    /// Number of renderer-owned reusable slots, matching the maximum allowed native generations in flight.
+    private static let nativeFrameSlotCount = 3
+    private static let quadBufferFrameCount = nativeFrameSlotCount
+
+    /// Reusable line-instance buffers, one per native frame slot. Slots grow on demand and are reused after warm-up.
+    private var lineBufferSlots: [MTLBuffer?] = Array(repeating: nil, count: CoreTextMetalRenderer.nativeFrameSlotCount)
+    private var lineBufferSlotBytes: [Int] = Array(repeating: 0, count: CoreTextMetalRenderer.nativeFrameSlotCount)
+
+    /// Reusable offscreen render targets, one per native frame slot. Slots grow on size changes and are reused after warm-up.
+    private var renderTargetSlots: [MTLTexture?] = Array(repeating: nil, count: CoreTextMetalRenderer.nativeFrameSlotCount)
+    private var renderTargetSlotSizes: [(width: Int, height: Int)] = Array(repeating: (0, 0), count: CoreTextMetalRenderer.nativeFrameSlotCount)
 
     /// Triple-buffered quad instance buffers for bg/overlay/diagnostic passes.
     ///
@@ -308,6 +317,10 @@ final class CoreTextMetalRenderer {
     /// in-flight frame (rotated each frame) avoids CPU/GPU contention: the CPU
     /// writes the next frame's buffer while the GPU reads the previous one.
     private var quadBuffers: [MTLBuffer] = []
+
+    /// Reusable quad buffer sets, one set per native frame slot. Each slot owns the buffers needed for all in-flight-safe uploads for that generation.
+    private var quadBufferSlots: [[MTLBuffer]] = Array(repeating: [], count: CoreTextMetalRenderer.nativeFrameSlotCount)
+    private var quadBufferSlotBytes: [Int] = Array(repeating: 0, count: CoreTextMetalRenderer.nativeFrameSlotCount)
 
     /// Capacity (in quads) of each entry in `quadBuffers`. Grows on demand.
     private var quadBufferCapacity: Int = 0
@@ -345,6 +358,17 @@ final class CoreTextMetalRenderer {
                 presentationInputSeq: UInt32 = 0,
                 latencyRecorder: LatencyRecorder? = nil,
                 onPresented: @escaping @MainActor (CommittedEditorSnapshot) -> Void = { _ in }) {
+        guard presentationGeneration.next &- presentationGeneration.completed < UInt64(Self.nativeFrameSlotCount) else {
+            let presentationFrame = GUICommittedFrame(generation: snapshot.generation, frameSeq: snapshot.frameSeq)
+            recordNativeFailure(NativePresentationFailure(
+                phase: .command, dimension: .submission,
+                frameSequence: presentationInputSeq, reason: .unavailable
+            ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
+            latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
+            return
+        }
+        let nativeFrameSlot = Int(presentationGeneration.next % UInt64(Self.nativeFrameSlotCount))
+
         let frameState = snapshot.frameState
         let themeColors = snapshot.themeColors
         let surfaces = snapshot.surfaces
@@ -500,6 +524,7 @@ final class CoreTextMetalRenderer {
         let resolvedCursor = CoreTextMetalRenderer.resolveCursor(
             windowContents: windowContents,
             gutters: renderGutters,
+            activeWindowId: snapshot.activeSurface?.windowId,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -892,33 +917,43 @@ final class CoreTextMetalRenderer {
         }
         let candidateInstanceBuffer: MTLBuffer?
         if bufferDemand.lineBytes > 0 {
-            guard let buffer = factories.makeBuffer(device, bufferDemand.lineBytes, .storageModeShared) else {
-                recordNativeFailure(NativePresentationFailure(
-                    phase: .buffers, dimension: .lineBuffer,
-                    requested: bufferDemand.lineBytes,
-                    frameSequence: presentationInputSeq, reason: .allocation
-                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
-                return
+            if lineBufferSlotBytes[nativeFrameSlot] < bufferDemand.lineBytes || lineBufferSlots[nativeFrameSlot] == nil {
+                guard let buffer = factories.makeBuffer(device, bufferDemand.lineBytes, .storageModeShared) else {
+                    recordNativeFailure(NativePresentationFailure(
+                        phase: .buffers, dimension: .lineBuffer,
+                        requested: bufferDemand.lineBytes,
+                        frameSequence: presentationInputSeq, reason: .allocation
+                    ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
+                    return
+                }
+                lineBufferSlots[nativeFrameSlot] = buffer
+                lineBufferSlotBytes[nativeFrameSlot] = bufferDemand.lineBytes
             }
-            candidateInstanceBuffer = buffer
+            candidateInstanceBuffer = lineBufferSlots[nativeFrameSlot]
         } else {
             candidateInstanceBuffer = nil
         }
         var candidateQuadBuffers: [MTLBuffer] = []
         if bufferDemand.quadBytesPerBuffer > 0 {
-            let dimensions: [NativeRenderResourceDimension] = [.quadBuffer0, .quadBuffer1, .quadBuffer2]
-            for index in 0..<Self.quadBufferFrameCount {
-                guard let buffer = factories.makeBuffer(device, bufferDemand.quadBytesPerBuffer,
-                                                        .storageModeShared) else {
-                    recordNativeFailure(NativePresentationFailure(
-                        phase: .buffers, dimension: dimensions[index],
-                        requested: bufferDemand.quadBytesPerBuffer,
-                        frameSequence: presentationInputSeq, reason: .allocation
-                    ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
-                    return
+            if quadBufferSlotBytes[nativeFrameSlot] < bufferDemand.quadBytesPerBuffer || quadBufferSlots[nativeFrameSlot].count != Self.quadBufferFrameCount {
+                var allocatedBuffers: [MTLBuffer] = []
+                let dimensions: [NativeRenderResourceDimension] = [.quadBuffer0, .quadBuffer1, .quadBuffer2]
+                for index in 0..<Self.quadBufferFrameCount {
+                    guard let buffer = factories.makeBuffer(device, bufferDemand.quadBytesPerBuffer,
+                                                            .storageModeShared) else {
+                        recordNativeFailure(NativePresentationFailure(
+                            phase: .buffers, dimension: dimensions[index],
+                            requested: bufferDemand.quadBytesPerBuffer,
+                            frameSequence: presentationInputSeq, reason: .allocation
+                        ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
+                        return
+                    }
+                    allocatedBuffers.append(buffer)
                 }
-                candidateQuadBuffers.append(buffer)
+                quadBufferSlots[nativeFrameSlot] = allocatedBuffers
+                quadBufferSlotBytes[nativeFrameSlot] = bufferDemand.quadBytesPerBuffer
             }
+            candidateQuadBuffers = quadBufferSlots[nativeFrameSlot]
         }
 
         // Render into a private candidate image. The drawable remains untouched
@@ -974,15 +1009,27 @@ final class CoreTextMetalRenderer {
             ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
             return
         }
-        let targetDescriptor = MTLTextureDescriptor.texture2DDescriptor(
-            pixelFormat: .bgra8Unorm_srgb,
-            width: targetDemand.width,
-            height: targetDemand.height,
-            mipmapped: false
-        )
-        targetDescriptor.usage = .renderTarget
-        targetDescriptor.storageMode = .private
-        guard let candidateRenderTarget = factories.makeTexture(device, targetDescriptor) else {
+        if renderTargetSlots[nativeFrameSlot] == nil || renderTargetSlotSizes[nativeFrameSlot].width != targetDemand.width || renderTargetSlotSizes[nativeFrameSlot].height != targetDemand.height {
+            let targetDescriptor = MTLTextureDescriptor.texture2DDescriptor(
+                pixelFormat: .bgra8Unorm_srgb,
+                width: targetDemand.width,
+                height: targetDemand.height,
+                mipmapped: false
+            )
+            targetDescriptor.usage = .renderTarget
+            targetDescriptor.storageMode = .private
+            guard let renderTarget = factories.makeTexture(device, targetDescriptor) else {
+                recordNativeFailure(NativePresentationFailure(
+                    phase: .drawable, dimension: .renderTarget,
+                    requested: targetDemand.byteCount, limit: resourcePolicy.renderTargetBytes,
+                    frameSequence: presentationInputSeq, reason: .allocation
+                ), latencyRecorder: latencyRecorder, presentationFrame: presentationFrame)
+                return
+            }
+            renderTargetSlots[nativeFrameSlot] = renderTarget
+            renderTargetSlotSizes[nativeFrameSlot] = (targetDemand.width, targetDemand.height)
+        }
+        guard let candidateRenderTarget = renderTargetSlots[nativeFrameSlot] else {
             recordNativeFailure(NativePresentationFailure(
                 phase: .drawable, dimension: .renderTarget,
                 requested: targetDemand.byteCount, limit: resourcePolicy.renderTargetBytes,
@@ -2736,22 +2783,24 @@ final class CoreTextMetalRenderer {
     nonisolated static func resolveCursor(
         windowContents: [UInt16: GUIWindowContent],
         gutters: [UInt16: Wire.WindowGutter],
+        activeWindowId: UInt16? = nil,
         cellW: Float,
         displayCellH: Float,
         scale: Float,
         gutterLeftMarginPx: Float,
         gutterPaddingPx: Float
     ) -> RenderCursor? {
-        for windowId in semanticCursorWindowIds(gutters) {
-            guard let gutter = gutters[windowId], let content = windowContents[windowId] else { continue }
+        for windowId in semanticCursorWindowIds(gutters, windowContents: windowContents, activeWindowId: activeWindowId) {
+            guard let content = windowContents[windowId] else { continue }
             guard content.cursorVisible else { continue }
 
-            let textCol = content.paneGeometry?.textRect.col ?? UInt16(Int(gutter.contentCol) + Int(gutter.lineNumberWidth) + Int(gutter.signColWidth))
+            let gutter = gutters[windowId]
+            let textCol = content.paneGeometry?.textRect.col ?? gutter.map { UInt16(Int($0.contentCol) + Int($0.lineNumberWidth) + Int($0.signColWidth)) } ?? 0
             let contentColOffset = Float(textCol) * cellW * scale + gutterLeftMarginPx + gutterPaddingPx
             let hScrollPx = Float(content.scrollLeft) * cellW * scale
             let cursorCol = resolvedSemanticCursorCol(content)
             let x = contentColOffset + Float(cursorCol) * cellW * scale - hScrollPx
-            let textRow = content.paneGeometry?.textRect.row ?? gutter.contentRow
+            let textRow = content.paneGeometry?.textRect.row ?? gutter?.contentRow ?? 0
             let y = viewportLocalRowY(
                 localRow: Int(content.cursorRow),
                 origin: Float(textRow) * displayCellH * scale,
@@ -2764,8 +2813,16 @@ final class CoreTextMetalRenderer {
     }
 
     /// Returns active semantic cursor owners in deterministic priority order. The agent prompt uses a reserved window id and must win over the retained chat content when both are active during focus transitions.
-    nonisolated static func semanticCursorWindowIds(_ gutters: [UInt16: Wire.WindowGutter]) -> [UInt16] {
-        gutters.values
+    nonisolated static func semanticCursorWindowIds(
+        _ gutters: [UInt16: Wire.WindowGutter],
+        windowContents: [UInt16: GUIWindowContent] = [:],
+        activeWindowId: UInt16? = nil
+    ) -> [UInt16] {
+        if let activeWindowId, windowContents[activeWindowId] != nil {
+            return [activeWindowId]
+        }
+
+        let activeGutterWindowIds = gutters.values
             .filter(\.isActive)
             .map(\.windowId)
             .sorted { lhs, rhs in
@@ -2774,6 +2831,10 @@ final class CoreTextMetalRenderer {
                 if leftPriority == rightPriority { return lhs < rhs }
                 return leftPriority < rightPriority
             }
+
+        if !activeGutterWindowIds.isEmpty { return activeGutterWindowIds }
+
+        return windowContents.keys.sorted()
     }
 
     nonisolated static func semanticCursorPriority(windowId: UInt16) -> Int {

--- a/macos/Sources/Renderer/CoreTextMetalRenderer.swift
+++ b/macos/Sources/Renderer/CoreTextMetalRenderer.swift
@@ -386,7 +386,7 @@ final class CoreTextMetalRenderer {
                 presentationInputSeq: UInt32 = 0,
                 latencyRecorder: LatencyRecorder? = nil,
                 onPresented: @escaping @MainActor (CommittedEditorSnapshot) -> Void = { _ in }) {
-        guard presentationGeneration.next &- presentationGeneration.completed < UInt64(Self.nativeFrameSlotCount) else {
+        guard let reservation = presentationGeneration.issue(slotCount: Self.nativeFrameSlotCount) else {
             let presentationFrame = GUICommittedFrame(generation: snapshot.generation, frameSeq: snapshot.frameSeq)
             recordNativeFailure(NativePresentationFailure(
                 phase: .command, dimension: .submission,
@@ -395,7 +395,12 @@ final class CoreTextMetalRenderer {
             latencyRecorder?.discard(seq: presentationInputSeq, reason: .superseded)
             return
         }
-        let nativeFrameSlot = Int(presentationGeneration.next % UInt64(Self.nativeFrameSlotCount))
+        let generation = reservation.generation
+        let nativeFrameSlot = reservation.slot
+        var submitted = false
+        defer {
+            if !submitted { presentationGeneration.retire(generation) }
+        }
 
         let frameState = snapshot.frameState
         let themeColors = snapshot.themeColors
@@ -1566,11 +1571,14 @@ final class CoreTextMetalRenderer {
         }
 
         let commitTime = CACurrentMediaTime()
-        let generation = presentationGeneration.issue()
         let candidateInstanceSlots = lineInstances.count
         let candidateQuadCapacity = bufferDemand.quadBytesPerBuffer / MemoryLayout<QuadGPU>.stride
         factories.observeCompletion(cmdBuf) { [weak self] completed, status in
             guard let self else { return }
+            var presentationSubmitted = false
+            defer {
+                if !presentationSubmitted { self.presentationGeneration.retire(generation) }
+            }
             let completionLatencyMs = (CACurrentMediaTime() - commitTime) * 1000.0
             os_signpost(.event, log: renderLog, name: "GPU Timing", signpostID: renderSignpostID,
                         "commit_to_complete_ms=%{public}.3f", completionLatencyMs)
@@ -1658,6 +1666,7 @@ final class CoreTextMetalRenderer {
 
             self.factories.observeCompletion(presentationBuffer) { [weak self] copied, _ in
                 guard let self else { return }
+                defer { self.presentationGeneration.retire(generation) }
                 guard copied else {
                     self.recordNativeFailure(NativePresentationFailure(
                         phase: .completion, dimension: .presentationCopy,
@@ -1707,12 +1716,14 @@ final class CoreTextMetalRenderer {
                             signpostID: renderSignpostID,
                             "input=%{public}u", presentationInputSeq)
             }
+            presentationSubmitted = true
             presentationBuffer.commit()
             self.presentationMetrics?.recordMetalSubmission(presentationFrame: presentationFrame)
             os_signpost(.event, log: renderLog, name: "MetalPresentationSubmit", signpostID: renderSignpostID,
                         "input=%{public}u frame=%{public}u", presentationInputSeq,
                         presentationFrame.frameSeq)
         }
+        submitted = true
         cmdBuf.commit()
         latencyRecorder?.markSubmitted(seq: presentationInputSeq)
         os_signpost(.event, log: renderLog, name: "MetalSubmit", signpostID: renderSignpostID,

--- a/macos/Sources/Renderer/EditorPresentation.swift
+++ b/macos/Sources/Renderer/EditorPresentation.swift
@@ -2,6 +2,18 @@ import Foundation
 import MingaProtocol
 import MingaUI
 
+/// Frontend-local transform captured with the Metal draw that produced a visible editor frame.
+struct EditorLocalPresentationTransform: Sendable, Equatable {
+    let windowId: UInt16
+    let offset: CGPoint
+}
+
+/// One editor presentation known to have reached the display surface.
+struct VisibleEditorPresentation: Sendable {
+    let snapshot: CommittedEditorSnapshot
+    let localTransform: EditorLocalPresentationTransform?
+}
+
 /// Immutable gutter state owned by one committed editor surface.
 enum GutterPresentation: Sendable {
     case none
@@ -11,6 +23,13 @@ enum GutterPresentation: Sendable {
         switch self {
         case .none: nil
         case .present(let gutter): gutter
+        }
+    }
+
+    var isActive: Bool {
+        switch self {
+        case .none: false
+        case .present(let gutter): gutter.isActive
         }
     }
 }
@@ -36,7 +55,7 @@ struct PresentedWindowSurface: Sendable {
                 contentRow: paneGeometry.textRect.row,
                 contentCol: paneGeometry.textRect.col,
                 contentHeight: paneGeometry.textRect.height,
-                isActive: activeByGeometry,
+                isActive: false,
                 contentWidth: paneGeometry.textRect.width,
                 cursorLine: UInt32(content.cursorRow),
                 lineNumberStyle: .absolute,
@@ -54,7 +73,9 @@ struct PresentedWindowSurface: Sendable {
         return min(start, content.rowStore.count)..<min(max(end, start), content.rowStore.count)
     }
 
-    private var activeByGeometry: Bool { false }
+    var cursorLineOffset: Int {
+        Int(content.cursorRow) * Int(paneGeometry.viewport.cols) + Int(content.cursorCol)
+    }
 }
 
 /// Complete semantic editor presentation captured once by Metal and input geometry consumers.
@@ -65,6 +86,12 @@ struct CommittedEditorSnapshot {
     let themeColors: ThemeColors?
     let surfaces: [PresentedWindowSurface]
     let activeWindowId: UInt16?
+
+    var activeSurface: PresentedWindowSurface? {
+        if let activeWindowId, let surface = surface(for: activeWindowId) { return surface }
+        if let active = surfaces.first(where: { $0.gutter.isActive }) { return active }
+        return surfaces.first
+    }
 
     var windowContents: [UInt16: GUIWindowContent] {
         Dictionary(uniqueKeysWithValues: surfaces.map { ($0.windowId, $0.content) })
@@ -97,7 +124,9 @@ struct CommittedEditorSnapshot {
         frameSeq: UInt32,
         frameState: FrameState,
         themeColors: ThemeColors?,
-        windowContents: [UInt16: GUIWindowContent]
+        windowContents: [UInt16: GUIWindowContent],
+        windowGutters: [UInt16: Wire.WindowGutter],
+        windowIndentGuides: [UInt16: IndentGuideData]
     ) -> Result<CommittedEditorSnapshot, PreparedFrameRejection> {
         var surfaces: [PresentedWindowSurface] = []
         surfaces.reserveCapacity(windowContents.count)
@@ -108,7 +137,7 @@ struct CommittedEditorSnapshot {
             }
 
             let gutterPresentation: GutterPresentation
-            if let gutter = frameState.windowGutters[content.windowId] {
+            if let gutter = windowGutters[content.windowId] {
                 guard gutter.contentRow == paneGeometry.textRect.row,
                       gutter.contentCol == paneGeometry.textRect.col,
                       gutter.contentHeight == paneGeometry.textRect.height,
@@ -130,12 +159,16 @@ struct CommittedEditorSnapshot {
                 content: content,
                 gutter: gutterPresentation,
                 paneGeometry: paneGeometry,
-                indentGuides: frameState.windowIndentGuides[content.windowId]
+                indentGuides: windowIndentGuides[content.windowId]
             ))
         }
 
-        if let activeWindowId = frameState.activeWindowId,
-           !windowContents.keys.contains(activeWindowId) {
+        let activeGutters = windowGutters.values.filter(\.isActive)
+        if activeGutters.count > 1 {
+            return .failure(.invalidActiveWindow(windowId: activeGutters.sorted(by: { $0.windowId < $1.windowId })[1].windowId))
+        }
+        let activeWindowId = activeGutters.first?.windowId
+        if let activeWindowId, !windowContents.keys.contains(activeWindowId) {
             return .failure(.invalidActiveWindow(windowId: activeWindowId))
         }
 
@@ -145,7 +178,7 @@ struct CommittedEditorSnapshot {
             frameState: frameState,
             themeColors: themeColors,
             surfaces: surfaces,
-            activeWindowId: frameState.activeWindowId
+            activeWindowId: activeWindowId
         ))
     }
 }

--- a/macos/Sources/Renderer/EditorPresentation.swift
+++ b/macos/Sources/Renderer/EditorPresentation.swift
@@ -1,0 +1,151 @@
+import Foundation
+import MingaProtocol
+import MingaUI
+
+/// Immutable gutter state owned by one committed editor surface.
+enum GutterPresentation: Sendable {
+    case none
+    case present(Wire.WindowGutter)
+
+    var gutter: Wire.WindowGutter? {
+        switch self {
+        case .none: nil
+        case .present(let gutter): gutter
+        }
+    }
+}
+
+/// One complete editor pane surface captured at transaction publication.
+struct PresentedWindowSurface: Sendable {
+    let content: GUIWindowContent
+    let gutter: GutterPresentation
+    let paneGeometry: GUIPaneGeometry
+    let indentGuides: IndentGuideData?
+
+    var windowId: UInt16 { content.windowId }
+
+    /// Renderer compatibility projection for code that needs a concrete gutter geometry value.
+    /// `.none` stays semantic in the snapshot; this value is derived only after freeze accepted explicit zero-width gutter geometry.
+    var renderGutter: Wire.WindowGutter {
+        switch gutter {
+        case .present(let gutter):
+            gutter
+        case .none:
+            Wire.WindowGutter(
+                windowId: windowId,
+                contentRow: paneGeometry.textRect.row,
+                contentCol: paneGeometry.textRect.col,
+                contentHeight: paneGeometry.textRect.height,
+                isActive: activeByGeometry,
+                contentWidth: paneGeometry.textRect.width,
+                cursorLine: UInt32(content.cursorRow),
+                lineNumberStyle: .absolute,
+                lineNumberWidth: 0,
+                signColWidth: 0,
+                entries: []
+            )
+        }
+    }
+
+    var visibleRowRange: Range<Int> {
+        let viewport = paneGeometry.viewport
+        let start = content.rowStore.lowerBound(bufferLine: viewport.top) + Int(viewport.visualRowOffset)
+        let end = start + Int(viewport.rows)
+        return min(start, content.rowStore.count)..<min(max(end, start), content.rowStore.count)
+    }
+
+    private var activeByGeometry: Bool { false }
+}
+
+/// Complete semantic editor presentation captured once by Metal and input geometry consumers.
+struct CommittedEditorSnapshot {
+    let generation: UInt32
+    let frameSeq: UInt32
+    let frameState: FrameState
+    let themeColors: ThemeColors?
+    let surfaces: [PresentedWindowSurface]
+    let activeWindowId: UInt16?
+
+    var windowContents: [UInt16: GUIWindowContent] {
+        Dictionary(uniqueKeysWithValues: surfaces.map { ($0.windowId, $0.content) })
+    }
+
+    var windowGutters: [UInt16: Wire.WindowGutter] {
+        Dictionary(uniqueKeysWithValues: surfaces.compactMap { surface in
+            surface.gutter.gutter.map { (surface.windowId, $0) }
+        })
+    }
+
+    var windowIndentGuides: [UInt16: IndentGuideData] {
+        Dictionary(uniqueKeysWithValues: surfaces.compactMap { surface in
+            surface.indentGuides.map { (surface.windowId, $0) }
+        })
+    }
+
+    var windowIds: Set<UInt16> { Set(surfaces.map(\.windowId)) }
+
+    func content(for windowId: UInt16) -> GUIWindowContent? {
+        surfaces.first { $0.windowId == windowId }?.content
+    }
+
+    func surface(for windowId: UInt16) -> PresentedWindowSurface? {
+        surfaces.first { $0.windowId == windowId }
+    }
+
+    static func make(
+        generation: UInt32,
+        frameSeq: UInt32,
+        frameState: FrameState,
+        themeColors: ThemeColors?,
+        windowContents: [UInt16: GUIWindowContent]
+    ) -> Result<CommittedEditorSnapshot, PreparedFrameRejection> {
+        var surfaces: [PresentedWindowSurface] = []
+        surfaces.reserveCapacity(windowContents.count)
+
+        for content in windowContents.values.sorted(by: { $0.windowId < $1.windowId }) {
+            guard let paneGeometry = content.paneGeometry else {
+                return .failure(.missingWindowGeometry(windowId: content.windowId))
+            }
+
+            let gutterPresentation: GutterPresentation
+            if let gutter = frameState.windowGutters[content.windowId] {
+                guard gutter.contentRow == paneGeometry.textRect.row,
+                      gutter.contentCol == paneGeometry.textRect.col,
+                      gutter.contentHeight == paneGeometry.textRect.height,
+                      gutter.contentWidth == paneGeometry.textRect.width,
+                      gutter.lineNumberWidth == paneGeometry.gutterMetrics.lineNumberWidth,
+                      gutter.signColWidth == paneGeometry.gutterMetrics.signColWidth else {
+                    return .failure(.incompatibleWindowGeometry(windowId: content.windowId))
+                }
+                gutterPresentation = .present(gutter)
+            } else if paneGeometry.gutterMetrics.lineNumberWidth == 0,
+                      paneGeometry.gutterMetrics.signColWidth == 0,
+                      !paneGeometry.hitRegions.contains(where: { $0.kind == .gutter || $0.kind == .foldControl }) {
+                gutterPresentation = .none
+            } else {
+                return .failure(.missingWindowGutter(windowId: content.windowId))
+            }
+
+            surfaces.append(PresentedWindowSurface(
+                content: content,
+                gutter: gutterPresentation,
+                paneGeometry: paneGeometry,
+                indentGuides: frameState.windowIndentGuides[content.windowId]
+            ))
+        }
+
+        if let activeWindowId = frameState.activeWindowId,
+           !windowContents.keys.contains(activeWindowId) {
+            return .failure(.invalidActiveWindow(windowId: activeWindowId))
+        }
+
+        return .success(CommittedEditorSnapshot(
+            generation: generation,
+            frameSeq: frameSeq,
+            frameState: frameState,
+            themeColors: themeColors,
+            surfaces: surfaces,
+            activeWindowId: frameState.activeWindowId
+        ))
+    }
+}

--- a/macos/Sources/Renderer/EditorPresentation.swift
+++ b/macos/Sources/Renderer/EditorPresentation.swift
@@ -34,6 +34,27 @@ enum GutterPresentation: Sendable {
     }
 }
 
+/// Focused editor render metadata that no single window surface owns.
+///
+/// After AC6 (#2999) removed the editor-global cursor shape, active gutter
+/// column, and split-separator geometry from mutable `FrameState`, this value is
+/// their committed home inside `CommittedEditorSnapshot`. Production draw and
+/// input read these only through the committed or visible snapshot; the next
+/// transaction seeds from this value rather than a live `FrameState` mirror.
+struct EditorSnapshotMetadata: Sendable {
+    /// Editor-global cursor shape from `set_cursor_shape` (0x05).
+    var cursorShape: CursorShape = .block
+    /// Active window gutter column count (line-number + sign columns) used for
+    /// gutter chrome padding and viewport-width derivation.
+    var gutterCol: UInt16 = 0
+    /// Split separator geometry from `gui_split_separators` (0x84).
+    var splitBorderColor: UInt32 = 0
+    var verticalSeparators: [Wire.VerticalSeparator] = []
+    var horizontalSeparators: [Wire.HorizontalSeparator] = []
+
+    static let empty = EditorSnapshotMetadata()
+}
+
 /// One complete editor pane surface captured at transaction publication.
 struct PresentedWindowSurface: Sendable {
     let content: GUIWindowContent
@@ -86,6 +107,12 @@ struct CommittedEditorSnapshot {
     let themeColors: ThemeColors?
     let surfaces: [PresentedWindowSurface]
     let activeWindowId: UInt16?
+    /// Editor render metadata that no single window surface owns.
+    let metadata: EditorSnapshotMetadata
+
+    /// Active gutter column count. Derived from the active window's committed
+    /// gutter, matching the value AC6 removed from mutable `FrameState`.
+    var gutterCol: UInt16 { metadata.gutterCol }
 
     var activeSurface: PresentedWindowSurface? {
         if let activeWindowId, let surface = surface(for: activeWindowId) { return surface }
@@ -128,8 +155,17 @@ struct CommittedEditorSnapshot {
         themeColors: ThemeColors?,
         windowContents: [UInt16: GUIWindowContent],
         windowGutters: [UInt16: Wire.WindowGutter],
-        windowIndentGuides: [UInt16: IndentGuideData]
+        windowIndentGuides: [UInt16: IndentGuideData],
+        metadata: EditorSnapshotMetadata = .empty
     ) -> Result<CommittedEditorSnapshot, PreparedFrameRejection> {
+        let liveWindowIds = Set(windowContents.keys)
+        if let orphanGutter = Set(windowGutters.keys).subtracting(liveWindowIds).min() {
+            return .failure(.missingWindowReference(windowId: orphanGutter))
+        }
+        if let orphanGuides = Set(windowIndentGuides.keys).subtracting(liveWindowIds).min() {
+            return .failure(.missingWindowReference(windowId: orphanGuides))
+        }
+
         var surfaces: [PresentedWindowSurface] = []
         surfaces.reserveCapacity(windowContents.count)
 
@@ -180,7 +216,8 @@ struct CommittedEditorSnapshot {
             frameState: frameState,
             themeColors: themeColors,
             surfaces: surfaces,
-            activeWindowId: activeWindowId
+            activeWindowId: activeWindowId,
+            metadata: metadata
         ))
     }
 }

--- a/macos/Sources/Renderer/EditorPresentation.swift
+++ b/macos/Sources/Renderer/EditorPresentation.swift
@@ -52,11 +52,11 @@ struct PresentedWindowSurface: Sendable {
         case .none:
             Wire.WindowGutter(
                 windowId: windowId,
-                contentRow: paneGeometry.textRect.row,
-                contentCol: paneGeometry.textRect.col,
-                contentHeight: paneGeometry.textRect.height,
+                contentRow: paneGeometry.contentRect.row,
+                contentCol: paneGeometry.contentRect.col,
+                contentHeight: paneGeometry.contentRect.height,
                 isActive: false,
-                contentWidth: paneGeometry.textRect.width,
+                contentWidth: paneGeometry.contentRect.width,
                 cursorLine: UInt32(content.cursorRow),
                 lineNumberStyle: .absolute,
                 lineNumberWidth: 0,
@@ -140,10 +140,10 @@ struct CommittedEditorSnapshot {
 
             let gutterPresentation: GutterPresentation
             if let gutter = windowGutters[content.windowId] {
-                guard gutter.contentRow == paneGeometry.textRect.row,
-                      gutter.contentCol == paneGeometry.textRect.col,
-                      gutter.contentHeight == paneGeometry.textRect.height,
-                      gutter.contentWidth == paneGeometry.textRect.width,
+                guard gutter.contentRow == paneGeometry.contentRect.row,
+                      gutter.contentCol == paneGeometry.contentRect.col,
+                      gutter.contentHeight == paneGeometry.contentRect.height,
+                      gutter.contentWidth == paneGeometry.contentRect.width,
                       gutter.lineNumberWidth == paneGeometry.gutterMetrics.lineNumberWidth,
                       gutter.signColWidth == paneGeometry.gutterMetrics.signColWidth else {
                     return .failure(.incompatibleWindowGeometry(windowId: content.windowId))

--- a/macos/Sources/Renderer/EditorPresentation.swift
+++ b/macos/Sources/Renderer/EditorPresentation.swift
@@ -90,6 +90,8 @@ struct CommittedEditorSnapshot {
     var activeSurface: PresentedWindowSurface? {
         if let activeWindowId, let surface = surface(for: activeWindowId) { return surface }
         if let active = surfaces.first(where: { $0.gutter.isActive }) { return active }
+        let cursorVisibleSurfaces = surfaces.filter(\.content.cursorVisible)
+        if cursorVisibleSurfaces.count == 1 { return cursorVisibleSurfaces[0] }
         return surfaces.first
     }
 

--- a/macos/Sources/Renderer/FrameState.swift
+++ b/macos/Sources/Renderer/FrameState.swift
@@ -1,6 +1,13 @@
-/// Lightweight editor metadata captured inside `CommittedEditorSnapshot`.
+/// Lightweight per-frame render metadata captured inside `CommittedEditorSnapshot`.
 ///
-/// CommandDispatcher still owns this mutable value while applying a prepared transaction, but production draw and input code read it only through the committed or visible editor snapshot. Missing or incompatible gutter, geometry, cursor, active-window, and split combinations must reject before snapshot publication instead of falling back during render.
+/// CommandDispatcher still owns this mutable value while applying a prepared transaction, but production draw and input code read it only through the committed or visible editor snapshot.
+///
+/// AC6 (#2999) removed the editor's semantic authority from this type: cursor,
+/// gutter geometry (`windowGutters`/`gutterCol`), active window, split
+/// separators, and per-window indent guides. Those authorities now live only on
+/// `CommittedEditorSnapshot` (its surfaces, `activeWindowId`, and
+/// `EditorSnapshotMetadata`). What remains here is chrome/theme render metadata
+/// that persists across frames and is frozen into each snapshot's `frameState`.
 
 import MingaProtocol
 
@@ -27,33 +34,17 @@ struct FrameState {
     var cols: UInt16
     var rows: UInt16
 
-    // Cursor
-    var cursorRow: UInt16 = 0
-    var cursorCol: UInt16 = 0
-    var cursorShape: CursorShape = .block
-    // Always true: protocol has no hideCursor command yet. Reserved for future use.
-    var cursorVisible: Bool = true
-
     // Background
     var defaultBg: UInt32 = 0
 
-    // Gutter geometry
-    var gutterCol: UInt16 = 0
+    // Gutter separator chrome (color only; the active gutter column lives on
+    // `EditorSnapshotMetadata.gutterCol`).
     var gutterSeparatorColor: UInt32 = 0
 
     // Cursorline
     /// `0xFFFF` = no active cursorline (sentinel; set by gui_cursorline opcode).
     var cursorlineRow: UInt16 = 0xFFFF
     var cursorlineBg: UInt32 = 0
-
-    // Per-window gutter data from gui_gutter (0x7B). Keyframes prune this map inside the successful prepared transaction, and snapshot freeze rejects content that requires a missing or incompatible gutter.
-    var windowGutters: [UInt16: Wire.WindowGutter] = [:]
-    var activeWindowId: UInt16?
-
-    // Split separator data from gui_split_separators (0x84).
-    var splitBorderColor: UInt32 = 0
-    var verticalSeparators: [Wire.VerticalSeparator] = []
-    var horizontalSeparators: [Wire.HorizontalSeparator] = []
 
     // Gutter theme colors
     var gutterColors: GutterThemeColors = GutterThemeColors()
@@ -62,9 +53,6 @@ struct FrameState {
     var viewportTopLine: UInt32 = 0xFFFF_FFFF
     var totalLineCount: UInt32 = 0
     var scrollIndicatorColor: UInt32 = 0x555555
-
-    // Indent guides (from 0x91 opcode)
-    var windowIndentGuides: [UInt16: IndentGuideData] = [:]
 
     // Line spacing multiplier (from gui_line_spacing opcode).
     var lineSpacing: Float = 1.0

--- a/macos/Sources/Renderer/FrameState.swift
+++ b/macos/Sources/Renderer/FrameState.swift
@@ -1,13 +1,6 @@
-/// Lightweight per-frame metadata for the Metal render pass.
+/// Lightweight editor metadata captured inside `CommittedEditorSnapshot`.
 ///
-/// Extracted from LineBuffer to separate frame metadata (cursor, gutter,
-/// cursorline, theme colors, grid dimensions) from styled run content.
-/// CommandDispatcher owns this as a mutable value; CoreTextMetalRenderer
-/// reads it synchronously during render().
-///
-/// No `clear()` method: metadata fields persist across frames and are
-/// overwritten individually by protocol opcodes. Only `dirty` resets
-/// at frame start via `beginFrame()`.
+/// CommandDispatcher still owns this mutable value while applying a prepared transaction, but production draw and input code read it only through the committed or visible editor snapshot. Missing or incompatible gutter, geometry, cursor, active-window, and split combinations must reject before snapshot publication instead of falling back during render.
 
 import MingaProtocol
 
@@ -53,9 +46,7 @@ struct FrameState {
     var cursorlineRow: UInt16 = 0xFFFF
     var cursorlineBg: UInt32 = 0
 
-    // Per-window gutter data from gui_gutter (0x7B).
-    // NOT cleared between frames: stale data serves as fallback to
-    // prevent blank-gutter flash if the gutter command hasn't arrived yet.
+    // Per-window gutter data from gui_gutter (0x7B). Keyframes prune this map inside the successful prepared transaction, and snapshot freeze rejects content that requires a missing or incompatible gutter.
     var windowGutters: [UInt16: Wire.WindowGutter] = [:]
     var activeWindowId: UInt16?
 
@@ -78,20 +69,16 @@ struct FrameState {
     // Line spacing multiplier (from gui_line_spacing opcode).
     var lineSpacing: Float = 1.0
 
-    // Dirty tracking
-    var dirty: Bool = true
-
     init(cols: UInt16, rows: UInt16) {
         self.cols = cols
         self.rows = rows
     }
 
-    /// Resize the grid. Marks dirty.
+    /// Resize the grid.
     mutating func resize(newCols: UInt16, newRows: UInt16) {
         guard newCols != cols || newRows != rows else { return }
         guard newCols > 0, newRows > 0 else { return }
         cols = newCols
         rows = newRows
-        dirty = true
     }
 }

--- a/macos/Sources/Renderer/NativeRenderResources.swift
+++ b/macos/Sources/Renderer/NativeRenderResources.swift
@@ -333,7 +333,7 @@ struct NativeRenderFactories {
         preSubmit: { _ in },
         prePresentationSubmit: { _ in },
         observeCompletion: { commandBuffer, completion in
-            commandBuffer.addCompletedHandler { completed in
+            commandBuffer.addCompletedHandler { @Sendable completed in
                 let succeeded = completed.status == .completed
                 let status = Int(completed.status.rawValue)
                 Task { @MainActor in completion(succeeded, status) }

--- a/macos/Sources/Renderer/NativeRenderResources.swift
+++ b/macos/Sources/Renderer/NativeRenderResources.swift
@@ -352,17 +352,33 @@ struct NativeRenderFactories {
 /// Orders asynchronous resource promotion. A completion from an older frame
 /// may never replace a generation that already completed later.
 struct NativePresentationGeneration: Sendable, Equatable {
+    struct Reservation: Sendable, Equatable {
+        let generation: UInt64
+        let slot: Int
+    }
+
     private(set) var next: UInt64 = 0
     private(set) var completed: UInt64 = 0
+    private var inFlightSlots: [UInt64: Int] = [:]
 
-    mutating func issue() -> UInt64 {
+    var inFlightCount: Int { inFlightSlots.count }
+
+    mutating func issue(slotCount: Int) -> Reservation? {
+        guard slotCount > 0 else { return nil }
+        guard let slot = (0..<slotCount).first(where: { !inFlightSlots.values.contains($0) }) else { return nil }
         next &+= 1
-        return next
+        inFlightSlots[next] = slot
+        return Reservation(generation: next, slot: slot)
     }
 
     mutating func complete(_ generation: UInt64) -> Bool {
-        guard generation > completed, generation <= next else { return false }
+        guard inFlightSlots.removeValue(forKey: generation) != nil,
+              generation > completed else { return false }
         completed = generation
         return true
+    }
+
+    mutating func retire(_ generation: UInt64) {
+        inFlightSlots.removeValue(forKey: generation)
     }
 }

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -68,6 +68,10 @@ enum PreparedFrameRejection: Error, Sendable, Equatable {
     case missingTheme
     case incompleteTheme(missingSlots: [UInt8])
     case missingWindowReference(windowId: UInt16)
+    case missingWindowGeometry(windowId: UInt16)
+    case missingWindowGutter(windowId: UInt16)
+    case incompatibleWindowGeometry(windowId: UInt16)
+    case invalidActiveWindow(windowId: UInt16)
     case windowEpochMismatch(windowId: UInt16, expected: UInt32, actual: UInt32)
     case invalidRetainedRows(windowId: UInt16, contentEpoch: UInt32)
     case invalidRowSplice(windowId: UInt16, contentEpoch: UInt32)
@@ -88,7 +92,9 @@ enum PreparedFrameRejection: Error, Sendable, Equatable {
         case .baseSequenceMismatch: return GeneratedProtocol.FrameRejectionReason.baseSequenceMismatch.rawValue
         case .missingTheme: return GeneratedProtocol.FrameRejectionReason.missingTheme.rawValue
         case .incompleteTheme: return GeneratedProtocol.FrameRejectionReason.incompleteTheme.rawValue
-        case .missingWindowReference: return GeneratedProtocol.FrameRejectionReason.missingWindowReference.rawValue
+        case .missingWindowReference, .missingWindowGeometry, .missingWindowGutter,
+             .incompatibleWindowGeometry, .invalidActiveWindow:
+            return GeneratedProtocol.FrameRejectionReason.missingWindowReference.rawValue
         case .windowEpochMismatch: return GeneratedProtocol.FrameRejectionReason.windowEpochMismatch.rawValue
         case .invalidRetainedRows: return GeneratedProtocol.FrameRejectionReason.invalidRetainedRows.rawValue
         case .missingFontResource: return GeneratedProtocol.FrameRejectionReason.missingFontResource.rawValue
@@ -127,6 +133,14 @@ enum PreparedFrameRejection: Error, Sendable, Equatable {
             return "missing gui_theme slots: \(formatted)"
         case .missingWindowReference(let windowId):
             return "missing live window reference \(windowId)"
+        case .missingWindowGeometry(let windowId):
+            return "window \(windowId) is missing pane geometry"
+        case .missingWindowGutter(let windowId):
+            return "window \(windowId) is missing required gutter"
+        case .incompatibleWindowGeometry(let windowId):
+            return "window \(windowId) has incompatible gutter and pane geometry"
+        case .invalidActiveWindow(let windowId):
+            return "active window \(windowId) is not present in the committed editor snapshot"
         case .windowEpochMismatch(let windowId, let expected, let actual):
             return "window \(windowId) epoch \(actual) != \(expected)"
         case .invalidRetainedRows(let windowId, let epoch):
@@ -267,6 +281,7 @@ struct PreparedFrameTransactionBuilder {
     private var theme: PreparedThemeUpdate?
     private var semanticImpact: GUIFrameImpact = []
     private var workingWindows: [UInt16: GUIWindowContent]
+    private var workingGutters: [UInt16: Wire.WindowGutter]
     private var changedWindows: [UInt16: GUIWindowContent] = [:]
     private var referencedWindowIds: Set<UInt16> = []
     private var touchedWindowIds: Set<UInt16> = []
@@ -292,6 +307,7 @@ struct PreparedFrameTransactionBuilder {
         baseFrameSeq: UInt32,
         generation: UInt32,
         committedWindows: [UInt16: GUIWindowContent],
+        committedGutters: [UInt16: Wire.WindowGutter],
         registeredFontIds: Set<UInt8>,
         committedTranscript: AgentTranscriptSnapshot,
         stagingLimit: FrameResourceWeight = FrameResourcePolicy.default.staging.weight,
@@ -301,6 +317,7 @@ struct PreparedFrameTransactionBuilder {
         self.baseFrameSeq = baseFrameSeq
         self.generation = generation
         self.workingWindows = baseFrameSeq == 0 ? [:] : committedWindows
+        self.workingGutters = baseFrameSeq == 0 ? [:] : committedGutters
         self.registeredFontIds = registeredFontIds
         self.registeredFontIds.insert(0)
         self.workingTranscript = committedTranscript
@@ -355,6 +372,7 @@ struct PreparedFrameTransactionBuilder {
         case .guiGutter(let data):
             referencedWindowIds.insert(data.windowId)
             touchedWindowIds.insert(data.windowId)
+            workingGutters[data.windowId] = data
             stageReplacing(
                 command, key: .window(kind: .gutter, id: data.windowId),
                 weight: resourceWeight, domain: .window
@@ -438,6 +456,9 @@ struct PreparedFrameTransactionBuilder {
         if let missingReference = referencedWindowIds.subtracting(liveWindowIds).min() {
             return .failure(.missingWindowReference(windowId: missingReference))
         }
+        if let presentationRejection = validateCompleteEditorSurfaces(liveWindowIds: liveWindowIds) {
+            return .failure(presentationRejection)
+        }
         if let missingFont = requiredFontIds.subtracting(registeredFontIds).min() {
             return .failure(.missingFontResource(fontId: missingFont))
         }
@@ -480,6 +501,37 @@ struct PreparedFrameTransactionBuilder {
             )
         )
         return .success(transaction)
+    }
+
+    private func validateCompleteEditorSurfaces(liveWindowIds: Set<UInt16>) -> PreparedFrameRejection? {
+        for windowId in workingGutters.keys where !liveWindowIds.contains(windowId) {
+            return .missingWindowReference(windowId: windowId)
+        }
+
+        for content in workingWindows.values.sorted(by: { $0.windowId < $1.windowId }) {
+            guard let paneGeometry = content.paneGeometry else {
+                return .missingWindowGeometry(windowId: content.windowId)
+            }
+
+            if let gutter = workingGutters[content.windowId] {
+                guard gutter.contentRow == paneGeometry.textRect.row,
+                      gutter.contentCol == paneGeometry.textRect.col,
+                      gutter.contentHeight == paneGeometry.textRect.height,
+                      gutter.contentWidth == paneGeometry.textRect.width,
+                      gutter.lineNumberWidth == paneGeometry.gutterMetrics.lineNumberWidth,
+                      gutter.signColWidth == paneGeometry.gutterMetrics.signColWidth else {
+                    return .incompatibleWindowGeometry(windowId: content.windowId)
+                }
+            } else if paneGeometry.gutterMetrics.lineNumberWidth == 0,
+                      paneGeometry.gutterMetrics.signColWidth == 0,
+                      !paneGeometry.hitRegions.contains(where: { $0.kind == .gutter || $0.kind == .foldControl }) {
+                continue
+            } else {
+                return .missingWindowGutter(windowId: content.windowId)
+            }
+        }
+
+        return nil
     }
 
     private mutating func resolveOverlayDelta(_ delta: GUIWindowOverlayDelta) {

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -625,10 +625,10 @@ struct PreparedFrameTransactionBuilder {
             }
 
             if let gutter = workingGutters[content.windowId] {
-                guard gutter.contentRow == paneGeometry.textRect.row,
-                      gutter.contentCol == paneGeometry.textRect.col,
-                      gutter.contentHeight == paneGeometry.textRect.height,
-                      gutter.contentWidth == paneGeometry.textRect.width,
+                guard gutter.contentRow == paneGeometry.contentRect.row,
+                      gutter.contentCol == paneGeometry.contentRect.col,
+                      gutter.contentHeight == paneGeometry.contentRect.height,
+                      gutter.contentWidth == paneGeometry.contentRect.width,
                       gutter.lineNumberWidth == paneGeometry.gutterMetrics.lineNumberWidth,
                       gutter.signColWidth == paneGeometry.gutterMetrics.signColWidth else {
                     return .incompatibleWindowGeometry(windowId: content.windowId)

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -182,13 +182,6 @@ struct PreparedThemeUpdate: Sendable {
     let slots: [(slotId: UInt8, r: UInt8, g: UInt8, b: UInt8)]
 }
 
-struct PreparedWindowUpdates: Sendable {
-    let replacements: [UInt16: GUIWindowContent]
-    let touchedWindowIds: Set<UInt16>
-    let authoritativeWindowIds: Set<UInt16>?
-    let commands: [RenderCommand]
-}
-
 struct PreparedChromeUpdates {
     let commands: [RenderCommand]
     let transcript: AgentTranscriptSnapshot?
@@ -207,13 +200,14 @@ struct PreparedFrameTransaction {
     /// Final consumer impact, including effects introduced while freezing the transaction.
     let impact: GUIFrameImpact
     let theme: PreparedThemeUpdate?
-    let windows: PreparedWindowUpdates?
     let chrome: PreparedChromeUpdates?
     let overlays: PreparedOverlayUpdates?
     let resources: PreparedResourceUpdates?
     let focus: PreparedFocusUpdates?
     let metadata: PreparedMetadataUpdates?
     let editorSnapshot: CommittedEditorSnapshot?
+    /// Non-nil only when resident window content changed or a keyframe authoritatively pruned it. The IDs scope scroll-reset reconciliation to content that actually changed.
+    let residentProjectionWindowIds: Set<UInt16>?
     let operationCounts: PreparedFrameOperationCounts
 }
 
@@ -295,6 +289,9 @@ struct PreparedFrameTransactionBuilder {
     private var metadataCommands = PreparedDomainBuffer()
     private var registeredFontIds: Set<UInt8>
     private var requiredFontIds: Set<UInt8> = []
+    /// Editor render metadata carried by the prior committed snapshot. Delta
+    /// frames build on this; base-0 keyframes reset the geometry parts.
+    private let committedMetadata: EditorSnapshotMetadata
     private var workingTranscript: AgentTranscriptSnapshot
     private var changedTranscript: AgentTranscriptSnapshot?
     private var themeWeight = FrameResourceWeight()
@@ -311,6 +308,7 @@ struct PreparedFrameTransactionBuilder {
         committedWindows: [UInt16: GUIWindowContent],
         committedGutters: [UInt16: Wire.WindowGutter],
         committedIndentGuides: [UInt16: IndentGuideData],
+        committedMetadata: EditorSnapshotMetadata = .empty,
         registeredFontIds: Set<UInt8>,
         committedTranscript: AgentTranscriptSnapshot,
         stagingLimit: FrameResourceWeight = FrameResourcePolicy.default.staging.weight,
@@ -322,6 +320,7 @@ struct PreparedFrameTransactionBuilder {
         self.workingWindows = baseFrameSeq == 0 ? [:] : committedWindows
         self.workingGutters = baseFrameSeq == 0 ? [:] : committedGutters
         self.workingIndentGuides = baseFrameSeq == 0 ? [:] : committedIndentGuides
+        self.committedMetadata = committedMetadata
         self.registeredFontIds = registeredFontIds
         self.registeredFontIds.insert(0)
         self.workingTranscript = committedTranscript
@@ -461,9 +460,6 @@ struct PreparedFrameTransactionBuilder {
         if let missingReference = referencedWindowIds.subtracting(liveWindowIds).min() {
             return .failure(.missingWindowReference(windowId: missingReference))
         }
-        if let presentationRejection = validateCompleteEditorSurfaces(liveWindowIds: liveWindowIds) {
-            return .failure(presentationRejection)
-        }
         if let missingFont = requiredFontIds.subtracting(registeredFontIds).min() {
             return .failure(.missingFontResource(fontId: missingFont))
         }
@@ -480,8 +476,7 @@ struct PreparedFrameTransactionBuilder {
         if finalImpact.contains(.editor) || baseFrameSeq == 0 {
             let snapshotFrameState = preparedFrameState(
                 from: frameState,
-                themeColors: preparedThemeColors,
-                liveWindowIds: liveWindowIds
+                themeColors: preparedThemeColors
             )
             switch CommittedEditorSnapshot.make(
                 generation: generation,
@@ -490,7 +485,8 @@ struct PreparedFrameTransactionBuilder {
                 themeColors: preparedThemeColors,
                 windowContents: workingWindows,
                 windowGutters: workingGutters,
-                windowIndentGuides: workingIndentGuides
+                windowIndentGuides: workingIndentGuides,
+                metadata: preparedMetadata()
             ) {
             case .success(let snapshot):
                 editorSnapshot = snapshot
@@ -507,12 +503,6 @@ struct PreparedFrameTransactionBuilder {
             generation: generation,
             impact: finalImpact,
             theme: theme,
-            windows: windowsChanged ? PreparedWindowUpdates(
-                replacements: changedWindows,
-                touchedWindowIds: touchedWindowIds,
-                authoritativeWindowIds: baseFrameSeq == 0 ? liveWindowIds : nil,
-                commands: windowCommands.commands
-            ) : nil,
             chrome: chromeCommands.isEmpty && changedTranscript == nil ? nil : PreparedChromeUpdates(
                 commands: chromeCommands.commands,
                 transcript: changedTranscript
@@ -522,6 +512,9 @@ struct PreparedFrameTransactionBuilder {
             focus: focusCommands.isEmpty ? nil : PreparedFocusUpdates(commands: focusCommands.commands),
             metadata: metadataCommands.isEmpty ? nil : PreparedMetadataUpdates(commands: metadataCommands.commands),
             editorSnapshot: editorSnapshot,
+            residentProjectionWindowIds: baseFrameSeq == 0
+                ? liveWindowIds
+                : (changedWindows.isEmpty ? nil : Set(changedWindows.keys)),
             operationCounts: PreparedFrameOperationCounts(
                 theme: theme == nil ? 0 : 1,
                 windows: windowsChanged ? 1 : 0,
@@ -542,10 +535,13 @@ struct PreparedFrameTransactionBuilder {
         return replacement
     }
 
+    /// Freezes the chrome/theme render metadata that persists inside the
+    /// snapshot's `frameState`. Editor semantic authority (cursor, gutter
+    /// geometry, active window, split separators) is no longer written here; it
+    /// lives on the snapshot's surfaces, `activeWindowId`, and metadata.
     private func preparedFrameState(
         from frameState: FrameState,
-        themeColors: ThemeColors?,
-        liveWindowIds: Set<UInt16>
+        themeColors: ThemeColors?
     ) -> FrameState {
         var prepared = frameState
         if let themeColors {
@@ -562,41 +558,26 @@ struct PreparedFrameTransactionBuilder {
                 gitDeletedFg: themeColors.gitDeletedFgRGB
             )
         }
-        prepared.windowGutters = Dictionary(uniqueKeysWithValues: workingGutters.filter { liveWindowIds.contains($0.key) })
-        prepared.windowIndentGuides = Dictionary(uniqueKeysWithValues: workingIndentGuides.filter { liveWindowIds.contains($0.key) })
-        prepared.activeWindowId = workingGutters.values.first(where: \.isActive)?.windowId
         if baseFrameSeq == 0 {
-            prepared.gutterCol = 0
             prepared.viewportTopLine = 0xFFFF_FFFF
-            prepared.splitBorderColor = 0
-            prepared.verticalSeparators = []
-            prepared.horizontalSeparators = []
         }
         for command in metadataCommands.commands + windowCommands.commands + focusCommands.commands {
             switch command {
             case .guiLineSpacing(let spacing):
                 prepared.lineSpacing = max(spacing, 1.0)
-            case .setCursorShape(let shape):
-                prepared.cursorShape = shape
             case .setWindowBg(let r, let g, let b):
                 prepared.defaultBg = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
-            case .guiGutterSeparator(let col, let r, let g, let b):
+            case .guiGutterSeparator(_, let r, let g, let b):
                 let rgb: UInt32 = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
                 prepared.scrollIndicatorColor = rgb
-                prepared.gutterCol = col
                 prepared.gutterSeparatorColor = rgb
             case .guiCursorline(let row, let r, let g, let b):
                 prepared.cursorlineRow = row
                 prepared.cursorlineBg = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
             case .guiGutter(let data):
-                if data.isActive {
-                    prepared.gutterCol = UInt16(data.lineNumberWidth) + UInt16(data.signColWidth)
-                    if let firstEntry = data.entries.first { prepared.viewportTopLine = firstEntry.bufLine }
+                if data.isActive, let firstEntry = data.entries.first {
+                    prepared.viewportTopLine = firstEntry.bufLine
                 }
-            case .guiSplitSeparators(let borderColor, let verticals, let horizontals):
-                prepared.verticalSeparators = verticals
-                prepared.horizontalSeparators = horizontals
-                prepared.splitBorderColor = borderColor
             case .guiStatusBar(let update):
                 prepared.totalLineCount = update.lineCount
             default:
@@ -606,43 +587,37 @@ struct PreparedFrameTransactionBuilder {
         return prepared
     }
 
-    private func validateCompleteEditorSurfaces(liveWindowIds: Set<UInt16>) -> PreparedFrameRejection? {
-        for windowId in workingGutters.keys where !liveWindowIds.contains(windowId) {
-            return .missingWindowReference(windowId: windowId)
+    /// Freezes the editor render metadata (cursor shape, active gutter column,
+    /// split separators) that no window surface owns. Delta frames build on the
+    /// prior committed metadata; a base-0 keyframe resets the geometry parts
+    /// while the cursor shape persists, matching the removed `FrameState` seeding.
+    private func preparedMetadata() -> EditorSnapshotMetadata {
+        var metadata = committedMetadata
+        if baseFrameSeq == 0 {
+            metadata.gutterCol = 0
+            metadata.splitBorderColor = 0
+            metadata.verticalSeparators = []
+            metadata.horizontalSeparators = []
         }
-
-        let activeGutters = workingGutters.values.filter(\.isActive)
-        if activeGutters.count > 1 {
-            return .invalidActiveWindow(windowId: activeGutters.sorted(by: { $0.windowId < $1.windowId })[1].windowId)
-        }
-        if let activeWindowId = activeGutters.first?.windowId, !liveWindowIds.contains(activeWindowId) {
-            return .invalidActiveWindow(windowId: activeWindowId)
-        }
-
-        for content in workingWindows.values.sorted(by: { $0.windowId < $1.windowId }) {
-            guard let paneGeometry = content.paneGeometry else {
-                return .missingWindowGeometry(windowId: content.windowId)
-            }
-
-            if let gutter = workingGutters[content.windowId] {
-                guard gutter.contentRow == paneGeometry.contentRect.row,
-                      gutter.contentCol == paneGeometry.contentRect.col,
-                      gutter.contentHeight == paneGeometry.contentRect.height,
-                      gutter.contentWidth == paneGeometry.contentRect.width,
-                      gutter.lineNumberWidth == paneGeometry.gutterMetrics.lineNumberWidth,
-                      gutter.signColWidth == paneGeometry.gutterMetrics.signColWidth else {
-                    return .incompatibleWindowGeometry(windowId: content.windowId)
+        for command in metadataCommands.commands + windowCommands.commands + focusCommands.commands {
+            switch command {
+            case .setCursorShape(let shape):
+                metadata.cursorShape = shape
+            case .guiGutterSeparator(let col, _, _, _):
+                metadata.gutterCol = col
+            case .guiGutter(let data):
+                if data.isActive {
+                    metadata.gutterCol = UInt16(data.lineNumberWidth) + UInt16(data.signColWidth)
                 }
-            } else if paneGeometry.gutterMetrics.lineNumberWidth == 0,
-                      paneGeometry.gutterMetrics.signColWidth == 0,
-                      !paneGeometry.hitRegions.contains(where: { $0.kind == .gutter || $0.kind == .foldControl }) {
-                continue
-            } else {
-                return .missingWindowGutter(windowId: content.windowId)
+            case .guiSplitSeparators(let borderColor, let verticals, let horizontals):
+                metadata.splitBorderColor = borderColor
+                metadata.verticalSeparators = verticals
+                metadata.horizontalSeparators = horizontals
+            default:
+                break
             }
         }
-
-        return nil
+        return metadata
     }
 
     private mutating func resolveOverlayDelta(_ delta: GUIWindowOverlayDelta) {

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -565,10 +565,21 @@ struct PreparedFrameTransactionBuilder {
         prepared.windowGutters = Dictionary(uniqueKeysWithValues: workingGutters.filter { liveWindowIds.contains($0.key) })
         prepared.windowIndentGuides = Dictionary(uniqueKeysWithValues: workingIndentGuides.filter { liveWindowIds.contains($0.key) })
         prepared.activeWindowId = workingGutters.values.first(where: \.isActive)?.windowId
-        for command in metadataCommands.commands + windowCommands.commands {
+        if baseFrameSeq == 0 {
+            prepared.gutterCol = 0
+            prepared.viewportTopLine = 0xFFFF_FFFF
+            prepared.splitBorderColor = 0
+            prepared.verticalSeparators = []
+            prepared.horizontalSeparators = []
+        }
+        for command in metadataCommands.commands + windowCommands.commands + focusCommands.commands {
             switch command {
             case .guiLineSpacing(let spacing):
                 prepared.lineSpacing = max(spacing, 1.0)
+            case .setCursorShape(let shape):
+                prepared.cursorShape = shape
+            case .setWindowBg(let r, let g, let b):
+                prepared.defaultBg = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
             case .guiGutterSeparator(let col, let r, let g, let b):
                 let rgb: UInt32 = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
                 prepared.scrollIndicatorColor = rgb

--- a/macos/Sources/Renderer/PreparedFrameTransaction.swift
+++ b/macos/Sources/Renderer/PreparedFrameTransaction.swift
@@ -213,6 +213,7 @@ struct PreparedFrameTransaction {
     let resources: PreparedResourceUpdates?
     let focus: PreparedFocusUpdates?
     let metadata: PreparedMetadataUpdates?
+    let editorSnapshot: CommittedEditorSnapshot?
     let operationCounts: PreparedFrameOperationCounts
 }
 
@@ -282,6 +283,7 @@ struct PreparedFrameTransactionBuilder {
     private var semanticImpact: GUIFrameImpact = []
     private var workingWindows: [UInt16: GUIWindowContent]
     private var workingGutters: [UInt16: Wire.WindowGutter]
+    private var workingIndentGuides: [UInt16: IndentGuideData]
     private var changedWindows: [UInt16: GUIWindowContent] = [:]
     private var referencedWindowIds: Set<UInt16> = []
     private var touchedWindowIds: Set<UInt16> = []
@@ -308,6 +310,7 @@ struct PreparedFrameTransactionBuilder {
         generation: UInt32,
         committedWindows: [UInt16: GUIWindowContent],
         committedGutters: [UInt16: Wire.WindowGutter],
+        committedIndentGuides: [UInt16: IndentGuideData],
         registeredFontIds: Set<UInt8>,
         committedTranscript: AgentTranscriptSnapshot,
         stagingLimit: FrameResourceWeight = FrameResourcePolicy.default.staging.weight,
@@ -318,6 +321,7 @@ struct PreparedFrameTransactionBuilder {
         self.generation = generation
         self.workingWindows = baseFrameSeq == 0 ? [:] : committedWindows
         self.workingGutters = baseFrameSeq == 0 ? [:] : committedGutters
+        self.workingIndentGuides = baseFrameSeq == 0 ? [:] : committedIndentGuides
         self.registeredFontIds = registeredFontIds
         self.registeredFontIds.insert(0)
         self.workingTranscript = committedTranscript
@@ -381,6 +385,7 @@ struct PreparedFrameTransactionBuilder {
         case .guiIndentGuides(let data):
             referencedWindowIds.insert(data.windowId)
             touchedWindowIds.insert(data.windowId)
+            workingIndentGuides[data.windowId] = data
             stageReplacing(
                 command, key: .window(kind: .indentGuides, id: data.windowId),
                 weight: resourceWeight, domain: .window
@@ -442,7 +447,7 @@ struct PreparedFrameTransactionBuilder {
         }
     }
 
-    func freeze(requiredThemeSlots: [UInt8]) -> Result<PreparedFrameTransaction, PreparedFrameRejection> {
+    func freeze(requiredThemeSlots: [UInt8], frameState: FrameState, themeColors: ThemeColors?) -> Result<PreparedFrameTransaction, PreparedFrameRejection> {
         if let rejection { return .failure(rejection) }
 
         if baseFrameSeq == 0, theme == nil { return .failure(.missingTheme) }
@@ -470,6 +475,32 @@ struct PreparedFrameTransactionBuilder {
             // local AppKit scroll-presentation discard performed during promotion.
             finalImpact.formUnion([.editor, .editorOverlay])
         }
+        let preparedThemeColors = preparedThemeColors(from: themeColors)
+        let editorSnapshot: CommittedEditorSnapshot?
+        if finalImpact.contains(.editor) || baseFrameSeq == 0 {
+            let snapshotFrameState = preparedFrameState(
+                from: frameState,
+                themeColors: preparedThemeColors,
+                liveWindowIds: liveWindowIds
+            )
+            switch CommittedEditorSnapshot.make(
+                generation: generation,
+                frameSeq: frameSeq,
+                frameState: snapshotFrameState,
+                themeColors: preparedThemeColors,
+                windowContents: workingWindows,
+                windowGutters: workingGutters,
+                windowIndentGuides: workingIndentGuides
+            ) {
+            case .success(let snapshot):
+                editorSnapshot = snapshot
+            case .failure(let rejection):
+                return .failure(rejection)
+            }
+        } else {
+            editorSnapshot = nil
+        }
+
         let transaction = PreparedFrameTransaction(
             frameSeq: frameSeq,
             baseFrameSeq: baseFrameSeq,
@@ -490,6 +521,7 @@ struct PreparedFrameTransactionBuilder {
             resources: resourceCommands.isEmpty ? nil : PreparedResourceUpdates(commands: resourceCommands.commands),
             focus: focusCommands.isEmpty ? nil : PreparedFocusUpdates(commands: focusCommands.commands),
             metadata: metadataCommands.isEmpty ? nil : PreparedMetadataUpdates(commands: metadataCommands.commands),
+            editorSnapshot: editorSnapshot,
             operationCounts: PreparedFrameOperationCounts(
                 theme: theme == nil ? 0 : 1,
                 windows: windowsChanged ? 1 : 0,
@@ -503,9 +535,77 @@ struct PreparedFrameTransactionBuilder {
         return .success(transaction)
     }
 
+    private func preparedThemeColors(from themeColors: ThemeColors?) -> ThemeColors? {
+        guard let theme else { return themeColors }
+        let replacement = ThemeColors()
+        replacement.applySlots(theme.slots)
+        return replacement
+    }
+
+    private func preparedFrameState(
+        from frameState: FrameState,
+        themeColors: ThemeColors?,
+        liveWindowIds: Set<UInt16>
+    ) -> FrameState {
+        var prepared = frameState
+        if let themeColors {
+            prepared.gutterColors = GutterThemeColors(
+                fg: themeColors.gutterFgRGB,
+                currentFg: themeColors.gutterCurrentFgRGB,
+                errorFg: themeColors.gutterErrorFgRGB,
+                warningFg: themeColors.gutterWarningFgRGB,
+                infoFg: themeColors.gutterInfoFgRGB,
+                hintFg: themeColors.gutterHintFgRGB,
+                foldFg: themeColors.gutterFoldFgRGB,
+                gitAddedFg: themeColors.gitAddedFgRGB,
+                gitModifiedFg: themeColors.gitModifiedFgRGB,
+                gitDeletedFg: themeColors.gitDeletedFgRGB
+            )
+        }
+        prepared.windowGutters = Dictionary(uniqueKeysWithValues: workingGutters.filter { liveWindowIds.contains($0.key) })
+        prepared.windowIndentGuides = Dictionary(uniqueKeysWithValues: workingIndentGuides.filter { liveWindowIds.contains($0.key) })
+        prepared.activeWindowId = workingGutters.values.first(where: \.isActive)?.windowId
+        for command in metadataCommands.commands + windowCommands.commands {
+            switch command {
+            case .guiLineSpacing(let spacing):
+                prepared.lineSpacing = max(spacing, 1.0)
+            case .guiGutterSeparator(let col, let r, let g, let b):
+                let rgb: UInt32 = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
+                prepared.scrollIndicatorColor = rgb
+                prepared.gutterCol = col
+                prepared.gutterSeparatorColor = rgb
+            case .guiCursorline(let row, let r, let g, let b):
+                prepared.cursorlineRow = row
+                prepared.cursorlineBg = (UInt32(r) << 16) | (UInt32(g) << 8) | UInt32(b)
+            case .guiGutter(let data):
+                if data.isActive {
+                    prepared.gutterCol = UInt16(data.lineNumberWidth) + UInt16(data.signColWidth)
+                    if let firstEntry = data.entries.first { prepared.viewportTopLine = firstEntry.bufLine }
+                }
+            case .guiSplitSeparators(let borderColor, let verticals, let horizontals):
+                prepared.verticalSeparators = verticals
+                prepared.horizontalSeparators = horizontals
+                prepared.splitBorderColor = borderColor
+            case .guiStatusBar(let update):
+                prepared.totalLineCount = update.lineCount
+            default:
+                break
+            }
+        }
+        return prepared
+    }
+
     private func validateCompleteEditorSurfaces(liveWindowIds: Set<UInt16>) -> PreparedFrameRejection? {
         for windowId in workingGutters.keys where !liveWindowIds.contains(windowId) {
             return .missingWindowReference(windowId: windowId)
+        }
+
+        let activeGutters = workingGutters.values.filter(\.isActive)
+        if activeGutters.count > 1 {
+            return .invalidActiveWindow(windowId: activeGutters.sorted(by: { $0.windowId < $1.windowId })[1].windowId)
+        }
+        if let activeWindowId = activeGutters.first?.windowId, !liveWindowIds.contains(activeWindowId) {
+            return .invalidActiveWindow(windowId: activeWindowId)
         }
 
         for content in workingWindows.values.sorted(by: { $0.windowId < $1.windowId }) {

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -526,9 +526,11 @@ public final class GUIWindowContent: Sendable {
     /// totals remain available from `rowStore.counters`.
     public let rowStoreOperationCounters: ResidentRowStoreCounters
 
+    #if DEBUG
     /// Compatibility view for protocol tests and non-rendering diagnostics.
-    /// Renderer hot paths must request a bounded slice from `rowStore`.
+    /// Renderer hot paths must request a bounded slice from `rowStore`; Release builds do not expose full resident-document materialization.
     public var rows: [GUIVisualRow] { rowStore.rows(in: 0..<rowStore.count).rows }
+    #endif
     public let selection: GUISelectionOverlay?
     public let searchMatches: [GUISearchMatch]
     public let diagnosticUnderlines: [GUIDiagnosticUnderline]
@@ -860,12 +862,13 @@ public final class GUIWindowContent: Sendable {
         afterApplying delta: GUIWindowRowsDelta, store: ResidentRowStore,
         scrollPresentation: GUIScrollPresentation?, residentLimit: FrameResourceWeight
     ) throws -> GUIWindowContent {
+        let nextPaneGeometry = delta.paneGeometry ?? paneGeometry
         let resultingWeight = try Self.resourceWeight(
             rowWeight: store.resourceWeight, selection: delta.selection,
             searchMatches: delta.searchMatches,
             diagnosticUnderlines: delta.diagnosticUnderlines,
             documentHighlights: delta.documentHighlights,
-            lineAnnotations: delta.lineAnnotations, paneGeometry: delta.paneGeometry
+            lineAnnotations: delta.lineAnnotations, paneGeometry: nextPaneGeometry
         )
         try Self.validate(resultingWeight, limit: residentLimit)
         return GUIWindowContent(
@@ -884,7 +887,7 @@ public final class GUIWindowContent: Sendable {
             diagnosticUnderlines: delta.diagnosticUnderlines,
             documentHighlights: delta.documentHighlights,
             lineAnnotations: delta.lineAnnotations,
-            paneGeometry: delta.paneGeometry,
+            paneGeometry: nextPaneGeometry,
             cursorline: delta.cursorline,
             scrollPresentation: scrollPresentation,
             resourceWeight: resultingWeight

--- a/macos/Sources/Renderer/WindowContent.swift
+++ b/macos/Sources/Renderer/WindowContent.swift
@@ -507,6 +507,8 @@ public struct GUIRetainedRowKey: Hashable, Sendable {
 /// this is stored but not yet used for rendering (draw_text still active).
 /// Phase 3 will switch rendering to use this data directly.
 public final class GUIWindowContent: Sendable {
+    /// Stable value identity for this immutable content instance without retaining it elsewhere.
+    public let renderIdentity: UUID
     public let windowId: UInt16
     public let fullRefresh: Bool
     public let contentEpoch: UInt32
@@ -565,6 +567,7 @@ public final class GUIWindowContent: Sendable {
         let store = try ResidentRowStore(
             decodedRows: rows, resourceWeight: rowWeight, limit: residentLimit
         )
+        self.renderIdentity = UUID()
         self.windowId = windowId
         self.fullRefresh = fullRefresh
         self.contentEpoch = contentEpoch
@@ -586,7 +589,7 @@ public final class GUIWindowContent: Sendable {
         self.resourceWeight = completeWeight
     }
 
-    private init(windowId: UInt16, fullRefresh: Bool, contentEpoch: UInt32,
+    private init(renderIdentity: UUID = UUID(), windowId: UInt16, fullRefresh: Bool, contentEpoch: UInt32,
          cursorVisible: Bool, cursorRow: UInt16, cursorCol: UInt16, cursorShape: CursorShape,
          scrollLeft: UInt16, rowStore: ResidentRowStore,
          rowStoreOperationCounters: ResidentRowStoreCounters,
@@ -595,6 +598,7 @@ public final class GUIWindowContent: Sendable {
          lineAnnotations: [GUILineAnnotation], paneGeometry: GUIPaneGeometry?,
          cursorline: GUICursorline?, scrollPresentation: GUIScrollPresentation?,
          resourceWeight: FrameResourceWeight) {
+        self.renderIdentity = renderIdentity
         self.windowId = windowId
         self.fullRefresh = fullRefresh
         self.contentEpoch = contentEpoch
@@ -619,6 +623,7 @@ public final class GUIWindowContent: Sendable {
     /// Returns the same immutable content while replacing per-frame operation counters.
     public func reportingOperationCounters(_ counters: ResidentRowStoreCounters) -> GUIWindowContent {
         GUIWindowContent(
+            renderIdentity: renderIdentity,
             windowId: windowId, fullRefresh: fullRefresh, contentEpoch: contentEpoch,
             cursorVisible: cursorVisible, cursorRow: cursorRow, cursorCol: cursorCol,
             cursorShape: cursorShape, scrollLeft: scrollLeft, rowStore: rowStore,

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -423,14 +423,20 @@ final class EditorNSView: MTKView {
     private var scrollElasticWindowId: UInt16?
 
     /// One immutable snapshot of the pane and effective offset used by both drawing and pointer normalization.
-    struct LocalScrollPresentation: Equatable {
-        let windowId: UInt16
-        let offset: CGPoint
+    typealias LocalScrollPresentation = EditorLocalPresentationTransform
+
+    /// The editor presentation visible to interaction and accessibility code. Metal promotes the exact presentation after presentation; committed-but-unpresented values are draw inputs only.
+    private var editorPresentation: VisibleEditorPresentation? {
+        dispatcher.visibleEditorPresentation
     }
 
     /// The editor snapshot visible to interaction and accessibility code. Metal promotes the exact snapshot after presentation; committed-but-unpresented snapshots are draw inputs only.
     private var editorPresentationSnapshot: CommittedEditorSnapshot? {
-        dispatcher.visibleEditorSnapshot
+        editorPresentation?.snapshot
+    }
+
+    private var visibleLocalScrollPresentation: LocalScrollPresentation? {
+        editorPresentation?.localTransform
     }
 
     private func interactionContent(windowId: UInt16) -> GUIWindowContent? {
@@ -600,8 +606,8 @@ final class EditorNSView: MTKView {
                                 presentationWindowId: localScrollPresentation?.windowId,
                                 presentationInputSeq: presentationInputSeq,
                                 latencyRecorder: dispatcher.latency,
-                                onPresented: { [weak self] snapshot in
-                                    self?.promotePresentedSnapshot(snapshot)
+                                onPresented: { [weak self, localScrollPresentation] snapshot in
+                                    self?.promotePresentedSnapshot(snapshot, localScrollPresentation: localScrollPresentation)
                                 })
         if coreTextRenderer.cursorAnimationGeneration != cursorAnimationGeneration {
             resetCursorBlink()
@@ -612,12 +618,12 @@ final class EditorNSView: MTKView {
         os_signpost(.event, log: renderLog, name: "DrawComplete")
     }
 
-    private func promotePresentedSnapshot(_ snapshot: CommittedEditorSnapshot) {
-        dispatcher.promoteVisibleEditorSnapshot(snapshot)
-        let fs = snapshot.frameState
-        if fs.cursorRow != lastAccessibilityCursorRow || fs.cursorCol != lastAccessibilityCursorCol {
-            lastAccessibilityCursorRow = fs.cursorRow
-            lastAccessibilityCursorCol = fs.cursorCol
+    private func promotePresentedSnapshot(_ snapshot: CommittedEditorSnapshot, localScrollPresentation: LocalScrollPresentation?) {
+        dispatcher.promoteVisibleEditorPresentation(snapshot: snapshot, localTransform: localScrollPresentation)
+        let cursor = snapshot.activeSurface.map { ($0.content.cursorRow, $0.content.cursorCol) } ?? (0, 0)
+        if cursor.0 != lastAccessibilityCursorRow || cursor.1 != lastAccessibilityCursorCol {
+            lastAccessibilityCursorRow = cursor.0
+            lastAccessibilityCursorCol = cursor.1
             NSAccessibility.post(element: self, notification: .selectedTextChanged)
             resetCursorBlink()
         }
@@ -2853,7 +2859,8 @@ final class EditorNSView: MTKView {
     // MARK: - Helpers
 
     private var effectiveCellHeight: CGFloat {
-        cellHeight * CGFloat(dispatcher.frameState.lineSpacing)
+        let lineSpacing = editorPresentationSnapshot?.frameState.lineSpacing ?? dispatcher.committedEditorSnapshot?.frameState.lineSpacing ?? dispatcher.frameState.lineSpacing
+        return cellHeight * CGFloat(lineSpacing)
     }
 
     private func shouldSendTextDrag(for event: NSEvent) -> Bool {
@@ -2917,7 +2924,7 @@ final class EditorNSView: MTKView {
     }
 
     private func foldChevronEntry(at point: NSPoint) -> (gutter: Wire.WindowGutter, entry: Wire.GutterEntry)? {
-        let presentation = localScrollPresentation
+        let presentation = visibleLocalScrollPresentation
         let point = Self.presentationNormalizedGutterPoint(
             point,
             presentation: presentation,
@@ -2951,7 +2958,7 @@ final class EditorNSView: MTKView {
     }
 
     private func updateGutterHover(at point: NSPoint) {
-        let presentation = localScrollPresentation
+        let presentation = visibleLocalScrollPresentation
         let point = Self.presentationNormalizedGutterPoint(
             point,
             presentation: presentation,
@@ -3019,7 +3026,7 @@ final class EditorNSView: MTKView {
     }
 
     private func presentationNormalizedPoint(_ point: NSPoint) -> NSPoint {
-        let presentation = localScrollPresentation
+        let presentation = visibleLocalScrollPresentation
         let rawRow = Int16(point.y / effectiveCellHeight)
         let rawCol = max(0, Int16(point.x / cellWidth))
         let rawPointWindowId = smoothScrollTargetWindowId(row: rawRow, col: rawCol)
@@ -3384,22 +3391,19 @@ extension EditorNSView: @preconcurrency NSTextInputClient {
     }
 
     private func visibleCursorRect() -> NSRect {
-        guard let snapshot = editorPresentationSnapshot else {
+        guard let surface = editorPresentationSnapshot?.activeSurface else {
             return NSRect(x: 0, y: 0, width: cellWidth, height: effectiveCellHeight)
         }
-        let fs = snapshot.frameState
-        return NSRect(
-            x: CGFloat(fs.cursorCol) * cellWidth,
-            y: CGFloat(fs.cursorRow) * effectiveCellHeight,
-            width: cellWidth,
-            height: effectiveCellHeight
-        )
+        let content = surface.content
+        let scrollLeft = CGFloat(content.scrollLeft) * cellWidth
+        let localOffset = visibleLocalScrollPresentation?.windowId == surface.windowId ? visibleLocalScrollPresentation?.offset ?? .zero : .zero
+        let x = CGFloat(surface.paneGeometry.textRect.col) * cellWidth + CGFloat(content.cursorCol) * cellWidth - scrollLeft - localOffset.x
+        let y = CGFloat(surface.paneGeometry.textRect.row) * effectiveCellHeight + CGFloat(content.cursorRow) * effectiveCellHeight - localOffset.y
+        return NSRect(x: x, y: y, width: cellWidth, height: effectiveCellHeight)
     }
 
     private func accessibilityCursorOffset() -> Int {
-        guard let snapshot = editorPresentationSnapshot else { return 0 }
-        let fs = snapshot.frameState
-        return Int(fs.cursorRow) * Int(fs.cols) + Int(fs.cursorCol)
+        editorPresentationSnapshot?.activeSurface?.cursorLineOffset ?? 0
     }
 
     private func visibleAccessibilityRows() -> [GUIVisualRow] {
@@ -3441,7 +3445,7 @@ extension EditorNSView {
     }
 
     override func accessibilityInsertionPointLineNumber() -> Int {
-        return Int(editorPresentationSnapshot?.frameState.cursorRow ?? 0)
+        return Int(editorPresentationSnapshot?.activeSurface?.content.cursorRow ?? 0)
     }
 
     override func accessibilitySelectedText() -> String? {

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -1082,11 +1082,12 @@ final class EditorNSView: MTKView {
     /// The track only captures clicks when the document can scroll, the viewport top is valid,
     /// and either the indicator is currently visible or the macOS setting forces it to stay visible.
     private func shouldCaptureScrollTrackClick(_ point: NSPoint) -> Bool {
-        EditorScrollTrack.isInTrack(x: point.x, viewWidth: bounds.width)
+        guard let metrics = visibleScrollTrackMetrics else { return false }
+        return EditorScrollTrack.isInTrack(x: point.x, viewWidth: bounds.width)
             && EditorScrollTrack.shouldCaptureTrackClick(
-                totalLines: dispatcher.frameState.totalLineCount,
-                visibleRows: UInt32(dispatcher.frameState.rows),
-                viewportTopLine: dispatcher.frameState.viewportTopLine,
+                totalLines: metrics.totalLines,
+                visibleRows: metrics.visibleRows,
+                viewportTopLine: metrics.viewportTopLine,
                 scrollIndicatorAlpha: coreTextRenderer.scrollIndicatorAlpha,
                 alwaysShowScrollbar: alwaysShowScrollbar
             )
@@ -1094,40 +1095,55 @@ final class EditorNSView: MTKView {
 
     /// Captures the pointer's offset inside the rendered thumb when the user starts dragging on the thumb.
     private func scrollTrackDragOffset(forY y: CGFloat) -> CGFloat? {
-        let fs = dispatcher.frameState
-        guard let thumb = EditorScrollTrack.thumb(
-            viewHeight: bounds.height,
-            totalLines: fs.totalLineCount,
-            visibleRows: UInt32(fs.rows),
-            viewportTopLine: fs.viewportTopLine,
-            resident: activeWindowIsResident
-        ) else { return nil }
+        guard let metrics = visibleScrollTrackMetrics,
+              let thumb = EditorScrollTrack.thumb(
+                  viewHeight: bounds.height,
+                  totalLines: metrics.totalLines,
+                  visibleRows: metrics.visibleRows,
+                  viewportTopLine: metrics.viewportTopLine,
+                  resident: metrics.resident
+              ) else { return nil }
         return EditorScrollTrack.dragOffset(forY: y, thumb: thumb)
     }
 
     /// Converts a Y coordinate in the scroll track to a target line number.
     private func scrollTrackYToLine(_ y: CGFloat) -> UInt32 {
-        let fs = dispatcher.frameState
-        let visibleRows = UInt32(fs.rows)
-        let resident = activeWindowIsResident
+        guard let metrics = visibleScrollTrackMetrics else { return 0 }
 
         if let scrollIndicatorDragOffset {
             return EditorScrollTrack.line(
                 forDraggedY: y,
                 dragOffset: scrollIndicatorDragOffset,
                 viewHeight: bounds.height,
-                totalLines: fs.totalLineCount,
-                visibleRows: visibleRows,
-                resident: resident
+                totalLines: metrics.totalLines,
+                visibleRows: metrics.visibleRows,
+                resident: metrics.resident
             )
         }
 
         return EditorScrollTrack.line(
             forY: y,
             viewHeight: bounds.height,
-            totalLines: fs.totalLineCount,
+            totalLines: metrics.totalLines,
+            visibleRows: metrics.visibleRows,
+            resident: metrics.resident
+        )
+    }
+
+    private var visibleScrollTrackMetrics: (totalLines: UInt32, visibleRows: UInt32, viewportTopLine: UInt32, resident: Bool)? {
+        guard let snapshot = editorPresentationSnapshot,
+              let surface = snapshot.activeSurface else { return nil }
+        let viewport = surface.paneGeometry.viewport
+        let visibleRows = viewport.rows > 0 ? UInt32(viewport.rows) : UInt32(snapshot.frameState.rows)
+        let totalLines = viewport.totalLines > 0 ? viewport.totalLines : snapshot.frameState.totalLineCount
+        return (
+            totalLines: totalLines,
             visibleRows: visibleRows,
-            resident: resident
+            viewportTopLine: viewport.top,
+            resident: Self.thumbDragCanPresentLocally(
+                scrollPresentation: surface.content.scrollPresentation,
+                totalLines: totalLines
+            )
         )
     }
 
@@ -1137,10 +1153,7 @@ final class EditorNSView: MTKView {
     /// operates on the active pane (its metrics drive `scrollTrackYToLine`), so this is the
     /// window a thumb drag scrolls.
     private var activeWindowId: UInt16? {
-        editorPresentationSnapshot?.surfaces
-            .compactMap { surface in surface.gutter.gutter?.isActive == true ? surface.windowId : nil }
-            .sorted()
-            .first
+        editorPresentationSnapshot?.activeSurface?.windowId
     }
 
     private var activeWindowIsResident: Bool {
@@ -2032,6 +2045,10 @@ final class EditorNSView: MTKView {
             scrollWindowId: localScrollPresentation?.windowId,
             scrollOffset: localScrollPresentation?.offset ?? .zero
         )
+    }
+
+    func scrollTrackLineForTesting(y: CGFloat) -> UInt32 {
+        scrollTrackYToLine(y)
     }
 #endif
 

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -204,8 +204,8 @@ final class EditorNSView: MTKView {
     // MARK: - Cursor blink
 
     /// Whether the cursor is currently visible in the blink cycle.
-    /// The Metal renderer ANDs this with `frameState.cursorVisible` to
-    /// determine whether to draw the cursor.
+    /// The Metal renderer ANDs this with the committed window content's
+    /// `cursorVisible` to determine whether to draw the cursor.
     public private(set) var cursorBlinkVisible: Bool = true
 
     /// Whether Minga config allows blinking the editor cursor.
@@ -640,7 +640,7 @@ final class EditorNSView: MTKView {
             return GridDimensions(cols: 1, rows: 1)
         }
 
-        let gutterPad: CGFloat = dispatcher.frameState.gutterCol > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
+        let gutterPad: CGFloat = (dispatcher.committedEditorSnapshot?.gutterCol ?? 0) > 0 ? CoreTextMetalRenderer.gutterPixelPaddingPt : 0
         let cols = UInt16(max((width - gutterPad) / resolvedCellWidth, 1))
         let rows = rowsThatFit(height: height, cellHeight: resolvedCellHeight, lineSpacing: dispatcher.frameState.lineSpacing)
         return GridDimensions(cols: cols, rows: rows)
@@ -2826,7 +2826,8 @@ final class EditorNSView: MTKView {
         guard modifiers == 0 else { return }
         let statusMode = statusBarState?.mode
         guard !Self.statusModeUsesLiteralSpace(statusMode: statusMode) else { return }
-        guard Self.shouldOptimisticallyEnterTextInputMode(codepoint: codepoint, statusMode: statusMode, cursorShape: dispatcher.frameState.cursorShape) else { return }
+        let cursorShape = dispatcher.committedEditorSnapshot?.metadata.cursorShape ?? .block
+        guard Self.shouldOptimisticallyEnterTextInputMode(codepoint: codepoint, statusMode: statusMode, cursorShape: cursorShape) else { return }
 
         markOptimisticTextInputMode()
     }
@@ -3245,7 +3246,7 @@ final class EditorNSView: MTKView {
     private func verticalSeparatorColFromFrameState(at point: NSPoint) -> UInt16? {
         let screenRow = Int(point.y / effectiveCellHeight)
         guard let snapshot = editorPresentationSnapshot else { return nil }
-        return snapshot.frameState.verticalSeparators.first { separator in
+        return snapshot.metadata.verticalSeparators.first { separator in
             let lineX = CGFloat(separator.col) * cellWidth
             return screenRow >= Int(separator.startRow) && screenRow <= Int(separator.endRow) && abs(point.x - lineX) <= dividerHitHalfTolerance
         }?.col
@@ -3254,7 +3255,7 @@ final class EditorNSView: MTKView {
     private func horizontalSeparatorRowFromFrameState(at point: NSPoint) -> UInt16? {
         let rawCol = Int(point.x / cellWidth)
         guard let snapshot = editorPresentationSnapshot else { return nil }
-        return snapshot.frameState.horizontalSeparators.first { separator in
+        return snapshot.metadata.horizontalSeparators.first { separator in
             let lineY = CGFloat(separator.row) * effectiveCellHeight + effectiveCellHeight * 0.5
             let startCol = Int(separator.col)
             let endCol = startCol + Int(separator.width)
@@ -3276,7 +3277,7 @@ final class EditorNSView: MTKView {
     }
 
     private func fallbackCellColumn(at point: NSPoint) -> Int16 {
-        let gutterCols = CGFloat((editorPresentationSnapshot)?.frameState.gutterCol ?? 0)
+        let gutterCols = CGFloat(editorPresentationSnapshot?.gutterCol ?? 0)
         guard gutterCols > 0 else {
             return max(0, Int16(point.x / cellWidth))
         }

--- a/macos/Sources/Views/Editor/EditorNSView.swift
+++ b/macos/Sources/Views/Editor/EditorNSView.swift
@@ -428,6 +428,15 @@ final class EditorNSView: MTKView {
         let offset: CGPoint
     }
 
+    /// The editor snapshot visible to interaction and accessibility code. Metal promotes the exact snapshot after presentation; committed-but-unpresented snapshots are draw inputs only.
+    private var editorPresentationSnapshot: CommittedEditorSnapshot? {
+        dispatcher.visibleEditorSnapshot
+    }
+
+    private func interactionContent(windowId: UInt16) -> GUIWindowContent? {
+        editorPresentationSnapshot?.content(for: windowId)
+    }
+
     /// The local scroll presentation for this frame or input event.
     /// Decouples "which window shows the offset" from "a gesture is active": during a settle or
     /// spring-back the gesture target is nil (so `onScrollPresentationReset` discards can win),
@@ -544,16 +553,12 @@ final class EditorNSView: MTKView {
         }
         let scale = Float(window?.backingScaleFactor ?? 2.0)
 
-        // Check for cursor movement to post accessibility notifications.
-        let fs = dispatcher.frameState
-
-        if fs.cursorRow != lastAccessibilityCursorRow ||
-           fs.cursorCol != lastAccessibilityCursorCol {
-            lastAccessibilityCursorRow = fs.cursorRow
-            lastAccessibilityCursorCol = fs.cursorCol
-            NSAccessibility.post(element: self, notification: .selectedTextChanged)
-            resetCursorBlink()
+        guard let committedSnapshot = dispatcher.committedEditorSnapshot else {
+            dispatcher.discardPendingPresentation(reason: .hidden)
+            return
         }
+
+        let fs = committedSnapshot.frameState
 
         // Flash scroll indicator when viewport position changes (keyboard scroll, cursor movement).
         // Skip scroll indicator updates while the user is dragging to prevent feedback loops.
@@ -566,20 +571,16 @@ final class EditorNSView: MTKView {
         clearSmoothScrollStateIfTargetWindowMissing()
         advancePresentationScrollAnimation()
         advanceThumbDragPresentation()
-
         let validGutterHoverWindowId = gutterHoverWindowId.flatMap { windowId in
-            dispatcher.currentFrameWindowIds.contains(windowId) ? windowId : nil
+            committedSnapshot.windowIds.contains(windowId) ? windowId : nil
         }
         let validGutterHoverRow = validGutterHoverWindowId == nil ? nil : gutterHoverRow
         let validMouseInGutter = isMouseInGutter && validGutterHoverWindowId != nil
         let cursorAnimationGeneration = coreTextRenderer.cursorAnimationGeneration
         let presentationInputSeq = dispatcher.takePresentationInputSeq()
-        let presentationFrame = dispatcher.pendingPresentationFrame()
         let localScrollPresentation = localScrollPresentation
-        coreTextRenderer.render(frameState: fs, fontManager: fontManager,
+        coreTextRenderer.render(snapshot: committedSnapshot, fontManager: fontManager,
                                 cursorBlinkVisible: cursorBlinkVisible,
-                                windowContents: editorInput?.currentWindowContents ?? [:],
-                                themeColors: editorInput?.currentTheme,
                                 isMouseInGutter: validMouseInGutter,
                                 gutterHoverWindowId: validGutterHoverWindowId,
                                 gutterHoverRow: validGutterHoverRow,
@@ -598,16 +599,28 @@ final class EditorNSView: MTKView {
                                 ),
                                 presentationWindowId: localScrollPresentation?.windowId,
                                 presentationInputSeq: presentationInputSeq,
-                                presentationFrame: presentationFrame,
-                                latencyRecorder: dispatcher.latency)
+                                latencyRecorder: dispatcher.latency,
+                                onPresented: { [weak self] snapshot in
+                                    self?.promotePresentedSnapshot(snapshot)
+                                })
         if coreTextRenderer.cursorAnimationGeneration != cursorAnimationGeneration {
             resetCursorBlink()
         }
         if coreTextRenderer.cursorAnimating {
             needsDisplay = true
         }
-        dispatcher.markRendered()
         os_signpost(.event, log: renderLog, name: "DrawComplete")
+    }
+
+    private func promotePresentedSnapshot(_ snapshot: CommittedEditorSnapshot) {
+        dispatcher.promoteVisibleEditorSnapshot(snapshot)
+        let fs = snapshot.frameState
+        if fs.cursorRow != lastAccessibilityCursorRow || fs.cursorCol != lastAccessibilityCursorCol {
+            lastAccessibilityCursorRow = fs.cursorRow
+            lastAccessibilityCursorCol = fs.cursorCol
+            NSAccessibility.post(element: self, notification: .selectedTextChanged)
+            resetCursorBlink()
+        }
     }
 
     private func currentGridDimensions() -> GridDimensions {
@@ -1118,19 +1131,19 @@ final class EditorNSView: MTKView {
     /// operates on the active pane (its metrics drive `scrollTrackYToLine`), so this is the
     /// window a thumb drag scrolls.
     private var activeWindowId: UInt16? {
-        dispatcher.frameState.windowGutters.values
-            .filter(\.isActive)
-            .sorted { $0.windowId < $1.windowId }
-            .first?
-            .windowId
+        editorPresentationSnapshot?.surfaces
+            .compactMap { surface in surface.gutter.gutter?.isActive == true ? surface.windowId : nil }
+            .sorted()
+            .first
     }
 
     private var activeWindowIsResident: Bool {
-        guard let windowId = activeWindowId,
-              let content = editorInput?.currentWindowContents[windowId] else { return false }
+        guard let snapshot = editorPresentationSnapshot,
+              let windowId = activeWindowId,
+              let content = snapshot.content(for: windowId) else { return false }
         return Self.thumbDragCanPresentLocally(
             scrollPresentation: content.scrollPresentation,
-            totalLines: content.paneGeometry?.viewport.totalLines ?? dispatcher.frameState.totalLineCount
+            totalLines: content.paneGeometry?.viewport.totalLines ?? snapshot.frameState.totalLineCount
         )
     }
 
@@ -1143,11 +1156,12 @@ final class EditorNSView: MTKView {
         // accumulator and reconciliation bookkeeping. Reset before residency routing so the
         // round-trip path cannot leave an old settle or rebound visible either.
         resetSmoothScrollState()
-        guard let windowId = activeWindowId,
-              let content = editorInput?.currentWindowContents[windowId],
+        guard let snapshot = editorPresentationSnapshot,
+              let windowId = activeWindowId,
+              let content = snapshot.content(for: windowId),
               Self.thumbDragCanPresentLocally(
                   scrollPresentation: content.scrollPresentation,
-                  totalLines: content.paneGeometry?.viewport.totalLines ?? dispatcher.frameState.totalLineCount
+                  totalLines: content.paneGeometry?.viewport.totalLines ?? snapshot.frameState.totalLineCount
               )
         else {
             thumbDragSession = nil
@@ -1209,7 +1223,7 @@ final class EditorNSView: MTKView {
 
     /// The committed scroll presentation of the thumb-drag pane, or nil when it is gone.
     private func committedThumbDrag(for windowId: UInt16) -> ThumbDragSession.Committed? {
-        guard let sp = editorInput?.currentWindowContents[windowId]?.scrollPresentation else { return nil }
+        guard let sp = interactionContent(windowId: windowId)?.scrollPresentation else { return nil }
         return ThumbDragSession.Committed(anchorTop: sp.anchorTop, scrollSeq: sp.scrollSeq, contentEpoch: sp.contentEpoch, layoutGeneration: sp.layoutGeneration)
     }
 
@@ -2066,7 +2080,7 @@ final class EditorNSView: MTKView {
         for e in hEvents {
             sendScrollEvent(e, row: targetCell.row, col: targetCell.col, mods: mods)
         }
-        let targetWindowContent = scrollTargetWindowId.flatMap { editorInput?.currentWindowContents[$0] }
+        let targetWindowContent = scrollTargetWindowId.flatMap { interactionContent(windowId: $0) }
         let targetScrollPresentation = targetWindowContent?.scrollPresentation
         let scrollBounds = Self.presentationScrollBounds(
             for: targetWindowContent,
@@ -2196,7 +2210,7 @@ final class EditorNSView: MTKView {
         }
         scrollSettleWindowId = windowId
         if scrollLastConfirmedAnchorTop == nil {
-            scrollLastConfirmedAnchorTop = editorInput?.currentWindowContents[windowId]?.scrollPresentation?.anchorTop
+            scrollLastConfirmedAnchorTop = interactionContent(windowId: windowId)?.scrollPresentation?.anchorTop
         }
         scrollSettleAnimator.start(offset: residual, duration: duration)
         // Reflect the seeded offset immediately so this frame is continuous with the last.
@@ -2228,7 +2242,7 @@ final class EditorNSView: MTKView {
         var keepAnimating = false
 
         if let windowId = scrollSettleWindowId {
-            if let sp = editorInput?.currentWindowContents[windowId]?.scrollPresentation {
+            if let sp = interactionContent(windowId: windowId)?.scrollPresentation {
                 reconcileUnconfirmedLines(against: sp)
             }
             let residual = scrollSettleAnimator.offset(now: now)
@@ -2350,7 +2364,7 @@ final class EditorNSView: MTKView {
         // outlive it: if any pane owning presentation state has closed, drop the offset and cancel
         // its animation so a stale whole-cell offset can't linger after the animator finishes on a
         // vanished pane.
-        let available = Set(dispatcher.currentFrameWindowIds.filter { editorInput?.currentWindowContents[$0] != nil })
+        guard let available = dispatcher.visibleEditorSnapshot?.windowIds else { return }
         if Self.missingPresentationWindow(
             candidateWindowIds: [scrollTargetWindowId, thumbDragSession?.windowId, scrollSettleWindowId, scrollElasticWindowId],
             availableWindowIds: available
@@ -2372,17 +2386,18 @@ final class EditorNSView: MTKView {
     }
 
     private func smoothScrollTargetWindowId(row: Int16, col: Int16) -> UInt16? {
-        if let contents = editorInput?.currentWindowContents {
+        if let snapshot = editorPresentationSnapshot {
             let rowValue = Int(row)
             let colValue = Int(col)
-            let geometry = contents.values
-                .compactMap(\.paneGeometry)
+            let geometry = snapshot.surfaces
+                .map(\.paneGeometry)
                 .filter { rowColInCellRect(row: rowValue, col: colValue, rect: $0.contentRect) }
                 .max { lhs, rhs in lhs.contentRect.col < rhs.contentRect.col }
             if let geometry { return geometry.windowId }
+            return EditorNSView.smoothScrollTargetWindowId(row: row, col: col, windowGutters: snapshot.windowGutters)
         }
 
-        return EditorNSView.smoothScrollTargetWindowId(row: row, col: col, windowGutters: dispatcher.frameState.windowGutters)
+        return EditorNSView.smoothScrollTargetWindowId(row: row, col: col, windowGutters: editorPresentationSnapshot?.windowGutters ?? [:])
     }
 
     private func clearSmoothScrollOffsetIfPointerLeftTarget(row: Int16, col: Int16) {
@@ -2652,7 +2667,7 @@ final class EditorNSView: MTKView {
 
         // A tick into a document boundary can't be committed by the BEAM, so predicting it would
         // park content one cell off-grid; suppress the seed (the scroll intent already sent above).
-        let windowContent = editorInput?.currentWindowContents[windowId]
+        let windowContent = interactionContent(windowId: windowId)
         let boundary = Self.presentationScrollBoundaryAvailability(
             for: windowContent,
             scrollPresentation: windowContent?.scrollPresentation
@@ -2906,14 +2921,14 @@ final class EditorNSView: MTKView {
         let point = Self.presentationNormalizedGutterPoint(
             point,
             presentation: presentation,
-            targetGutterRect: presentation.flatMap { editorInput?.currentWindowContents[$0.windowId]?.paneGeometry?.gutterRect },
+            targetGutterRect: presentation.flatMap { interactionContent(windowId: $0.windowId)?.paneGeometry?.gutterRect },
             cellWidth: cellWidth,
             cellHeight: effectiveCellHeight
         )
         guard let (gutter, rowIndex) = gutterHit(at: point) else { return nil }
         guard Int(gutter.signColWidth) >= 3 else { return nil }
 
-        let content = editorInput?.currentWindowContents[gutter.windowId]
+        let content = interactionContent(windowId: gutter.windowId)
         let presentationBeforeRows = Self.presentationScrollPayloadOverscanBounds(
             for: content,
             scrollPresentation: content?.scrollPresentation
@@ -2940,7 +2955,7 @@ final class EditorNSView: MTKView {
         let point = Self.presentationNormalizedGutterPoint(
             point,
             presentation: presentation,
-            targetGutterRect: presentation.flatMap { editorInput?.currentWindowContents[$0.windowId]?.paneGeometry?.gutterRect },
+            targetGutterRect: presentation.flatMap { interactionContent(windowId: $0.windowId)?.paneGeometry?.gutterRect },
             cellWidth: cellWidth,
             cellHeight: effectiveCellHeight
         )
@@ -2969,13 +2984,16 @@ final class EditorNSView: MTKView {
     private func gutterHit(at point: NSPoint) -> (gutter: Wire.WindowGutter, rowIndex: Int)? {
         let screenRow = Int(point.y / effectiveCellHeight)
 
+        guard let snapshot = editorPresentationSnapshot else { return nil }
+        let gutters = snapshot.windowGutters
+
         if let geometry = paneGeometryGutterHit(at: point, screenRow: screenRow),
-           let gutter = dispatcher.frameState.windowGutters[geometry.windowId] {
+           let gutter = gutters[geometry.windowId] {
             return (gutter, screenRow - Int(geometry.gutterRect.row))
         }
 
-        for windowId in dispatcher.currentFrameWindowIds {
-            guard let gutter = dispatcher.frameState.windowGutters[windowId] else { continue }
+        for windowId in snapshot.windowIds {
+            guard let gutter = gutters[windowId] else { continue }
             let startRow = Int(gutter.contentRow)
             let endRow = startRow + Int(gutter.contentHeight)
             guard screenRow >= startRow && screenRow < endRow else { continue }
@@ -3005,7 +3023,7 @@ final class EditorNSView: MTKView {
         let rawRow = Int16(point.y / effectiveCellHeight)
         let rawCol = max(0, Int16(point.x / cellWidth))
         let rawPointWindowId = smoothScrollTargetWindowId(row: rawRow, col: rawCol)
-        let content = presentation.flatMap { editorInput?.currentWindowContents[$0.windowId] }
+        let content = presentation.flatMap { editorPresentationSnapshot?.content(for: $0.windowId) }
         return Self.presentationNormalizedPoint(
             point,
             rawPointWindowId: rawPointWindowId,
@@ -3107,21 +3125,20 @@ final class EditorNSView: MTKView {
     private func gutterForCellPosition(at point: NSPoint, row: Int16) -> Wire.WindowGutter? {
         guard row >= 0 else { return nil }
         let rowValue = Int(row)
-        let frameState = dispatcher.frameState
+        guard let snapshot = editorPresentationSnapshot else { return nil }
+        let gutters = snapshot.windowGutters
 
         if let geometry = paneGeometryHit(at: point, screenRow: rowValue),
-           let gutter = frameState.windowGutters[geometry.windowId] {
+           let gutter = gutters[geometry.windowId] {
             return gutter
         }
 
-        let windowIds = dispatcher.currentFrameWindowIds.isEmpty ? Set(frameState.windowGutters.keys) : dispatcher.currentFrameWindowIds
-
-        return windowIds.compactMap { frameState.windowGutters[$0] }
+        return snapshot.windowIds.compactMap { gutters[$0] }
             .filter { gutter in
                 let startRow = Int(gutter.contentRow)
                 let endRow = startRow + Int(gutter.contentHeight)
                 let startX = CGFloat(gutter.contentCol) * cellWidth
-                let endX = startX + CGFloat(CoreTextMetalRenderer.windowWidthCols(gutter: gutter, frameCols: frameState.cols)) * cellWidth
+                let endX = startX + CGFloat(CoreTextMetalRenderer.windowWidthCols(gutter: gutter, frameCols: snapshot.frameState.cols)) * cellWidth
                 return rowValue >= startRow && rowValue < endRow && point.x >= startX && point.x < endX
             }
             .max { lhs, rhs in lhs.contentCol < rhs.contentCol }
@@ -3143,21 +3160,21 @@ final class EditorNSView: MTKView {
     }
 
     private func paneGeometries(at point: NSPoint, screenRow: Int) -> [GUIPaneGeometry] {
-        guard let contents = editorInput?.currentWindowContents else { return [] }
+        guard let snapshot = editorPresentationSnapshot else { return [] }
         let rawCol = Int(point.x / cellWidth)
 
-        return contents.values.compactMap(\.paneGeometry).filter { geometry in
+        return snapshot.surfaces.map(\.paneGeometry).filter { geometry in
             rowColInCellRect(row: screenRow, col: rawCol, rect: geometry.totalRect)
         }
     }
 
     private func hitRegion(at point: NSPoint, kind: GUIHitRegion.Kind) -> GUIHitRegion? {
-        guard let contents = editorInput?.currentWindowContents else { return nil }
+        guard let snapshot = editorPresentationSnapshot else { return nil }
         let screenRow = Int(point.y / effectiveCellHeight)
         let rawCol = Int(point.x / cellWidth)
 
-        return contents.values
-            .compactMap(\.paneGeometry)
+        return snapshot.surfaces
+            .map(\.paneGeometry)
             .flatMap(\.hitRegions)
             .filter { region in
                 region.kind == kind && rowColInCellRect(row: screenRow, col: rawCol, rect: region.rect)
@@ -3166,12 +3183,12 @@ final class EditorNSView: MTKView {
     }
 
     private func dividerHitRegion(at point: NSPoint) -> GUIHitRegion? {
-        guard let contents = editorInput?.currentWindowContents else { return nil }
+        guard let snapshot = editorPresentationSnapshot else { return nil }
         let screenRow = Int(point.y / effectiveCellHeight)
         let rawCol = Int(point.x / cellWidth)
 
-        return contents.values
-            .compactMap(\.paneGeometry)
+        return snapshot.surfaces
+            .map(\.paneGeometry)
             .flatMap(\.hitRegions)
             .filter { region in
                 region.kind == .divider && pointInDividerHitBounds(point, screenRow: screenRow, rawCol: rawCol, region: region)
@@ -3203,7 +3220,8 @@ final class EditorNSView: MTKView {
 
     private func verticalSeparatorColFromFrameState(at point: NSPoint) -> UInt16? {
         let screenRow = Int(point.y / effectiveCellHeight)
-        return dispatcher.frameState.verticalSeparators.first { separator in
+        guard let snapshot = editorPresentationSnapshot else { return nil }
+        return snapshot.frameState.verticalSeparators.first { separator in
             let lineX = CGFloat(separator.col) * cellWidth
             return screenRow >= Int(separator.startRow) && screenRow <= Int(separator.endRow) && abs(point.x - lineX) <= dividerHitHalfTolerance
         }?.col
@@ -3211,7 +3229,8 @@ final class EditorNSView: MTKView {
 
     private func horizontalSeparatorRowFromFrameState(at point: NSPoint) -> UInt16? {
         let rawCol = Int(point.x / cellWidth)
-        return dispatcher.frameState.horizontalSeparators.first { separator in
+        guard let snapshot = editorPresentationSnapshot else { return nil }
+        return snapshot.frameState.horizontalSeparators.first { separator in
             let lineY = CGFloat(separator.row) * effectiveCellHeight + effectiveCellHeight * 0.5
             let startCol = Int(separator.col)
             let endCol = startCol + Int(separator.width)
@@ -3233,7 +3252,7 @@ final class EditorNSView: MTKView {
     }
 
     private func fallbackCellColumn(at point: NSPoint) -> Int16 {
-        let gutterCols = CGFloat(dispatcher.frameState.gutterCol)
+        let gutterCols = CGFloat((editorPresentationSnapshot)?.frameState.gutterCol ?? 0)
         guard gutterCols > 0 else {
             return max(0, Int16(point.x / cellWidth))
         }
@@ -3320,10 +3339,7 @@ extension EditorNSView: @preconcurrency NSTextInputClient {
 
     /// Returns the range of the current selection (cursor position as zero-length range).
     func selectedRange() -> NSRange {
-        // The cursor position in terms of character offset from start of document.
-        // For a cell-based editor, approximate as col + row * cols.
-        let offset = Int(dispatcher.frameState.cursorRow) * Int(dispatcher.frameState.cols) + Int(dispatcher.frameState.cursorCol)
-        return NSRange(location: offset, length: 0)
+        return NSRange(location: accessibilityCursorOffset(), length: 0)
     }
 
     func hasMarkedText() -> Bool {
@@ -3335,22 +3351,7 @@ extension EditorNSView: @preconcurrency NSTextInputClient {
     func firstRect(forCharacterRange range: NSRange, actualRange: NSRangePointer?) -> NSRect {
         actualRange?.pointee = range
 
-        // Position at the cursor location.
-        let col = CGFloat(dispatcher.frameState.cursorCol)
-        let row = CGFloat(dispatcher.frameState.cursorRow)
-        let gutterPad: CGFloat
-        if dispatcher.frameState.gutterCol > 0 {
-            if dispatcher.frameState.cursorCol >= dispatcher.frameState.gutterCol {
-                gutterPad = CoreTextMetalRenderer.gutterLeftMarginPt + CoreTextMetalRenderer.gutterRightGapPt
-            } else {
-                gutterPad = CoreTextMetalRenderer.gutterLeftMarginPt
-            }
-        } else {
-            gutterPad = 0
-        }
-        let displayCellHeight = effectiveCellHeight
-        let localRect = NSRect(x: col * cellWidth + gutterPad, y: row * displayCellHeight,
-                                width: cellWidth, height: displayCellHeight)
+        let localRect = visibleCursorRect()
 
         // Convert to screen coordinates.
         guard let window else { return localRect }
@@ -3363,22 +3364,10 @@ extension EditorNSView: @preconcurrency NSTextInputClient {
         guard let window else { return 0 }
         let windowPoint = window.convertPoint(fromScreen: point)
         let localPoint = convert(windowPoint, from: nil)
-        let gutterCols = CGFloat(dispatcher.frameState.gutterCol)
-        let col: Int
-        if gutterCols > 0 {
-            let leftMargin = CoreTextMetalRenderer.gutterLeftMarginPt
-            let rightGap = CoreTextMetalRenderer.gutterRightGapPt
-            let gutterPixelEnd = leftMargin + gutterCols * cellWidth
-            if localPoint.x < gutterPixelEnd {
-                col = max(0, Int((localPoint.x - leftMargin) / cellWidth))
-            } else {
-                col = max(0, Int((localPoint.x - leftMargin - rightGap) / cellWidth))
-            }
-        } else {
-            col = max(0, Int(localPoint.x / cellWidth))
-        }
-        let row = Int(localPoint.y / effectiveCellHeight)
-        return row * Int(dispatcher.frameState.cols) + col
+        let point = presentationNormalizedPoint(localPoint)
+        let row = max(0, Int(point.y / effectiveCellHeight))
+        let col = max(0, Int(cellColumn(at: point, row: Int16(clamping: row))))
+        return row * Int(editorPresentationSnapshot?.frameState.cols ?? 0) + col
     }
 
     /// Returns the attributed substring for the given range.
@@ -3392,6 +3381,36 @@ extension EditorNSView: @preconcurrency NSTextInputClient {
     /// Attributes that can be applied to marked text.
     func validAttributesForMarkedText() -> [NSAttributedString.Key] {
         return [.underlineStyle, .underlineColor]
+    }
+
+    private func visibleCursorRect() -> NSRect {
+        guard let snapshot = editorPresentationSnapshot else {
+            return NSRect(x: 0, y: 0, width: cellWidth, height: effectiveCellHeight)
+        }
+        let fs = snapshot.frameState
+        return NSRect(
+            x: CGFloat(fs.cursorCol) * cellWidth,
+            y: CGFloat(fs.cursorRow) * effectiveCellHeight,
+            width: cellWidth,
+            height: effectiveCellHeight
+        )
+    }
+
+    private func accessibilityCursorOffset() -> Int {
+        guard let snapshot = editorPresentationSnapshot else { return 0 }
+        let fs = snapshot.frameState
+        return Int(fs.cursorRow) * Int(fs.cols) + Int(fs.cursorCol)
+    }
+
+    private func visibleAccessibilityRows() -> [GUIVisualRow] {
+        guard let snapshot = editorPresentationSnapshot else { return [] }
+        var rows: [GUIVisualRow] = []
+        for surface in snapshot.surfaces.sorted(by: { $0.windowId < $1.windowId }) {
+            let visibleRange = surface.visibleRowRange
+            guard !visibleRange.isEmpty else { continue }
+            rows.append(contentsOf: surface.content.rowStore.rows(in: visibleRange).rows)
+        }
+        return rows
     }
 }
 
@@ -3407,34 +3426,22 @@ extension EditorNSView {
     }
 
     /// Returns the full text content of all visible lines.
-    /// Reads from GUIWindowContent (0x80 opcode) semantic data.
+    /// Reads from the same visible editor snapshot that backs pointer interaction.
     override func accessibilityValue() -> Any? {
-        guard let contents = editorInput?.currentWindowContents else { return "" }
-        var lines: [String] = []
-        for (_, content) in contents.sorted(by: { $0.key < $1.key }) {
-            for row in content.rows {
-                lines.append(row.text)
-            }
-        }
+        let lines = visibleAccessibilityRows().map(\.text)
         return lines.isEmpty ? "" : lines.joined(separator: "\n")
     }
 
     override func accessibilityNumberOfCharacters() -> Int {
-        guard let contents = editorInput?.currentWindowContents else { return 0 }
-        var count = 0
-        for (_, content) in contents.sorted(by: { $0.key < $1.key }) {
-            for (i, row) in content.rows.enumerated() {
-                count += row.text.count
-                if i < content.rows.count - 1 {
-                    count += 1  // newline between rows
-                }
-            }
+        let rows = visibleAccessibilityRows()
+        return rows.enumerated().reduce(0) { count, element in
+            let newline = element.offset < rows.count - 1 ? 1 : 0
+            return count + element.element.text.count + newline
         }
-        return count
     }
 
     override func accessibilityInsertionPointLineNumber() -> Int {
-        return Int(dispatcher.frameState.cursorRow)
+        return Int(editorPresentationSnapshot?.frameState.cursorRow ?? 0)
     }
 
     override func accessibilitySelectedText() -> String? {
@@ -3443,8 +3450,7 @@ extension EditorNSView {
     }
 
     override func accessibilitySelectedTextRange() -> NSRange {
-        let offset = Int(dispatcher.frameState.cursorRow) * Int(dispatcher.frameState.cols) + Int(dispatcher.frameState.cursorCol)
-        return NSRange(location: offset, length: 0)
+        return NSRange(location: accessibilityCursorOffset(), length: 0)
     }
 
     override func isAccessibilityElement() -> Bool {

--- a/macos/Sources/Views/Shared/GUIFramePresentationMetrics.swift
+++ b/macos/Sources/Views/Shared/GUIFramePresentationMetrics.swift
@@ -1,11 +1,10 @@
 import AppKit
-import Observation
 import os
 import SwiftUI
 
 /// Release telemetry for commit-to-first-affected-native-presentation.
+/// This object is passive instrumentation, not an Observation dependency for editor correctness or SwiftUI invalidation.
 @MainActor
-@Observable
 public final class GUIFramePresentationMetrics {
     public enum Outcome: String, CaseIterable, Sendable {
         case submitted
@@ -29,10 +28,10 @@ public final class GUIFramePresentationMetrics {
         var submitted: Bool
     }
 
-    @ObservationIgnored private let log = OSLog(subsystem: "com.minga.editor", category: "GUIFramePresentation")
+    private let log = OSLog(subsystem: "com.minga.editor", category: "GUIFramePresentation")
     private var pending: [GUIFrameImpact: Pending] = [:]
     #if DEBUG
-    @ObservationIgnored private var samples: [Sample] = []
+    private var samples: [Sample] = []
     #endif
 
     public init() {}
@@ -47,14 +46,11 @@ public final class GUIFramePresentationMetrics {
         }
     }
 
-    /// Returns the committed editor frame currently waiting for Metal submission.
-    public func pendingEditorFrame() -> GUICommittedFrame? {
-        pending[.editor]?.frame
-    }
-
-    /// Returns the committed identity currently awaiting presentation in one domain.
-    func pendingFrame(domain: GUIFrameImpact) -> GUICommittedFrame? {
-        pending[domain]?.frame
+    /// Returns the committed identity currently awaiting native presentation in one non-editor domain.
+    /// SwiftUI probes use this only as passive expected-frame telemetry; the metrics object is intentionally not observable.
+    func expectedNativeDrawFrame(domain: GUIFrameImpact) -> GUICommittedFrame? {
+        guard domain != .editor else { return nil }
+        return pending[domain]?.frame
     }
 
     /// Resolves a native SwiftUI/AppKit consumer only from the frame captured when its draw was scheduled.
@@ -242,7 +238,7 @@ extension View {
         background {
             GUIFrameNativeDrawProbe(
                 domain: domain,
-                expectedFrame: metrics.pendingFrame(domain: domain),
+                expectedFrame: metrics.expectedNativeDrawFrame(domain: domain),
                 metrics: metrics
             )
             .frame(width: 1, height: 1)

--- a/macos/TestHarness/main.swift
+++ b/macos/TestHarness/main.swift
@@ -60,6 +60,32 @@ func jsonUInt64(_ value: UInt64) -> Any {
     return String(value)
 }
 
+func highlightSpanJSON(_ span: GUIHighlightSpan) -> [String: Any] {
+    var result: [String: Any] = [:]
+    result["start_col"] = Int(span.startCol)
+    result["end_col"] = Int(span.endCol)
+    result["fg"] = Int(span.fg)
+    result["bg"] = Int(span.bg)
+    result["attrs"] = Int(span.attrs)
+    result["font_weight"] = Int(span.fontWeight)
+    result["font_id"] = Int(span.fontId)
+    return result
+}
+
+func visualRowJSON(_ row: GUIVisualRow) -> [String: Any] {
+    let spans: [[String: Any]] = row.spans.map { span in
+        highlightSpanJSON(span)
+    }
+    var result: [String: Any] = [:]
+    result["row_type"] = Int(row.rowType.rawValue)
+    result["row_id"] = jsonUInt64(row.rowId)
+    result["buf_line"] = Int(row.bufLine)
+    result["content_hash"] = Int(row.contentHash)
+    result["text"] = row.text
+    result["spans"] = spans
+    return result
+}
+
 func windowRowsDeltaResult(type: String, delta: GUIWindowRowsDelta) -> [String: Any] {
     func entryJSON(_ entry: GUIWindowRowDeltaEntry) -> [String: Any] {
         switch entry {
@@ -275,14 +301,9 @@ func commandToJSON(_ command: RenderCommand) -> [String: Any]? {
                 "entries": entries]
 
     case .guiWindowContent(let data):
-        let rows = data.rows.map { row -> [String: Any] in
-            let spans = row.spans.map { s -> [String: Any] in
-                ["start_col": Int(s.startCol), "end_col": Int(s.endCol),
-                 "fg": Int(s.fg), "bg": Int(s.bg), "attrs": Int(s.attrs),
-                 "font_weight": Int(s.fontWeight), "font_id": Int(s.fontId)]
-            }
-            return ["row_type": Int(row.rowType.rawValue), "row_id": jsonUInt64(row.rowId), "buf_line": Int(row.bufLine),
-                    "content_hash": Int(row.contentHash), "text": row.text, "spans": spans]
+        let decodedRows = data.rowStore.rows(in: 0..<data.rowStore.count).rows
+        let rows: [[String: Any]] = decodedRows.map { row in
+            visualRowJSON(row)
         }
         var result: [String: Any] = [
             "type": "gui_window_content", "window_id": Int(data.windowId),

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -1429,6 +1429,29 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.themeColors.hasAppliedTheme)
     }
 
+    @Test("staged theme colors are frozen into the committed editor snapshot")
+    @MainActor func stagedThemeColorsFreezeIntoCommittedEditorSnapshot() throws {
+        let (dispatcher, _) = makeDispatcher()
+        let expected: UInt32 = (0x12 << 16) | (0x34 << 8) | 0x56
+        let slots = completeThemeSlots().map { slot, r, g, b in
+            slot == GUI_COLOR_GUTTER_FG ? (slot, 0x12, 0x34, 0x56) : (slot, r, g, b)
+        }
+        let geometry = editorGeometry(windowId: 1, lineNumberWidth: 4, signColWidth: 3)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 4, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: slots))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.guiIndentGuides(data: IndentGuideData(
+            windowId: 1, tabWidth: 4, activeGuideCol: 0xFFFF,
+            guideCols: [], lineIndentLevels: []
+        )))
+        dispatcher.dispatch(.commitFrame(frameSeq: 4, seq: 0))
+
+        #expect(dispatcher.committedEditorSnapshot?.frameState.gutterColors.fg == expected)
+        #expect(dispatcher.frameState.gutterColors.fg == expected)
+    }
+
     @Test("keyframe with content but no guiTheme returns a typed rejection")
     @MainActor func keyframeWithoutThemeErrors() throws {
         let (dispatcher, gui) = makeDispatcher()
@@ -1679,6 +1702,30 @@ struct CommandDispatcherStagingTests {
         }
     }
 
+    @Test("freeze rejects multiple active gutter owners before publication")
+    @MainActor func freezeRejectsMultipleActiveGutters() throws {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+        let firstGeometry = editorGeometry(windowId: 1)
+        let secondGeometry = editorGeometry(windowId: 2)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: firstGeometry)))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 2, geometry: secondGeometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(windowId: 1, geometry: firstGeometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(windowId: 2, geometry: secondGeometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
+
+        #expect(gui.windowContents.isEmpty)
+        #expect(dispatcher.committedEditorSnapshot == nil)
+        guard case .rejected(generation: 1, frameSeq: 5, lastAppliedFrameSeq: 0, reason: .invalidActiveWindow(windowId: 2)) = results.first else {
+            Issue.record("expected multiple-active-window rejection")
+            return
+        }
+    }
+
     @Test("visible editor snapshot advances only after matching presentation")
     @MainActor func visibleSnapshotAdvancesOnlyAfterMatchingPresentation() throws {
         let (dispatcher, _) = makeDispatcher()
@@ -1718,6 +1765,52 @@ struct CommandDispatcherStagingTests {
         dispatcher.promoteVisibleEditorSnapshot(thirdSnapshot)
         #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 3)
         #expect(dispatcher.pendingPresentationFrame() == nil)
+    }
+
+    @Test("older in-flight presentation promotes when a newer commit is pending")
+    @MainActor func olderInFlightPresentationPromotesWhileNewerCommitIsPending() throws {
+        let (dispatcher, _) = makeDispatcher()
+        let geometry = editorGeometry(lineNumberWidth: 0, signColWidth: 0)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        let visibleBase = try #require(dispatcher.committedEditorSnapshot)
+        dispatcher.promoteVisibleEditorSnapshot(visibleBase)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+        let inFlightA = try #require(dispatcher.committedEditorSnapshot)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 2, generation: 1))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
+        let inFlightB = try #require(dispatcher.committedEditorSnapshot)
+        let inFlightBFrame = GUICommittedFrame(generation: inFlightB.generation, frameSeq: inFlightB.frameSeq)
+        #expect(dispatcher.pendingPresentationFrame() == inFlightBFrame)
+
+        dispatcher.promoteVisibleEditorSnapshot(inFlightA)
+        #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 2)
+        #expect(dispatcher.pendingPresentationFrame() == inFlightBFrame)
+    }
+
+    @Test("visible presentation retains captured local transform")
+    @MainActor func visiblePresentationRetainsCapturedLocalTransform() throws {
+        let (dispatcher, _) = makeDispatcher()
+        let geometry = editorGeometry(lineNumberWidth: 0, signColWidth: 0)
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        let transform = EditorLocalPresentationTransform(windowId: 1, offset: CGPoint(x: 7, y: 11))
+
+        dispatcher.promoteVisibleEditorPresentation(snapshot: snapshot, localTransform: transform)
+
+        #expect(dispatcher.visibleEditorPresentation?.snapshot.frameSeq == 1)
+        #expect(dispatcher.visibleEditorPresentation?.localTransform == transform)
     }
 
     // MARK: - Nothing paints between begin and commit

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -52,7 +52,7 @@ struct CommandDispatcherRoutingTests {
             windowId: 1, tabWidth: 4, activeGuideCol: 0xFFFF,
             guideCols: [2], lineIndentLevels: [1]
         )))
-        #expect(dispatcher.currentFrameWindowIds == [1])
+        #expect(dispatcher.frameState.windowGutters[1] != nil)
         #expect(dispatcher.frameState.gutterCol == 7)
         #expect(dispatcher.frameState.viewportTopLine == 9)
 
@@ -63,7 +63,7 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.windowContents.isEmpty)
         #expect(dispatcher.frameState.windowGutters.isEmpty)
         #expect(dispatcher.frameState.windowIndentGuides.isEmpty)
-        #expect(dispatcher.currentFrameWindowIds.isEmpty)
+        #expect(dispatcher.committedEditorSnapshot?.windowIds.isEmpty == true)
         #expect(dispatcher.frameState.gutterCol == 0)
         #expect(dispatcher.frameState.viewportTopLine == 0xFFFF_FFFF)
     }
@@ -90,18 +90,9 @@ struct CommandDispatcherRoutingTests {
 
         dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: try GUIWindowContent(
-            windowId: 1, fullRefresh: false,
-            cursorRow: 0, cursorCol: 0, cursorShape: .block,
-            rows: [], selection: nil,
-            searchMatches: [], diagnosticUnderlines: [],
-            documentHighlights: []
-        )))
-        dispatcher.dispatch(.guiGutter(data: Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 5, contentHeight: 24,
-            isActive: true, contentWidth: 80, cursorLine: 0, lineNumberStyle: .hybrid,
-            lineNumberWidth: 4, signColWidth: 3, entries: []
-        )))
+        let geometry = editorGeometry(windowId: 1, lineNumberWidth: 4, signColWidth: 3)
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(windowId: 1, geometry: geometry)))
         dispatcher.dispatch(.guiIndentGuides(data: IndentGuideData(
             windowId: 1, tabWidth: 4, activeGuideCol: 0xFFFF,
             guideCols: [], lineIndentLevels: []
@@ -114,7 +105,7 @@ struct CommandDispatcherRoutingTests {
         #expect(dispatcher.frameState.windowGutters[2] == nil)
         #expect(dispatcher.frameState.windowIndentGuides[1] != nil)
         #expect(dispatcher.frameState.windowIndentGuides[2] == nil)
-        #expect(dispatcher.currentFrameWindowIds == [1])
+        #expect(dispatcher.committedEditorSnapshot?.windowIds == [1])
     }
 
     @Test("setCursorShape updates frameState cursor shape")
@@ -145,44 +136,25 @@ struct CommandDispatcherRoutingTests {
 
     // MARK: - View-driven FrameState mutations
 
-    @Test("applyViewportResize writes grid dimensions and marks dirty")
+    @Test("applyViewportResize writes grid dimensions")
     @MainActor func applyViewportResizeUpdatesGrid() throws {
         let (dispatcher, _) = makeDispatcher()
-        // Clear the dirty flag set at init so we can assert the resize sets it.
-        dispatcher.markRendered()
-        #expect(dispatcher.frameState.dirty == false)
 
         // A view-driven resize (e.g. font change) funnels through the dispatcher.
         dispatcher.applyViewportResize(newCols: 120, newRows: 40)
 
         #expect(dispatcher.frameState.cols == 120)
         #expect(dispatcher.frameState.rows == 40)
-        #expect(dispatcher.frameState.dirty == true)
     }
 
     @Test("applyViewportResize is a no-op when dimensions are unchanged")
     @MainActor func applyViewportResizeNoOp() throws {
         let (dispatcher, _) = makeDispatcher()
-        // Dispatcher starts at 80x24 (see makeDispatcher).
-        dispatcher.markRendered()
-        #expect(dispatcher.frameState.dirty == false)
 
         dispatcher.applyViewportResize(newCols: 80, newRows: 24)
 
         #expect(dispatcher.frameState.cols == 80)
         #expect(dispatcher.frameState.rows == 24)
-        #expect(dispatcher.frameState.dirty == false)
-    }
-
-    @Test("markRendered clears the dirty flag the view consumed")
-    @MainActor func markRenderedClearsDirty() throws {
-        let (dispatcher, _) = makeDispatcher()
-        dispatcher.applyViewportResize(newCols: 100, newRows: 30)
-        #expect(dispatcher.frameState.dirty == true)
-
-        dispatcher.markRendered()
-
-        #expect(dispatcher.frameState.dirty == false)
     }
 
     // MARK: - GUI chrome routing
@@ -1160,7 +1132,7 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.windowContents[7]?.cursorCol == 11)
         #expect(gui.windowContents[7]?.cursorShape == .beam)
         #expect(gui.windowContents[7]?.cursorline == GUICursorline(row: 6, bg: 0x112233))
-        #expect(dispatcher.currentFrameWindowIds.contains(7))
+        #expect(gui.windowContents[7] != nil)
         #expect(dispatcher.frameState.cursorVisible == false)
     }
 
@@ -1186,7 +1158,7 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.windowContents[7]?.cursorRow == 6)
         #expect(gui.windowContents[7]?.cursorCol == 11)
         #expect(gui.windowContents[7]?.cursorShape == .beam)
-        #expect(dispatcher.currentFrameWindowIds.contains(7))
+        #expect(gui.windowContents[7] != nil)
     }
 
     @Test("stale guiWindowOverlayDelta is ignored without marking the window live")
@@ -1209,7 +1181,6 @@ struct CommandDispatcherRoutingTests {
         )))
 
         #expect(gui.windowContents[7] === content)
-        #expect(dispatcher.currentFrameWindowIds.contains(7) == false)
         #expect(dispatcher.frameState.cursorVisible == true)
     }
 
@@ -1225,7 +1196,6 @@ struct CommandDispatcherRoutingTests {
         )))
 
         #expect(gui.windowContents[7] == nil)
-        #expect(dispatcher.currentFrameWindowIds.contains(7) == false)
         #expect(dispatcher.frameState.cursorVisible == true)
     }
 
@@ -1263,7 +1233,7 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.windowContents[7]?.rows.map(\.text) == ["old", "new"])
         #expect(gui.windowContents[7]?.scrollLeft == 2)
         #expect(gui.windowContents[7]?.cursorShape == .beam)
-        #expect(dispatcher.currentFrameWindowIds.contains(7))
+        #expect(gui.windowContents[7] != nil)
     }
 
     @Test("guiWindowViewportDelta updates retained rows and marks window live")
@@ -1299,7 +1269,7 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.windowContents[7]?.rows.map(\.text) == ["old"])
         #expect(gui.windowContents[7]?.scrollLeft == 2)
         #expect(gui.windowContents[7]?.cursorShape == .beam)
-        #expect(dispatcher.currentFrameWindowIds.contains(7))
+        #expect(gui.windowContents[7] != nil)
     }
 
     @Test("stale guiWindowRowsDelta is ignored without clearing current content")
@@ -1334,7 +1304,6 @@ struct CommandDispatcherRoutingTests {
         )))
 
         #expect(gui.windowContents[7] === content)
-        #expect(dispatcher.currentFrameWindowIds.contains(7) == false)
     }
 
     @Test("guiWindowRowsDelta missing retained ref clears content for full-refresh recovery")
@@ -1368,7 +1337,6 @@ struct CommandDispatcherRoutingTests {
         )))
 
         #expect(gui.windowContents[7] == nil)
-        #expect(dispatcher.currentFrameWindowIds.contains(7) == false)
     }
 
     @Test("guiGutterSeparator updates frameState gutter state")
@@ -1402,7 +1370,7 @@ struct CommandDispatcherRoutingTests {
         dispatcher.applyForTesting(.guiGutter(data: gutter))
 
         #expect(dispatcher.frameState.windowGutters[1] != nil)
-        #expect(dispatcher.currentFrameWindowIds.contains(1))
+        #expect(dispatcher.frameState.windowGutters[1] != nil)
         // Active window gutter syncs gutterCol
         #expect(dispatcher.frameState.gutterCol == 5) // 4 + 1
     }
@@ -1526,6 +1494,38 @@ struct CommandDispatcherRoutingTests {
 /// begin and commit, commit promotes atomically, invalidation requests a
 /// keyframe with no partial promotion, and out-of-band commands apply without a
 /// transaction.
+fileprivate func editorGeometry(windowId: UInt16 = 1, lineNumberWidth: UInt16 = 4, signColWidth: UInt16 = 1) -> GUIPaneGeometry {
+    GUIPaneGeometry(
+        windowId: windowId,
+        totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+        contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+        textRect: GUICellRect(row: 0, col: UInt16(lineNumberWidth + signColWidth), width: UInt16(80 - lineNumberWidth - signColWidth), height: 24),
+        gutterRect: GUICellRect(row: 0, col: 0, width: UInt16(lineNumberWidth + signColWidth), height: 24),
+        clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+        viewport: GUIViewportSummary(top: 0, left: 0, rows: 24, cols: 80, totalLines: 24, visualRowOffset: 0, totalVisualRows: 24),
+        gutterMetrics: GUIGutterMetrics(lineNumberWidth: lineNumberWidth, signColWidth: signColWidth),
+        hitRegions: lineNumberWidth + signColWidth == 0 ? [] : [GUIHitRegion(kind: .gutter, rect: GUICellRect(row: 0, col: 0, width: UInt16(lineNumberWidth + signColWidth), height: 24), windowId: windowId)]
+    )
+}
+
+fileprivate func editorContent(windowId: UInt16 = 1, geometry: GUIPaneGeometry? = editorGeometry()) throws -> GUIWindowContent {
+    try GUIWindowContent(
+        windowId: windowId, fullRefresh: true,
+        cursorRow: 0, cursorCol: 0, cursorShape: .block,
+        rows: [], selection: nil,
+        searchMatches: [], diagnosticUnderlines: [],
+        documentHighlights: [], paneGeometry: geometry
+    )
+}
+
+fileprivate func editorGutter(windowId: UInt16 = 1, geometry: GUIPaneGeometry = editorGeometry()) -> Wire.WindowGutter {
+    Wire.WindowGutter(
+        windowId: windowId, contentRow: geometry.textRect.row, contentCol: geometry.textRect.col, contentHeight: geometry.textRect.height,
+        isActive: true, contentWidth: geometry.textRect.width, cursorLine: 0, lineNumberStyle: .hybrid,
+        lineNumberWidth: UInt8(geometry.gutterMetrics.lineNumberWidth), signColWidth: UInt8(geometry.gutterMetrics.signColWidth), entries: []
+    )
+}
+
 @Suite("CommandDispatcher Frame Staging")
 struct CommandDispatcherStagingTests {
 
@@ -1561,6 +1561,7 @@ struct CommandDispatcherStagingTests {
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [row], selection: nil, searchMatches: [],
             diagnosticUnderlines: [], documentHighlights: [],
+            paneGeometry: editorGeometry(windowId: windowId, lineNumberWidth: 0, signColWidth: 0),
             scrollPresentation: scrollPresentation
         )
     }
@@ -1593,6 +1594,130 @@ struct CommandDispatcherStagingTests {
             wire: defaults.wire, decode: defaults.decode,
             staging: .init(weight: stagingWeight), resident: defaults.resident
         )
+    }
+
+    @Test("committed editor snapshot contains complete surfaces after freeze")
+    @MainActor func committedEditorSnapshotContainsCompleteSurfaces() throws {
+        let (dispatcher, _) = makeDispatcher()
+        let geometry = editorGeometry()
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(snapshot.frameSeq == 1)
+        #expect(snapshot.surfaces.count == 1)
+        #expect(snapshot.windowContents[1] != nil)
+        #expect(snapshot.windowGutters[1] != nil)
+        #expect(snapshot.surfaces.first?.paneGeometry == geometry)
+    }
+
+    @Test("freeze rejects content that requires a missing gutter")
+    @MainActor func freezeRejectsMissingRequiredGutter() throws {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+        let geometry = editorGeometry()
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+
+        #expect(gui.windowContents.isEmpty)
+        #expect(dispatcher.committedEditorSnapshot == nil)
+        guard case .rejected(generation: 1, frameSeq: 2, lastAppliedFrameSeq: 0, reason: .missingWindowGutter(windowId: 1)) = results.first else {
+            Issue.record("expected missing gutter rejection")
+            return
+        }
+    }
+
+    @Test("freeze accepts explicitly gutterless zero-width geometry")
+    @MainActor func freezeAcceptsExplicitGutterlessGeometry() throws {
+        let (dispatcher, _) = makeDispatcher()
+        let geometry = editorGeometry(lineNumberWidth: 0, signColWidth: 0)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
+
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(snapshot.windowGutters.isEmpty)
+        guard case .none = try #require(snapshot.surfaces.first).gutter else {
+            Issue.record("expected explicit gutterless surface")
+            return
+        }
+    }
+
+    @Test("freeze rejects gutter widths that differ from pane geometry")
+    @MainActor func freezeRejectsIncompatibleGutterWidths() throws {
+        let (dispatcher, gui) = makeDispatcher()
+        var results: [FrameTransactionResult] = []
+        dispatcher.onTransactionResult = { results.append($0) }
+        let geometry = editorGeometry(lineNumberWidth: 4, signColWidth: 1)
+        let gutter = Wire.WindowGutter(
+            windowId: 1, contentRow: geometry.textRect.row, contentCol: geometry.textRect.col, contentHeight: geometry.textRect.height,
+            isActive: true, contentWidth: geometry.textRect.width + 1, cursorLine: 0, lineNumberStyle: .hybrid,
+            lineNumberWidth: 3, signColWidth: UInt8(geometry.gutterMetrics.signColWidth), entries: []
+        )
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 4, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: gutter))
+        dispatcher.dispatch(.commitFrame(frameSeq: 4, seq: 0))
+
+        #expect(gui.windowContents.isEmpty)
+        #expect(dispatcher.committedEditorSnapshot == nil)
+        guard case .rejected(generation: 1, frameSeq: 4, lastAppliedFrameSeq: 0, reason: .incompatibleWindowGeometry(windowId: 1)) = results.first else {
+            Issue.record("expected incompatible geometry rejection")
+            return
+        }
+    }
+
+    @Test("visible editor snapshot advances only after matching presentation")
+    @MainActor func visibleSnapshotAdvancesOnlyAfterMatchingPresentation() throws {
+        let (dispatcher, _) = makeDispatcher()
+        let geometry = editorGeometry(lineNumberWidth: 0, signColWidth: 0)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        let firstSnapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(dispatcher.visibleEditorSnapshot == nil)
+        #expect(dispatcher.pendingPresentationFrame() == GUICommittedFrame(generation: 1, frameSeq: 1))
+
+        dispatcher.promoteVisibleEditorSnapshot(firstSnapshot)
+        #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 1)
+        #expect(dispatcher.pendingPresentationFrame() == nil)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
+        dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [tab("shell-only")]))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+        #expect(dispatcher.committedEditorSnapshot?.frameSeq == 1)
+        #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 1)
+        #expect(dispatcher.pendingPresentationFrame() == nil)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 2, generation: 1))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
+        let thirdSnapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(thirdSnapshot.frameSeq == 3)
+        #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 1)
+        #expect(dispatcher.pendingPresentationFrame() == GUICommittedFrame(generation: 1, frameSeq: 3))
+
+        dispatcher.promoteVisibleEditorSnapshot(firstSnapshot)
+        #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 1)
+        #expect(dispatcher.pendingPresentationFrame() == GUICommittedFrame(generation: 1, frameSeq: 3))
+
+        dispatcher.promoteVisibleEditorSnapshot(thirdSnapshot)
+        #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 3)
+        #expect(dispatcher.pendingPresentationFrame() == nil)
     }
 
     // MARK: - Nothing paints between begin and commit
@@ -2046,7 +2171,7 @@ struct CommandDispatcherStagingTests {
                 gui.themeColors.hasAppliedTheme,
                 gui.windowContents[7]?.rows.first?.text,
                 gui.statusBarState.modeName,
-                dispatcher.currentFrameWindowIds,
+                dispatcher.committedEditorSnapshot?.windowIds ?? [],
                 gui.completionState.visible
             )
         }
@@ -2134,11 +2259,8 @@ struct CommandDispatcherStagingTests {
     @Test("gutter and indent guide keys cannot collide across window ids")
     @MainActor func typedWindowCoalescingKeysDoNotCollide() throws {
         let (dispatcher, _) = makeDispatcher()
-        let gutter = Wire.WindowGutter(
-            windowId: 1001, contentRow: 0, contentCol: 4, contentHeight: 1,
-            isActive: false, contentWidth: 40, cursorLine: 0, lineNumberStyle: .absolute,
-            lineNumberWidth: 3, signColWidth: 1, entries: []
-        )
+        let gutterGeometry = editorGeometry(windowId: 1001, lineNumberWidth: 3, signColWidth: 1)
+        let gutter = editorGutter(windowId: 1001, geometry: gutterGeometry)
         let guides = IndentGuideData(
             windowId: 1, tabWidth: 4, activeGuideCol: 4,
             guideCols: [4, 8], lineIndentLevels: [2]
@@ -2146,7 +2268,7 @@ struct CommandDispatcherStagingTests {
 
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
-        dispatcher.dispatch(.guiWindowContent(data: try windowContent(windowId: 1001)))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1001, geometry: gutterGeometry)))
         dispatcher.dispatch(.guiWindowContent(data: try windowContent(windowId: 1)))
         dispatcher.dispatch(.guiGutter(data: gutter))
         dispatcher.dispatch(.guiIndentGuides(data: guides))

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -35,52 +35,66 @@ struct CommandDispatcherRoutingTests {
     @Test("empty keyframe prunes retained windows and stale gutter globals")
     @MainActor func emptyKeyframePrunesRetainedWindowState() throws {
         let (dispatcher, gui) = makeDispatcher()
-        gui.windowContents[1] = try GUIWindowContent(
-            windowId: 1, fullRefresh: false,
-            cursorRow: 0, cursorCol: 0, cursorShape: .block,
-            rows: [], selection: nil,
-            searchMatches: [], diagnosticUnderlines: [],
-            documentHighlights: []
-        )
-        dispatcher.applyForTesting(.guiGutter(data: Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 5, contentHeight: 24,
+
+        // Establish retained editor state through a committed keyframe: the prior
+        // committed snapshot is the sole authority the next transaction seeds from.
+        let geometry = editorGeometry(windowId: 1, lineNumberWidth: 4, signColWidth: 3)
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 24,
             isActive: true, contentWidth: 80, cursorLine: 9, lineNumberStyle: .hybrid,
             lineNumberWidth: 4, signColWidth: 3,
             entries: [Wire.GutterEntry(bufLine: 9, displayType: .normal, signType: .none, foldEndLine: 0xFFFF_FFFF, signFg: 0, signText: "")]
         )))
-        dispatcher.applyForTesting(.guiIndentGuides(data: IndentGuideData(
+        dispatcher.dispatch(.guiIndentGuides(data: IndentGuideData(
             windowId: 1, tabWidth: 4, activeGuideCol: 0xFFFF,
             guideCols: [2], lineIndentLevels: [1]
         )))
-        #expect(dispatcher.frameState.windowGutters[1] != nil)
-        #expect(dispatcher.frameState.gutterCol == 7)
-        #expect(dispatcher.frameState.viewportTopLine == 9)
-
-        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
-        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
+        let seeded = try #require(dispatcher.committedEditorSnapshot)
+        #expect(seeded.windowGutters[1] != nil)
+        #expect(seeded.gutterCol == 7)
+        #expect(seeded.windowIndentGuides[1] != nil)
+        #expect(dispatcher.frameState.viewportTopLine == 9)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+
         #expect(gui.windowContents.isEmpty)
-        #expect(dispatcher.frameState.windowGutters.isEmpty)
-        #expect(dispatcher.frameState.windowIndentGuides.isEmpty)
-        #expect(dispatcher.committedEditorSnapshot?.windowIds.isEmpty == true)
-        #expect(dispatcher.frameState.gutterCol == 0)
+        let pruned = try #require(dispatcher.committedEditorSnapshot)
+        #expect(pruned.windowGutters.isEmpty)
+        #expect(pruned.windowIndentGuides.isEmpty)
+        #expect(pruned.windowIds.isEmpty)
+        #expect(pruned.gutterCol == 0)
         #expect(dispatcher.frameState.viewportTopLine == 0xFFFF_FFFF)
     }
 
     @Test("keyframe commit prunes stale split separator metadata")
     @MainActor func keyframeCommitPrunesStaleSplitMetadata() throws {
         let (dispatcher, _) = makeDispatcher()
-        dispatcher.applyForTesting(.guiSplitSeparators(
+        let geometry = editorGeometry(windowId: 1, lineNumberWidth: 4, signColWidth: 3)
+
+        // Establish split separator metadata through a committed keyframe.
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.guiSplitSeparators(
             borderColor: 0xAABBCC,
             verticals: [Wire.VerticalSeparator(col: 40, startRow: 0, endRow: 23)],
             horizontals: [Wire.HorizontalSeparator(row: 12, col: 0, width: 80, filename: "stale.ex")]
         ))
-        #expect(dispatcher.frameState.splitBorderColor == 0xAABBCC)
-        #expect(!dispatcher.frameState.verticalSeparators.isEmpty)
-        #expect(!dispatcher.frameState.horizontalSeparators.isEmpty)
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        let geometry = editorGeometry(windowId: 1, lineNumberWidth: 4, signColWidth: 3)
+        let seeded = try #require(dispatcher.committedEditorSnapshot)
+        #expect(seeded.metadata.splitBorderColor == 0xAABBCC)
+        #expect(!seeded.metadata.verticalSeparators.isEmpty)
+        #expect(!seeded.metadata.horizontalSeparators.isEmpty)
+
         dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: geometry)))
@@ -88,33 +102,27 @@ struct CommandDispatcherRoutingTests {
         dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
 
         let snapshot = try #require(dispatcher.committedEditorSnapshot)
-        #expect(snapshot.frameState.splitBorderColor == 0)
-        #expect(snapshot.frameState.verticalSeparators.isEmpty)
-        #expect(snapshot.frameState.horizontalSeparators.isEmpty)
-        #expect(dispatcher.frameState.splitBorderColor == 0)
-        #expect(dispatcher.frameState.verticalSeparators.isEmpty)
-        #expect(dispatcher.frameState.horizontalSeparators.isEmpty)
+        #expect(snapshot.metadata.splitBorderColor == 0)
+        #expect(snapshot.metadata.verticalSeparators.isEmpty)
+        #expect(snapshot.metadata.horizontalSeparators.isEmpty)
     }
 
     @Test("keyframe commit prunes stale window content, gutters, and indent guides")
     @MainActor func keyframeCommitPrunesStaleWindowState() throws {
         let (dispatcher, gui) = makeDispatcher()
-        gui.windowContents[2] = try GUIWindowContent(
-            windowId: 2, fullRefresh: false,
-            cursorRow: 0, cursorCol: 0, cursorShape: .block,
-            rows: [], selection: nil,
-            searchMatches: [], diagnosticUnderlines: [],
-            documentHighlights: []
-        )
-        dispatcher.applyForTesting(.guiGutter(data: Wire.WindowGutter(
-            windowId: 2, contentRow: 0, contentCol: 5, contentHeight: 24,
-            isActive: false, contentWidth: 80, cursorLine: 0, lineNumberStyle: .hybrid,
-            lineNumberWidth: 4, signColWidth: 3, entries: []
-        )))
-        dispatcher.applyForTesting(.guiIndentGuides(data: IndentGuideData(
+        let staleGeometry = editorGeometry(windowId: 2, lineNumberWidth: 4, signColWidth: 3)
+
+        // Establish stale window 2 through a committed keyframe.
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 2, geometry: staleGeometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(windowId: 2, geometry: staleGeometry)))
+        dispatcher.dispatch(.guiIndentGuides(data: IndentGuideData(
             windowId: 2, tabWidth: 4, activeGuideCol: 0xFFFF,
             guideCols: [], lineIndentLevels: []
         )))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        #expect(dispatcher.committedEditorSnapshot?.windowIds == [2])
 
         dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 0, generation: 1))
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
@@ -129,18 +137,25 @@ struct CommandDispatcherRoutingTests {
 
         #expect(gui.windowContents[1] != nil)
         #expect(gui.windowContents[2] == nil)
-        #expect(dispatcher.frameState.windowGutters[1] != nil)
-        #expect(dispatcher.frameState.windowGutters[2] == nil)
-        #expect(dispatcher.frameState.windowIndentGuides[1] != nil)
-        #expect(dispatcher.frameState.windowIndentGuides[2] == nil)
-        #expect(dispatcher.committedEditorSnapshot?.windowIds == [1])
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(snapshot.windowGutters[1] != nil)
+        #expect(snapshot.windowGutters[2] == nil)
+        #expect(snapshot.windowIndentGuides[1] != nil)
+        #expect(snapshot.windowIndentGuides[2] == nil)
+        #expect(snapshot.windowIds == [1])
     }
 
-    @Test("setCursorShape updates frameState cursor shape")
+    @Test("setCursorShape updates committed metadata cursor shape")
     @MainActor func setCursorShapeCommand() throws {
         let (dispatcher, _) = makeDispatcher()
-        dispatcher.applyForTesting(.setCursorShape(.beam))
-        #expect(dispatcher.frameState.cursorShape == .beam)
+        let geometry = editorGeometry()
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(geometry: geometry)))
+        dispatcher.dispatch(.setCursorShape(.beam))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        #expect(dispatcher.committedEditorSnapshot?.metadata.cursorShape == .beam)
     }
 
     @Test("protocolError latches a blocking message on protocolErrorState")
@@ -1161,7 +1176,6 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.windowContents[7]?.cursorShape == .beam)
         #expect(gui.windowContents[7]?.cursorline == GUICursorline(row: 6, bg: 0x112233))
         #expect(gui.windowContents[7] != nil)
-        #expect(dispatcher.frameState.cursorVisible == false)
     }
 
     @Test("guiWindowOverlayDelta clears retained cursorline when cursorline is omitted")
@@ -1200,7 +1214,6 @@ struct CommandDispatcherRoutingTests {
             documentHighlights: []
         )
         gui.windowContents[7] = content
-        dispatcher.frameState.cursorVisible = true
 
         dispatcher.applyForTesting(.guiWindowOverlayDelta(data: GUIWindowOverlayDelta(
             windowId: 7, contentEpoch: 41, cursorVisible: false,
@@ -1209,13 +1222,11 @@ struct CommandDispatcherRoutingTests {
         )))
 
         #expect(gui.windowContents[7] === content)
-        #expect(dispatcher.frameState.cursorVisible == true)
     }
 
     @Test("guiWindowOverlayDelta without retained content is ignored")
     @MainActor func missingGuiWindowOverlayDeltaIgnored() throws {
         let (dispatcher, gui) = makeDispatcher()
-        dispatcher.frameState.cursorVisible = true
 
         dispatcher.applyForTesting(.guiWindowOverlayDelta(data: GUIWindowOverlayDelta(
             windowId: 7, contentEpoch: 42, cursorVisible: false,
@@ -1224,7 +1235,6 @@ struct CommandDispatcherRoutingTests {
         )))
 
         #expect(gui.windowContents[7] == nil)
-        #expect(dispatcher.frameState.cursorVisible == true)
     }
 
     @Test("guiWindowRowsDelta updates retained rows and marks window live")
@@ -1367,14 +1377,19 @@ struct CommandDispatcherRoutingTests {
         #expect(gui.windowContents[7] == nil)
     }
 
-    @Test("guiGutterSeparator updates frameState gutter state")
+    @Test("guiGutterSeparator updates gutter chrome and committed gutter column")
     @MainActor func guiGutterSepRouting() throws {
         let (dispatcher, _) = makeDispatcher()
-        dispatcher.applyForTesting(.guiGutterSeparator(col: 4, r: 0x3F, g: 0x44, b: 0x4A))
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiGutterSeparator(col: 4, r: 0x3F, g: 0x44, b: 0x4A))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        #expect(dispatcher.frameState.gutterCol == 4)
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(snapshot.metadata.gutterCol == 4)
         let expected: UInt32 = (0x3F << 16) | (0x44 << 8) | 0x4A
         #expect(dispatcher.frameState.gutterSeparatorColor == expected)
+        #expect(snapshot.frameState.gutterSeparatorColor == expected)
     }
 
     @Test("guiCursorline updates frameState cursorline state")
@@ -1387,20 +1402,20 @@ struct CommandDispatcherRoutingTests {
         #expect(dispatcher.frameState.cursorlineBg == expected)
     }
 
-    @Test("guiGutter stores gutter data in frameState")
+    @Test("guiGutter stores gutter data in the committed snapshot")
     @MainActor func guiGutterRouting() throws {
         let (dispatcher, _) = makeDispatcher()
-        let gutter = Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 5, contentHeight: 24,
-            isActive: true, contentWidth: 80, cursorLine: 10, lineNumberStyle: .hybrid,
-            lineNumberWidth: 4, signColWidth: 1, entries: []
-        )
-        dispatcher.applyForTesting(.guiGutter(data: gutter))
+        let geometry = editorGeometry(windowId: 1, lineNumberWidth: 4, signColWidth: 1)
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        #expect(dispatcher.frameState.windowGutters[1] != nil)
-        #expect(dispatcher.frameState.windowGutters[1] != nil)
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(snapshot.windowGutters[1] != nil)
         // Active window gutter syncs gutterCol
-        #expect(dispatcher.frameState.gutterCol == 5) // 4 + 1
+        #expect(snapshot.gutterCol == 5) // 4 + 1
     }
 
     @Test("guiHoverPopup exposes lines after scroll offset")
@@ -1705,6 +1720,89 @@ struct CommandDispatcherStagingTests {
         #expect(snapshot.surfaces.first?.paneGeometry == geometry)
     }
 
+    @Test("snapshot factory rejects orphan gutter and indent-guide state")
+    func snapshotFactoryRejectsOrphanSurfaceState() throws {
+        let geometry = editorGeometry(windowId: 1, lineNumberWidth: 0, signColWidth: 0)
+        let content = try editorContent(windowId: 1, geometry: geometry)
+        let orphanGeometry = editorGeometry(windowId: 2)
+        let orphanGutter = editorGutter(windowId: 2, geometry: orphanGeometry)
+        let orphanGuides = IndentGuideData(windowId: 2, tabWidth: 4, activeGuideCol: 0xFFFF, guideCols: [2], lineIndentLevels: [1])
+
+        let gutterResult = CommittedEditorSnapshot.make(
+            generation: 1,
+            frameSeq: 1,
+            frameState: FrameState(cols: 80, rows: 24),
+            themeColors: nil,
+            windowContents: [1: content],
+            windowGutters: [2: orphanGutter],
+            windowIndentGuides: [:]
+        )
+        guard case .failure(.missingWindowReference(windowId: 2)) = gutterResult else {
+            Issue.record("expected orphan gutter rejection")
+            return
+        }
+
+        let guidesResult = CommittedEditorSnapshot.make(
+            generation: 1,
+            frameSeq: 1,
+            frameState: FrameState(cols: 80, rows: 24),
+            themeColors: nil,
+            windowContents: [1: content],
+            windowGutters: [:],
+            windowIndentGuides: [2: orphanGuides]
+        )
+        guard case .failure(.missingWindowReference(windowId: 2)) = guidesResult else {
+            Issue.record("expected orphan indent-guide rejection")
+            return
+        }
+    }
+
+    @Test("metadata and unrelated-window commits preserve resident projection and scroll state")
+    @MainActor func unrelatedEditorCommitsPreserveResidentProjection() throws {
+        let (dispatcher, gui) = makeDispatcher()
+        var resetCount = 0
+        dispatcher.onScrollPresentationReset = { resetCount += 1 }
+        let observationCount = Mutex(0)
+        let resetPresentation = GUIScrollPresentation(
+            windowId: 7,
+            resetRequired: true,
+            anchorTop: 5,
+            anchorLeft: 0,
+            anchorVisualRowOffset: 0,
+            visibleStartLine: 5,
+            visibleEndLine: 20,
+            overscanStartLine: 4,
+            overscanEndLine: 21,
+            contentEpoch: 42,
+            layoutGeneration: 1
+        )
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent(scrollPresentation: resetPresentation)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        #expect(resetCount == 1)
+
+        withObservationTracking {
+            _ = gui.windowContents
+        } onChange: {
+            observationCount.withLock { $0 += 1 }
+        }
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 2))
+        dispatcher.dispatch(.setCursorShape(.beam))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+        #expect(observationCount.withLock { $0 } == 0)
+        #expect(resetCount == 1)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 3, baseFrameSeq: 2, generation: 3))
+        dispatcher.dispatch(.guiWindowContent(data: try windowContent(windowId: 8)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 3, seq: 0))
+        #expect(observationCount.withLock { $0 } == 1)
+        #expect(resetCount == 1)
+        #expect(gui.windowContents.keys.sorted() == [7, 8])
+    }
+
     @Test("freeze rejects content that requires a missing gutter")
     @MainActor func freezeRejectsMissingRequiredGutter() throws {
         let (dispatcher, gui) = makeDispatcher()
@@ -1901,7 +1999,7 @@ struct CommandDispatcherStagingTests {
         #expect(gui.tabBarState.tabs.first?.label == "old.ex")
     }
 
-    @Test("observable FrameState is unchanged between begin and a partial frame")
+    @Test("committed cursor shape is unchanged between begin and a partial frame")
     @MainActor func frameStateUnchangedMidTransaction() throws {
         let (dispatcher, _) = makeDispatcher()
 
@@ -1909,12 +2007,12 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
         dispatcher.dispatch(.setCursorShape(.block))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
-        #expect(dispatcher.frameState.cursorShape == .block)
+        #expect(dispatcher.committedEditorSnapshot?.metadata.cursorShape == .block)
 
         // Stage a shape change without committing; the presented shape holds.
         dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
         dispatcher.dispatch(.setCursorShape(.beam))
-        #expect(dispatcher.frameState.cursorShape == .block)
+        #expect(dispatcher.committedEditorSnapshot?.metadata.cursorShape == .block)
     }
 
     // MARK: - Commit promotes atomically
@@ -1929,13 +2027,13 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.setCursorShape(.beam))
         // Nothing promoted yet.
         #expect(gui.tabBarState.tabs.isEmpty)
-        #expect(dispatcher.frameState.cursorShape == .block)
+        #expect(dispatcher.committedEditorSnapshot == nil)
 
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
         // Both staged mutations land together at commit.
         #expect(gui.tabBarState.tabs.first?.label == "a.ex")
-        #expect(dispatcher.frameState.cursorShape == .beam)
+        #expect(dispatcher.committedEditorSnapshot?.metadata.cursorShape == .beam)
         #expect(dispatcher.lastCommittedFrameSeq == 1)
     }
 
@@ -2251,7 +2349,9 @@ struct CommandDispatcherStagingTests {
         #expect(preparedGUI.themeColors.editorBg == directGUI.themeColors.editorBg)
         #expect(preparedGUI.windowContents[7]?.rows.map(\.text) == directGUI.windowContents[7]?.rows.map(\.text))
         #expect(preparedGUI.tabBarState.tabs.map(\.label) == directGUI.tabBarState.tabs.map(\.label))
-        #expect(prepared.frameState.cursorShape == direct.frameState.cursorShape)
+        // The editor-global cursor shape is authoritative only on the committed
+        // snapshot's metadata after the prepared publication (#2999 AC6).
+        #expect(prepared.committedEditorSnapshot?.metadata.cursorShape == .beam)
     }
 
     @Test("one valid frame enters the publication boundary exactly once")
@@ -2434,8 +2534,9 @@ struct CommandDispatcherStagingTests {
         dispatcher.dispatch(.guiIndentGuides(data: guides))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
 
-        #expect(dispatcher.frameState.windowGutters[1001]?.lineNumberWidth == 3)
-        #expect(dispatcher.frameState.windowIndentGuides[1]?.guideCols == [4, 8])
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(snapshot.windowGutters[1001]?.lineNumberWidth == 3)
+        #expect(snapshot.windowIndentGuides[1]?.guideCols == [4, 8])
     }
 
     @Test("terminal resource-policy rejection preserves committed state and emits once")

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -1610,8 +1610,8 @@ fileprivate func editorContent(windowId: UInt16 = 1, geometry: GUIPaneGeometry? 
 
 fileprivate func editorGutter(windowId: UInt16 = 1, geometry: GUIPaneGeometry = editorGeometry()) -> Wire.WindowGutter {
     Wire.WindowGutter(
-        windowId: windowId, contentRow: geometry.textRect.row, contentCol: geometry.textRect.col, contentHeight: geometry.textRect.height,
-        isActive: true, contentWidth: geometry.textRect.width, cursorLine: 0, lineNumberStyle: .hybrid,
+        windowId: windowId, contentRow: geometry.contentRect.row, contentCol: geometry.contentRect.col, contentHeight: geometry.contentRect.height,
+        isActive: true, contentWidth: geometry.contentRect.width, cursorLine: 0, lineNumberStyle: .hybrid,
         lineNumberWidth: UInt8(geometry.gutterMetrics.lineNumberWidth), signColWidth: UInt8(geometry.gutterMetrics.signColWidth), entries: []
     )
 }
@@ -1750,8 +1750,8 @@ struct CommandDispatcherStagingTests {
         dispatcher.onTransactionResult = { results.append($0) }
         let geometry = editorGeometry(lineNumberWidth: 4, signColWidth: 1)
         let gutter = Wire.WindowGutter(
-            windowId: 1, contentRow: geometry.textRect.row, contentCol: geometry.textRect.col, contentHeight: geometry.textRect.height,
-            isActive: true, contentWidth: geometry.textRect.width + 1, cursorLine: 0, lineNumberStyle: .hybrid,
+            windowId: 1, contentRow: geometry.contentRect.row, contentCol: geometry.contentRect.col, contentHeight: geometry.contentRect.height,
+            isActive: true, contentWidth: geometry.contentRect.width + 1, cursorLine: 0, lineNumberStyle: .hybrid,
             lineNumberWidth: 3, signColWidth: UInt8(geometry.gutterMetrics.signColWidth), entries: []
         )
 

--- a/macos/Tests/MingaTests/CommandDispatcherTests.swift
+++ b/macos/Tests/MingaTests/CommandDispatcherTests.swift
@@ -68,6 +68,34 @@ struct CommandDispatcherRoutingTests {
         #expect(dispatcher.frameState.viewportTopLine == 0xFFFF_FFFF)
     }
 
+    @Test("keyframe commit prunes stale split separator metadata")
+    @MainActor func keyframeCommitPrunesStaleSplitMetadata() throws {
+        let (dispatcher, _) = makeDispatcher()
+        dispatcher.applyForTesting(.guiSplitSeparators(
+            borderColor: 0xAABBCC,
+            verticals: [Wire.VerticalSeparator(col: 40, startRow: 0, endRow: 23)],
+            horizontals: [Wire.HorizontalSeparator(row: 12, col: 0, width: 80, filename: "stale.ex")]
+        ))
+        #expect(dispatcher.frameState.splitBorderColor == 0xAABBCC)
+        #expect(!dispatcher.frameState.verticalSeparators.isEmpty)
+        #expect(!dispatcher.frameState.horizontalSeparators.isEmpty)
+
+        let geometry = editorGeometry(windowId: 1, lineNumberWidth: 4, signColWidth: 3)
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(snapshot.frameState.splitBorderColor == 0)
+        #expect(snapshot.frameState.verticalSeparators.isEmpty)
+        #expect(snapshot.frameState.horizontalSeparators.isEmpty)
+        #expect(dispatcher.frameState.splitBorderColor == 0)
+        #expect(dispatcher.frameState.verticalSeparators.isEmpty)
+        #expect(dispatcher.frameState.horizontalSeparators.isEmpty)
+    }
+
     @Test("keyframe commit prunes stale window content, gutters, and indent guides")
     @MainActor func keyframeCommitPrunesStaleWindowState() throws {
         let (dispatcher, gui) = makeDispatcher()
@@ -1452,6 +1480,44 @@ struct CommandDispatcherRoutingTests {
         #expect(dispatcher.frameState.gutterColors.fg == expected)
     }
 
+    @Test("staged window background is frozen into the committed editor snapshot")
+    @MainActor func stagedWindowBackgroundFreezeIntoCommittedEditorSnapshot() throws {
+        let (dispatcher, _) = makeDispatcher()
+        let expected: UInt32 = (0x28 << 16) | (0x2C << 8) | 0x34
+        let geometry = editorGeometry(windowId: 1, lineNumberWidth: 4, signColWidth: 3)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 5, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.setWindowBg(r: 0x28, g: 0x2C, b: 0x34))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.guiGutter(data: editorGutter(windowId: 1, geometry: geometry)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 5, seq: 0))
+
+        #expect(dispatcher.committedEditorSnapshot?.frameState.defaultBg == expected)
+        #expect(dispatcher.frameState.defaultBg == expected)
+    }
+
+    @Test("gutterless committed snapshot remains active for cursor and resident scroll ownership")
+    @MainActor func gutterlessCommittedSnapshotRemainsActive() throws {
+        let (dispatcher, _) = makeDispatcher()
+        let inactiveGeometry = editorGeometry(windowId: 1, lineNumberWidth: 0, signColWidth: 0)
+        let activeGeometry = editorGeometry(windowId: 2, lineNumberWidth: 0, signColWidth: 0)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 6, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 1, geometry: inactiveGeometry, cursorVisible: false)))
+        dispatcher.dispatch(.guiWindowContent(data: try editorContent(windowId: 2, geometry: activeGeometry, cursorVisible: true)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 6, seq: 0))
+
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        #expect(snapshot.activeSurface?.windowId == 2)
+        #expect(snapshot.windowGutters.isEmpty)
+        guard case .none = try #require(snapshot.activeSurface).gutter else {
+            Issue.record("expected gutterless active surface")
+            return
+        }
+    }
+
     @Test("keyframe with content but no guiTheme returns a typed rejection")
     @MainActor func keyframeWithoutThemeErrors() throws {
         let (dispatcher, gui) = makeDispatcher()
@@ -1531,9 +1597,10 @@ fileprivate func editorGeometry(windowId: UInt16 = 1, lineNumberWidth: UInt16 = 
     )
 }
 
-fileprivate func editorContent(windowId: UInt16 = 1, geometry: GUIPaneGeometry? = editorGeometry()) throws -> GUIWindowContent {
+fileprivate func editorContent(windowId: UInt16 = 1, geometry: GUIPaneGeometry? = editorGeometry(), cursorVisible: Bool = true) throws -> GUIWindowContent {
     try GUIWindowContent(
         windowId: windowId, fullRefresh: true,
+        cursorVisible: cursorVisible,
         cursorRow: 0, cursorCol: 0, cursorShape: .block,
         rows: [], selection: nil,
         searchMatches: [], diagnosticUnderlines: [],

--- a/macos/Tests/MingaTests/ConformanceTranscriptTests.swift
+++ b/macos/Tests/MingaTests/ConformanceTranscriptTests.swift
@@ -277,10 +277,12 @@ struct ConformanceTranscriptTests {
         var results: [FrameTransactionResult] = []
         dispatcher.onTransactionResult = { results.append($0) }
         let theme = CommandDispatcher.requiredThemeSlots.map { ($0, $0, $0, $0) }
+        let paneGeometry = productionPaneGeometry(rowCount: rowCount)
         let epochContent = try GUIWindowContent(
             windowId: 1, fullRefresh: true, contentEpoch: epoch,
             cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: originalRows,
-            selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+            selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [],
+            paneGeometry: paneGeometry
         )
         dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: generation))
         dispatcher.dispatch(.guiTheme(slots: theme))
@@ -360,7 +362,8 @@ struct ConformanceTranscriptTests {
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [GUIVisualRow(rowType: .normal, rowId: 999, bufLine: 0,
                                 contentHash: 999, text: "must-not-publish", spans: [])],
-            selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+            selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [],
+            paneGeometry: paneGeometry
         )))
         dispatcher.dispatch(.commitFrame(frameSeq: 7, seq: 0))
         let staleGenerationStatus: ProductionCorpusStatus =
@@ -387,6 +390,20 @@ struct ConformanceTranscriptTests {
     static func expectedCount(_ operation: String, _ field: String,
                               _ operations: [[String: Any]]) -> Int {
         operations.first { $0["name"] as? String == operation }?[field] as? Int ?? 0
+    }
+
+    private static func productionPaneGeometry(rowCount: Int) -> GUIPaneGeometry {
+        GUIPaneGeometry(
+            windowId: 1,
+            totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            textRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            gutterRect: GUICellRect(row: 0, col: 0, width: 0, height: 24),
+            clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            viewport: GUIViewportSummary(top: 0, left: 0, rows: 24, cols: 80, totalLines: UInt32(rowCount), visualRowOffset: 0, totalVisualRows: UInt32(rowCount)),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 0, signColWidth: 0),
+            hitRegions: []
+        )
     }
 
     private static func productionStatus(_ result: FrameTransactionResult) -> ProductionCorpusStatus {

--- a/macos/Tests/MingaTests/ContentViewTests.swift
+++ b/macos/Tests/MingaTests/ContentViewTests.swift
@@ -237,7 +237,7 @@ struct ContentViewTests {
             contentRect: GUICellRect(row: 0, col: paneCol, width: paneWidth, height: 24),
             textRect: GUICellRect(row: 0, col: textCol, width: textWidth, height: 24),
             gutterRect: GUICellRect(row: 0, col: paneCol, width: 7, height: 24),
-            clipRect: GUICellRect(row: 0, col: paneCol, width: paneWidth, height: 24),
+            clipRect: GUICellRect(row: 0, col: textCol, width: textWidth, height: 24),
             viewport: GUIViewportSummary(
                 top: 0,
                 left: 0,
@@ -289,10 +289,10 @@ struct ContentViewTests {
         Wire.WindowGutter(
             windowId: windowId,
             contentRow: 0,
-            contentCol: paneCol + 7,
+            contentCol: paneCol,
             contentHeight: 24,
             isActive: isActive,
-            contentWidth: paneWidth - 7,
+            contentWidth: paneWidth,
             cursorLine: foldLine,
             lineNumberStyle: .hybrid,
             lineNumberWidth: 4,
@@ -573,7 +573,7 @@ struct ContentViewTests {
         ))
         editorView.mouseDown(with: textEvent)
         #expect(spy.mouseEventCalls.last?.row == 1)
-        #expect(spy.mouseEventCalls.last?.col == 11)
+        #expect(spy.mouseEventCalls.last?.col == 9)
 
         let dragPoint = NSPoint(x: editorView.cellWidth * 14.2, y: editorView.cellHeight * 2.5)
         let dragEvent = try #require(mouseEvent(
@@ -584,9 +584,10 @@ struct ContentViewTests {
         editorView.mouseDragged(with: dragEvent)
         #expect(spy.mouseEventCalls.last?.eventType == MOUSE_DRAG)
         #expect(spy.mouseEventCalls.last?.row == 3)
-        #expect(spy.mouseEventCalls.last?.col == 13)
+        #expect(spy.mouseEventCalls.last?.col == 11)
 
-        let foldPoint = NSPoint(x: editorView.cellWidth * 10.2, y: editorView.cellHeight * 0.5)
+        dispatcher.promoteVisibleEditorPresentation(snapshot: visibleSnapshot, localTransform: nil)
+        let foldPoint = NSPoint(x: editorView.cellWidth * 3.2, y: editorView.cellHeight * 0.5)
         let foldEvent = try #require(mouseEvent(
             type: .leftMouseDown,
             locationInWindow: editorView.convert(foldPoint, to: nil),
@@ -601,7 +602,7 @@ struct ContentViewTests {
         #expect((editorView.accessibilityValue() as? String)?.contains("committed row 1") == true)
         editorView.mouseDown(with: textEvent)
         #expect(spy.mouseEventCalls.last?.row == 0)
-        #expect(spy.mouseEventCalls.last?.col == 11)
+        #expect(spy.mouseEventCalls.last?.col == 9)
     }
 
     @Test(
@@ -637,7 +638,7 @@ struct ContentViewTests {
         await Task.yield()
 
         dispatcher.promoteVisibleEditorSnapshot(try #require(dispatcher.committedEditorSnapshot))
-        let localPoint = NSPoint(x: editorView.cellWidth * 12.2, y: editorView.cellHeight * 1.5)
+        let localPoint = NSPoint(x: editorView.cellWidth * 45.2, y: editorView.cellHeight * 1.5)
         let windowPoint = editorView.convert(localPoint, to: nil)
         let screenPoint = window.convertPoint(toScreen: windowPoint)
         let imeA = editorView.firstRect(forCharacterRange: NSRange(location: 0, length: 0), actualRange: nil)

--- a/macos/Tests/MingaTests/ContentViewTests.swift
+++ b/macos/Tests/MingaTests/ContentViewTests.swift
@@ -407,6 +407,7 @@ struct ContentViewTests {
             label: "before.ex"
         )]))
         dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+        dispatcher.promoteVisibleEditorSnapshot(try #require(dispatcher.committedEditorSnapshot))
 
         let root = ContentView(
             gui: gui,

--- a/macos/Tests/MingaTests/ContentViewTests.swift
+++ b/macos/Tests/MingaTests/ContentViewTests.swift
@@ -11,12 +11,20 @@ private final class MountedPreciseScrollEvent: NSEvent {
     private let mountedWindowNumber: Int
     private let mountedDeltaY: CGFloat
     private let mountedPhase: NSEvent.Phase
+    private let mountedMomentumPhase: NSEvent.Phase
 
-    init(locationInWindow: NSPoint, windowNumber: Int, deltaY: CGFloat, phase: NSEvent.Phase) {
+    init(
+        locationInWindow: NSPoint,
+        windowNumber: Int,
+        deltaY: CGFloat,
+        phase: NSEvent.Phase,
+        momentumPhase: NSEvent.Phase = []
+    ) {
         mountedLocation = locationInWindow
         mountedWindowNumber = windowNumber
         mountedDeltaY = deltaY
         mountedPhase = phase
+        mountedMomentumPhase = momentumPhase
         super.init()
     }
 
@@ -32,7 +40,7 @@ private final class MountedPreciseScrollEvent: NSEvent {
     override var scrollingDeltaY: CGFloat { mountedDeltaY }
     override var hasPreciseScrollingDeltas: Bool { true }
     override var phase: NSEvent.Phase { mountedPhase }
-    override var momentumPhase: NSEvent.Phase { [] }
+    override var momentumPhase: NSEvent.Phase { mountedMomentumPhase }
 }
 
 @MainActor
@@ -107,7 +115,7 @@ private struct MountedEditorSurface: View {
     }
 }
 
-@Suite("Content view")
+@Suite("Content view", .serialized)
 @MainActor
 struct ContentViewTests {
     private func makeEditorNSView(
@@ -200,7 +208,17 @@ struct ContentViewTests {
         )
     }
 
-    private func nativeFoldInteractionContent(prefix: String, foldLine: UInt32, contentEpoch: UInt32, totalLines: UInt32 = 4) throws -> GUIWindowContent {
+    private func nativeFoldInteractionContent(
+        prefix: String,
+        foldLine: UInt32,
+        contentEpoch: UInt32,
+        totalLines: UInt32 = 4,
+        windowId: UInt16 = 1,
+        paneCol: UInt16 = 0,
+        paneWidth: UInt16 = 80,
+        cursorRow: UInt16 = 1,
+        cursorCol: UInt16 = 2
+    ) throws -> GUIWindowContent {
         let rows = (0..<4).map { index in
             GUIVisualRow(
                 rowType: .normal,
@@ -211,31 +229,33 @@ struct ContentViewTests {
                 spans: []
             )
         }
+        let textCol = paneCol + 7
+        let textWidth = paneWidth - 7
         let geometry = GUIPaneGeometry(
-            windowId: 1,
-            totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
-            contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
-            textRect: GUICellRect(row: 0, col: 7, width: 73, height: 24),
-            gutterRect: GUICellRect(row: 0, col: 0, width: 7, height: 24),
-            clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            windowId: windowId,
+            totalRect: GUICellRect(row: 0, col: paneCol, width: paneWidth, height: 24),
+            contentRect: GUICellRect(row: 0, col: paneCol, width: paneWidth, height: 24),
+            textRect: GUICellRect(row: 0, col: textCol, width: textWidth, height: 24),
+            gutterRect: GUICellRect(row: 0, col: paneCol, width: 7, height: 24),
+            clipRect: GUICellRect(row: 0, col: paneCol, width: paneWidth, height: 24),
             viewport: GUIViewportSummary(
                 top: 0,
                 left: 0,
                 rows: 4,
-                cols: 73,
+                cols: textWidth,
                 totalLines: totalLines,
                 visualRowOffset: 0,
                 totalVisualRows: 4
             ),
             gutterMetrics: GUIGutterMetrics(lineNumberWidth: 4, signColWidth: 3),
-            hitRegions: [GUIHitRegion(kind: .gutter, rect: GUICellRect(row: 0, col: 0, width: 7, height: 24), windowId: 1)]
+            hitRegions: [GUIHitRegion(kind: .gutter, rect: GUICellRect(row: 0, col: paneCol, width: 7, height: 24), windowId: windowId)]
         )
         return try GUIWindowContent(
-            windowId: 1,
+            windowId: windowId,
             fullRefresh: true,
             contentEpoch: contentEpoch,
-            cursorRow: 1,
-            cursorCol: 2,
+            cursorRow: cursorRow,
+            cursorCol: cursorCol,
             cursorShape: .block,
             rows: rows,
             selection: nil,
@@ -244,7 +264,7 @@ struct ContentViewTests {
             documentHighlights: [],
             paneGeometry: geometry,
             scrollPresentation: GUIScrollPresentation(
-                windowId: 1,
+                windowId: windowId,
                 resetRequired: false,
                 anchorTop: 0,
                 anchorLeft: 0,
@@ -259,14 +279,20 @@ struct ContentViewTests {
         )
     }
 
-    private func nativeFoldGutter(foldLine: UInt32) -> Wire.WindowGutter {
+    private func nativeFoldGutter(
+        foldLine: UInt32,
+        windowId: UInt16 = 1,
+        paneCol: UInt16 = 0,
+        paneWidth: UInt16 = 80,
+        isActive: Bool = true
+    ) -> Wire.WindowGutter {
         Wire.WindowGutter(
-            windowId: 1,
+            windowId: windowId,
             contentRow: 0,
-            contentCol: 7,
+            contentCol: paneCol + 7,
             contentHeight: 24,
-            isActive: true,
-            contentWidth: 73,
+            isActive: isActive,
+            contentWidth: paneWidth - 7,
             cursorLine: foldLine,
             lineNumberStyle: .hybrid,
             lineNumberWidth: 4,
@@ -308,13 +334,15 @@ struct ContentViewTests {
         window: NSWindow,
         locationInWindow: NSPoint,
         deltaY: CGFloat,
-        phase: NSEvent.Phase
+        phase: NSEvent.Phase,
+        momentumPhase: NSEvent.Phase = []
     ) -> NSEvent {
         MountedPreciseScrollEvent(
             locationInWindow: locationInWindow,
             windowNumber: window.windowNumber,
             deltaY: deltaY,
-            phase: phase
+            phase: phase,
+            momentumPhase: momentumPhase
         )
     }
 
@@ -547,6 +575,17 @@ struct ContentViewTests {
         #expect(spy.mouseEventCalls.last?.row == 1)
         #expect(spy.mouseEventCalls.last?.col == 11)
 
+        let dragPoint = NSPoint(x: editorView.cellWidth * 14.2, y: editorView.cellHeight * 2.5)
+        let dragEvent = try #require(mouseEvent(
+            type: .leftMouseDragged,
+            locationInWindow: editorView.convert(dragPoint, to: nil),
+            windowNumber: window.windowNumber
+        ))
+        editorView.mouseDragged(with: dragEvent)
+        #expect(spy.mouseEventCalls.last?.eventType == MOUSE_DRAG)
+        #expect(spy.mouseEventCalls.last?.row == 3)
+        #expect(spy.mouseEventCalls.last?.col == 13)
+
         let foldPoint = NSPoint(x: editorView.cellWidth * 10.2, y: editorView.cellHeight * 0.5)
         let foldEvent = try #require(mouseEvent(
             type: .leftMouseDown,
@@ -555,6 +594,84 @@ struct ContentViewTests {
         ))
         editorView.mouseDown(with: foldEvent)
         #expect(spy.guiActions.last == .foldToggleAtLine(windowId: 1, bufferLine: 101))
+
+        let committedSnapshot = try #require(dispatcher.committedEditorSnapshot)
+        dispatcher.promoteVisibleEditorPresentation(snapshot: committedSnapshot, localTransform: nil)
+        #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 2)
+        #expect((editorView.accessibilityValue() as? String)?.contains("committed row 1") == true)
+        editorView.mouseDown(with: textEvent)
+        #expect(spy.mouseEventCalls.last?.row == 0)
+        #expect(spy.mouseEventCalls.last?.col == 11)
+    }
+
+    @Test(
+        "active-pane input IME and accessibility move only after visible promotion",
+        .timeLimit(.minutes(1))
+    )
+    func activePaneGeometryMovesAtomicallyAtVisiblePromotion() async throws {
+        let gui = GUIState()
+        let dispatcher = CommandDispatcher(cols: 80, rows: 24, guiState: gui)
+        let spy = SpyEncoder()
+        let editorView = try makeEditorNSView(gui: gui, dispatcher: dispatcher, encoder: spy)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try nativeFoldInteractionContent(prefix: "pane A", foldLine: 10, contentEpoch: 1, windowId: 1, paneCol: 0, paneWidth: 40, cursorRow: 0)))
+        dispatcher.dispatch(.guiGutter(data: nativeFoldGutter(foldLine: 10, windowId: 1, paneCol: 0, paneWidth: 40)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        let root = ContentView(gui: gui, encoder: { spy }, editorGeometry: { .preview }, chrome: .preview, onAgentChatVisibleChange: { _ in }) {
+            EditorView(editorNSView: editorView)
+        }
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let hostingView = NSHostingView(rootView: root)
+        hostingView.frame = frame
+        let window = NSWindow(contentRect: frame, styleMask: [.titled], backing: .buffered, defer: false)
+        window.contentView = hostingView
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            window.orderOut(nil)
+            window.contentView = nil
+        }
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+
+        dispatcher.promoteVisibleEditorSnapshot(try #require(dispatcher.committedEditorSnapshot))
+        let localPoint = NSPoint(x: editorView.cellWidth * 12.2, y: editorView.cellHeight * 1.5)
+        let windowPoint = editorView.convert(localPoint, to: nil)
+        let screenPoint = window.convertPoint(toScreen: windowPoint)
+        let imeA = editorView.firstRect(forCharacterRange: NSRange(location: 0, length: 0), actualRange: nil)
+        let characterA = editorView.characterIndex(for: screenPoint)
+        let rangeA = editorView.accessibilitySelectedTextRange()
+        #expect((editorView.accessibilityValue() as? String)?.contains("pane A row 0") == true)
+        #expect(editorView.accessibilityInsertionPointLineNumber() == 0)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try nativeFoldInteractionContent(prefix: "pane B successor", foldLine: 20, contentEpoch: 2, windowId: 2, paneCol: 40, paneWidth: 40, cursorRow: 2, cursorCol: 4)))
+        dispatcher.dispatch(.guiGutter(data: nativeFoldGutter(foldLine: 20, windowId: 2, paneCol: 40, paneWidth: 40)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+        #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 1)
+        #expect(editorView.firstRect(forCharacterRange: NSRange(location: 0, length: 0), actualRange: nil) == imeA)
+        #expect(editorView.characterIndex(for: screenPoint) == characterA)
+        #expect(editorView.accessibilitySelectedTextRange() == rangeA)
+        #expect(editorView.accessibilityInsertionPointLineNumber() == 0)
+        #expect((editorView.accessibilityValue() as? String)?.contains("pane A row 0") == true)
+
+        let click = try #require(mouseEvent(type: .leftMouseDown, locationInWindow: windowPoint, windowNumber: window.windowNumber))
+        editorView.mouseDown(with: click)
+        let visibleClick = try #require(spy.mouseEventCalls.last)
+
+        dispatcher.promoteVisibleEditorSnapshot(try #require(dispatcher.committedEditorSnapshot))
+        let imeB = editorView.firstRect(forCharacterRange: NSRange(location: 0, length: 0), actualRange: nil)
+        #expect(imeB.minX > imeA.minX)
+        #expect(editorView.characterIndex(for: screenPoint) != characterA)
+        #expect(editorView.accessibilitySelectedTextRange() != rangeA)
+        #expect(editorView.accessibilityInsertionPointLineNumber() == 2)
+        #expect((editorView.accessibilityValue() as? String)?.contains("pane B successor row 0") == true)
+        editorView.mouseDown(with: click)
+        let promotedClick = try #require(spy.mouseEventCalls.last)
+        #expect(promotedClick.row != visibleClick.row || promotedClick.col != visibleClick.col)
     }
 
     @Test(
@@ -654,6 +771,18 @@ struct ContentViewTests {
         editorView.scrollWheel(with: scrollBegan)
         editorView.scrollWheel(with: scrollChanged)
 
+        let visibleContent = try #require(dispatcher.visibleEditorSnapshot?.surfaces.first?.content)
+        let momentumEvents = [
+            preciseScrollEvent(window: window, locationInWindow: locationInWindow, deltaY: -6, phase: [], momentumPhase: .began),
+            preciseScrollEvent(window: window, locationInWindow: locationInWindow, deltaY: -5, phase: [], momentumPhase: .changed),
+            preciseScrollEvent(window: window, locationInWindow: locationInWindow, deltaY: 0, phase: [], momentumPhase: .ended),
+            preciseScrollEvent(window: window, locationInWindow: locationInWindow, deltaY: -4, phase: [], momentumPhase: .began),
+            preciseScrollEvent(window: window, locationInWindow: locationInWindow, deltaY: -3, phase: [], momentumPhase: .changed),
+            preciseScrollEvent(window: window, locationInWindow: locationInWindow, deltaY: -2, phase: .began),
+        ]
+        for event in momentumEvents { editorView.scrollWheel(with: event) }
+        #expect(dispatcher.visibleEditorSnapshot?.surfaces.first?.content === visibleContent)
+
         let mouseDown = try #require(mouseEvent(
             type: .leftMouseDown,
             locationInWindow: locationInWindow,
@@ -677,7 +806,6 @@ struct ContentViewTests {
         #expect(before.selectionDragActive)
         #expect(before.selectionDragStarted)
         #expect(before.scrollWindowId != nil)
-        #expect(before.scrollOffset != .zero)
 
         dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
         dispatcher.dispatch(.guiTabBar(activeIndex: 0, tabs: [Wire.TabEntry(

--- a/macos/Tests/MingaTests/ContentViewTests.swift
+++ b/macos/Tests/MingaTests/ContentViewTests.swift
@@ -200,6 +200,86 @@ struct ContentViewTests {
         )
     }
 
+    private func nativeFoldInteractionContent(prefix: String, foldLine: UInt32, contentEpoch: UInt32, totalLines: UInt32 = 4) throws -> GUIWindowContent {
+        let rows = (0..<4).map { index in
+            GUIVisualRow(
+                rowType: .normal,
+                rowId: UInt64(contentEpoch) * 10 + UInt64(index),
+                bufLine: UInt32(index),
+                contentHash: UInt32(contentEpoch) * 10 + UInt32(index),
+                text: "\(prefix) row \(index)",
+                spans: []
+            )
+        }
+        let geometry = GUIPaneGeometry(
+            windowId: 1,
+            totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            textRect: GUICellRect(row: 0, col: 7, width: 73, height: 24),
+            gutterRect: GUICellRect(row: 0, col: 0, width: 7, height: 24),
+            clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            viewport: GUIViewportSummary(
+                top: 0,
+                left: 0,
+                rows: 4,
+                cols: 73,
+                totalLines: totalLines,
+                visualRowOffset: 0,
+                totalVisualRows: 4
+            ),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 4, signColWidth: 3),
+            hitRegions: [GUIHitRegion(kind: .gutter, rect: GUICellRect(row: 0, col: 0, width: 7, height: 24), windowId: 1)]
+        )
+        return try GUIWindowContent(
+            windowId: 1,
+            fullRefresh: true,
+            contentEpoch: contentEpoch,
+            cursorRow: 1,
+            cursorCol: 2,
+            cursorShape: .block,
+            rows: rows,
+            selection: nil,
+            searchMatches: [],
+            diagnosticUnderlines: [],
+            documentHighlights: [],
+            paneGeometry: geometry,
+            scrollPresentation: GUIScrollPresentation(
+                windowId: 1,
+                resetRequired: false,
+                anchorTop: 0,
+                anchorLeft: 0,
+                anchorVisualRowOffset: 0,
+                visibleStartLine: 0,
+                visibleEndLine: 4,
+                overscanStartLine: 0,
+                overscanEndLine: totalLines,
+                contentEpoch: contentEpoch,
+                layoutGeneration: 1
+            )
+        )
+    }
+
+    private func nativeFoldGutter(foldLine: UInt32) -> Wire.WindowGutter {
+        Wire.WindowGutter(
+            windowId: 1,
+            contentRow: 0,
+            contentCol: 7,
+            contentHeight: 24,
+            isActive: true,
+            contentWidth: 73,
+            cursorLine: foldLine,
+            lineNumberStyle: .hybrid,
+            lineNumberWidth: 4,
+            signColWidth: 3,
+            entries: [
+                Wire.GutterEntry(bufLine: foldLine, displayType: .foldStart, signType: .none, foldEndLine: foldLine + 5),
+                Wire.GutterEntry(bufLine: foldLine + 1, displayType: .normal, signType: .none),
+                Wire.GutterEntry(bufLine: foldLine + 2, displayType: .normal, signType: .none),
+                Wire.GutterEntry(bufLine: foldLine + 3, displayType: .normal, signType: .none)
+            ]
+        )
+    }
+
     private func mouseEvent(
         type: NSEvent.EventType,
         locationInWindow: NSPoint,
@@ -378,6 +458,103 @@ struct ContentViewTests {
 
         #expect(legacyOnlyStrings.contains("fallback.ex"))
         #expect((try? legacyOnlyRoot.inspect().find(viewWithAccessibilityIdentifier: "workspace-tabbar")) != nil)
+    }
+
+    @Test(
+        "mounted editor interactions use visible snapshot while newer commit is unpresented",
+        .timeLimit(.minutes(1))
+    )
+    func mountedEditorInteractionsUseVisibleSnapshotWhileNewerCommitIsUnpresented() async throws {
+        let gui = GUIState()
+        let dispatcher = CommandDispatcher(cols: 80, rows: 24, guiState: gui)
+        let spy = SpyEncoder()
+        let editorView = try makeEditorNSView(gui: gui, dispatcher: dispatcher, encoder: spy)
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+        dispatcher.dispatch(.guiWindowContent(data: try nativeFoldInteractionContent(prefix: "visible", foldLine: 101, contentEpoch: 1, totalLines: 100)))
+        dispatcher.dispatch(.guiGutter(data: nativeFoldGutter(foldLine: 101)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        let root = ContentView(
+            gui: gui,
+            encoder: { spy },
+            editorGeometry: { .preview },
+            chrome: .preview,
+            onAgentChatVisibleChange: { _ in }
+        ) {
+            EditorView(editorNSView: editorView)
+        }
+        let frame = NSRect(x: 0, y: 0, width: 800, height: 600)
+        let hostingView = NSHostingView(rootView: root)
+        hostingView.frame = frame
+        let window = NSWindow(
+            contentRect: frame,
+            styleMask: [.titled],
+            backing: .buffered,
+            defer: false
+        )
+        window.contentView = hostingView
+        window.makeKeyAndOrderFront(nil)
+        defer {
+            window.orderOut(nil)
+            window.contentView = nil
+        }
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+
+        let visibleSnapshot = try #require(dispatcher.committedEditorSnapshot)
+        dispatcher.promoteVisibleEditorPresentation(
+            snapshot: visibleSnapshot,
+            localTransform: EditorLocalPresentationTransform(windowId: 1, offset: CGPoint(x: 0, y: editorView.cellHeight))
+        )
+
+        dispatcher.dispatch(.beginFrame(frameSeq: 2, baseFrameSeq: 1, generation: 1))
+        dispatcher.dispatch(.guiWindowContent(data: try nativeFoldInteractionContent(prefix: "committed", foldLine: 201, contentEpoch: 2, totalLines: 300)))
+        dispatcher.dispatch(.guiGutter(data: nativeFoldGutter(foldLine: 201)))
+        dispatcher.dispatch(.commitFrame(frameSeq: 2, seq: 0))
+        #expect(dispatcher.committedEditorSnapshot?.frameSeq == 2)
+        #expect(dispatcher.visibleEditorSnapshot?.frameSeq == 1)
+
+        #expect((editorView.accessibilityValue() as? String)?.contains("visible row 1") == true)
+        #expect((editorView.accessibilityValue() as? String)?.contains("committed row") == false)
+        #expect(editorView.accessibilityInsertionPointLineNumber() == 1)
+        let scrollY = editorView.bounds.height * 0.75
+        let visibleLine = EditorScrollTrack.line(
+            forY: scrollY,
+            viewHeight: editorView.bounds.height,
+            totalLines: 100,
+            visibleRows: 4,
+            resident: true
+        )
+        let committedLine = EditorScrollTrack.line(
+            forY: scrollY,
+            viewHeight: editorView.bounds.height,
+            totalLines: 300,
+            visibleRows: 24,
+            resident: true
+        )
+        #expect(visibleLine != committedLine)
+        #expect(editorView.scrollTrackLineForTesting(y: scrollY) == visibleLine)
+
+        let textPoint = NSPoint(x: editorView.cellWidth * 12.2, y: editorView.cellHeight * 0.5)
+        let textEvent = try #require(mouseEvent(
+            type: .leftMouseDown,
+            locationInWindow: editorView.convert(textPoint, to: nil),
+            windowNumber: window.windowNumber
+        ))
+        editorView.mouseDown(with: textEvent)
+        #expect(spy.mouseEventCalls.last?.row == 1)
+        #expect(spy.mouseEventCalls.last?.col == 11)
+
+        let foldPoint = NSPoint(x: editorView.cellWidth * 10.2, y: editorView.cellHeight * 0.5)
+        let foldEvent = try #require(mouseEvent(
+            type: .leftMouseDown,
+            locationInWindow: editorView.convert(foldPoint, to: nil),
+            windowNumber: window.windowNumber
+        ))
+        editorView.mouseDown(with: foldEvent)
+        #expect(spy.guiActions.last == .foldToggleAtLine(windowId: 1, bufferLine: 101))
     }
 
     @Test(

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -55,6 +55,44 @@ struct CoreTextMetalRendererCursorTests {
         #expect(abs((cursor?.y ?? 0) - expectedY) < 0.001)
     }
 
+    @Test("gutterless snapshot active window still resolves cursor")
+    func gutterlessSnapshotActiveWindowStillResolvesCursor() throws {
+        let content = try GUIWindowContent(
+            windowId: 4, fullRefresh: true,
+            cursorRow: 3, cursorCol: 8, cursorShape: .beam,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [],
+            paneGeometry: GUIPaneGeometry(
+                windowId: 4,
+                totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+                contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+                textRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+                gutterRect: GUICellRect(row: 0, col: 0, width: 0, height: 24),
+                clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+                viewport: GUIViewportSummary(top: 0, left: 0, rows: 24, cols: 80, totalLines: 24, visualRowOffset: 0, totalVisualRows: 24),
+                gutterMetrics: GUIGutterMetrics(lineNumberWidth: 0, signColWidth: 0),
+                hitRegions: []
+            )
+        )
+
+        let cursor = CoreTextMetalRenderer.resolveCursor(
+            windowContents: [4: content],
+            gutters: [:],
+            activeWindowId: 4,
+            cellW: 7,
+            displayCellH: 13,
+            scale: 2,
+            gutterLeftMarginPx: 0,
+            gutterPaddingPx: 0
+        )
+
+        #expect(cursor?.windowId == 4)
+        #expect(cursor?.shape == .beam)
+        #expect(cursor?.x == Float(8 * 7 * 2))
+        #expect(cursor?.y == Float(3 * 13 * 2))
+    }
+
     @Test("smooth scroll offset applies only to its target window")
     func smoothScrollOffsetAppliesOnlyToTargetWindow() {
         let offset = SIMD2<Float>(0, 7)

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -36,7 +36,6 @@ struct CoreTextMetalRendererCursorTests {
         )
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
-            frameState: frameState,
             windowContents: [2: content],
             gutters: frameState.windowGutters,
             cellW: cellW,
@@ -640,14 +639,8 @@ struct CoreTextMetalRendererCursorTests {
         #expect(CoreTextMetalRenderer.clipVerticalQuad(y: 0, height: 5, top: 10, bottom: 20) == nil)
     }
 
-    @Test("legacy cursor is used when semantic content is unavailable")
+    @Test("legacy frameState cursor is not used when semantic content is unavailable")
     func legacyCursorFallback() {
-        let cellW: Float = 7.5
-        let displayCellH: Float = 16.0
-        let scale: Float = 2.0
-        let gutterLeft: Float = 3.0
-        let gutterPadding: Float = 5.0
-
         var frameState = FrameState(cols: 80, rows: 24)
         frameState.cursorRow = 3
         frameState.cursorCol = 10
@@ -655,26 +648,20 @@ struct CoreTextMetalRendererCursorTests {
         frameState.gutterCol = 5
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
-            frameState: frameState,
             windowContents: [:],
             gutters: [:],
-            cellW: cellW,
-            displayCellH: displayCellH,
-            scale: scale,
-            gutterLeftMarginPx: gutterLeft,
-            gutterPaddingPx: gutterPadding
+            cellW: 7.5,
+            displayCellH: 16,
+            scale: 2,
+            gutterLeftMarginPx: 3,
+            gutterPaddingPx: 5
         )
 
-        let expectedX = Float(10) * cellW * scale + gutterLeft + gutterPadding
-        let expectedY = Float(3) * displayCellH * scale
-
-        #expect(cursor?.shape == .underline)
-        #expect(abs((cursor?.x ?? 0) - expectedX) < 0.001)
-        #expect(abs((cursor?.y ?? 0) - expectedY) < 0.001)
+        #expect(cursor == nil)
     }
 
-    @Test("cursor row Y uses spaced cell height at line spacing 1.2")
-    func cursorRowYUsesSpacedCellHeightAtSpacing1_2() {
+    @Test("semantic cursor row Y uses spaced cell height at line spacing 1.2")
+    func cursorRowYUsesSpacedCellHeightAtSpacing1_2() throws {
         let cellW: Float = 7.5
         let baseCellH: Float = 16.0
         let lineSpacing: Float = 1.2
@@ -683,15 +670,22 @@ struct CoreTextMetalRendererCursorTests {
 
         var frameState = FrameState(cols: 80, rows: 24)
         frameState.lineSpacing = lineSpacing
-        frameState.cursorRow = 10
-        frameState.cursorCol = 4
-        frameState.cursorShape = .block
-        frameState.gutterCol = 0
+        frameState.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
+            isActive: true, contentWidth: 80, cursorLine: 10, lineNumberStyle: .none,
+            lineNumberWidth: 0, signColWidth: 0, entries: []
+        )
+        let content = try GUIWindowContent(
+            windowId: 1, fullRefresh: true,
+            cursorRow: 10, cursorCol: 4, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
-            frameState: frameState,
-            windowContents: [:],
-            gutters: [:],
+            windowContents: [1: content],
+            gutters: frameState.windowGutters,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -699,15 +693,14 @@ struct CoreTextMetalRendererCursorTests {
             gutterPaddingPx: 0
         )
 
-        // Row Y must land on the spaced row position, not the unspaced one.
         let spacedY = Float(10) * displayCellH * scale
         let unspacedY = Float(10) * baseCellH * scale
         #expect(abs((cursor?.y ?? 0) - spacedY) < 0.001)
         #expect(abs((cursor?.y ?? 0) - unspacedY) > 0.001)
     }
 
-    @Test("cursor row Y at line spacing 1.0 matches the unspaced baseline")
-    func cursorRowYAtSpacing1_0MatchesUnspacedBaseline() {
+    @Test("semantic cursor row Y at line spacing 1.0 matches the unspaced baseline")
+    func cursorRowYAtSpacing1_0MatchesUnspacedBaseline() throws {
         let cellW: Float = 7.5
         let baseCellH: Float = 16.0
         let lineSpacing: Float = 1.0
@@ -716,15 +709,22 @@ struct CoreTextMetalRendererCursorTests {
 
         var frameState = FrameState(cols: 80, rows: 24)
         frameState.lineSpacing = lineSpacing
-        frameState.cursorRow = 10
-        frameState.cursorCol = 4
-        frameState.cursorShape = .block
-        frameState.gutterCol = 0
+        frameState.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
+            isActive: true, contentWidth: 80, cursorLine: 10, lineNumberStyle: .none,
+            lineNumberWidth: 0, signColWidth: 0, entries: []
+        )
+        let content = try GUIWindowContent(
+            windowId: 1, fullRefresh: true,
+            cursorRow: 10, cursorCol: 4, cursorShape: .block,
+            rows: [], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: []
+        )
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
-            frameState: frameState,
-            windowContents: [:],
-            gutters: [:],
+            windowContents: [1: content],
+            gutters: frameState.windowGutters,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -732,8 +732,6 @@ struct CoreTextMetalRendererCursorTests {
             gutterPaddingPx: 0
         )
 
-        // At 1.0 the spaced and unspaced positions are identical (byte-for-byte
-        // parity with pre-1.2-default behavior).
         let expectedY = Float(10) * baseCellH * scale
         #expect(abs((cursor?.y ?? 0) - expectedY) < 0.001)
     }
@@ -771,7 +769,6 @@ struct CoreTextMetalRendererCursorTests {
         )
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
-            frameState: frameState,
             windowContents: [1: content],
             gutters: frameState.windowGutters,
             cellW: cellW,
@@ -916,7 +913,6 @@ struct CoreTextMetalRendererCursorTests {
         )
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
-            frameState: frameState,
             windowContents: [1: hiddenChat, 65_534: visiblePrompt],
             gutters: frameState.windowGutters,
             cellW: 8,
@@ -955,7 +951,6 @@ struct CoreTextMetalRendererCursorTests {
         dispatcher.applyForTesting(.guiWindowContent(data: content))
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
-            frameState: dispatcher.frameState,
             windowContents: gui.windowContents,
             gutters: dispatcher.frameState.windowGutters,
             cellW: 7.5,

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -8,7 +8,7 @@ import MingaProtocol
 
 @Suite("CoreTextMetalRenderer cursor geometry")
 struct CoreTextMetalRendererCursorTests {
-    @Test("semantic window cursor overrides legacy frameState cursor")
+    @Test("semantic window cursor drives resolved cursor geometry")
     func semanticCursorOverridesLegacyCursor() throws {
         let cellW: Float = 7.5
         let displayCellH: Float = 16.0
@@ -16,15 +16,11 @@ struct CoreTextMetalRendererCursorTests {
         let gutterLeft: Float = 3.0
         let gutterPadding: Float = 5.0
 
-        var frameState = FrameState(cols: 80, rows: 24)
-        frameState.cursorRow = 20
-        frameState.cursorCol = 70
-        frameState.cursorShape = .block
-        frameState.windowGutters[2] = Wire.WindowGutter(
+        let windowGutters: [UInt16: Wire.WindowGutter] = [2: Wire.WindowGutter(
             windowId: 2, contentRow: 4, contentCol: 1, contentHeight: 20,
             isActive: true, contentWidth: 80, cursorLine: 10, lineNumberStyle: .hybrid,
             lineNumberWidth: 4, signColWidth: 1, entries: []
-        )
+        )]
 
         let content = try GUIWindowContent(
             windowId: 2, fullRefresh: true,
@@ -37,7 +33,7 @@ struct CoreTextMetalRendererCursorTests {
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
             windowContents: [2: content],
-            gutters: frameState.windowGutters,
+            gutters: windowGutters,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -251,15 +247,15 @@ struct CoreTextMetalRendererCursorTests {
     func rightSplitGutterSeparatorUsesPerWindowScreenCoordinates() {
         var frameState = FrameState(cols: 100, rows: 40)
         frameState.gutterSeparatorColor = 0x334455
-        frameState.windowGutters[2] = Wire.WindowGutter(
+        let windowGutters: [UInt16: Wire.WindowGutter] = [2: Wire.WindowGutter(
             windowId: 2, contentRow: 3, contentCol: 40, contentHeight: 10,
             isActive: true, contentWidth: 40, cursorLine: 0, lineNumberStyle: .hybrid,
             lineNumberWidth: 4, signColWidth: 1, entries: []
-        )
+        )]
 
         let rects = CoreTextMetalRenderer.gutterChromeRects(
             frameState: frameState,
-            gutters: frameState.windowGutters,
+            gutters: windowGutters,
             cellW: 8,
             cellH: 16,
             scale: 2,
@@ -677,14 +673,8 @@ struct CoreTextMetalRendererCursorTests {
         #expect(CoreTextMetalRenderer.clipVerticalQuad(y: 0, height: 5, top: 10, bottom: 20) == nil)
     }
 
-    @Test("legacy frameState cursor is not used when semantic content is unavailable")
+    @Test("no cursor resolves when semantic content is unavailable")
     func legacyCursorFallback() {
-        var frameState = FrameState(cols: 80, rows: 24)
-        frameState.cursorRow = 3
-        frameState.cursorCol = 10
-        frameState.cursorShape = .underline
-        frameState.gutterCol = 5
-
         let cursor = CoreTextMetalRenderer.resolveCursor(
             windowContents: [:],
             gutters: [:],
@@ -706,13 +696,11 @@ struct CoreTextMetalRendererCursorTests {
         let displayCellH = baseCellH * lineSpacing
         let scale: Float = 2.0
 
-        var frameState = FrameState(cols: 80, rows: 24)
-        frameState.lineSpacing = lineSpacing
-        frameState.windowGutters[1] = Wire.WindowGutter(
+        let windowGutters: [UInt16: Wire.WindowGutter] = [1: Wire.WindowGutter(
             windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
             isActive: true, contentWidth: 80, cursorLine: 10, lineNumberStyle: .none,
             lineNumberWidth: 0, signColWidth: 0, entries: []
-        )
+        )]
         let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 10, cursorCol: 4, cursorShape: .block,
@@ -723,7 +711,7 @@ struct CoreTextMetalRendererCursorTests {
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
             windowContents: [1: content],
-            gutters: frameState.windowGutters,
+            gutters: windowGutters,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -745,13 +733,11 @@ struct CoreTextMetalRendererCursorTests {
         let displayCellH = baseCellH * lineSpacing
         let scale: Float = 2.0
 
-        var frameState = FrameState(cols: 80, rows: 24)
-        frameState.lineSpacing = lineSpacing
-        frameState.windowGutters[1] = Wire.WindowGutter(
+        let windowGutters: [UInt16: Wire.WindowGutter] = [1: Wire.WindowGutter(
             windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
             isActive: true, contentWidth: 80, cursorLine: 10, lineNumberStyle: .none,
             lineNumberWidth: 0, signColWidth: 0, entries: []
-        )
+        )]
         let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 10, cursorCol: 4, cursorShape: .block,
@@ -762,7 +748,7 @@ struct CoreTextMetalRendererCursorTests {
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
             windowContents: [1: content],
-            gutters: frameState.windowGutters,
+            gutters: windowGutters,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -786,16 +772,11 @@ struct CoreTextMetalRendererCursorTests {
         let displayCellH = baseCellH * lineSpacing
         let scale: Float = 2.0
 
-        var frameState = FrameState(cols: 80, rows: 24)
-        frameState.lineSpacing = lineSpacing
-        frameState.cursorRow = 0
-        frameState.cursorCol = 0
-        frameState.cursorShape = .block
-        frameState.windowGutters[1] = Wire.WindowGutter(
+        let windowGutters: [UInt16: Wire.WindowGutter] = [1: Wire.WindowGutter(
             windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
             isActive: true, contentWidth: 80, cursorLine: 5, lineNumberStyle: .none,
             lineNumberWidth: 0, signColWidth: 0, entries: []
-        )
+        )]
 
         // Cursor is on the 6th visible row of the window content.
         let content = try GUIWindowContent(
@@ -808,7 +789,7 @@ struct CoreTextMetalRendererCursorTests {
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
             windowContents: [1: content],
-            gutters: frameState.windowGutters,
+            gutters: windowGutters,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -923,17 +904,18 @@ struct CoreTextMetalRendererCursorTests {
 
     @Test("hidden active semantic cursor is skipped so visible prompt cursor wins")
     func hiddenActiveSemanticCursorIsSkippedSoPromptWins() throws {
-        var frameState = FrameState(cols: 80, rows: 24)
-        frameState.windowGutters[1] = Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
-            isActive: true, contentWidth: 80, cursorLine: 1, lineNumberStyle: .none,
-            lineNumberWidth: 0, signColWidth: 0, entries: []
-        )
-        frameState.windowGutters[65_534] = Wire.WindowGutter(
-            windowId: 65_534, contentRow: 21, contentCol: 2, contentHeight: 2,
-            isActive: true, contentWidth: 40, cursorLine: 0, lineNumberStyle: .none,
-            lineNumberWidth: 0, signColWidth: 0, entries: []
-        )
+        let windowGutters: [UInt16: Wire.WindowGutter] = [
+            1: Wire.WindowGutter(
+                windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 20,
+                isActive: true, contentWidth: 80, cursorLine: 1, lineNumberStyle: .none,
+                lineNumberWidth: 0, signColWidth: 0, entries: []
+            ),
+            65_534: Wire.WindowGutter(
+                windowId: 65_534, contentRow: 21, contentCol: 2, contentHeight: 2,
+                isActive: true, contentWidth: 40, cursorLine: 0, lineNumberStyle: .none,
+                lineNumberWidth: 0, signColWidth: 0, entries: []
+            )
+        ]
 
         let hiddenChat = try GUIWindowContent(
             windowId: 1, fullRefresh: true, cursorVisible: false,
@@ -952,7 +934,7 @@ struct CoreTextMetalRendererCursorTests {
 
         let cursor = CoreTextMetalRenderer.resolveCursor(
             windowContents: [1: hiddenChat, 65_534: visiblePrompt],
-            gutters: frameState.windowGutters,
+            gutters: windowGutters,
             cellW: 8,
             displayCellH: 16,
             scale: 1,
@@ -966,31 +948,46 @@ struct CoreTextMetalRendererCursorTests {
         #expect(cursor?.y == 336)
     }
 
-    @Test("hidden semantic cursor suppresses legacy fallback after dispatcher sync")
+    @Test("hidden semantic cursor suppresses cursor resolution after dispatcher sync")
     @MainActor func hiddenSemanticCursorSuppressesFallback() throws {
         let gui = GUIState()
         let dispatcher = CommandDispatcher(cols: 80, rows: 24, guiState: gui)
-        dispatcher.frameState.cursorRow = 3
-        dispatcher.frameState.cursorCol = 10
-        dispatcher.frameState.cursorShape = .block
-        dispatcher.frameState.windowGutters[1] = Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 24,
-            isActive: true, contentWidth: 80, cursorLine: 1, lineNumberStyle: .hybrid,
-            lineNumberWidth: 4, signColWidth: 1, entries: []
-        )
 
+        let geometry = GUIPaneGeometry(
+            windowId: 1,
+            totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            textRect: GUICellRect(row: 0, col: 5, width: 75, height: 24),
+            gutterRect: GUICellRect(row: 0, col: 0, width: 5, height: 24),
+            clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+            viewport: GUIViewportSummary(top: 0, left: 0, rows: 24, cols: 75, totalLines: 24, visualRowOffset: 0, totalVisualRows: 24),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: 4, signColWidth: 1),
+            hitRegions: [GUIHitRegion(kind: .gutter, rect: GUICellRect(row: 0, col: 0, width: 5, height: 24), windowId: 1)]
+        )
         let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, cursorVisible: false,
             cursorRow: 0, cursorCol: 0, cursorShape: .beam,
             rows: [], selection: nil,
             searchMatches: [], diagnosticUnderlines: [],
-            documentHighlights: []
+            documentHighlights: [], paneGeometry: geometry
         )
-        dispatcher.applyForTesting(.guiWindowContent(data: content))
+        let gutter = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 24,
+            isActive: true, contentWidth: 80, cursorLine: 1, lineNumberStyle: .hybrid,
+            lineNumberWidth: 4, signColWidth: 1, entries: []
+        )
 
+        // Editor authority lives on the committed snapshot; resolve from it.
+        dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: CommandDispatcher.requiredThemeSlots.map { ($0, $0, $0, $0) }))
+        dispatcher.dispatch(.guiWindowContent(data: content))
+        dispatcher.dispatch(.guiGutter(data: gutter))
+        dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
         let cursor = CoreTextMetalRenderer.resolveCursor(
-            windowContents: gui.windowContents,
-            gutters: dispatcher.frameState.windowGutters,
+            windowContents: snapshot.windowContents,
+            gutters: snapshot.windowGutters,
             cellW: 7.5,
             displayCellH: 16.0,
             scale: 2.0,
@@ -998,7 +995,7 @@ struct CoreTextMetalRendererCursorTests {
             gutterPaddingPx: 0
         )
 
-        #expect(dispatcher.frameState.cursorVisible == false)
+        #expect(snapshot.content(for: 1)?.cursorVisible == false)
         #expect(cursor == nil)
     }
 }

--- a/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
+++ b/macos/Tests/MingaTests/CoreTextMetalRendererCursorTests.swift
@@ -38,6 +38,7 @@ struct CoreTextMetalRendererCursorTests {
         let cursor = CoreTextMetalRenderer.resolveCursor(
             frameState: frameState,
             windowContents: [2: content],
+            gutters: frameState.windowGutters,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -221,6 +222,7 @@ struct CoreTextMetalRendererCursorTests {
 
         let rects = CoreTextMetalRenderer.gutterChromeRects(
             frameState: frameState,
+            gutters: frameState.windowGutters,
             cellW: 8,
             cellH: 16,
             scale: 2,
@@ -655,6 +657,7 @@ struct CoreTextMetalRendererCursorTests {
         let cursor = CoreTextMetalRenderer.resolveCursor(
             frameState: frameState,
             windowContents: [:],
+            gutters: [:],
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -688,6 +691,7 @@ struct CoreTextMetalRendererCursorTests {
         let cursor = CoreTextMetalRenderer.resolveCursor(
             frameState: frameState,
             windowContents: [:],
+            gutters: [:],
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -720,6 +724,7 @@ struct CoreTextMetalRendererCursorTests {
         let cursor = CoreTextMetalRenderer.resolveCursor(
             frameState: frameState,
             windowContents: [:],
+            gutters: [:],
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -768,6 +773,7 @@ struct CoreTextMetalRendererCursorTests {
         let cursor = CoreTextMetalRenderer.resolveCursor(
             frameState: frameState,
             windowContents: [1: content],
+            gutters: frameState.windowGutters,
             cellW: cellW,
             displayCellH: displayCellH,
             scale: scale,
@@ -912,6 +918,7 @@ struct CoreTextMetalRendererCursorTests {
         let cursor = CoreTextMetalRenderer.resolveCursor(
             frameState: frameState,
             windowContents: [1: hiddenChat, 65_534: visiblePrompt],
+            gutters: frameState.windowGutters,
             cellW: 8,
             displayCellH: 16,
             scale: 1,
@@ -950,6 +957,7 @@ struct CoreTextMetalRendererCursorTests {
         let cursor = CoreTextMetalRenderer.resolveCursor(
             frameState: dispatcher.frameState,
             windowContents: gui.windowContents,
+            gutters: dispatcher.frameState.windowGutters,
             cellW: 7.5,
             displayCellH: 16.0,
             scale: 2.0,

--- a/macos/Tests/MingaTests/GUIFrameRoutingAndMetricsTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameRoutingAndMetricsTests.swift
@@ -124,23 +124,22 @@ struct GUIFrameRoutingTests {
 
 @Suite("GUI frame presentation metrics")
 struct GUIFramePresentationMetricsTests {
-    @Test("pending native correlation is observable without semantic frame state")
-    @MainActor func pendingNativeCorrelationIsObservable() {
+    @Test("pending native correlation is passive telemetry")
+    @MainActor func pendingNativeCorrelationIsPassiveTelemetry() throws {
         let metrics = GUIFramePresentationMetrics()
         let notificationCount = Mutex(0)
 
         withObservationTracking {
-            _ = metrics.pendingFrame(domain: .shell)
+            _ = metrics.expectedNativeDrawFrame(domain: .shell)
         } onChange: {
             notificationCount.withLock { $0 += 1 }
         }
 
-        metrics.beginCommitted(
-            frame: GUICommittedFrame(generation: 3, frameSeq: 5),
-            impact: .shell
-        )
+        let frame = GUICommittedFrame(generation: 3, frameSeq: 5)
+        metrics.beginCommitted(frame: frame, impact: .shell)
 
-        #expect(notificationCount.withLock { $0 } == 1)
+        #expect(notificationCount.withLock { $0 } == 0)
+        #expect(try #require(metrics.expectedNativeDrawFrame(domain: .shell)) == frame)
     }
 
     @Test("stale native draw and availability callbacks cannot resolve a newer frame")
@@ -150,9 +149,9 @@ struct GUIFramePresentationMetricsTests {
         let second = GUICommittedFrame(generation: 7, frameSeq: 31)
 
         metrics.beginCommitted(frame: first, impact: .shell)
-        let staleExpected = try #require(metrics.pendingFrame(domain: .shell))
+        let staleExpected = try #require(metrics.expectedNativeDrawFrame(domain: .shell))
         metrics.beginCommitted(frame: second, impact: .shell)
-        let currentExpected = try #require(metrics.pendingFrame(domain: .shell))
+        let currentExpected = try #require(metrics.expectedNativeDrawFrame(domain: .shell))
 
         metrics.recordNativeDraw(domain: .shell, expectedFrame: staleExpected)
         metrics.discardNativeDraw(
@@ -178,19 +177,17 @@ struct GUIFramePresentationMetricsTests {
         let current = GUICommittedFrame(generation: 2, frameSeq: 30)
 
         metrics.beginCommitted(frame: stale, impact: .editor)
-        let capturedStale = try #require(metrics.pendingEditorFrame())
         metrics.beginCommitted(frame: current, impact: .editor)
-        let capturedCurrent = try #require(metrics.pendingEditorFrame())
 
-        metrics.recordMetalSubmission(presentationFrame: capturedStale)
-        metrics.recordMetalPresented(presentationFrame: capturedStale)
-        metrics.discard(domain: .editor, outcome: .failed, frame: capturedStale)
+        metrics.recordMetalSubmission(presentationFrame: stale)
+        metrics.recordMetalPresented(presentationFrame: stale)
+        metrics.discard(domain: .editor, outcome: .failed, frame: stale)
         #expect(metrics.snapshot() == [
             .init(frame: stale, domain: .editor, outcome: .superseded)
         ])
 
-        metrics.recordMetalSubmission(presentationFrame: capturedCurrent)
-        metrics.recordMetalPresented(presentationFrame: capturedCurrent)
+        metrics.recordMetalSubmission(presentationFrame: current)
+        metrics.recordMetalPresented(presentationFrame: current)
         #expect(metrics.snapshot() == [
             .init(frame: stale, domain: .editor, outcome: .superseded),
             .init(frame: current, domain: .editor, outcome: .submitted),
@@ -237,9 +234,9 @@ struct GUIFramePresentationMetricsTests {
         metrics.beginCommitted(frame: frame, impact: .all)
         #expect(metrics.snapshot().isEmpty)
 
-        let shell = try #require(metrics.pendingFrame(domain: .shell))
-        let editorOverlay = try #require(metrics.pendingFrame(domain: .editorOverlay))
-        let windowOverlay = try #require(metrics.pendingFrame(domain: .windowOverlay))
+        let shell = try #require(metrics.expectedNativeDrawFrame(domain: .shell))
+        let editorOverlay = try #require(metrics.expectedNativeDrawFrame(domain: .editorOverlay))
+        let windowOverlay = try #require(metrics.expectedNativeDrawFrame(domain: .windowOverlay))
         metrics.recordNativeDraw(domain: .shell, expectedFrame: shell)
         metrics.recordNativeDraw(domain: .editorOverlay, expectedFrame: editorOverlay)
         metrics.recordNativeDraw(domain: .windowOverlay, expectedFrame: windowOverlay)

--- a/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
@@ -1518,7 +1518,18 @@ struct GUIFrameSwiftUIInvalidationTests {
             selection: nil,
             searchMatches: [],
             diagnosticUnderlines: [],
-            documentHighlights: []
+            documentHighlights: [],
+            paneGeometry: GUIPaneGeometry(
+                windowId: 1,
+                totalRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+                contentRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+                textRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+                gutterRect: GUICellRect(row: 0, col: 0, width: 0, height: 24),
+                clipRect: GUICellRect(row: 0, col: 0, width: 80, height: 24),
+                viewport: GUIViewportSummary(top: 0, left: 0, rows: 24, cols: 80, totalLines: 1, visualRowOffset: 0, totalVisualRows: 1),
+                gutterMetrics: GUIGutterMetrics(lineNumberWidth: 0, signColWidth: 0),
+                hitRegions: []
+            )
         )
     }
 

--- a/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
+++ b/macos/Tests/MingaTests/GUIFrameSwiftUIInvalidationTests.swift
@@ -508,6 +508,18 @@ struct GUIFrameSwiftUIInvalidationTests {
             recorder: recorder
         )
 
+        let countsBeforeEditorOnlyCommits = updateCounts(recorder)
+        var baseFrameSeq: UInt32 = 5
+        for frameSeq: UInt32 in 6...8 {
+            dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: baseFrameSeq, generation: 1))
+            dispatcher.dispatch(.setCursorShape(frameSeq.isMultiple(of: 2) ? .beam : .block))
+            dispatcher.dispatch(.commitFrame(frameSeq: frameSeq, seq: 0))
+            baseFrameSeq = frameSeq
+        }
+        hostingView.layoutSubtreeIfNeeded()
+        await Task.yield()
+        expectUnchangedCounts(countsBeforeEditorOnlyCommits, recorder: recorder)
+
         #expect(gui.shellInput === shellInput)
         #expect(gui.editorInput === editorInput)
         #expect(gui.editorOverlayInput === editorOverlayInput)

--- a/macos/Tests/MingaTests/GUIObservationGuardrailTests.swift
+++ b/macos/Tests/MingaTests/GUIObservationGuardrailTests.swift
@@ -110,19 +110,41 @@ struct GUIObservationGuardrailTests {
             "markRendered(",
             "editorInput?.currentWindowContents",
             "visibleEditorSnapshot?.windowIds ?? dispatcher.committedEditorSnapshot",
-            "dispatcher.frameState.windowGutters",
         ]
-        let allowedPaths: [String: Set<String>] = [
-            "dispatcher.frameState.windowGutters": ["Sources/PreviewRegistry.swift"],
+
+        // AC6 (#2999) moved these editor authorities off mutable `FrameState` onto
+        // the committed snapshot (its surfaces, `activeWindowId`, and
+        // `EditorSnapshotMetadata`). A new `frameState.<field>` read for any of them
+        // re-fragments that single authority. Word boundaries keep the still-valid
+        // chrome fields `frameState.gutterColors` and `frameState.gutterSeparatorColor`
+        // — and identically named snapshot/content/metadata properties — from
+        // tripping the ban.
+        let removedFrameStateFields = [
+            "cursorRow", "cursorCol", "cursorShape", "cursorVisible", "gutterCol",
+            "windowGutters", "activeWindowId", "splitBorderColor", "verticalSeparators",
+            "horizontalSeparators", "windowIndentGuides",
         ]
+        let removedFieldPatterns = try removedFrameStateFields.map { field in
+            (field: field, regex: try NSRegularExpression(pattern: #"\bframeState\s*\.\s*"# + field + #"\b"#))
+        }
+        // `PreparedWindowUpdates` was the pre-AC6 fragmented per-window update
+        // bundle; the committed editor snapshot fully replaced it.
+        let preparedWindowUpdatesPattern = try NSRegularExpression(pattern: #"\bPreparedWindowUpdates\b"#)
+
         var violations: [String] = []
 
         for source in try productionSources() {
             for fragment in bannedFragments where source.sanitized.contains(fragment) {
-                guard allowedPaths[fragment, default: []].contains(source.path) else {
-                    violations.append("\(source.path): banned editor presentation fragment `\(fragment)`")
-                    continue
-                }
+                violations.append("\(source.path): banned editor presentation fragment `\(fragment)`")
+            }
+
+            let range = NSRange(source.sanitized.startIndex..<source.sanitized.endIndex, in: source.sanitized)
+            for banned in removedFieldPatterns
+            where banned.regex.firstMatch(in: source.sanitized, range: range) != nil {
+                violations.append("\(source.path): banned removed FrameState authority `frameState.\(banned.field)`")
+            }
+            if preparedWindowUpdatesPattern.firstMatch(in: source.sanitized, range: range) != nil {
+                violations.append("\(source.path): banned fragmented authority `PreparedWindowUpdates`")
             }
         }
 

--- a/macos/Tests/MingaTests/GUIObservationGuardrailTests.swift
+++ b/macos/Tests/MingaTests/GUIObservationGuardrailTests.swift
@@ -52,7 +52,6 @@ struct GUIObservationGuardrailTests {
         "Sources/Views/Overlays/WhichKeyState.swift#WhichKeyState": "protocol presentation owner",
         "Sources/Views/Settings/SettingsState.swift#SettingsState": "settings observable state",
         "Sources/Views/Shared/EditTimelineState.swift#EditTimelineState": "protocol presentation owner",
-        "Sources/Views/Shared/GUIFramePresentationMetrics.swift#GUIFramePresentationMetrics": "observable native correlation tickets",
         "Sources/Views/Shared/GUIState.swift#GUIThemeBacking": "observable theme backing",
         "Sources/Views/Shared/GUIState.swift#GUIWindowContentBacking": "observable resident-window backing",
         "Sources/Views/Shared/GUIState.swift#GUIState": "aggregate observable state",
@@ -72,8 +71,6 @@ struct GUIObservationGuardrailTests {
         "Sources/Views/EditorChrome/FeedbackState.swift: @ObservationIgnored private var lastMessage = \"\"": "feedback timing cache; rendered fields remain observed",
         "Sources/Views/EditorChrome/FeedbackState.swift: @ObservationIgnored private var showTask: Task<Void, Never>?": "task lifecycle handle, not rendered state",
         "Sources/Views/EditorChrome/FeedbackState.swift: @ObservationIgnored private var spinnerOnTime: ContinuousClock.Instant?": "timing bookkeeping, not rendered state",
-        "Sources/Views/Shared/GUIFramePresentationMetrics.swift: @ObservationIgnored private let log = OSLog(subsystem: \"com.minga.editor\", category: \"GUIFramePresentation\")": "telemetry logging handle, not rendered state",
-        "Sources/Views/Shared/GUIFramePresentationMetrics.swift: @ObservationIgnored private var samples: [Sample] = []": "debug telemetry sample buffer, not rendered state",
         "Sources/Views/Shared/GUIState.swift: @ObservationIgnored private let themeBacking = GUIThemeBacking()": "stable dependency reference; backing fields are observed",
         "Sources/Views/Shared/GUIState.swift: @ObservationIgnored private let windowContentBacking: GUIWindowContentBacking": "stable dependency reference; backing fields are observed",
         "Sources/Views/Shared/GUIState.swift: @ObservationIgnored public lazy private(set) var editorInput = EditorHostInput(": "stable host dependency bundle, not rendered state",
@@ -97,6 +94,35 @@ struct GUIObservationGuardrailTests {
             }
             for call in try revisionDrivenIdentityCalls(in: source.sanitized, original: source.contents) {
                 violations.append("\(source.path): revision/frame-token identity `\(call)`")
+            }
+        }
+
+        record(violations)
+    }
+
+    @Test("editor presentation paths do not regain fragmented authorities")
+    func editorPresentationRejectsFragmentedAuthorities() throws {
+        let bannedFragments = [
+            "func render(frameState:",
+            "render(frameState:",
+            "currentFrameWindowIds",
+            "frameState.dirty",
+            "markRendered(",
+            "editorInput?.currentWindowContents",
+            "visibleEditorSnapshot?.windowIds ?? dispatcher.committedEditorSnapshot",
+            "dispatcher.frameState.windowGutters",
+        ]
+        let allowedPaths: [String: Set<String>] = [
+            "dispatcher.frameState.windowGutters": ["Sources/PreviewRegistry.swift"],
+        ]
+        var violations: [String] = []
+
+        for source in try productionSources() {
+            for fragment in bannedFragments where source.sanitized.contains(fragment) {
+                guard allowedPaths[fragment, default: []].contains(source.path) else {
+                    violations.append("\(source.path): banned editor presentation fragment `\(fragment)`")
+                    continue
+                }
             }
         }
 
@@ -147,12 +173,8 @@ struct GUIObservationGuardrailTests {
                 "Sources/Renderer/CommandDispatcher.swift",
                 "Sources/Renderer/PreparedFrameTransaction.swift",
             ],
-            "pendingFrame": [
+            "expectedNativeDrawFrame": [
                 "Sources/Views/Shared/GUIFramePresentationMetrics.swift",
-            ],
-            "pendingEditorFrame": [
-                "Sources/Views/Shared/GUIFramePresentationMetrics.swift",
-                "Sources/Renderer/CommandDispatcher.swift",
             ],
             "pendingPresentationFrame": [
                 "Sources/Renderer/CommandDispatcher.swift",
@@ -176,14 +198,9 @@ struct GUIObservationGuardrailTests {
         }
 
         let exactAccessorOccurrences: [String: [String: Int]] = [
-            "pendingFrame": ["Sources/Views/Shared/GUIFramePresentationMetrics.swift": 2],
-            "pendingEditorFrame": [
-                "Sources/Views/Shared/GUIFramePresentationMetrics.swift": 1,
-                "Sources/Renderer/CommandDispatcher.swift": 1,
-            ],
+            "expectedNativeDrawFrame": ["Sources/Views/Shared/GUIFramePresentationMetrics.swift": 2],
             "pendingPresentationFrame": [
                 "Sources/Renderer/CommandDispatcher.swift": 1,
-                "Sources/Views/Editor/EditorNSView.swift": 1,
             ],
         ]
         for (accessor, expected) in exactAccessorOccurrences {
@@ -266,14 +283,15 @@ struct GUIObservationGuardrailTests {
         #expect(try discardedCorrelationReads(in: sanitizeSwiftSource("_ = item.id")).isEmpty)
     }
 
-    @Test("presentation metrics observe pending correlation and ignore only classified telemetry infrastructure")
+    @Test("presentation metrics remain passive frame-correlated telemetry")
     func metricsSourcePolicy() throws {
         let source = try source(at: "Sources/Views/Shared/GUIFramePresentationMetrics.swift")
-        #expect(source.sanitized.contains("@MainActor\n@Observable\npublic final class GUIFramePresentationMetrics"))
+        #expect(source.sanitized.contains("@MainActor\npublic final class GUIFramePresentationMetrics"))
+        #expect(!source.sanitized.contains("@Observable\npublic final class GUIFramePresentationMetrics"))
         #expect(source.sanitized.contains("private var pending: [GUIFrameImpact: Pending] = [:]"))
-        #expect(source.sanitized.contains("expectedFrame: metrics.pendingFrame(domain: domain)"))
+        #expect(source.sanitized.contains("expectedFrame: metrics.expectedNativeDrawFrame(domain: domain)"))
         #expect(source.sanitized.contains("func frameNativeDrawProbe("))
-        #expect(identifierTokens(in: source.sanitized).count { $0 == "pending" } == 13)
+        #expect(identifierTokens(in: source.sanitized).count { $0 == "pending" } == 12)
     }
 
     private func productionSources() throws -> [ProductionSource] {

--- a/macos/Tests/MingaTests/MouseInputTests.swift
+++ b/macos/Tests/MingaTests/MouseInputTests.swift
@@ -75,14 +75,125 @@ struct MouseInputTests {
             ]
         )
 
-        view.dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [], selection: nil,
             searchMatches: [], diagnosticUnderlines: [],
             documentHighlights: [],
             paneGeometry: geometry
-        )))
+        )
+        _ = try commitEditorFrame(view, contents: [content])
+    }
+
+    /// Required theme slots painted neutral grey so the keyframe theme-completeness
+    /// gate passes. Committed `themeColors` freeze from pre-apply defaults, so the
+    /// values do not affect hit testing.
+    @MainActor
+    private func committedThemeSlots() -> [(UInt8, UInt8, UInt8, UInt8)] {
+        CommandDispatcher.requiredThemeSlots.map { ($0, 0x99, 0x99, 0x99) }
+    }
+
+    /// Derives a committed pane geometry from a gutter so the snapshot freeze
+    /// accepts the surface. Mirrors the production/preview geometry derivation:
+    /// the editor authority now lives only on `CommittedEditorSnapshot` (#2999
+    /// AC6), so tests drive a real keyframe rather than mutating removed
+    /// `FrameState` fields.
+    @MainActor
+    private func paneGeometry(
+        for gutter: Wire.WindowGutter,
+        viewport: GUIViewportSummary? = nil,
+        hitRegions: [GUIHitRegion] = []
+    ) -> GUIPaneGeometry {
+        let gutterWidth = min(UInt16(gutter.lineNumberWidth) + UInt16(gutter.signColWidth), gutter.contentWidth)
+        let totalRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutter.contentWidth, height: gutter.contentHeight)
+        let textRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol + gutterWidth, width: gutter.contentWidth - gutterWidth, height: gutter.contentHeight)
+        let gutterRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutterWidth, height: gutter.contentHeight)
+        let resolvedViewport = viewport ?? GUIViewportSummary(
+            top: 0, left: 0, rows: gutter.contentHeight, cols: textRect.width,
+            totalLines: UInt32(gutter.contentHeight), visualRowOffset: 0, totalVisualRows: UInt32(gutter.contentHeight)
+        )
+        return GUIPaneGeometry(
+            windowId: gutter.windowId,
+            totalRect: totalRect,
+            contentRect: totalRect,
+            textRect: textRect,
+            gutterRect: gutterRect,
+            clipRect: totalRect,
+            viewport: resolvedViewport,
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: UInt16(gutter.lineNumberWidth), signColWidth: UInt16(gutter.signColWidth)),
+            hitRegions: hitRegions
+        )
+    }
+
+    /// Builds a complete window surface content matching a gutter's geometry so
+    /// the committed keyframe can carry the gutter (every committed gutter needs
+    /// a referencing window content with a compatible pane geometry).
+    @MainActor
+    private func windowContent(
+        for gutter: Wire.WindowGutter,
+        rows: [GUIVisualRow] = [],
+        geometry: GUIPaneGeometry? = nil,
+        scrollPresentation: GUIScrollPresentation? = nil
+    ) throws -> GUIWindowContent {
+        try GUIWindowContent(
+            windowId: gutter.windowId, fullRefresh: true,
+            cursorRow: 0, cursorCol: 0, cursorShape: .block,
+            rows: rows, selection: nil,
+            searchMatches: [], diagnosticUnderlines: [],
+            documentHighlights: [],
+            paneGeometry: geometry ?? paneGeometry(for: gutter),
+            scrollPresentation: scrollPresentation
+        )
+    }
+
+    /// Publishes an editor keyframe through the real begin/commit path so the
+    /// committed snapshot is the sole editor authority, then (by default) promotes
+    /// it to the visible presentation that production hit testing reads via
+    /// `dispatcher.visibleEditorPresentation?.snapshot`. Pass `promote: false` to
+    /// model a committed-but-unpresented frame whose gutters must stay invisible
+    /// to interaction.
+    @MainActor
+    @discardableResult
+    private func commitEditorFrame(
+        _ view: EditorNSView,
+        frameSeq: UInt32 = 1,
+        contents: [GUIWindowContent] = [],
+        gutters: [Wire.WindowGutter] = [],
+        indentGuides: [IndentGuideData] = [],
+        cursorShape: CursorShape? = nil,
+        splitSeparators: (borderColor: UInt32, verticals: [Wire.VerticalSeparator], horizontals: [Wire.HorizontalSeparator])? = nil,
+        promote: Bool = true,
+        localTransform: EditorLocalPresentationTransform? = nil
+    ) throws -> CommittedEditorSnapshot {
+        let dispatcher = view.dispatcher
+        dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: 0, generation: 1))
+        dispatcher.dispatch(.guiTheme(slots: committedThemeSlots()))
+        if let cursorShape {
+            dispatcher.dispatch(.setCursorShape(cursorShape))
+        }
+        for content in contents {
+            dispatcher.dispatch(.guiWindowContent(data: content))
+        }
+        for gutter in gutters {
+            dispatcher.dispatch(.guiGutter(data: gutter))
+        }
+        for guides in indentGuides {
+            dispatcher.dispatch(.guiIndentGuides(data: guides))
+        }
+        if let splitSeparators {
+            dispatcher.dispatch(.guiSplitSeparators(
+                borderColor: splitSeparators.borderColor,
+                verticals: splitSeparators.verticals,
+                horizontals: splitSeparators.horizontals
+            ))
+        }
+        dispatcher.dispatch(.commitFrame(frameSeq: frameSeq, seq: 0))
+        let snapshot = try #require(dispatcher.committedEditorSnapshot)
+        if promote {
+            dispatcher.promoteVisibleEditorPresentation(snapshot: snapshot, localTransform: localTransform)
+        }
+        return snapshot
     }
 
     /// Creates a mouse event at the given pixel position.
@@ -153,7 +264,7 @@ struct MouseInputTests {
         let cw = view.cellWidth
         let ch = view.cellHeight
 
-        view.dispatcher.applyForTesting(.guiSplitSeparators(
+        try commitEditorFrame(view, splitSeparators: (
             borderColor: 0x555555,
             verticals: [Wire.VerticalSeparator(col: 40, startRow: 0, endRow: 23)],
             horizontals: []
@@ -174,7 +285,7 @@ struct MouseInputTests {
         let cw = view.cellWidth
         let ch = view.cellHeight
 
-        view.dispatcher.applyForTesting(.guiSplitSeparators(
+        try commitEditorFrame(view, splitSeparators: (
             borderColor: 0x555555,
             verticals: [Wire.VerticalSeparator(col: 40, startRow: 0, endRow: 23)],
             horizontals: []
@@ -225,8 +336,11 @@ struct MouseInputTests {
             isActive: true, contentWidth: 39, cursorLine: 3, lineNumberStyle: .hybrid,
             lineNumberWidth: 8, signColWidth: 1, entries: []
         )
-        view.dispatcher.applyForTesting(.guiGutter(data: clickedGutter))
-        view.dispatcher.applyForTesting(.guiGutter(data: activeWideGutter))
+        try commitEditorFrame(
+            view,
+            contents: [try windowContent(for: clickedGutter), try windowContent(for: activeWideGutter)],
+            gutters: [clickedGutter, activeWideGutter]
+        )
 
         let firstTextColX = CoreTextMetalRenderer.gutterLeftMarginPt + CGFloat(clickedGutter.lineNumberWidth + clickedGutter.signColWidth) * cw + CoreTextMetalRenderer.gutterRightGapPt + cw * 0.2
         guard let event = mouseEvent(type: .leftMouseDown, location: NSPoint(x: firstTextColX, y: ch * 2.5)) else { return }
@@ -352,20 +466,20 @@ struct MouseInputTests {
                 Wire.GutterEntry(bufLine: 42, displayType: .foldStart, signType: .none, foldEndLine: 50)
             ]
         )
-        view.dispatcher.applyForTesting(.guiGutter(data: activeGutter))
-        view.dispatcher.applyForTesting(.guiGutter(data: inactiveGutter))
-        view.dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
-            windowId: 7, fullRefresh: true,
-            cursorRow: 0, cursorCol: 0, cursorShape: .block,
-            rows: [], selection: nil,
-            searchMatches: [], diagnosticUnderlines: [],
-            documentHighlights: [],
+        let activeContent = try windowContent(for: activeGutter)
+        let inactiveContent = try windowContent(
+            for: inactiveGutter,
             scrollPresentation: GUIScrollPresentation(
                 windowId: 7, resetRequired: false, anchorTop: 42, anchorLeft: 0, anchorVisualRowOffset: 0,
                 visibleStartLine: 42, visibleEndLine: 43, overscanStartLine: 41, overscanEndLine: 43,
                 contentEpoch: 1, layoutGeneration: 1
             )
-        )))
+        )
+        try commitEditorFrame(
+            view,
+            contents: [activeContent, inactiveContent],
+            gutters: [activeGutter, inactiveGutter]
+        )
 
         guard let event = mouseEvent(type: .leftMouseDown,
                                      location: NSPoint(x: cw * 22.2, y: ch * 0.5)) else { return }
@@ -403,8 +517,7 @@ struct MouseInputTests {
             hitRegions: []
         )
 
-        view.dispatcher.applyForTesting(.guiGutter(data: gutter))
-        view.dispatcher.applyForTesting(.guiWindowContent(data: try GUIWindowContent(
+        let content = try GUIWindowContent(
             windowId: 7, fullRefresh: true,
             cursorRow: 0, cursorCol: 0, cursorShape: .block,
             rows: [
@@ -419,7 +532,8 @@ struct MouseInputTests {
                 visibleStartLine: 10, visibleEndLine: 12, overscanStartLine: 10, overscanEndLine: 12,
                 contentEpoch: 1, layoutGeneration: 1
             )
-        )))
+        )
+        try commitEditorFrame(view, contents: [content], gutters: [gutter])
 
         guard let event = mouseEvent(type: .leftMouseDown,
                                      location: NSPoint(x: cw * 6.2, y: ch * 0.5)) else { return }
@@ -444,18 +558,28 @@ struct MouseInputTests {
         #expect(normalized.y > 3.0)
     }
 
-    @Test("mouseDown ignores stale gutter data from a previous frame")
+    @Test("mouseDown ignores committed-but-unpresented gutter data")
     @MainActor func staleGutterIgnoredForHitTesting() throws {
         let spy = SpyEncoder()
         guard let view = makeView(spy: spy) else { return }
         let cw = view.cellWidth
         let ch = view.cellHeight
 
-        view.dispatcher.frameState.windowGutters[9] = Wire.WindowGutter(
+        // A gutter that was committed but whose frame never reached the display
+        // surface must stay invisible to interaction: production hit testing reads
+        // only the promoted `visibleEditorPresentation`, so a committed-but-unpromoted
+        // snapshot is a draw input, not an interaction authority.
+        let staleGutter = Wire.WindowGutter(
             windowId: 9, contentRow: 0, contentCol: 5, contentHeight: 24,
             isActive: true, contentWidth: 80, cursorLine: 42, lineNumberStyle: .hybrid,
             lineNumberWidth: 4, signColWidth: 3,
             entries: [Wire.GutterEntry(bufLine: 42, displayType: .foldStart, signType: .none, foldEndLine: 50)]
+        )
+        try commitEditorFrame(
+            view,
+            contents: [try windowContent(for: staleGutter)],
+            gutters: [staleGutter],
+            promote: false
         )
 
         guard let event = mouseEvent(type: .leftMouseDown,

--- a/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
+++ b/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
@@ -713,6 +713,71 @@ struct NativeRenderResourcesTests {
         #expect(renderer.activeResourceSnapshot() != before)
     }
 
+    @Test("warm native slots reuse draw buffers and render targets after three in-flight generations")
+    @MainActor func warmNativeSlotsReuseResources() throws {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+        let row = GUIVisualRow(rowType: .normal, rowId: 51, bufLine: 0,
+                               contentHash: 51, text: "warm", spans: [])
+        let content = try GUIWindowContent(
+            windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0,
+            cursorShape: .block, rows: [row], selection: nil,
+            searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+        )
+        var frame = FrameState(cols: 4, rows: 4)
+        frame.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 4,
+            isActive: true, contentWidth: 4, cursorLine: 0,
+            lineNumberStyle: .none, lineNumberWidth: 0, signColWidth: 0,
+            entries: [.init(bufLine: 0, displayType: .normal, signType: .none)]
+        )
+
+        var bufferAllocations = 0
+        var textureAllocations = 0
+        var factories = nativeTestFactories()
+        factories.makeBuffer = { device, length, options in
+            bufferAllocations += 1
+            return device.makeBuffer(length: length, options: options)
+        }
+        factories.makeTexture = { device, descriptor in
+            textureAllocations += 1
+            return device.makeTexture(descriptor: descriptor)
+        }
+        factories.observeCompletion = { _, completion in
+            completion(true, Int(MTLCommandBufferStatus.completed.rawValue))
+        }
+        factories.present = { _ in }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+
+        for seq in 1...3 {
+            renderer.render(
+                frameState: frame, fontManager: fontManager,
+                windowContents: [1: content], drawableProvider: { NativeTestDrawable(texture: texture) },
+                viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
+                presentationInputSeq: UInt32(seq)
+            )
+        }
+        let warmBufferAllocations = bufferAllocations
+        let warmTextureAllocations = textureAllocations
+
+        renderer.render(
+            frameState: frame, fontManager: fontManager,
+            windowContents: [1: content], drawableProvider: { NativeTestDrawable(texture: texture) },
+            viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
+            presentationInputSeq: 4
+        )
+
+        #expect(bufferAllocations == warmBufferAllocations)
+        #expect(textureAllocations == warmTextureAllocations)
+        #expect(renderer.lastCompletedPresentationGeneration == 4)
+    }
+
     @Test("failed frame preserves a populated completed frame")
     @MainActor func failedFramePreservesPopulatedFrame() throws {
         guard let device = MTLCreateSystemDefaultDevice() else { return }

--- a/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
+++ b/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
@@ -348,15 +348,36 @@ struct NativeRenderResourcesTests {
     }
 
     @Test("late older completion cannot replace a newer completed generation")
-    func completionOrdering() {
+    func completionOrdering() throws {
         var ordering = NativePresentationGeneration()
-        let older = ordering.issue()
-        let newer = ordering.issue()
-        let promotedNewer = ordering.complete(newer)
-        let promotedOlder = ordering.complete(older)
+        let olderReservation = ordering.issue(slotCount: 3)
+        let newerReservation = ordering.issue(slotCount: 3)
+        let older = try #require(olderReservation)
+        let newer = try #require(newerReservation)
+        let promotedNewer = ordering.complete(newer.generation)
+        let promotedOlder = ordering.complete(older.generation)
         #expect(promotedNewer)
         #expect(!promotedOlder)
-        #expect(ordering.completed == newer)
+        #expect(ordering.completed == newer.generation)
+        #expect(ordering.inFlightCount == 0)
+    }
+
+    @Test("retired generation releases its native frame slot")
+    func retirementReleasesSlot() throws {
+        var ordering = NativePresentationGeneration()
+        let firstReservation = ordering.issue(slotCount: 2)
+        let secondReservation = ordering.issue(slotCount: 2)
+        let first = try #require(firstReservation)
+        let second = try #require(secondReservation)
+        #expect(ordering.issue(slotCount: 2) == nil)
+
+        ordering.retire(first.generation)
+        let replacementReservation = ordering.issue(slotCount: 2)
+        let replacement = try #require(replacementReservation)
+
+        #expect(replacement.slot == first.slot)
+        #expect(replacement.slot != second.slot)
+        #expect(ordering.inFlightCount == 2)
     }
 
     @Test("production raster allocator refusal is a typed local failure")
@@ -658,6 +679,44 @@ struct NativeRenderResourcesTests {
         #expect(reports.first?.phase == .completion)
         #expect(renderer.activeResourceSnapshot() == before)
         #expect(renderer.lastCompletedPresentationGeneration == 0)
+    }
+
+    @Test("renderer recovers after three consecutive completion failures")
+    @MainActor func completionFailuresReleaseNativeSlots() {
+        guard let device = MTLCreateSystemDefaultDevice() else { return }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else { return }
+
+        var completionCalls = 0
+        var presentCalls = 0
+        var reports: [NativePresentationFailure] = []
+        var factories = nativeTestFactories()
+        factories.observeCompletion = { _, completion in
+            completionCalls += 1
+            let succeeds = completionCalls > 3
+            completion(succeeds, Int((succeeds ? MTLCommandBufferStatus.completed : .error).rawValue))
+        }
+        factories.present = { _ in presentCalls += 1 }
+        factories.reportFailure = { reports.append($0) }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+
+        for sequence in 1...4 {
+            renderer.render(
+                frameState: FrameState(cols: 4, rows: 4), fontManager: fontManager,
+                drawableProvider: { NativeTestDrawable(texture: texture) },
+                viewportSize: CGSize(width: 64, height: 64), contentScale: 1,
+                presentationInputSeq: UInt32(sequence)
+            )
+        }
+
+        #expect(reports.count == 3)
+        #expect(presentCalls == 1)
+        #expect(renderer.lastCompletedPresentationGeneration == 4)
     }
 
     @Test("candidate presents and promotes only after both commands complete")

--- a/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
+++ b/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
@@ -20,6 +20,22 @@ private final class NativeTestDrawable: NSObject, CAMetalDrawable {
 
 private enum InjectedSubmissionFailure: Error { case failed }
 
+/// Zero-gutter pane geometry so `render(frameState:windowContents:)` fixtures can
+/// build a committed snapshot without seeding removed `FrameState` gutter fields
+/// (#2999 AC6). The gutter authority now lives on the snapshot's surfaces.
+private func nativeContentGeometry(windowId: UInt16 = 1, cols: UInt16, rows: UInt16) -> GUIPaneGeometry {
+    let rect = GUICellRect(row: 0, col: 0, width: cols, height: rows)
+    return GUIPaneGeometry(
+        windowId: windowId,
+        totalRect: rect, contentRect: rect, textRect: rect,
+        gutterRect: GUICellRect(row: 0, col: 0, width: 0, height: rows),
+        clipRect: rect,
+        viewport: GUIViewportSummary(top: 0, left: 0, rows: rows, cols: cols, totalLines: UInt32(rows), visualRowOffset: 0, totalVisualRows: UInt32(rows)),
+        gutterMetrics: GUIGutterMetrics(lineNumberWidth: 0, signColWidth: 0),
+        hitRegions: []
+    )
+}
+
 @Suite("Failure-atomic native render demand")
 struct NativeRenderResourcesTests {
     private let policy = FrameResourcePolicy.NativeRendererLimits(
@@ -489,15 +505,10 @@ struct NativeRenderResourcesTests {
         let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0,
             cursorShape: .block, rows: [row], selection: nil,
-            searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+            searchMatches: [], diagnosticUnderlines: [], documentHighlights: [],
+            paneGeometry: nativeContentGeometry(cols: 40, rows: 2)
         )
-        var frame = FrameState(cols: 40, rows: 2)
-        frame.windowGutters[1] = Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 2,
-            isActive: true, contentWidth: 40, cursorLine: 0,
-            lineNumberStyle: .absolute, lineNumberWidth: 2, signColWidth: 1,
-            entries: [.init(bufLine: 0, displayType: .normal, signType: .none)]
-        )
+        let frame = FrameState(cols: 40, rows: 2)
         let expected: [NativeRenderResourceDimension] = [
             .lineBuffer, .quadBuffer0, .quadBuffer1, .quadBuffer2
         ]
@@ -552,15 +563,10 @@ struct NativeRenderResourcesTests {
         let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0,
             cursorShape: .block, rows: [row], selection: nil,
-            searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+            searchMatches: [], diagnosticUnderlines: [], documentHighlights: [],
+            paneGeometry: nativeContentGeometry(cols: 40, rows: 2)
         )
-        var frame = FrameState(cols: 40, rows: 2)
-        frame.windowGutters[1] = Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 2,
-            isActive: true, contentWidth: 40, cursorLine: 0,
-            lineNumberStyle: .none, lineNumberWidth: 0, signColWidth: 0,
-            entries: [.init(bufLine: 0, displayType: .normal, signType: .none)]
-        )
+        let frame = FrameState(cols: 40, rows: 2)
         let cases: [(NativePresentationFailure.Phase, (inout NativeRenderFactories) -> Void)] = [
             (.atlas, { factories in factories.makeTexture = { _, _ in nil } }),
             (.raster, { factories in
@@ -785,15 +791,10 @@ struct NativeRenderResourcesTests {
         let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0,
             cursorShape: .block, rows: [row], selection: nil,
-            searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+            searchMatches: [], diagnosticUnderlines: [], documentHighlights: [],
+            paneGeometry: nativeContentGeometry(cols: 4, rows: 4)
         )
-        var frame = FrameState(cols: 4, rows: 4)
-        frame.windowGutters[1] = Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 4,
-            isActive: true, contentWidth: 4, cursorLine: 0,
-            lineNumberStyle: .none, lineNumberWidth: 0, signColWidth: 0,
-            entries: [.init(bufLine: 0, displayType: .normal, signType: .none)]
-        )
+        let frame = FrameState(cols: 4, rows: 4)
 
         var bufferAllocations = 0
         var textureAllocations = 0
@@ -898,15 +899,10 @@ struct NativeRenderResourcesTests {
         let content = try GUIWindowContent(
             windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0,
             cursorShape: .block, rows: [row], selection: nil,
-            searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+            searchMatches: [], diagnosticUnderlines: [], documentHighlights: [],
+            paneGeometry: nativeContentGeometry(cols: 4, rows: 4)
         )
-        var frame = FrameState(cols: 4, rows: 4)
-        frame.windowGutters[1] = Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 4,
-            isActive: true, contentWidth: 4, cursorLine: 0,
-            lineNumberStyle: .none, lineNumberWidth: 0, signColWidth: 0,
-            entries: [.init(bufLine: 0, displayType: .normal, signType: .none)]
-        )
+        let frame = FrameState(cols: 4, rows: 4)
 
         var refuseSubmission = false
         var reports: [NativePresentationFailure] = []

--- a/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
+++ b/macos/Tests/MingaTests/NativeRenderResourcesTests.swift
@@ -778,6 +778,54 @@ struct NativeRenderResourcesTests {
         #expect(renderer.lastCompletedPresentationGeneration == 4)
     }
 
+    @Test("a fourth native generation is rejected while three are in flight")
+    @MainActor func fourthInFlightGenerationIsRejected() {
+        guard let device = MTLCreateSystemDefaultDevice() else {
+            Issue.record("Metal device is required for native generation coverage")
+            return
+        }
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 64, height: 64, mipmapped: false
+        )
+        descriptor.usage = .renderTarget
+        guard let texture = device.makeTexture(descriptor: descriptor) else {
+            Issue.record("Metal texture is required for native generation coverage")
+            return
+        }
+
+        typealias Completion = @MainActor @Sendable (Bool, Int) -> Void
+        var completions: [Completion] = []
+        var reports: [NativePresentationFailure] = []
+        var factories = nativeTestFactories()
+        factories.observeCompletion = { _, completion in completions.append(completion) }
+        factories.reportFailure = { reports.append($0) }
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else {
+            Issue.record("Native renderer is required for generation coverage")
+            return
+        }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let drawable = NativeTestDrawable(texture: texture)
+
+        for sequence in 1...4 {
+            renderer.render(
+                frameState: FrameState(cols: 4, rows: 4),
+                fontManager: fontManager,
+                drawableProvider: { drawable },
+                viewportSize: CGSize(width: 64, height: 64),
+                contentScale: 1,
+                presentationInputSeq: UInt32(sequence)
+            )
+        }
+
+        #expect(completions.count == 3)
+        #expect(reports.count == 1)
+        #expect(reports.first?.phase == .command)
+        #expect(reports.first?.dimension == .submission)
+        #expect(reports.first?.frameSequence == 4)
+        #expect(renderer.lastCompletedPresentationGeneration == 0)
+    }
+
     @Test("failed frame preserves a populated completed frame")
     @MainActor func failedFramePreservesPopulatedFrame() throws {
         guard let device = MTLCreateSystemDefaultDevice() else { return }

--- a/macos/Tests/MingaTests/OffscreenMetalReadback.swift
+++ b/macos/Tests/MingaTests/OffscreenMetalReadback.swift
@@ -161,6 +161,7 @@ enum OffscreenReadback {
 
     /// Read `texture` back into a CPU image via a test-queue blit to a
     /// `storageModeShared` buffer, awaiting GPU completion asynchronously.
+    @MainActor
     static func read(texture: MTLTexture, queue: MTLCommandQueue) async -> ReadbackImage? {
         guard texture.device.registryID == queue.device.registryID else { return nil }
         let device = texture.device
@@ -185,7 +186,7 @@ enum OffscreenReadback {
         blit.endEncoding()
 
         let completed = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
-            cmd.addCompletedHandler { completed in
+            cmd.addCompletedHandler { @Sendable completed in
                 continuation.resume(returning: completed.status == .completed)
             }
             cmd.commit()
@@ -260,7 +261,7 @@ final class QueuedCompletionCoordinator {
     /// deterministic draining instead of being invoked immediately.
     func observeCompletion(_ commandBuffer: MTLCommandBuffer,
                            _ completion: @escaping @MainActor @Sendable (Bool, Int) -> Void) {
-        commandBuffer.addCompletedHandler { completed in
+        commandBuffer.addCompletedHandler { @Sendable completed in
             let succeeded = completed.status == .completed
             let status = Int(completed.status.rawValue)
             Task { @MainActor in

--- a/macos/Tests/MingaTests/OffscreenMetalReadback.swift
+++ b/macos/Tests/MingaTests/OffscreenMetalReadback.swift
@@ -1,0 +1,310 @@
+import Foundation
+import Metal
+import QuartzCore
+@testable import MingaUI
+
+/// Test-only offscreen Metal readback harness for the temporal renderer
+/// acceptance tests.
+///
+/// The production renderer draws into a private target and then blits into a
+/// `CAMetalDrawable`. To assert on real GPU-rendered, drawable-copy-completed
+/// pixels without blocking the main actor, each fake drawable owns a uniquely
+/// allocated `bgra8Unorm_srgb` texture. After `onPresented` fires, we read that texture through a
+/// dedicated test queue blit into a `storageModeShared` buffer whose
+/// `bytesPerRow` is rounded up to 256. Completion is awaited asynchronously via
+/// `addCompletedHandler` bridged to a continuation, never `waitUntilCompleted`,
+/// never a semaphore/sleep/run-loop spin, and never blocking the main actor.
+
+/// A `CAMetalDrawable` that owns its own texture so out-of-order A/B frames
+/// cannot alias one shared surface.
+final class ReadbackDrawable: NSObject, CAMetalDrawable {
+    let texture: MTLTexture
+    let layer = CAMetalLayer()
+    let drawableID: Int
+    let presentedTime: CFTimeInterval = 0
+    private(set) var presentCount = 0
+
+    init(texture: MTLTexture, drawableID: Int = 1) {
+        self.texture = texture
+        self.drawableID = drawableID
+    }
+
+    func present() { presentCount += 1 }
+    func present(at presentationTime: CFTimeInterval) { presentCount += 1; _ = presentationTime }
+    func present(afterMinimumDuration duration: CFTimeInterval) { presentCount += 1; _ = duration }
+    func addPresentedHandler(_ block: @escaping MTLDrawablePresentedHandler) { _ = block }
+}
+
+/// A single normalized (0...1) BGRA pixel color sample.
+struct PixelColor: Equatable {
+    let r: Double
+    let g: Double
+    let b: Double
+    let a: Double
+
+    /// Squared Euclidean RGB distance to another color; cheap classifier metric.
+    func rgbDistanceSquared(to other: PixelColor) -> Double {
+        let dr = r - other.r, dg = g - other.g, db = b - other.b
+        return dr * dr + dg * dg + db * db
+    }
+}
+
+/// A CPU-side snapshot of a presented drawable texture.
+struct ReadbackImage {
+    let width: Int
+    let height: Int
+    let bytesPerRow: Int
+    let bytes: [UInt8]
+
+    /// Sample the pixel at (x, y). Texture bytes are BGRA8 (sRGB-encoded).
+    func pixel(x: Int, y: Int) -> PixelColor {
+        precondition(x >= 0 && x < width && y >= 0 && y < height, "pixel out of bounds")
+        let offset = y * bytesPerRow + x * 4
+        let b = Double(bytes[offset + 0]) / 255.0
+        let g = Double(bytes[offset + 1]) / 255.0
+        let r = Double(bytes[offset + 2]) / 255.0
+        let a = Double(bytes[offset + 3]) / 255.0
+        return PixelColor(r: r, g: g, b: b, a: a)
+    }
+
+    /// Count pixels inside a rectangle whose RGB distance to `reference`
+    /// exceeds `threshold` (squared). Used to prove occupancy while tolerating
+    /// antialiasing at glyph edges.
+    func occupancy(x0: Int, y0: Int, x1: Int, y1: Int,
+                   differingFrom reference: PixelColor, thresholdSquared: Double) -> Int {
+        var count = 0
+        let lox = max(0, x0), loy = max(0, y0)
+        let hix = min(width, x1), hiy = min(height, y1)
+        var y = loy
+        while y < hiy {
+            var x = lox
+            while x < hix {
+                if pixel(x: x, y: y).rgbDistanceSquared(to: reference) > thresholdSquared {
+                    count += 1
+                }
+                x += 1
+            }
+            y += 1
+        }
+        return count
+    }
+
+    /// Count pixels whose RGB distance from `reference` is within `thresholdSquared`.
+    func matching(x0: Int, y0: Int, x1: Int, y1: Int,
+                  reference: PixelColor, thresholdSquared: Double) -> Int {
+        var count = 0
+        let lox = max(0, x0), loy = max(0, y0)
+        let hix = min(width, x1), hiy = min(height, y1)
+        var y = loy
+        while y < hiy {
+            var x = lox
+            while x < hix {
+                if pixel(x: x, y: y).rgbDistanceSquared(to: reference) <= thresholdSquared {
+                    count += 1
+                }
+                x += 1
+            }
+            y += 1
+        }
+        return count
+    }
+
+    /// Classify every pixel in a rectangle as nearer to `a` or `b`.
+    /// Returns (aCount, bCount, ambiguousCount) where ambiguous pixels are
+    /// within `ambiguousBand` (squared) of the midpoint distance — i.e. edge
+    /// antialiasing that belongs to neither region.
+    func classifyAB(x0: Int, y0: Int, x1: Int, y1: Int,
+                    a: PixelColor, b: PixelColor,
+                    ambiguousBand: Double) -> (a: Int, b: Int, ambiguous: Int) {
+        var aCount = 0, bCount = 0, ambiguous = 0
+        let lox = max(0, x0), loy = max(0, y0)
+        let hix = min(width, x1), hiy = min(height, y1)
+        var y = loy
+        while y < hiy {
+            var x = lox
+            while x < hix {
+                let p = pixel(x: x, y: y)
+                let da = p.rgbDistanceSquared(to: a)
+                let db = p.rgbDistanceSquared(to: b)
+                if abs(da - db) <= ambiguousBand {
+                    ambiguous += 1
+                } else if da < db {
+                    aCount += 1
+                } else {
+                    bCount += 1
+                }
+                x += 1
+            }
+            y += 1
+        }
+        return (aCount, bCount, ambiguous)
+    }
+}
+
+enum OffscreenReadback {
+    /// Round `value` up to the nearest multiple of `alignment`.
+    static func alignUp(_ value: Int, to alignment: Int) -> Int {
+        let remainder = value % alignment
+        return remainder == 0 ? value : value + (alignment - remainder)
+    }
+
+    /// Allocate a fresh, uniquely owned `bgra8Unorm_srgb` texture usable both as
+    /// the renderer's blit destination and as a blit source for readback.
+    static func makeDrawableTexture(device: MTLDevice, width: Int, height: Int) -> MTLTexture? {
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: width, height: height, mipmapped: false
+        )
+        descriptor.usage = [.renderTarget, .shaderRead]
+        descriptor.storageMode = .private
+        return device.makeTexture(descriptor: descriptor)
+    }
+
+    /// Read `texture` back into a CPU image via a test-queue blit to a
+    /// `storageModeShared` buffer, awaiting GPU completion asynchronously.
+    static func read(texture: MTLTexture, queue: MTLCommandQueue) async -> ReadbackImage? {
+        guard texture.device.registryID == queue.device.registryID else { return nil }
+        let device = texture.device
+        let width = texture.width
+        let height = texture.height
+        let bytesPerRow = alignUp(width * 4, to: 256)
+        let byteCount = bytesPerRow * height
+        guard let buffer = device.makeBuffer(length: byteCount, options: .storageModeShared),
+              let cmd = queue.makeCommandBuffer(),
+              let blit = cmd.makeBlitCommandEncoder() else { return nil }
+
+        blit.copy(
+            from: texture,
+            sourceSlice: 0, sourceLevel: 0,
+            sourceOrigin: MTLOrigin(x: 0, y: 0, z: 0),
+            sourceSize: MTLSize(width: width, height: height, depth: 1),
+            to: buffer,
+            destinationOffset: 0,
+            destinationBytesPerRow: bytesPerRow,
+            destinationBytesPerImage: byteCount
+        )
+        blit.endEncoding()
+
+        let completed = await withCheckedContinuation { (continuation: CheckedContinuation<Bool, Never>) in
+            cmd.addCompletedHandler { completed in
+                continuation.resume(returning: completed.status == .completed)
+            }
+            cmd.commit()
+        }
+        guard completed else { return nil }
+
+        let pointer = buffer.contents().bindMemory(to: UInt8.self, capacity: byteCount)
+        let bytes = Array(UnsafeBufferPointer(start: pointer, count: byteCount))
+        return ReadbackImage(width: width, height: height, bytesPerRow: bytesPerRow, bytes: bytes)
+    }
+}
+
+/// Terminal outcome of one production render: exactly one of these fires for a
+/// frame that is neither superseded nor discarded.
+enum PresentationOutcome {
+    case presented(CommittedEditorSnapshot)
+    case failed(NativePresentationFailure)
+}
+
+/// Bridges the renderer's asynchronous, production-style `onPresented` /
+/// `reportFailure` callbacks to a single `await`. Resumes on the first terminal
+/// event, so success and failure paths both make progress without any timeout,
+/// sleep, or main-actor block.
+@MainActor
+final class PresentationWaiter {
+    private enum State {
+        case idle
+        case awaiting(CheckedContinuation<PresentationOutcome, Never>)
+    }
+
+    private var state = State.idle
+
+    func succeed(_ snapshot: CommittedEditorSnapshot) { finish(.presented(snapshot)) }
+    func fail(_ failure: NativePresentationFailure) { finish(.failed(failure)) }
+
+    private func finish(_ outcome: PresentationOutcome) {
+        guard case .awaiting(let continuation) = state else { return }
+        state = .idle
+        continuation.resume(returning: outcome)
+    }
+
+    /// Verifies the previous frame completed before this waiter is reused.
+    func reset() {
+        guard case .idle = state else {
+            preconditionFailure("cannot reset while awaiting a presentation outcome")
+        }
+    }
+
+    /// Runs `body` (which starts the render) and awaits the first terminal event.
+    func awaitOutcome(running body: @MainActor () -> Void) async -> PresentationOutcome {
+        await withCheckedContinuation { continuation in
+            guard case .idle = state else {
+                preconditionFailure("cannot await two presentation outcomes concurrently")
+            }
+            state = .awaiting(continuation)
+            body()
+        }
+    }
+}
+
+/// Deterministically re-orders production `addCompletedHandler` completions
+/// without faking their success/status. GPU work still runs for real (so pixels
+/// are real); only the main-actor *delivery* of each completion is queued so a
+/// test can promote frames out of submission order.
+@MainActor
+final class QueuedCompletionCoordinator {
+    private var pending: [() -> Void] = []
+    private var waiters: [(Int, CheckedContinuation<Void, Never>)] = []
+
+    /// The production-style observeCompletion seam: real `addCompletedHandler`
+    /// plus `Task { @MainActor }`, but the completion closure is enqueued for
+    /// deterministic draining instead of being invoked immediately.
+    func observeCompletion(_ commandBuffer: MTLCommandBuffer,
+                           _ completion: @escaping @MainActor @Sendable (Bool, Int) -> Void) {
+        commandBuffer.addCompletedHandler { completed in
+            let succeeded = completed.status == .completed
+            let status = Int(completed.status.rawValue)
+            Task { @MainActor in
+                self.enqueue { completion(succeeded, status) }
+            }
+        }
+    }
+
+    private func enqueue(_ work: @escaping () -> Void) {
+        pending.append(work)
+        resumeSatisfiedWaiters()
+    }
+
+    private func resumeSatisfiedWaiters() {
+        waiters.removeAll { count, cont in
+            if pending.count >= count {
+                cont.resume()
+                return true
+            }
+            return false
+        }
+    }
+
+    /// Suspend until at least `count` completions have been enqueued.
+    func waitForPending(_ count: Int) async {
+        if pending.count >= count { return }
+        await withCheckedContinuation { (cont: CheckedContinuation<Void, Never>) in
+            waiters.append((count, cont))
+        }
+    }
+
+    /// Invoke and remove the first pending completion. Invoking a completion may
+    /// enqueue a follow-on completion (the presentation-copy stage).
+    func flushFirst() {
+        guard !pending.isEmpty else { return }
+        let work = pending.removeFirst()
+        work()
+    }
+
+    /// Invoke the most recently enqueued completion so tests can deliver a newer serially submitted frame before an older one.
+    func flushLast() {
+        guard let work = pending.popLast() else { return }
+        work()
+    }
+
+    var pendingCount: Int { pending.count }
+}

--- a/macos/Tests/MingaTests/RenderPerformanceGateTests.swift
+++ b/macos/Tests/MingaTests/RenderPerformanceGateTests.swift
@@ -321,3 +321,100 @@ struct RenderPerformanceGateTests {
         )
     }
 }
+
+@Suite("Native render performance gate")
+struct NativeRenderPerformanceGateTests {
+    @Test("ticket budgets pass at their exact boundaries")
+    func exactBoundariesPass() {
+        #expect(NativeRenderPerformanceGate.absoluteFailures(measurement()).isEmpty)
+    }
+
+    @Test("each native stage fails above its ticket budget")
+    func stageBudgetsFailClosed() {
+        let freeze = measurement(freezeP95: 1.01)
+        let drawP95 = measurement(drawP95: 2.51)
+        let drawP99 = measurement(drawP99: 4.01)
+        let gpu = measurement(gpuP95: 8.34)
+        let completionWall = measurement(completionWallP95: 8.34)
+
+        #expect(NativeRenderPerformanceGate.absoluteFailures(freeze).contains { $0.contains("freeze_publication") })
+        #expect(NativeRenderPerformanceGate.absoluteFailures(drawP95).contains { $0.contains("draw_cpu p95") })
+        #expect(NativeRenderPerformanceGate.absoluteFailures(drawP99).contains { $0.contains("draw_cpu p99") })
+        #expect(NativeRenderPerformanceGate.absoluteFailures(gpu).contains { $0.contains("gpu_active_time p95") })
+        #expect(NativeRenderPerformanceGate.absoluteFailures(completionWall).contains { $0.contains("handoff_to_copy_completion p95") })
+    }
+
+    @Test("warm allocations, failed frames, and excess generations fail")
+    func boundedResourcePoliciesFailClosed() {
+        let failures = NativeRenderPerformanceGate.absoluteFailures(measurement(
+            allocatedBytes: 4_096,
+            allocations: 1,
+            dropped: 1,
+            generations: 4
+        ))
+
+        #expect(failures.contains { $0.contains("4096 bytes") })
+        #expect(failures.contains { $0.contains("1 native allocations") })
+        #expect(failures.contains { $0.contains("failed or discarded 1 frames") })
+        #expect(failures.contains { $0.contains("retained 4 generations") })
+    }
+
+    @Test("paired end-to-end p50 regression above ten percent fails")
+    func pairedRegressionFails() {
+        let base = measurement(completionWallP50: 2.0)
+        let head = measurement(completionWallP50: 2.21)
+        #expect(NativeRenderPerformanceGate.pairedFailures(base: base, head: head)
+            .contains { $0.contains("handoff-to-copy-completion p50 paired median ratio 1.10x exceeds 1.10x") })
+    }
+
+    @Test("native frame accounting fails closed when results are truncated")
+    func frameAccountingFailsClosed() {
+        #expect(NativeRenderPerformanceGate.absoluteFailures(measurement(attempted: 999))
+            .contains { $0.contains("invalid or incomplete") })
+    }
+
+    @Test("paired native comparison requires equal odd sample counts")
+    func pairedSampleShapeFailsClosed() {
+        let sample = measurement()
+        #expect(NativeRenderPerformanceGate.pairedFailures(
+            baseMeasurements: [sample, sample],
+            headMeasurements: [sample, sample]
+        ).contains { $0.contains("odd count") })
+        #expect(NativeRenderPerformanceGate.pairedFailures(
+            baseMeasurements: [sample, sample, sample],
+            headMeasurements: [sample]
+        ).contains { $0.contains("unequal counts") })
+    }
+
+    private func measurement(
+        freezeP95: Double = 1.0,
+        drawP95: Double = 2.5,
+        drawP99: Double = 4.0,
+        gpuP95: Double = 8.33,
+        completionWallP50: Double = 2.0,
+        completionWallP95: Double = 8.33,
+        allocatedBytes: Int = 0,
+        allocations: Int = 0,
+        dropped: Int = 0,
+        generations: Int = 3,
+        attempted: Int? = nil
+    ) -> NativeRenderPerformanceMeasurement {
+        NativeRenderPerformanceMeasurement(
+            freezePublicationP50Ms: 0.5,
+            freezePublicationP95Ms: freezeP95,
+            drawCPUP50Ms: 1.0,
+            drawCPUP95Ms: drawP95,
+            drawCPUP99Ms: drawP99,
+            gpuP50Ms: 4.0,
+            gpuP95Ms: gpuP95,
+            completionWallP50Ms: completionWallP50,
+            completionWallP95Ms: completionWallP95,
+            maximumAllocatedBytesPerFrame: allocatedBytes,
+            allocationCountAfterWarmup: allocations,
+            attemptedFrameCount: attempted ?? 1_000 + dropped,
+            copyCompletedFrameCount: 1_000,
+            failedOrDiscardedFrameCount: dropped,
+            maximumInFlightGenerations: generations
+        )
+    }
+}

--- a/macos/Tests/MingaTests/RenderPerformanceGateTests.swift
+++ b/macos/Tests/MingaTests/RenderPerformanceGateTests.swift
@@ -21,8 +21,8 @@ struct RenderPerformanceGateTests {
 
     @Test("exact relative boundary passes and the next representable value fails")
     func relativeBoundary() {
-        #expect(failures(stage: 1.20, combined: 2.40).isEmpty)
-        #expect(failures(stage: 1.20.nextUp, combined: 2.40).contains { $0.contains("1.20x baseline") })
+        #expect(failures(stage: 1.10, combined: 2.20).isEmpty)
+        #expect(failures(stage: 1.10.nextUp, combined: 2.20).contains { $0.contains("1.10x baseline") })
     }
 
     @Test("sub-millisecond references include a fixed host-noise allowance")
@@ -56,10 +56,10 @@ struct RenderPerformanceGateTests {
         ).isEmpty)
     }
 
-    @Test("HEAD combined-p50 regression above 1.20x fails")
+    @Test("HEAD combined-p50 regression above 1.10x fails")
     func pairedCombinedP50RegressionFails() {
         let base = Array(repeating: pairedMeasurement(combinedP50: 1.0), count: 3)
-        let head = Array(repeating: pairedMeasurement(combinedP50: 1.21), count: 3)
+        let head = Array(repeating: pairedMeasurement(combinedP50: 1.11), count: 3)
         let failures = RenderPerformanceGate.pairedFailures(
             baseMeasurements: base,
             headMeasurements: head
@@ -82,7 +82,7 @@ struct RenderPerformanceGateTests {
     @Test("five-pair confirmation decides over all pair ratios")
     func fivePairConfirmationMedianPasses() {
         let base = Array(repeating: pairedMeasurement(combinedP50: 1.0), count: 5)
-        let ratios = [1.30, 1.30, 1.0, 1.0, 1.0]
+        let ratios = [1.15, 1.15, 1.0, 1.0, 1.0]
         let head = ratios.map { pairedMeasurement(combinedP50: $0) }
         let initialFailures = RenderPerformanceGate.pairedFailures(
             baseMeasurements: Array(base.prefix(3)),

--- a/macos/Tests/MingaTests/RendererResidentSliceTests.swift
+++ b/macos/Tests/MingaTests/RendererResidentSliceTests.swift
@@ -44,8 +44,8 @@ struct RendererResidentSliceTests {
         smallFrame.windowGutters = [1: smallGutter]
         var largeFrame = FrameState(cols: 80, rows: 40)
         largeFrame.windowGutters = [1: largeGutter]
-        let smallDemand = CoreTextMetalRenderer.atlasSlotDemand(frameState: smallFrame, windowContents: [1: small])
-        let largeDemand = CoreTextMetalRenderer.atlasSlotDemand(frameState: largeFrame, windowContents: [1: large])
+        let smallDemand = CoreTextMetalRenderer.atlasSlotDemand(frameState: smallFrame, windowContents: [1: small], gutters: [1: smallGutter], visibleSlices: [1: smallSlice])
+        let largeDemand = CoreTextMetalRenderer.atlasSlotDemand(frameState: largeFrame, windowContents: [1: large], gutters: [1: largeGutter], visibleSlices: [1: largeSlice])
         #expect(smallDemand == largeDemand)
         #expect(largeDemand < 200)
 
@@ -185,7 +185,7 @@ struct RendererResidentSliceTests {
         var frame = FrameState(cols: 80, rows: 40)
         frame.windowGutters = [1: gutter(entries: [])]
         let demand = CoreTextMetalRenderer.atlasSlotDemand(
-            frameState: frame, windowContents: [1: resident], preparedRows: [1: prepared]
+            frameState: frame, windowContents: [1: resident], gutters: frame.windowGutters, preparedRows: [1: prepared]
         )
 
         #expect(prepared.rows.count == 44)
@@ -223,6 +223,7 @@ struct RendererResidentSliceTests {
         let cursor = try #require(CoreTextMetalRenderer.resolveCursor(
             frameState: frame,
             windowContents: [1: resident],
+            gutters: frame.windowGutters,
             cellW: 8,
             displayCellH: 20,
             scale: 1,

--- a/macos/Tests/MingaTests/RendererResidentSliceTests.swift
+++ b/macos/Tests/MingaTests/RendererResidentSliceTests.swift
@@ -40,10 +40,8 @@ struct RendererResidentSliceTests {
         #expect(large.selection?.startRow == 0)
         #expect(large.lineAnnotations[0].row == 0)
 
-        var smallFrame = FrameState(cols: 80, rows: 40)
-        smallFrame.windowGutters = [1: smallGutter]
-        var largeFrame = FrameState(cols: 80, rows: 40)
-        largeFrame.windowGutters = [1: largeGutter]
+        let smallFrame = FrameState(cols: 80, rows: 40)
+        let largeFrame = FrameState(cols: 80, rows: 40)
         let smallDemand = CoreTextMetalRenderer.atlasSlotDemand(frameState: smallFrame, windowContents: [1: small], gutters: [1: smallGutter], visibleSlices: [1: smallSlice])
         let largeDemand = CoreTextMetalRenderer.atlasSlotDemand(frameState: largeFrame, windowContents: [1: large], gutters: [1: largeGutter], visibleSlices: [1: largeSlice])
         #expect(smallDemand == largeDemand)
@@ -182,10 +180,10 @@ struct RendererResidentSliceTests {
         var metrics = FrameMetrics()
         RendererSignposts.recordVisibleSlice(RendererSignposts.rowSlice(for: prepared), in: &metrics)
 
-        var frame = FrameState(cols: 80, rows: 40)
-        frame.windowGutters = [1: gutter(entries: [])]
+        let frame = FrameState(cols: 80, rows: 40)
+        let gutters = [UInt16(1): gutter(entries: [])]
         let demand = CoreTextMetalRenderer.atlasSlotDemand(
-            frameState: frame, windowContents: [1: resident], gutters: frame.windowGutters, preparedRows: [1: prepared]
+            frameState: frame, windowContents: [1: resident], gutters: gutters, preparedRows: [1: prepared]
         )
 
         #expect(prepared.rows.count == 44)
@@ -218,11 +216,10 @@ struct RendererResidentSliceTests {
         let slice = RendererSignposts.visibleSlice(for: resident, fallbackVisibleRows: 40)
         #expect(slice.visibleStartIndex == 50_003)
 
-        var frame = FrameState(cols: 80, rows: 40)
-        frame.windowGutters = [1: gutter(entries: [])]
+        let gutters = [UInt16(1): gutter(entries: [])]
         let cursor = try #require(CoreTextMetalRenderer.resolveCursor(
             windowContents: [1: resident],
-            gutters: frame.windowGutters,
+            gutters: gutters,
             cellW: 8,
             displayCellH: 20,
             scale: 1,

--- a/macos/Tests/MingaTests/RendererResidentSliceTests.swift
+++ b/macos/Tests/MingaTests/RendererResidentSliceTests.swift
@@ -221,7 +221,6 @@ struct RendererResidentSliceTests {
         var frame = FrameState(cols: 80, rows: 40)
         frame.windowGutters = [1: gutter(entries: [])]
         let cursor = try #require(CoreTextMetalRenderer.resolveCursor(
-            frameState: frame,
             windowContents: [1: resident],
             gutters: frame.windowGutters,
             cellW: 8,

--- a/macos/Tests/MingaTests/RendererSnapshotTestSupport.swift
+++ b/macos/Tests/MingaTests/RendererSnapshotTestSupport.swift
@@ -1,0 +1,130 @@
+import Foundation
+import QuartzCore
+import MingaProtocol
+import MingaUI
+import Testing
+
+@MainActor
+func rendererSnapshot(
+    generation: UInt32 = 1,
+    frameSeq: UInt32 = 1,
+    frameState: FrameState,
+    themeColors: ThemeColors? = nil,
+    windowContents: [UInt16: GUIWindowContent]
+) -> CommittedEditorSnapshot {
+    let normalizedContents = Dictionary(uniqueKeysWithValues: windowContents.map { windowId, content in
+        (windowId, normalizedRendererContent(content, frameState: frameState))
+    })
+
+    switch CommittedEditorSnapshot.make(
+        generation: generation,
+        frameSeq: frameSeq,
+        frameState: frameState,
+        themeColors: themeColors,
+        windowContents: normalizedContents
+    ) {
+    case .success(let snapshot):
+        return snapshot
+    case .failure(let rejection):
+        Issue.record("Invalid renderer snapshot fixture: \(rejection.logDescription)")
+        fatalError("Invalid renderer snapshot fixture: \(rejection.logDescription)")
+    }
+}
+
+private func normalizedRendererContent(_ content: GUIWindowContent, frameState: FrameState) -> GUIWindowContent {
+    guard content.paneGeometry == nil,
+          let gutter = frameState.windowGutters[content.windowId] else { return content }
+
+    let geometry = rendererPaneGeometry(windowId: content.windowId, gutter: gutter, frameState: frameState)
+    let rows = content.rows.map(GUIWindowRowDeltaEntry.full)
+    let delta = GUIWindowRowsDelta(
+        windowId: content.windowId,
+        contentEpoch: content.contentEpoch,
+        cursorVisible: content.cursorVisible,
+        cursorRow: content.cursorRow,
+        cursorCol: content.cursorCol,
+        cursorShape: content.cursorShape,
+        scrollLeft: content.scrollLeft,
+        rows: rows,
+        selection: content.selection,
+        searchMatches: content.searchMatches,
+        diagnosticUnderlines: content.diagnosticUnderlines,
+        documentHighlights: content.documentHighlights,
+        lineAnnotations: content.lineAnnotations,
+        paneGeometry: geometry,
+        cursorline: content.cursorline,
+        scrollPresentation: content.scrollPresentation
+    )
+    return content.applyingRowsDelta(delta) ?? content
+}
+
+private func rendererPaneGeometry(windowId: UInt16, gutter: Wire.WindowGutter, frameState: FrameState) -> GUIPaneGeometry {
+    let gutterWidth = UInt16(gutter.lineNumberWidth) + UInt16(gutter.signColWidth)
+    let gutterCol = gutter.contentCol >= gutterWidth ? gutter.contentCol - gutterWidth : 0
+    let totalWidth = max(UInt16(gutter.contentWidth) + gutterWidth, 1)
+    let totalRect = GUICellRect(row: gutter.contentRow, col: gutterCol, width: totalWidth, height: gutter.contentHeight)
+    let textRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: UInt16(gutter.contentWidth), height: gutter.contentHeight)
+    let gutterRect = GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutterWidth, height: gutter.contentHeight)
+    let viewportRows = gutter.contentHeight == 0 ? frameState.rows : gutter.contentHeight
+    let totalLines = max(frameState.totalLineCount, UInt32(viewportRows))
+    let hitRegions = gutterWidth == 0 ? [] : [GUIHitRegion(kind: .gutter, rect: gutterRect, windowId: windowId)]
+
+    return GUIPaneGeometry(
+        windowId: windowId,
+        totalRect: totalRect,
+        contentRect: totalRect,
+        textRect: textRect,
+        gutterRect: gutterRect,
+        clipRect: totalRect,
+        viewport: GUIViewportSummary(top: 0, left: 0, rows: viewportRows, cols: UInt16(gutter.contentWidth), totalLines: totalLines, visualRowOffset: 0, totalVisualRows: totalLines),
+        gutterMetrics: GUIGutterMetrics(lineNumberWidth: UInt16(gutter.lineNumberWidth), signColWidth: UInt16(gutter.signColWidth)),
+        hitRegions: hitRegions
+    )
+}
+
+extension CoreTextMetalRenderer {
+    @MainActor
+    func render(
+        frameState: FrameState,
+        fontManager: FontManager,
+        cursorBlinkVisible: Bool = true,
+        windowContents: [UInt16: GUIWindowContent] = [:],
+        themeColors: ThemeColors? = nil,
+        isMouseInGutter: Bool = false,
+        gutterHoverWindowId: UInt16? = nil,
+        gutterHoverRow: UInt16? = nil,
+        drawableProvider: @escaping @MainActor () -> CAMetalDrawable?,
+        viewportSize: CGSize,
+        contentScale: Float,
+        scrollOffset: SIMD2<Float> = .zero,
+        presentationWindowId: UInt16? = nil,
+        presentationInputSeq: UInt32 = 0,
+        presentationFrame: GUICommittedFrame? = nil,
+        latencyRecorder: LatencyRecorder? = nil,
+        onPresented: @escaping @MainActor (CommittedEditorSnapshot) -> Void = { _ in }
+    ) {
+        let snapshot = rendererSnapshot(
+            generation: presentationFrame?.generation ?? 1,
+            frameSeq: presentationFrame?.frameSeq ?? presentationInputSeq,
+            frameState: frameState,
+            themeColors: themeColors,
+            windowContents: windowContents
+        )
+        render(
+            snapshot: snapshot,
+            fontManager: fontManager,
+            cursorBlinkVisible: cursorBlinkVisible,
+            isMouseInGutter: isMouseInGutter,
+            gutterHoverWindowId: gutterHoverWindowId,
+            gutterHoverRow: gutterHoverRow,
+            drawableProvider: drawableProvider,
+            viewportSize: viewportSize,
+            contentScale: contentScale,
+            scrollOffset: scrollOffset,
+            presentationWindowId: presentationWindowId,
+            presentationInputSeq: presentationInputSeq,
+            latencyRecorder: latencyRecorder,
+            onPresented: onPresented
+        )
+    }
+}

--- a/macos/Tests/MingaTests/RendererSnapshotTestSupport.swift
+++ b/macos/Tests/MingaTests/RendererSnapshotTestSupport.swift
@@ -62,12 +62,10 @@ private func normalizedRendererContent(_ content: GUIWindowContent, frameState: 
 }
 
 private func rendererPaneGeometry(windowId: UInt16, gutter: Wire.WindowGutter, frameState: FrameState) -> GUIPaneGeometry {
-    let gutterWidth = UInt16(gutter.lineNumberWidth) + UInt16(gutter.signColWidth)
-    let gutterCol = gutter.contentCol >= gutterWidth ? gutter.contentCol - gutterWidth : 0
-    let totalWidth = max(UInt16(gutter.contentWidth) + gutterWidth, 1)
-    let totalRect = GUICellRect(row: gutter.contentRow, col: gutterCol, width: totalWidth, height: gutter.contentHeight)
-    let textRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: UInt16(gutter.contentWidth), height: gutter.contentHeight)
-    let gutterRect = GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutterWidth, height: gutter.contentHeight)
+    let gutterWidth = min(UInt16(gutter.lineNumberWidth) + UInt16(gutter.signColWidth), gutter.contentWidth)
+    let totalRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: max(gutter.contentWidth, 1), height: gutter.contentHeight)
+    let textRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol + gutterWidth, width: gutter.contentWidth - gutterWidth, height: gutter.contentHeight)
+    let gutterRect = GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutterWidth, height: gutter.contentHeight)
     let viewportRows = gutter.contentHeight == 0 ? frameState.rows : gutter.contentHeight
     let totalLines = max(frameState.totalLineCount, UInt32(viewportRows))
     let hitRegions = gutterWidth == 0 ? [] : [GUIHitRegion(kind: .gutter, rect: gutterRect, windowId: windowId)]
@@ -79,7 +77,7 @@ private func rendererPaneGeometry(windowId: UInt16, gutter: Wire.WindowGutter, f
         textRect: textRect,
         gutterRect: gutterRect,
         clipRect: totalRect,
-        viewport: GUIViewportSummary(top: 0, left: 0, rows: viewportRows, cols: UInt16(gutter.contentWidth), totalLines: totalLines, visualRowOffset: 0, totalVisualRows: totalLines),
+        viewport: GUIViewportSummary(top: 0, left: 0, rows: viewportRows, cols: textRect.width, totalLines: totalLines, visualRowOffset: 0, totalVisualRows: totalLines),
         gutterMetrics: GUIGutterMetrics(lineNumberWidth: UInt16(gutter.lineNumberWidth), signColWidth: UInt16(gutter.signColWidth)),
         hitRegions: hitRegions
     )

--- a/macos/Tests/MingaTests/RendererSnapshotTestSupport.swift
+++ b/macos/Tests/MingaTests/RendererSnapshotTestSupport.swift
@@ -10,10 +10,13 @@ func rendererSnapshot(
     frameSeq: UInt32 = 1,
     frameState: FrameState,
     themeColors: ThemeColors? = nil,
-    windowContents: [UInt16: GUIWindowContent]
+    windowContents: [UInt16: GUIWindowContent],
+    windowGutters: [UInt16: Wire.WindowGutter] = [:],
+    windowIndentGuides: [UInt16: IndentGuideData] = [:],
+    metadata: EditorSnapshotMetadata = .empty
 ) -> CommittedEditorSnapshot {
     let normalizedContents = Dictionary(uniqueKeysWithValues: windowContents.map { windowId, content in
-        (windowId, normalizedRendererContent(content, frameState: frameState))
+        (windowId, normalizedRendererContent(content, gutters: windowGutters, frameState: frameState))
     })
 
     switch CommittedEditorSnapshot.make(
@@ -22,8 +25,9 @@ func rendererSnapshot(
         frameState: frameState,
         themeColors: themeColors,
         windowContents: normalizedContents,
-        windowGutters: frameState.windowGutters,
-        windowIndentGuides: frameState.windowIndentGuides
+        windowGutters: windowGutters,
+        windowIndentGuides: windowIndentGuides,
+        metadata: metadata
     ) {
     case .success(let snapshot):
         return snapshot
@@ -34,9 +38,9 @@ func rendererSnapshot(
     }
 }
 
-private func normalizedRendererContent(_ content: GUIWindowContent, frameState: FrameState) -> GUIWindowContent {
+private func normalizedRendererContent(_ content: GUIWindowContent, gutters: [UInt16: Wire.WindowGutter], frameState: FrameState) -> GUIWindowContent {
     guard content.paneGeometry == nil,
-          let gutter = frameState.windowGutters[content.windowId] else { return content }
+          let gutter = gutters[content.windowId] else { return content }
 
     let geometry = rendererPaneGeometry(windowId: content.windowId, gutter: gutter, frameState: frameState)
     let rows = content.rows.map(GUIWindowRowDeltaEntry.full)
@@ -90,6 +94,9 @@ extension CoreTextMetalRenderer {
         fontManager: FontManager,
         cursorBlinkVisible: Bool = true,
         windowContents: [UInt16: GUIWindowContent] = [:],
+        windowGutters: [UInt16: Wire.WindowGutter] = [:],
+        windowIndentGuides: [UInt16: IndentGuideData] = [:],
+        metadata: EditorSnapshotMetadata = .empty,
         themeColors: ThemeColors? = nil,
         isMouseInGutter: Bool = false,
         gutterHoverWindowId: UInt16? = nil,
@@ -109,7 +116,10 @@ extension CoreTextMetalRenderer {
             frameSeq: presentationFrame?.frameSeq ?? presentationInputSeq,
             frameState: frameState,
             themeColors: themeColors,
-            windowContents: windowContents
+            windowContents: windowContents,
+            windowGutters: windowGutters,
+            windowIndentGuides: windowIndentGuides,
+            metadata: metadata
         )
         render(
             snapshot: snapshot,

--- a/macos/Tests/MingaTests/RendererSnapshotTestSupport.swift
+++ b/macos/Tests/MingaTests/RendererSnapshotTestSupport.swift
@@ -21,13 +21,16 @@ func rendererSnapshot(
         frameSeq: frameSeq,
         frameState: frameState,
         themeColors: themeColors,
-        windowContents: normalizedContents
+        windowContents: normalizedContents,
+        windowGutters: frameState.windowGutters,
+        windowIndentGuides: frameState.windowIndentGuides
     ) {
     case .success(let snapshot):
         return snapshot
     case .failure(let rejection):
-        Issue.record("Invalid renderer snapshot fixture: \(rejection.logDescription)")
-        fatalError("Invalid renderer snapshot fixture: \(rejection.logDescription)")
+        let message = "Invalid renderer snapshot fixture: \(String(describing: rejection.logDescription))"
+        Issue.record(Comment(rawValue: message))
+        fatalError(message)
     }
 }
 

--- a/macos/Tests/MingaTests/TemporalOffscreenMetalTests.swift
+++ b/macos/Tests/MingaTests/TemporalOffscreenMetalTests.swift
@@ -119,7 +119,7 @@ struct TemporalOffscreenMetalTests {
         frameState.defaultBg = Self.neutral
         frameState.gutterColors = GutterThemeColors()
         frameState.totalLineCount = UInt32(rowCount)
-        frameState.windowGutters[1] = gutter(windowId: 1, cols: cols, rows: rowCount)
+        let windowGutters: [UInt16: Wire.WindowGutter] = [1: gutter(windowId: 1, cols: cols, rows: rowCount)]
 
         let text = String(repeating: "M", count: Int(cols))
         let rows = (0..<Int(rowCount)).map { bandRow(rowId: UInt64($0), text: text, bg: Self.colorA) }
@@ -141,6 +141,7 @@ struct TemporalOffscreenMetalTests {
                 renderer.render(
                     frameState: frameState, fontManager: fontManager,
                     windowContents: [1: content],
+                    windowGutters: windowGutters,
                     drawableProvider: { drawable },
                     viewportSize: CGSize(width: width, height: height),
                     contentScale: 1, scrollOffset: offset,
@@ -202,7 +203,7 @@ struct TemporalOffscreenMetalTests {
         frameState.defaultBg = Self.neutral
         frameState.totalLineCount = 100
         frameState.viewportTopLine = 50
-        frameState.windowGutters[1] = gutter(windowId: 1, cols: cols, rows: rowCount, lineNumberWidth: 0)
+        let windowGutters: [UInt16: Wire.WindowGutter] = [1: gutter(windowId: 1, cols: cols, rows: rowCount, lineNumberWidth: 0)]
 
         let text = String(repeating: "M", count: Int(cols))
         let rows = (0..<Int(rowCount)).map { bandRow(rowId: UInt64($0), text: text, bg: Self.colorA) }
@@ -214,7 +215,7 @@ struct TemporalOffscreenMetalTests {
         let outcome = await waiter.awaitOutcome {
             renderer.render(
                 frameState: frameState, fontManager: fontManager,
-                windowContents: [1: content], drawableProvider: { drawable },
+                windowContents: [1: content], windowGutters: windowGutters, drawableProvider: { drawable },
                 viewportSize: CGSize(width: width, height: height), contentScale: 1,
                 scrollOffset: .zero, presentationWindowId: 1, presentationInputSeq: 100,
                 onPresented: { waiter.succeed($0) }
@@ -244,7 +245,7 @@ struct TemporalOffscreenMetalTests {
         let fadedOutcome = await waiter.awaitOutcome {
             renderer.render(
                 frameState: frameState, fontManager: fontManager,
-                windowContents: [1: content], drawableProvider: { fadedDrawable },
+                windowContents: [1: content], windowGutters: windowGutters, drawableProvider: { fadedDrawable },
                 viewportSize: CGSize(width: width, height: height), contentScale: 1,
                 scrollOffset: .zero, presentationWindowId: 1, presentationInputSeq: 101,
                 onPresented: { waiter.succeed($0) }
@@ -376,16 +377,18 @@ struct TemporalOffscreenMetalTests {
         frameState.totalLineCount = UInt32(rowCount)
 
         // Left pane window (id 1) at col 0; right pane window (id 2) at leftCols.
-        frameState.windowGutters[1] = Wire.WindowGutter(
-            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: rowCount,
-            isActive: true, contentWidth: leftCols, cursorLine: 0,
-            lineNumberStyle: .absolute, lineNumberWidth: 0, signColWidth: 0, entries: []
-        )
-        frameState.windowGutters[2] = Wire.WindowGutter(
-            windowId: 2, contentRow: 0, contentCol: leftCols, contentHeight: rowCount,
-            isActive: false, contentWidth: rightCols, cursorLine: 0,
-            lineNumberStyle: .absolute, lineNumberWidth: 0, signColWidth: 0, entries: []
-        )
+        let windowGutters: [UInt16: Wire.WindowGutter] = [
+            1: Wire.WindowGutter(
+                windowId: 1, contentRow: 0, contentCol: 0, contentHeight: rowCount,
+                isActive: true, contentWidth: leftCols, cursorLine: 0,
+                lineNumberStyle: .absolute, lineNumberWidth: 0, signColWidth: 0, entries: []
+            ),
+            2: Wire.WindowGutter(
+                windowId: 2, contentRow: 0, contentCol: leftCols, contentHeight: rowCount,
+                isActive: false, contentWidth: rightCols, cursorLine: 0,
+                lineNumberStyle: .absolute, lineNumberWidth: 0, signColWidth: 0, entries: []
+            )
+        ]
 
         let leftText = String(repeating: "M", count: Int(leftCols))
         let rightText = String(repeating: "M", count: Int(rightCols))
@@ -409,6 +412,7 @@ struct TemporalOffscreenMetalTests {
             renderer.render(
                 frameState: frameState, fontManager: fontManager,
                 windowContents: [1: leftContent, 2: rightContent],
+                windowGutters: windowGutters,
                 drawableProvider: { drawable },
                 viewportSize: CGSize(width: width, height: height), contentScale: 1,
                 onPresented: { waiter.succeed($0) }
@@ -471,15 +475,14 @@ struct TemporalOffscreenMetalTests {
 
         var frameState = FrameState(cols: cols, rows: rowCount)
         frameState.defaultBg = Self.neutral
-        frameState.cursorRow = 2
-        frameState.cursorCol = 3
-        frameState.cursorShape = .block
         frameState.totalLineCount = UInt32(rowCount)
-        frameState.windowGutters[1] = Wire.WindowGutter(
+        var metadata = EditorSnapshotMetadata()
+        metadata.cursorShape = .block
+        let windowGutters: [UInt16: Wire.WindowGutter] = [1: Wire.WindowGutter(
             windowId: 1, contentRow: 0, contentCol: 0, contentHeight: rowCount,
             isActive: true, contentWidth: cols, cursorLine: 2,
             lineNumberStyle: .absolute, lineNumberWidth: 0, signColWidth: 0, entries: []
-        )
+        )]
         let text = String(repeating: " ", count: Int(cols))
         let rows = (0..<Int(rowCount)).map { bandRow(rowId: UInt64($0), text: text, bg: Self.neutral) }
         let content = try GUIWindowContent(
@@ -503,6 +506,7 @@ struct TemporalOffscreenMetalTests {
                 renderer.render(
                     frameState: frameState, fontManager: fontManager,
                     cursorBlinkVisible: cursorVisible, windowContents: [1: content],
+                    windowGutters: windowGutters, metadata: metadata,
                     drawableProvider: { drawable },
                     viewportSize: CGSize(width: width, height: height), contentScale: 1,
                     presentationWindowId: 1, presentationInputSeq: seq,

--- a/macos/Tests/MingaTests/TemporalOffscreenMetalTests.swift
+++ b/macos/Tests/MingaTests/TemporalOffscreenMetalTests.swift
@@ -1,0 +1,672 @@
+import Foundation
+import Metal
+import MingaProtocol
+@testable import MingaUI
+import QuartzCore
+import Testing
+
+/// Temporal offscreen Metal acceptance tests (Minga issue #2999).
+///
+/// These exercise the production presentation path
+/// `CoreTextMetalRenderer.render(snapshot:..., drawableProvider:, onPresented:)`
+/// (via the `render(frameState:...)` fixture wrapper in
+/// RendererSnapshotTestSupport) against real GPU work, then read the
+/// drawable-copy-completed pixels through `OffscreenReadback`. Completion is always
+/// awaited asynchronously via `addCompletedHandler`; nothing here blocks the
+/// main actor, spins a run loop, sleeps, or uses a semaphore.
+///
+/// Live-resize crop cannot be proven at the direct-renderer pixel layer here:
+/// the renderer receives an already-committed snapshot and cannot observe the
+/// AppKit live-resize gesture that produces a transient crop. That state-machine
+/// behaviour is covered by LiveResizeDebounceTests; we deliberately do not fake
+/// a pixel test for it.
+@Suite("Temporal offscreen Metal rendering", .serialized)
+struct TemporalOffscreenMetalTests {
+    // Saturated, well-separated background colors make robust A/B regions.
+    private static let colorA: UInt32 = 0xE0_10_10 // saturated red
+    private static let colorB: UInt32 = 0x10_10_E0 // saturated blue
+    private static let neutral: UInt32 = 0x20_20_20 // neutral clear/background
+
+    private static func expectedColor(_ rgb24: UInt32) -> PixelColor {
+        PixelColor(
+            r: Double((rgb24 >> 16) & 0xFF) / 255.0,
+            g: Double((rgb24 >> 8) & 0xFF) / 255.0,
+            b: Double(rgb24 & 0xFF) / 255.0,
+            a: 1.0
+        )
+    }
+
+    @MainActor private func nativeTestFactories() -> NativeRenderFactories {
+        var factories = NativeRenderFactories.production
+        factories.makeLibrary = { device in
+            Bundle.allBundles.lazy.compactMap { try? device.makeDefaultLibrary(bundle: $0) }.first
+        }
+        return factories
+    }
+
+    @MainActor
+    private func makeRenderer(factories: NativeRenderFactories,
+                             fontManager: FontManager) -> CoreTextMetalRenderer? {
+        guard let renderer = CoreTextMetalRenderer(factories: factories) else { return nil }
+        renderer.setupRenderers(fontManager: fontManager)
+        return renderer
+    }
+
+    /// Full-width row of `text` painted with a single saturated background span,
+    /// so the content area for that row reads back as `bg`.
+    private func bandRow(rowId: UInt64, text: String, bg: UInt32) -> GUIVisualRow {
+        let span = GUIHighlightSpan(
+            startCol: 0, endCol: UInt16(text.count),
+            fg: bg, bg: 0, attrs: 0, fontWeight: 0, fontId: 0
+        )
+        return GUIVisualRow(rowType: .normal, rowId: rowId, bufLine: UInt32(rowId),
+                            contentHash: UInt32(truncatingIfNeeded: rowId &* 2_654_435_761),
+                            text: text, spans: [span])
+    }
+
+    private func windowWithGutter(windowId: UInt16, rows: [GUIVisualRow],
+                                  scrollLeft: UInt16 = 0) throws -> GUIWindowContent {
+        try GUIWindowContent(
+            windowId: windowId, fullRefresh: true, cursorRow: 0, cursorCol: 0,
+            cursorShape: .block, scrollLeft: scrollLeft, rows: rows, selection: nil,
+            searchMatches: [], diagnosticUnderlines: [], documentHighlights: []
+        )
+    }
+
+    private func gutter(windowId: UInt16, cols: UInt16, rows: UInt16,
+                        lineNumberWidth: UInt8 = 4) -> Wire.WindowGutter {
+        let entries = (0..<Int(rows)).map { i in
+            Wire.GutterEntry(bufLine: UInt32(i), displayType: .normal, signType: .none)
+        }
+        return Wire.WindowGutter(
+            windowId: windowId, contentRow: 0, contentCol: UInt16(lineNumberWidth) + 1,
+            contentHeight: rows, isActive: true,
+            contentWidth: cols - (UInt16(lineNumberWidth) + 1),
+            cursorLine: 0, lineNumberStyle: .absolute,
+            lineNumberWidth: lineNumberWidth, signColWidth: 1, entries: entries
+        )
+    }
+
+    private func requireDevice() -> (MTLDevice, MTLCommandQueue)? {
+        guard let device = MTLCreateSystemDefaultDevice(), let queue = device.makeCommandQueue() else {
+            Issue.record("A Metal device and command queue are required for temporal offscreen pixel acceptance tests; none available in this environment")
+            return nil
+        }
+        return (device, queue)
+    }
+
+    // MARK: 1. Sequence of production frames: every drawable-copy-completed frame is nonblank
+    // with occupied gutter/line-number columns.
+
+    @Test("local-scroll and settle-offset frames each present nonblank content with gutter occupancy")
+    @MainActor
+    func scrollAndSettleSequenceIsNonblankWithGutter() async throws {
+        guard let (device, queue) = requireDevice() else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        let waiter = PresentationWaiter()
+        var factories = nativeTestFactories()
+        factories.reportFailure = { waiter.fail($0) }
+        guard let renderer = makeRenderer(factories: factories, fontManager: fontManager) else {
+            Issue.record("renderer unavailable"); return
+        }
+
+        let cols: UInt16 = 24, rowCount: UInt16 = 8
+        let cellW = Float(fontManager.cellWidth)
+        let cellH = Float(fontManager.cellHeight)
+        let width = Int((Float(cols) * cellW).rounded(.up)) + 16
+        let height = Int((Float(rowCount) * cellH).rounded(.up)) + 8
+
+        var frameState = FrameState(cols: cols, rows: rowCount)
+        frameState.defaultBg = Self.neutral
+        frameState.gutterColors = GutterThemeColors()
+        frameState.totalLineCount = UInt32(rowCount)
+        frameState.windowGutters[1] = gutter(windowId: 1, cols: cols, rows: rowCount)
+
+        let text = String(repeating: "M", count: Int(cols))
+        let rows = (0..<Int(rowCount)).map { bandRow(rowId: UInt64($0), text: text, bg: Self.colorA) }
+        let content = try windowWithGutter(windowId: 1, rows: rows)
+
+        // base frame, precise local-scroll frame, settle-offset frame
+        let offsets: [SIMD2<Float>] = [.zero, SIMD2<Float>(0, 6), SIMD2<Float>(0, 2.5)]
+        let neutralColor = Self.expectedColor(Self.neutral)
+        let gutterPixelWidth = Int((Float(4 + 1) * cellW).rounded(.up))
+
+        for (index, offset) in offsets.enumerated() {
+            waiter.reset()
+            guard let texture = OffscreenReadback.makeDrawableTexture(device: device, width: width, height: height) else {
+                Issue.record("drawable texture allocation failed"); return
+            }
+            let drawable = ReadbackDrawable(texture: texture, drawableID: index + 1)
+
+            let outcome = await waiter.awaitOutcome {
+                renderer.render(
+                    frameState: frameState, fontManager: fontManager,
+                    windowContents: [1: content],
+                    drawableProvider: { drawable },
+                    viewportSize: CGSize(width: width, height: height),
+                    contentScale: 1, scrollOffset: offset,
+                    presentationWindowId: 1, presentationInputSeq: UInt32(index + 1),
+                    onPresented: { waiter.succeed($0) }
+                )
+            }
+            guard case .presented = outcome else {
+                Issue.record("frame \(index) did not present: \(outcome)"); continue
+            }
+            guard let image = await OffscreenReadback.read(texture: texture, queue: queue) else {
+                Issue.record("readback failed for frame \(index)"); continue
+            }
+
+            // Content region (to the right of the gutter) must be non-blank:
+            // the saturated band must clearly dominate over the neutral clear.
+            let contentColor = Self.expectedColor(Self.colorA)
+            let contentPixels = image.occupancy(
+                x0: gutterPixelWidth + 2, y0: 1, x1: width - 1, y1: Int(cellH),
+                differingFrom: neutralColor, thresholdSquared: 0.02
+            )
+            #expect(contentPixels > 0, "frame \(index) content region is blank")
+            let classifiedContent = image.classifyAB(
+                x0: gutterPixelWidth + 2, y0: 0, x1: width - 1, y1: Int(cellH),
+                a: contentColor, b: neutralColor, ambiguousBand: 0.01
+            )
+            #expect(classifiedContent.a > 0, "frame \(index) content row has no saturated text pixels")
+
+            // Gutter/line-number occupancy: glyph pixels must appear in the
+            // gutter columns (digits painted over the background).
+            let gutterOccupancy = image.occupancy(
+                x0: 0, y0: 0, x1: gutterPixelWidth, y1: height,
+                differingFrom: neutralColor, thresholdSquared: 0.02
+            )
+            #expect(gutterOccupancy > 0, "frame \(index) gutter has no line-number occupancy")
+        }
+    }
+
+    @Test("scrollbar track masks editor glyphs beneath the thumb overlay")
+    @MainActor
+    func scrollbarTrackMasksEditorContent() async throws {
+        guard let (device, queue) = requireDevice() else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        let waiter = PresentationWaiter()
+        var factories = nativeTestFactories()
+        factories.reportFailure = { waiter.fail($0) }
+        guard let renderer = makeRenderer(factories: factories, fontManager: fontManager) else {
+            Issue.record("renderer unavailable"); return
+        }
+        renderer.scrollIndicatorAlpha = 1
+
+        let cols: UInt16 = 24, rowCount: UInt16 = 8
+        let cellW = Float(fontManager.cellWidth)
+        let cellH = Float(fontManager.cellHeight)
+        let width = Int((Float(cols) * cellW).rounded(.up))
+        let height = Int((Float(rowCount) * cellH).rounded(.up)) + 8
+
+        var frameState = FrameState(cols: cols, rows: rowCount)
+        frameState.defaultBg = Self.neutral
+        frameState.totalLineCount = 100
+        frameState.viewportTopLine = 50
+        frameState.windowGutters[1] = gutter(windowId: 1, cols: cols, rows: rowCount, lineNumberWidth: 0)
+
+        let text = String(repeating: "M", count: Int(cols))
+        let rows = (0..<Int(rowCount)).map { bandRow(rowId: UInt64($0), text: text, bg: Self.colorA) }
+        let content = try windowWithGutter(windowId: 1, rows: rows)
+        guard let texture = OffscreenReadback.makeDrawableTexture(device: device, width: width, height: height) else {
+            Issue.record("drawable texture allocation failed"); return
+        }
+        let drawable = ReadbackDrawable(texture: texture)
+        let outcome = await waiter.awaitOutcome {
+            renderer.render(
+                frameState: frameState, fontManager: fontManager,
+                windowContents: [1: content], drawableProvider: { drawable },
+                viewportSize: CGSize(width: width, height: height), contentScale: 1,
+                scrollOffset: .zero, presentationWindowId: 1, presentationInputSeq: 100,
+                onPresented: { waiter.succeed($0) }
+            )
+        }
+        guard case .presented = outcome,
+              let image = await OffscreenReadback.read(texture: texture, queue: queue) else {
+            Issue.record("scrollbar frame did not present"); return
+        }
+
+        let sampleY = 4
+        let trackColor = Self.expectedColor(Self.neutral)
+        let contentOccupancy = image.occupancy(
+            x0: max(0, width - 32), y0: sampleY, x1: max(1, width - 12), y1: min(height, sampleY + Int(cellH)),
+            differingFrom: trackColor, thresholdSquared: 0.02
+        )
+        #expect(contentOccupancy > 0, "content immediately beside the scrollbar track is blank")
+        #expect(image.pixel(x: width - 5, y: sampleY).rgbDistanceSquared(to: trackColor) < 0.02,
+                "editor content bled through the opaque scrollbar track")
+
+        renderer.scrollIndicatorAlpha = 0.5
+        waiter.reset()
+        guard let fadedTexture = OffscreenReadback.makeDrawableTexture(device: device, width: width, height: height) else {
+            Issue.record("faded drawable texture allocation failed"); return
+        }
+        let fadedDrawable = ReadbackDrawable(texture: fadedTexture, drawableID: 2)
+        let fadedOutcome = await waiter.awaitOutcome {
+            renderer.render(
+                frameState: frameState, fontManager: fontManager,
+                windowContents: [1: content], drawableProvider: { fadedDrawable },
+                viewportSize: CGSize(width: width, height: height), contentScale: 1,
+                scrollOffset: .zero, presentationWindowId: 1, presentationInputSeq: 101,
+                onPresented: { waiter.succeed($0) }
+            )
+        }
+        guard case .presented = fadedOutcome,
+              let fadedImage = await OffscreenReadback.read(texture: fadedTexture, queue: queue) else {
+            Issue.record("faded scrollbar frame did not complete"); return
+        }
+        #expect(fadedImage.pixel(x: width - 5, y: sampleY)
+            .rgbDistanceSquared(to: image.pixel(x: width - 5, y: sampleY)) > 0.001,
+            "scrollbar track did not fade with the thumb")
+    }
+
+    // MARK: 2. Out-of-order A/B completion — pixels are wholly A or wholly B,
+    // identity matches pixels, and a late older completion cannot promote.
+
+    @Test("out-of-order A/B completion presents the winner wholly and never promotes the late older frame")
+    @MainActor
+    func outOfOrderABCompletionIsCoherent() async throws {
+        guard let (device, queue) = requireDevice() else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+
+        let width = 64, height = 64
+        let coordinator = QueuedCompletionCoordinator()
+        var presentedDrawables: [Int] = []
+        var factories = nativeTestFactories()
+        factories.observeCompletion = { coordinator.observeCompletion($0, $1) }
+        factories.present = { drawable in
+            if let d = drawable as? ReadbackDrawable { presentedDrawables.append(d.drawableID) }
+        }
+        guard let renderer = makeRenderer(factories: factories, fontManager: fontManager) else {
+            Issue.record("renderer unavailable"); return
+        }
+
+        func emptyFrame(_ bg: UInt32) -> FrameState {
+            var fs = FrameState(cols: 4, rows: 4)
+            fs.defaultBg = bg
+            return fs
+        }
+        guard let textureA = OffscreenReadback.makeDrawableTexture(device: device, width: width, height: height),
+              let textureB = OffscreenReadback.makeDrawableTexture(device: device, width: width, height: height) else {
+            Issue.record("drawable texture allocation failed"); return
+        }
+        let drawableA = ReadbackDrawable(texture: textureA, drawableID: 1) // older generation
+        let drawableB = ReadbackDrawable(texture: textureB, drawableID: 2) // newer generation
+
+        var presentedSnapshotA: CommittedEditorSnapshot?
+        var presentedSnapshotB: CommittedEditorSnapshot?
+
+        // Submit A (gen 1) then B (gen 2). GPU runs both; completions are queued.
+        renderer.render(
+            frameState: emptyFrame(Self.colorA), fontManager: fontManager,
+            drawableProvider: { drawableA },
+            viewportSize: CGSize(width: width, height: height), contentScale: 1,
+            presentationInputSeq: 1,
+            onPresented: { presentedSnapshotA = $0 }
+        )
+        renderer.render(
+            frameState: emptyFrame(Self.colorB), fontManager: fontManager,
+            drawableProvider: { drawableB },
+            viewportSize: CGSize(width: width, height: height), contentScale: 1,
+            presentationInputSeq: 2,
+            onPresented: { presentedSnapshotB = $0 }
+        )
+
+        // Stage 1: both offscreen renders complete (order irrelevant). Flush both
+        // to submit the presentation-copy blits.
+        await coordinator.waitForPending(2)
+        coordinator.flushFirst()
+        coordinator.flushFirst()
+
+        // Stage 2: both presentation copies complete. Promote the NEWER frame (B)
+        // first, then deliver the older frame (A) late — it must be superseded.
+        await coordinator.waitForPending(2)
+        coordinator.flushLast() // serial command-queue completion order is A then B, so deliver B first
+        coordinator.flushFirst()
+
+        // B is the newer generation; regardless of copy completion order the
+        // generation gate guarantees only B promotes and presents.
+        #expect(presentedSnapshotB != nil, "newer frame B never presented")
+        #expect(presentedSnapshotA == nil, "older frame A promoted after a newer generation completed")
+        #expect(presentedDrawables == [2], "only the newer drawable B may present; got \(presentedDrawables)")
+
+        // Identity ↔ pixels: the presented snapshot is B, and B's drawable is wholly B.
+        #expect(presentedSnapshotB?.frameState.defaultBg == Self.colorB)
+        guard let imageB = await OffscreenReadback.read(texture: textureB, queue: queue) else {
+            Issue.record("readback failed for B"); return
+        }
+        let ab = imageB.classifyAB(x0: 0, y0: 0, x1: width, y1: height,
+                                   a: Self.expectedColor(Self.colorA),
+                                   b: Self.expectedColor(Self.colorB),
+                                   ambiguousBand: 0.01)
+        #expect(ab.b > 0, "winner drawable has no B pixels")
+        #expect(ab.a == 0, "winner drawable contains A pixels — hybrid frame")
+
+        // The superseded drawable A received its own clean blit (wholly A),
+        // proving frames never blend into a hybrid surface even out of order.
+        guard let imageA = await OffscreenReadback.read(texture: textureA, queue: queue) else {
+            Issue.record("readback failed for A"); return
+        }
+        let abA = imageA.classifyAB(x0: 0, y0: 0, x1: width, y1: height,
+                                    a: Self.expectedColor(Self.colorA),
+                                    b: Self.expectedColor(Self.colorB),
+                                    ambiguousBand: 0.01)
+        #expect(abA.a > 0, "superseded drawable A has no A pixels")
+        #expect(abA.b == 0, "superseded drawable A contains B pixels — hybrid frame")
+    }
+
+    // MARK: 3. Split panes — saturated colors stay inside each pane's clip
+    // rectangle and pane row bands align vertically within one device pixel.
+
+    @Test("split pane saturated colors stay within each pane clip and rows align within one device pixel")
+    @MainActor
+    func splitPanesClipAndAlign() async throws {
+        guard let (device, queue) = requireDevice() else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+
+        let cellW = Float(fontManager.cellWidth)
+        let cellH = Float(fontManager.cellHeight)
+        let leftCols: UInt16 = 16, rightCols: UInt16 = 16, rowCount: UInt16 = 6
+        let totalCols = leftCols + rightCols
+        let width = Int((Float(totalCols) * cellW).rounded(.up)) + 8
+        let height = Int((Float(rowCount) * cellH).rounded(.up)) + 4
+        let splitX = Int((Float(leftCols) * cellW).rounded())
+
+        var frameState = FrameState(cols: totalCols, rows: rowCount)
+        frameState.defaultBg = Self.neutral
+        frameState.totalLineCount = UInt32(rowCount)
+
+        // Left pane window (id 1) at col 0; right pane window (id 2) at leftCols.
+        frameState.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: rowCount,
+            isActive: true, contentWidth: leftCols, cursorLine: 0,
+            lineNumberStyle: .absolute, lineNumberWidth: 0, signColWidth: 0, entries: []
+        )
+        frameState.windowGutters[2] = Wire.WindowGutter(
+            windowId: 2, contentRow: 0, contentCol: leftCols, contentHeight: rowCount,
+            isActive: false, contentWidth: rightCols, cursorLine: 0,
+            lineNumberStyle: .absolute, lineNumberWidth: 0, signColWidth: 0, entries: []
+        )
+
+        let leftText = String(repeating: "M", count: Int(leftCols))
+        let rightText = String(repeating: "M", count: Int(rightCols))
+        let leftRows = (0..<Int(rowCount)).map { bandRow(rowId: UInt64($0), text: leftText, bg: Self.colorA) }
+        let rightRows = (0..<Int(rowCount)).map { bandRow(rowId: UInt64(100 + $0), text: rightText, bg: Self.colorB) }
+        let leftContent = try windowWithGutter(windowId: 1, rows: leftRows)
+        let rightContent = try windowWithGutter(windowId: 2, rows: rightRows)
+
+        let waiter = PresentationWaiter()
+        var factories = nativeTestFactories()
+        factories.reportFailure = { waiter.fail($0) }
+        guard let renderer = makeRenderer(factories: factories, fontManager: fontManager) else {
+            Issue.record("renderer unavailable"); return
+        }
+        guard let texture = OffscreenReadback.makeDrawableTexture(device: device, width: width, height: height) else {
+            Issue.record("drawable texture allocation failed"); return
+        }
+        let drawable = ReadbackDrawable(texture: texture)
+
+        let outcome = await waiter.awaitOutcome {
+            renderer.render(
+                frameState: frameState, fontManager: fontManager,
+                windowContents: [1: leftContent, 2: rightContent],
+                drawableProvider: { drawable },
+                viewportSize: CGSize(width: width, height: height), contentScale: 1,
+                onPresented: { waiter.succeed($0) }
+            )
+        }
+        guard case .presented = outcome else { Issue.record("split frame did not present: \(outcome)"); return }
+        guard let image = await OffscreenReadback.read(texture: texture, queue: queue) else {
+            Issue.record("readback failed"); return
+        }
+
+        let a = Self.expectedColor(Self.colorA)
+        let b = Self.expectedColor(Self.colorB)
+        let yMid = Int(cellH / 2)
+
+        // Color A must be confined to the left of the split; B to the right.
+        let paneBottom = Int(Float(rowCount) * cellH)
+        let leftA = image.matching(x0: 1, y0: 0, x1: splitX - 2, y1: paneBottom, reference: a, thresholdSquared: 0.02)
+        let leftB = image.matching(x0: 1, y0: 0, x1: splitX - 2, y1: paneBottom, reference: b, thresholdSquared: 0.02)
+        #expect(leftA > 0, "left pane has no A pixels")
+        #expect(leftB == 0, "B color leaked into the left pane clip rect")
+        let rightB = image.matching(x0: splitX + 2, y0: 0, x1: width - 1, y1: paneBottom, reference: b, thresholdSquared: 0.02)
+        let rightA = image.matching(x0: splitX + 2, y0: 0, x1: width - 1, y1: paneBottom, reference: a, thresholdSquared: 0.02)
+        #expect(rightB > 0, "right pane has no B pixels")
+        #expect(rightA == 0, "A color leaked into the right pane clip rect")
+
+        // Row-band top edges must align vertically across panes within 1 device px.
+        func firstBandTop(x0: Int, x1: Int, reference: PixelColor) -> Int? {
+            var y = 0
+            while y < height {
+                if image.matching(x0: x0, y0: y, x1: x1, y1: y + 1, reference: reference, thresholdSquared: 0.02) > 0 {
+                    return y
+                }
+                y += 1
+            }
+            return nil
+        }
+        let leftTop = firstBandTop(x0: 1, x1: splitX - 2, reference: a)
+        let rightTop = firstBandTop(x0: splitX + 2, x1: width - 1, reference: b)
+        _ = yMid
+        if let lt = leftTop, let rt = rightTop {
+            #expect(abs(lt - rt) <= 1, "pane row bands misaligned: left top \(lt) vs right top \(rt)")
+        } else {
+            Issue.record("could not locate a row band in one of the panes (left: \(String(describing: leftTop)), right: \(String(describing: rightTop)))")
+        }
+    }
+
+    // MARK: 4. Cursor blink toggles only the cursor ROI.
+
+    @Test("cursor blink toggles only the cursor region of interest")
+    @MainActor
+    func cursorBlinkTogglesOnlyCursorROI() async throws {
+        guard let (device, queue) = requireDevice() else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+
+        let cellW = Float(fontManager.cellWidth)
+        let cellH = Float(fontManager.cellHeight)
+        let cols: UInt16 = 20, rowCount: UInt16 = 6
+        let width = Int((Float(cols) * cellW).rounded(.up)) + 8
+        let height = Int((Float(rowCount) * cellH).rounded(.up)) + 4
+
+        var frameState = FrameState(cols: cols, rows: rowCount)
+        frameState.defaultBg = Self.neutral
+        frameState.cursorRow = 2
+        frameState.cursorCol = 3
+        frameState.cursorShape = .block
+        frameState.totalLineCount = UInt32(rowCount)
+        frameState.windowGutters[1] = Wire.WindowGutter(
+            windowId: 1, contentRow: 0, contentCol: 0, contentHeight: rowCount,
+            isActive: true, contentWidth: cols, cursorLine: 2,
+            lineNumberStyle: .absolute, lineNumberWidth: 0, signColWidth: 0, entries: []
+        )
+        let text = String(repeating: " ", count: Int(cols))
+        let rows = (0..<Int(rowCount)).map { bandRow(rowId: UInt64($0), text: text, bg: Self.neutral) }
+        let content = try GUIWindowContent(
+            windowId: 1, fullRefresh: true, cursorVisible: true, cursorRow: 2, cursorCol: 3,
+            cursorShape: .block, rows: rows, selection: nil, searchMatches: [],
+            diagnosticUnderlines: [], documentHighlights: []
+        )
+
+        let waiter = PresentationWaiter()
+        var factories = nativeTestFactories()
+        factories.reportFailure = { waiter.fail($0) }
+        guard let renderer = makeRenderer(factories: factories, fontManager: fontManager) else {
+            Issue.record("renderer unavailable"); return
+        }
+
+        func renderFrame(cursorVisible: Bool, seq: UInt32) async -> ReadbackImage? {
+            waiter.reset()
+            guard let texture = OffscreenReadback.makeDrawableTexture(device: device, width: width, height: height) else { return nil }
+            let drawable = ReadbackDrawable(texture: texture, drawableID: Int(seq))
+            let outcome = await waiter.awaitOutcome {
+                renderer.render(
+                    frameState: frameState, fontManager: fontManager,
+                    cursorBlinkVisible: cursorVisible, windowContents: [1: content],
+                    drawableProvider: { drawable },
+                    viewportSize: CGSize(width: width, height: height), contentScale: 1,
+                    presentationWindowId: 1, presentationInputSeq: seq,
+                    onPresented: { waiter.succeed($0) }
+                )
+            }
+            guard case .presented = outcome else {
+                Issue.record("cursor frame (visible=\(cursorVisible)) did not present: \(outcome)")
+                return nil
+            }
+            return await OffscreenReadback.read(texture: texture, queue: queue)
+        }
+
+        guard let onImage = await renderFrame(cursorVisible: true, seq: 1),
+              let offImage = await renderFrame(cursorVisible: false, seq: 2) else { return }
+
+        // Cursor ROI around (row 2, col 3).
+        let roiX0 = Int((Float(3) * cellW).rounded()) - 1
+        let roiX1 = Int((Float(4) * cellW).rounded()) + 1
+        let roiY0 = Int((Float(2) * cellH).rounded()) - 1
+        let roiY1 = Int((Float(3) * cellH).rounded()) + 1
+
+        // Inside the ROI, the two frames must differ (cursor drawn vs not).
+        var roiDiffers = false
+        var y = max(0, roiY0)
+        while y < min(height, roiY1) && !roiDiffers {
+            var x = max(0, roiX0)
+            while x < min(width, roiX1) {
+                if onImage.pixel(x: x, y: y).rgbDistanceSquared(to: offImage.pixel(x: x, y: y)) > 0.01 {
+                    roiDiffers = true; break
+                }
+                x += 1
+            }
+            y += 1
+        }
+        #expect(roiDiffers, "cursor ROI did not change between blink-on and blink-off frames")
+
+        // Outside the ROI, the two frames must be identical (blink is local).
+        var outsideDiffCount = 0
+        y = 0
+        while y < height {
+            var x = 0
+            while x < width {
+                let inRoi = x >= roiX0 && x < roiX1 && y >= roiY0 && y < roiY1
+                if !inRoi {
+                    if onImage.pixel(x: x, y: y).rgbDistanceSquared(to: offImage.pixel(x: x, y: y)) > 0.01 {
+                        outsideDiffCount += 1
+                    }
+                }
+                x += 1
+            }
+            y += 1
+        }
+        #expect(outsideDiffCount == 0, "blink changed \(outsideDiffCount) pixels outside the cursor ROI")
+    }
+
+    // MARK: 5. Failure preservation + recovery — a nil drawable preserves the
+    // last good presented pixels and snapshot; a later valid frame recovers.
+
+    @Test("nil drawable preserves last good pixels and snapshot, then a valid frame recovers")
+    @MainActor
+    func nilDrawablePreservesThenRecovers() async throws {
+        guard let (device, queue) = requireDevice() else { return }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+
+        let width = 64, height = 64
+        // A single renderer preserves last-good state across frames; its
+        // reportFailure is routed through a mutable sink the test retargets.
+        final class FailureSink { var handler: (@MainActor (NativePresentationFailure) -> Void)? }
+        let sink = FailureSink()
+        var factories = nativeTestFactories()
+        factories.reportFailure = { failure in sink.handler?(failure) }
+        guard let renderer = makeRenderer(factories: factories, fontManager: fontManager) else {
+            Issue.record("renderer unavailable"); return
+        }
+
+        func emptyFrame(_ bg: UInt32) -> FrameState {
+            var fs = FrameState(cols: 4, rows: 4); fs.defaultBg = bg; return fs
+        }
+
+        // Frame 1: good frame (color A). Await onPresented, read pixels A.
+        guard let goodTexture = OffscreenReadback.makeDrawableTexture(device: device, width: width, height: height) else {
+            Issue.record("texture alloc failed"); return
+        }
+        let goodDrawable = ReadbackDrawable(texture: goodTexture, drawableID: 1)
+        let goodWaiter = PresentationWaiter()
+        sink.handler = { goodWaiter.fail($0) }
+        let goodOutcome = await goodWaiter.awaitOutcome {
+            renderer.render(
+                frameState: emptyFrame(Self.colorA), fontManager: fontManager,
+                drawableProvider: { goodDrawable },
+                viewportSize: CGSize(width: width, height: height), contentScale: 1,
+                presentationInputSeq: 1,
+                onPresented: { goodWaiter.succeed($0) }
+            )
+        }
+        guard case .presented(let goodSnapshot) = goodOutcome else {
+            Issue.record("good frame did not present: \(goodOutcome)"); return
+        }
+        #expect(goodSnapshot.frameState.defaultBg == Self.colorA)
+        let goodGeneration = renderer.lastCompletedPresentationGeneration
+        #expect(goodGeneration > 0)
+        guard let goodImage = await OffscreenReadback.read(texture: goodTexture, queue: queue) else {
+            Issue.record("readback failed for good frame"); return
+        }
+        #expect(goodImage.pixel(x: width / 2, y: height / 2)
+            .rgbDistanceSquared(to: Self.expectedColor(Self.colorA)) < 0.02)
+
+        // Frame 2: nil drawable at acquisition time. The offscreen render still
+        // runs; the drawable is nil so presentation is refused. Must NOT promote
+        // and must NOT present onto the good drawable.
+        let failWaiter = PresentationWaiter()
+        sink.handler = { failWaiter.fail($0) }
+        let failOutcome = await failWaiter.awaitOutcome {
+            renderer.render(
+                frameState: emptyFrame(Self.colorB), fontManager: fontManager,
+                drawableProvider: { nil },
+                viewportSize: CGSize(width: width, height: height), contentScale: 1,
+                presentationInputSeq: 2,
+                onPresented: { failWaiter.succeed($0) }
+            )
+        }
+        guard case .failed(let failure) = failOutcome else {
+            Issue.record("nil-drawable frame unexpectedly presented: \(failOutcome)"); return
+        }
+        #expect(failure.phase == .drawable)
+        // Generation must be unchanged — the good frame is still the last good one.
+        #expect(renderer.lastCompletedPresentationGeneration == goodGeneration,
+                "failed frame promoted its generation")
+        // The good drawable's pixels are untouched by the failed frame.
+        guard let preservedImage = await OffscreenReadback.read(texture: goodTexture, queue: queue) else {
+            Issue.record("readback failed for preserved frame"); return
+        }
+        #expect(preservedImage.pixel(x: width / 2, y: height / 2)
+            .rgbDistanceSquared(to: Self.expectedColor(Self.colorA)) < 0.02,
+            "failed frame corrupted the last good presented pixels")
+
+        // Frame 3: valid recovery frame (color B) onto a fresh drawable.
+        guard let recoveryTexture = OffscreenReadback.makeDrawableTexture(device: device, width: width, height: height) else {
+            Issue.record("texture alloc failed"); return
+        }
+        let recoveryDrawable = ReadbackDrawable(texture: recoveryTexture, drawableID: 3)
+        let recoveryWaiter = PresentationWaiter()
+        sink.handler = { recoveryWaiter.fail($0) }
+        let recoveryOutcome = await recoveryWaiter.awaitOutcome {
+            renderer.render(
+                frameState: emptyFrame(Self.colorB), fontManager: fontManager,
+                drawableProvider: { recoveryDrawable },
+                viewportSize: CGSize(width: width, height: height), contentScale: 1,
+                presentationInputSeq: 3,
+                onPresented: { recoveryWaiter.succeed($0) }
+            )
+        }
+        guard case .presented(let recoverySnapshot) = recoveryOutcome else {
+            Issue.record("recovery frame did not present: \(recoveryOutcome)"); return
+        }
+        #expect(recoverySnapshot.frameState.defaultBg == Self.colorB)
+        #expect(renderer.lastCompletedPresentationGeneration > goodGeneration)
+        guard let recoveryImage = await OffscreenReadback.read(texture: recoveryTexture, queue: queue) else {
+            Issue.record("readback failed for recovery frame"); return
+        }
+        #expect(recoveryImage.pixel(x: width / 2, y: height / 2)
+            .rgbDistanceSquared(to: Self.expectedColor(Self.colorB)) < 0.02,
+            "recovery frame did not present the new content")
+    }
+}

--- a/macos/Tests/MingaTests/TemporalOffscreenMetalTests.swift
+++ b/macos/Tests/MingaTests/TemporalOffscreenMetalTests.swift
@@ -79,9 +79,8 @@ struct TemporalOffscreenMetalTests {
             Wire.GutterEntry(bufLine: UInt32(i), displayType: .normal, signType: .none)
         }
         return Wire.WindowGutter(
-            windowId: windowId, contentRow: 0, contentCol: UInt16(lineNumberWidth) + 1,
-            contentHeight: rows, isActive: true,
-            contentWidth: cols - (UInt16(lineNumberWidth) + 1),
+            windowId: windowId, contentRow: 0, contentCol: 0,
+            contentHeight: rows, isActive: true, contentWidth: cols,
             cursorLine: 0, lineNumberStyle: .absolute,
             lineNumberWidth: lineNumberWidth, signColWidth: 1, entries: entries
         )

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -156,16 +156,17 @@ struct WindowContentFrameMetricsTests {
         gutter: Wire.WindowGutter,
         totalLines: UInt32
     ) -> PresentedWindowSurface {
-        let gutterWidth = UInt16(gutter.lineNumberWidth) + UInt16(gutter.signColWidth)
-        let gutterCol = gutter.contentCol >= gutterWidth ? gutter.contentCol - gutterWidth : 0
+        let gutterWidth = min(UInt16(gutter.lineNumberWidth) + UInt16(gutter.signColWidth), gutter.contentWidth)
+        let textCol = gutter.contentCol + gutterWidth
+        let textWidth = gutter.contentWidth - gutterWidth
         let geometry = content.paneGeometry ?? GUIPaneGeometry(
             windowId: content.windowId,
-            totalRect: GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutter.contentWidth + gutterWidth, height: gutter.contentHeight),
-            contentRect: GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutter.contentWidth + gutterWidth, height: gutter.contentHeight),
-            textRect: GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutter.contentWidth, height: gutter.contentHeight),
-            gutterRect: GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutterWidth, height: gutter.contentHeight),
-            clipRect: GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutter.contentWidth + gutterWidth, height: gutter.contentHeight),
-            viewport: GUIViewportSummary(top: 0, left: 0, rows: gutter.contentHeight, cols: gutter.contentWidth, totalLines: totalLines, visualRowOffset: 0, totalVisualRows: totalLines),
+            totalRect: GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutter.contentWidth, height: gutter.contentHeight),
+            contentRect: GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutter.contentWidth, height: gutter.contentHeight),
+            textRect: GUICellRect(row: gutter.contentRow, col: textCol, width: textWidth, height: gutter.contentHeight),
+            gutterRect: GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutterWidth, height: gutter.contentHeight),
+            clipRect: GUICellRect(row: gutter.contentRow, col: textCol, width: textWidth, height: gutter.contentHeight),
+            viewport: GUIViewportSummary(top: 0, left: 0, rows: gutter.contentHeight, cols: textWidth, totalLines: totalLines, visualRowOffset: 0, totalVisualRows: totalLines),
             gutterMetrics: GUIGutterMetrics(lineNumberWidth: UInt16(gutter.lineNumberWidth), signColWidth: UInt16(gutter.signColWidth)),
             hitRegions: []
         )
@@ -376,11 +377,26 @@ struct WindowContentFrameMetricsTests {
             2: Wire.WindowGutter(windowId: 2, contentRow: 0, contentCol: 40, contentHeight: 2, isActive: false, contentWidth: 40, cursorLine: 0, lineNumberStyle: .absolute, lineNumberWidth: 2, signColWidth: 2, entries: [Wire.GutterEntry(bufLine: 0, displayType: .normal, signType: .annotation, signFg: 0xFFFFFF, signText: "●")])
         ]
         frameState.horizontalSeparators = [Wire.HorizontalSeparator(row: 1, col: 0, width: 80, filename: "split.ex")]
+        frameState.gutterSeparatorColor = 0x334455
 
         let leftGutter = try #require(frameState.windowGutters[1])
         let rightGutter = try #require(frameState.windowGutters[2])
         let leftSurface = surface(content: left, gutter: leftGutter, totalLines: 1)
         let rightSurface = surface(content: right, gutter: rightGutter, totalLines: 1)
+        let chrome = CoreTextMetalRenderer.gutterChromeRects(
+            frameState: frameState,
+            surfaces: [leftSurface, rightSurface],
+            cellW: 8,
+            cellH: 16,
+            scale: 2,
+            gutterLeftMarginPx: 12,
+            gutterPaddingPx: 16,
+            viewportHeight: 100
+        )
+        #expect(chrome.leftFills.map(\.x) == [0, 640])
+        #expect(chrome.rightFills.map(\.x) == [76, 716])
+        #expect(chrome.separators.map(\.x) == [84, 724])
+
         let demand = CoreTextMetalRenderer.atlasSlotDemand(
             frameState: frameState,
             preparedSurfaces: [preparedSurface(leftSurface), preparedSurface(rightSurface)]

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -151,6 +151,38 @@ struct WindowContentFrameMetricsTests {
         return (renderer, atlas)
     }
 
+    private func surface(
+        content: GUIWindowContent,
+        gutter: Wire.WindowGutter,
+        totalLines: UInt32
+    ) -> PresentedWindowSurface {
+        let gutterWidth = UInt16(gutter.lineNumberWidth) + UInt16(gutter.signColWidth)
+        let gutterCol = gutter.contentCol >= gutterWidth ? gutter.contentCol - gutterWidth : 0
+        let geometry = content.paneGeometry ?? GUIPaneGeometry(
+            windowId: content.windowId,
+            totalRect: GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutter.contentWidth + gutterWidth, height: gutter.contentHeight),
+            contentRect: GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutter.contentWidth + gutterWidth, height: gutter.contentHeight),
+            textRect: GUICellRect(row: gutter.contentRow, col: gutter.contentCol, width: gutter.contentWidth, height: gutter.contentHeight),
+            gutterRect: GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutterWidth, height: gutter.contentHeight),
+            clipRect: GUICellRect(row: gutter.contentRow, col: gutterCol, width: gutter.contentWidth + gutterWidth, height: gutter.contentHeight),
+            viewport: GUIViewportSummary(top: 0, left: 0, rows: gutter.contentHeight, cols: gutter.contentWidth, totalLines: totalLines, visualRowOffset: 0, totalVisualRows: totalLines),
+            gutterMetrics: GUIGutterMetrics(lineNumberWidth: UInt16(gutter.lineNumberWidth), signColWidth: UInt16(gutter.signColWidth)),
+            hitRegions: []
+        )
+        return PresentedWindowSurface(content: content, gutter: .present(gutter), paneGeometry: geometry, indentGuides: nil)
+    }
+
+    private func preparedSurface(_ surface: PresentedWindowSurface) -> PreparedPresentedSurface {
+        let prepared = ResidentRenderPreparation.prepare(
+            content: surface.content,
+            fallbackVisibleRows: Int(surface.paneGeometry.textRect.height),
+            overscanRows: RendererSignposts.configuredOverscanRows,
+            scrollLeft: Int(surface.content.scrollLeft),
+            viewportCols: Int(surface.paneGeometry.textRect.width)
+        )
+        return PreparedPresentedSurface(surface: surface, prepared: prepared)
+    }
+
     @Test("Buffer row metrics distinguish rasterized rows from reused rows")
     @MainActor func bufferRowMetrics() throws {
         guard let (renderer, atlas) = makeRendererAndAtlas() else { return }
@@ -277,14 +309,33 @@ struct WindowContentFrameMetricsTests {
         #expect(metrics.bufferRowsRasterized == 1)
 
         let content = try GUIWindowContent(windowId: 1, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: [row], selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
+        let gutter = Wire.WindowGutter(windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 1, isActive: true, contentWidth: 80, cursorLine: 0, lineNumberStyle: .none, lineNumberWidth: 0, signColWidth: 0, entries: [])
+        let presentedSurface = surface(content: content, gutter: gutter, totalLines: 1)
+        var lastIdentities: [UInt16: UUID] = [:]
         atlas.beginFrame()
-        CoreTextMetalRenderer.invalidateFullRefreshWindows(in: atlas, windowContents: [1: content])
+        CoreTextMetalRenderer.invalidateFullRefreshWindows(
+            in: atlas,
+            surfaces: [presentedSurface],
+            lastIdentities: &lastIdentities
+        )
         metrics.reset()
         let second = renderer.renderRowToAtlas(displayRow: 0, row: row, windowId: 1, atlas: atlas, metrics: &metrics)
         #expect(second != nil)
         #expect(metrics.bufferRowsRasterized == 1)
         #expect(metrics.bufferRowsReused == 0)
         #expect(metrics.atlasNewKeys == 1)
+
+        atlas.beginFrame()
+        CoreTextMetalRenderer.invalidateFullRefreshWindows(
+            in: atlas,
+            surfaces: [presentedSurface],
+            lastIdentities: &lastIdentities
+        )
+        metrics.reset()
+        let third = renderer.renderRowToAtlas(displayRow: 0, row: row, windowId: 1, atlas: atlas, metrics: &metrics)
+        #expect(third != nil)
+        #expect(metrics.bufferRowsRasterized == 0)
+        #expect(metrics.bufferRowsReused == 1)
     }
 
     @Test("Horizontal scroll keeps row identity but changes the atlas hash")
@@ -326,9 +377,14 @@ struct WindowContentFrameMetricsTests {
         ]
         frameState.horizontalSeparators = [Wire.HorizontalSeparator(row: 1, col: 0, width: 80, filename: "split.ex")]
 
-        let leftSlice = RendererSignposts.visibleSlice(for: left, fallbackVisibleRows: 2)
-        let rightSlice = RendererSignposts.visibleSlice(for: right, fallbackVisibleRows: 2)
-        let demand = CoreTextMetalRenderer.atlasSlotDemand(frameState: frameState, windowContents: [1: left, 2: right], gutters: frameState.windowGutters, visibleSlices: [1: leftSlice, 2: rightSlice])
+        let leftGutter = try #require(frameState.windowGutters[1])
+        let rightGutter = try #require(frameState.windowGutters[2])
+        let leftSurface = surface(content: left, gutter: leftGutter, totalLines: 1)
+        let rightSurface = surface(content: right, gutter: rightGutter, totalLines: 1)
+        let demand = CoreTextMetalRenderer.atlasSlotDemand(
+            frameState: frameState,
+            preparedSurfaces: [preparedSurface(leftSurface), preparedSurface(rightSurface)]
+        )
 
         #expect(demand >= 2 + 1 + 4 + 1 + 32)
     }
@@ -357,8 +413,13 @@ struct WindowContentFrameMetricsTests {
             documentHighlights: [], paneGeometry: geometry
         )
         let frameState = FrameState(cols: 80, rows: 40)
+        let gutter = Wire.WindowGutter(windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 40, isActive: true, contentWidth: 80, cursorLine: 0, lineNumberStyle: .none, lineNumberWidth: 0, signColWidth: 0, entries: [])
+        let presentedSurface = surface(content: content, gutter: gutter, totalLines: 5_000)
 
-        let demand = CoreTextMetalRenderer.atlasSlotDemand(frameState: frameState, windowContents: [1: content], gutters: [:], visibleSlices: [1: RendererSignposts.visibleSlice(for: content, fallbackVisibleRows: 40)])
+        let demand = CoreTextMetalRenderer.atlasSlotDemand(
+            frameState: frameState,
+            preparedSurfaces: [preparedSurface(presentedSurface)]
+        )
 
         #expect(demand < 5_000)
         #expect(demand >= 40)

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -326,7 +326,9 @@ struct WindowContentFrameMetricsTests {
         ]
         frameState.horizontalSeparators = [Wire.HorizontalSeparator(row: 1, col: 0, width: 80, filename: "split.ex")]
 
-        let demand = CoreTextMetalRenderer.atlasSlotDemand(frameState: frameState, windowContents: [1: left, 2: right])
+        let leftSlice = RendererSignposts.visibleSlice(for: left, fallbackVisibleRows: 2)
+        let rightSlice = RendererSignposts.visibleSlice(for: right, fallbackVisibleRows: 2)
+        let demand = CoreTextMetalRenderer.atlasSlotDemand(frameState: frameState, windowContents: [1: left, 2: right], gutters: frameState.windowGutters, visibleSlices: [1: leftSlice, 2: rightSlice])
 
         #expect(demand >= 2 + 1 + 4 + 1 + 32)
     }
@@ -356,7 +358,7 @@ struct WindowContentFrameMetricsTests {
         )
         let frameState = FrameState(cols: 80, rows: 40)
 
-        let demand = CoreTextMetalRenderer.atlasSlotDemand(frameState: frameState, windowContents: [1: content])
+        let demand = CoreTextMetalRenderer.atlasSlotDemand(frameState: frameState, windowContents: [1: content], gutters: [:], visibleSlices: [1: RendererSignposts.visibleSlice(for: content, fallbackVisibleRows: 40)])
 
         #expect(demand < 5_000)
         #expect(demand >= 40)

--- a/macos/Tests/MingaTests/WindowContentRendererTests.swift
+++ b/macos/Tests/MingaTests/WindowContentRendererTests.swift
@@ -372,15 +372,16 @@ struct WindowContentFrameMetricsTests {
         let right = try GUIWindowContent(windowId: 2, fullRefresh: true, cursorRow: 0, cursorCol: 0, cursorShape: .block, rows: rows, selection: nil, searchMatches: [], diagnosticUnderlines: [], documentHighlights: [])
 
         var frameState = FrameState(cols: 80, rows: 2)
-        frameState.windowGutters = [
+        let gutters: [UInt16: Wire.WindowGutter] = [
             1: Wire.WindowGutter(windowId: 1, contentRow: 0, contentCol: 0, contentHeight: 2, isActive: true, contentWidth: 40, cursorLine: 0, lineNumberStyle: .absolute, lineNumberWidth: 2, signColWidth: 2, entries: [Wire.GutterEntry(bufLine: 0, displayType: .normal, signType: .diagError)]),
             2: Wire.WindowGutter(windowId: 2, contentRow: 0, contentCol: 40, contentHeight: 2, isActive: false, contentWidth: 40, cursorLine: 0, lineNumberStyle: .absolute, lineNumberWidth: 2, signColWidth: 2, entries: [Wire.GutterEntry(bufLine: 0, displayType: .normal, signType: .annotation, signFg: 0xFFFFFF, signText: "●")])
         ]
-        frameState.horizontalSeparators = [Wire.HorizontalSeparator(row: 1, col: 0, width: 80, filename: "split.ex")]
+        var metadata = EditorSnapshotMetadata()
+        metadata.horizontalSeparators = [Wire.HorizontalSeparator(row: 1, col: 0, width: 80, filename: "split.ex")]
         frameState.gutterSeparatorColor = 0x334455
 
-        let leftGutter = try #require(frameState.windowGutters[1])
-        let rightGutter = try #require(frameState.windowGutters[2])
+        let leftGutter = try #require(gutters[1])
+        let rightGutter = try #require(gutters[2])
         let leftSurface = surface(content: left, gutter: leftGutter, totalLines: 1)
         let rightSurface = surface(content: right, gutter: rightGutter, totalLines: 1)
         let chrome = CoreTextMetalRenderer.gutterChromeRects(
@@ -399,6 +400,7 @@ struct WindowContentFrameMetricsTests {
 
         let demand = CoreTextMetalRenderer.atlasSlotDemand(
             frameState: frameState,
+            metadata: metadata,
             preparedSurfaces: [preparedSurface(leftSurface), preparedSurface(rightSurface)]
         )
 

--- a/macos/Tests/MingaTests/WindowContentTests.swift
+++ b/macos/Tests/MingaTests/WindowContentTests.swift
@@ -566,7 +566,9 @@ struct WindowContentDecoderTests {
         #expect(content.resourceWeight == expected)
         #expect(content.exactResourceWeight() == expected)
         #expect(content.exactResourceWeight() == content.resourceWeight)
-        #expect(content.reportingOperationCounters(.init()).exactResourceWeight() == expected)
+        let reported = content.reportingOperationCounters(.init())
+        #expect(reported.exactResourceWeight() == expected)
+        #expect(reported.renderIdentity == content.renderIdentity)
     }
 
     @Test("Full content rejects complete weight before row-store construction")

--- a/macos/Tests/NativePerformance/NativeRenderPerformanceMain.swift
+++ b/macos/Tests/NativePerformance/NativeRenderPerformanceMain.swift
@@ -1,0 +1,440 @@
+import AppKit
+import Darwin
+import Foundation
+import Metal
+import MingaProtocol
+import MingaUI
+import QuartzCore
+
+private let residentRowCount = 65_536
+private let viewportRows: UInt16 = 80
+private let viewportCols: UInt16 = 160
+private let warmupFrameCount = 9
+private let measuredFrameCount = 240
+
+private final class BenchmarkDrawable: NSObject, CAMetalDrawable {
+    let texture: MTLTexture
+    let layer = CAMetalLayer()
+    let drawableID: Int = 1
+    let presentedTime: CFTimeInterval = 0
+
+    init(texture: MTLTexture) { self.texture = texture }
+    func present() {}
+    func present(at presentationTime: CFTimeInterval) { _ = presentationTime }
+    func present(afterMinimumDuration duration: CFTimeInterval) { _ = duration }
+    func addPresentedHandler(_ block: @escaping MTLDrawablePresentedHandler) { _ = block }
+}
+
+private struct CompletedFrame {
+    let drawCPUMs: Double
+    let gpuMs: Double
+    let completionWallMs: Double
+    let allocatedBytes: Int
+    let allocationCount: Int
+    let presented: Bool
+}
+
+@MainActor
+private final class NativeBenchmarkProbe {
+    private enum Phase {
+        case idle
+        case submitting(CheckedContinuation<CompletedFrame, Never>)
+        case awaiting(CheckedContinuation<CompletedFrame, Never>)
+        case terminal(CheckedContinuation<CompletedFrame, Never>, presented: Bool)
+    }
+
+    private var phase = Phase.idle
+    private var startedAt: ContinuousClock.Instant = .now
+    private var drawCPUMs = 0.0
+    private var gpuMs = 0.0
+    private var allocatedBytes = 0
+    private var allocationCount = 0
+    private(set) var inFlight = 0
+    private(set) var maximumInFlight = 0
+
+    func measure(_ submit: () -> Double) async -> CompletedFrame {
+        await withCheckedContinuation { continuation in
+            guard case .idle = phase else {
+                preconditionFailure("cannot start a benchmark frame while another frame is pending")
+            }
+            startedAt = .now
+            drawCPUMs = 0
+            gpuMs = 0
+            allocatedBytes = 0
+            allocationCount = 0
+            inFlight += 1
+            maximumInFlight = max(maximumInFlight, inFlight)
+            phase = .submitting(continuation)
+            drawCPUMs = submit()
+
+            switch phase {
+            case .submitting(let pending):
+                phase = .awaiting(pending)
+            case .terminal(let pending, let presented):
+                complete(pending, presented: presented)
+            case .idle, .awaiting:
+                preconditionFailure("invalid benchmark submission transition")
+            }
+        }
+    }
+
+    func recordGPU(_ milliseconds: Double) { gpuMs += milliseconds }
+
+    func recordCompletionCPU(_ milliseconds: Double) { drawCPUMs += milliseconds }
+
+    func recordBufferAllocation(bytes: Int) {
+        allocationCount += 1
+        allocatedBytes += bytes
+    }
+
+    func recordTextureAllocation(_ descriptor: MTLTextureDescriptor) {
+        allocationCount += 1
+        allocatedBytes += descriptor.width * descriptor.height * 4
+    }
+
+    func finishPresented() { finish(presented: true) }
+
+    func finishFailed() { finish(presented: false) }
+
+    private func finish(presented: Bool) {
+        switch phase {
+        case .submitting(let continuation):
+            phase = .terminal(continuation, presented: presented)
+        case .awaiting(let continuation):
+            complete(continuation, presented: presented)
+        case .idle, .terminal:
+            return
+        }
+    }
+
+    private func complete(
+        _ continuation: CheckedContinuation<CompletedFrame, Never>,
+        presented: Bool
+    ) {
+        phase = .idle
+        inFlight -= 1
+        let duration = startedAt.duration(to: .now)
+        let completionWallMs = Double(duration.components.seconds) * 1_000
+            + Double(duration.components.attoseconds) / 1_000_000_000_000_000
+        continuation.resume(returning: CompletedFrame(
+            drawCPUMs: drawCPUMs,
+            gpuMs: gpuMs,
+            completionWallMs: completionWallMs,
+            allocatedBytes: allocatedBytes,
+            allocationCount: allocationCount,
+            presented: presented
+        ))
+    }
+}
+
+private func threadCPUTimeNanoseconds() -> UInt64 {
+    clock_gettime_nsec_np(CLOCK_THREAD_CPUTIME_ID)
+}
+
+private func percentile(_ samples: [Double], _ ratio: Double) -> Double {
+    let sorted = samples.sorted()
+    let index = min(max(Int((Double(sorted.count) * ratio).rounded(.up)) - 1, 0), sorted.count - 1)
+    return sorted[index]
+}
+
+@MainActor
+private func completeThemeSlots() -> [(UInt8, UInt8, UInt8, UInt8)] {
+    CommandDispatcher.requiredThemeSlots.map { slot in (slot, slot, slot, slot) }
+}
+
+private func paneGeometry() -> GUIPaneGeometry {
+    let gutterWidth: UInt16 = 6
+    return GUIPaneGeometry(
+        windowId: 1,
+        totalRect: GUICellRect(row: 0, col: 0, width: viewportCols, height: viewportRows),
+        contentRect: GUICellRect(row: 0, col: 0, width: viewportCols, height: viewportRows),
+        textRect: GUICellRect(row: 0, col: gutterWidth, width: viewportCols - gutterWidth, height: viewportRows),
+        gutterRect: GUICellRect(row: 0, col: 0, width: gutterWidth, height: viewportRows),
+        clipRect: GUICellRect(row: 0, col: 0, width: viewportCols, height: viewportRows),
+        viewport: GUIViewportSummary(
+            top: 0, left: 0, rows: viewportRows, cols: viewportCols - gutterWidth,
+            totalLines: UInt32(residentRowCount), visualRowOffset: 0,
+            totalVisualRows: UInt32(residentRowCount)
+        ),
+        gutterMetrics: GUIGutterMetrics(lineNumberWidth: 5, signColWidth: 1),
+        hitRegions: [GUIHitRegion(
+            kind: .gutter,
+            rect: GUICellRect(row: 0, col: 0, width: gutterWidth, height: viewportRows),
+            windowId: 1
+        )]
+    )
+}
+
+private func residentContent(geometry: GUIPaneGeometry) throws -> GUIWindowContent {
+    var rows: [GUIVisualRow] = []
+    rows.reserveCapacity(residentRowCount)
+    for index in 0..<residentRowCount {
+        rows.append(GUIVisualRow(
+            rowType: .normal,
+            rowId: UInt64(index + 1),
+            bufLine: UInt32(index),
+            contentHash: UInt32(index + 1),
+            text: "row \(index) let value = \(index)",
+            spans: []
+        ))
+    }
+    return try GUIWindowContent(
+        windowId: 1,
+        fullRefresh: true,
+        contentEpoch: 1,
+        cursorVisible: true,
+        cursorRow: 20,
+        cursorCol: 8,
+        cursorShape: .block,
+        rows: rows,
+        selection: nil,
+        searchMatches: [],
+        diagnosticUnderlines: [],
+        documentHighlights: [],
+        paneGeometry: geometry,
+        scrollPresentation: GUIScrollPresentation(
+            windowId: 1,
+            resetRequired: false,
+            anchorTop: 0,
+            anchorLeft: 0,
+            anchorVisualRowOffset: 0,
+            visibleStartLine: 0,
+            visibleEndLine: UInt32(viewportRows),
+            overscanStartLine: 0,
+            overscanEndLine: UInt32(residentRowCount),
+            contentEpoch: 1,
+            layoutGeneration: 1,
+            scrollSeq: 1
+        )
+    )
+}
+
+private func gutter(geometry: GUIPaneGeometry) -> Wire.WindowGutter {
+    Wire.WindowGutter(
+        windowId: 1,
+        contentRow: geometry.textRect.row,
+        contentCol: geometry.textRect.col,
+        contentHeight: geometry.textRect.height,
+        isActive: true,
+        contentWidth: geometry.textRect.width,
+        cursorLine: 20,
+        lineNumberStyle: .hybrid,
+        lineNumberWidth: 5,
+        signColWidth: 1,
+        entries: (0..<Int(viewportRows)).map { index in
+            Wire.GutterEntry(
+                bufLine: UInt32(index), displayType: .normal, signType: .none,
+                foldEndLine: 0xFFFF_FFFF, signFg: 0, signText: ""
+            )
+        }
+    )
+}
+
+@MainActor
+private func commitKeyframe(
+    dispatcher: CommandDispatcher,
+    content: GUIWindowContent,
+    gutter: Wire.WindowGutter
+) {
+    dispatcher.dispatch(.beginFrame(frameSeq: 1, baseFrameSeq: 0, generation: 1))
+    dispatcher.dispatch(.guiTheme(slots: completeThemeSlots()))
+    dispatcher.dispatch(.guiWindowContent(data: content))
+    dispatcher.dispatch(.guiGutter(data: gutter))
+    dispatcher.dispatch(.commitFrame(frameSeq: 1, seq: 0))
+}
+
+@MainActor
+private func measureFreezePublication(dispatcher: CommandDispatcher) -> [Double] {
+    var samples: [Double] = []
+    samples.reserveCapacity(measuredFrameCount)
+    var priorFrameSeq: UInt32 = 1
+    for index in 0..<measuredFrameCount {
+        let frameSeq = priorFrameSeq + 1
+        let start = threadCPUTimeNanoseconds()
+        dispatcher.dispatch(.beginFrame(frameSeq: frameSeq, baseFrameSeq: priorFrameSeq, generation: 1))
+        dispatcher.dispatch(.setCursorShape(index.isMultiple(of: 2) ? .block : .beam))
+        dispatcher.dispatch(.commitFrame(frameSeq: frameSeq, seq: 0))
+        samples.append(Double(threadCPUTimeNanoseconds() - start) / 1_000_000)
+        priorFrameSeq = frameSeq
+    }
+    return samples
+}
+
+@MainActor
+private func makeFactories(probe: NativeBenchmarkProbe) -> NativeRenderFactories {
+    var factories = NativeRenderFactories.production
+    factories.makeBuffer = { device, length, options in
+        probe.recordBufferAllocation(bytes: length)
+        return device.makeBuffer(length: length, options: options)
+    }
+    factories.makeTexture = { device, descriptor in
+        probe.recordTextureAllocation(descriptor)
+        return device.makeTexture(descriptor: descriptor)
+    }
+    factories.observeCompletion = { commandBuffer, completion in
+        commandBuffer.addCompletedHandler { completed in
+            let succeeded = completed.status == .completed
+            let status = Int(completed.status.rawValue)
+            let gpuMs = max(completed.gpuEndTime - completed.gpuStartTime, 0) * 1_000
+            Task { @MainActor in
+                probe.recordGPU(gpuMs)
+                let cpuStart = threadCPUTimeNanoseconds()
+                completion(succeeded, status)
+                probe.recordCompletionCPU(
+                    Double(threadCPUTimeNanoseconds() - cpuStart) / 1_000_000
+                )
+            }
+        }
+    }
+    factories.present = { drawable in
+        drawable.present()
+        probe.finishPresented()
+    }
+    factories.reportFailure = { _ in
+        probe.finishFailed()
+    }
+    return factories
+}
+
+@MainActor
+private func renderFrame(
+    renderer: CoreTextMetalRenderer,
+    dispatcher: CommandDispatcher,
+    guiState: GUIState,
+    fontManager: FontManager,
+    drawable: BenchmarkDrawable,
+    probe: NativeBenchmarkProbe,
+    index: Int
+) async -> CompletedFrame {
+    await probe.measure {
+        let cpuStart = threadCPUTimeNanoseconds()
+        #if MINGA_SNAPSHOT_RENDERER
+        guard let snapshot = dispatcher.committedEditorSnapshot else {
+            probe.finishFailed()
+            return Double(threadCPUTimeNanoseconds() - cpuStart) / 1_000_000
+        }
+        renderer.render(
+            snapshot: snapshot,
+            fontManager: fontManager,
+            cursorBlinkVisible: index.isMultiple(of: 2),
+            drawableProvider: { drawable },
+            viewportSize: CGSize(width: 1_920, height: 1_200),
+            contentScale: 1,
+            scrollOffset: SIMD2<Float>(0, Float(index % 4) * -0.25),
+            presentationWindowId: 1,
+            presentationInputSeq: UInt32(index + 1)
+        )
+        #else
+        renderer.render(
+            frameState: dispatcher.frameState,
+            fontManager: fontManager,
+            cursorBlinkVisible: index.isMultiple(of: 2),
+            windowContents: guiState.windowContents,
+            themeColors: guiState.themeColors,
+            drawableProvider: { drawable },
+            viewportSize: CGSize(width: 1_920, height: 1_200),
+            contentScale: 1,
+            scrollOffset: SIMD2<Float>(0, Float(index % 4) * -0.25),
+            presentationWindowId: 1,
+            presentationInputSeq: UInt32(index + 1)
+        )
+        #endif
+        return Double(threadCPUTimeNanoseconds() - cpuStart) / 1_000_000
+    }
+}
+
+@main
+private struct NativeRenderPerformanceMain {
+    @MainActor
+    static func main() async throws {
+        guard CommandLine.arguments.count == 3,
+              CommandLine.arguments[1] == "--measurement-output" else {
+            FileHandle.standardError.write(Data("usage: minga-native-render-performance --measurement-output OUTPUT.json\n".utf8))
+            exit(2)
+        }
+        guard MTLCreateSystemDefaultDevice() != nil else {
+            FileHandle.standardError.write(Data("error: native render benchmark requires a Metal device\n".utf8))
+            exit(2)
+        }
+
+        let geometry = paneGeometry()
+        let content = try residentContent(geometry: geometry)
+        let guiState = GUIState()
+        let dispatcher = CommandDispatcher(cols: viewportCols, rows: viewportRows, guiState: guiState)
+        commitKeyframe(dispatcher: dispatcher, content: content, gutter: gutter(geometry: geometry))
+        let freezeSamples = measureFreezePublication(dispatcher: dispatcher)
+
+        let probe = NativeBenchmarkProbe()
+        guard let renderer = CoreTextMetalRenderer(factories: makeFactories(probe: probe)) else {
+            FileHandle.standardError.write(Data("error: unable to initialize native renderer\n".utf8))
+            exit(2)
+        }
+        let fontManager = FontManager(name: "Menlo", size: 13, scale: 1)
+        renderer.setupRenderers(fontManager: fontManager)
+        let descriptor = MTLTextureDescriptor.texture2DDescriptor(
+            pixelFormat: .bgra8Unorm_srgb, width: 1_920, height: 1_200, mipmapped: false
+        )
+        descriptor.usage = [.renderTarget, .shaderRead]
+        guard let texture = renderer.device.makeTexture(descriptor: descriptor) else {
+            FileHandle.standardError.write(Data("error: unable to allocate benchmark drawable\n".utf8))
+            exit(2)
+        }
+        let drawable = BenchmarkDrawable(texture: texture)
+
+        for index in 0..<warmupFrameCount {
+            _ = await renderFrame(
+                renderer: renderer, dispatcher: dispatcher, guiState: guiState,
+                fontManager: fontManager, drawable: drawable, probe: probe, index: index
+            )
+        }
+
+        var frames: [CompletedFrame] = []
+        frames.reserveCapacity(measuredFrameCount)
+        for index in 0..<measuredFrameCount {
+            frames.append(await renderFrame(
+                renderer: renderer, dispatcher: dispatcher, guiState: guiState,
+                fontManager: fontManager, drawable: drawable, probe: probe,
+                index: warmupFrameCount + index
+            ))
+        }
+
+        let drawSamples = frames.map(\.drawCPUMs)
+        let gpuSamples = frames.map(\.gpuMs)
+        let completionWallSamples = frames.map(\.completionWallMs)
+        let measurement = NativeRenderPerformanceMeasurement(
+            freezePublicationP50Ms: percentile(freezeSamples, 0.50),
+            freezePublicationP95Ms: percentile(freezeSamples, 0.95),
+            drawCPUP50Ms: percentile(drawSamples, 0.50),
+            drawCPUP95Ms: percentile(drawSamples, 0.95),
+            drawCPUP99Ms: percentile(drawSamples, 0.99),
+            gpuP50Ms: percentile(gpuSamples, 0.50),
+            gpuP95Ms: percentile(gpuSamples, 0.95),
+            completionWallP50Ms: percentile(completionWallSamples, 0.50),
+            completionWallP95Ms: percentile(completionWallSamples, 0.95),
+            maximumAllocatedBytesPerFrame: frames.map(\.allocatedBytes).max() ?? 0,
+            allocationCountAfterWarmup: frames.reduce(0) { $0 + $1.allocationCount },
+            attemptedFrameCount: frames.count,
+            copyCompletedFrameCount: frames.filter(\.presented).count,
+            failedOrDiscardedFrameCount: frames.filter { !$0.presented }.count,
+            maximumInFlightGenerations: probe.maximumInFlight
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let data = try encoder.encode(measurement)
+        try data.write(to: URL(fileURLWithPath: CommandLine.arguments[2]), options: .atomic)
+        print(String(decoding: data, as: UTF8.self))
+        #if MINGA_SNAPSHOT_RENDERER
+        let rendererPath = "snapshot"
+        #else
+        let rendererPath = "legacy-fragmented"
+        #endif
+        print("fixture=native-resident-cursor-local-scroll-v1 path=\(rendererPath) device=\(renderer.device.name) os=\(ProcessInfo.processInfo.operatingSystemVersionString) rows=\(residentRowCount) viewport=\(viewportCols)x\(viewportRows) warmup=\(warmupFrameCount) measured=\(measuredFrameCount)")
+
+        let failures = NativeRenderPerformanceGate.absoluteFailures(measurement)
+        for failure in failures {
+            FileHandle.standardError.write(Data("error: \(failure)\n".utf8))
+        }
+        if !failures.isEmpty { exit(1) }
+    }
+}

--- a/macos/Tests/NativePerformance/NativeRenderPerformanceMain.swift
+++ b/macos/Tests/NativePerformance/NativeRenderPerformanceMain.swift
@@ -272,7 +272,7 @@ private func makeFactories(probe: NativeBenchmarkProbe) -> NativeRenderFactories
         return device.makeTexture(descriptor: descriptor)
     }
     factories.observeCompletion = { commandBuffer, completion in
-        commandBuffer.addCompletedHandler { completed in
+        commandBuffer.addCompletedHandler { @Sendable completed in
             let succeeded = completed.status == .completed
             let status = Int(completed.status.rawValue)
             let gpuMs = max(completed.gpuEndTime - completed.gpuStartTime, 0) * 1_000

--- a/macos/Tests/NativePerformance/NativeRenderPerformanceMain.swift
+++ b/macos/Tests/NativePerformance/NativeRenderPerformanceMain.swift
@@ -212,11 +212,11 @@ private func residentContent(geometry: GUIPaneGeometry) throws -> GUIWindowConte
 private func gutter(geometry: GUIPaneGeometry) -> Wire.WindowGutter {
     Wire.WindowGutter(
         windowId: 1,
-        contentRow: geometry.textRect.row,
-        contentCol: geometry.textRect.col,
-        contentHeight: geometry.textRect.height,
+        contentRow: geometry.contentRect.row,
+        contentCol: geometry.contentRect.col,
+        contentHeight: geometry.contentRect.height,
         isActive: true,
-        contentWidth: geometry.textRect.width,
+        contentWidth: geometry.contentRect.width,
         cursorLine: 20,
         lineNumberStyle: .hybrid,
         lineNumberWidth: 5,

--- a/macos/Tests/Performance/NativeCompare/main.swift
+++ b/macos/Tests/Performance/NativeCompare/main.swift
@@ -1,0 +1,44 @@
+import Foundation
+
+private func usage() -> Never {
+    FileHandle.standardError.write(Data("usage: native-render-compare --base BASE.json... --head HEAD.json...\n".utf8))
+    exit(2)
+}
+
+private var baseURLs: [URL] = []
+private var headURLs: [URL] = []
+private var index = 1
+while index < CommandLine.arguments.count {
+    guard index + 1 < CommandLine.arguments.count else { usage() }
+    let url = URL(fileURLWithPath: CommandLine.arguments[index + 1])
+    switch CommandLine.arguments[index] {
+    case "--base": baseURLs.append(url)
+    case "--head": headURLs.append(url)
+    default: usage()
+    }
+    index += 2
+}
+
+private func decode(_ urls: [URL]) throws -> [NativeRenderPerformanceMeasurement] {
+    try urls.map { url in
+        try JSONDecoder().decode(NativeRenderPerformanceMeasurement.self, from: Data(contentsOf: url))
+    }
+}
+
+let baseMeasurements = try decode(baseURLs)
+let headMeasurements = try decode(headURLs)
+let failures = NativeRenderPerformanceGate.pairedFailures(
+    baseMeasurements: baseMeasurements,
+    headMeasurements: headMeasurements
+)
+let pairedRatios = zip(baseMeasurements, headMeasurements).map { base, head in
+    head.completionWallP50Ms / base.completionWallP50Ms
+}.sorted()
+if !pairedRatios.isEmpty {
+    let medianRatio = pairedRatios[pairedRatios.count / 2]
+    print(String(format: "native handoff-to-copy-completion p50 paired median ratio %.3fx (%d pairs)", medianRatio, pairedRatios.count))
+}
+for failure in failures {
+    FileHandle.standardError.write(Data("error: \(failure)\n".utf8))
+}
+if !failures.isEmpty { exit(1) }

--- a/macos/project.yml
+++ b/macos/project.yml
@@ -255,6 +255,7 @@ targets:
           - "Snapshots/**"
           # Standalone optimized executable; unit tests cover its comparator separately.
           - "Performance/**"
+          - "NativePerformance/**"
       - path: Sources
         type: group
         excludes:
@@ -312,6 +313,7 @@ targets:
         GENERATE_INFOPLIST_FILE: "YES"
         # Compiles Renderer/ Metal sources; needs the Metal toolchain pin.
         TOOLCHAINS: com.apple.dt.toolchain.Metal.32023.864
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) MINGA_SNAPSHOT_RENDERER"
     dependencies:
       - target: MingaProtocol
       - target: MingaUI
@@ -328,6 +330,80 @@ targets:
             echo "error: mix is required to generate protocol artifacts. Install Elixir, then run: mix protocol.gen"
             exit 1
           fi
+          mix protocol.gen
+        basedOnDependencyAnalysis: false
+
+  NativeRenderPerformance:
+    type: tool
+    platform: macOS
+    sources:
+      - path: Tests/NativePerformance/NativeRenderPerformanceMain.swift
+        type: file
+      - path: Sources
+        type: group
+        excludes:
+          - "MingaApp.swift"
+          - "PreviewHostApp.swift"
+          - "PreviewRegistry.swift"
+          - "Protocol/ProtocolTypes.swift"
+          - "Protocol/StatusBarUpdate.swift"
+          - "Protocol/GUIColorSlots.swift"
+          - "Protocol/FrameResourcePolicy.swift"
+          - "Renderer/WindowContent.swift"
+          - "Renderer/ResidentRowStore.swift"
+          - "Renderer/ResidentRenderPreparation.swift"
+          - "Protocol/AgentSurfaceTypes.swift"
+          - "Protocol/LatencyRecorder.swift"
+          - "Protocol/RenderPerformanceGate.swift"
+          - "Protocol/FrontendExtensionRuntimeMessage.swift"
+          - "Protocol/InputEncoder.swift"
+          - "Protocol/PortLogger.swift"
+          - "Extensions/FrontendExtensionRuntime.swift"
+          - "Views/Editor/InlineEditField.swift"
+          - "Views/Editor/BlinkingCursor.swift"
+          - "PreviewFixtures.swift"
+          - "ContentView.swift"
+          - "Views/Shared/EditorGeometry.swift"
+          - "Views/Agent/**"
+          - "Views/EditorChrome/**"
+          - "Views/Extensions/**"
+          - "Views/Modifiers/**"
+          - "Views/Overlays/**"
+          - "Views/Settings/**"
+          - "Views/Sidebar/**"
+          - "Views/Shared/EditTimelineState.swift"
+          - "Views/Shared/EditTimelineView.swift"
+          - "Views/Shared/GUIFramePresentationMetrics.swift"
+          - "Views/Shared/GUIFrameCorrelation.swift"
+          - "Views/Shared/GUIState.swift"
+          - "Views/Shared/SparklineView.swift"
+          - "Views/Shared/TextHighlighting.swift"
+          - "Views/Shared/ThemeColors.swift"
+      - path: .generated/protocol/ProtocolOpcodes.generated.swift
+        name: ProtocolOpcodes.generated.swift
+        type: file
+      - path: .generated/protocol/ProtocolCommandSize.generated.swift
+        name: ProtocolCommandSize.generated.swift
+        type: file
+      - path: .generated/protocol/ProtocolSemanticDecode.generated.swift
+        name: ProtocolSemanticDecode.generated.swift
+        type: file
+    settings:
+      base:
+        PRODUCT_NAME: minga-native-render-performance
+        GENERATE_INFOPLIST_FILE: "YES"
+        TOOLCHAINS: com.apple.dt.toolchain.Metal.32023.864
+        SWIFT_ACTIVE_COMPILATION_CONDITIONS: "$(inherited) MINGA_SNAPSHOT_RENDERER"
+    dependencies:
+      - target: MingaProtocol
+      - target: MingaUI
+    preBuildScripts:
+      - name: Generate protocol opcodes
+        script: |
+          if [[ "${MINGA_NATIVE_RENDER_SKIP_PROTOCOL_GEN:-0}" == "1" ]]; then
+            exit 0
+          fi
+          cd "${SRCROOT}/.."
           mix protocol.gen
         basedOnDependencyAnalysis: false
 

--- a/scripts/bench_native_render_performance_ab
+++ b/scripts/bench_native_render_performance_ab
@@ -69,6 +69,10 @@ measure_revision() {
   MINGA_NATIVE_RENDER_ROOT="$source_root" "$runner" --measure "$build_dir" "$output" 2>&1 | tee -a "$metrics_file" || status=$?
   if (( status != 0 )); then
     find "$HOME/Library/Logs/DiagnosticReports" -maxdepth 1 -type f -name 'minga-native-render-performance*.ips' -mmin -10 -print -exec cp {} "$artifact_dir/" \; -exec cat {} \; 2>/dev/null || true
+    if command -v lldb >/dev/null; then
+      echo "Native benchmark trapped; rerunning once under LLDB for a symbolic backtrace" | tee -a "$metrics_file"
+      lldb --batch -o run -o "thread backtrace all" -- "$build_dir/Build/Products/Release/minga-native-render-performance" --measurement-output "$work_dir/$side-$pair-lldb.json" 2>&1 | tee -a "$metrics_file" || true
+    fi
   fi
   echo "::endgroup::"
   [[ -s "$output" ]] || return 1

--- a/scripts/bench_native_render_performance_ab
+++ b/scripts/bench_native_render_performance_ab
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# Run the complete native Metal renderer on alternating same-runner base/HEAD pairs.
+set -uo pipefail
+
+repo_root=$(git rev-parse --show-toplevel) || exit 2
+cd "$repo_root" || exit 2
+
+if [[ $# -eq 2 && $1 == "--head-only" ]]; then
+  head_only=1
+  base_sha=""
+  head_sha=$(git rev-parse "$2") || exit 2
+elif [[ $# -eq 2 ]]; then
+  head_only=0
+  base_sha=$(git rev-parse "$1") || exit 2
+  head_sha=$(git rev-parse "$2") || exit 2
+else
+  echo "usage: $0 BASE_SHA HEAD_SHA | --head-only HEAD_SHA" >&2
+  exit 2
+fi
+
+artifact_dir="${GITHUB_WORKSPACE:-$repo_root}"
+metrics_file="$artifact_dir/native_render_performance_metrics.txt"
+head_output="$artifact_dir/native_render_performance.json"
+work_dir=$(mktemp -d "${TMPDIR:-/tmp}/minga-native-render-performance.XXXXXX")
+runner="$work_dir/check_native_render_performance"
+base_source="$work_dir/base-source"
+head_source="$work_dir/head-source"
+base_build="$work_dir/base-build"
+head_build="$work_dir/head-build"
+base_runs=()
+head_runs=()
+
+cleanup() { rm -rf "$work_dir"; }
+trap cleanup EXIT
+
+ruler_paths=(
+  macos/project.yml
+  macos/Sources/Protocol/RenderPerformanceGate.swift
+  macos/Tests/NativePerformance/NativeRenderPerformanceMain.swift
+  macos/Tests/Performance/NativeCompare/main.swift
+)
+
+git show "$head_sha:scripts/check_native_render_performance" > "$runner" || exit 2
+chmod +x "$runner"
+: > "$metrics_file"
+rm -f "$head_output"
+
+build_revision() {
+  local revision=$1 side=$2 source_root=$3 build_dir=$4 conditions=$5 path
+  echo "::group::Build native Metal benchmark $side ($revision)"
+  mkdir -p "$source_root"
+  git archive "$revision" | tar -x -C "$source_root" || return 1
+  for path in "${ruler_paths[@]}"; do
+    mkdir -p "$source_root/$(dirname "$path")"
+    git show "$head_sha:$path" > "$source_root/$path" || return 1
+  done
+  (cd "$source_root" && MIX_DEPS_PATH="$repo_root/deps" MIX_BUILD_PATH="$repo_root/_build/test" MIX_ENV=test mix protocol.gen >/dev/null) || return 1
+  MINGA_NATIVE_RENDER_ROOT="$source_root" \
+    MINGA_NATIVE_RENDER_SKIP_PROTOCOL_GEN=1 \
+    MINGA_NATIVE_RENDER_SWIFT_CONDITIONS="$conditions" \
+    "$runner" --build "$build_dir" || return 1
+  echo "::endgroup::"
+}
+
+measure_revision() {
+  local side=$1 pair=$2 source_root=$3 build_dir=$4
+  local output="$work_dir/$side-$pair.json" status=0
+  echo "::group::Measure native Metal benchmark $side pair $pair"
+  MINGA_NATIVE_RENDER_ROOT="$source_root" "$runner" --measure "$build_dir" "$output" 2>&1 | tee -a "$metrics_file" || status=$?
+  echo "::endgroup::"
+  [[ -s "$output" ]] || return 1
+  if [[ "$side" == base ]]; then
+    base_runs+=("$output")
+  else
+    head_runs+=("$output")
+    cp "$output" "$head_output"
+  fi
+  if [[ "$side" == head && $status -ne 0 ]]; then
+    echo "HEAD native measurement breached an absolute budget" >&2
+    return "$status"
+  fi
+}
+
+run_pairs() {
+  local pair
+  for pair in 1 2 3; do
+    if (( pair % 2 == 1 )); then
+      measure_revision base "$pair" "$base_source" "$base_build" || return 1
+      measure_revision head "$pair" "$head_source" "$head_build" || return 1
+    else
+      measure_revision head "$pair" "$head_source" "$head_build" || return 1
+      measure_revision base "$pair" "$base_source" "$base_build" || return 1
+    fi
+  done
+}
+
+compare_pairs() {
+  local args=() path
+  for path in "${base_runs[@]}"; do args+=(--base "$path"); done
+  for path in "${head_runs[@]}"; do args+=(--head "$path"); done
+  MINGA_NATIVE_RENDER_ROOT="$head_source" "$runner" --compare "$head_build" "${args[@]}" 2>&1 | tee -a "$metrics_file"
+}
+
+if ! build_revision "$head_sha" head "$head_source" "$head_build" MINGA_SNAPSHOT_RENDERER; then
+  echo "HEAD native Metal benchmark could not be built" >&2
+  exit 1
+fi
+
+if (( head_only )); then
+  measure_revision head 1 "$head_source" "$head_build" || exit 1
+  exit 0
+fi
+
+git cat-file -e "$base_sha^{commit}" 2>/dev/null || {
+  echo "error: merge-base $base_sha is unavailable for required native paired gate" >&2
+  exit 1
+}
+if ! build_revision "$base_sha" base "$base_source" "$base_build" MINGA_LEGACY_FRAGMENTED_RENDERER; then
+  echo "merge-base native Metal benchmark could not be built" >&2
+  exit 1
+fi
+run_pairs || exit 1
+compare_pairs

--- a/scripts/bench_native_render_performance_ab
+++ b/scripts/bench_native_render_performance_ab
@@ -67,6 +67,9 @@ measure_revision() {
   local output="$work_dir/$side-$pair.json" status=0
   echo "::group::Measure native Metal benchmark $side pair $pair"
   MINGA_NATIVE_RENDER_ROOT="$source_root" "$runner" --measure "$build_dir" "$output" 2>&1 | tee -a "$metrics_file" || status=$?
+  if (( status != 0 )); then
+    find "$HOME/Library/Logs/DiagnosticReports" -maxdepth 1 -type f -name 'minga-native-render-performance*.ips' -mmin -10 -print -exec cp {} "$artifact_dir/" \; -exec cat {} \; 2>/dev/null || true
+  fi
   echo "::endgroup::"
   [[ -s "$output" ]] || return 1
   if [[ "$side" == base ]]; then

--- a/scripts/bench_native_render_performance_ab
+++ b/scripts/bench_native_render_performance_ab
@@ -71,7 +71,7 @@ measure_revision() {
     find "$HOME/Library/Logs/DiagnosticReports" -maxdepth 1 -type f -name 'minga-native-render-performance*.ips' -mmin -10 -print -exec cp {} "$artifact_dir/" \; -exec cat {} \; 2>/dev/null || true
     if command -v lldb >/dev/null; then
       echo "Native benchmark trapped; rerunning once under LLDB for a symbolic backtrace" | tee -a "$metrics_file"
-      lldb --batch -o run -o "thread backtrace all" -- "$build_dir/Build/Products/Release/minga-native-render-performance" --measurement-output "$work_dir/$side-$pair-lldb.json" 2>&1 | tee -a "$metrics_file" || true
+      lldb --batch -o run -k "thread backtrace all" -- "$build_dir/Build/Products/Release/minga-native-render-performance" --measurement-output "$work_dir/$side-$pair-lldb.json" 2>&1 | tee -a "$metrics_file" || true
     fi
   fi
   echo "::endgroup::"

--- a/scripts/check_native_render_performance
+++ b/scripts/check_native_render_performance
@@ -38,6 +38,10 @@ build_harness() {
     -derivedDataPath "$build_dir" \
     CODE_SIGNING_ALLOWED=NO \
     SWIFT_ACTIVE_COMPILATION_CONDITIONS="$conditions"
+  local framework_dir="$build_dir/Build/Products/Frameworks"
+  mkdir -p "$framework_dir"
+  ln -sfn ../Release/MingaProtocol.framework "$framework_dir/MingaProtocol.framework"
+  ln -sfn ../Release/MingaUI.framework "$framework_dir/MingaUI.framework"
   swiftc -O \
     "$ROOT/macos/Sources/Protocol/RenderPerformanceGate.swift" \
     "$ROOT/macos/Tests/Performance/NativeCompare/main.swift" \
@@ -55,7 +59,6 @@ measure_harness() {
   fi
   mkdir -p "$(dirname "$output")"
   SWIFT_BACKTRACE=enable=yes \
-    DYLD_FRAMEWORK_PATH="$products${DYLD_FRAMEWORK_PATH:+:$DYLD_FRAMEWORK_PATH}" \
     "$binary" --measurement-output "$output"
 }
 

--- a/scripts/check_native_render_performance
+++ b/scripts/check_native_render_performance
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+ROOT="${MINGA_NATIVE_RENDER_ROOT:-$SCRIPT_ROOT}"
+ROOT="$(cd "$ROOT" && pwd)"
+DEFAULT_BUILD_DIR="${ROOT}/_build/native-render-performance"
+
+usage() {
+  echo "usage: $0 [--build BUILD_DIR | --measure BUILD_DIR OUTPUT.json | --compare BUILD_DIR --base BASE.json... --head HEAD.json...]" >&2
+  exit 2
+}
+
+require_macos() {
+  if [[ "$(uname -s)" != "Darwin" ]]; then
+    echo "error: native Metal render gate requires macOS" >&2
+    exit 2
+  fi
+  command -v xcodegen >/dev/null || {
+    echo "error: native Metal render gate requires xcodegen" >&2
+    exit 2
+  }
+}
+
+build_harness() {
+  local build_dir=$1
+  local conditions=${MINGA_NATIVE_RENDER_SWIFT_CONDITIONS:-MINGA_SNAPSHOT_RENDERER}
+
+  rm -rf "$build_dir"
+  if [[ "${MINGA_NATIVE_RENDER_SKIP_PROTOCOL_GEN:-0}" != "1" ]]; then
+    (cd "$ROOT" && mix protocol.gen >/dev/null)
+  fi
+  (cd "$ROOT/macos" && xcodegen generate >/dev/null)
+  xcodebuild build \
+    -project "$ROOT/macos/Minga.xcodeproj" \
+    -scheme NativeRenderPerformance \
+    -configuration Release \
+    -derivedDataPath "$build_dir" \
+    CODE_SIGNING_ALLOWED=NO \
+    SWIFT_ACTIVE_COMPILATION_CONDITIONS="$conditions"
+  swiftc -O \
+    "$ROOT/macos/Sources/Protocol/RenderPerformanceGate.swift" \
+    "$ROOT/macos/Tests/Performance/NativeCompare/main.swift" \
+    -o "$build_dir/native-render-compare"
+}
+
+measure_harness() {
+  local build_dir=$1
+  local output=$2
+  local products="$build_dir/Build/Products/Release"
+  local binary="$products/minga-native-render-performance"
+  if [[ ! -x "$binary" ]]; then
+    echo "error: native render benchmark binary not found: $binary" >&2
+    exit 2
+  fi
+  mkdir -p "$(dirname "$output")"
+  DYLD_FRAMEWORK_PATH="$products${DYLD_FRAMEWORK_PATH:+:$DYLD_FRAMEWORK_PATH}" \
+    "$binary" --measurement-output "$output"
+}
+
+require_macos
+case "${1:-}" in
+  --build)
+    [[ $# -eq 2 ]] || usage
+    build_harness "$2"
+    ;;
+  --measure)
+    [[ $# -eq 3 ]] || usage
+    measure_harness "$2" "$3"
+    ;;
+  --compare)
+    [[ $# -ge 8 ]] || usage
+    build_dir=$2
+    shift 2
+    "$build_dir/native-render-compare" "$@"
+    ;;
+  "")
+    build_harness "$DEFAULT_BUILD_DIR"
+    measure_harness "$DEFAULT_BUILD_DIR" "$ROOT/native_render_performance.json"
+    ;;
+  *) usage ;;
+esac

--- a/scripts/check_native_render_performance
+++ b/scripts/check_native_render_performance
@@ -54,7 +54,8 @@ measure_harness() {
     exit 2
   fi
   mkdir -p "$(dirname "$output")"
-  DYLD_FRAMEWORK_PATH="$products${DYLD_FRAMEWORK_PATH:+:$DYLD_FRAMEWORK_PATH}" \
+  SWIFT_BACKTRACE=enable=yes \
+    DYLD_FRAMEWORK_PATH="$products${DYLD_FRAMEWORK_PATH:+:$DYLD_FRAMEWORK_PATH}" \
     "$binary" --measurement-output "$output"
 }
 

--- a/test/minga/extension/compile_cache_test.exs
+++ b/test/minga/extension/compile_cache_test.exs
@@ -3,6 +3,9 @@ defmodule Minga.Extension.CompileCacheTest do
   # avoid the runtime's erl_child_setup EPIPE race.
   use ExUnit.Case, async: false
 
+  @moduletag :heavy
+  @moduletag :extension_compile_cache
+
   import ExUnit.CaptureIO
 
   alias Minga.Extension.ArtifactAdmission


### PR DESCRIPTION
Closes #2999

## Context
Issue #2999 identified a structural macOS editor bug: independently owned frame pieces could be combined at draw or input time, which allowed blank editor frames, line-number flicker, mismatched gutter/content pairs, and pointer or accessibility geometry that did not match the pixels onscreen.

The fix follows the locked architecture in the ticket: freeze one complete committed editor snapshot, render from that exact value, then promote that captured value to the visible input snapshot only after presentation succeeds.

## Changes
- Added `CommittedEditorSnapshot`, `PresentedWindowSurface`, `GutterPresentation`, `EditorLocalPresentationTransform`, and `VisibleEditorPresentation` as immutable editor presentation values.
- Moved editor completeness checks into transaction freeze so missing pane geometry, missing required gutters, orphan gutters, incompatible gutter geometry/metrics, multiple active gutters, and invalid active windows reject before publication.
- Changed the Metal renderer to accept one committed snapshot instead of separate `FrameState` and window-content dictionaries.
- Added committed-versus-visible lifecycle tracking in `CommandDispatcher`, including successful older in-flight presentation promotion when a newer commit is pending, and stale-presentation protection once newer pixels are visible.
- Moved editor input, scroll bookkeeping, gutter hit testing, IME/accessibility geometry, and cursor/accessibility notifications to the visible presentation boundary.
- Moved committed editor snapshot construction into `PreparedFrameTransaction.freeze`, including staged theme, window, gutter, and indent-guide state before publication.
- Removed the old dirty render lifecycle (`frameState.dirty`, `markRendered`) and made presentation metrics passive telemetry instead of observable invalidation state.
- Removed the legacy `FrameState` cursor fallback from `CoreTextMetalRenderer.resolveCursor`.
- Kept resident row storage bounded by preserving `ResidentRowStore` and restricting full row materialization to DEBUG/test-only access.
- Added source guardrails so fragmented editor render/input authorities and committed-snapshot fallbacks do not reappear.
- Tightened the render performance regression gate from 1.20x to 1.10x.

## Review Fixes
- Fixed in-flight drawable completion so an older successfully presented frame can still become visible when a newer commit is pending, while already-visible newer frames still win.
- Promoted the exact visible value as snapshot plus local scroll transform, and moved input/accessibility/gutter geometry to that promoted visible value.
- Froze the committed editor snapshot inside the prepared transaction instead of rebuilding it after publication.
- Rejected multiple active semantic cursor/gutter owners before publication.
- Removed remaining legacy cursor fallback authority.
- Fixed staged theme colors and staged `.setWindowBg` so frozen snapshots use the same colors as the published frame.
- Moved scroll-track line mapping off mutable `FrameState` and onto the visible editor snapshot.
- Cleared stale split separator, gutter column, and viewport globals on keyframes before snapshot freeze.
- Replayed staged cursor-shape commands into prepared frame state before freeze.
- Preserved gutterless active ownership by selecting the unique cursor-visible surface when no active gutter exists.
- Added three-slot native draw/render-target reuse so warm cursor/local-scroll frames do not allocate line buffers, quad buffers, or offscreen render targets after warm-up.

## Verification
- `mix swift.build` ✅
- `cd macos && xcodebuild test -scheme Minga -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO` ✅, 1255 tests
- `cd macos && xcodebuild build -scheme Minga -configuration Release -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO` ✅
- `make lint` ✅
- `mix test.llm` ✅, 58 doctests, 98 properties, 9942 tests, 0 failures, 1 skipped, 550 excluded
- `scripts/check_render_performance` ✅, aggregate decode+apply p95 0.009ms, command-prep p95 0.119ms, combined p95 0.131ms
- Swift LSP diagnostics on touched Swift files ✅, 0 diagnostics
- pi-lens full/cheap scan on touched files ✅, no issues from available checks
- Focused NativeRenderResources, CommandDispatcher, and cursor suites ✅
- Focused bug-hunting review ✅, fixed the reported gutterless active-owner issue
- Targeted re-review of gutterless active ownership ✅, PASS

Note: an earlier `mix test.llm` run exposed a corrupted local `~/.local/share/minga/agent_events.db`. I verified the DB with `sqlite3 PRAGMA integrity_check`, moved it aside, reran the failed test locations successfully, then reran the full `mix test.llm` successfully. A later full `mix test.llm` run had one NativeMCP provider test miss `AgentEnd`; the isolated test passed immediately afterward and the full suite passed on the next run.

## Acceptance Criteria Addressed
- Complete editor presentations are frozen before publication, with explicit gutter-present or gutterless surfaces ✅
- Rejected, incomplete, stale, or incompatible editor updates preserve the last good presentation ✅
- Metal drawing consumes one committed editor snapshot and captures it once per draw ✅
- Successful drawable presentation promotes the exact captured snapshot and frontend-local transform to visible input geometry ✅
- Mouse, scroll, gutter hit testing, IME, cursor, and accessibility geometry consume visible presentation state rather than newer unpresented committed state ✅
- Frontend-local interaction state stays owned by `EditorNSView` and survives unrelated shell/editor commits when identities remain valid ✅
- Superseded dirty lifecycle, fragmented renderer entry points, post-freeze joins, and observable metrics paths are removed or guarded ✅
- Resident row storage remains bounded, with full-document materialization restricted to test/debug-only paths ✅
- Regression coverage now includes freeze rejection, committed-to-visible lifecycle, shell-only identity preservation, Release accessibility compilation, conformance fixtures, and guardrails for old authority seams ✅



---
**Updated after acceptance review:** Added end-to-end native Metal performance gating, temporal pixel tests, mounted AppKit interaction/host tests, complete surface rendering, gutter contract corrections, failed-presentation slot recovery, and the scrollbar content-mask fix.

## Additional Verification
- `make lint` ✅
- `mix test` CI partitions ✅: 10,231 checks with the compile-cache module excluded, plus 44 compile-cache checks in an isolated BEAM, all passing
- Full macOS `xcodebuild test` ✅
- Release native Metal gate ✅ after rebasing onto `origin/main` `b79123683`: 240 attempted / 240 drawable-copy-completed, 0 failed or discarded, 0 warm allocations, freeze/publication p95 0.019ms, draw CPU p95 0.093459ms and p99 0.101126ms, GPU active-time p95 0.370292ms, handoff-to-copy-completion p95 1.230125ms
- Alternating same-machine `origin/main`/HEAD A/B benchmark ✅, paired handoff-to-copy-completion p50 median ratio 0.080x across 3 pairs; base showed 1,440 warm allocations and up to 28,628,480 bytes per frame, while HEAD showed 0
- Offscreen Metal temporal tests ✅, including scroll/settle pixels, out-of-order completion, split clipping, cursor blink, nil-drawable recovery, and scrollbar masking/fade
- Mounted AppKit interaction and host-identity tests ✅, including click/drag mapping, atomic visible geometry, active-pane IME/accessibility handoff, momentum cancellation, and unrelated-host invalidation isolation
- Correctness, Ponytail, and Swift craftsmanship reviews completed; targeted blocker re-review ✅ PASS

## Manual Evidence Status
Automated evidence is complete, but the ticket's live manual matrix is not being inferred from tests:
- Pending: scroll with line numbers, rapid resize, split switching, picker preview, Cmd-Tab/focus return, IME composition, and Reduce Motion
- Hardware-blocked locally: physical 120 Hz momentum/presentation on the attached 60 Hz Dell P2723QE, and external-display scale-change coverage that requires a suitable multi-display configuration
- Pending visual confirmation: the opaque scrollbar track masks editor glyphs while visible and fades with the thumb


**CI note:** Hosted macOS CI gates HEAD's absolute native Metal budgets. The prior hosted HEAD-only run trapped before emitting measurements even though the same gate passes locally; The hosted trap was traced to Xcode 16 inferring Metal completion callbacks as main-actor closures and asserting on Metal’s completion queue. Head `1e510e7e5` makes those callbacks explicitly `@Sendable`, preserving the deliberate main-actor hop; LLDB and `.ips` crash diagnostics remain enabled. The alternating base/HEAD benchmark remains an explicit stable-hardware command, and the attached post-rebase local three-pair result is 0.122x.




