### PR TITLE
refactor(renderer): remove unused display map queries

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2864,3 +2864,32 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Merge SHA:** `14a14055e042552e36a5ee0ea1cc4668d90d61d9`.
 - **Merge evidence:** PR #3096 merged after CI run `29784304166` passed Elixir, Swift macOS, Swift protocol integration, Go TUI, Zig, Dialyzer, lint/format, Neovim conformance, Go TUI boot smoke, and keystroke latency.
 - **Completion date:** 2026-07-20.
+
+### W056: Delete D40 DisplayMap query helpers
+
+- **Status:** ACTIVE
+- **Audit ID:** W056/D40
+- **Planning profile:** `D40DisplayMapPlanner`, `editor-lifecycle-planner`, `openai-codex/gpt-5.5`, read-only.
+- **Implementation profile:** `D40DisplayMapWorker`, `editor-lifecycle-worker`, `openai-codex/gpt-5.5`, no delegation.
+- **Freshness commit SHA:** `d63a4cf52b133241caf13f2474896e2f14640769`.
+- **Observable result:** `MingaEditor.DisplayMap` no longer exports the test-only query helpers `buffer_range/1`, `buf_line_for_display_row/2`, `next_visible_line/2`, `prev_visible_line/2`, or `total_display_lines/3,4`. The retained live DisplayMap contracts are unchanged: `compute/5,6`, `required?/2`, `to_visible_line_map/1`, `display_row_for_buf_line/2`, the entry type, and the `%DisplayMap{entries: ..., total_display_lines: ...}` struct shape.
+- **Failure reproduction / source trace:** Before deletion, focused tests still exercised the stale helpers: `mix test.debug test/minga_editor/display_map_test.exs test/minga/buffer/block_decoration_test.exs` passed 51 tests while relying on the query-only helper assertions. Focused trace found `DisplayMap.buffer_range/1`, `DisplayMap.buf_line_for_display_row/2`, `DisplayMap.next_visible_line/2`, `DisplayMap.prev_visible_line/2`, and `DisplayMap.total_display_lines/3` callsites only in `test/minga_editor/display_map_test.exs` and `test/minga/buffer/block_decoration_test.exs`; no `lib`, `extensions`, `macos`, `go`, or production caller existed. The deleted definitions lived only in `lib/minga_editor/display_map.ex`, and private `line_inside_fold?/2` was orphaned by the `total_display_lines/3,4` removal.
+- **Implementation result:** Deleted only the locked DisplayMap query-helper docs, specs, functions, and orphan private fold-line predicate. Deleted the query-only `buffer_range/1`, navigation-helper, total-display-line, and block-decoration navigation tests. Replaced the deleted `buf_line_for_display_row/2` block with the required `to_visible_line_map/1` row-order assertion for rows 0, 3, and 4.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/display_map.ex`; `test/minga_editor/display_map_test.exs`; `test/minga/buffer/block_decoration_test.exs`.
+- **Focused validation:** `mix test.debug test/minga_editor/display_map_test.exs test/minga/buffer/block_decoration_test.exs` passed 43 tests. `mix test.debug test/minga_editor/mouse/hit_test_test.exs test/minga_editor/mouse_test.exs` passed 51 tests. `mix test.debug test/minga_editor/render_pipeline/content_test.exs test/minga_editor/render_pipeline/scroll_test.exs test/minga_editor/render_model/window/builder_test.exs` passed 53 tests.
+- **Formatting, reference, and diff validation:** `mix format lib/minga_editor/display_map.ex test/minga_editor/display_map_test.exs test/minga/buffer/block_decoration_test.exs` ran. `mix format --check-formatted lib/minga_editor/display_map.ex test/minga_editor/display_map_test.exs test/minga/buffer/block_decoration_test.exs` passed. Focused post-delete source/test trace searches for deleted DisplayMap calls across `lib`, `test`, `extensions`, `macos`, and `go` returned no matches, and deleted definitions plus `line_inside_fold?/2` returned no matches in `lib/minga_editor/display_map.ex`. Retained export search confirmed `compute/5,6`, `required?/2`, `to_visible_line_map/1`, and `display_row_for_buf_line/2` remain defined. `git diff --check` passed.
+- **Numstat before roadmap evidence:** `lib/minga_editor/display_map.ex 1 94; test/minga_editor/display_map_test.exs 6 83; test/minga/buffer/block_decoration_test.exs 0 34`.
+- **Production lines added/removed:** `1 added / 94 removed` (net `-93`, within production net `<= 0`).
+- **Test lines added/removed:** `6 added / 117 removed` (net `-111`, within test net `<= 0`).
+- **Concepts removed:** Removed the obsolete test-only DisplayMap query-helper surface.
+- **Concepts added:** None. No module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, replacement abstraction, data representation, helper, telemetry path, frontend path, mouse path, render path, or movement path was added.
+- **Retained contracts:** `DisplayMap.compute/5,6`, `required?/2`, `to_visible_line_map/1`, `display_row_for_buf_line/2`, `entry/0`, `%DisplayMap{entries: ..., total_display_lines: ...}`, buffer prefetch cursor visibility, render content visible-line-map handoff, mouse hit testing, fold-target hit testing, movement wrap gating, block decoration ordering, virtual-line ordering, and fold row construction remain unchanged.
+- **Findings resolved:** W056 implements only the D40 DisplayMap query-helper deletion slice while preserving live DisplayMap producers and consumers.
+- **Discoveries affecting later work:** No replan trigger, production caller, extension caller, frontend caller, telemetry dependency, replacement API need, or D40 completed-surface dependency was found. The `total_display_lines` struct field remains intentionally retained for a separately evidenced data-shape slice.
+- **Broad validation:** `make lint` passed Credo, compile, format, and incremental Dialyzer with 0 errors. `ERL_FLAGS='+S 2:2' mix test.llm` passed 9,744 tests with 58 doctests, 98 properties, 1 skipped, and 572 excluded.
+- **Pre-acceptance reviews:** Correctness, Elixir craftsmanship, and Ponytail all returned `PASS / Lean` with no blockers or cuts. They confirmed the exact query-helper and orphan predicate deletion, zero remaining traces, retained live DisplayMap contracts, meaningful renderer-facing row-order coverage, truthful negative budgets, and zero added concepts.
+- **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the exact five-helper and orphan predicate deletion, retained live APIs and struct shape, specified test cuts and behavioral retarget, clean traces, truthful budgets, complete validation evidence, zero added concepts, and merge safety.
+- **PR URL:** Pending.
+- **Implementation commit SHA:** Pending.
+- **Merge SHA:** Pending.
+- **Completion date:** Pending.

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -2889,7 +2889,7 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Broad validation:** `make lint` passed Credo, compile, format, and incremental Dialyzer with 0 errors. `ERL_FLAGS='+S 2:2' mix test.llm` passed 9,744 tests with 58 doctests, 98 properties, 1 skipped, and 572 excluded.
 - **Pre-acceptance reviews:** Correctness, Elixir craftsmanship, and Ponytail all returned `PASS / Lean` with no blockers or cuts. They confirmed the exact query-helper and orphan predicate deletion, zero remaining traces, retained live DisplayMap contracts, meaningful renderer-facing row-order coverage, truthful negative budgets, and zero added concepts.
 - **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the exact five-helper and orphan predicate deletion, retained live APIs and struct shape, specified test cuts and behavioral retarget, clean traces, truthful budgets, complete validation evidence, zero added concepts, and merge safety.
-- **PR URL:** Pending.
-- **Implementation commit SHA:** Pending.
+- **PR URL:** https://github.com/jsmestad/minga/pull/3098
+- **Implementation commit SHA:** `e70be1c80`.
 - **Merge SHA:** Pending.
 - **Completion date:** Pending.

--- a/lib/minga_editor/display_map.ex
+++ b/lib/minga_editor/display_map.ex
@@ -141,16 +141,7 @@ defmodule MingaEditor.DisplayMap do
     has_window_folds or closed_dec_folds != [] or has_virtual_lines or has_blocks
   end
 
-  # ── Public query API ─────────────────────────────────────────────────────
-
-  @doc "Returns the buffer line range needed to fetch all visible lines."
-  @spec buffer_range(t()) :: {non_neg_integer(), non_neg_integer()} | nil
-  def buffer_range(%__MODULE__{entries: []}), do: nil
-
-  def buffer_range(%__MODULE__{entries: entries}) do
-    buf_lines = entries |> Enum.map(fn {line, _} -> line end) |> Enum.uniq()
-    {Enum.min(buf_lines), Enum.max(buf_lines)}
-  end
+  # ── Public live API ─────────────────────────────────────────────────────
 
   @doc "Returns the entry list for the content renderer."
   @spec to_visible_line_map(t()) :: [entry()]
@@ -160,83 +151,6 @@ defmodule MingaEditor.DisplayMap do
   @spec display_row_for_buf_line(t(), non_neg_integer()) :: non_neg_integer() | nil
   def display_row_for_buf_line(%__MODULE__{entries: entries}, buf_line) do
     Enum.find_index(entries, fn {line, type} -> line == buf_line and buffer_line_entry?(type) end)
-  end
-
-  @doc "Returns the buffer line at the given display row."
-  @spec buf_line_for_display_row(t(), non_neg_integer()) :: non_neg_integer() | nil
-  def buf_line_for_display_row(%__MODULE__{entries: entries}, display_row) do
-    case Enum.at(entries, display_row) do
-      nil -> nil
-      {line, _} -> line
-    end
-  end
-
-  @doc "Returns the next visible buffer line after the given line."
-  @spec next_visible_line(t(), non_neg_integer()) :: non_neg_integer()
-  def next_visible_line(%__MODULE__{entries: entries}, line) do
-    idx = Enum.find_index(entries, fn {l, type} -> l == line and buffer_line_entry?(type) end)
-
-    case idx do
-      nil ->
-        line + 1
-
-      i ->
-        entries
-        |> Enum.drop(i + 1)
-        |> Enum.find(fn {_l, type} -> buffer_line_entry?(type) end)
-        |> case do
-          nil -> line + 1
-          {next_line, _} -> next_line
-        end
-    end
-  end
-
-  @doc "Returns the previous visible buffer line before the given line."
-  @spec prev_visible_line(t(), non_neg_integer()) :: non_neg_integer()
-  def prev_visible_line(%__MODULE__{entries: entries}, line) do
-    idx = Enum.find_index(entries, fn {l, type} -> l == line and buffer_line_entry?(type) end)
-
-    case idx do
-      nil ->
-        max(line - 1, 0)
-
-      0 ->
-        max(line - 1, 0)
-
-      i ->
-        entries
-        |> Enum.take(i)
-        |> Enum.reverse()
-        |> Enum.find(fn {_l, type} -> buffer_line_entry?(type) end)
-        |> case do
-          nil -> max(line - 1, 0)
-          {prev_line, _} -> prev_line
-        end
-    end
-  end
-
-  @doc "Total display lines for the entire buffer (scrollbar calculations)."
-  @spec total_display_lines(FoldMap.t(), Decorations.t(), non_neg_integer(), pos_integer()) ::
-          non_neg_integer()
-  def total_display_lines(fold_map, decorations, total_buf_lines, content_width \\ 80) do
-    window_hidden =
-      FoldMap.visible_folds(fold_map)
-      |> Enum.reduce(0, fn f, acc -> acc + (f.end_line - f.start_line) end)
-
-    dec_hidden =
-      Decorations.closed_fold_regions(decorations)
-      |> Enum.reduce(0, fn f, acc -> acc + FoldRegion.hidden_count(f) end)
-
-    virt_lines = Decorations.virtual_line_count(decorations, 0, total_buf_lines)
-
-    all_folds = FoldMap.visible_folds(fold_map) ++ Decorations.closed_fold_regions(decorations)
-
-    block_rows =
-      decorations.block_decorations
-      |> Enum.reject(fn b -> line_inside_fold?(b.anchor_line, all_folds) end)
-      |> Enum.reduce(0, fn b, acc -> acc + BlockDecoration.resolve_height(b, content_width) end)
-
-    max(total_buf_lines - window_hidden - dec_hidden + virt_lines + block_rows, 0)
   end
 
   # ── Private: entry classification ────────────────────────────────────────
@@ -351,12 +265,5 @@ defmodule MingaEditor.DisplayMap do
 
   defp find_dec_fold(dec_folds, line) do
     Enum.find(dec_folds, fn fold -> fold.start_line == line end)
-  end
-
-  defp line_inside_fold?(line, folds) do
-    Enum.any?(folds, fn
-      %FoldRange{start_line: s, end_line: e} -> line > s and line <= e
-      %FoldRegion{start_line: s, end_line: e} -> line > s and line <= e
-    end)
   end
 end

--- a/test/minga/buffer/block_decoration_test.exs
+++ b/test/minga/buffer/block_decoration_test.exs
@@ -286,40 +286,6 @@ defmodule Minga.Buffer.BlockDecorationTest do
       assert Enum.count(fold_entries) == 1
     end
 
-    test "next_visible_line skips block entries" do
-      fm = FoldMap.new()
-      decs = Decorations.new()
-
-      {_, decs} =
-        Decorations.add_block_decoration(decs, 5,
-          placement: :above,
-          render: fn _w -> [{"header", Minga.Core.Face.new()}] end
-        )
-
-      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
-
-      # Line 4 → next should be 5 (skipping the block entry)
-      assert DisplayMap.next_visible_line(dm, 4) == 5
-      # Line 5 → next should be 6 (block is above 5, doesn't affect forward nav)
-      assert DisplayMap.next_visible_line(dm, 5) == 6
-    end
-
-    test "prev_visible_line skips block entries" do
-      fm = FoldMap.new()
-      decs = Decorations.new()
-
-      {_, decs} =
-        Decorations.add_block_decoration(decs, 5,
-          placement: :below,
-          render: fn _w -> [{"separator", Minga.Core.Face.new()}] end
-        )
-
-      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
-
-      # Line 6 → prev should be 5 (skipping the block below 5)
-      assert DisplayMap.prev_visible_line(dm, 6) == 5
-    end
-
     test "block consumes display rows" do
       fm = FoldMap.new()
       decs = Decorations.new()

--- a/test/minga_editor/display_map_test.exs
+++ b/test/minga_editor/display_map_test.exs
@@ -43,16 +43,6 @@ defmodule MingaEditor.DisplayMapTest do
       refute 7 in visible_lines
       refute 10 in visible_lines
     end
-
-    test "buffer_range returns correct range" do
-      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(5, 10))
-      decs = Decorations.new()
-      dm = DisplayMap.compute(fm, decs, 0, 15, 20)
-
-      {first, last} = DisplayMap.buffer_range(dm)
-      assert first == 0
-      assert last >= 11
-    end
   end
 
   # ── Decoration folds only ───────────────────────────────────────────────
@@ -300,83 +290,16 @@ defmodule MingaEditor.DisplayMapTest do
     end
   end
 
-  describe "buf_line_for_display_row/2" do
-    test "returns correct line with folds" do
+  describe "to_visible_line_map/1 row ordering" do
+    test "preserves display-row order with folds" do
       fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(3, 6))
       decs = Decorations.new()
       dm = DisplayMap.compute(fm, decs, 0, 15, 20)
+      entries = DisplayMap.to_visible_line_map(dm)
 
-      assert DisplayMap.buf_line_for_display_row(dm, 0) == 0
-      assert DisplayMap.buf_line_for_display_row(dm, 3) == 3
-      assert DisplayMap.buf_line_for_display_row(dm, 4) == 7
-    end
-  end
-
-  # ── next/prev visible line ────────────────────────────────────────────────
-
-  describe "next_visible_line/2 and prev_visible_line/2" do
-    test "skips over window fold" do
-      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(5, 10))
-      decs = Decorations.new()
-      dm = DisplayMap.compute(fm, decs, 0, 20, 25)
-
-      assert DisplayMap.next_visible_line(dm, 4) == 5
-      # Line 5 is fold start; next visible after it should be 11
-      assert DisplayMap.next_visible_line(dm, 5) == 11
-      assert DisplayMap.prev_visible_line(dm, 11) == 5
-    end
-
-    test "skips over decoration fold" do
-      fm = FoldMap.new()
-      decs = Decorations.new()
-      {_id, decs} = Decorations.add_fold_region(decs, 5, 10, closed: true)
-
-      dm = DisplayMap.compute(fm, decs, 0, 20, 25)
-
-      assert DisplayMap.next_visible_line(dm, 5) == 11
-      assert DisplayMap.prev_visible_line(dm, 11) == 5
-    end
-
-    test "skips over virtual lines" do
-      fm = FoldMap.new()
-      decs = Decorations.new()
-
-      {_, decs} =
-        Decorations.add_virtual_text(decs, {5, 0},
-          segments: [{"header", Minga.Core.Face.new()}],
-          placement: :above
-        )
-
-      dm = DisplayMap.compute(fm, decs, 0, 20, 25)
-
-      # next_visible_line after line 4 should be 5 (the virtual line is
-      # not a buffer line, so it's skipped)
-      assert DisplayMap.next_visible_line(dm, 4) == 5
-    end
-  end
-
-  # ── total_display_lines ─────────────────────────────────────────────────
-
-  describe "total_display_lines/3" do
-    test "subtracts hidden fold lines and adds virtual lines" do
-      fm = FoldMap.new() |> FoldMap.fold(FoldRange.new!(5, 10))
-
-      decs = Decorations.new()
-
-      {_, decs} =
-        Decorations.add_virtual_text(decs, {0, 0},
-          segments: [{"header", Minga.Core.Face.new()}],
-          placement: :above
-        )
-
-      # 100 buffer lines - 5 hidden (fold 5-10) + 1 virtual line = 96
-      assert DisplayMap.total_display_lines(fm, decs, 100) == 96
-    end
-
-    test "no folds or virtual lines returns buffer line count" do
-      fm = FoldMap.new()
-      decs = Decorations.new()
-      assert DisplayMap.total_display_lines(fm, decs, 100) == 100
+      assert Enum.at(entries, 0) == {0, :normal}
+      assert Enum.at(entries, 3) == {3, {:fold_start, 3}}
+      assert Enum.at(entries, 4) == {7, :normal}
     end
   end
 


### PR DESCRIPTION
# TL;DR

Remove unused DisplayMap query helpers while preserving the live mapping surface used by rendering, mouse hit testing, movement, and buffer prefetch.

## Changes

- Delete `buffer_range/1`, `buf_line_for_display_row/2`, `next_visible_line/2`, `prev_visible_line/2`, `total_display_lines/3,4`, and orphan `line_inside_fold?/2`.
- Retarget display-row ordering coverage to the live `to_visible_line_map/1` boundary.
- Remove tests that existed only for the deleted query contracts.
- Retain `compute/5,6`, `required?/2`, `to_visible_line_map/1`, `display_row_for_buf_line/2`, and the existing struct shape.

## Validation

- Focused DisplayMap/block suite: 43 passed.
- Focused mouse suite: 51 passed.
- Focused render/window suite: 53 passed.
- `make lint`: passed, 0 Dialyzer errors.
- `ERL_FLAGS='+S 2:2' mix test.llm`: 9,744 passed, 0 failures.
- Final reviewer: PASS, 0.99 confidence.
- Production delta: +1/-94. Tests: +6/-117. Zero added concepts.