### PR TITLE
fix(ui): make title metadata reads exit-safe

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2308,8 +2308,8 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Bug-hunt verdict:** Correctness `PASS`; same-buffer `:noproc` specificity, all four stale-buffer surfaces, live and agent behavior, synchronization, scope, budgets, and evidence accepted with no blockers.
 - **Elixir craftsmanship verdict:** Initial review required consuming `ctx.filepath` in the agent branch; recheck `PASS` after the one-line correction.
 - **Final reviewer verdict:** `PASS` after correcting the roadmap decision from `ACCEPT/direct` to the immutable audit classification `ACCEPT/shrink`; implementation, exception boundary, regressions, ownership, scope, budgets, and validation evidence accepted with no remaining findings.
-- **PR URL:** Pending.
-- **Implementation commit SHA:** Pending.
+- **PR URL:** https://github.com/jsmestad/minga/pull/3038
+- **Implementation commit SHA:** `dff4592ef`
 - **Merge SHA:** Pending.
 - **Completion date:** Pending.
 

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2284,6 +2284,35 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Merge SHA:** `7fe6c648371c55cac81078636edefab77e6d85b1`; PR #3036 merged after CI run `29684733018` passed every required check, including Elixir, Swift, Go, Zig, Dialyzer, lint/format, Neovim conformance, boot smoke, protocol integration, and keystroke latency.
 - **Completion date:** 2026-07-19
 
+### W026: Make title metadata reads stale-buffer safe
+
+- **Status:** ACTIVE
+- **Audit ID:** L30
+- **Decision:** ACCEPT/shrink
+- **Planning profile:** `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, `high`, read-only
+- **Implementation profile:** `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, `medium`
+- **Freshness commit SHA:** `fb382a47f7fd00fc4525ad2ed32131faafc3a25b`
+- **Observable outcome:** Plain-map and `EditorState` terminal and GUI title formatting now survive stale stopped active-buffer pids. Dead buffers fall back to `[no file]`, empty filepath, empty directory, clean dirty marker, and the current mode where terminal formatting has a mode. Agent titles remain `Agent`, GUI punctuation remains unchanged, and live buffer formatting keeps the existing basename, directory, dirty, mode, special-buffer, and `bufname` behavior.
+- **Locked implementation:** `MingaEditor.Title` owns one private `read_buffer_title_metadata/1` helper that reads only `Buffer.file_path/1`, `Buffer.buffer_name/1`, and `Buffer.dirty?/1`, catching only `{:noproc, {GenServer, :call, [^buf, _request, _timeout]}}` for the same buffer pid as `:dead_buffer`. Title context no longer carries filetype, agent context carries `filepath: ""`, plain-map GUI context delegates through `buffer_content_context/1`, both `build_vars/1` context branches consume `ctx.filepath`, `build_vars_from_buffer/2` uses the same helper, and the obsolete duplicate `buffer_filepath/1` helper is deleted. No public API, process, dependency, configuration, compatibility shim, or extra abstraction was added.
+- **Regression reproduction:** With only the four dead-buffer regressions added, `mix test.debug test/minga_editor/title_test.exs` failed deterministically before the source correction. The run stopped after 3 failures: the plain-map terminal path exited from `GenServer.call(dead_pid, :file_path, 5000)` in `build_vars_from_buffer/2`; the `EditorState` terminal path exited from `Buffer.file_path/1` in `buffer_content_context/1`; and the `EditorState` GUI path exited from the same unguarded context read. Result before source correction: `8/11 passed`, `3 failed`, max-failures reached.
+- **Focused tests:** `mix test.debug test/minga_editor/title_test.exs` passed after the mandatory Ponytail and Elixir corrections. Result: `20 passed`.
+- **Broad validation:** `mix test.llm --seed 798303` exposed one unrelated five-second `MingaAgent.SessionManagerTest` timeout at the local default 64-way concurrency; the isolated 29-test module passed. The identical seed passed on unchanged current main, while a separate current-main default-concurrency run exposed a different unrelated two-second observatory timeout, confirming existing load sensitivity rather than title behavior. `mix test --max-cases 4` passed 10,452 tests, including 58 doctests and 99 properties, with 0 failures, 1 skipped, and 210 excluded. `make lint` passed Credo, compile, format, and incremental Dialyzer with 0 errors.
+- **Formatting:** `mix format lib/minga_editor/title.ex test/minga_editor/title_test.exs` exited `0` for the implementation and again after the mandatory Elixir correction; `mix format test/minga_editor/title_test.exs` exited `0` after the mandatory Ponytail test simplification.
+- **Line budget:** Final `git diff --numstat -- lib/minga_editor/title.ex test/minga_editor/title_test.exs docs/workstreams/editor-lifecycle-roadmap.md` reported `60 52 lib/minga_editor/title.ex` and `78 0 test/minga_editor/title_test.exs` before this evidence correction. Production net `+8 <= +25`; tests net `+78 <= +100`.
+- **Production lines added/removed:** `60 added / 52 removed`
+- **Test lines added/removed:** `78 added / 0 removed`
+- **Concepts added/removed:** Added one private title metadata helper and one private fallback context shape inside the existing title owner. Removed title `filetype` context fields, both `Buffer.filetype/1` title reads, and the obsolete duplicate `buffer_filepath/1` read helper. Added no public API or external abstraction.
+- **Findings resolved:** L30 only.
+- **Discoveries affecting later work:** None.
+- **Ponytail verdict:** Initial review required extracting repeated dead-buffer setup; after `dead_buffer!/0`, recheck returned `Lean already. Ship.`
+- **Bug-hunt verdict:** Correctness `PASS`; same-buffer `:noproc` specificity, all four stale-buffer surfaces, live and agent behavior, synchronization, scope, budgets, and evidence accepted with no blockers.
+- **Elixir craftsmanship verdict:** Initial review required consuming `ctx.filepath` in the agent branch; recheck `PASS` after the one-line correction.
+- **Final reviewer verdict:** `PASS` after correcting the roadmap decision from `ACCEPT/direct` to the immutable audit classification `ACCEPT/shrink`; implementation, exception boundary, regressions, ownership, scope, budgets, and validation evidence accepted with no remaining findings.
+- **PR URL:** Pending.
+- **Implementation commit SHA:** Pending.
+- **Merge SHA:** Pending.
+- **Completion date:** Pending.
+
 ## Follow-on simplifications
 
 ### Remove Dired completely

