### PR TITLE
fix(editor): roll back failed native IPC init

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2121,6 +2121,37 @@ New split and float popup windows initialize their viewport metadata from `state
   - **Merged CI:** Run `29676744074` passed every required check, including Elixir, Dialyzer, lint/format, Zig, Go, Swift, protocol integration, Neovim conformance, boot smoke, and keystroke latency.
   - **Completion date:** 2026-07-19
 
+### W021: Roll back partial native IPC initialization
+
+- **Status:** ACTIVE
+- **Audit ID:** L25
+- **Decision:** ACCEPT/direct
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness commit SHA:** `2f5bb009d3663657d36809b7e042edbb8ad66170`
+- **Observable outcome:** Native IPC initialization failures after listener creation preserve the original failure while removing the failed generation's descriptor, temporary descriptor, listener, and socket path in reverse acquisition order.
+- **Authoritative owner:** `MingaEditor.NativeIPC.Server` owns endpoint acquisition and partial-init rollback; `Server.State` remains the unchanged steady-state owner.
+- **Locked implementation:** Fetch required options before resource acquisition. Keep all parent, directory, socket, descriptor, identity, and authentication checks unchanged. On post-listen failure, close the listener then unlink its socket. Descriptor publication removes its temp file on pre-rename failure and removes published `current.json` only when its `core_instance_id` matches the failed generation. Start the acceptor only after complete acquisition.
+- **Tests:** Pre-create `runtime_dir/current.json` as a directory, start the real IPC supervisor, assert the original `:eisdir` startup error, preserve the blocker directory, and assert no `control-*` socket or `current.json.tmp-*` remains. Preserve symlink rejection and normal endpoint lifecycle tests.
+- **Focused validation:** `mix test test/minga/frontend/native_ipc_test.exs --seed 0`.
+- **Broad validation:** `mix test`; `make lint`; `git diff --check`.
+- **Non-goals:** No endpoint struct, new module, process, registry, behavior, dependency, public API, config, protocol/schema change, test injection, trust-check weakening, runtime directory removal, helper change, or connection/request redesign.
+- **Maximum production additions:** 50 net lines.
+- **Maximum test additions:** 45 lines.
+- **Dependencies:** Existing File, Path, `:gen_tcp`, JSON, supervisor, identity, and descriptor APIs only; no unresolved implementer question remains.
+- **Completion evidence:**
+  - **Implementation result:** `MingaEditor.NativeIPC.Server.init/1` now fetches the required task supervisor before identity/runtime/socket work, validates the private parent/runtime directory before resource acquisition, opens the AF_UNIX listener inside a staged endpoint boundary, and starts the acceptor only after socket validation and descriptor publication succeed. Post-listen errors close the listener and unlink the socket while preserving the original reason; descriptor publication removes only the temp file before a successful rename and removes `current.json` after rename only when the failed generation's `core_instance_id` is still current.
+  - **Regression evidence:** Added the real filesystem/AF_UNIX blocker-directory regression in `test/minga/frontend/native_ipc_test.exs`; before the fix, `mix test test/minga/frontend/native_ipc_test.exs --seed 0` failed because `entries` still contained `control-DThY6HrvSBE_ilfh.sock` next to `current.json`. After the fix, the same test asserts the original `:eisdir` startup error, preserved blocker directory, no `control-*` socket, no `current.json.tmp-*`, and only `current.json` remaining.
+  - **Focused validation:** `mix test test/minga/frontend/native_ipc_test.exs --seed 0` passed with 8 tests on 2026-07-19.
+  - **Line budget:** Production delta `+77/-30` in `lib/minga_editor/native_ipc/server.ex` for net `+47`; test delta `+45/-0` in `test/minga/frontend/native_ipc_test.exs`, within W021 limits.
+  - **Concepts added/removed:** Added private staged endpoint acquisition and rollback helpers inside the existing server owner. Added no endpoint struct, module, process, registry, behavior, dependency, public API, config, protocol, schema, or test injection. Removed no steady-state trust check or normal terminate behavior.
+  - **Pre-acceptance reviews:** Correctness `PASS`; Elixir craftsmanship `PASS` after flattening listener-owned error flow and consolidating finalization rollback into one catch-and-reraise path; Ponytail `Lean already. Ship.`
+  - **Broad validation:** `mix test --max-cases 4` passed 10,444 tests, including 58 doctests and 99 properties, with 0 failures, 1 skipped, and 210 excluded after building the worktree's missing native parser and hook runner; `make lint` passed Credo, compile, and incremental Dialyzer after the final control-flow correction; `git diff --check` passed.
+  - **Final reviewer:** `PASS`; staged rollback, trust checks, original errors, steady-state ownership, public APIs, real IPC regression, line budgets, validation evidence, and merge safety accepted with no findings.
+  - **PR URL:** Pending.
+  - **Merge evidence:** Pending.
+  - **Completion date:** Pending merge.
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2148,7 +2148,7 @@ New split and float popup windows initialize their viewport metadata from `state
   - **Pre-acceptance reviews:** Correctness `PASS`; Elixir craftsmanship `PASS` after flattening listener-owned error flow and consolidating finalization rollback into one catch-and-reraise path; Ponytail `Lean already. Ship.`
   - **Broad validation:** `mix test --max-cases 4` passed 10,444 tests, including 58 doctests and 99 properties, with 0 failures, 1 skipped, and 210 excluded after building the worktree's missing native parser and hook runner; `make lint` passed Credo, compile, and incremental Dialyzer after the final control-flow correction; `git diff --check` passed.
   - **Final reviewer:** `PASS`; staged rollback, trust checks, original errors, steady-state ownership, public APIs, real IPC regression, line budgets, validation evidence, and merge safety accepted with no findings.
