### PR TITLE
fix(input): capture resize drag lifecycle

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2018,6 +2018,37 @@ New split and float popup windows initialize their viewport metadata from `state
   - **Discoveries affecting later work:** Resident semantic models already carry stable identity; frontend actions must echo that identity instead of deriving a local array position.
   - **Completion date:** 2026-07-19
 
+### W018: Capture resize drags and clear release state
+
+- **Status:** ACTIVE
+- **Audit ID:** L22
+- **Decision:** ACCEPT/direct
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness commit SHA:** `5aa3ea6e2b8b3ec87246610ee5b9b917f017fa58`
+- **Observable outcome:** Active left-button resize drag and release events bypass focus-tree hit routing, and active text or resize release always clears its drag state even when the pointer leaves the tree, coordinates are negative, or the active buffer disappears.
+- **Failure path:** Router captured text drags directly but routed resize drags through the focus tree, where outside coordinates or another handler could swallow them. Mouse checked for an active buffer and negative coordinates before release cleanup, preserving stale drag state on early return.
+- **Authoritative owners:** `Input.Router.dispatch_mouse/7` owns capture order; `Mouse.handle/7` owns release semantics; `State.Mouse.stop_drag/1` and `stop_resize/1` own value transitions; `Session.State.set_mouse/2` owns workspace installation.
+- **Locked implementation:** Direct-route active `%MouseState{dragging: true}` and `%MouseState{resize_dragging: {_, _}}` left drag/release events before negative-coordinate and focus-tree routing. Move existing text and resize release clauses before the no-buffer and negative-coordinate guards without changing their bodies or auto-copy behavior.
+- **Tests:** Router regressions prove resize release outside the focus tree clears state and active resize drag bypasses node handlers. Mouse regressions prove text and resize release clear state after the active buffer disappears; include negative-coordinate resize release if it remains concise.
+- **Focused validation:** `mix test.debug test/minga_editor/input/router_test.exs test/minga_editor/mouse_test.exs test/minga_editor/state/mouse_test.exs` -> 75 passed.
+- **Broad validation:** `make lint`; `mix test.llm --max-cases 4`; `git diff --check`.
+- **Non-goals:** No focus-tree, shell lifecycle, mouse protocol, separator math, drag-start, selection, auto-copy, hover, click-count, wheel, frontend, process, module, dependency, registry, config, compatibility, or data-shape changes.
+- **Maximum production additions:** 50 net lines; expected 10 to 25.
+- **Maximum test additions:** 80 lines.
+- **Dependencies:** W017 is VERIFIED and merged; no unresolved dependency or implementer question remains.
+- **Completion evidence:**
+  - **Implementation result:** `Input.Router.dispatch_mouse/7` now captures active `%MouseState{dragging: true}` and `%MouseState{resize_dragging: {_, _}}` left drag/release events before negative-coordinate and focus-tree routing, running the existing shell availability check and `Mouse.handle/7` path directly. `Mouse.handle/7` now runs active text and resize release cleanup before the no-active-buffer and negative-coordinate guards, preserving the existing text visual auto-copy path and owner APIs.
+  - **Regression coverage:** Added router regressions for resize release outside the focus tree clearing resize state and active resize drag bypassing focus-tree node handlers. Added Mouse regressions for resize and text release clearing state after active-buffer loss. The optional negative-coordinate Mouse regression was not added so test additions stay within the locked budget; the production release clauses are still ordered before the negative-coordinate guards.
+  - **Failure reproduced:** Before the production fix, the new focused regressions failed 5 times: resize drag reached `InputRouterMouseProbe`, resize release outside the focus tree left `resize_dragging` set, and text/resize release cleanup was skipped after active-buffer loss or negative coordinates.
+  - **Focused validation:** `mix test.debug test/minga_editor/input/router_test.exs test/minga_editor/mouse_test.exs test/minga_editor/state/mouse_test.exs` passed with 75 tests.
+  - **Broad validation:** `make lint` passed Credo, compile, and incremental Dialyzer; `mix test.llm --max-cases 4` passed 58 doctests, 98 properties, and 9,920 tests with 0 failures, 1 skipped, and 578 excluded.
+  - **Line deltas:** Production `lib/minga_editor/input/router.ex` +21/-3 and `lib/minga_editor/mouse.ex` +38/-60, net -4. Tests `test/minga_editor/input/router_test.exs` +33 and `test/minga_editor/mouse_test.exs` +41, total +74 additions.
+  - **Concepts added/removed:** Added no architecture or data shape; removed duplicated release-state installation and the stale routing/guard ordering path that could swallow active resize release cleanup.
+  - **Pre-acceptance reviews:** Correctness found no routing or state defect after its evidence-only correction; Elixir craftsmanship `PASS` after release clauses reused `update_mouse/2` and fixtures used `Windows.set_tree/2` and `Buffers.remove/2`; Ponytail `Lean already. Ship.`
+  - **Final reviewer:** `PASS`; locked routing and release-cleanup contract, ownership, lifecycle, API, tests, budgets, evidence, and merge safety accepted with no findings.
+  - **Completion date:** Pending merge.
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -26,6 +26,7 @@ defmodule MingaEditor.Input.Router do
   alias MingaEditor.Shell.Traditional
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Mouse, as: MouseState
 
   @typedoc "Pre-action snapshot for housekeeping comparisons."
   @type snapshot :: %{
@@ -336,7 +337,7 @@ defmodule MingaEditor.Input.Router do
           pos_integer()
         ) :: EditorState.t()
   def dispatch_mouse(
-        %{workspace: %{mouse: %{dragging: true}}} = state,
+        %{workspace: %{mouse: %MouseState{dragging: true}}} = state,
         row,
         col,
         :left,
@@ -345,8 +346,20 @@ defmodule MingaEditor.Input.Router do
         click_count
       )
       when event_type in [:drag, :release] do
-    state = MingaEditor.Shell.Workflow.ensure_available(state)
-    MingaEditor.Mouse.handle(state, row, col, :left, mods, event_type, click_count)
+    direct_mouse(state, row, col, :left, mods, event_type, click_count)
+  end
+
+  def dispatch_mouse(
+        %{workspace: %{mouse: %MouseState{resize_dragging: {_, _}}}} = state,
+        row,
+        col,
+        :left,
+        mods,
+        event_type,
+        click_count
+      )
+      when event_type in [:drag, :release] do
+    direct_mouse(state, row, col, :left, mods, event_type, click_count)
   end
 
   def dispatch_mouse(state, row, col, _button, _mods, _event_type, _click_count)
@@ -370,6 +383,11 @@ defmodule MingaEditor.Input.Router do
     |> FocusTree.get()
     |> mouse_path(row, col, button)
     |> dispatch_mouse_path(state, event)
+  end
+
+  defp direct_mouse(state, row, col, button, mods, event_type, click_count) do
+    state = MingaEditor.Shell.Workflow.ensure_available(state)
+    MingaEditor.Mouse.handle(state, row, col, button, mods, event_type, click_count)
   end
 
   @spec mouse_path(FocusTree.t(), integer(), integer(), atom()) :: FocusTree.path()

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -181,6 +181,46 @@ defmodule MingaEditor.Mouse do
           pos_integer()
         ) :: state()
 
+  # ── Left release ──
+
+  def handle(
+        %{workspace: %{mouse: %MouseState{dragging: true}, editing: %{mode: :visual}}} = state,
+        _r,
+        _c,
+        :left,
+        _m,
+        :release,
+        _cc
+      ) do
+    state
+    |> update_mouse(&MouseState.stop_drag/1)
+    |> auto_copy_selection()
+  end
+
+  def handle(
+        %{workspace: %{mouse: %MouseState{dragging: true}}} = state,
+        _r,
+        _c,
+        :left,
+        _m,
+        :release,
+        _cc
+      ) do
+    update_mouse(state, &MouseState.stop_drag/1)
+  end
+
+  def handle(
+        %{workspace: %{mouse: %MouseState{resize_dragging: {_, _}}}} = state,
+        _r,
+        _c,
+        :left,
+        _m,
+        :release,
+        _cc
+      ) do
+    update_mouse(state, &MouseState.stop_resize/1)
+  end
+
   # Ignore mouse events when no buffer is open.
   def handle(
         %{workspace: %{buffers: %{active: nil}}} = state,
@@ -204,47 +244,6 @@ defmodule MingaEditor.Mouse do
         _cc
       ) do
     handle_left_drag(state, row, col, anchor, dcc)
-  end
-
-  def handle(
-        %{workspace: %{mouse: %MouseState{dragging: true}, editing: %{mode: :visual}}} = state,
-        _r,
-        _c,
-        :left,
-        _m,
-        :release,
-        _cc
-      ) do
-    state = %{
-      state
-      | workspace:
-          MingaEditor.Session.State.set_mouse(
-            state.workspace,
-            (&MouseState.stop_drag/1).(state.workspace.mouse)
-          )
-    }
-
-    # TUI keeps legacy selection auto-copy. Native GUI selection stays separate from the clipboard.
-    auto_copy_selection(state)
-  end
-
-  def handle(
-        %{workspace: %{mouse: %MouseState{dragging: true}}} = state,
-        _r,
-        _c,
-        :left,
-        _m,
-        :release,
-        _cc
-      ) do
-    %{
-      state
-      | workspace:
-          MingaEditor.Session.State.set_mouse(
-            state.workspace,
-            (&MouseState.stop_drag/1).(state.workspace.mouse)
-          )
-    }
   end
 
   # Ignore negative coordinates except active drags, which clamp to the originating window edge.
@@ -355,27 +354,6 @@ defmodule MingaEditor.Mouse do
         _cc
       ) do
     handle_separator_drag(state, :horizontal, sep_pos, row)
-  end
-
-  # ── Left release ──
-
-  def handle(
-        %{workspace: %{mouse: %MouseState{resize_dragging: {_, _}}}} = state,
-        _r,
-        _c,
-        :left,
-        _m,
-        :release,
-        _cc
-      ) do
-    %{
-      state
-      | workspace:
-          MingaEditor.Session.State.set_mouse(
-            state.workspace,
-            (&MouseState.stop_resize/1).(state.workspace.mouse)
-          )
-    }
   end
 
   # ── Mouse motion (hover tracking + Cmd/Ctrl link preview) ──

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -16,6 +16,8 @@ defmodule MingaEditor.Input.RouterTest do
   alias MingaEditor.Input
   alias MingaEditor.Input.Router
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.State.Mouse, as: MouseState
+  alias MingaEditor.State.Windows
 
   @async_render_timeout 5_000
 
@@ -148,6 +150,19 @@ defmodule MingaEditor.Input.RouterTest do
     after
       0 -> count
     end
+  end
+
+  defp install_resize_drag(state) do
+    windows = Windows.set_tree(state.workspace.windows, {:leaf, state.workspace.windows.active})
+
+    workspace =
+      state.workspace
+      |> MingaEditor.Session.State.set_mouse(
+        MouseState.start_resize(state.workspace.mouse, :vertical, 10)
+      )
+      |> MingaEditor.Session.State.set_windows(windows)
+
+    %{state | workspace: workspace}
   end
 
   describe "dispatch/3" do
@@ -453,6 +468,24 @@ defmodule MingaEditor.Input.RouterTest do
       state = state_with_focus_tree(separator_gap_tree())
 
       assert ^state = Router.dispatch_mouse(state, 3, 10, :left, 0, :press, 1)
+      refute_receive {:mouse_probe, _type, _ref}, 20
+    end
+
+    test "active resize release outside the focus tree bypasses hit routing and clears resize state" do
+      state = probe_tree(:deep) |> state_with_focus_tree() |> install_resize_drag()
+
+      new_state = Router.dispatch_mouse(state, 25, 5, :left, 0, :release, 1)
+
+      assert new_state.workspace.mouse.resize_dragging == nil
+      refute_receive {:mouse_probe, _type, _ref}, 20
+    end
+
+    test "active resize drag bypasses focus-tree node handlers" do
+      state = probe_tree(:deep) |> state_with_focus_tree() |> install_resize_drag()
+
+      new_state = Router.dispatch_mouse(state, 5, 5, :left, 0, :drag, 1)
+
+      assert new_state.workspace.mouse.resize_dragging == {:vertical, 10}
       refute_receive {:mouse_probe, _type, _ref}, 20
     end
 

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -18,6 +18,9 @@ defmodule MingaEditor.MouseTest do
   alias MingaEditor.Mouse
   alias MingaEditor.Startup
   alias MingaEditor.State.Windows
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Mouse, as: MouseState
   alias MingaEditor.Viewport
   alias MingaEditor.WindowTree
 
@@ -408,6 +411,35 @@ defmodule MingaEditor.MouseTest do
     end
   end
 
+  describe "active drag release cleanup" do
+    test "resize release clears state even after the active buffer disappears" do
+      {state, _buffer} = start_mouse_state("hello")
+
+      state =
+        state
+        |> install_mouse(MouseState.start_resize(state.workspace.mouse, :vertical, 10))
+        |> remove_active_buffer()
+
+      new_state = mouse(state, 0, 0, :left, :release)
+
+      assert new_state.workspace.mouse.resize_dragging == nil
+    end
+
+    test "text drag release clears dragging even after the active buffer disappears" do
+      {state, _buffer} = start_mouse_state("hello")
+
+      state =
+        state
+        |> install_mouse(MouseState.start_drag(state.workspace.mouse, {0, 0}))
+        |> remove_active_buffer()
+
+      new_state = mouse(state, 0, 0, :left, :release)
+
+      refute new_state.workspace.mouse.dragging
+      assert new_state.workspace.mouse.anchor == nil
+    end
+  end
+
   describe "drag selection" do
     test "left press and drag creates a visual selection" do
       {state, buffer} = start_mouse_state("hello world foo")
@@ -728,6 +760,15 @@ defmodule MingaEditor.MouseTest do
       )
 
     {state, buffer}
+  end
+
+  defp install_mouse(state, mouse) do
+    %{state | workspace: SessionState.set_mouse(state.workspace, mouse)}
+  end
+
+  defp remove_active_buffer(state) do
+    buffers = Buffers.remove(state.workspace.buffers, state.workspace.buffers.active)
+    %{state | workspace: SessionState.set_buffers(state.workspace, buffers)}
   end
 
   defp start_sidebar_registry(id) do


### PR DESCRIPTION
# TL;DR

Resize drags and releases now stay in the active mouse workflow when the pointer leaves the focus tree. Text and resize releases also clear stale drag state after active-buffer loss or negative coordinates.

## Context

This is W018 in the editor lifecycle roadmap. The old router captured text-selection drags but sent active resize drags through ordinary focus-tree hit routing, where an outside pointer or another handler could swallow the event. Mouse release cleanup also ran after early no-buffer and coordinate guards.

## Changes

- Direct-route active left-button text and resize drag/release events through the existing shell availability and mouse handling path.
- Run active text and resize release cleanup before no-buffer and negative-coordinate guards.
- Reuse the existing mouse, window, buffer, and session owner APIs.
- Add regressions for resize events outside the focus tree and text/resize cleanup after active-buffer loss.
- Record W018 implementation and validation evidence in the lifecycle roadmap.

## Compatibility

No mouse protocol, frontend, focus-tree, separator math, selection, auto-copy, shell lifecycle, process, dependency, or data-shape changes.

## Verification

- `mix test.debug test/minga_editor/input/router_test.exs test/minga_editor/mouse_test.exs test/minga_editor/state/mouse_test.exs` (75 tests passed)
- `make lint` (Credo, compile, and incremental Dialyzer passed)
- `mix test.llm --max-cases 4` (58 doctests, 98 properties, and 9,920 tests passed; 0 failures)
- `git diff --check`

## Acceptance Criteria Addressed

- Active resize drag and release bypass focus-tree hit routing.
- Active text and resize release clear their state before no-buffer and negative-coordinate early returns.
- Existing selection auto-copy and owner transitions remain intact.
- Production net line count is -4; tests add 74 lines, both within the locked W018 budgets.
