### PR TITLE
test(macos): update observation authority inventory

### DIFF
--- a/macos/Tests/MingaTests/GUIObservationGuardrailTests.swift
+++ b/macos/Tests/MingaTests/GUIObservationGuardrailTests.swift
@@ -156,7 +156,7 @@ struct GUIObservationGuardrailTests {
         let sources = try productionSources()
         let actualObservable = try Set(sources.flatMap(observableDeclarations(in:)))
         #expect(actualObservable == Set(Self.observationTypeAllowlist.keys))
-        #expect(Self.observationTypeAllowlist.count == 37)
+        #expect(Self.observationTypeAllowlist.count == 36)
 
         let actualIgnored = occurrenceCounts(sources.flatMap(ignoredDeclarations(in:)))
         let expectedIgnored = Dictionary(uniqueKeysWithValues: Self.ignoredDeclarationAllowlist.keys.map { ($0, 1) })


### PR DESCRIPTION
## Summary

- correct the exact Observation authority inventory after #3017 removed `GUIFramePresentationMetrics`
- restore the Swift test gate on current `main`

## Context

PR #3017 auto-merged while its final Swift run was red solely because the rebased guardrail retained `37` after the allowlist dropped to `36`. This follow-up carries the already validated one-line correction.

## Validation

- `xcodebuild test -scheme Minga -configuration Debug -derivedDataPath DerivedData CODE_SIGNING_ALLOWED=NO -only-testing:MingaTests/GUIObservationGuardrailTests`
- Swift LSP diagnostics: clean
- `git diff --check origin/main...HEAD`