-  - **PR URL:** Pending.
+  - **PR URL:** https://github.com/jsmestad/minga/pull/3028
   - **Merge evidence:** Pending.
   - **Completion date:** Pending merge.
 

--- a/lib/minga_editor/native_ipc/server.ex
+++ b/lib/minga_editor/native_ipc/server.ex
@@ -48,33 +48,18 @@ defmodule MingaEditor.NativeIPC.Server do
   def init(opts) do
     Process.flag(:trap_exit, true)
 
+    task_supervisor = Keyword.fetch!(opts, :task_supervisor)
+
+    connection_opts =
+      Keyword.take(opts, [:wait_tracker, :editor_server, :open_wait, :open_request, :kill_checker])
+
     with {:ok, base} <- identity_base(opts),
          {:ok, runtime_parent} <- runtime_parent(opts),
          :ok <- validate_private_parent(runtime_parent, base.euid),
          {:ok, runtime_dir} <- runtime_dir(opts, runtime_parent),
          :ok <- prepare_runtime_dir(runtime_dir, base.euid),
-         socket_path <- random_socket_path(runtime_dir),
-         {:ok, listener} <- listen(socket_path),
-         :ok <- File.chmod(socket_path, 0o600),
-         :ok <- validate_private_file(socket_path, :other, base.euid, 0o600),
-         identity <- build_identity(base, socket_path),
-         descriptor_path <- Path.join(runtime_dir, "current.json"),
-         :ok <- publish_descriptor(descriptor_path, identity, base.euid) do
-      task_supervisor = Keyword.fetch!(opts, :task_supervisor)
-
-      connection_opts =
-        Keyword.take(opts, [
-          :wait_tracker,
-          :editor_server,
-          :open_wait,
-          :open_request,
-          :kill_checker
-        ])
-
-      acceptor =
-        spawn_link(fn -> accept_loop(listener, task_supervisor, identity, connection_opts) end)
-
-      {:ok, State.new(listener, acceptor, descriptor_path, identity)}
+         {:ok, {listener, descriptor_path, identity}} <- open_endpoint(runtime_dir, base) do
+      finalize_endpoint(listener, task_supervisor, identity, connection_opts, descriptor_path)
     else
       {:error, reason} -> {:stop, reason}
     end
@@ -289,20 +274,82 @@ defmodule MingaEditor.NativeIPC.Server do
   @spec publish_descriptor(String.t(), Identity.t(), non_neg_integer()) ::
           :ok | {:error, term()}
   defp publish_descriptor(path, identity, euid) do
-    descriptor = Identity.descriptor(identity, @descriptor_version)
     temp = path <> ".tmp-#{random_secret(8)}"
 
-    with :ok <- File.write(temp, JSON.encode!(descriptor) <> "\n", [:exclusive]),
+    with :ok <-
+           File.write(
+             temp,
+             JSON.encode!(Identity.descriptor(identity, @descriptor_version)) <> "\n",
+             [:exclusive]
+           ),
          :ok <- File.chmod(temp, 0o600),
-         :ok <- validate_private_file(temp, :regular, euid, 0o600),
-         :ok <- File.rename(temp, path),
-         :ok <- validate_private_file(path, :regular, euid, 0o600) do
-      :ok
+         :ok <- validate_private_file(temp, :regular, euid, 0o600) do
+      publish_current_descriptor(path, temp, identity, euid)
     else
-      {:error, _reason} = error ->
-        _ = File.rm(temp)
-        error
+      {:error, _reason} = error -> remove_temp_descriptor(temp, error)
     end