--- a/lib/minga_editor/title.ex
+++ b/lib/minga_editor/title.ex
@@ -25,6 +25,12 @@ defmodule MingaEditor.Title do
   @typedoc "Editor state (same as MingaEditor.State.t())."
   @type state :: EditorState.t() | map()
 
+  @typep buffer_title_metadata :: %{
+           path: String.t() | nil,
+           name: String.t() | nil,
+           dirty: boolean()
+         }
+
   @doc """
   Formats the terminal title from the current editor state and format string.
   """
@@ -72,9 +78,9 @@ defmodule MingaEditor.Title do
         %{
           type: :agent,
           display_name: "Agent",
+          filepath: "",
           directory: project_directory(),
-          dirty: false,
-          filetype: :markdown
+          dirty: false
         }
 
       _window ->
@@ -84,41 +90,47 @@ defmodule MingaEditor.Title do
 
   defp build_content_context(%{workspace: %{buffers: %{active: buf}}} = _state)
        when is_pid(buf) do
-    path = Minga.Buffer.file_path(buf)
-    name = Minga.Buffer.buffer_name(buf)
-    dirty = Minga.Buffer.dirty?(buf)
-    display_name = if path, do: Path.basename(path), else: name || "[no file]"
-    directory = if path, do: path |> Path.dirname() |> Path.basename(), else: ""
-
-    %{
-      type: :buffer,
-      display_name: display_name,
-      directory: directory,
-      dirty: dirty,
-      filetype: Minga.Buffer.filetype(buf) || :text
-    }
+    buffer_content_context(buf)
   end
 
   defp build_content_context(_state) do
-    %{type: :buffer, display_name: "[no file]", directory: "", dirty: false, filetype: :text}
+    buffer_context_fallback()
+  end
+
+  @spec buffer_context_fallback() :: map()
+  defp buffer_context_fallback do
+    %{type: :buffer, display_name: "[no file]", filepath: "", directory: "", dirty: false}
+  end
+
+  @spec read_buffer_title_metadata(pid()) :: {:ok, buffer_title_metadata()} | :dead_buffer
+  defp read_buffer_title_metadata(buf) do
+    {:ok,
+     %{path: Buffer.file_path(buf), name: Buffer.buffer_name(buf), dirty: Buffer.dirty?(buf)}}
+  catch
+    :exit, {:noproc, {GenServer, :call, [^buf, _request, _timeout]}} -> :dead_buffer
   end
 
   @spec buffer_content_context(pid() | nil) :: map()
   defp buffer_content_context(buffer) when is_pid(buffer) do
