### PR TITLE
fix(editor): retire stale tool status timer

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2053,6 +2053,39 @@ New split and float popup windows initialize their viewport metadata from `state
   - **Final reviewer:** `PASS`; locked routing and release-cleanup contract, ownership, lifecycle, API, tests, budgets, evidence, and merge safety accepted with no findings.
   - **Completion date:** 2026-07-19
 
+### W019: Retire redundant tool-status clear timers
+
+- **Status:** ACTIVE
+- **Audit ID:** L23
+- **Decision:** ACCEPT/direct
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness commit SHA:** `a139cf97ca0ba7d4225eab1a41dc1ae15c8e5f03`
+- **Observable outcome:** An old tool-install completion cannot dismiss a newer tool-like notice. Tool completion retains its text, log, picker refresh, and render effects, then expires only through the ordinary identity-safe notice lifecycle.
+- **Failure path:** Tool completion publishes through `NoticeWorkflow`, then also schedules bare `:clear_tool_status`. The old atom later routes through `ToolHandler`, infers ownership from the current message prefix, and can dismiss a newer `Installing ...` or `✓ ... installed` notice.
+- **Authoritative owners:** `Shell.Traditional.Notice` owns ordinary notice identity; `NoticeWorkflow` owns publish, timer cancellation/creation, and timeout delivery; `Shell.Traditional.State` installs Notice transitions. `ToolHandler` does not own notice lifecycle.
+- **Locked implementation:** Delete ToolHandler's conditional five-second clear effect, prefix-based clear handler, `send_after` effect type/executor, and the Editor atom-dispatch entry. Retain `%Notice{id, message, timer}` and `{:notice_timeout, id}` unchanged. Do not replace the redundant timer with another tagged timer.
+- **Tests:** Replace old clear scheduling/prefix tests with non-headless and headless ownership assertions; add an Editor `handle_info/2` regression proving a legacy bare clear atom cannot dismiss newer `Installing ...` or `✓ ... installed` notices; retain existing stale/matching notice-ID tests.
+- **Focused validation:** `mix test test/minga_editor/handlers/tool_handler_test.exs test/minga_editor/shell/traditional/notice_workflow_test.exs`.
+- **Broad validation:** `mix test test/minga_editor/handlers test/minga_editor/shell/traditional`; `mix test.llm --max-cases 4`; `make lint`; `git diff --check`.
+- **Non-goals:** No ToolStatus struct, tagged replacement timer, registry, process, behaviour, protocol, config, public API, compatibility shim, Tool Manager payload, notification, operation-feedback, status-bar, or frontend changes.
+- **Maximum production additions:** 0 net lines; expected net deletion. Any positive additions require explanation and remain capped at 50.
+- **Maximum test additions:** 40 lines expected, 80 hard ceiling.
+- **Dependencies:** Existing NoticeWorkflow identity-safe timeouts are merged; no unresolved dependency or implementer question remains.
+- **Completion evidence:**
+  - **Implementation result:** Deleted ToolHandler's five-second clear effect, prefix-based clear handler, timer effect type/executor, and Editor atom route. Tool completion still publishes the same success notice and returns the same log, picker refresh, and render effects; NoticeWorkflow is now the sole timeout owner.
+  - **Failure reproduced:** Before production deletion, focused regressions observed `{:send_after, :clear_tool_status, 5_000}` and a legacy bare atom dismissed a newer `Installing fd...` notice.
+  - **Regression coverage:** Non-headless completion records the NoticeWorkflow timer and no ToolHandler clear effect; headless completion records no notice timer; legacy bare delivery preserves both `Installing ...` and `✓ ... installed` notices and their IDs; existing stale/matching notice-ID tests remain unchanged.
+  - **Focused validation:** `mix test.debug test/minga_editor/handlers/tool_handler_test.exs test/minga_editor/shell/traditional/notice_workflow_test.exs` passed 16 tests; `mix test test/minga_editor/handlers test/minga_editor/shell/traditional` passed 209 tests.
+  - **Broad validation:** `make lint` passed Credo, compile, and incremental Dialyzer after the final effect-union narrowing; `mix test.llm --max-cases 4` passed 58 doctests, 98 properties, and 9,918 tests with 0 failures, 1 skipped, and 578 excluded.
+  - **Line deltas:** Production `lib/minga_editor.ex` +3/-5 and `lib/minga_editor/handlers/tool_handler.ex` +13/-59, net -48. Tests `test/minga_editor/handlers/tool_handler_test.exs` +25/-51, net -26.
+  - **Concepts added/removed:** Added none. Removed the second tool-status timer lifecycle, prefix ownership inference, generic timer effect, bare Editor dispatch route, unreachable generic log levels, and obsolete duplicate tests.
+  - **Pre-acceptance reviews:** Correctness `PASS`; Elixir craftsmanship `PASS` after documentation and effect types were aligned to actual ownership; Ponytail `Lean already. Ship.` after duplicate headless effect coverage was removed.
+  - **Final reviewer:** `PASS`; redundant timer deletion, sole NoticeWorkflow ownership, preserved tool effects, tests, budgets, evidence, and merge safety accepted with no findings.
+  - **PR URL:** Pending.
+  - **Merge evidence:** Pending.
+  - **Completion date:** Pending merge.
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -51,7 +51,6 @@ defmodule MingaEditor do
   alias MingaEditor.Handlers.LspEventHandler
   alias MingaEditor.Handlers.RenderHandler
   alias MingaEditor.Handlers.SessionHandler
-  alias MingaEditor.Handlers.ToolHandler
   # WarningLog removed in #825; warnings route through MessageLog with level override
   alias MingaEditor.Window
   alias MingaEditor.Input
@@ -838,15 +837,14 @@ defmodule MingaEditor do
   end
 
   # ── Handler-delegated bare atom events ─────────────────────────────────────
-  # Bare atom messages routed to HighlightHandler, SessionHandler, or
-  # ToolHandler via a module attribute map (guard-safe via is_map_key/2).
+  # Bare atom messages routed to HighlightHandler or SessionHandler via a module
+  # attribute map (guard-safe via is_map_key/2).
 
   @handler_atom_dispatch %{
     setup_highlight: HighlightHandler,
     evict_parser_trees: HighlightHandler,
     check_swap_recovery: SessionHandler,
-    save_session: SessionHandler,
-    clear_tool_status: ToolHandler
+    save_session: SessionHandler
   }
 
   def handle_info(msg, state) when is_map_key(@handler_atom_dispatch, msg) do

--- a/lib/minga_editor/handlers/tool_handler.ex
+++ b/lib/minga_editor/handlers/tool_handler.ex
@@ -2,12 +2,9 @@ defmodule MingaEditor.Handlers.ToolHandler do
   @moduledoc """
   Owns tool installation/management transitions and external actions.
 
-  `dispatch/2` updates tool prompts/notices first, then applies focused actions
-  in list order. Picker refreshes, logs, renders, and the clear-status timer run
-  in the Editor process, so the same process creates and receives timer
-  messages. Installer supervision remains with the tool service; this workflow
-  only presents its ordered events. Unknown/stale events are ignored, install
-  failures are logged and rendered, and headless mode creates no timer.
+  `dispatch/2` updates tool prompts/notices first, then applies focused actions in list order.
+  Picker refreshes, logs, and renders run in the Editor process.
+  Installer supervision remains with the tool service; this workflow only presents its ordered events. Unknown/stale events are ignored, and install failures are logged and rendered.
   """
 
   alias MingaEditor.Shell.Traditional.ToolPrompts
@@ -18,9 +15,8 @@ defmodule MingaEditor.Handlers.ToolHandler do
   @type tool_effect ::
           :render
           | {:log_message, String.t()}
-          | {:log, atom(), :debug | :info | :warning | :error, String.t()}
+          | {:log, :editor, :debug, String.t()}
           | {:refresh_tool_picker}
-          | {:send_after, term(), non_neg_integer()}
 
   @doc "Applies one tool event and its focused actions."
   @spec dispatch(EditorState.t(), term()) :: EditorState.t()
@@ -29,12 +25,7 @@ defmodule MingaEditor.Handlers.ToolHandler do
     apply_effects(state, effects)
   end
 
-  @doc """
-  Dispatches a tool event to the appropriate handler.
-
-  Returns `{state, effects}` where effects encode all side-effectful
-  operations.
-  """
+  @doc "Handles one tool event, returning updated state and deferred tool-local effects."
   @spec handle(EditorState.t(), term()) :: {EditorState.t(), [tool_effect()]}
 
   def handle(state, {:minga_event, :tool_install_started, %{name: name}}) do
@@ -56,21 +47,12 @@ defmodule MingaEditor.Handlers.ToolHandler do
         "\u2713 #{name} v#{version} installed"
       )
 
-    effects = [
-      {:log_message, "Tool installed: #{name} v#{version}"},
-      {:refresh_tool_picker},
-      :render
-    ]
-
-    # Schedule status clear after 5 seconds (skip in headless)
-    effects =
-      if state.frontend.backend != :headless do
-        Enum.concat(effects, [{:send_after, :clear_tool_status, 5_000}])
-      else
-        effects
-      end
-
-    {new_state, effects}
+    {new_state,
+     [
+       {:log_message, "Tool installed: #{name} v#{version}"},
+       {:refresh_tool_picker},
+       :render
+     ]}
   end
 
   def handle(state, {:minga_event, :tool_install_failed, %{name: name, reason: reason}}) do
@@ -97,23 +79,6 @@ defmodule MingaEditor.Handlers.ToolHandler do
        {:refresh_tool_picker},
        :render
      ]}
-  end
-
-  def handle(state, :clear_tool_status) do
-    current = MingaEditor.Shell.Traditional.NoticeWorkflow.message(state) || ""
-
-    new_state =
-      if String.starts_with?(current, [
-           "\u2713 ",
-           "Installing ",
-           "Updating "
-         ]) do
-        MingaEditor.Shell.Traditional.NoticeWorkflow.dismiss(state)
-      else
-        state
-      end
-
-    {new_state, [:render]}
   end
 
   # ── Tool missing prompt ──────────────────────────────────────────────────
@@ -150,24 +115,13 @@ defmodule MingaEditor.Handlers.ToolHandler do
     state
   end
 
-  defp apply_effect(state, {:log, subsystem, level, message}) do
-    log(subsystem, level, message)
+  defp apply_effect(state, {:log, :editor, :debug, message}) do
+    Minga.Log.debug(:editor, message)
     state
   end
 
   defp apply_effect(state, {:refresh_tool_picker}),
     do: MingaEditor.maybe_refresh_tool_picker(state)
-
-  defp apply_effect(state, {:send_after, message, delay_ms}) do
-    if state.frontend.backend != :headless, do: Process.send_after(self(), message, delay_ms)
-    state
-  end
-
-  @spec log(atom(), :debug | :info | :warning | :error, String.t()) :: :ok
-  defp log(subsystem, :debug, message), do: Minga.Log.debug(subsystem, message)
-  defp log(subsystem, :info, message), do: Minga.Log.info(subsystem, message)
-  defp log(subsystem, :warning, message), do: Minga.Log.warning(subsystem, message)
-  defp log(subsystem, :error, message), do: Minga.Log.error(subsystem, message)
 
   @spec handle_tool_missing(EditorState.t(), String.t(), boolean()) ::
           {EditorState.t(), [tool_effect()]}

--- a/test/minga_editor/handlers/tool_handler_test.exs
+++ b/test/minga_editor/handlers/tool_handler_test.exs
@@ -1,14 +1,10 @@
 defmodule MingaEditor.Handlers.ToolHandlerTest do
-  @moduledoc """
-  Pure-function tests for `MingaEditor.Handlers.ToolHandler`.
-
-  Uses `RenderPipeline.TestHelpers.base_state/1` to construct state
-  without starting a GenServer.
-  """
+  @moduledoc "Focused workflow tests for `MingaEditor.Handlers.ToolHandler`."
 
   use ExUnit.Case, async: true
 
   alias MingaEditor.Handlers.ToolHandler
+  alias MingaEditor.Shell.Traditional.NoticeWorkflow
   alias MingaEditor.Shell.Traditional.ToolPromptWorkflow
 
   import MingaEditor.RenderPipeline.TestHelpers
@@ -44,39 +40,30 @@ defmodule MingaEditor.Handlers.ToolHandlerTest do
   end
 
   describe "tool_install_complete" do
-    test "sets success status and returns log + render effects" do
-      state = base_state()
+    test "relies on NoticeWorkflow timer and emits no tool clear timer" do
+      state = base_state(backend: :tui)
       event = {:minga_event, :tool_install_complete, %{name: "ripgrep", version: "14.1"}}
       {new_state, effects} = ToolHandler.handle(state, event)
 
-      assert String.contains?(
-               MingaEditor.Shell.Traditional.NoticeWorkflow.message(new_state),
-               "ripgrep v14.1 installed"
-             )
-
+      assert String.contains?(NoticeWorkflow.message(new_state), "ripgrep v14.1 installed")
       assert {:log_message, "Tool installed: ripgrep v14.1"} in effects
-      assert :render in effects
       assert {:refresh_tool_picker} in effects
+      assert :render in effects
+
+      refute Enum.any?(effects, &match?({:send_after, :clear_tool_status, _}, &1))
+
+      timer = new_state.shell_runtime.state.notice.timer
+      assert is_reference(timer)
+      assert Process.read_timer(timer) in 1..2_000
+      NoticeWorkflow.dismiss(new_state)
     end
 
-    test "schedules clear_tool_status in non-headless mode" do
-      state = base_state(backend: :tui)
-      event = {:minga_event, :tool_install_complete, %{name: "ripgrep", version: "14.1"}}
-      {_state, effects} = ToolHandler.handle(state, event)
-
-      assert {:send_after, :clear_tool_status, 5_000} in effects
-    end
-
-    test "does not schedule timer in headless mode" do
+    test "headless completion creates no notice timer" do
       state = base_state()
-      # base_state defaults to headless
       event = {:minga_event, :tool_install_complete, %{name: "ripgrep", version: "14.1"}}
-      {_state, effects} = ToolHandler.handle(state, event)
+      {new_state, _effects} = ToolHandler.handle(state, event)
 
-      refute Enum.any?(effects, fn
-               {:send_after, :clear_tool_status, _} -> true
-               _ -> false
-             end)
+      assert new_state.shell_runtime.state.notice.timer == nil
     end
   end
 
@@ -123,32 +110,19 @@ defmodule MingaEditor.Handlers.ToolHandlerTest do
     end
   end
 
-  describe "clear_tool_status" do
-    test "clears status when it starts with a tool prefix" do
-      state = base_state()
+  describe "legacy clear_tool_status delivery" do
+    test "cannot dismiss newer tool-like notices" do
+      for message <- ["Installing fd...", "✓ fd v9 installed"] do
+        state =
+          base_state(rendering: :disabled)
+          |> NoticeWorkflow.publish(message)
 
-      state =
-        MingaEditor.Shell.Traditional.NoticeWorkflow.publish(
-          state,
-          "\u2713 ripgrep v14.1 installed"
-        )
+        notice_id = state.shell_runtime.state.notice.id
 
-      {new_state, effects} = ToolHandler.handle(state, :clear_tool_status)
-
-      assert MingaEditor.Shell.Traditional.NoticeWorkflow.message(new_state) == nil
-      assert :render in effects
-    end
-
-    test "preserves non-tool status messages" do
-      state = base_state()
-      state = MingaEditor.Shell.Traditional.NoticeWorkflow.publish(state, "Some other message")
-
-      {new_state, effects} = ToolHandler.handle(state, :clear_tool_status)
-
-      assert MingaEditor.Shell.Traditional.NoticeWorkflow.message(new_state) ==
-               "Some other message"
-
-      assert :render in effects
+        assert {:noreply, delivered} = MingaEditor.handle_info(:clear_tool_status, state)
+        assert NoticeWorkflow.message(delivered) == message
+        assert delivered.shell_runtime.state.notice.id == notice_id
+      end
     end
   end
 


### PR DESCRIPTION
# TL;DR

Tool installation notices now expire only through the existing identity-safe notice lifecycle. This removes the redundant bare clear timer that could dismiss a newer tool-like notice.

## Context

This is W019 in the editor lifecycle roadmap. Tool completion published through `NoticeWorkflow`, then also scheduled an uncorrelated `:clear_tool_status` atom. When that old atom arrived, ToolHandler inferred ownership from the current message prefix and could clear a newer notice.

## Changes

- Remove ToolHandler's five-second clear timer effect, timer executor, prefix-based clear handler, and Editor atom route.
- Keep `%Notice{id, message, timer}` and `{:notice_timeout, id}` as the sole ordinary notice lifecycle.
- Preserve tool success text, logging, picker refresh, rendering, and headless behavior.
- Narrow ToolHandler's remaining log effect to its actual supported shape and remove unreachable branches.
- Add regressions for NoticeWorkflow timer ownership and legacy bare delivery against newer install and success notices.
- Record W019 implementation and validation evidence in the lifecycle roadmap.

## Compatibility

No Tool Manager payload, protocol, frontend, notification, operation-feedback, status-bar, process, registry, configuration, public API, or data-shape changes. Already-enqueued legacy atoms fall through the existing no-op Editor handler.

## Verification

- `mix test.debug test/minga_editor/handlers/tool_handler_test.exs test/minga_editor/shell/traditional/notice_workflow_test.exs` (16 tests passed)
- `mix test test/minga_editor/handlers test/minga_editor/shell/traditional` (209 tests passed)
- `make lint` (Credo, compile, and incremental Dialyzer passed)
- `mix test.llm --max-cases 4` (58 doctests, 98 properties, and 9,918 tests passed; 0 failures)
- `git diff --check`

## Acceptance Criteria Addressed

- Old tool completion timers cannot dismiss newer tool-like notices.
- NoticeWorkflow is the sole identity-safe timeout owner.
- Tool completion output and headless behavior remain intact.
- Production removes 48 net lines and tests remove 26 net lines.