+  end
+
+  defp open_endpoint(runtime_dir, base) do
+    socket_path = random_socket_path(runtime_dir)
+
+    with {:ok, listener} <- listen(socket_path) do
+      with :ok <- File.chmod(socket_path, 0o600),
+           :ok <- validate_private_file(socket_path, :other, base.euid, 0o600),
+           identity = build_identity(base, socket_path),
+           descriptor_path = Path.join(runtime_dir, "current.json"),
+           :ok <- publish_descriptor(descriptor_path, identity, base.euid) do
+        {:ok, {listener, descriptor_path, identity}}
+      else
+        {:error, _reason} = error ->
+          rollback_listener_socket(listener, socket_path)
+          error
+      end
+    end
+  end
+
+  defp finalize_endpoint(listener, task_supervisor, identity, connection_opts, descriptor_path) do
+    acceptor =
+      spawn_link(fn -> accept_loop(listener, task_supervisor, identity, connection_opts) end)
+
+    {:ok, State.new(listener, acceptor, descriptor_path, identity)}
+  catch
+    kind, reason ->
+      rollback_published_endpoint(descriptor_path, identity, listener)
+      :erlang.raise(kind, reason, __STACKTRACE__)
+  end
+
+  defp publish_current_descriptor(path, temp, identity, euid) do
+    case File.rename(temp, path) do
+      :ok ->
+        case validate_private_file(path, :regular, euid, 0o600) do
+          :ok ->
+            :ok
+
+          {:error, _reason} = error ->
+            remove_descriptor_if_current(path, identity.core_instance_id)
+            error
+        end
+
+      {:error, _reason} = error ->
+        remove_temp_descriptor(temp, error)
+    end
+  end
+
+  defp remove_temp_descriptor(temp, error) do
+    _ = File.rm(temp)
+    error
+  end
+
+  defp rollback_published_endpoint(descriptor_path, identity, listener) do
+    remove_descriptor_if_current(descriptor_path, identity.core_instance_id)
+    rollback_listener_socket(listener, identity.socket_path)
+  end
+
+  defp rollback_listener_socket(listener, socket_path) do
+    _ = :gen_tcp.close(listener)
+    _ = File.rm(socket_path)
+    :ok
   end
 
   @spec remove_descriptor_if_current(String.t(), String.t()) :: :ok

--- a/test/minga/frontend/native_ipc_test.exs
+++ b/test/minga/frontend/native_ipc_test.exs
@@ -140,6 +140,51 @@ defmodule Minga.Frontend.NativeIPCTest do
     assert inspect(reason) =~ "insecure_runtime_entry"
   end
 
+  test "rolls back listener socket and temp descriptor when descriptor publication fails after listen",
+       ctx do
+    suffix = System.unique_integer([:positive])
+    parent = Path.join("/tmp", "minga-native-ipc-rollback-#{suffix}")
+    runtime_dir = Path.join(parent, "com.minga.editor")
+    blocker = Path.join(runtime_dir, "current.json")
+    File.rm_rf!(parent)
+    File.mkdir!(parent)
+    File.chmod!(parent, 0o700)
+    File.mkdir!(runtime_dir)
+    File.chmod!(runtime_dir, 0o700)
+    File.mkdir!(blocker)
+
+    on_exit(fn -> File.rm_rf!(parent) end)
+
+    previous_trap = Process.flag(:trap_exit, true)
+
+    result =
+      IPCSupervisor.start_link(
+        name: nil,
+        server_name: nil,
+        task_supervisor_name: Module.concat(__MODULE__, "RollbackTasks#{suffix}"),
+        runtime_parent: parent,
+        runtime_dir: runtime_dir,
+        app_instance_id: "app-instance-1234567890",
+        app_pid: ctx.app_pid,
+        euid: File.stat!(File.cwd!()).uid,
+        kill_checker: fn _pid -> true end
+      )
+
+    receive do
+      {:EXIT, _pid, _reason} -> :ok
+    after
+      0 -> :ok
+    end
+
+    Process.flag(:trap_exit, previous_trap)
+    assert {:error, {:shutdown, {:failed_to_start_child, _, :eisdir}}} = result
+    assert File.dir?(blocker)
+    entries = File.ls!(runtime_dir)
+    refute Enum.any?(entries, &String.starts_with?(&1, "control-"))
+    refute Enum.any?(entries, &String.starts_with?(&1, "current.json.tmp-"))
+    assert entries == ["current.json"]
+  end
+
   test "authenticates a real AF_UNIX probe and rejects a substituted token", ctx do
     socket = connect(ctx.descriptor)
     send_json(socket, hello(ctx.descriptor))


### PR DESCRIPTION
# TL;DR

Native IPC startup now removes every resource owned by a failed endpoint generation instead of leaving an AF_UNIX socket path behind.

## Context

The listener and socket path are created before the native endpoint descriptor is published and before GenServer state exists. A descriptor publication failure therefore bypassed normal `terminate/2` cleanup and leaked the socket entry.

## Changes

- Fetch required startup configuration before opening filesystem or socket resources.
- Stage listener, socket, temporary descriptor, published descriptor, and acceptor acquisition inside the existing server owner.
- Preserve the original startup error while removing owned resources in reverse order.
- Remove a published descriptor only when its `core_instance_id` belongs to the failed generation, preserving foreign or pre-existing paths.
- Add a real AF_UNIX and filesystem regression that forces descriptor publication to fail after listener creation.

## Compatibility

No public API, process, state shape, protocol, descriptor schema, authentication, path, UID, type, or permission check changes. Normal endpoint termination remains unchanged.

## Verification

- `mix test test/minga/frontend/native_ipc_test.exs --seed 0` passed 8 tests.
- `mix test --max-cases 4` passed 10,444 tests with 0 failures, 1 skipped, and 210 excluded.
- `make lint` passed Credo, compile, and incremental Dialyzer.
- `git diff --check` passed.