-    path = Buffer.file_path(buffer)
-    name = Buffer.buffer_name(buffer)
+    case read_buffer_title_metadata(buffer) do
+      {:ok, metadata} ->
+        path = metadata.path
 
-    %{
-      type: :buffer,
-      display_name: if(path, do: Path.basename(path), else: name || "[no file]"),
-      directory: if(path, do: path |> Path.dirname() |> Path.basename(), else: ""),
-      dirty: Buffer.dirty?(buffer),
-      filetype: Buffer.filetype(buffer) || :text
-    }
+        %{
+          type: :buffer,
+          display_name: if(path, do: Path.basename(path), else: metadata.name || "[no file]"),
+          filepath: path || "",
+          directory: if(path, do: path |> Path.dirname() |> Path.basename(), else: ""),
+          dirty: metadata.dirty
+        }
+
+      :dead_buffer ->
+        buffer_context_fallback()
+    end
   end
 
   defp buffer_content_context(_buffer) do
-    %{type: :buffer, display_name: "[no file]", directory: "", dirty: false, filetype: :text}
+    buffer_context_fallback()
   end
 
   @spec project_directory() :: String.t()
@@ -140,7 +152,7 @@ defmodule MingaEditor.Title do
       :agent ->
         [
           {"filename", ctx.display_name},
-          {"filepath", ""},
+          {"filepath", ctx.filepath},
           {"directory", ctx.directory},
           {"dirty", ""},
           {"readonly", ""},
@@ -149,7 +161,7 @@ defmodule MingaEditor.Title do
         ]
 
       :buffer ->
-        filepath = buffer_filepath(state)
+        filepath = ctx.filepath
 
         [
           {"filename", ctx.display_name},
@@ -180,24 +192,27 @@ defmodule MingaEditor.Title do
 
   @spec build_vars_from_buffer(pid(), atom()) :: [{String.t(), String.t()}]
   defp build_vars_from_buffer(buf, mode) do
-    path = Buffer.file_path(buf)
-    dirty = Buffer.dirty?(buf)
-    name = Buffer.buffer_name(buf)
+    case read_buffer_title_metadata(buf) do
+      {:ok, metadata} ->
+        path = metadata.path
+        filename = if path, do: Path.basename(path), else: metadata.name || "[no file]"
+        directory = if path, do: path |> Path.dirname() |> Path.basename(), else: ""
+        filepath = path || ""
+        bufname = metadata.name || filename
 
-    filename = if path, do: Path.basename(path), else: name || "[no file]"
-    directory = if path, do: path |> Path.dirname() |> Path.basename(), else: ""
-    filepath = path || ""
-    bufname = name || filename
+        [
+          {"filename", filename},
+          {"filepath", filepath},
+          {"directory", directory},
+          {"dirty", if(metadata.dirty, do: "[+] ", else: "")},
+          {"readonly", ""},
+          {"mode", mode |> to_string() |> String.upcase()},
+          {"bufname", bufname}
+        ]
 
-    [
-      {"filename", filename},
-      {"filepath", filepath},
-      {"directory", directory},
-      {"dirty", if(dirty, do: "[+] ", else: "")},
-      {"readonly", ""},
-      {"mode", mode |> to_string() |> String.upcase()},
-      {"bufname", bufname}
-    ]
+      :dead_buffer ->
+        default_vars(mode)
+    end
   end
 
   @spec default_vars(atom()) :: [{String.t(), String.t()}]
@@ -212,11 +227,4 @@ defmodule MingaEditor.Title do
       {"bufname", "[no file]"}
     ]
   end
-
-  @spec buffer_filepath(EditorState.t()) :: String.t()
-  defp buffer_filepath(%{workspace: %{buffers: %{active: buf}}}) when is_pid(buf) do
-    Buffer.file_path(buf) || ""
-  end
-
-  defp buffer_filepath(_), do: ""
 end

--- a/test/minga_editor/title_test.exs
+++ b/test/minga_editor/title_test.exs
@@ -36,6 +36,45 @@ defmodule MingaEditor.TitleTest do
     }
   end
 
