### PR TITLE
refactor(render): own observed buffer lifecycle

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -26,11 +26,11 @@ The independent Ponytail gate produced 91 `ACCEPT`, 28 `ROUTE`, 11 `PRESERVE`, a
 Current accepted inventory:
 
 - **VERIFIED:** L01, L02, L04, L05, L10, L12
-- **IMPLEMENTED:** S34, S35, E02, E03, E05
+- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08
 - **CANDIDATE, lifecycle:** L11, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30
 - **CANDIDATE, deletion:** D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40
 - **CANDIDATE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
-- **CANDIDATE, craftsmanship:** E08
+- **CANDIDATE, craftsmanship:** (none)
 - **CANDIDATE, data shape:** ES03, ES05, ES07, ES08, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES21, ES24
 
 ### Freshness wave at `6e175b87764145577999a1c04a532960cb89222f`
@@ -40,7 +40,7 @@ Eleven independent read-only GPT-5.5 `medium` batches checked all 85 remaining `
 - **STILL_REPRODUCIBLE, lifecycle:** L11, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30
 - **STILL_REPRODUCIBLE, deletion:** D05, D06, D08, D09, D10, D11, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D39
 - **STILL_REPRODUCIBLE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
-- **STILL_REPRODUCIBLE, craftsmanship:** E02, E03, E08
+- **STILL_REPRODUCIBLE, craftsmanship:** E02, E03
 - **STILL_REPRODUCIBLE, data shape:** ES03, ES05, ES07, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES24
 - **DRIFTED:** D13, D36, D40, S14, ES08, ES21
 
@@ -4198,4 +4198,31 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Final reviewer and delivery:** `PASS` with 0.99 confidence. PR: https://github.com/jsmestad/minga/pull/3191. Implementation commit: `cc12c99af`.
 - **Discoveries affecting later work:** `Server.identity_base/1` retains its private random-secret helper because Server still owns option/env identity inputs while Endpoint owns socket and descriptor generation; sharing it would add API without removing a concept. No replan trigger, owner drift, trust-boundary change, protocol/frontend dependency, compatibility need, second endpoint concept, production budget miss, or test budget issue was found.
 - **Merge evidence:** PR #3191 merged at `b66986d2a73c6c951fa77dcbb2c3385b161139af` after CI run `29952162881` passed Dialyzer, Elixir, Swift macOS, Swift protocol integration, Go TUI, Zig, lint/format, Neovim conformance, Go TUI boot smoke, and keystroke latency.
+- **Completion date:** 2026-07-22.
+
+### W101/E08: Own renderer observed buffer lifecycle
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** E08
+- **Planning profile:** `E08Planner`, editor-lifecycle-planner, read-only.
+- **Implementation profile:** `E08Worker`, no delegation.
+- **Ready provenance:** Locked by `agent://E08Planner` for current SHA `6c26c791c57b74080de2e8b436782c19520ec732`; scope was exactly one renderer-private `MingaEditor.Renderer.ObservedBuffers` owner, clean-cutover `Renderer.State` aggregation, direct `:DOWN` routing from `FrameHandler`, focused owner/renderer tests, and this evidence.
+- **Observable result:** `MingaEditor.Renderer.State` now carries one `%MingaEditor.Renderer.ObservedBuffers{monitors, versions}` aggregate instead of parallel `buffer_monitors` and `buffer_versions` root maps. Window reconciliation, buffer version recording, filtered intent-version reads, demonitoring, and exact PID plus ref `:DOWN` matching flow through the owner; resident-window retirement stays in `State`.
+- **Failure reproduction / source trace:** Before implementation, source inspection at the locked SHA showed `Renderer.State` defining separate `buffer_monitors` and `buffer_versions`, private `reconcile_monitors/2`, and split `drop_buffer_down/3` map updates; `BufferChanges` directly read and wrote `state.buffer_versions` and exposed `handle_down/3`; `FrameHandler` routed `{:DOWN, ...}` through `BufferChanges.handle_down/3`.
+- **Implementation result:** Added the single observed-buffer owner with `new/0`, `reconcile/2`, `record_version/3`, `drop_down/3`, `recorded_version/2`, and `monitored_versions/2`; replaced State root maps with `observed_buffers`; deleted State's private monitor reconciliation and BufferChanges DOWN shim; kept consume-before-fanout ordering and telemetry metadata; routed renderer mailbox `:DOWN` directly to `State.drop_buffer_down/3`.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/renderer/observed_buffers.ex`; `lib/minga_editor/renderer/state.ex`; `lib/minga_editor/renderer/buffer_changes.ex`; `lib/minga_editor/renderer/frame_handler.ex`; `test/minga_editor/renderer/observed_buffers_test.exs`; `test/minga_editor/renderer/buffer_changes_test.exs`; `test/minga_editor/renderer/server_test.exs`.
+- **Focused validation:** `mix test.debug test/minga_editor/renderer/observed_buffers_test.exs test/minga_editor/renderer/buffer_changes_test.exs` passed 9 tests. `mix test.debug test/minga_editor/renderer/server_test.exs:899` passed 1 test with 35 excluded.
+- **Formatting and reference validation:** `mix format --check-formatted lib/minga_editor/renderer/observed_buffers.ex lib/minga_editor/renderer/state.ex lib/minga_editor/renderer/buffer_changes.ex lib/minga_editor/renderer/frame_handler.ex test/minga_editor/renderer/observed_buffers_test.exs test/minga_editor/renderer/buffer_changes_test.exs test/minga_editor/renderer/server_test.exs docs/workstreams/editor-lifecycle-roadmap.md` passed after formatting the touched source and test paths.
+- **Production lines added/removed before roadmap evidence:** New `ObservedBuffers` adds 71 lines; existing renderer production files add 27 and remove 54 lines, net production `+44`, within the locked target `<= +45` and hard stop `<= +50`.
+- **Test lines added/removed before roadmap evidence:** New owner tests add 88 lines; existing renderer tests add 17 and remove 9 lines, net test `+96`, within the locked `<= +120` budget.
+- **Concepts added:** Exactly one production concept: `MingaEditor.Renderer.ObservedBuffers`. No process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, adapter, manager, generic wrapper, or parallel observed-buffer representation was added.
+- **Concepts removed:** Removed renderer root `buffer_monitors` and `buffer_versions`, removed State's private monitor reconciliation helper, and removed `BufferChanges.handle_down/3` as a DOWN-routing shim.
+- **Retained contracts:** Resident-window construction and retirement remain State-owned; BufferChanges still consumes changed buffers before fanout and preserves telemetry metadata; Intent still produces `buffer_versions`; recovery, frame credit, acknowledgement handling, stale retry behavior, frontend protocol, and render DTO shapes remain unchanged.
+- **Findings resolved:** E08's split renderer monitor/version lifecycle is resolved by centralizing monitor refs, consumed versions, demonitoring, filtered reads, record writes, and exact DOWN matching in one renderer-private owner while keeping resident windows outside that owner.
+- **Broad validation:** `make lint` passed Credo, compile, format, and incremental Dialyzer with zero Dialyzer errors; Credo retained two pre-existing buffer-management refactoring opportunities and one registry-test warning. `mix test.quick` returned a session-manager cleanup timeout and a subagent credential-state failure outside the renderer paths; the exact two tests passed with the original seed and one-case concurrency. `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` then passed 9,715 tests, 58 doctests, and 98 properties with zero failures.
+- **Pre-acceptance reviews:** Correctness returned `PASS/Lean` with 0.99 confidence, Elixir craftsmanship returned `PASS/Lean` with 0.99 confidence, and Ponytail returned `PASS/Lean`; all three confirmed the single owner, monitor/version subset invariant, exact DOWN handling, consume-before-fanout ordering, clean cutover, exact budgets, and no mandatory correction.
+- **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the complete eight-file artifact, sole monitor/version owner, subset invariant, `[:flush]` demonitoring, exact PID plus ref cleanup, State-owned resident retirement, preserved consume-before-fanout behavior, clean cutover, exact budgets, grounded validation evidence, and merge safety.
+- **Final reviewer and delivery:** Pending PR.
+- **Discoveries affecting later work:** `mix test.debug test/minga_editor/renderer/server_test.exs:898` selected the preceding test after line shifts; rerunning current line `:899` exercised the intended headless cache/delta test. No replan trigger, owner drift, protocol/frontend dependency, compatibility need, second lifecycle concept, production budget miss, or test budget miss was found.
+- **Merge evidence:** Pending.
 - **Completion date:** 2026-07-22.

