### PR TITLE
refactor(editor): own native IPC endpoint lifecycle

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -26,11 +26,11 @@ The independent Ponytail gate produced 91 `ACCEPT`, 28 `ROUTE`, 11 `PRESERVE`, a
 Current accepted inventory:
 
 - **VERIFIED:** L01, L02, L04, L05, L10, L12
-- **IMPLEMENTED:** S34, S35, E02, E03
+- **IMPLEMENTED:** S34, S35, E02, E03, E05
 - **CANDIDATE, lifecycle:** L11, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30
 - **CANDIDATE, deletion:** D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40
 - **CANDIDATE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
-- **CANDIDATE, craftsmanship:** E05, E08
+- **CANDIDATE, craftsmanship:** E08
 - **CANDIDATE, data shape:** ES03, ES05, ES07, ES08, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES21, ES24
 
 ### Freshness wave at `6e175b87764145577999a1c04a532960cb89222f`
@@ -40,7 +40,7 @@ Eleven independent read-only GPT-5.5 `medium` batches checked all 85 remaining `
 - **STILL_REPRODUCIBLE, lifecycle:** L11, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30
 - **STILL_REPRODUCIBLE, deletion:** D05, D06, D08, D09, D10, D11, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D39
 - **STILL_REPRODUCIBLE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
-- **STILL_REPRODUCIBLE, craftsmanship:** E02, E03, E05, E08
+- **STILL_REPRODUCIBLE, craftsmanship:** E02, E03, E08
 - **STILL_REPRODUCIBLE, data shape:** ES03, ES05, ES07, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES24
 - **DRIFTED:** D13, D36, D40, S14, ES08, ES21
 
@@ -4172,3 +4172,27 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Final reviewer and delivery:** `PASS` with 0.99 confidence. The reviewer confirmed the complete seven-file artifact, clean single-struct normalization, no external construction or updates, preserved dispatch/effect semantics, enforced nonempty failure invariant, valid evidence, exact budgets, and merge safety. PR: https://github.com/jsmestad/minga/pull/3188. Implementation commit: `55b61e62a`.
 - **Merge evidence:** PR #3188 merged at `bd61a3cd999ee4bf54707b0bf32e2c63a37ccfe4` after CI run `29949270064` passed Dialyzer, Elixir, Swift macOS, Swift protocol integration, Go TUI, Zig, lint/format, Neovim conformance, Go TUI boot smoke, and keystroke latency.
 - **Completion date:** 2026-07-22.
+
+### W100/E05: Own native IPC endpoint generations
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** E05
+- **Planning profile:** `E05Planner`, editor-lifecycle-planner, read-only.
+- **Implementation profile:** `E05Worker`, no delegation.
+- **Ready provenance:** Locked by `agent://E05Planner` for current SHA `356f445083a3a4ad888406392aa242e0608c6bd9`; scope was exactly one `MingaEditor.NativeIPC.Endpoint` owner, `Server.State` endpoint aggregation, server migration, focused native IPC owner tests, and this evidence.
+- **Observable result:** One internal `%MingaEditor.NativeIPC.Endpoint{}` now owns one AF_UNIX listener, identity, and `current.json` descriptor generation. Server workflow still owns option/env parsing, runtime directory admission, acceptor startup, connection task supervision, identity diagnostics, and termination.
+- **Failure reproduction / source trace:** Before implementation there was no `MingaEditor.NativeIPC.Endpoint`; `Server.State` stored flat `listener`, `descriptor_path`, and `identity`; `Server` owned endpoint listener, descriptor publication, identity construction, partial rollback, published rollback, identity-matched descriptor removal, and termination cleanup directly.
+- **Implementation result:** Added `Endpoint.open/1` and `Endpoint.close/1`, moved listener/socket/descriptor publication and idempotent identity-matched cleanup helpers into the endpoint owner, migrated `Server.init/1`, acceptor startup, `identity/1`, and `terminate/2` to consume the endpoint value, and changed `Server.State` to aggregate `%Endpoint{}` plus the acceptor pid.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/native_ipc/endpoint.ex`; `lib/minga_editor/native_ipc/server.ex`; `lib/minga_editor/native_ipc/server/state.ex`; `test/minga/frontend/native_ipc_test.exs`.
+- **Focused validation:** `mix test test/minga/frontend/native_ipc_test.exs --seed 0` passed 9 tests after formatting.
+- **Formatting and reference validation:** `mix format --check-formatted lib/minga_editor/native_ipc/endpoint.ex lib/minga_editor/native_ipc/server.ex lib/minga_editor/native_ipc/server/state.ex test/minga/frontend/native_ipc_test.exs docs/workstreams/editor-lifecycle-roadmap.md` passed after formatting the touched source and test paths.
+- **Production lines added/removed before roadmap evidence:** New `Endpoint` adds 157 lines; existing native IPC production files add 19 and remove 136 lines, net production `+40`, within the locked target `<= +40` and hard stop `<= +50`.
+- **Test lines added/removed before roadmap evidence:** `test/minga/frontend/native_ipc_test.exs` added 61 and removed 23 lines, net test `+38`, within the locked target `<= +70` and hard stop `<= +90`.
+- **Concepts added:** Exactly one production concept: `MingaEditor.NativeIPC.Endpoint`. No process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, descriptor representation, frontend path, fallback, or generic resource abstraction was added.
+- **Concepts removed:** Removed flat endpoint fields from `Server.State` and removed duplicated server-owned listener/socket/descriptor rollback helper concepts from `Server`.
+- **Retained contracts:** Native IPC descriptor JSON shape and version, max frame size, AF_UNIX listener options, socket and descriptor lstat UID/type/mode checks, atomic descriptor publication, identity-matched descriptor removal, listener closure, socket unlinking, token/authentication identity, app liveness inputs, runtime parent/directory policy, acceptor-after-acquisition ordering, connection command handling, wait/open behavior, supervisor strategy, and macOS helper descriptor consumption remain unchanged.
+- **Findings resolved:** E05's split endpoint-resource ownership is resolved by giving one internal Endpoint value the complete generation acquisition/publication/cleanup lifecycle while leaving Server as the process workflow owner.
+- **Broad validation:** `make lint` passed Credo, compile, format, and incremental Dialyzer with zero Dialyzer errors; Credo retained two pre-existing buffer-management refactoring opportunities and one registry-test warning. `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` passed 9,712 tests, 58 doctests, and 98 properties with zero failures.
+- **Pre-acceptance reviews:** Correctness returned `PASS/Lean` with 0.99 confidence, Elixir craftsmanship returned `PASS/Lean` with 0.98 confidence, and Ponytail returned `PASS/Lean`; all three confirmed the single-owner lifecycle, original-error preservation, identity-safe idempotent cleanup, retained contracts, exact line budgets, and no mandatory correction.
+- **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the complete five-file artifact, sole Endpoint generation owner, no parallel representation, original-error preservation, identity-safe idempotent cleanup, retained IPC behavior, exact budgets, grounded validation evidence, and merge safety.
+- **Discoveries affecting later work:** `Server.identity_base/1` retains its private random-secret helper because Server still owns option/env identity inputs while Endpoint owns socket and descriptor generation; sharing it would add API without removing a concept. No replan trigger, owner drift, trust-boundary change, protocol/frontend dependency, compatibility need, second endpoint concept, production budget miss, or test budget issue was found.

--- a/lib/minga_editor/native_ipc/endpoint.ex
+++ b/lib/minga_editor/native_ipc/endpoint.ex
@@ -1,0 +1,157 @@
+defmodule MingaEditor.NativeIPC.Endpoint do
+  @moduledoc false
+
+  import Bitwise
+
+  alias MingaEditor.NativeIPC.Identity
+
+  @max_frame 65_536
+  @descriptor_version 1
+
+  @enforce_keys [:listener, :identity, :descriptor_path]
+  defstruct [:listener, :identity, :descriptor_path]
+
+  @type t :: %__MODULE__{
+          listener: port(),
+          identity: Identity.t(),
+          descriptor_path: String.t()
+        }
+
+  @spec open(keyword()) :: {:ok, t()} | {:error, term()}
+  def open(opts) do
+    runtime_dir = Keyword.fetch!(opts, :runtime_dir)
+    base = Keyword.fetch!(opts, :identity_base)
+    socket_path = random_socket_path(runtime_dir)
+
+    with {:ok, listener} <- listen(socket_path) do
+      endpoint = %__MODULE__{
+        listener: listener,
+        identity: build_identity(base, socket_path),
+        descriptor_path: Path.join(runtime_dir, "current.json")
+      }
+
+      with :ok <- File.chmod(socket_path, 0o600),
+           :ok <- validate_private_file(socket_path, :other, base.euid, 0o600),
+           :ok <- publish_descriptor(endpoint.descriptor_path, endpoint.identity, base.euid) do
+        {:ok, endpoint}
+      else
+        {:error, _reason} = error ->
+          close(endpoint)
+          error
+      end
+    end
+  end
+
+  @spec close(t()) :: :ok
+  def close(%__MODULE__{} = endpoint) do
+    remove_descriptor_if_current(endpoint.descriptor_path, endpoint.identity.core_instance_id)
+    _ = :gen_tcp.close(endpoint.listener)
+    _ = File.rm(endpoint.identity.socket_path)
+    :ok
+  end
+
+  @spec build_identity(map(), String.t()) :: Identity.t()
+  defp build_identity(base, socket_path) do
+    Identity.new(
+      app_instance_id: base.app_instance_id,
+      core_instance_id: base.core_instance_id,
+      app_pid: base.app_pid,
+      euid: base.euid,
+      launch_nonce: base.launch_nonce,
+      socket_path: socket_path,
+      token: base.token
+    )
+  end
+
+  @spec listen(String.t()) :: {:ok, port()} | {:error, term()}
+  defp listen(socket_path) do
+    :gen_tcp.listen(0, [
+      :binary,
+      {:ifaddr, {:local, socket_path}},
+      {:active, false},
+      {:packet, 4},
+      {:packet_size, @max_frame},
+      {:reuseaddr, true}
+    ])
+  end
+
+  @spec publish_descriptor(String.t(), Identity.t(), non_neg_integer()) :: :ok | {:error, term()}
+  defp publish_descriptor(path, identity, euid) do
+    temp = path <> ".tmp-#{random_secret(8)}"
+
+    with :ok <-
+           File.write(
+             temp,
+             JSON.encode!(Identity.descriptor(identity, @descriptor_version)) <> "\n",
+             [:exclusive]
+           ),
+         :ok <- File.chmod(temp, 0o600),
+         :ok <- validate_private_file(temp, :regular, euid, 0o600) do
+      publish_current_descriptor(path, temp, identity, euid)
+    else
+      {:error, _reason} = error -> remove_temp_descriptor(temp, error)
+    end
+  end
+
+  @spec publish_current_descriptor(String.t(), String.t(), Identity.t(), non_neg_integer()) ::
+          :ok | {:error, term()}
+  defp publish_current_descriptor(path, temp, identity, euid) do
+    case File.rename(temp, path) do
+      :ok -> validate_published_descriptor(path, identity, euid)
+      {:error, _reason} = error -> remove_temp_descriptor(temp, error)
+    end
+  end
+
+  @spec validate_published_descriptor(String.t(), Identity.t(), non_neg_integer()) ::
+          :ok | {:error, term()}
+  defp validate_published_descriptor(path, identity, euid) do
+    case validate_private_file(path, :regular, euid, 0o600) do
+      :ok ->
+        :ok
+
+      {:error, _reason} = error ->
+        remove_descriptor_if_current(path, identity.core_instance_id)
+        error
+    end
+  end
+
+  @spec remove_temp_descriptor(String.t(), {:error, term()}) :: {:error, term()}
+  defp remove_temp_descriptor(temp, error) do
+    _ = File.rm(temp)
+    error
+  end
+
+  @spec remove_descriptor_if_current(String.t(), String.t()) :: :ok
+  defp remove_descriptor_if_current(path, core_instance_id) do
+    with {:ok, contents} <- File.read(path),
+         {:ok, %{"core_instance_id" => ^core_instance_id}} <- JSON.decode(contents) do
+      _ = File.rm(path)
+    end
+
+    :ok
+  end
+
+  @spec validate_private_file(String.t(), atom(), non_neg_integer(), non_neg_integer()) ::
+          :ok | {:error, term()}
+  defp validate_private_file(path, expected_type, euid, permissions) do
+    case File.lstat(path) do
+      {:ok, %File.Stat{type: ^expected_type, uid: ^euid, mode: mode}}
+      when (mode &&& 0o777) == permissions ->
+        :ok
+
+      {:ok, %File.Stat{} = stat} ->
+        {:error, {:insecure_runtime_entry, path, stat.type, stat.uid, stat.mode &&& 0o777}}
+
+      {:error, reason} ->
+        {:error, {:runtime_entry, path, reason}}
+    end
+  end
+
+  @spec random_socket_path(String.t()) :: String.t()
+  defp random_socket_path(runtime_dir),
+    do: Path.join(runtime_dir, "control-#{random_secret(12)}.sock")
+
+  @spec random_secret(pos_integer()) :: String.t()
+  defp random_secret(bytes),
+    do: bytes |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
+end

--- a/lib/minga_editor/native_ipc/server.ex
+++ b/lib/minga_editor/native_ipc/server.ex
@@ -6,11 +6,10 @@ defmodule MingaEditor.NativeIPC.Server do
   use GenServer
   import Bitwise
 
+  alias MingaEditor.NativeIPC.Endpoint
   alias MingaEditor.NativeIPC.Identity
   alias MingaEditor.NativeIPC.Server.State
 
-  @max_frame 65_536
-  @descriptor_version 1
   @runtime_directory_name "com.minga.editor"
 
   @typedoc "Server option."
@@ -58,8 +57,8 @@ defmodule MingaEditor.NativeIPC.Server do
          :ok <- validate_private_parent(runtime_parent, base.euid),
          {:ok, runtime_dir} <- runtime_dir(opts, runtime_parent),
          :ok <- prepare_runtime_dir(runtime_dir, base.euid),
-         {:ok, {listener, descriptor_path, identity}} <- open_endpoint(runtime_dir, base) do
-      finalize_endpoint(listener, task_supervisor, identity, connection_opts, descriptor_path)
+         {:ok, endpoint} <- Endpoint.open(runtime_dir: runtime_dir, identity_base: base) do
+      finalize_endpoint(endpoint, task_supervisor, connection_opts)
     else
       {:error, reason} -> {:stop, reason}
     end
@@ -67,7 +66,7 @@ defmodule MingaEditor.NativeIPC.Server do
 
   @impl true
   @spec handle_call(term(), GenServer.from(), State.t()) :: {:reply, term(), State.t()}
-  def handle_call(:identity, _from, state), do: {:reply, state.identity, state}
+  def handle_call(:identity, _from, state), do: {:reply, state.endpoint.identity, state}
 
   @impl true
   @spec handle_info(term(), State.t()) :: {:noreply, State.t()} | {:stop, term(), State.t()}
@@ -80,9 +79,7 @@ defmodule MingaEditor.NativeIPC.Server do
   @impl true
   @spec terminate(term(), State.t()) :: :ok
   def terminate(_reason, state) do
-    _ = :gen_tcp.close(state.listener)
-    _ = File.rm(state.identity.socket_path)
-    remove_descriptor_if_current(state.descriptor_path, state.identity.core_instance_id)
+    Endpoint.close(state.endpoint)
     :ok
   end
 
@@ -104,19 +101,6 @@ defmodule MingaEditor.NativeIPC.Server do
          token: random_secret(32)
        }}
     end
-  end
-
-  @spec build_identity(map(), String.t()) :: Identity.t()
-  defp build_identity(base, socket_path) do
-    Identity.new(
-      app_instance_id: base.app_instance_id,
-      core_instance_id: base.core_instance_id,
-      app_pid: base.app_pid,
-      euid: base.euid,
-      launch_nonce: base.launch_nonce,
-      socket_path: socket_path,
-      token: base.token
-    )
   end
 
   @spec required_string(keyword(), atom(), String.t()) :: {:ok, String.t()} | {:error, term()}
@@ -235,18 +219,6 @@ defmodule MingaEditor.NativeIPC.Server do
     end
   end
 
-  @spec listen(String.t()) :: {:ok, port()} | {:error, term()}
-  defp listen(socket_path) do
-    :gen_tcp.listen(0, [
-      :binary,
-      {:ifaddr, {:local, socket_path}},
-      {:active, false},
-      {:packet, 4},
-      {:packet_size, @max_frame},
-      {:reuseaddr, true}
-    ])
-  end
-
   @spec accept_loop(port(), atom(), Identity.t(), keyword()) :: no_return()
   defp accept_loop(listener, task_supervisor, identity, opts) do
     case :gen_tcp.accept(listener) do
@@ -271,100 +243,18 @@ defmodule MingaEditor.NativeIPC.Server do
     end
   end
 
-  @spec publish_descriptor(String.t(), Identity.t(), non_neg_integer()) ::
-          :ok | {:error, term()}
-  defp publish_descriptor(path, identity, euid) do
-    temp = path <> ".tmp-#{random_secret(8)}"
-
-    with :ok <-
-           File.write(
-             temp,
-             JSON.encode!(Identity.descriptor(identity, @descriptor_version)) <> "\n",
-             [:exclusive]
-           ),
-         :ok <- File.chmod(temp, 0o600),
-         :ok <- validate_private_file(temp, :regular, euid, 0o600) do
-      publish_current_descriptor(path, temp, identity, euid)
-    else
-      {:error, _reason} = error -> remove_temp_descriptor(temp, error)
-    end
-  end
-
-  defp open_endpoint(runtime_dir, base) do
-    socket_path = random_socket_path(runtime_dir)
-
-    with {:ok, listener} <- listen(socket_path) do
-      with :ok <- File.chmod(socket_path, 0o600),
-           :ok <- validate_private_file(socket_path, :other, base.euid, 0o600),
-           identity = build_identity(base, socket_path),
-           descriptor_path = Path.join(runtime_dir, "current.json"),
-           :ok <- publish_descriptor(descriptor_path, identity, base.euid) do
-        {:ok, {listener, descriptor_path, identity}}
-      else
-        {:error, _reason} = error ->
-          rollback_listener_socket(listener, socket_path)
-          error
-      end
-    end
-  end
-
-  defp finalize_endpoint(listener, task_supervisor, identity, connection_opts, descriptor_path) do
+  defp finalize_endpoint(%Endpoint{} = endpoint, task_supervisor, connection_opts) do
     acceptor =
-      spawn_link(fn -> accept_loop(listener, task_supervisor, identity, connection_opts) end)
+      spawn_link(fn ->
+        accept_loop(endpoint.listener, task_supervisor, endpoint.identity, connection_opts)
+      end)
 
-    {:ok, State.new(listener, acceptor, descriptor_path, identity)}
+    {:ok, State.new(endpoint, acceptor)}
   catch
     kind, reason ->
-      rollback_published_endpoint(descriptor_path, identity, listener)
+      Endpoint.close(endpoint)
       :erlang.raise(kind, reason, __STACKTRACE__)
   end
-
-  defp publish_current_descriptor(path, temp, identity, euid) do
-    case File.rename(temp, path) do
-      :ok ->
-        case validate_private_file(path, :regular, euid, 0o600) do
-          :ok ->
-            :ok
-
-          {:error, _reason} = error ->
-            remove_descriptor_if_current(path, identity.core_instance_id)
-            error
-        end
-
-      {:error, _reason} = error ->
-        remove_temp_descriptor(temp, error)
-    end
-  end
-
-  defp remove_temp_descriptor(temp, error) do
-    _ = File.rm(temp)
-    error
-  end
-
-  defp rollback_published_endpoint(descriptor_path, identity, listener) do
-    remove_descriptor_if_current(descriptor_path, identity.core_instance_id)
-    rollback_listener_socket(listener, identity.socket_path)
-  end
-
-  defp rollback_listener_socket(listener, socket_path) do
-    _ = :gen_tcp.close(listener)
-    _ = File.rm(socket_path)
-    :ok
-  end
-
-  @spec remove_descriptor_if_current(String.t(), String.t()) :: :ok
-  defp remove_descriptor_if_current(path, core_instance_id) do
-    with {:ok, contents} <- File.read(path),
-         {:ok, %{"core_instance_id" => ^core_instance_id}} <- JSON.decode(contents) do
-      _ = File.rm(path)
-    end
-
-    :ok
-  end
-
-  @spec random_socket_path(String.t()) :: String.t()
-  defp random_socket_path(runtime_dir),
-    do: Path.join(runtime_dir, "control-#{random_secret(12)}.sock")
 
   @spec random_secret(pos_integer()) :: String.t()
   defp random_secret(bytes),

--- a/lib/minga_editor/native_ipc/server/state.ex
+++ b/lib/minga_editor/native_ipc/server/state.ex
@@ -1,27 +1,20 @@
 defmodule MingaEditor.NativeIPC.Server.State do
   @moduledoc "Internal state owned by the native IPC endpoint server."
 
-  alias MingaEditor.NativeIPC.Identity
+  alias MingaEditor.NativeIPC.Endpoint
 
-  @enforce_keys [:listener, :acceptor, :descriptor_path, :identity]
-  defstruct [:listener, :acceptor, :descriptor_path, :identity]
+  @enforce_keys [:endpoint, :acceptor]
+  defstruct [:endpoint, :acceptor]
 
   @typedoc "Native IPC endpoint server state."
   @type t :: %__MODULE__{
-          listener: port(),
-          acceptor: pid(),
-          descriptor_path: String.t(),
-          identity: Identity.t()
+          endpoint: Endpoint.t(),
+          acceptor: pid()
         }
 
   @doc "Builds server state after the endpoint and acceptor are ready."
-  @spec new(port(), pid(), String.t(), Identity.t()) :: t()
-  def new(listener, acceptor, descriptor_path, %Identity{} = identity) do
-    %__MODULE__{
-      listener: listener,
-      acceptor: acceptor,
-      descriptor_path: descriptor_path,
-      identity: identity
-    }
+  @spec new(Endpoint.t(), pid()) :: t()
+  def new(%Endpoint{} = endpoint, acceptor) when is_pid(acceptor) do
+    %__MODULE__{endpoint: endpoint, acceptor: acceptor}
   end
 end

--- a/test/minga/frontend/native_ipc_test.exs
+++ b/test/minga/frontend/native_ipc_test.exs
@@ -4,6 +4,8 @@ defmodule Minga.Frontend.NativeIPCTest do
 
   import Bitwise
 
+  alias MingaEditor.NativeIPC.Endpoint
+  alias MingaEditor.NativeIPC.Identity
   alias MingaEditor.NativeIPC.Supervisor, as: IPCSupervisor
   alias Minga.Frontend.WaitRequests
 
@@ -140,7 +142,7 @@ defmodule Minga.Frontend.NativeIPCTest do
     assert inspect(reason) =~ "insecure_runtime_entry"
   end
 
-  test "rolls back listener socket and temp descriptor when descriptor publication fails after listen",
+  test "endpoint rolls back listener socket and temp descriptor when descriptor publication fails",
        ctx do
     suffix = System.unique_integer([:positive])
     parent = Path.join("/tmp", "minga-native-ipc-rollback-#{suffix}")
@@ -155,34 +157,56 @@ defmodule Minga.Frontend.NativeIPCTest do
 
     on_exit(fn -> File.rm_rf!(parent) end)
 
-    previous_trap = Process.flag(:trap_exit, true)
+    assert {:error, :eisdir} =
+             Endpoint.open(runtime_dir: runtime_dir, identity_base: endpoint_base(ctx))
 
-    result =
-      IPCSupervisor.start_link(
-        name: nil,
-        server_name: nil,
-        task_supervisor_name: Module.concat(__MODULE__, "RollbackTasks#{suffix}"),
-        runtime_parent: parent,
-        runtime_dir: runtime_dir,
-        app_instance_id: "app-instance-1234567890",
-        app_pid: ctx.app_pid,
-        euid: File.stat!(File.cwd!()).uid,
-        kill_checker: fn _pid -> true end
-      )
-
-    receive do
-      {:EXIT, _pid, _reason} -> :ok
-    after
-      0 -> :ok
-    end
-
-    Process.flag(:trap_exit, previous_trap)
-    assert {:error, {:shutdown, {:failed_to_start_child, _, :eisdir}}} = result
     assert File.dir?(blocker)
     entries = File.ls!(runtime_dir)
     refute Enum.any?(entries, &String.starts_with?(&1, "control-"))
     refute Enum.any?(entries, &String.starts_with?(&1, "current.json.tmp-"))
     assert entries == ["current.json"]
+  end
+
+  test "endpoint close is idempotent and removes only the current generation", ctx do
+    suffix = System.unique_integer([:positive])
+    runtime_dir = Path.join("/tmp", "minga-native-ipc-close-#{suffix}")
+    File.rm_rf!(runtime_dir)
+    File.mkdir!(runtime_dir)
+    File.chmod!(runtime_dir, 0o700)
+
+    on_exit(fn -> File.rm_rf!(runtime_dir) end)
+
+    assert {:ok, endpoint} =
+             Endpoint.open(runtime_dir: runtime_dir, identity_base: endpoint_base(ctx))
+
+    descriptor_path = Path.join(runtime_dir, "current.json")
+    descriptor = JSON.decode!(File.read!(descriptor_path))
+    socket = File.lstat!(endpoint.identity.socket_path)
+    descriptor_stat = File.lstat!(descriptor_path)
+    assert socket.type == :other
+    assert (socket.mode &&& 0o777) == 0o600
+    assert descriptor_stat.type == :regular
+    assert (descriptor_stat.mode &&& 0o777) == 0o600
+    assert descriptor["core_instance_id"] == endpoint.identity.core_instance_id
+
+    assert :ok = Endpoint.close(endpoint)
+    assert :ok = Endpoint.close(endpoint)
+    refute File.exists?(endpoint.identity.socket_path)
+    refute File.exists?(descriptor_path)
+
+    assert {:ok, replacement} =
+             Endpoint.open(runtime_dir: runtime_dir, identity_base: endpoint_base(ctx))
+
+    stale_descriptor =
+      replacement.identity
+      |> Identity.descriptor(1)
+      |> Map.put(:core_instance_id, "replacement-core")
+
+    File.write!(descriptor_path, JSON.encode!(stale_descriptor) <> "\n")
+    File.chmod!(descriptor_path, 0o600)
+
+    assert :ok = Endpoint.close(replacement)
+    assert JSON.decode!(File.read!(descriptor_path))["core_instance_id"] == "replacement-core"
   end
 
   test "authenticates a real AF_UNIX probe and rejects a substituted token", ctx do
@@ -323,6 +347,20 @@ defmodule Minga.Frontend.NativeIPCTest do
     assert :ok = Supervisor.stop(ctx.supervisor)
     assert {:error, :closed} = :gen_tcp.recv(socket, 0, 1_000)
   end
+
+  defp endpoint_base(ctx) do
+    %{
+      app_instance_id: "app-instance-1234567890",
+      core_instance_id: unique_secret(16),
+      app_pid: ctx.app_pid,
+      euid: File.stat!(File.cwd!()).uid,
+      launch_nonce: "launch-nonce-123456",
+      token: unique_secret(32)
+    }
+  end
+
+  defp unique_secret(bytes),
+    do: bytes |> :crypto.strong_rand_bytes() |> Base.url_encode64(padding: false)
 
   defp connect(descriptor) do
     {:ok, socket} =


### PR DESCRIPTION
## TL;DR

Own each native IPC endpoint generation as one value so acquisition rollback, acceptor-start failure, normal termination, and repeated cleanup share the same lifecycle path.

## Context

This is W100/E05 from `docs/workstreams/editor-lifecycle-roadmap.md`. The server previously stored listener, identity, and descriptor state separately while also owning multiple cleanup paths.

## Changes

- Add `MingaEditor.NativeIPC.Endpoint` as the sole owner of one listener, identity, socket path, and published descriptor generation.
- Preserve original acquisition errors while routing every post-listen failure through idempotent, identity-matched cleanup.
- Aggregate the endpoint in `Server.State`; keep runtime admission, option parsing, acceptor workflow, and connection supervision in `Server`.
- Add direct regressions for partial acquisition rollback, repeated close, matched descriptor removal, and preservation of a replacement generation.
- Record implementation, validation, review, and line-budget evidence in the lifecycle roadmap.

## Compatibility

The native IPC descriptor bytes and version, AF_UNIX listener options, authentication identity, lstat checks, atomic publication, runtime-directory policy, connection commands, wait/open behavior, supervisor strategy, and macOS helper consumption are unchanged.

## Verification

- `mix test test/minga/frontend/native_ipc_test.exs --seed 0` passed 9 tests.
- `make lint` passed Credo, compile, format, and incremental Dialyzer with zero Dialyzer errors.
- `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` passed 9,712 tests, 58 doctests, and 98 properties with zero failures.
- Final acceptance review returned PASS with 0.99 confidence.
