### PR TITLE
refactor(ui): remove dormant TODO async path

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2679,7 +2679,7 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Broad validation:** `make lint` passed Credo, compile, format, and incremental Dialyzer with 0 errors. `ERL_FLAGS='+S 2:2' mix test.llm` passed 9,753 tests with 58 doctests, 98 properties, 1 skipped, and 572 excluded.
 - **Pre-acceptance reviews:** Elixir craftsmanship returned `PASS / Lean` with 0.99 confidence. Correctness and Ponytail found one exact generic-async test bug: the first test edit removed the `MingaEditor.UI.Picker.FetchEffect` alias while retained finalization assertions still referenced `FetchEffect`, making those checks target an inert nested module atom. The alias was restored, the module documentation was corrected to distinguish generic test-source coverage from the dedicated TODO effect, and the focused 64-test suite passed again. The targeted recheck returned `RESOLVED/PASS` and confirmed the handler identity plus exact numstat. Test-analysis was unavailable because its runtime had no model configured.
 - **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the exact generic-async advertisement deletion, retained typed TODO workflow/effect owner path, meaningful generic async coverage, resolved alias blocker, truthful validation, budgets, and merge safety.
-- **PR URL:** Pending.
-- **Implementation commit SHA:** Pending.
+- **PR URL:** https://github.com/jsmestad/minga/pull/3084
+- **Implementation commit SHA:** `0503f0259`.
 - **Merge SHA:** Pending.
 - **Completion date:** Pending.

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2653,3 +2653,33 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Merge SHA:** `c896310ca374db96ba84ede175c2ad1086726f30`.
 - **Merge evidence:** PR #3082 merged after CI run `29742040183` passed Elixir, Swift macOS, Swift protocol integration, Go TUI, Zig, Dialyzer, lint/format, Neovim conformance, Go TUI boot smoke, and keystroke latency.
 - **Completion date:** 2026-07-20.