--- a/lib/minga_editor/renderer/buffer_changes.ex
+++ b/lib/minga_editor/renderer/buffer_changes.ex
@@ -15,6 +15,7 @@ defmodule MingaEditor.Renderer.BufferChanges do
   alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.RenderPipeline.WindowIntent
   alias MingaEditor.State.Windows
+  alias MingaEditor.Renderer.ObservedBuffers
   alias MingaEditor.Renderer.ResidentWindowState
   alias MingaEditor.Renderer.State
 
@@ -23,7 +24,8 @@ defmodule MingaEditor.Renderer.BufferChanges do
 
   def prepare(%State{} = state, %Intent{} = intent) do
     state = State.reconcile_windows(state, intent)
-    state = consume_changed_buffers(state, intent.buffer_versions)
+    versions = ObservedBuffers.monitored_versions(state.observed_buffers, intent.buffer_versions)
+    state = consume_changed_buffers(state, versions)
     {state, materialize(state, intent)}
   end
 
@@ -34,7 +36,7 @@ defmodule MingaEditor.Renderer.BufferChanges do
       Enum.reduce(output.workspace.windows.map, state.resident_windows, fn {id, window}, acc ->
         case Map.get(acc, id) do
           %ResidentWindowState{} = resident ->
-            version = Map.get(state.buffer_versions, resident.buffer)
+            version = ObservedBuffers.recorded_version(state.observed_buffers, resident.buffer)
             Map.put(acc, id, ResidentWindowState.commit_window(resident, window, version))
 
           nil ->
@@ -59,13 +61,6 @@ defmodule MingaEditor.Renderer.BufferChanges do
       |> Map.reject(fn {_id, value} -> is_nil(value) end)
 
     %{state | resident_windows: residents}
-  end
-
-  @doc "Handles an exact monitored buffer death."
-  @spec handle_down(State.t(), reference(), pid()) :: State.t()
-  def handle_down(%State{} = state, ref, buffer) do
-    {state, _matched?} = State.drop_buffer_down(state, ref, buffer)
-    state
   end
 
   @spec consume_changed_buffers(State.t(), %{optional(pid()) => non_neg_integer()}) :: State.t()
@@ -99,11 +94,10 @@ defmodule MingaEditor.Renderer.BufferChanges do
       }
     )
 
