### PR TITLE
refactor(renderer): remove write-only emit caches

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2648,7 +2648,7 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Broad validation:** `make lint` passed twice, including after the test deletion and documentation correction, with Credo, compile, format, and incremental Dialyzer reporting 0 errors. `ERL_FLAGS='+S 2:2' mix test.llm` passed 9,752 tests with 58 doctests, 98 properties, 1 skipped, and 572 excluded.
 - **Pre-acceptance reviews:** Elixir craftsmanship returned `PASS / Lean`. Correctness and Ponytail confirmed the code deletion was exact and lean, and required truthful ledger corrections after the structural absence test was deleted; correctness also found one stale Emit moduledoc claim. The ledger now records the 17-test focused pass and final numstat, the obsolete test remains deleted without replacement, and the Emit moduledoc names only live semantic encoding and side-channel ownership. Both targeted rechecks returned `RESOLVED/PASS`.
 - **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the exact seven-field and private-helper deletion, retained emit, adapter, frame-lineage, recovery, content, telemetry, and WindowCache contracts, truthful focused and broad validation, zero trace, budgets, and merge safety.
-- **PR URL:** Pending.
-- **Implementation commit SHA:** Pending.
+- **PR URL:** https://github.com/jsmestad/minga/pull/3082
+- **Implementation commit SHA:** `f85c96d33`.
 - **Merge SHA:** Pending.
 - **Completion date:** Pending.

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2623,3 +2623,32 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Merge SHA:** `7729d732e47b4bbdc8524323365fbc24506db18e`.
 - **Merge evidence:** PR #3080 merged after CI run `29736782257` passed Elixir, Swift macOS, Swift protocol integration, Go TUI, Zig, Dialyzer, lint/format, Neovim conformance, Go TUI boot smoke, and keystroke latency.
 - **Completion date:** 2026-07-20.
