### PR TITLE
fix(ui): synchronize FileTree sidebar state

### DIFF
--- a/lib/minga_editor/shell/traditional/sidebar_workflow.ex
+++ b/lib/minga_editor/shell/traditional/sidebar_workflow.ex
@@ -7,6 +7,7 @@ defmodule MingaEditor.Shell.Traditional.SidebarWorkflow do
   """
 
   alias Minga.Log
+  alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.GitStatus.TUIState
   alias MingaEditor.Shell.Runtime
@@ -27,6 +28,7 @@ defmodule MingaEditor.Shell.Traditional.SidebarWorkflow do
   @doc "Selects a native sidebar and synchronizes registry focus."
   @spec select(state(), String.t() | nil) :: state()
   def select(%EditorState{} = state, id) when is_binary(id) or is_nil(id) do
+    sync_file_tree_sidebar(state)
     sync_active_sidebar(state, id)
     update(state, &TraditionalState.select_sidebar(&1, id))
   end
@@ -197,6 +199,20 @@ defmodule MingaEditor.Shell.Traditional.SidebarWorkflow do
 
       _extension_state ->
         {:stale, state}
+    end
+  end
+
+  @spec sync_file_tree_sidebar(state()) :: :ok
+  defp sync_file_tree_sidebar(state) do
+    case FileTreeFeature.sync_sidebar(
+           state.workspace.file_tree,
+           state.extension_surfaces.sidebar_registry
+         ) do
+      :ok ->
+        :ok
+
+      {:error, reason} ->
+        Log.warning(:editor, "File Tree sidebar sync failed: #{inspect(reason)}")
     end
   end
 

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -17,8 +17,10 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
   alias MingaEditor.Extension.Sidebar
   alias MingaEditor.FileTree.Feature, as: FileTreeFeature
   alias MingaEditor.Frontend.Capabilities
+  alias MingaEditor.Frontend.Emit.Context
   alias MingaEditor.GitStatus.Panel, as: GitStatusPanel
   alias MingaEditor.Handlers.GuiActionHandler
+  alias MingaEditor.RenderModel.UI.SidebarsBuilder
   alias MingaEditor.RenderPipeline.TestHelpers
   alias MingaEditor.Shell.Entry
   alias MingaEditor.Test.SidebarActionProbe
@@ -300,6 +302,10 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
     assert opened.workspace.file_tree.tree != nil
     assert opened.workspace.file_tree.focused
     assert SidebarWorkflow.active_id(opened) == "file_tree"
+    assert %{visible?: true, focused?: true} = Sidebar.get(table, "file_tree")
+
+    assert %{active_id: "file_tree", sidebars: [%{visible?: true, focused?: true}]} =
+             SidebarsBuilder.build(Context.from_editor_state(opened))
 
     focused =
       GuiActionHandler.dispatch(
@@ -322,6 +328,10 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
     refute FileTreeState.visible?(hidden_state)
     refute hidden_state.focused
     assert SidebarWorkflow.active_id(hidden) == nil
+    assert %{visible?: false, focused?: false} = Sidebar.get(table, "file_tree")
+
+    assert %{active_id: "", sidebars: [%{visible?: false, focused?: false}]} =
+             SidebarsBuilder.build(Context.from_editor_state(hidden))
   end
 
   test "optional GUI commands report scheduling failures instead of no-op", %{


### PR DESCRIPTION
# TL;DR

The macOS FileTree activity button now publishes visible and focused sidebar metadata before the shell selection changes, so SwiftUI mounts the tree instead of observing only an internal state change.

Closes #3136

## Context

FileTree activation updates two related BEAM values: the authoritative FileTree state and the source-owned sidebar registry consumed by the semantic `gui_sidebars` model. The registry projection previously ran only at startup. A button click could therefore make `gui_file_tree` visible while leaving `gui_sidebars` hidden, and the macOS frontend correctly declined to mount a sidebar the shell model said was absent.

This is separate from the editor scroll and gutter presentation defect tracked by #2999 and addressed by #3017.

## Changes

- Synchronize the current FileTree visibility, focus, and width at the Traditional shell sidebar-selection boundary.
- Keep sidebar focus and shell selection ordered after that projection, preserving one semantic source of truth for native chrome.
- Extend the native GUI action regression test through both the registry entry and final `SidebarsBuilder` model for show and hide transitions.

## Verification

- `mix test.debug test/minga_editor/handlers/gui_action_handler_test.exs test/minga_editor/file_tree/feature_test.exs test/minga_editor/render_model/ui/sidebars_builder_test.exs` (34 passed)
- `make lint` (format, changed Credo, warnings-as-errors compile, incremental Dialyzer)
- `mix test.llm` (9,722 tests, 0 failures, 1 skipped, rerun after rebasing onto current `main`)
- `bin/minga-mac README.md` built and launched the native frontend; macOS Accessibility automation toggled FileTree visible → hidden → visible and observed 21 → 0 → 21 mounted tree-row controls, with window captures confirming the sidebar disappears and returns while editor content remains rendered

## Acceptance Criteria Addressed

1. Clicking the inactive FileTree activity button renders and focuses the FileTree sidebar. ✅
2. Clicking the active FileTree activity button hides the sidebar and clears its focus metadata. ✅
3. The semantic sidebars model matches authoritative FileTree visibility and focus after both transitions. ✅