+
+### W049: Delete D25 TODO generic async advertisement
+
+- **Status:** ACTIVE
+- **Audit ID:** W049/D25
+- **Planning profile:** `D25Planner`, `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, high, read-only.
+- **Implementation profile:** `D25Worker`, `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, no delegation.
+- **Freshness commit SHA:** `48623dd013f9c6aae790dc08533cffe74fecda9e`.
+- **Observable result:** `MingaEditor.UI.Picker.Source.async?(MingaEditor.UI.Picker.TodoSearchSource)` now returns `false` through the existing callback fallback, while `TodoSearchSource.candidates/1` remains behaviour-compliant and intentionally returns `[]`. The live `:search_todos` path remains the dedicated `TodoSearchWorkflow.open/1` loading picker plus `%MingaEditor.Effects.TodoSearch{}` scheduler request and `TodoSearch.apply/2` result path.
+- **Failure reproduction / source trace:** Before deletion, `mix run -e 'alias MingaEditor.UI.Picker.{Source,TodoSearchSource}; IO.inspect({Source.async?(TodoSearchSource), TodoSearchSource.candidates(nil), Source.fetch(TodoSearchSource, nil)})'` returned `{true, [], {:ok, [], %{}}}`, proving the source advertised generic async fetching while the generic fallback could only return an empty candidate set. The dedicated command path already used `TodoSearchWorkflow` and `TodoSearch`, not `FetchEffect`, for repository TODO scanning.
+- **Implementation result:** Deleted only `TodoSearchSource.async?/0`. Added the locked source-callback assertions, changed TODO stale/live-result tests to construct `TodoSearch.request(Project.snapshot(), revision)` and `%TodoSearch.Result{}` before calling `TodoSearch.apply/2`, and retargeted the generic delayed shell-switch `FetchEffect` test to `FileSource`.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/ui/picker/todo_search_source.ex`; `test/minga_editor/ui/picker/todo_search_source_test.exs`; `test/minga_editor/picker_async_stale_test.exs`; `test/minga_editor/delayed_callback_shell_switch_test.exs`.
+- **Focused validation:** `mix test test/minga_editor/ui/picker/todo_search_source_test.exs test/minga_editor/shell/traditional/todo_search_workflow_test.exs test/minga_editor/picker_async_stale_test.exs test/minga_editor/delayed_callback_shell_switch_test.exs test/minga_editor/ui/picker/fetch_effect_test.exs test/minga_editor/ui/picker/source_test.exs` passed with 64 tests.
+- **Formatting, reference, and diff validation:** `mix format` ran on the touched Elixir source and tests. `mix format --check-formatted lib/minga_editor/ui/picker/todo_search_source.ex test/minga_editor/ui/picker/todo_search_source_test.exs test/minga_editor/picker_async_stale_test.exs test/minga_editor/delayed_callback_shell_switch_test.exs` passed. Focused search found no `async?/0` definition or spec in `TodoSearchSource` and no remaining `FetchEffect.request(TodoSearchSource, ...)` trace in the retargeted stale tests. `git diff --check` passed.
+- **Callback validation:** After deletion, `mix run -e 'alias MingaEditor.UI.Picker.{Source,TodoSearchSource}; IO.inspect({Source.async?(TodoSearchSource), TodoSearchSource.candidates(nil), Source.fetch(TodoSearchSource, nil)})'` returned `{false, [], {:ok, [], %{}}}`.
+- **Numstat before roadmap evidence:** `lib/minga_editor/ui/picker/todo_search_source.ex 0 4; test/minga_editor/delayed_callback_shell_switch_test.exs 3 3; test/minga_editor/picker_async_stale_test.exs 23 27; test/minga_editor/ui/picker/todo_search_source_test.exs 9 0`.
+- **Production lines added/removed:** `0 added / 4 removed` (net `-4`, within production net `<= 0`).
+- **Test lines added/removed:** `35 added / 30 removed` (net `+5`, within test net `<= +10`).
+- **Concepts removed:** Removed the misleading generic async callback advertisement from TODO search.
+- **Concepts added:** None. No production module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, replacement abstraction, data representation, scheduler path, generic wrapper, or callback contract was added.
+- **Retained contracts:** `TodoSearchSource.candidates/1`, parsing, candidate building, select, cancel, and preview behavior remain. `TodoSearchWorkflow.open/1`, `TodoSearch.request/2`, scheduler latest-wins policy, root authorization, repository probing, stale workspace/revision guards, `PickerUI.apply_fetch_result/4`, command registration, keymap binding, and generic async picker support for real async sources remain unchanged.
+- **Findings resolved:** D25 implementation slice removes the dormant generic TODO fetch advertisement while preserving the dedicated workflow/effect owner path.
+- **Discoveries affecting later work:** No replan trigger was found. The focused test command emitted one transient `erl_child_setup: failed with error 32 on line 284` line on an initial passing run, then passed cleanly on rerun; no source or contract drift was required.
+- **Broad validation:** `make lint` passed Credo, compile, format, and incremental Dialyzer with 0 errors. `ERL_FLAGS='+S 2:2' mix test.llm` passed 9,753 tests with 58 doctests, 98 properties, 1 skipped, and 572 excluded.
+- **Pre-acceptance reviews:** Elixir craftsmanship returned `PASS / Lean` with 0.99 confidence. Correctness and Ponytail found one exact generic-async test bug: the first test edit removed the `MingaEditor.UI.Picker.FetchEffect` alias while retained finalization assertions still referenced `FetchEffect`, making those checks target an inert nested module atom. The alias was restored, the module documentation was corrected to distinguish generic test-source coverage from the dedicated TODO effect, and the focused 64-test suite passed again. The targeted recheck returned `RESOLVED/PASS` and confirmed the handler identity plus exact numstat. Test-analysis was unavailable because its runtime had no model configured.
+- **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the exact generic-async advertisement deletion, retained typed TODO workflow/effect owner path, meaningful generic async coverage, resolved alias blocker, truthful validation, budgets, and merge safety.
+- **PR URL:** Pending.
+- **Implementation commit SHA:** Pending.
+- **Merge SHA:** Pending.
+- **Completion date:** Pending.

--- a/lib/minga_editor/ui/picker/todo_search_source.ex
+++ b/lib/minga_editor/ui/picker/todo_search_source.ex
@@ -38,10 +38,6 @@ defmodule MingaEditor.UI.Picker.TodoSearchSource do
   def preview?, do: true
 
   @impl true
-  @spec async?() :: boolean()
-  def async?, do: true
-
-  @impl true
   @spec candidates(Context.t()) :: [Item.t()]
   def candidates(_context), do: []
 

--- a/test/minga_editor/delayed_callback_shell_switch_test.exs
+++ b/test/minga_editor/delayed_callback_shell_switch_test.exs
@@ -17,7 +17,7 @@ defmodule MingaEditor.DelayedCallbackShellSwitchTest do
   alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.FetchEffect
   alias MingaEditor.UI.Picker.Item
-  alias MingaEditor.UI.Picker.TodoSearchSource
+  alias MingaEditor.UI.Picker.FileSource
 
   setup do
     Registry.reset_for_test()
@@ -43,7 +43,7 @@ defmodule MingaEditor.DelayedCallbackShellSwitchTest do
   test "picker candidate delivery is dropped without touching or replaying a foreign shell" do
     {traditional_state, revision} =
       TestHelpers.base_state(rendering: :disabled)
-      |> PickerUI.open_loading(TodoSearchSource)
+      |> PickerUI.open_loading(FileSource)
 
     assert is_reference(revision)
     context = Context.from_editor_state(traditional_state)
@@ -53,7 +53,7 @@ defmodule MingaEditor.DelayedCallbackShellSwitchTest do
     items = [%Item{id: %{path: "/tmp/stale.ex", line: 1}, label: "stale candidate"}]
     result = {:ok, items, Candidate.from_items(items), %{status: "stale status"}}
 
-    request = FetchEffect.request(TodoSearchSource, nil, context, revision)
+    request = FetchEffect.request(FileSource, nil, context, revision)
 
     outcome = Outcome.completed(request, result)
 

--- a/test/minga_editor/picker_async_stale_test.exs
+++ b/test/minga_editor/picker_async_stale_test.exs
@@ -7,9 +7,8 @@ defmodule MingaEditor.PickerAsyncStaleTest do
     * results are revision-tagged so a stale (older-revision) result is dropped
       latest-wins and never overwrites the live picker (AC2/AC6).
 
-  Uses the TODO search source (async). The stale-drop assertion is robust against
-  the real background fetch: a sentinel item carried on a non-live revision can
-  never appear, regardless of whether the real fetch has landed.
+  Covers the generic async picker path with test sources and the dedicated TODO
+  search effect's revision handling.
   """
 
   # TODO fetches spawn git/grep Ports and read the process-global Project workspace.
@@ -21,9 +20,8 @@ defmodule MingaEditor.PickerAsyncStaleTest do
   alias MingaEditor.Effects.TodoSearch
   alias MingaEditor.EffectScheduler
   alias MingaEditor.PickerUI
-  alias MingaEditor.UI.Picker.Candidate
-  alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.FetchEffect
+  alias MingaEditor.UI.Picker.Candidate
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.TodoSearchSource
 
@@ -139,22 +137,19 @@ defmodule MingaEditor.PickerAsyncStaleTest do
 
     state = :sys.get_state(ctx.editor, @sync_timeout)
 
-    request =
-      FetchEffect.request(
-        TodoSearchSource,
-        nil,
-        Context.from_editor_state(state),
-        stale_revision
-      )
+    request = TodoSearch.request(Project.snapshot(), stale_revision)
 
-    outcome =
-      Outcome.completed(
-        request,
-        {:ok, stale_items, Candidate.from_items(stale_items), %{}}
-      )
+    result = %TodoSearch.Result{
+      revision: stale_revision,
+      items: stale_items,
+      candidates: Candidate.from_items(stale_items),
+      meta: %{}
+    }
+
+    outcome = Outcome.completed(request, result)
 
     assert {^state, %Outcome{status: :stale, reason: :picker_closed_or_replaced}} =
-             FetchEffect.apply(state, outcome)
+             TodoSearch.apply(state, outcome)
   end
 
   @spec await_ready_picker(pid(), module()) :: MingaEditor.State.ModalOverlay.Picker.t()
@@ -253,16 +248,17 @@ defmodule MingaEditor.PickerAsyncStaleTest do
 
     state = :sys.get_state(ctx.editor, @sync_timeout)
 
-    request =
-      FetchEffect.request(
-        TodoSearchSource,
-        nil,
-        Context.from_editor_state(state),
-        live_revision
-      )
+    request = TodoSearch.request(Project.snapshot(), live_revision)
 
-    outcome = Outcome.completed(request, {:ok, items, candidates, %{}})
-    assert {new_state, ^outcome} = FetchEffect.apply(state, outcome)
+    result = %TodoSearch.Result{
+      revision: live_revision,
+      items: items,
+      candidates: candidates,
+      meta: %{}
+    }
+
+    outcome = Outcome.completed(request, result)
+    assert {new_state, ^outcome} = TodoSearch.apply(state, outcome)
     {:picker, payload} = new_state.shell_runtime.state.modal
 
     labels = Enum.map(payload.picker_ui.picker.items, & &1.label)

--- a/test/minga_editor/ui/picker/todo_search_source_test.exs
+++ b/test/minga_editor/ui/picker/todo_search_source_test.exs
@@ -12,14 +12,23 @@ defmodule MingaEditor.UI.Picker.TodoSearchSourceTest do
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Effects.TodoSearch
   alias MingaEditor.PickerUI
+  alias MingaEditor.UI.Picker.Context
   alias MingaEditor.UI.Picker.FileSource
   alias MingaEditor.UI.Picker.Item
   alias MingaEditor.UI.Picker.TodoSearchSource
+  alias MingaEditor.UI.Picker.Source
 
   setup do
     original_workspace = Project.snapshot()
     on_exit(fn -> restore_project(original_workspace) end)
     :ok
+  end
+
+  test "does not advertise generic async fetching and keeps fallback candidates inert" do
+    context = Context.from_editor_state(base_state(content: "scratch"))
+
+    refute Source.async?(TodoSearchSource)
+    assert TodoSearchSource.candidates(context) == []
   end
 
   describe "parse_output/2" do


### PR DESCRIPTION
# TL;DR

Remove the dormant generic async advertisement from TODO search while preserving the dedicated typed workflow and effect path.

## Changes

- Delete `TodoSearchSource.async?/0`; the shared Source fallback now reports `false`.
- Keep mandatory `candidates/1`, parse/build/select/cancel behavior, and the dedicated `TodoSearchWorkflow` plus `TodoSearch` effect path.
- Retarget generic async tests to real async sources and test TODO stale-result handling through its actual effect owner.

## Validation

- Focused picker and TODO workflow suite: 64 tests passed.
- `make lint`: passed with 0 Dialyzer errors.
- `ERL_FLAGS='+S 2:2' mix test.llm`: 9,753 tests passed, 0 failures.
- Final reviewer: PASS, 0.99 confidence.
- Production delta: 0 added, 4 removed. Tests: net +5.