### PR TITLE
fix(agent): target collapse by stable message ID

### DIFF
--- a/docs/GUI_PROTOCOL.md
+++ b/docs/GUI_PROTOCOL.md
@@ -1188,7 +1188,7 @@ opcode(1) + action_type(1) + payload...
 | 0x12 | tool_uninstall | name_len(2) + name(name_len) | Uninstall a tool by name |
 | 0x13 | tool_update | name_len(2) + name(name_len) | Update a tool by name |
 | 0x14 | tool_dismiss | (empty) | Dismiss the tool manager panel |
-| 0x15 | agent_tool_toggle | index(2) | Toggle collapse/expand of agent tool call at message index |
+| 0x15 | agent_tool_toggle | message_id(4) | Toggle collapse/expand of the agent tool or thinking entry with the stable transcript message ID |
 | 0x16 | execute_command | name_len(2) + name(name_len) | Execute a named command from the BEAM command registry |
 | 0x17 | minibuffer_select | index(2) | Select minibuffer candidate at index |
 | 0x18 | git_stage_file | path_len(2) + path(path_len) | Stage a file |

--- a/docs/protocol_schema.toml
+++ b/docs/protocol_schema.toml
@@ -30,7 +30,9 @@ version = "2.0.0"
 # RowSplices section 0x0B (#2741).
 # protocol_version 12 appends a disposition byte to frame_rejected and appends
 # the versioned hard-dimension resource policy to frontend capabilities (#2801).
