### PR TITLE
test(editor): synchronize private registry assertion

### DIFF
--- a/test/minga_editor/handlers/buffer_opened_event_flow_test.exs
+++ b/test/minga_editor/handlers/buffer_opened_event_flow_test.exs
@@ -91,8 +91,9 @@ defmodule MingaEditor.Handlers.BufferOpenedEventFlowTest do
         receive do
           {:minga_event, :buffer_opened, event} ->
             send(parent, {:default_registry_event, event})
-        after
-          100 -> send(parent, {:default_registry_quiet, self()})
+
+          :assert_quiet ->
+            send(parent, {:default_registry_quiet, self()})
         end
       end)
 
@@ -104,8 +105,9 @@ defmodule MingaEditor.Handlers.BufferOpenedEventFlowTest do
     assert [pid] = Enum.filter(state.workspace.buffers.list, &(Buffer.file_path(&1) == path))
 
     assert_receive {:minga_event, :buffer_opened, %Events.BufferEvent{buffer: ^pid, path: ^path}}
+    send(default_observer, :assert_quiet)
 
-    assert_receive {:default_registry_quiet, ^default_observer}, 200
+    assert_receive {:default_registry_quiet, ^default_observer}
 
     refute_receive {:default_registry_event, %Events.BufferEvent{buffer: ^pid, path: ^path}}
   end


### PR DESCRIPTION
## TL;DR

Make the private event-registry assertion deterministic by replacing a 100/200 ms timer race with an explicit observer handshake.

## Context

CI run `29956587669` timed out waiting for the observer's timer while the full suite was under load. Event broadcasting is synchronous in the test caller, so an accidental default-registry event and the subsequent assertion message have deterministic same-sender mailbox order.

## Changes

- Keep the default-registry observer alive until the test sends `:assert_quiet`.
- Report an accidental `:buffer_opened` event before the quiet acknowledgement.
- Remove elapsed-time dependence from the assertion.

## Verification

- `mix format --check-formatted test/minga_editor/handlers/buffer_opened_event_flow_test.exs` passed.
- `mix test.debug test/minga_editor/handlers/buffer_opened_event_flow_test.exs` passed 5 tests.
- Final review returned PASS with 0.99 confidence.
