### PR TITLE
test(agent): allow loaded native workflows to start

### DIFF
--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -861,7 +861,7 @@ defmodule MingaAgent.Providers.NativeTest do
             receive do
               {^release_ref, :release} -> {:ok, "slow result"}
             after
-              1_000 -> {:error, "slow tool timed out"}
+              2_000 -> {:error, "slow tool timed out"}
             end
           end
         )
@@ -903,8 +903,8 @@ defmodule MingaAgent.Providers.NativeTest do
 
       assert :ok = Native.send_prompt(pid, "Run both tools")
       assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
-      assert_receive {:tool_started, "slow_tool", slow_pid}, 1_000
-      assert_receive {:tool_started, "failing_tool", _failing_pid}, 1_000
+      assert_receive {:tool_started, "slow_tool", slow_pid}, 2_000
+      assert_receive {:tool_started, "failing_tool", _failing_pid}, 2_000
 
       send(slow_pid, {release_ref, :release})
       events = collect_run_events()
@@ -1610,7 +1610,7 @@ defmodule MingaAgent.Providers.NativeTest do
 
       assert_receive {:agent_provider_event,
                       %Event.ToolApproval{tool_call_id: "tc_1", reply_to: reply_to_1}},
-                     1_000
+                     2_000
 
       send(reply_to_1, {:tool_approval_response, "tc_1", :approve})
 


### PR DESCRIPTION
# TL;DR

Prevents two async native-provider tests from failing under full-suite scheduler load while preserving bounded, assertion-driven synchronization.

## Context

CI run `29907728893` failed two `MingaAgent.Providers.NativeTest` cases because expected tool-start and approval events arrived after the existing 1-second waits. The same failures reproduce locally with the CI seed and `max_cases: 8` when running the complete test file.

## Changes

- Extend the two concurrent tool-start waits from 1 to 2 seconds.
- Extend the blocking tool's matching internal deadline to 2 seconds.
- Extend the first batch approval wait from 1 to 2 seconds, matching the existing second approval wait.

The tests still require exact events, ordered tool results, approvals, and successful completion. No production behavior changes.

## Verification

- Before: `mix test test/minga_agent/providers/native_test.exs --seed 959170 --max-cases 8` reproduced 2 failures.
- After: the same command passed all 61 tests.
- `make lint` passed.
- Formatter and `git diff --check` passed.
- Final reviewer: PASS with 0.98 confidence.