-protocol_version = 12
+# protocol_version 13 changes gui_action agent_tool_toggle (0x15) from resident
+# index(2) to stable transcript message_id(4).
+protocol_version = 13
 description = "Minga port protocol opcode registry"
 
 # Directions:

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2011,7 +2011,8 @@ New split and float popup windows initialize their viewport metadata from `state
   - **Concepts removed:** Resident-index collapse targeting, two-byte 0x15 payload acceptance, Go resident index selectors, and one draft single-use Transcript transform helper.
   - **Pre-acceptance reviews:** Correctness `PASS`; Elixir craftsmanship `PASS` after eliminating no-op list allocation and aligning the owner typespec; Ponytail `Lean already. Ship.`
   - **Final reviewer:** `PASS`; the stable-ID cutover, owner transition, effects, callsites, tests, budgets, and merge safety are accepted.
-  - **PR URL:** Pending.
+  - **PR URL:** https://github.com/jsmestad/minga/pull/3020
+  - **Implementation commit SHA:** `da792f30d`
   - **Merge evidence:** Pending.
 
 ## Follow-on simplifications

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -1980,6 +1980,40 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Discoveries affecting later work:** Buffer retirement invariants span root owners; each owner must expose its own transition and root removal must install every returned owner value atomically.
 - **Completion date:** 2026-07-19
 
+### W017: Target agent tool collapse by stable message ID
+
+- **Status:** ACTIVE
+- **Audit ID:** L19
+- **Decision:** ACCEPT/direct
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness commit SHA:** `129f1dd9f981ef4cdbc73c4d4bc35deefd833f5e`
+- **Observable outcome:** macOS and Go actions for resident tool or thinking entries send the existing stable uint32 transcript message ID, and Session toggles only the full-transcript entry with that ID after any resident front trim.
+- **Failure path:** Both frontends sent a resident suffix index in GUI action 0x15; BEAM decoded `index(2)` and applied it through `Transcript.update_at/3` to the full transcript, so resident index zero could mutate an unrelated older message.
+- **Wire contract:** Clean cutover of GUI action 0x15 from `index(2)` to big-endian `message_id(4)` and protocol version 12 to 13. No old two-byte fallback. Zero, unknown, and non-collapsible IDs are Session no-ops without notification or save scheduling.
+- **Authoritative owner:** `MingaAgent.Session.Transcript` owns stable-ID collapse mutation; Session owns effects; `MingaEditor.Frontend.Protocol.GUI` owns BEAM decoding; Swift and Go echo IDs already present in their resident models.
+- **Locked implementation:** Add owner-local `Transcript.toggle_message_collapse/2`; update Session without changing `toggle_tool_collapse/2` arity; decode uint32 IDs; update macOS card/input encoding and Go shortcut/protocol encoding; bump and regenerate protocol version outputs; update GUI protocol documentation.
+- **Accepted mutations:** Matching tool calls use `ToolCall.toggle_collapsed/1`; matching thinking entries invert their collapsed flag. Every other message kind and missing ID returns the original transcript.
+- **Tests:** Lock BEAM 4-byte decode and malformed old payloads, owner no-op/revision behavior, Session later-ID targeting, Swift six-byte encoding, and Go stable-ID shortcut encoding including zero-ID refusal.
+- **Focused validation:** `mix protocol.gen --check`; focused BEAM protocol/transcript/session tests; focused Go protocol/UI tests; focused Swift GUI action encoder tests.
+- **Broad validation:** `make lint`; `mix test.llm --max-cases 4`; `cd go/tui && go test ./...`; `cd macos && xcodebuild test -scheme Minga -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO`.
+- **Non-goals:** No resident-store redesign, new action, compatibility shim, old-index fallback, negotiation branch, config, process, module, dependency, parallel data shape, new UI state, liveness behavior, or changes to toggle-all, approvals, scrolling, epochs, or other actions.
+- **Maximum production additions:** 45 net lines across Elixir, Swift, and Go; documentation and generated outputs excluded.
+- **Maximum test additions:** 120 lines across BEAM, Swift, and Go.
+- **Dependencies:** W016 is VERIFIED and merged; no unresolved dependency or implementer question remains.
+- **Completion evidence:**
+  - **Implementation result:** Protocol schema/docs cut over GUI action 0x15 to big-endian `message_id(4)` and protocol version 13; BEAM decodes only 4-byte payloads; `MingaAgent.Session.Transcript.toggle_message_collapse/2` owns stable-ID tool/thinking mutation; Session only publishes/saves on changed transcript; macOS and Go producers echo resident stable IDs and suppress zero IDs.
+  - **Failure reproduced:** `mix run -e ...` before the fix returned `old_uint16: {:ok, {:agent_tool_toggle, 7}}` and `uint32_id: :error`.
+  - **Focused validation:** `mix protocol.gen --check` passed; the locked BEAM protocol, Transcript, and Session set passed 171 tests, then 28 focused tests and the 11-test Transcript suite passed after review fixes; the locked Go protocol/UI selection passed both packages. Swift encoder tests are committed but cannot run on Linux because `xcodebuild` is unavailable.
+  - **Broad validation:** `make lint` passed after the final production edit; `mix test.llm --max-cases 4` passed 58 doctests, 98 properties, and 9,916 tests with 0 failures, 1 skipped, and 578 excluded; `cd go/tui && go test ./...` passed 7 packages with 1 package containing no tests.
+  - **Line deltas:** Production Elixir/Swift/Go net +23 lines, under the +45 cap. Tests net +118 lines, under the +120 cap. Docs/schema net +2 lines. Generated Go protocol version net 0.
+  - **Concepts added:** One Transcript-owned stable message-ID collapse transition and the uint32 GUI action payload for `agent_tool_toggle`.
+  - **Concepts removed:** Resident-index collapse targeting, two-byte 0x15 payload acceptance, Go resident index selectors, and one draft single-use Transcript transform helper.
+  - **Pre-acceptance reviews:** Correctness `PASS`; Elixir craftsmanship `PASS` after eliminating no-op list allocation and aligning the owner typespec; Ponytail `Lean already. Ship.`
+  - **Final reviewer:** `PASS`; the stable-ID cutover, owner transition, effects, callsites, tests, budgets, and merge safety are accepted.
+  - **PR URL:** Pending.
+  - **Merge evidence:** Pending.
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/go/tui/internal/generated/opcodes.go
+++ b/go/tui/internal/generated/opcodes.go
@@ -4,7 +4,7 @@ package generated
 
 // ProtocolVersion is the wire-contract version the frontend exchanges with
 // the BEAM in the ready handshake. A mismatch yields an explicit protocol_error.
-const ProtocolVersion uint16 = 12
+const ProtocolVersion uint16 = 13
 
 const (
 	// Input

--- a/go/tui/internal/protocol/events.go
+++ b/go/tui/internal/protocol/events.go
@@ -230,8 +230,8 @@ func EncodeGUIExecuteCommand(command string) []byte {
 	return append(out, payload...)
 }
 
-func EncodeGUIAgentToolToggle(index uint16) []byte {
-	return []byte{generated.OPGuiAction, generated.GUIActionAgentToolToggle, byte(index >> 8), byte(index)}
+func EncodeGUIAgentToolToggle(messageID uint32) []byte {
+	return []byte{generated.OPGuiAction, generated.GUIActionAgentToolToggle, byte(messageID >> 24), byte(messageID >> 16), byte(messageID >> 8), byte(messageID)}
 }
 
 // EncodeGUIBreadcrumbClick encodes a breadcrumb_click action. Wire format:

--- a/go/tui/internal/protocol/events_test.go
+++ b/go/tui/internal/protocol/events_test.go
@@ -58,8 +58,8 @@ func TestEncodeGUIExecuteCommand(t *testing.T) {
 }
 
 func TestEncodeGUIAgentToolToggle(t *testing.T) {
-	got := EncodeGUIAgentToolToggle(0x0102)
-	want := []byte{generated.OPGuiAction, generated.GUIActionAgentToolToggle, 0x01, 0x02}
+	got := EncodeGUIAgentToolToggle(0x01020304)
+	want := []byte{generated.OPGuiAction, generated.GUIActionAgentToolToggle, 0x01, 0x02, 0x03, 0x04}
 	if !bytes.Equal(got, want) {
 		t.Fatalf("agent tool toggle packet = %v, want %v", got, want)
 	}

--- a/go/tui/internal/ui/agent_chat_panel.go
+++ b/go/tui/internal/ui/agent_chat_panel.go
@@ -39,13 +39,9 @@ func (a *agentPanel) spinner() string {
 	return frames[int(a.animationFrame)%len(frames)]
 }
 
-// handleKey handles the Ctrl+Alt+X/Z collapse toggles. The index is resolved
-// against `messages` (the resident transcript, #2654), not the windowed 0x78
-// list: the BEAM's toggle handler applies List.update_at on the full session
-// conversation, which the resident store mirrors (messages_with_ids, with
-// transcript enrichments appended after the tool/thinking messages), so the
-// latest-tool/thinking index aligns. The windowed 0x78 list would drift once the
-// conversation exceeds the window.
+// handleKey handles the Ctrl+Alt+X/Z collapse toggles. The stable message ID is
+// resolved against `messages` (the resident transcript, #2654) because it echoes
+// the BEAM-owned transcript IDs and remains valid after resident front trimming.
 func (a *agentPanel) handleKey(chat protocol.AgentChat, messages []protocol.AgentChatMessage, msg tea.KeyPressMsg) ([]byte, bool) {
 	if !chat.Visible {
 		return nil, false
@@ -56,17 +52,17 @@ func (a *agentPanel) handleKey(chat protocol.AgentChat, messages []protocol.Agen
 	}
 	switch key.Code {
 	case 'x', 'X':
-		index, ok := latestToolMessageIndex(messages)
+		messageID, ok := latestToolMessageID(messages)
 		if !ok {
 			return nil, false
 		}
-		return protocol.EncodeGUIAgentToolToggle(index), true
+		return protocol.EncodeGUIAgentToolToggle(messageID), true
 	case 'z', 'Z':
-		index, ok := latestThinkingMessageIndex(messages)
+		messageID, ok := latestThinkingMessageID(messages)
 		if !ok {
 			return nil, false
 		}
-		return protocol.EncodeGUIAgentToolToggle(index), true
+		return protocol.EncodeGUIAgentToolToggle(messageID), true
 	default:
 		return nil, false
 	}

--- a/go/tui/internal/ui/agent_transcript_render_test.go
+++ b/go/tui/internal/ui/agent_transcript_render_test.go
@@ -72,19 +72,14 @@ func TestAgentTranscriptLocalScrollRevealsOlderSameFrame(t *testing.T) {
 	}
 }
 
-func TestAgentToggleIndexesResidentNotWindowed(t *testing.T) {
-	// The BEAM collapse toggle applies List.update_at on the full session
-	// conversation, so the Ctrl+Alt+X/Z index must be resolved against the
-	// resident store, not the windowed 0x78 list (#2654). Here the resident list
-	// puts the latest tool at index 3; a windowed slice would have reported a
-	// different position.
+func TestAgentToggleUsesStableMessageID(t *testing.T) {
 	var panel agentPanel
 	chat := protocol.AgentChat{Visible: true}
 	resident := []protocol.AgentChatMessage{
-		{ID: 1, Kind: agentKindUser, Text: "u"},
-		{ID: 2, Kind: agentKindAssistant, Text: "a"},
-		{ID: 3, Kind: agentKindUser, Text: "u2"},
-		{ID: 4, Kind: agentKindTool, Text: "tool"},
+		{ID: 101, Kind: agentKindUser, Text: "u"},
+		{ID: 202, Kind: agentKindAssistant, Text: "a"},
+		{ID: 303, Kind: agentKindUser, Text: "u2"},
+		{ID: 404, Kind: agentKindTool, Text: "tool"},
 	}
 	press := tea.KeyPressMsg(tea.Key{Code: 'x', Mod: tea.ModCtrl | tea.ModAlt})
 
@@ -92,12 +87,11 @@ func TestAgentToggleIndexesResidentNotWindowed(t *testing.T) {
 	if !handled {
 		t.Fatalf("Ctrl+Alt+X should be handled when a tool message exists")
 	}
-	// packet = [OPGuiAction, GUIActionAgentToolToggle, idx>>8, idx].
 	if packet[0] != generated.OPGuiAction || packet[1] != generated.GUIActionAgentToolToggle {
 		t.Fatalf("unexpected toggle packet header: %v", packet)
 	}
-	if idx := int(packet[2])<<8 | int(packet[3]); idx != 3 {
-		t.Fatalf("toggle index = %d, want 3 (resident position)", idx)
+	if id := uint32(packet[2])<<24 | uint32(packet[3])<<16 | uint32(packet[4])<<8 | uint32(packet[5]); id != 404 {
+		t.Fatalf("toggle message ID = %d, want 404", id)
 	}
 }
 

--- a/go/tui/internal/ui/model.go
+++ b/go/tui/internal/ui/model.go
@@ -1157,19 +1157,21 @@ func (m *Model) toggleHUD(msg tea.KeyPressMsg) bool {
 	return false
 }
 
-func latestToolMessageIndex(messages []protocol.AgentChatMessage) (uint16, bool) {
+func latestToolMessageID(messages []protocol.AgentChatMessage) (uint32, bool) {
 	for index := len(messages) - 1; index >= 0; index-- {
-		if (messages[index].Kind == agentKindTool || messages[index].Kind == agentKindStyledTool) && index <= 0xFFFF {
-			return uint16(index), true
+		msg := messages[index]
+		if (msg.Kind == agentKindTool || msg.Kind == agentKindStyledTool) && msg.ID > 0 {
+			return msg.ID, true
 		}
 	}
 	return 0, false
 }
 
-func latestThinkingMessageIndex(messages []protocol.AgentChatMessage) (uint16, bool) {
+func latestThinkingMessageID(messages []protocol.AgentChatMessage) (uint32, bool) {
 	for index := len(messages) - 1; index >= 0; index-- {
-		if messages[index].Kind == agentKindThinking && index <= 0xFFFF {
-			return uint16(index), true
+		msg := messages[index]
+		if msg.Kind == agentKindThinking && msg.ID > 0 {
+			return msg.ID, true
 		}
 	}
 	return 0, false

--- a/go/tui/internal/ui/model_test.go
+++ b/go/tui/internal/ui/model_test.go
@@ -1541,15 +1541,15 @@ func TestAgentChatShortcutTogglesLatestThinkingBlock(t *testing.T) {
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentChat: {AgentChat: protocol.AgentChat{
 		Visible: true,
 		Messages: []protocol.AgentChatMessage{
-			{Kind: agentKindUser, Text: "fix this"},
-			{Kind: agentKindThinking, Text: "first", Collapsed: true},
-			{Kind: agentKindAssistant, Text: "ok"},
-			{Kind: agentKindThinking, Text: "second", Collapsed: false},
+			{ID: 11, Kind: agentKindUser, Text: "fix this"},
+			{ID: 22, Kind: agentKindThinking, Text: "first", Collapsed: true},
+			{ID: 33, Kind: agentKindAssistant, Text: "ok"},
+			{ID: 44, Kind: agentKindThinking, Text: "second", Collapsed: false},
 		},
 	}}}
 
 	_, _ = model.Update(tea.KeyPressMsg(tea.Key{Code: 'z', Mod: tea.ModCtrl | tea.ModAlt}))
-	if got, want := <-out, protocol.EncodeGUIAgentToolToggle(3); !bytes.Equal(got, want) {
+	if got, want := <-out, protocol.EncodeGUIAgentToolToggle(44); !bytes.Equal(got, want) {
 		t.Fatalf("ctrl+alt+z packet = %v, want %v", got, want)
 	}
 }
@@ -1560,16 +1560,30 @@ func TestAgentChatShortcutTogglesLatestToolBlock(t *testing.T) {
 	model.chrome = map[byte]protocol.ChromePayload{generated.OPGuiAgentChat: {AgentChat: protocol.AgentChat{
 		Visible: true,
 		Messages: []protocol.AgentChatMessage{
-			{Kind: agentKindUser, Text: "fix this"},
-			{Kind: agentKindTool, Name: "read_file", Collapsed: true},
-			{Kind: agentKindAssistant, Text: "ok"},
-			{Kind: agentKindStyledTool, Name: "grep", Collapsed: false},
+			{ID: 11, Kind: agentKindUser, Text: "fix this"},
+			{ID: 22, Kind: agentKindTool, Name: "read_file", Collapsed: true},
+			{ID: 33, Kind: agentKindAssistant, Text: "ok"},
+			{ID: 44, Kind: agentKindStyledTool, Name: "grep", Collapsed: false},
 		},
 	}}}
 
 	_, _ = model.Update(tea.KeyPressMsg(tea.Key{Code: 'x', Mod: tea.ModCtrl | tea.ModAlt}))
-	if got, want := <-out, protocol.EncodeGUIAgentToolToggle(3); !bytes.Equal(got, want) {
+	if got, want := <-out, protocol.EncodeGUIAgentToolToggle(44); !bytes.Equal(got, want) {
 		t.Fatalf("ctrl+alt+x packet = %v, want %v", got, want)
+	}
+}
+
+func TestAgentChatShortcutTogglesLatestToolBlockIgnoresZeroID(t *testing.T) {
+	var panel agentPanel
+	chat := protocol.AgentChat{Visible: true}
+	messages := []protocol.AgentChatMessage{
+		{ID: 7, Kind: agentKindUser, Text: "fix this"},
+		{ID: 0, Kind: agentKindTool, Name: "read_file", Collapsed: true},
+	}
+
+	packet, handled := panel.handleKey(chat, messages, tea.KeyPressMsg(tea.Key{Code: 'x', Mod: tea.ModCtrl | tea.ModAlt}))
+	if handled || packet != nil {
+		t.Fatalf("ctrl+alt+x should not send a toggle for zero ID tool block, handled=%v packet=%v", handled, packet)
 	}
 }
 

--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -435,10 +435,10 @@ defmodule MingaAgent.Session do
     GenServer.call(session, {:set_model, model}, timeout)
   end
 
-  @doc "Toggles the collapsed state of a tool call message."
+  @doc "Toggles the collapsed state of a tool or thinking message by stable transcript ID."
   @spec toggle_tool_collapse(GenServer.server(), non_neg_integer()) :: :ok
-  def toggle_tool_collapse(session, message_index) do
-    GenServer.call(session, {:toggle_tool_collapse, message_index})
+  def toggle_tool_collapse(session, message_id) do
+    GenServer.call(session, {:toggle_tool_collapse, message_id})
   end
 
   @doc "Toggles all tool call messages between collapsed and expanded."
@@ -1208,22 +1208,19 @@ defmodule MingaAgent.Session do
     {:reply, result, state}
   end
 
-  def handle_call({:toggle_tool_collapse, index}, _from, state) do
-    transcript =
-      Transcript.update_at(state.transcript, index, fn
-        {:tool_call, %ToolCall{} = tool_call} ->
-          {:tool_call, ToolCall.toggle_collapsed(tool_call)}
+  def handle_call({:toggle_tool_collapse, message_id}, _from, state) do
+    transcript = Transcript.toggle_message_collapse(state.transcript, message_id)
 
-        {:thinking, text, collapsed} ->
-          {:thinking, text, !collapsed}
+    if transcript == state.transcript do
+      {:reply, :ok, state}
+    else
+      state =
+        state
+        |> Map.put(:transcript, transcript)
+        |> notify_messages_changed()
 
-        other ->
-          other
-      end)
-
-    state = %{state | transcript: transcript}
-    state = notify_messages_changed(state)
-    {:reply, :ok, state}
+      {:reply, :ok, state}
+    end
   end
 
   def handle_call(:toggle_all_tool_collapses, _from, state) do

--- a/lib/minga_agent/session/transcript.ex
+++ b/lib/minga_agent/session/transcript.ex
@@ -205,6 +205,34 @@ defmodule MingaAgent.Session.Transcript do
     replace_entries_if_changed(transcript, entries)
   end
 
+  @doc "Toggles collapse for one collapsible active entry by stable transcript ID."
+  @spec toggle_message_collapse(t(), non_neg_integer()) :: t()
+  def toggle_message_collapse(%__MODULE__{} = transcript, message_id)
+      when is_integer(message_id) and message_id > 0 do
+    index =
+      Enum.find_index(transcript.entries, fn
+        %TranscriptEntry{id: ^message_id, message: {:tool_call, %ToolCall{}}} -> true
+        %TranscriptEntry{id: ^message_id, message: {:thinking, _, _}} -> true
+        _ -> false
+      end)
+
+    case index do
+      nil ->
+        transcript
+
+      index ->
+        update_at(transcript, index, fn
+          {:tool_call, %ToolCall{} = tool_call} ->
+            {:tool_call, ToolCall.toggle_collapsed(tool_call)}
+
+          {:thinking, text, collapsed} ->
+            {:thinking, text, !collapsed}
+        end)
+    end
+  end
+
+  def toggle_message_collapse(%__MODULE__{} = transcript, _message_id), do: transcript
+
   @doc "Updates the matching tool-call entry while preserving its stable identity."
   @spec update_tool_call(t(), String.t(), (ToolCall.t() -> ToolCall.t())) :: t()
   def update_tool_call(%__MODULE__{} = transcript, tool_call_id, update)

--- a/lib/minga_editor/frontend/protocol/gui.ex
+++ b/lib/minga_editor/frontend/protocol/gui.ex
@@ -346,7 +346,7 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
           | {:tool_uninstall, name :: String.t()}
           | {:tool_update, name :: String.t()}
           | :tool_dismiss
-          | {:agent_tool_toggle, message_index :: non_neg_integer()}
+          | {:agent_tool_toggle, message_id :: non_neg_integer()}
           | {:execute_command, name :: String.t()}
           | {:minibuffer_select, candidate_index :: non_neg_integer()}
           | {:git_stage_file, path :: String.t()}
@@ -2354,8 +2354,8 @@ defmodule MingaEditor.Frontend.Protocol.GUI do
 
   def decode_gui_action(@gui_action_tool_dismiss, <<>>), do: {:ok, :tool_dismiss}
 
-  def decode_gui_action(@gui_action_agent_tool_toggle, <<index::16>>),
-    do: {:ok, {:agent_tool_toggle, index}}
+  def decode_gui_action(@gui_action_agent_tool_toggle, <<message_id::32>>),
+    do: {:ok, {:agent_tool_toggle, message_id}}
 
   def decode_gui_action(
         @gui_action_execute_command,

--- a/lib/minga_editor/handlers/gui_action_handler.ex
+++ b/lib/minga_editor/handlers/gui_action_handler.ex
@@ -600,12 +600,12 @@ defmodule MingaEditor.Handlers.GuiActionHandler do
     state
   end
 
-  defp dispatch_action(state, {:agent_tool_toggle, message_index}) do
+  defp dispatch_action(state, {:agent_tool_toggle, message_id}) do
     session = MingaEditor.Shell.Runtime.active_session(state.shell_runtime)
 
     if session do
       try do
-        AgentSession.toggle_tool_collapse(session, message_index)
+        AgentSession.toggle_tool_collapse(session, message_id)
       catch
         :exit, _ -> :ok
       end

--- a/macos/Sources/Protocol/InputEncoder.swift
+++ b/macos/Sources/Protocol/InputEncoder.swift
@@ -81,7 +81,7 @@ public protocol InputEncoder: AnyObject, Sendable {
     func sendToolDismiss()
 
     // Agent chat actions
-    func sendAgentToolToggle(index: UInt16)
+    func sendAgentToolToggle(messageID: UInt32)
 
     // Generic command execution
     func sendExecuteCommand(name: String)
@@ -279,7 +279,7 @@ public final class NullInputEncoder: InputEncoder, @unchecked Sendable {
     public func sendToolUninstall(name: String) {}
     public func sendToolUpdate(name: String) {}
     public func sendToolDismiss() {}
-    public func sendAgentToolToggle(index: UInt16) {}
+    public func sendAgentToolToggle(messageID: UInt32) {}
     public func sendExecuteCommand(name: String) {}
     public func sendMinibufferSelect(index: UInt16) {}
     public func sendGitStageFile(path: String) {}

--- a/macos/Sources/Protocol/ProtocolEncoder.swift
+++ b/macos/Sources/Protocol/ProtocolEncoder.swift
@@ -687,12 +687,12 @@ final class ProtocolEncoder: InputEncoder, @unchecked Sendable {
         writeFrame(buf)
     }
 
-    /// Send a gui_action: agent_tool_toggle. Layout: opcode(1) + action_type(1) + index(2).
-    func sendAgentToolToggle(index: UInt16) {
-        var buf = Data(count: 4)
+    /// Send a gui_action: agent_tool_toggle. Layout: opcode(1) + action_type(1) + message_id(4).
+    func sendAgentToolToggle(messageID: UInt32) {
+        var buf = Data(count: 6)
         buf[0] = OP_GUI_ACTION
         buf[1] = GUI_ACTION_AGENT_TOOL_TOGGLE
-        writeU16(&buf, 2, index)
+        writeU32(&buf, 2, messageID)
         writeFrame(buf)
     }
 

--- a/macos/Sources/Views/Agent/AgentChatView.swift
+++ b/macos/Sources/Views/Agent/AgentChatView.swift
@@ -157,12 +157,12 @@ public struct AgentChatView: View {
             assistantMarkdownBlock(blocks)
         case .thinking(_, let text, let collapsed):
             thinkingBlock(text, collapsed: collapsed)
-        case .toolCall(_, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let result, _, let previewLines):
-            AgentToolCallCard(messageIndex: index, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, resultLines: nil, previewLines: previewLines, encoder: encoder, styledLineView: { runs, fontSize, mono in
+        case .toolCall(let id, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let result, _, let previewLines):
+            AgentToolCallCard(messageID: id, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: result, resultLines: nil, previewLines: previewLines, encoder: encoder, styledLineView: { runs, fontSize, mono in
                 AnyView(styledLineView(runs, baseFontSize: fontSize, monospaced: mono))
             })
-        case .styledToolCall(_, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let resultLines, _, let previewLines):
-            AgentToolCallCard(messageIndex: index, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: nil, resultLines: resultLines, previewLines: previewLines, encoder: encoder, styledLineView: { runs, fontSize, mono in
+        case .styledToolCall(let id, let name, let summary, let status, let isError, let collapsed, let autoApprovedScope, let duration, let resultLines, _, let previewLines):
+            AgentToolCallCard(messageID: id, name: name, summary: summary, status: status, isError: isError, collapsed: collapsed, autoApprovedScope: autoApprovedScope, durationMs: duration, result: nil, resultLines: resultLines, previewLines: previewLines, encoder: encoder, styledLineView: { runs, fontSize, mono in
                 AnyView(styledLineView(runs, baseFontSize: fontSize, monospaced: mono))
             })
         case .approvalToolCall(_, let name, let summary, let toolCallId, let previewKind, let previewLines):

--- a/macos/Sources/Views/Agent/AgentToolCallCard.swift
+++ b/macos/Sources/Views/Agent/AgentToolCallCard.swift
@@ -2,8 +2,8 @@ import SwiftUI
 import MingaProtocol
 
 public struct AgentToolCallCard: View {
-    public init(messageIndex: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String? = nil, resultLines: [[Wire.StyledTextRun]]? = nil, previewLines: [String], encoder: InputEncoder? = nil, styledLineView: @escaping ([Wire.StyledTextRun], CGFloat, Bool) -> AnyView) {
-        self.messageIndex = messageIndex
+    public init(messageID: Int, name: String, summary: String, status: UInt8, isError: Bool, collapsed: Bool, autoApprovedScope: UInt8, durationMs: UInt32, result: String? = nil, resultLines: [[Wire.StyledTextRun]]? = nil, previewLines: [String], encoder: InputEncoder? = nil, styledLineView: @escaping ([Wire.StyledTextRun], CGFloat, Bool) -> AnyView) {
+        self.messageID = messageID
         self.name = name
         self.summary = summary
         self.status = status
@@ -17,7 +17,7 @@ public struct AgentToolCallCard: View {
         self.encoder = encoder
         self.styledLineView = styledLineView
     }
-    public let messageIndex: Int
+    public let messageID: Int
     public let name: String
     public let summary: String
     public let status: UInt8
@@ -87,8 +87,8 @@ public struct AgentToolCallCard: View {
             .padding(.vertical, 6)
             .contentShape(Rectangle())
             .onTapGesture {
-                if hasResult, messageIndex <= Int(UInt16.max) {
-                    encoder?.sendAgentToolToggle(index: UInt16(messageIndex))
+                if hasResult, let messageID = UInt32(exactly: messageID), messageID != 0 {
+                    encoder?.sendAgentToolToggle(messageID: messageID)
                 }
             }
 

--- a/macos/Tests/MingaTests/GUIActionEncoderTests.swift
+++ b/macos/Tests/MingaTests/GUIActionEncoderTests.swift
@@ -214,6 +214,15 @@ struct GUIActionEncoderTests {
         ])
     }
 
+    @Test("sendAgentToolToggle records stable message ID")
+    func agentToolToggle() {
+        let spy = SpyEncoder()
+        let encoder: InputEncoder = spy
+        encoder.sendAgentToolToggle(messageID: 0x01020304)
+
+        #expect(spy.guiActions == [.agentToolToggle(messageID: 0x01020304)])
+    }
+
     @Test("sendOpenFile records path")
     func openFile() {
         let spy = SpyEncoder()

--- a/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
+++ b/macos/Tests/MingaTests/ProtocolEncoderBinaryTests.swift
@@ -621,6 +621,16 @@ struct EncoderGUIActionTests {
         #expect(payload[1] == GUI_ACTION_TOOL_DISMISS)
     }
 
+    @Test("agent_tool_toggle encodes stable message ID")
+    func agentToolToggleLayout() {
+        let payload = captureFrame { $0.sendAgentToolToggle(messageID: 0x01020304) }
+
+        #expect(payload.count == 6)
+        #expect(payload[0] == OP_GUI_ACTION)
+        #expect(payload[1] == GUI_ACTION_AGENT_TOOL_TOGGLE)
+        #expect(readU32(payload, 2) == 0x01020304)
+    }
+
     @Test("execute_command encodes command name with length prefix")
     func executeCommandLayout() {
         let payload = captureFrame { $0.sendExecuteCommand(name: "buffer_prev") }

--- a/macos/Tests/MingaTests/ProtocolTests.swift
+++ b/macos/Tests/MingaTests/ProtocolTests.swift
@@ -997,7 +997,7 @@ final class SpyEncoder: InputEncoder, Sendable {
         case toolUninstall(name: String)
         case toolUpdate(name: String)
         case toolDismiss
-        case agentToolToggle(index: UInt16)
+        case agentToolToggle(messageID: UInt32)
         case executeCommand(name: String)
         case minibufferSelect(index: UInt16)
 
@@ -1107,7 +1107,7 @@ final class SpyEncoder: InputEncoder, Sendable {
     func sendToolUninstall(name: String) { state.withLock { $0.guiActions.append(.toolUninstall(name: name)) } }
     func sendToolUpdate(name: String) { state.withLock { $0.guiActions.append(.toolUpdate(name: name)) } }
     func sendToolDismiss() { state.withLock { $0.guiActions.append(.toolDismiss) } }
-    func sendAgentToolToggle(index: UInt16) { state.withLock { $0.guiActions.append(.agentToolToggle(index: index)) } }
+    func sendAgentToolToggle(messageID: UInt32) { state.withLock { $0.guiActions.append(.agentToolToggle(messageID: messageID)) } }
     func sendExecuteCommand(name: String) { state.withLock { $0.guiActions.append(.executeCommand(name: name)) } }
     func sendMinibufferSelect(index: UInt16) { state.withLock { $0.guiActions.append(.minibufferSelect(index: index)) } }
 

--- a/test/minga_agent/session/transcript_test.exs
+++ b/test/minga_agent/session/transcript_test.exs
@@ -52,6 +52,32 @@ defmodule MingaAgent.Session.TranscriptTest do
              Transcript.messages(changed)
   end
 
+  test "toggle_message_collapse targets collapsible stable IDs only" do
+    tool = %ToolCall{id: "tool-1", name: "shell", status: :complete, collapsed: true}
+
+    transcript =
+      Transcript.new(
+        [{:user, "u"}, {:tool_call, tool}, {:thinking, "t", false}, {:assistant, "a"}],
+        @now
+      )
+
+    tool_toggled = Transcript.toggle_message_collapse(transcript, 2)
+    assert entry_ids(tool_toggled) == [1, 2, 3, 4]
+    assert Transcript.revision(tool_toggled) == Transcript.revision(transcript) + 1
+
+    assert {:tool_call, %{collapsed: false}} = Enum.at(Transcript.messages(tool_toggled), 1)
+
+    thinking_toggled = Transcript.toggle_message_collapse(tool_toggled, 3)
+
+    assert {:thinking, "t", true} = Enum.at(Transcript.messages(thinking_toggled), 2)
+
+    for id <- [999, 0, 1] do
+      unchanged = Transcript.toggle_message_collapse(transcript, id)
+      assert unchanged == transcript
+      assert Transcript.revision(unchanged) == Transcript.revision(transcript)
+    end
+  end
+
   test "branching freezes identified entries and switching restores them without ID reuse" do
     transcript =
       Transcript.new(

--- a/test/minga_agent/session_transcript_test.exs
+++ b/test/minga_agent/session_transcript_test.exs
@@ -18,24 +18,78 @@ defmodule MingaAgent.SessionTranscriptTest do
       )
 
       # GenServer.call after send ensures all handle_info have run
-      messages = Session.messages(session)
+      pairs = Session.messages_with_ids(session)
 
-      tool_index =
-        Enum.find_index(messages, fn
-          {:tool_call, _} -> true
+      {tool_id, {:tool_call, tc}} =
+        Enum.find(pairs, fn
+          {_id, {:tool_call, _}} -> true
           _ -> false
         end)
 
-      assert tool_index != nil
-
-      {:tool_call, tc} = Enum.at(messages, tool_index)
       assert tc.collapsed == true
 
-      :ok = Session.toggle_tool_collapse(session, tool_index)
+      :ok = Session.toggle_tool_collapse(session, tool_id)
 
       messages = Session.messages(session)
-      {:tool_call, tc} = Enum.at(messages, tool_index)
+      {:tool_call, tc} = Enum.find(messages, &match?({:tool_call, _}, &1))
       assert tc.collapsed == false
+
+      flush_messages_changed(session)
+      :ok = Session.toggle_tool_collapse(session, 0)
+      refute_receive {:agent_event, ^session, :messages_changed}, 20
+    end
+
+    test "stable ID targets later tool without toggling earlier full-transcript entry" do
+      session = start_subscribed_session()
+      assert :ok = Session.continue(session)
+
+      send(
+        session,
+        {:agent_provider_event, %Event.ToolStart{tool_call_id: "tc1", name: "bash", args: %{}}}
+      )
+
+      send(
+        session,
+        {:agent_provider_event,
+         %Event.ToolEnd{tool_call_id: "tc1", name: "bash", result: "first"}}
+      )
+
+      send(
+        session,
+        {:agent_provider_event, %Event.ToolStart{tool_call_id: "tc2", name: "grep", args: %{}}}
+      )
+
+      send(
+        session,
+        {:agent_provider_event,
+         %Event.ToolEnd{tool_call_id: "tc2", name: "grep", result: "second"}}
+      )
+
+      pairs_before = Session.messages_with_ids(session)
+      ids_before = Enum.map(pairs_before, &elem(&1, 0))
+
+      tools_before =
+        Enum.filter(pairs_before, fn {_id, message} -> match?({:tool_call, _}, message) end)
+
+      [{_first_id, {:tool_call, first_before}}, {later_id, {:tool_call, later_before}}] =
+        tools_before
+
+      assert first_before.collapsed == true
+      assert later_before.collapsed == true
+
+      :ok = Session.toggle_tool_collapse(session, later_id)
+
+      pairs_after = Session.messages_with_ids(session)
+
+      tools_after =
+        Enum.filter(pairs_after, fn {_id, message} -> match?({:tool_call, _}, message) end)
+
+      [{_first_id, {:tool_call, first_after}}, {^later_id, {:tool_call, later_after}}] =
+        tools_after
+
+      assert first_after.collapsed == true
+      assert later_after.collapsed == false
+      assert Enum.map(pairs_after, &elem(&1, 0)) == ids_before
     end
   end
 
@@ -386,10 +440,10 @@ defmodule MingaAgent.SessionTranscriptTest do
       pairs_before = Session.messages_with_ids(session)
       ids_before = Enum.map(pairs_before, &elem(&1, 0))
 
-      tool_index =
-        Enum.find_index(pairs_before, fn {_id, msg} -> match?({:tool_call, _}, msg) end)
+      {tool_id, _message} =
+        Enum.find(pairs_before, fn {_id, msg} -> match?({:tool_call, _}, msg) end)
 
-      :ok = Session.toggle_tool_collapse(session, tool_index)
+      :ok = Session.toggle_tool_collapse(session, tool_id)
       assert Enum.map(Session.messages_with_ids(session), &elem(&1, 0)) == ids_before
 
       :ok = Session.toggle_all_tool_collapses(session)
@@ -428,6 +482,14 @@ defmodule MingaAgent.SessionTranscriptTest do
       assert length(ids_after) == length(pairs_before) + 1
       assert Enum.at(ids_after, -1) > max_id_before
       assert length(pairs_after) == length(Session.messages(session))
+    end
+  end
+
+  defp flush_messages_changed(session) do
+    receive do
+      {:agent_event, ^session, :messages_changed} -> flush_messages_changed(session)
+    after
+      0 -> :ok
     end
   end
 end

--- a/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
+++ b/test/minga_editor/frontend/gui_agent_chat_protocol_test.exs
@@ -2,29 +2,32 @@ defmodule MingaEditor.Frontend.GUIAgentChatProtocolTest do
   use ExUnit.Case, async: true
 
   alias MingaEditor.Frontend.Protocol.GUI, as: ProtocolGUI
+  alias MingaEditor.Frontend.Protocol
 
   describe "decode_gui_action for agent_tool_toggle" do
-    test "decodes a valid agent_tool_toggle action" do
-      assert {:ok, {:agent_tool_toggle, 7}} ==
-               ProtocolGUI.decode_gui_action(0x15, <<7::16>>)
-    end
+    test "decodes stable message IDs" do
+      assert {:ok, {:agent_tool_toggle, 0x01020304}} ==
+               ProtocolGUI.decode_gui_action(0x15, <<0x01020304::32>>)
 
-    test "decodes agent_tool_toggle at index 0" do
       assert {:ok, {:agent_tool_toggle, 0}} ==
-               ProtocolGUI.decode_gui_action(0x15, <<0::16>>)
+               ProtocolGUI.decode_gui_action(0x15, <<0::32>>)
+
+      assert {:ok, {:agent_tool_toggle, 0xFFFF_FFFF}} ==
+               ProtocolGUI.decode_gui_action(0x15, <<0xFFFF_FFFF::32>>)
     end
 
-    test "decodes agent_tool_toggle at max UInt16" do
-      assert {:ok, {:agent_tool_toggle, 65_535}} ==
-               ProtocolGUI.decode_gui_action(0x15, <<65_535::16>>)
-    end
-
-    test "returns error for short payload" do
+    test "rejects old and malformed payload sizes" do
+      assert :error == ProtocolGUI.decode_gui_action(0x15, <<7::16>>)
       assert :error == ProtocolGUI.decode_gui_action(0x15, <<7>>)
+      assert :error == ProtocolGUI.decode_gui_action(0x15, <<>>)
+      assert :error == ProtocolGUI.decode_gui_action(0x15, <<1, 2, 3>>)
     end
 
-    test "returns error for empty payload" do
-      assert :error == ProtocolGUI.decode_gui_action(0x15, <<>>)
+    test "decodes the full gui_action event with stable message ID" do
+      assert {:ok, {:gui_action, {:agent_tool_toggle, 0x01020304}}} ==
+               Protocol.decode_event(
+                 <<Minga.Protocol.Opcodes.gui_action(), 0x15, 0x01, 0x02, 0x03, 0x04>>
+               )
     end
   end
 end


### PR DESCRIPTION
# TL;DR

Agent tool and thinking collapse actions now target stable transcript message IDs instead of resident-list indexes. This prevents a trimmed resident transcript from toggling an unrelated older entry in the full session transcript.

## Context

The BEAM already assigns stable IDs to transcript entries and includes them in resident agent-chat messages. The macOS and Go frontends discarded that identity and sent a local suffix index through GUI action `0x15`, while Session applied the index to the full transcript.

This is a clean protocol cutover. Protocol version 13 changes action `0x15` from a two-byte index to a four-byte big-endian message ID, so stale frontends fail the existing version handshake instead of silently targeting the wrong entry.

## Changes

- Add a Transcript-owned stable-ID collapse transition for tool and thinking entries.
- Suppress Session notification and persistence effects for zero, unknown, and non-collapsible IDs.
- Encode and decode action `0x15` as a uint32 message ID across BEAM, Swift, and Go.
- Make macOS cards and Go shortcuts echo existing resident message IDs and refuse zero IDs.
- Bump the protocol version to 13 and update the protocol schema, generated Go constant, documentation, tests, and lifecycle roadmap evidence.
- Remove the old uint16 payload path and resident-index selector helpers without a compatibility fallback.

## Verification

- `make lint`
- `mix protocol.gen --check`
- Focused BEAM protocol, Transcript, and Session tests: 171 passed
- Post-review focused BEAM tests: 28 passed; Transcript suite: 11 passed
- `mix test.llm --max-cases 4`: 58 doctests, 98 properties, and 9,916 tests passed; 0 failures, 1 skipped
- Focused Go protocol/UI tests: passed
- `cd go/tui && go test ./...`: 7 packages passed; 1 package has no tests
- Correctness review: PASS
- Elixir craftsmanship review: PASS
- Ponytail review: `Lean already. Ship.`
- Final acceptance review: PASS

Swift encoder tests are included but were not runnable on the Linux development host because `xcodebuild` is unavailable. macOS CI is the platform validation gate.

## Acceptance Criteria Addressed

- Resident tool and thinking collapse actions target stable transcript identities.
- Front trimming cannot redirect a toggle to an older full-transcript entry.
- Old two-byte and malformed action payloads are rejected.
- No-op IDs do not publish or schedule persistence.
- Protocol producers and consumers use version 13 consistently.
