### PR TITLE
refactor(agent): centralize workspace auto-name install

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -3502,3 +3502,31 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Merge SHA:** `498d5cc84050bde730fcf480ed01a7ca4f02c014`.
 - **Merge evidence:** PR #3140 merged after CI run `29865904012` passed Elixir, Swift macOS, Swift protocol integration, Go TUI, Zig, Dialyzer, lint/format, Neovim conformance, Go TUI boot smoke, and keystroke latency.
 - **Completion date:** 2026-07-21.
+
+### W077/S04: Share workspace auto-name installation in WorkspaceWorkflow
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** S04
+- **Planning profile:** `S04Planner`, `editor-lifecycle-planner`, read-only.
+- **Implementation profile:** `S04Worker`, `editor-lifecycle-worker`, no delegation.
+- **Ready provenance:** Locked by `agent://S04Planner` for current SHA `6c6d83ec561e931098285e72efa83ce8744b77d6`; the plan constrained this slice to sharing only the workspace mutation/install operation while leaving queued-prompt and first-assistant trigger eligibility local to their existing workflows.
+- **Freshness commit SHA:** `6c6d83ec561e931098285e72efa83ce8744b77d6`.
+- **Observable result:** `MingaEditor.WorkspaceWorkflow.install_auto_named_workspace/3` is now the single owner-local workflow transition that reads the active Traditional tab bar, finds the already-selected workspace id, applies `Workspace.auto_name/2`, no-ops when the label is unchanged or the workspace/shell is unavailable, and installs the accepted workspace through `WorkspaceWorkflow.install_tab_bar/2`. `SessionEventWorkflow.prompt_queued/3` and `StreamEventWorkflow.messages_changed/1` now call that shared transition while retaining their distinct eligibility gates.
+- **Failure reproduction / source trace:** Before the correction, `SessionEventWorkflow` and `StreamEventWorkflow` each carried the same local `maybe_apply_auto_name/3`, `install_auto_name/3`, and `install_tab_bar/2` helper chain: derive `Workspace.auto_name/2`, replace through `TabBar.accept_workspace/2`, and delegate to `WorkspaceWorkflow.install_tab_bar/2`. Focused source search after the correction found no remaining `maybe_apply_auto_name`, `install_auto_name(`, or local `install_tab_bar(` references in either agent workflow.
+- **Implementation result:** Added `MingaEditor.WorkspaceWorkflow.install_auto_named_workspace/3`; migrated queued-prompt and first-assistant callers to pass the selected workspace id and prompt/text; deleted the duplicated local install helpers from both agent workflows; added queued-prompt workflow coverage; strengthened the stream workflow assertion to prove auto-named workspaces leave `custom_name` unset; made nil tab bars, missing workspace ids, and non-Traditional runtimes explicit unchanged-state transitions.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/workspace_workflow.ex`; `lib/minga_editor/agent/session_event_workflow.ex`; `lib/minga_editor/agent/stream_event_workflow.ex`; `test/minga_editor/agent/focused_event_workflows_test.exs`.
+- **Focused validation:** `mix test test/minga_editor/agent/focused_event_workflows_test.exs test/minga_editor/state/workspace_test.exs` passed with 45 tests. The broader focused command covering `test/minga_editor/agent`, `state/workspace_test.exs`, and `state/tab_bar_test.exs` passed with 509 tests before the nil-tab-bar regression was added.
+- **Production lines added/removed before roadmap evidence:** `34 added / 57 removed` across the three production files, net `-23`, within the locked production net `<= 0`.
+- **Test lines added/removed before roadmap evidence:** `44 added / 1 removed` in `test/minga_editor/agent/focused_event_workflows_test.exs`, net `+43`, limited to the two locked workflow assertions, three public-transition fallback assertions, and formatter-required layout.
+- **Concepts added:** None. The new public function is the locked owner-local workflow transition in the existing `WorkspaceWorkflow`, not a new module, process, dependency, behaviour, protocol, registry, configuration, compatibility shim, data representation, or helper abstraction.
+- **Concepts removed:** Removed six duplicated local helper functions from the two agent workflows: `maybe_apply_auto_name/3`, `install_auto_name/3`, and `install_tab_bar/2` in both `SessionEventWorkflow` and `StreamEventWorkflow`.
+- **Retained contracts:** `Workspace.auto_name/2` still owns name derivation, truncation, blank no-op, and manual-name protection; `TabBar.find_workspace_by_session/2`, `TabBar.get_workspace/2`, and `TabBar.accept_workspace/2` remain the workspace lookup/replacement APIs; render scheduling, transcript synchronization, tab-label refresh, active-session selection, assistant-message extraction, and queued-prompt eligibility remain unchanged.
+- **Broad validation:** `make lint` passed changed-file Credo, compile, format, and incremental Dialyzer with zero errors. `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` passed 9,740 tests with 58 doctests, 98 properties, 1 skipped, and 572 excluded.
+- **Pre-acceptance reviews:** Ponytail returned `PASS/Lean` and confirmed the consolidation is the smallest correct slice. Elixir craftsmanship returned `PASS/Lean` and confirmed the owner boundary, patterns, specs, and zero-concept shape. Correctness initially blocked a nil-tab-bar crash and stale line counts; the transition now pattern-matches `%TabBar{}` inside the no-op `with`, direct regressions cover nil tab bar, missing workspace id, and non-Traditional runtime, and final counts are corrected. Targeted correctness and Ponytail rechecks returned `RESOLVED/PASS` with no remaining blocker or cut.
+- **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the locked owner boundary, local trigger eligibility, unchanged-state fallbacks, post-fix coverage, exact budgets, evidence, and merge safety.
+- **Findings resolved:** S04's duplicated workspace auto-name installation path is removed; future install/persistence behavior now has one workspace workflow owner.
+- **Discoveries affecting later work:** None. The locked owner, contract, scope, test layer, dependencies, and production-line budget remained valid.
+- **PR URL:** Pending.
+- **Implementation commit SHA:** Pending.
+- **Merge SHA:** Pending.
+- **Completion date:** Pending.

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -3526,7 +3526,7 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the locked owner boundary, local trigger eligibility, unchanged-state fallbacks, post-fix coverage, exact budgets, evidence, and merge safety.
 - **Findings resolved:** S04's duplicated workspace auto-name installation path is removed; future install/persistence behavior now has one workspace workflow owner.
 - **Discoveries affecting later work:** None. The locked owner, contract, scope, test layer, dependencies, and production-line budget remained valid.
-- **PR URL:** Pending.
-- **Implementation commit SHA:** Pending.
+- **PR URL:** https://github.com/jsmestad/minga/pull/3142
+- **Implementation commit SHA:** `782504475`.
 - **Merge SHA:** Pending.
 - **Completion date:** Pending.

--- a/lib/minga_editor/agent/session_event_workflow.ex
+++ b/lib/minga_editor/agent/session_event_workflow.ex
@@ -13,6 +13,7 @@ defmodule MingaEditor.Agent.SessionEventWorkflow do
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
+  alias MingaEditor.WorkspaceWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.TabBar
@@ -148,8 +149,11 @@ defmodule MingaEditor.Agent.SessionEventWorkflow do
     session = Runtime.active_session(state.shell_runtime)
 
     case workspace_for_session(traditional_tab_bar(state), session) do
-      %Workspace{} = workspace -> maybe_apply_auto_name(state, workspace, prompt)
-      nil -> state
+      %Workspace{id: workspace_id} ->
+        WorkspaceWorkflow.install_auto_named_workspace(state, workspace_id, prompt)
+
+      nil ->
+        state
     end
   end
 
@@ -160,28 +164,6 @@ defmodule MingaEditor.Agent.SessionEventWorkflow do
   defp workspace_for_session(tab_bar, session),
     do: TabBar.find_workspace_by_session(tab_bar, session)
 
-  @spec maybe_apply_auto_name(EditorState.t(), Workspace.t(), String.t()) :: EditorState.t()
-  defp maybe_apply_auto_name(state, workspace, prompt) do
-    updated_workspace = Workspace.auto_name(workspace, prompt)
-    install_auto_name(state, workspace, updated_workspace)
-  end
-
-  @spec install_auto_name(EditorState.t(), Workspace.t(), Workspace.t()) :: EditorState.t()
-  defp install_auto_name(state, %Workspace{label: label}, %Workspace{label: label}), do: state
-
-  defp install_auto_name(state, _workspace, updated_workspace) do
-    case traditional_tab_bar(state) do
-      %TabBar{} = tab_bar ->
-        tab_bar =
-          TabBar.accept_workspace(tab_bar, updated_workspace)
-
-        install_tab_bar(state, tab_bar)
-
-      nil ->
-        state
-    end
-  end
-
   @spec traditional_tab_bar(EditorState.t()) :: TabBar.t() | nil
   defp traditional_tab_bar(%EditorState{
          shell_runtime: %Runtime{state: %TraditionalState{} = state}
@@ -189,11 +171,6 @@ defmodule MingaEditor.Agent.SessionEventWorkflow do
        do: TraditionalState.tab_bar(state)
 
   defp traditional_tab_bar(%EditorState{}), do: nil
-
-  @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
-  defp install_tab_bar(%EditorState{} = state, %TabBar{} = tab_bar) do
-    MingaEditor.WorkspaceWorkflow.install_tab_bar(state, tab_bar)
-  end
 
   @spec update_activity(EditorState.t(), (Activity.t() -> Activity.t())) :: EditorState.t()
   defp update_activity(state, fun) when is_function(fun, 1) do

--- a/lib/minga_editor/agent/stream_event_workflow.ex
+++ b/lib/minga_editor/agent/stream_event_workflow.ex
@@ -11,6 +11,7 @@ defmodule MingaEditor.Agent.StreamEventWorkflow do
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
+  alias MingaEditor.WorkspaceWorkflow
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace
@@ -86,7 +87,7 @@ defmodule MingaEditor.Agent.StreamEventWorkflow do
          text when is_binary(text) <- first_assistant_opening(safe_messages(pid)),
          candidate = text |> String.slice(0, 30) |> String.trim(),
          true <- candidate != "" and candidate != workspace.label do
-      maybe_apply_auto_name(state, workspace, text)
+      WorkspaceWorkflow.install_auto_named_workspace(state, workspace.id, text)
     else
       _unavailable -> state
     end
@@ -112,28 +113,6 @@ defmodule MingaEditor.Agent.StreamEventWorkflow do
     :exit, _reason -> []
   end
 
-  @spec maybe_apply_auto_name(EditorState.t(), Workspace.t(), String.t()) :: EditorState.t()
-  defp maybe_apply_auto_name(state, workspace, prompt) do
-    updated_workspace = Workspace.auto_name(workspace, prompt)
-    install_auto_name(state, workspace, updated_workspace)
-  end
-
-  @spec install_auto_name(EditorState.t(), Workspace.t(), Workspace.t()) :: EditorState.t()
-  defp install_auto_name(state, %Workspace{label: label}, %Workspace{label: label}), do: state
-
-  defp install_auto_name(state, _workspace, updated_workspace) do
-    case traditional_tab_bar(state) do
-      %TabBar{} = tab_bar ->
-        tab_bar =
-          TabBar.accept_workspace(tab_bar, updated_workspace)
-
-        install_tab_bar(state, tab_bar)
-
-      nil ->
-        state
-    end
-  end
-
   @spec traditional_tab_bar(EditorState.t()) :: TabBar.t() | nil
   defp traditional_tab_bar(%EditorState{
          shell_runtime: %Runtime{state: %TraditionalState{} = state}
@@ -141,9 +120,4 @@ defmodule MingaEditor.Agent.StreamEventWorkflow do
        do: TraditionalState.tab_bar(state)
 
   defp traditional_tab_bar(%EditorState{}), do: nil
-
-  @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
-  defp install_tab_bar(%EditorState{} = state, %TabBar{} = tab_bar) do
-    MingaEditor.WorkspaceWorkflow.install_tab_bar(state, tab_bar)
-  end
 end

--- a/lib/minga_editor/workspace_workflow.ex
+++ b/lib/minga_editor/workspace_workflow.ex
@@ -71,6 +71,32 @@ defmodule MingaEditor.WorkspaceWorkflow do
 
   def persist_tab_bar_changes(_previous, _current), do: :ok
 
+  @doc "Auto-names and installs an already-selected Traditional workspace."
+  @spec install_auto_named_workspace(EditorState.t(), non_neg_integer(), String.t()) ::
+          EditorState.t()
+  def install_auto_named_workspace(
+        %EditorState{
+          shell_runtime: %Runtime{
+            entry: %{module: MingaEditor.Shell.Traditional},
+            state: %TraditionalState{} = traditional
+          }
+        } = state,
+        workspace_id,
+        prompt
+      )
+      when is_integer(workspace_id) and workspace_id >= 0 and is_binary(prompt) do
+    with %TabBar{} = tab_bar <- TraditionalState.tab_bar(traditional),
+         %Workspace{} = workspace <- TabBar.get_workspace(tab_bar, workspace_id),
+         %Workspace{} = updated_workspace <- Workspace.auto_name(workspace, prompt),
+         false <- updated_workspace.label == workspace.label do
+      install_tab_bar(state, TabBar.accept_workspace(tab_bar, updated_workspace))
+    else
+      _unchanged_or_missing -> state
+    end
+  end
+
+  def install_auto_named_workspace(%EditorState{} = state, _workspace_id, _prompt), do: state
+
   @doc "Persists and installs an already-calculated Traditional tab bar."
   @spec install_tab_bar(EditorState.t(), TabBar.t()) :: EditorState.t()
   def install_tab_bar(

--- a/test/minga_editor/agent/focused_event_workflows_test.exs
+++ b/test/minga_editor/agent/focused_event_workflows_test.exs
@@ -24,6 +24,7 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace
+  alias MingaEditor.WorkspaceWorkflow
   alias MingaEditor.Viewport
   alias MingaEditor.Session.State, as: SessionState
   alias MingaAgent.Session
@@ -97,7 +98,49 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
       |> TraditionalState.tab_bar()
       |> TabBar.find_workspace_by_session(session)
 
-    assert %Workspace{label: "Summarize focused workflows"} = workspace
+    assert %Workspace{label: "Summarize focused workflows", custom_name: nil} = workspace
+  end
+
+  test "session workflow auto-names the active session workspace from queued prompts" do
+    {:ok, session} = start_supervised({Session, provider_opts: []})
+    state = event_state(session)
+
+    updated =
+      SessionEventWorkflow.prompt_queued(
+        state,
+        "Investigate workspace drift\nMore detail",
+        :steering
+      )
+
+    workspace =
+      updated.shell_runtime.state
+      |> TraditionalState.tab_bar()
+      |> TabBar.find_workspace_by_session(session)
+
+    assert %Workspace{label: "Investigate workspace drift", custom_name: nil} = workspace
+    assert RenderCorrelation.scheduled?(updated.render.render_correlation)
+  end
+
+  test "workspace auto-name transition no-ops when its target is unavailable" do
+    missing_tab_bar =
+      %{event_state() | shell_runtime: Runtime.new(Runtime.default_entry(), %TraditionalState{})}
+
+    missing_workspace = event_state()
+    fake_entry = Entry.builtin!(:fake, FakeShell, "Fake", "Fake shell", false)
+
+    non_traditional = %{
+      event_state()
+      | shell_runtime: Runtime.new(fake_entry, FakeShell.init([]))
+    }
+
+    assert WorkspaceWorkflow.install_auto_named_workspace(missing_tab_bar, 1, "Name") ===
+             missing_tab_bar
+
+    assert WorkspaceWorkflow.install_auto_named_workspace(missing_workspace, 999, "Name") ===
+             missing_workspace
+
+    assert WorkspaceWorkflow.install_auto_named_workspace(non_traditional, 1, "Name") ===
+             non_traditional
   end
 
   test "tool workflow follows the session snapshot and clears completed activity" do


### PR DESCRIPTION
## TL;DR

Centralize workspace auto-name installation in `MingaEditor.WorkspaceWorkflow` while keeping queued-prompt and first-assistant eligibility in their existing workflows.

## What changed

- Added `WorkspaceWorkflow.install_auto_named_workspace/3` as the shared owner-local transition.
- Migrated `SessionEventWorkflow` and `StreamEventWorkflow` to the shared transition.
- Removed six duplicated local install helpers.
- Added workflow coverage for both producer paths and unchanged-state coverage for nil tab bars, missing workspace ids, and non-Traditional shells.
- Recorded W077/S04 implementation and validation evidence in the lifecycle roadmap.

## Scope

Production code is 34 lines added and 57 removed, net `-23`. No module, process, dependency, protocol, registry, configuration, data shape, or compatibility shim was added.

## Validation

- Focused tests: 45 passed after the fallback fix.
- Agent/workspace/tab-bar focused suite: 509 passed before the added fallback regression.
- `make lint`: passed.
- `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4`: 9,740 tests passed, plus 58 doctests and 98 properties.
- Correctness: `RESOLVED/PASS` after one nil-tab-bar blocker fix.
- Elixir craftsmanship: `PASS/Lean`.
- Ponytail: `PASS/Lean`, targeted recheck `RESOLVED/PASS`.
- Final reviewer: `PASS`, confidence 0.99.
