### PR TITLE
fix(editor): resolve triple-click hit targets

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2216,8 +2216,8 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Pre-acceptance reviews:** Correctness `PASS`; Elixir craftsmanship `PASS`; Ponytail `Lean already. Ship.`
 - **Broad validation:** The focused mouse and hit-test command passed 51 tests. The first `mix test --max-cases 4` run exposed the worktree's missing native parser binary; after `mix compile.minga_zig`, the same command passed 10,448 tests, including 58 doctests and 99 properties, with 0 failures, 1 skipped, and 210 excluded. `make lint` passed Credo, compile, format, and incremental Dialyzer. `git diff --check` passed.
 - **Final reviewer:** `PASS`; canonical target consumption, focus/mode/drag preservation, duplicate-mapper deletion, wrapped/folded regressions, line budgets, validation evidence, and merge safety accepted with no findings.
-- **PR URL:** Pending.
-- **Implementation commit SHA:** Pending.
+- **PR URL:** https://github.com/jsmestad/minga/pull/3032
+- **Implementation commit SHA:** `309c08144`
 - **Merge evidence:** Pending.
 - **Completion date:** Pending merge.
 

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2187,6 +2187,40 @@ New split and float popup windows initialize their viewport metadata from `state
   - **Merged CI:** Run `29680427172` passed every required check, including Elixir, Dialyzer, lint/format, Zig, Go, Swift, protocol integration, Neovim conformance, boot smoke, and keystroke latency.
   - **Completion date:** 2026-07-19
 
+### W023: Resolve triple-click targets through `HitTest`
+
+- **Status:** ACTIVE
+- **Audit ID:** L27
+- **Decision:** ACCEPT/direct
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness:** Reproduced on current main SHA `edf2442ceb314e8f712dfb5de268bb529ed0b84f`.
+- **Observable outcome:** Triple-click consumes the canonical `%MingaEditor.Mouse.Target.Buffer{}` resolved for the clicked screen cell, so wrapped continuation rows and folded display rows select their source buffer line and the drag origin retains the resolved window.
+- **Current failure path:** `Mouse.handle_triple_click/3` focuses independently, derives a window with `origin_window_id_at/3`, derives a line with `mouse_to_buffer_line/2`, and reads `state.workspace.buffers.active`. The line helper bypasses `HitTest.position/7`, wrapping, folds, composed decorations, virtual text, and the resolved target buffer/window. A triple-click on the second visual row of a one-line wrapped buffer returns unchanged state; a folded row can select a hidden line.
+- **Owner and target shape:** `MingaEditor.Mouse.HitTest.resolve_buffer/3` owns screen-to-buffer resolution and returns `%MingaEditor.Mouse.Target.Buffer{window_id, buffer, line, col, local_row, local_col, viewport}`. `MingaEditor.Mouse` remains the workflow consumer and must use `target.window_id`, `target.buffer`, and `target.line`.
+- **Locked source files:** Modify only `lib/minga_editor/mouse.ex`. `lib/minga_editor/mouse/hit_test.ex` and `lib/minga_editor/mouse/target/buffer.ex` remain unchanged.
+- **Locked implementation:** Preserve the leading `maybe_focus_window_at/3` call and its focus side effects. Replace the independently derived origin, line, and active buffer in `handle_triple_click/3` with one `HitTest.resolve_buffer/3` match on `{:buffer, %BufferTarget{} = target}`. Keep the existing line-end calculation, buffer move, Visual Line transition, and drag transition, passing `target.window_id` to `MouseState.start_drag/3`. Return the focused state unchanged for commands, block no-ops, and misses. Delete the now-unused `mouse_to_buffer_line/2`. Do not change any other mouse path.
+- **Ordered steps:** Add failing wrapped-row and folded-row triple-click regressions at the `Mouse.handle/7` boundary; replace the triple-click target derivation with the canonical target; delete `mouse_to_buffer_line/2`; run the focused and broad commands.
+- **Required regression 1:** In `test/minga_editor/mouse_test.exs`, create a 100-character one-line buffer at width 20 with wrap enabled, linebreak disabled, and line numbers disabled. Triple-click the second visual row. Assert cursor `{0, 99}`, Visual Line anchor `{0, 0}`, line visual type, active drag anchor `{0, 0}`, and drag origin equal to the active window.
+- **Required regression 2:** In the same file, fold lines 0 through 2, set viewport top to 1, and triple-click the first visible content row. Assert cursor `{3, 5}`, Visual Line anchor `{3, 0}`, line visual type, drag anchor `{3, 0}`, and drag origin equal to the active window.
+- **Optional compact regression:** If it fits the locked test ceiling, triple-click a non-active split and assert the resulting active window, active buffer, drag origin, and visual anchor equal the pre-resolved `BufferTarget` fields.
+- **Focused validation:** `mix test test/minga_editor/mouse_test.exs --seed 0`
+- **Broad validation:** `mix test test/minga_editor/mouse_test.exs test/minga_editor/mouse/hit_test_test.exs --seed 0`
+- **Line budget:** Production net addition at most `+10`; test additions at most `+80`.
+- **Non-goals:** No `HitTest`, target-struct, layout, fold, decoration, renderer, protocol, router, Unicode line-end, ordinary click, double-click, shift-click, modifier-click, block-command, hover, scrolling, resize, or drag-autoscroll changes. No new abstraction, process, dependency, public API, compatibility path, or target shape.
+- **Dependencies and constraints:** Current `HitTest.resolve_buffer/3`, `%BufferTarget{}`, `WindowFocus`, buffer APIs, mode transition API, and mouse-state owner. Preserve focus-before-selection behavior and every unrelated mouse behavior. Return `NEEDS_REPLAN` rather than exceeding either line ceiling or changing a locked file.
+- **Implementation result:** `Mouse.handle_triple_click/3` now preserves the leading focus call, consumes `HitTest.resolve_buffer/3` as `{:buffer, %BufferTarget{} = target}`, uses `target.line`, `target.buffer`, and `target.window_id` for the line selection and drag origin, and deletes obsolete `mouse_to_buffer_line/2`.
+- **Failure reproduction:** Before the source correction, `mix test test/minga_editor/mouse_test.exs --seed 0` failed the two new regressions as expected: wrapped continuation row left the cursor at `{0, 0}` instead of `{0, 99}`, and folded visible-row mapping selected hidden line `{1, 5}` instead of `{3, 5}`. Result: 41/43 passed, 2 failed.
+- **Focused regression:** `mix test test/minga_editor/mouse_test.exs --seed 0` passed after the source correction. Result: 43 passed.
+- **Line budget:** After formatting, `git diff --numstat origin/main` reports `lib/minga_editor/mouse.ex` `8	33` (production net `-25`, within `+10`), `test/minga_editor/mouse_test.exs` `39	0` (test additions `+39`, within `+80`), and `docs/workstreams/editor-lifecycle-roadmap.md` `34	0`.
+- **Pre-acceptance reviews:** Correctness `PASS`; Elixir craftsmanship `PASS`; Ponytail `Lean already. Ship.`
+- **Broad validation:** The focused mouse and hit-test command passed 51 tests. The first `mix test --max-cases 4` run exposed the worktree's missing native parser binary; after `mix compile.minga_zig`, the same command passed 10,448 tests, including 58 doctests and 99 properties, with 0 failures, 1 skipped, and 210 excluded. `make lint` passed Credo, compile, format, and incremental Dialyzer. `git diff --check` passed.
+- **Final reviewer:** `PASS`; canonical target consumption, focus/mode/drag preservation, duplicate-mapper deletion, wrapped/folded regressions, line budgets, validation evidence, and merge safety accepted with no findings.
+- **PR URL:** Pending.
+- **Implementation commit SHA:** Pending.
+- **Merge evidence:** Pending.
+- **Completion date:** Pending merge.
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/lib/minga_editor/mouse.ex
+++ b/lib/minga_editor/mouse.ex
@@ -882,14 +882,11 @@ defmodule MingaEditor.Mouse do
   @spec handle_triple_click(state(), integer(), integer()) :: state()
   defp handle_triple_click(state, row, col) do
     state = maybe_focus_window_at(state, row, col)
-    origin_window = origin_window_id_at(state, row, col)
 
-    case mouse_to_buffer_line(state, row) do
-      nil ->
-        state
-
-      line ->
-        buf = state.workspace.buffers.active
+    case HitTest.resolve_buffer(state, row, col) do
+      {:buffer, %BufferTarget{} = target} ->
+        line = target.line
+        buf = target.buffer
 
         line_text =
           case Buffer.lines(buf, line, 1) do
@@ -911,7 +908,10 @@ defmodule MingaEditor.Mouse do
               MingaEditor.Session.State.transition_mode(state.workspace, :visual, visual_state)
         }
 
-        update_mouse(state, &MouseState.start_drag(&1, {line, 0}, origin_window))
+        update_mouse(state, &MouseState.start_drag(&1, {line, 0}, target.window_id))
+
+      _command_or_miss ->
+        state
     end
   end
 
@@ -1594,31 +1594,6 @@ defmodule MingaEditor.Mouse do
         BufferTarget.position(target)
 
       _command_or_miss ->
-        nil
-    end
-  end
-
-  # Like mouse_to_buffer_pos but only returns the line (for triple-click).
-  @spec mouse_to_buffer_line(state(), non_neg_integer()) :: non_neg_integer() | nil
-  defp mouse_to_buffer_line(%{workspace: %{buffers: %{active: buf}}} = state, row) do
-    layout = Layout.get(state)
-
-    case Layout.active_window_layout(layout, state) do
-      %{content: {win_row, _win_col, content_w, win_h}} ->
-        window = MingaEditor.Session.State.active_window_struct(state.workspace)
-        total_lines = Buffer.line_count(buf)
-        {cursor_line, _} = Buffer.cursor(buf)
-        scroll_top = HitTest.scroll_top(window, win_h, content_w, cursor_line, buf)
-        local_row = row - win_row
-        target_line = local_row + scroll_top
-
-        if local_row < 0 or local_row >= win_h or target_line >= total_lines do
-          nil
-        else
-          target_line
-        end
-
-      nil ->
         nil
     end
   end

--- a/test/minga_editor/mouse_test.exs
+++ b/test/minga_editor/mouse_test.exs
@@ -251,6 +251,45 @@ defmodule MingaEditor.MouseTest do
       assert BufferProcess.cursor(buffer) == {1, 2}
     end
 
+    test "triple-click on a wrapped continuation row selects the source line" do
+      {state, buffer} = start_mouse_state(String.duplicate("a", 100), width: 20)
+      assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)
+      assert {:ok, false} = BufferProcess.set_option(buffer, :linebreak, false)
+      assert {:ok, :none} = BufferProcess.set_option(buffer, :line_numbers, :none)
+      {content_row, content_col} = active_content_origin(state)
+
+      state = mouse(state, content_row + 1, content_col, :left, :press, 0, 3)
+
+      assert BufferProcess.cursor(buffer) == {0, 99}
+      assert state.workspace.editing.mode == :visual
+      assert state.workspace.editing.mode_state.visual_anchor == {0, 0}
+      assert state.workspace.editing.mode_state.visual_type == :line
+      assert state.workspace.mouse.dragging
+      assert state.workspace.mouse.anchor == {0, 0}
+      assert state.workspace.mouse.drag_origin_window == state.workspace.windows.active
+    end
+
+    test "triple-click uses folded display-map line mapping" do
+      {state, buffer} = start_mouse_state(lines(0..49))
+      state = set_active_fold_ranges(state, [FoldRange.new!(0, 2)])
+      state = fold_active_window_at(state, 0)
+      state = set_window_top(state, state.workspace.windows.active, 1)
+      {content_row, content_col} = active_content_origin(state)
+
+      gutter_width =
+        MingaEditor.Mouse.HitTest.buffer_gutter_width(buffer, BufferProcess.line_count(buffer))
+
+      state = mouse(state, content_row, content_col + gutter_width, :left, :press, 0, 3)
+
+      assert BufferProcess.cursor(buffer) == {3, 5}
+      assert state.workspace.editing.mode == :visual
+      assert state.workspace.editing.mode_state.visual_anchor == {3, 0}
+      assert state.workspace.editing.mode_state.visual_type == :line
+      assert state.workspace.mouse.dragging
+      assert state.workspace.mouse.anchor == {3, 0}
+      assert state.workspace.mouse.drag_origin_window == state.workspace.windows.active
+    end
+
     test "wrapped visual row offset maps top-screen clicks into the visible continuation row" do
       {state, buffer} = start_mouse_state(String.duplicate("a", 120), width: 20)
       assert {:ok, true} = BufferProcess.set_option(buffer, :wrap, true)


### PR DESCRIPTION
# TL;DR

Triple-click now resolves the clicked line, buffer, and window through the canonical mouse hit-test target. Wrapped continuation rows and folded display rows select the buffer line the user actually clicked.

## Context

The triple-click path previously recomputed a line from the active window after focus. That duplicate mapping bypassed wrapping and fold display maps, so a continuation row could do nothing and a folded row could select a hidden line.

## Changes

- Consume `%MingaEditor.Mouse.Target.Buffer{}` from `HitTest.resolve_buffer/3` in the triple-click workflow.
- Preserve the existing focus-before-selection, Visual Line transition, line-end cursor move, and drag behavior.
- Remove the obsolete line-only coordinate mapper.
- Add regressions for wrapped continuation rows and folded visible-row mapping.
- Record the implementation and validation evidence in the editor lifecycle roadmap.

## Verification

- `mix test test/minga_editor/mouse_test.exs test/minga_editor/mouse/hit_test_test.exs --seed 0` passed 51 tests.
- `mix test --max-cases 4` passed 10,448 tests, including 58 doctests and 99 properties, with 0 failures, 1 skipped, and 210 excluded.
- `make lint` passed Credo, compile, format, and incremental Dialyzer.
- `git diff --check` passed.

## Acceptance Criteria Addressed

- Triple-click on a wrapped continuation row selects its source line.
- Triple-click on a folded visible row selects the displayed buffer line, not a hidden folded line.
- Triple-click uses the hit-test-owned buffer and window identities without changing unrelated mouse behavior.
