### PR TITLE
docs(editor): verify W025 lifecycle fix

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2256,7 +2256,7 @@ New split and float popup windows initialize their viewport metadata from `state
 
 ### W025: Validate omitted link and advisory color overrides
 
-- **Status:** ACTIVE
+- **Status:** VERIFIED
 - **Audit ID:** L29
 - **Decision:** ACCEPT/direct
 - **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
@@ -2281,8 +2281,8 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Final reviewer verdict:** `PASS`; exact metadata scope, construction-time ownership, valid and invalid regressions, budgets, transparent validation evidence, and merge safety accepted with no findings.
 - **PR URL:** https://github.com/jsmestad/minga/pull/3036
 - **Implementation commit SHA:** `0347ab168`
-- **Merge SHA:** Pending.
-- **Completion date:** Pending merge.
+- **Merge SHA:** `7fe6c648371c55cac81078636edefab77e6d85b1`; PR #3036 merged after CI run `29684733018` passed every required check, including Elixir, Swift, Go, Zig, Dialyzer, lint/format, Neovim conformance, boot smoke, protocol integration, and keystroke latency.
+- **Completion date:** 2026-07-19
 
 ## Follow-on simplifications
 


### PR DESCRIPTION
# TL;DR

Mark W025 VERIFIED after the optional-theme-color validation fix merged in PR #3036 with every required CI check passing.

## Changes

- Record merge commit `7fe6c648371c55cac81078636edefab77e6d85b1`.
- Record successful CI run `29684733018`.
- Set the W025 completion date to 2026-07-19.

## Verification

- `git diff --check`
- Confirmed PR #3036 is merged.
- Confirmed CI run `29684733018` passed every required check.