+
+### W048: Delete D11 write-only renderer cache fields
+
+- **Status:** ACTIVE
+- **Audit ID:** W048/D11
+- **Planning profile:** `D11Planner`, `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, high, read-only.
+- **Implementation profile:** `D11Worker`, `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, no delegation.
+- **Freshness commit SHA:** `825a6b2164cd26adca611e9cb1ba33db8f8d3249`.
+- **Observable result:** `MingaEditor.Renderer.Caches` no longer carries the seven write-only renderer cache fields, and `MingaEditor.Frontend.Emit` no longer builds the obsolete viewport, content-rect, gutter-width, buffer-version, cursor-line, editing-mode, or block-render tracking values before recording frame lineage. Emit still returns `{Caches.t(), FontRegistry.t(), MessageStore.t()}`, updates adapter GUI caches, advances emitted and acknowledged frame state, preserves recovery generation behavior, and keeps title, window background, and link-cursor side-channel dedupe.
+- **Failure reproduction / source trace:** Before deletion, `Caches` constructed and typed the unused `block_render_cache` field plus six `emit_prev_*` fields. `Emit.emit_encoded_frame/7` called private `update_tracking/2`, which computed and wrote those six maps or values into the returned caches. Focused source tracing found no production consumer for those fields or helpers; the only test consumer was the obsolete structural assertion in `test/minga_editor/frontend/emit_test.exs`.
+- **Implementation result:** Deleted only the seven fields from `Caches.defstruct/1`, `Caches.t/0`, and stale ownership docs; removed the `update_tracking/2` call plus private `update_tracking/2` and `window_cache_field/3` helpers from `Emit`; deleted the obsolete structural emit test without replacement.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/frontend/emit.ex`; `lib/minga_editor/renderer/caches.ex`; `test/minga_editor/frontend/emit_test.exs`.
+- **Focused validation:** `mix test test/minga_editor/frontend/emit_test.exs test/minga_editor/frontend/emit/keyframe_side_channel_test.exs` passed with 17 tests after deleting the structural test. `mix test test/minga_editor/render_pipeline/content_test.exs test/minga_editor/window/render_cache_test.exs test/minga_editor/render_pipeline/scroll_test.exs test/minga_editor/renderer/buffer_changes_test.exs test/minga_editor/renderer/server_test.exs` passed with 70 tests.
+- **Formatting, reference, and diff validation:** `mix format --check-formatted lib/minga_editor/renderer/caches.ex lib/minga_editor/frontend/emit.ex test/minga_editor/frontend/emit_test.exs` passed. Focused forbidden-reference search over `lib/` and `test/` for `emit_prev_`, `block_render_cache`, `update_tracking`, and `window_cache_field` returned no matches. `git diff --check` passed.
+- **Numstat before roadmap evidence:** `lib/minga_editor/frontend/emit.ex 1 63; lib/minga_editor/renderer/caches.ex 2 19; test/minga_editor/frontend/emit_test.exs 0 18`.
+- **Production lines added/removed:** `3 added / 82 removed` (net `-79`, within production net `<= 0`).
+- **Test lines added/removed:** `0 added / 18 removed` (net `-18`, within test net `<= +20`).
+- **Concepts removed:** Removed one write-only renderer cache tracking surface and its private emit helper path.
+- **Concepts added:** None. No module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, replacement abstraction, data representation, telemetry, or cache owner was added.
+- **Retained contracts:** `chrome_prev_fingerprint`, `chrome_prev_result`, `search_decoration_cache`, `doc_highlight_cache`, `cmd_hover_link_cache`, `frame_rows_rasterized`, `frame_render_path`, `last_title`, `last_window_bg`, `last_link_cursor`, `last_emitted_frame_seq`, `last_acknowledged_frame_seq`, `recovery_generation`, `last_frame_keyframe?`, and `adapter_gui_caches` remain in `Caches`. WindowCache resident, retention, scroll, epoch, dirty, lineage, and snapshot fields were not touched.
+- **Findings resolved:** D11 implementation slice removes the locked write-only cache fields and helpers while preserving the live emit, adapter, side-channel, acknowledgement, recovery, content-cache, telemetry, and WindowCache contracts.
+- **Discoveries affecting later work:** No source-shape replacement test was retained. The compile gate and zero-trace source check prove the removed private fields and helpers are gone, while existing emit, keyframe, content, WindowCache, scroll, buffer-change, and renderer-server tests continue to cover the retained observable contracts.
+- **Broad validation:** `make lint` passed twice, including after the test deletion and documentation correction, with Credo, compile, format, and incremental Dialyzer reporting 0 errors. `ERL_FLAGS='+S 2:2' mix test.llm` passed 9,752 tests with 58 doctests, 98 properties, 1 skipped, and 572 excluded.
+- **Pre-acceptance reviews:** Elixir craftsmanship returned `PASS / Lean`. Correctness and Ponytail confirmed the code deletion was exact and lean, and required truthful ledger corrections after the structural absence test was deleted; correctness also found one stale Emit moduledoc claim. The ledger now records the 17-test focused pass and final numstat, the obsolete test remains deleted without replacement, and the Emit moduledoc names only live semantic encoding and side-channel ownership. Both targeted rechecks returned `RESOLVED/PASS`.
+- **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the exact seven-field and private-helper deletion, retained emit, adapter, frame-lineage, recovery, content, telemetry, and WindowCache contracts, truthful focused and broad validation, zero trace, budgets, and merge safety.
+- **PR URL:** Pending.
+- **Implementation commit SHA:** Pending.
+- **Merge SHA:** Pending.
+- **Completion date:** Pending.

--- a/lib/minga_editor/frontend/emit.ex
+++ b/lib/minga_editor/frontend/emit.ex
@@ -2,7 +2,7 @@ defmodule MingaEditor.Frontend.Emit do
   @moduledoc """
   Stage 7: Emit.
 
-  Encodes the composed frame as semantic render-model protocol commands, then handles shared concerns (viewport tracking, title, window background).
+  Encodes the composed frame as semantic render-model protocol commands, then handles shared title and window-background side channels.
   """
 
   alias MingaEditor.RenderModel.Builder, as: RenderModelBuilder
@@ -145,7 +145,6 @@ defmodule MingaEditor.Frontend.Emit do
       )
     end
 
-    caches = update_tracking(ctx, caches)
     caches = %{caches | last_emitted_frame_seq: frame_seq, last_frame_keyframe?: keyframe?}
 
     caches =
@@ -211,67 +210,6 @@ defmodule MingaEditor.Frontend.Emit do
 
     commands
   end
-
-  # ── Tracking state (shared) ──────────────────────────────────────────────
-
-  @spec update_tracking(ctx(), Caches.t()) :: Caches.t()
-  defp update_tracking(ctx, caches) do
-    layout = ctx.layout
-
-    tops =
-      Map.new(layout.window_layouts, fn {win_id, _wl} ->
-        window = Map.get(ctx.windows.map, win_id)
-
-        {win_id, window_cache_field(window, :last_viewport_top, :viewport_top)}
-      end)
-
-    rects =
-      Map.new(layout.window_layouts, fn {win_id, wl} ->
-        {win_id, wl.content}
-      end)
-
-    gutter_ws =
-      Map.new(layout.window_layouts, fn {win_id, _wl} ->
-        window = Map.get(ctx.windows.map, win_id)
-
-        {win_id, window_cache_field(window, :last_gutter_w)}
-      end)
-
-    buf_versions =
-      Map.new(layout.window_layouts, fn {win_id, _wl} ->
-        window = Map.get(ctx.windows.map, win_id)
-
-        {win_id, window_cache_field(window, :last_buf_version, :buffer_version)}
-      end)
-
-    cursor_lines =
-      Map.new(layout.window_layouts, fn {win_id, _wl} ->
-        window = Map.get(ctx.windows.map, win_id)
-
-        {win_id, window_cache_field(window, :last_cursor_line, :cursor_line)}
-      end)
-
-    editing_mode = if ctx.editing, do: ctx.editing.mode, else: nil
-
-    %{
-      caches
-      | emit_prev_viewport_tops: tops,
-        emit_prev_content_rects: rects,
-        emit_prev_gutter_ws: gutter_ws,
-        emit_prev_buf_versions: buf_versions,
-        emit_prev_cursor_lines: cursor_lines,
-        emit_prev_editing_mode: editing_mode
-    }
-  end
-
-  @spec window_cache_field(map() | nil, atom(), atom() | nil) :: integer()
-  defp window_cache_field(window, renderer_field, editor_field \\ nil)
-
-  defp window_cache_field(%{render_cache: cache}, renderer_field, editor_field) do
-    Map.get(cache, renderer_field, Map.get(cache, editor_field, -1))
-  end
-
-  defp window_cache_field(nil, _renderer_field, _editor_field), do: -1
 
   # ── Side-channel writes (shared) ─────────────────────────────────────────
 

--- a/lib/minga_editor/renderer/caches.ex
+++ b/lib/minga_editor/renderer/caches.ex
@@ -10,9 +10,8 @@ defmodule MingaEditor.Renderer.Caches do
   - **Chrome** (`chrome_prev_*`): `RenderPipeline`, stage 5 fingerprint cache.
   - **Content** (`search_decoration_cache`, `doc_highlight_cache`): consumed by
     `ContentHelpers.build_render_ctx/3`; cleared when the fingerprint changes.
-    `block_render_cache` is a within-frame cache reset after each window render.
-  - **Emit** (`emit_prev_*`, `last_title`, `last_window_bg`):
-    consumed by `Frontend.Emit` stage 7.
+  - **Emit** (`last_title`, `last_window_bg`, `last_link_cursor`): consumed by
+    `Frontend.Emit` stage 7.
   - **Adapter** (`adapter_gui_caches`): core GUI adapter fingerprint state.
   """
 
@@ -26,9 +25,6 @@ defmodule MingaEditor.Renderer.Caches do
     doc_highlight_cache: nil,
     cmd_hover_link_cache: nil,
 
-    # ── Content stage: within-frame cache (reset after each window render) ────
-    block_render_cache: %{},
-
     # Number of buffer rows freshly rasterized (composed) this frame, summed
     # across windows. Reset at the start of the Content stage and read by the
     # pipeline telemetry span as `rows_rasterized` (#2287). A transient
@@ -41,12 +37,6 @@ defmodule MingaEditor.Renderer.Caches do
     frame_render_path: :full,
 
     # ── Emit stage ────────────────────────────────────────────────────────────
-    emit_prev_viewport_tops: %{},
-    emit_prev_content_rects: %{},
-    emit_prev_gutter_ws: %{},
-    emit_prev_buf_versions: %{},
-    emit_prev_cursor_lines: %{},
-    emit_prev_editing_mode: nil,
     last_title: nil,
     last_window_bg: nil,
     last_link_cursor: nil,
@@ -73,15 +63,8 @@ defmodule MingaEditor.Renderer.Caches do
           search_decoration_cache: term(),
           doc_highlight_cache: term(),
           cmd_hover_link_cache: term(),
-          block_render_cache: %{term() => term()},
           frame_rows_rasterized: non_neg_integer(),
           frame_render_path: :patch | :full,
-          emit_prev_viewport_tops: %{term() => non_neg_integer()},
-          emit_prev_content_rects: %{term() => term()},
-          emit_prev_gutter_ws: %{term() => non_neg_integer()},
-          emit_prev_buf_versions: %{term() => non_neg_integer()},
-          emit_prev_cursor_lines: %{term() => non_neg_integer()},
-          emit_prev_editing_mode: atom() | nil,
           last_title: String.t() | nil,
           last_window_bg: non_neg_integer() | nil,
           last_link_cursor: boolean() | nil,

--- a/test/minga_editor/frontend/emit_test.exs
+++ b/test/minga_editor/frontend/emit_test.exs
@@ -11,7 +11,6 @@ defmodule MingaEditor.Frontend.EmitTest do
   alias Minga.Editing.Completion
   alias Minga.RenderModel.Cursor
   alias MingaEditor.RenderPipeline.ComposedFrame
-  alias MingaEditor.Layout
   alias MingaEditor.Frontend.Capabilities
   alias MingaEditor.Frontend.Emit
   alias MingaEditor.Frontend.Emit.Context
@@ -332,23 +331,6 @@ defmodule MingaEditor.Frontend.EmitTest do
                <<0x52, 1, _::binary>> -> true
                _ -> false
              end)
-    end
-  end
-
-  describe "update_tracking (shared)" do
-    test "writes viewport tracking state into returned caches" do
-      frame = build_frame_with_window(emit_state(), viewport_top: 0)
-      state = emit_state()
-      _layout = Layout.put(state)
-      ctx = Context.from_editor_state(state)
-
-      {caches, _font_registry, _message_store} = Emit.emit(frame, ctx, nil, %Caches{})
-      _ = assert_receive_frame_commands()
-
-      assert is_map(caches.emit_prev_viewport_tops)
-      assert is_map(caches.emit_prev_content_rects)
-      assert is_map(caches.emit_prev_gutter_ws)
-      assert is_map(caches.emit_prev_buf_versions)
     end
   end
 


### PR DESCRIPTION
# TL;DR

Remove seven write-only renderer cache fields and their obsolete Emit tracking path while preserving live frame, recovery, side-channel, adapter, content, telemetry, and WindowCache behavior.

## Changes

- Remove `block_render_cache` and six `emit_prev_*` fields from `Renderer.Caches`.
- Remove the private `Emit.update_tracking/2` and `window_cache_field/3` path.
- Delete the obsolete structural cache-shape test without replacement.
- Correct the Emit ownership documentation.
- Leave every live Caches and WindowCache field untouched.

## Validation

- Focused Emit/keyframe suite: 17 tests passed.
- Focused content/WindowCache/scroll/buffer-change/server suite: 70 tests passed.
- `make lint`: passed twice, incremental Dialyzer 0 errors.
- `ERL_FLAGS='+S 2:2' mix test.llm`: 9,752 tests passed, 0 failures.
- Final reviewer: PASS, 0.99 confidence.
- Production delta: 3 added, 82 removed, net -79. Tests: 18 removed.