### PR TITLE
fix(editor): batch session restore LSP refresh

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -3642,7 +3642,7 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed schedule-once ownership, live-buffer detection, headless/partial/all-missing boundaries, retained foreground/recovery/GUI behavior, active-buffer consumption, exact budgets, validation evidence, and merge safety.
 - **Findings resolved:** S09 implementation slice removes per-restored-buffer timers and replaces them with one post-batch active-buffer refresh for non-headless live restores.
 - **Discoveries affecting later work:** No contract drift, dependency change, owner invalidation, or budget issue required replanning. The LSP handler regression locks the current active-buffer consumer semantics, leaving buffer-correlated code-lens/inlay storage to the separately routed L06/L08 work.
-- **PR URL:** Pending.
-- **Implementation commit SHA:** Pending.
+- **PR URL:** https://github.com/jsmestad/minga/pull/3150
+- **Implementation commit SHA:** `793e1bffa`.
 - **Merge SHA:** Pending.
 - **Completion date:** Pending.

--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -3618,3 +3618,31 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Merge SHA:** `545c839a5800f79cd850e4b45cf3771bbb17f6c1`.
 - **Merge evidence:** PR #3148 merged after CI run `29877756606` passed Elixir, Swift macOS, Swift protocol integration, Go TUI, Zig, Dialyzer, lint/format, Neovim conformance, Go TUI boot smoke, and keystroke latency.
 - **Completion date:** 2026-07-21.