+  defp editor_state_with_buffer_window(buf) do
+    window = Window.new(1, buf, 24, 80)
+
+    %EditorState{
+      frontend: %MingaEditor.State.Frontend{port_manager: self()},
+      workspace: %MingaEditor.Session.State{
+        viewport: Viewport.new(24, 80),
+        editing: VimState.new(),
+        buffers: %Buffers{active: buf, list: [buf]},
+        windows: %Windows{
+          tree: WindowTree.new(1),
+          map: %{1 => window},
+          active: 1,
+          next_id: 2
+        }
+      },
+      interaction: %MingaEditor.State.Interaction{
+        focus_stack: MingaEditor.Input.default_stack()
+      }
+    }
+  end
+
+  defp stop_buffer!(pid) do
+    ref = Process.monitor(pid)
+    GenServer.stop(pid)
+    assert_receive {:DOWN, ^ref, :process, ^pid, :normal}
+    pid
+  end
+
+  defp dead_buffer! do
+    {:ok, buf} =
+      BufferProcess.start_link(
+        content: "hello",
+        file_path: "/home/user/project/lib/editor.ex"
+      )
+
+    stop_buffer!(buf)
+  end
+
   describe "format/2" do
     test "default format produces expected title" do
       state = state_with()
@@ -95,6 +134,21 @@ defmodule MingaEditor.TitleTest do
       state = %{buffers: %{active: nil}, editing: %{mode: :normal}}
       result = Title.format(state, "{filename} - Minga")
       assert result == "[no file] - Minga"
+    end
+
+    test "dead active buffer falls back to no-file variables and keeps mode" do
+      buf = dead_buffer!()
+
+      state = %{
+        workspace: %{
+          buffers: %{active: buf},
+          editing: %{mode: :insert}
+        }
+      }
+
+      result = Title.format(state, "{filename}|{filepath}|{directory}|{dirty}|{mode}|{bufname}")
+
+      assert result == "[no file]||||INSERT|[no file]"
     end
   end
 
@@ -157,9 +211,25 @@ defmodule MingaEditor.TitleTest do
 
       assert result == "editor.ex (lib) - Minga"
     end
+
+    test "dead active buffer falls back to no-file variables and keeps mode" do
+      state = dead_buffer!() |> editor_state_with_buffer_window()
+
+      result = Title.format(state, "{filename}|{filepath}|{directory}|{dirty}|{mode}|{bufname}")
+
+      assert result == "[no file]||||NORMAL|[no file]"
+    end
   end
 
   describe "format_gui/1" do
+    test "dead active buffer uses the GUI no-file fallback for plain maps" do
+      state = %{workspace: %{buffers: %{active: dead_buffer!()}}}
+
+      result = Title.format_gui(state)
+
+      assert result == "[no file] — Minga"
+    end
+
     test "buffer window shows clean GUI title" do
       {:ok, buf} =
         BufferProcess.start_link(
@@ -278,6 +348,14 @@ defmodule MingaEditor.TitleTest do
 
       result = Title.format_gui(state)
       assert String.starts_with?(result, "Agent")
+    end
+
+    test "dead active buffer uses the GUI no-file fallback for EditorState" do
+      state = dead_buffer!() |> editor_state_with_buffer_window()
+
+      result = Title.format_gui(state)
+
+      assert result == "[no file] — Minga"
     end
   end
 end


### PR DESCRIPTION
## TL;DR

Title formatting now treats a stopped active buffer as unavailable instead of crashing terminal or GUI title generation.

## Context

Part of the editor lifecycle audit. Resolves L30, which identified unused title metadata reads and stale-buffer exits in `MingaEditor.Title`.

## Changes

- Centralize title buffer metadata reads behind one private exit-safe helper.
- Catch only same-buffer `:noproc` `GenServer.call` exits and use the existing no-file fallback.
- Remove unused title `filetype` reads and the duplicate filepath helper.
- Cover stale buffer pids across plain-map and `EditorState`, terminal and GUI paths.
- Record implementation and validation evidence in the lifecycle roadmap.

## Verification

- `mix test.debug test/minga_editor/title_test.exs`: 20 passed.
- `mix test.llm test/minga_agent/session_manager_test.exs --seed 798303`: 29 passed after an unrelated default-concurrency timeout in the broad run.
- `mix test --max-cases 4`: 10,452 passed, 0 failures.
- `make lint`: passed Credo, compile, format, and incremental Dialyzer.
- `git diff --check`: passed.

The default 64-way local suite exposed one unrelated five-second session-manager timeout. The isolated module passed; unchanged current main showed separate load-sensitive timeout behavior at the same concurrency. The bounded-concurrency full suite passed.
