### PR TITLE
test(extension): synchronize concurrent lifecycle assertions

### DIFF
--- a/test/minga/extension/lifecycle_contract_test.exs
+++ b/test/minga/extension/lifecycle_contract_test.exs
@@ -658,7 +658,14 @@ defmodule Minga.Extension.LifecycleContractTest do
     assert_receive {:init_entered, workflow}, 5_000
 
     second = Task.async(fn -> start_extension(ctx, name, entry) end)
-    refute Task.yield(second, 50)
+
+    assert {:starting, %{waiters: [_, _]}} =
+             eventually(fn ->
+               case Instance.phase(instance(ctx, name)) do
+                 {:starting, %{waiters: [_, _]}} = phase -> phase
+                 _phase -> nil
+               end
+             end)
 
     send(workflow, :continue_init)
     assert {:ok, pid} = Task.await(first)
@@ -674,6 +681,15 @@ defmodule Minga.Extension.LifecycleContractTest do
     first = Task.async(fn -> start_extension(ctx, name, entry) end)
     assert_receive {:init_entered, workflow}, 5_000
     second = Task.async(fn -> start_extension(ctx, name, entry) end)
+
+    assert {:starting, %{waiters: [_, _]}} =
+             eventually(fn ->
+               case Instance.phase(instance(ctx, name)) do
+                 {:starting, %{waiters: [_, _]}} = phase -> phase
+                 _phase -> nil
+               end
+             end)
+
     send(workflow, :continue_init)
 
     assert {:error, reason} = Task.await(first)

--- a/test/minga_agent/providers/native_test.exs
+++ b/test/minga_agent/providers/native_test.exs
@@ -1964,12 +1964,12 @@ defmodule MingaAgent.Providers.NativeTest do
 
       assert :ok = Native.send_prompt(pid, "Run the blocking tool")
       assert_receive {:agent_provider_event, %Event.AgentStart{}}, 1_000
-      assert_receive {:abort_blocking_tool_started, worker_pid}, 1_000
+      assert_receive {:abort_blocking_tool_started, worker_pid}, 5_000
       worker_ref = Process.monitor(worker_pid)
 
       assert :ok = Native.abort(pid)
       assert {:ok, %{is_streaming: false}} = Native.get_state(pid)
-      assert_receive {:DOWN, ^worker_ref, :process, ^worker_pid, _reason}, 1_000
+      assert_receive {:DOWN, ^worker_ref, :process, ^worker_pid, _reason}, 5_000
 
       send(worker_pid, {release_ref, :release})
       refute_receive :abort_blocking_tool_continued, 50


### PR DESCRIPTION
## TL;DR

Two timing-sensitive tests now wait for observable lifecycle state instead of scheduler timing.

## Changes

- Wait for both concurrent extension start callers to appear in `Instance.phase/1` before releasing the gated workflow.
- Apply the same synchronization to successful and failed concurrent starts.
- Give the concurrent native-provider abort assertions the existing five-second async budget.

## Validation

- `ERL_FLAGS='+S 2:2' mix test.debug test/minga/extension/lifecycle_contract_test.exs test/minga_agent/providers/native_test.exs --seed 674985`
- `make lint`
- `ERL_FLAGS='+S 2:2' make test`: 10,297 passed, 1 skipped, 204 excluded
- `git diff --check`
- Final reviewer: RESOLVED/PASS, 0.99 confidence