+
+### W081/S09: Schedule one LSP refresh after session restore batch
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** S09
+- **Planning profile:** `S09Planner`, `editor-lifecycle-planner`, read-only.
+- **Implementation profile:** `S09Worker`, `editor-lifecycle-worker`, no delegation.
+- **Ready provenance:** Locked by `agent://S09Planner` for current SHA `4fdb9d3a97cd8469d6eb4b1d6ec948a6fe3d012e`; the locked owner is `MingaEditor.Handlers.SessionRestore` for the restore batch refresh, with `MingaEditor.Handlers.BufferRegistry` retaining ordinary foreground registration scheduling by default.
+- **Freshness commit SHA:** `4fdb9d3a97cd8469d6eb4b1d6ec948a6fe3d012e`.
+- **Observable result:** Session restore now suppresses per-restored-buffer code-lens/inlay timers during saved-buffer registration, restores the persisted active tab, then enqueues one existing `:request_code_lens_and_inlay_hints` atom after the batch only when at least one live buffer was restored and the frontend backend is non-headless. Ordinary foreground registration, swap recovery, GUI active-window registration, the 800 ms delay, and active-buffer LSP consumption remain unchanged.
+- **Failure reproduction / source trace:** Before the correction, `mix test.debug test/minga_editor/handlers/session_restore_test.exs` failed the new non-headless restore regression because two restored buffers queued two delayed `:request_code_lens_and_inlay_hints` messages; the first `assert_receive` consumed one message and the following `refute_receive` unexpectedly received the duplicate within 900 ms.
+- **Implementation result:** Added the internal `schedule_lsp_refresh?: false` opt-out to `BufferRegistry.register_buffer/4`, used it only from `SessionRestore.restore_session_buffer/2`, and moved restore scheduling to `SessionRestore.apply_session_snapshot/2` after `restore_active_file/2`. The delayed atom, 800 ms delay, `LspEventHandler`, `LspActions`, decoration state, request kind, and active-buffer semantics were not changed.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/handlers/session_restore.ex`; `lib/minga_editor/handlers/buffer_registry.ex`; `test/minga_editor/handlers/session_restore_test.exs`; `test/minga_editor/handlers/lsp_event_handler_test.exs`.
+- **Focused validation:** `mix test.debug test/minga_editor/handlers/session_restore_test.exs` first reproduced the duplicate-timer failure, then passed 7 tests after the correction and boundary additions. `mix test.debug test/minga_editor/handlers/lsp_event_handler_test.exs` passed 34 tests. Final `mix test.llm test/minga_editor/handlers/session_restore_test.exs test/minga_editor/handlers/lsp_event_handler_test.exs test/minga_editor/lsp_actions_test.exs` passed 59 tests across 3 modules.
+- **Broad validation:** `make lint` passed changed-file Credo, compile, format, and incremental Dialyzer with zero errors; Credo reported one intentional global-state test warning and two unrelated pre-existing refactoring opportunities. `ERL_FLAGS='+S 2:2' mix test.quick --max-cases 4` and `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` each passed 9,752 tests with 58 doctests, 98 properties, 1 skipped, 572 excluded, and zero failures.
+- **Production lines added/removed before roadmap evidence:** `16 added / 16 removed`, net `0`, within the locked production net `<= 0`; per-file numstat: `lib/minga_editor/handlers/buffer_registry.ex 3 12`; `lib/minga_editor/handlers/session_restore.ex 13 4`.
+- **Test lines added/removed before roadmap evidence:** `141 added / 0 removed`; per-file numstat: `test/minga_editor/handlers/lsp_event_handler_test.exs 72 0`; `test/minga_editor/handlers/session_restore_test.exs 69 0`.
+- **Concepts added:** None. No new module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, per-buffer correlation state, mailbox tag, data representation, or LSP request shape was added.
+- **Concepts removed:** Removed duplicate restore-time LSP refresh scheduling for inactive restored buffers.
+- **Retained contracts:** Foreground buffer registration still schedules by default, swap recovery still uses foreground registration scheduling, GUI active-window registration remains unchanged, the delayed message remains the existing atom, the delay remains 800 ms, and code-lens/inlay request handling still targets the active buffer at consumption time.
+- **Pre-acceptance reviews:** Correctness confirmed the production schedule-once behavior and required explicit partial/all-missing non-headless boundaries plus corrected line evidence; the targeted recheck returned `RESOLVED/PASS`. Elixir craftsmanship returned `PASS/Lean` with no mandatory cut and confirmed the option, list comparison, timer clauses, and ownership are proportionate. Ponytail returned `PASS/Lean` with 0.99 confidence and confirmed the net-zero cut adds no concept or architecture creep.
+- **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed schedule-once ownership, live-buffer detection, headless/partial/all-missing boundaries, retained foreground/recovery/GUI behavior, active-buffer consumption, exact budgets, validation evidence, and merge safety.
+- **Findings resolved:** S09 implementation slice removes per-restored-buffer timers and replaces them with one post-batch active-buffer refresh for non-headless live restores.
+- **Discoveries affecting later work:** No contract drift, dependency change, owner invalidation, or budget issue required replanning. The LSP handler regression locks the current active-buffer consumer semantics, leaving buffer-correlated code-lens/inlay storage to the separately routed L06/L08 work.
+- **PR URL:** Pending.
+- **Implementation commit SHA:** Pending.
+- **Merge SHA:** Pending.
+- **Completion date:** Pending.

--- a/lib/minga_editor/handlers/buffer_registry.ex
+++ b/lib/minga_editor/handlers/buffer_registry.ex
@@ -195,23 +195,14 @@ defmodule MingaEditor.Handlers.BufferRegistry do
     state
   end
 
-  # Shared foreground buffer registration: updates the workspace, logs, highlights,
-  # and schedules foreground editor follow-up work. Buffer creation owns
-  # :buffer_opened broadcasts.
-  @spec register_buffer(state(), pid(), String.t()) :: state()
-  def register_buffer(state, buffer_pid, file_path) do
+  @spec register_buffer(state(), pid(), String.t(), keyword()) :: state()
+  def register_buffer(state, buffer_pid, file_path, opts \\ []) do
     state = Commands.add_buffer(state, buffer_pid)
     Minga.Log.info(:editor, "Opened: #{file_path}")
 
-    # Eagerly set up syntax highlighting for this specific buffer.
-    # Uses the PID-targeted variant so each restored buffer gets its
-    # own parse request, not just whoever is active last.
     state = HighlightSync.setup_for_buffer_pid(state, buffer_pid)
 
-    # Schedule code lens and inlay hint requests after LSP clients connect.
-    # The SyncServer handles didOpen via the event bus; by the time 800ms
-    # elapses the LSP client should be ready to serve requests.
-    if state.frontend.backend != :headless do
+    if state.frontend.backend != :headless and Keyword.get(opts, :schedule_lsp_refresh?, true) do
       Process.send_after(self(), :request_code_lens_and_inlay_hints, 800)
     end
 

--- a/lib/minga_editor/handlers/session_restore.ex
+++ b/lib/minga_editor/handlers/session_restore.ex
@@ -31,9 +31,18 @@ defmodule MingaEditor.Handlers.SessionRestore do
   def apply_session_snapshot(state, session) do
     Minga.Log.info(:editor, "Restored from previous session")
 
-    session.buffers
-    |> Enum.reduce(state, &restore_session_buffer/2)
-    |> restore_active_file(session.active_file)
+    pre_restore_buffers = state.workspace.buffers.list
+
+    state =
+      session.buffers
+      |> Enum.reduce(state, &restore_session_buffer/2)
+      |> restore_active_file(session.active_file)
+
+    if state.frontend.backend != :headless and state.workspace.buffers.list != pre_restore_buffers do
+      Process.send_after(self(), :request_code_lens_and_inlay_hints, 800)
+    end
+
+    state
   end
 
   @spec recover_swap_entries(state(), [Minga.Session.swap_entry()]) :: state()
@@ -76,7 +85,7 @@ defmodule MingaEditor.Handlers.SessionRestore do
            ) do
         {:ok, pid} ->
           :ok = Buffer.move_to(pid, {entry.cursor_line, entry.cursor_col})
-          BufferRegistry.register_buffer(state, pid, file)
+          BufferRegistry.register_buffer(state, pid, file, schedule_lsp_refresh?: false)
 
         {:error, _} ->
           state

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -56,6 +56,32 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
   end
 
   describe "handle/2" do
+    test "scheduled code lens and inlay hint refresh uses the active buffer" do
+      {state, inactive_path, active_path} = two_file_buffer_state()
+      inactive_client = start_fake_lsp_client()
+      active_client = start_fake_lsp_client()
+      [inactive_buffer, active_buffer] = state.workspace.buffers.list
+      register_lsp_client(inactive_buffer, inactive_client)
+      register_lsp_client(active_buffer, active_client)
+
+      {new_state, effects} = LspEventHandler.handle(state, :request_code_lens_and_inlay_hints)
+
+      active_uri = Minga.LSP.SyncServer.path_to_uri(active_path)
+      inactive_uri = Minga.LSP.SyncServer.path_to_uri(inactive_path)
+      assert effects == []
+      assert new_state.workspace.lsp_pending != %{}
+
+      assert_receive {:lsp_request, "textDocument/codeLens",
+                      %{"textDocument" => %{"uri" => ^active_uri}}, code_lens_caller, _}
+
+      assert_receive {:lsp_request, "textDocument/inlayHint",
+                      %{"textDocument" => %{"uri" => ^active_uri}}, inlay_hint_caller, _}
+
+      assert code_lens_caller == self()
+      assert inlay_hint_caller == self()
+      refute_receive {:lsp_request, _, %{"textDocument" => %{"uri" => ^inactive_uri}}, _, _}
+    end
+
     test "references uses one structured identity from request through no-result response" do
       state = file_buffer_state("hello\n")
       client = start_fake_lsp_client()
@@ -922,6 +948,48 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
     }
   end
 
+  defp two_file_buffer_state do
+    inactive_path = tmp_lsp_path("inactive")
+    active_path = tmp_lsp_path("active")
+    File.write!(inactive_path, "inactive\n")
+    File.write!(active_path, "active\n")
+    on_exit(fn -> File.rm(inactive_path) end)
+    on_exit(fn -> File.rm(active_path) end)
+
+    inactive_buffer =
+      start_supervised!(
+        {BufferProcess, file_path: inactive_path, content: "inactive\n"},
+        id: {:buffer, make_ref()}
+      )
+
+    active_buffer =
+      start_supervised!(
+        {BufferProcess, file_path: active_path, content: "active\n"},
+        id: {:buffer, make_ref()}
+      )
+
+    workspace = %{
+      workspace_for(active_buffer)
+      | buffers: %Buffers{
+          active: active_buffer,
+          list: [inactive_buffer, active_buffer],
+          active_index: 1
+        }
+    }
+
+    {%EditorState{
+       frontend: %MingaEditor.State.Frontend{port_manager: self()},
+       workspace: workspace
+     }, inactive_path, active_path}
+  end
+
+  defp tmp_lsp_path(name) do
+    Path.join(
+      System.tmp_dir!(),
+      "lsp-event-handler-#{name}-#{System.unique_integer([:positive])}.ex"
+    )
+  end
+
   defp workspace_for(buffer) do
     %MingaEditor.Session.State{
       viewport: Viewport.new(24, 80),
@@ -947,6 +1015,10 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
   defp fake_lsp_client_loop(parent) do
     receive do
+      {:"$gen_call", from, :capabilities} ->
+        GenServer.reply(from, %{"codeLensProvider" => true, "inlayHintProvider" => true})
+        fake_lsp_client_loop(parent)
+
       {:"$gen_call", from, :semantic_token_legend} ->
         GenServer.reply(from, {["variable"], []})
         fake_lsp_client_loop(parent)

--- a/test/minga_editor/handlers/session_restore_test.exs
+++ b/test/minga_editor/handlers/session_restore_test.exs
@@ -66,6 +66,74 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
     assert switched.parser.injection_ranges == with_spans.parser.injection_ranges
   end
 
+  test "non-headless session restore schedules one post-batch LSP refresh", %{tmp_dir: dir} do
+    first_path = Path.join(dir, "first.ex")
+    second_path = Path.join(dir, "second.ex")
+    File.write!(first_path, "defmodule First do\nend\n")
+    File.write!(second_path, "defmodule Second do\nend\n")
+
+    snapshot = %Snapshot{
+      version: 1,
+      buffers: [%BufferEntry{file: first_path}, %BufferEntry{file: second_path}],
+      active_file: first_path
+    }
+
+    assert :ok = Session.save(snapshot, session_dir: dir)
+
+    %EditorState{} = state = initial_state(dir)
+
+    restored =
+      SessionRestore.restore_session(%{state | frontend: %{state.frontend | backend: :tui}})
+
+    assert [_, _] = TabBar.visible_file_tabs(restored.shell_runtime.state.tab_bar)
+    assert Minga.Buffer.file_path(restored.workspace.buffers.active) == first_path
+    assert_receive :request_code_lens_and_inlay_hints, 1_000
+    refute_receive :request_code_lens_and_inlay_hints, 900
+  end
+
+  test "partial non-headless restore schedules one refresh for the live buffer", %{tmp_dir: dir} do
+    existing_path = Path.join(dir, "existing.ex")
+    missing_path = Path.join(dir, "missing.ex")
+    File.write!(existing_path, "defmodule Existing do\nend\n")
+
+    snapshot = %Snapshot{
+      version: 1,
+      buffers: [%BufferEntry{file: existing_path}, %BufferEntry{file: missing_path}],
+      active_file: missing_path
+    }
+
+    assert :ok = Session.save(snapshot, session_dir: dir)
+    %EditorState{} = state = initial_state(dir)
+
+    restored =
+      SessionRestore.restore_session(%{state | frontend: %{state.frontend | backend: :tui}})
+
+    assert [_] = TabBar.visible_file_tabs(restored.shell_runtime.state.tab_bar)
+    assert Minga.Buffer.file_path(restored.workspace.buffers.active) == existing_path
+    assert_receive :request_code_lens_and_inlay_hints, 1_000
+    refute_receive :request_code_lens_and_inlay_hints, 900
+  end
+
+  test "all-missing non-headless restore schedules no refresh", %{tmp_dir: dir} do
+    first_path = Path.join(dir, "first-missing.ex")
+    second_path = Path.join(dir, "second-missing.ex")
+
+    snapshot = %Snapshot{
+      version: 1,
+      buffers: [%BufferEntry{file: first_path}, %BufferEntry{file: second_path}],
+      active_file: first_path
+    }
+
+    assert :ok = Session.save(snapshot, session_dir: dir)
+    %EditorState{} = state = initial_state(dir)
+
+    restored =
+      SessionRestore.restore_session(%{state | frontend: %{state.frontend | backend: :tui}})
+
+    assert [] = TabBar.visible_file_tabs(restored.shell_runtime.state.tab_bar)
+    refute_receive :request_code_lens_and_inlay_hints, 900
+  end
+
   test "restoring loose files under a marker-bearing home keeps the workspace unset", %{
     tmp_dir: dir
   } do
@@ -132,6 +200,7 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
     assert [_] = TabBar.visible_file_tabs(restored.shell_runtime.state.tab_bar)
     assert Minga.Buffer.file_path(restored.workspace.buffers.active) == existing_path
     refute File.exists?(missing_path)
+    refute_receive :request_code_lens_and_inlay_hints, 20
   end
 
   @spec initial_state(String.t(), keyword()) :: EditorState.t()


### PR DESCRIPTION
# TL;DR

Schedule one code-lens and inlay-hint refresh after a session restore batch instead of one indistinguishable timer per restored buffer.

## Context

Each restore-time registration queued the same delayed atom, but the consumer always refreshes the buffer active when the message is handled. Multi-buffer restores therefore refreshed one active buffer repeatedly rather than correlating work to each restored buffer.

## Changes

- Suppress ordinary per-buffer refresh scheduling only while restoring saved buffers.
- Restore the persisted active file, then queue one existing refresh atom when at least one live buffer was restored on a non-headless frontend.
- Preserve foreground registration, swap recovery, GUI registration, the 800 ms delay, and current active-buffer LSP semantics.
- Add coverage for multi-buffer, partial, all-missing, headless, and active-buffer consumption boundaries.
- Record W081/S09 implementation and validation evidence in the lifecycle roadmap.

## Verification

- Focused restore and LSP handler/action suite passed 59 tests.
- `make lint` passed changed-file Credo, compile, format, and incremental Dialyzer.
- `ERL_FLAGS='+S 2:2' mix test.quick --max-cases 4` passed 9,752 tests.
- `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` passed 9,752 tests.

## Acceptance Criteria Addressed

- A successful non-headless restore batch schedules exactly one refresh.
- Partial restores schedule once; all-missing and headless restores schedule none.
- The refresh still targets the active buffer at consumption time.
- Foreground, swap-recovery, and GUI scheduling behavior remains unchanged.
- Production remains net zero and adds no new state, message, or correlation concept.