-    %{
-      state
-      | resident_windows: residents,
-        buffer_versions: Map.put(state.buffer_versions, buffer, consumed.version)
-    }
+    observed_buffers =
+      ObservedBuffers.record_version(state.observed_buffers, buffer, consumed.version)
+
+    %{state | resident_windows: residents, observed_buffers: observed_buffers}
   end
 
   @spec safe_consume(

--- a/lib/minga_editor/renderer/frame_handler.ex
+++ b/lib/minga_editor/renderer/frame_handler.ex
@@ -62,8 +62,10 @@ defmodule MingaEditor.Renderer.FrameHandler do
 
   def dispatch(:request_recovery, state), do: MingaEditor.Renderer.RecoveryHandler.request(state)
 
-  def dispatch({:DOWN, ref, :process, buffer, _reason}, state),
-    do: {:noreply, BufferChanges.handle_down(state, ref, buffer)}
+  def dispatch({:DOWN, ref, :process, buffer, _reason}, state) do
+    {state, _matched?} = State.drop_buffer_down(state, ref, buffer)
+    {:noreply, state}
+  end
 
   def dispatch(_message, state), do: {:noreply, state}
 

--- a/lib/minga_editor/renderer/observed_buffers.ex
+++ b/lib/minga_editor/renderer/observed_buffers.ex
@@ -1,0 +1,71 @@
+defmodule MingaEditor.Renderer.ObservedBuffers do
+  @moduledoc """
+  Renderer-local buffer monitor and consumed-version owner.
+  Versions are retained only for currently monitored buffers. Exact `:DOWN`
+  matching removes both the monitor reference and the recorded version, while
+  stale `:DOWN` messages are ignored.
+  """
+
+  @type t :: %__MODULE__{
+          monitors: %{optional(pid()) => reference()},
+          versions: %{optional(pid()) => non_neg_integer()}
+        }
+
+  defstruct monitors: %{}, versions: %{}
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @spec reconcile(t(), MapSet.t(pid())) :: t()
+  def reconcile(%__MODULE__{} = observed, %MapSet{} = buffers) do
+    Enum.each(observed.monitors, fn {buffer, ref} ->
+      if not MapSet.member?(buffers, buffer), do: Process.demonitor(ref, [:flush])
+    end)
+
+    monitors =
+      Map.new(buffers, fn buffer ->
+        {buffer, Map.get_lazy(observed.monitors, buffer, fn -> Process.monitor(buffer) end)}
+      end)
+
+    %__MODULE__{
+      monitors: monitors,
+      versions: Map.take(observed.versions, MapSet.to_list(buffers))
+    }
+  end
+
+  @spec record_version(t(), pid(), non_neg_integer()) :: t()
+  def record_version(%__MODULE__{} = observed, buffer, version)
+      when is_pid(buffer) and is_integer(version) and version >= 0 do
+    if Map.has_key?(observed.monitors, buffer) do
+      %{observed | versions: Map.put(observed.versions, buffer, version)}
+    else
+      observed
+    end
+  end
+
+  @spec drop_down(t(), reference(), pid()) :: {t(), boolean()}
+  def drop_down(%__MODULE__{} = observed, ref, buffer)
+      when is_reference(ref) and is_pid(buffer) do
+    case Map.get(observed.monitors, buffer) do
+      ^ref ->
+        {%{
+           observed
+           | monitors: Map.delete(observed.monitors, buffer),
+             versions: Map.delete(observed.versions, buffer)
+         }, true}
+
+      _other ->
+        {observed, false}
+    end
+  end
+
+  @spec recorded_version(t(), pid()) :: non_neg_integer() | nil
+  def recorded_version(%__MODULE__{} = observed, buffer) when is_pid(buffer),
+    do: Map.get(observed.versions, buffer)
+
+  @spec monitored_versions(t(), %{optional(pid()) => non_neg_integer()}) :: %{
+          optional(pid()) => non_neg_integer()
+        }
+  def monitored_versions(%__MODULE__{} = observed, versions) when is_map(versions),
+    do: Map.take(versions, Map.keys(observed.monitors))
+end

--- a/lib/minga_editor/renderer/state.ex
+++ b/lib/minga_editor/renderer/state.ex
@@ -3,7 +3,7 @@ defmodule MingaEditor.Renderer.State do
   Complete long-lived state owned by `MingaEditor.Renderer.Server`.
 
   Renderer caches, font registration, frontend acknowledgement state, resident
-  windows, buffer monitors, and coalesced frame credit live here. Public
+  windows, observed buffer monitors, and coalesced frame credit live here. Public
   transitions centralize lifecycle cleanup so window close, buffer replacement,
   reset, and exact monitor `:DOWN` all discard the same state.
   """
@@ -17,6 +17,7 @@ defmodule MingaEditor.Renderer.State do
   alias MingaEditor.Renderer.FrameAttempt
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Renderer.RejectionState
+  alias MingaEditor.Renderer.ObservedBuffers
   alias MingaEditor.Renderer.ResidentWindowState
   alias MingaEditor.UI.FontRegistry
   alias MingaEditor.UI.Panel.MessageStore
@@ -38,8 +39,7 @@ defmodule MingaEditor.Renderer.State do
           caches: Caches.t(),
           message_store: MessageStore.t() | nil,
           resident_windows: %{optional(Window.id()) => ResidentWindowState.t()},
-          buffer_monitors: %{optional(pid()) => reference()},
-          buffer_versions: %{optional(pid()) => non_neg_integer()},
+          observed_buffers: ObservedBuffers.t(),
           pipeline: pipeline(),
           require_ack?: boolean(),
           rejection_state: RejectionState.t()
@@ -57,8 +57,7 @@ defmodule MingaEditor.Renderer.State do
             caches: Caches.new(),
             message_store: nil,
             resident_windows: %{},
-            buffer_monitors: %{},
-            buffer_versions: %{},
+            observed_buffers: ObservedBuffers.new(),
             pipeline: &RenderPipeline.run/1,
             require_ack?: true,
             rejection_state: RejectionState.new()
@@ -232,13 +231,12 @@ defmodule MingaEditor.Renderer.State do
       end)
 
     buffers = resident_windows |> Map.values() |> MapSet.new(& &1.buffer)
-    {monitors, versions} = reconcile_monitors(state, buffers)
+    observed_buffers = ObservedBuffers.reconcile(state.observed_buffers, buffers)
 
     %{
       state
       | resident_windows: resident_windows,
-        buffer_monitors: monitors,
-        buffer_versions: versions
+        observed_buffers: observed_buffers
     }
   end
 
@@ -246,20 +244,15 @@ defmodule MingaEditor.Renderer.State do
   @spec drop_buffer_down(t(), reference(), pid()) :: {t(), boolean()}
   def drop_buffer_down(%__MODULE__{} = state, ref, buffer)
       when is_reference(ref) and is_pid(buffer) do
-    case Map.get(state.buffer_monitors, buffer) do
-      ^ref ->
-        windows =
-          Map.reject(state.resident_windows, fn {_id, resident} -> resident.buffer == buffer end)
+    {observed_buffers, matched?} = ObservedBuffers.drop_down(state.observed_buffers, ref, buffer)
 
-        {%{
-           state
-           | resident_windows: windows,
-             buffer_monitors: Map.delete(state.buffer_monitors, buffer),
-             buffer_versions: Map.delete(state.buffer_versions, buffer)
-         }, true}
+    if matched? do
+      windows =
+        Map.reject(state.resident_windows, fn {_id, resident} -> resident.buffer == buffer end)
 
-      _other ->
-        {state, false}
+      {%{state | resident_windows: windows, observed_buffers: observed_buffers}, true}
+    else
+      {state, false}
     end
   end
 
@@ -297,22 +290,6 @@ defmodule MingaEditor.Renderer.State do
        do: ResourcePolicy.advertised?(policy, dimension)
 
   defp advertised_dimension?(%Intent{}, _dimension), do: false
-
-  @spec reconcile_monitors(t(), MapSet.t(pid())) ::
-          {%{optional(pid()) => reference()}, %{optional(pid()) => non_neg_integer()}}
-  defp reconcile_monitors(state, buffers) do
-    Enum.each(state.buffer_monitors, fn {buffer, ref} ->
-      if not MapSet.member?(buffers, buffer), do: Process.demonitor(ref, [:flush])
-    end)
-
-    monitors =
-      Map.new(buffers, fn buffer ->
-        {buffer, Map.get_lazy(state.buffer_monitors, buffer, fn -> Process.monitor(buffer) end)}
-      end)
-
-    versions = Map.take(state.buffer_versions, MapSet.to_list(buffers))
-    {monitors, versions}
-  end
 
   @spec reset_message_cursor(MessageStore.t() | nil) :: MessageStore.t() | nil
   defp reset_message_cursor(%MessageStore{} = store), do: MessageStore.reset_sent_cursor(store)

--- a/test/minga_editor/renderer/buffer_changes_test.exs
+++ b/test/minga_editor/renderer/buffer_changes_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.Renderer.BufferChangesTest do
   alias MingaEditor.RenderPipeline.Input
   alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.Renderer.BufferChanges
+  alias MingaEditor.Renderer.ObservedBuffers
   alias MingaEditor.Renderer.State
   alias MingaEditor.Shell.Traditional.ClickRegions
   alias MingaEditor.State.Windows
@@ -29,6 +30,9 @@ defmodule MingaEditor.Renderer.BufferChangesTest do
 
     assert Enum.count(calls.messages, &match?({:renderer_consume, _}, &1)) == 1
     refute Enum.any?(calls.messages, &match?(:version, &1))
+
+    assert ObservedBuffers.recorded_version(state.observed_buffers, buffer) ==
+             Minga.Buffer.version(buffer)
 
     first_pending = state.resident_windows[1].render_cache.pending_edit_deltas
     second_pending = state.resident_windows[2].render_cache.pending_edit_deltas
@@ -92,11 +96,12 @@ defmodule MingaEditor.Renderer.BufferChangesTest do
     first = start_supervised!({Minga.Buffer.Process, content: "first"}, id: :first_buffer)
     second = start_supervised!({Minga.Buffer.Process, content: "second"}, id: :second_buffer)
     {state, _} = BufferChanges.prepare(State.new([]), intent(first, 0))
-    first_ref = state.buffer_monitors[first]
+    first_ref = state.observed_buffers.monitors[first]
 
     {state, _} = BufferChanges.prepare(state, intent(second, 0))
-    refute Map.has_key?(state.buffer_monitors, first)
-    assert Map.has_key?(state.buffer_monitors, second)
+    refute Map.has_key?(state.observed_buffers.monitors, first)
+    refute Map.has_key?(state.observed_buffers.versions, first)
+    assert Map.has_key?(state.observed_buffers.monitors, second)
 
     assert Enum.all?(state.resident_windows, fn {_id, resident} ->
              resident.buffer == second and resident.hydration == :buffer_replacement and
@@ -104,12 +109,14 @@ defmodule MingaEditor.Renderer.BufferChangesTest do
            end)
 
     # A stale DOWN for the replaced buffer cannot remove the new resident state.
-    assert BufferChanges.handle_down(state, first_ref, first) == state
+    assert {stale, false} = State.drop_buffer_down(state, first_ref, first)
+    assert stale == state
 
-    second_ref = state.buffer_monitors[second]
-    dropped = BufferChanges.handle_down(state, second_ref, second)
+    second_ref = state.observed_buffers.monitors[second]
+    assert {dropped, true} = State.drop_buffer_down(state, second_ref, second)
     assert dropped.resident_windows == %{}
-    assert dropped.buffer_monitors == %{}
+    assert dropped.observed_buffers.monitors == %{}
+    assert dropped.observed_buffers.versions == %{}
   end
 
   test "focused receipt excludes resident/cache stores and stays within a fixed small bound" do

--- a/test/minga_editor/renderer/observed_buffers_test.exs
+++ b/test/minga_editor/renderer/observed_buffers_test.exs
@@ -1,0 +1,88 @@
+defmodule MingaEditor.Renderer.ObservedBuffersTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Renderer.ObservedBuffers
+
+  test "reconcile preserves retained monitors and drops retired versions" do
+    first = start_supervised!({Agent, fn -> :first end}, id: :observed_first)
+    second = start_supervised!({Agent, fn -> :second end}, id: :observed_second)
+
+    observed = ObservedBuffers.reconcile(ObservedBuffers.new(), MapSet.new([first, second]))
+    first_ref = observed.monitors[first]
+    second_ref = observed.monitors[second]
+
+    assert is_reference(first_ref)
+    assert is_reference(second_ref)
+    assert monitored?(first)
+    assert monitored?(second)
+
+    observed =
+      observed
+      |> ObservedBuffers.record_version(first, 1)
+      |> ObservedBuffers.record_version(second, 2)
+      |> ObservedBuffers.reconcile(MapSet.new([second]))
+
+    refute Map.has_key?(observed.monitors, first)
+    refute Map.has_key?(observed.versions, first)
+    refute monitored?(first)
+    assert observed.monitors[second] == second_ref
+    assert observed.versions == %{second => 2}
+
+    assert MapSet.subset?(
+             MapSet.new(Map.keys(observed.versions)),
+             MapSet.new(Map.keys(observed.monitors))
+           )
+  end
+
+  test "recorded and intent versions are constrained to monitored buffers" do
+    monitored = start_supervised!({Agent, fn -> :monitored end}, id: :observed_monitored)
+    unmonitored = start_supervised!({Agent, fn -> :unmonitored end}, id: :observed_unmonitored)
+
+    observed =
+      ObservedBuffers.new()
+      |> ObservedBuffers.reconcile(MapSet.new([monitored]))
+      |> ObservedBuffers.record_version(monitored, 3)
+      |> ObservedBuffers.record_version(unmonitored, 4)
+
+    assert ObservedBuffers.recorded_version(observed, monitored) == 3
+    assert ObservedBuffers.recorded_version(observed, unmonitored) == nil
+    assert observed.versions == %{monitored => 3}
+
+    assert ObservedBuffers.monitored_versions(observed, %{monitored => 5, unmonitored => 6}) == %{
+             monitored => 5
+           }
+  end
+
+  test "drop_down ignores stale messages and removes only exact pid and ref matches" do
+    first = start_supervised!({Agent, fn -> :first_down end}, id: :observed_first_down)
+    second = start_supervised!({Agent, fn -> :second_down end}, id: :observed_second_down)
+
+    observed =
+      ObservedBuffers.new()
+      |> ObservedBuffers.reconcile(MapSet.new([first, second]))
+      |> ObservedBuffers.record_version(first, 1)
+      |> ObservedBuffers.record_version(second, 2)
+
+    first_ref = observed.monitors[first]
+    second_ref = observed.monitors[second]
+
+    wrong_ref =
+      Process.monitor(start_supervised!({Agent, fn -> :wrong end}, id: :observed_wrong_down))
+
+    assert {^observed, false} = ObservedBuffers.drop_down(observed, wrong_ref, first)
+    assert {^observed, false} = ObservedBuffers.drop_down(observed, first_ref, second)
+
+    assert {dropped, true} = ObservedBuffers.drop_down(observed, second_ref, second)
+    refute Map.has_key?(dropped.monitors, second)
+    refute Map.has_key?(dropped.versions, second)
+    assert dropped.monitors == %{first => first_ref}
+    assert dropped.versions == %{first => 1}
+
+    Process.demonitor(wrong_ref, [:flush])
+  end
+
+  defp monitored?(pid) do
+    {:monitors, monitors} = Process.info(self(), :monitors)
+    {:process, pid} in monitors
+  end
+end

--- a/test/minga_editor/renderer/server_test.exs
+++ b/test/minga_editor/renderer/server_test.exs
@@ -17,6 +17,7 @@ defmodule MingaEditor.Renderer.ServerTest do
   alias MingaEditor.RenderPipeline.Intent
   alias MingaEditor.Renderer.Caches
   alias MingaEditor.Renderer.FrameAttempt
+  alias MingaEditor.Renderer.ObservedBuffers
   alias MingaEditor.Renderer.RenderReceipt
   alias MingaEditor.Renderer.Server, as: RendererServer
   alias MingaEditor.State.Render
@@ -944,8 +945,8 @@ defmodule MingaEditor.Renderer.ServerTest do
       assert LineIdentity.source_ids(identity_after) == ids_before
       assert resident_after.render_cache.content_epoch == epoch_before
 
-      assert :sys.get_state(edited.render.renderer).buffer_versions[buffer] ==
-               Minga.Buffer.version(buffer)
+      observed = :sys.get_state(edited.render.renderer).observed_buffers
+      assert ObservedBuffers.recorded_version(observed, buffer) == Minga.Buffer.version(buffer)
 
       assert resident_after.render_cache.pending_edit_deltas == []
       assert {:ok, []} = Minga.Buffer.consume_edit_deltas(buffer, :renderer)


### PR DESCRIPTION
## TL;DR

Give renderer-observed buffers one lifecycle owner so monitor refs and consumed versions cannot drift apart.

## Context

This is W101/E08 from `docs/workstreams/editor-lifecycle-roadmap.md`. Renderer state previously carried parallel monitor and version maps, while reconciliation, recording, and exact process-down cleanup were split across modules.

## Changes

- Add `MingaEditor.Renderer.ObservedBuffers` as the sole owner of monitor refs and consumed versions.
- Preserve retained monitor refs, demonitor retired buffers with `[:flush]`, and constrain versions to monitored PIDs.
- Match both PID and ref for process-down cleanup; let `Renderer.State` retire resident windows only after an exact match.
- Route process-down messages directly from `FrameHandler` to the aggregate State transition.
- Keep one buffer consume before per-window fanout and record consumed versions through the owner.
- Add owner, renderer-flow, and server-cache regressions; record validation and review evidence in the roadmap.

## Compatibility

Render intent shape, resident-window ownership, buffer consumption semantics, telemetry, frame credit, acknowledgements, recovery, stale retry, frontend protocol, and render DTOs are unchanged.

## Verification

- Focused owner and BufferChanges suites passed 9 tests.
- Focused server cache path passed 1 test.
- `make lint` passed with zero Dialyzer errors.
- `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` passed 9,715 tests, 58 doctests, and 98 properties with zero failures.
- Correctness, Elixir craftsmanship, Ponytail, and final acceptance reviews passed.
