### PR TITLE
refactor(editor): type highlight span storage

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -26,12 +26,12 @@ The independent Ponytail gate produced 91 `ACCEPT`, 28 `ROUTE`, 11 `PRESERVE`, a
 Current accepted inventory:
 
 - **VERIFIED:** L01, L02, L04, L05, L10, L12
-- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08, ES03, ES05, ES07
+- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08, ES03, ES05, ES07, ES08
 - **CANDIDATE, lifecycle:** L11, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30
 - **CANDIDATE, deletion:** D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40
 - **CANDIDATE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
 - **CANDIDATE, craftsmanship:** (none)
-- **CANDIDATE, data shape:** ES08, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES21, ES24
+- **CANDIDATE, data shape:** ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES21, ES24
 
 ### Freshness wave at `6e175b87764145577999a1c04a532960cb89222f`
 
@@ -42,7 +42,7 @@ Eleven independent read-only GPT-5.5 `medium` batches checked all 85 remaining `
 - **STILL_REPRODUCIBLE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
 - **STILL_REPRODUCIBLE, craftsmanship:** E02, E03
 - **STILL_REPRODUCIBLE, data shape:** ES05, ES07, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES24
-- **DRIFTED:** D13, D36, D40, S14, ES08, ES21
+- **DRIFTED:** D13, D36, D40, S14, ES21
 
 Drift evidence:
 
@@ -4310,3 +4310,30 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Implementation commit SHA:** `426aa7a9f8574cf6ac39084f05341128faa2eaaf`.
 - **Merge SHA:** `33d00edb30d2e4e82e4224b5e3f52d69acb6f93a`; **Merge evidence:** PR #3200 merged after CI run `29967431751` passed Elixir, Swift macOS, Swift protocol integration, Go TUI, Zig, Dialyzer, lint/format, Neovim conformance, Go TUI boot smoke, and keystroke latency.
 - **Completion date:** 2026-07-23.
+
+### W105/ES08: Make Highlight storage tuple-only Span values
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** ES08
+- **Planning profile:** `ES08Planner`, editor-lifecycle-planner, read-only.
+- **Implementation profile:** `ES08Worker`, no delegation.
+- **Current baseline:** `485d8900d0c8eda92d850f880f6465bb5ecab9b8`.
+- **Ready provenance:** Locked by `agent://ES08Planner`; scope was exactly Highlight storage, SemanticTokenSync merge, typed specs, markdown helper, named true-highlight map fixture migrations, focused validation, formatting, `git diff --check`, production/test deltas, concept count, and this evidence.
+- **Observable result:** `MingaEditor.UI.Highlight` now stores only tuple-resident `%Minga.Language.Highlight.Span{}` values. `put_spans/3` accepts only lists of `Span` structs, rejects stale versions before validating payloads, validates accepted payload elements, and stores a tuple. Scope lookup, comment ranges, line styling, visible-line batching, masked-line batching, markdown code-block overlays, prettify-symbol input, semantic-token merging, capture IDs, layer priority, width ordering, pattern-index tie-breaks, parser correlation, and semantic layer replacement keep the same named behavior.
+- **Failure reproduction / source trace:** Before implementation, `Highlight.t()` allowed `tuple() | [map()]`, query paths accepted list-resident spans and normalized them to tuples, private helpers were typed as maps, `scope_entry/1` and `sweep_events/7` used `Map.get/3` defaults for layer and pattern index, `SemanticTokenSync.merge_tokens/3` normalized tuple-or-list storage and wrote `%Highlight{spans: ...}` directly, and the markdown helper had a private list-residency fallback.
+- **Implementation result:** Added the existing `Minga.Language.Highlight.Span` struct as the Highlight storage element type, documented the tuple-of-`Span` residency and named its private tuple type, removed list-resident query fallbacks, replaced map/default field reads with direct struct fields, routed semantic-token merge through `Highlight.put_names/2` and `Highlight.put_spans/3`, tightened parser highlight specs to `[Span.t()]`, simplified the markdown `has_spans?/1` helper to call the Highlight owner, and migrated named true-highlight fixtures to pass `Span` lists through the owner pipeline without touching parser/LSP producers, Span definition, frontend protocol, renderer model spans, conceal/injection/fold/edit shapes, or unrelated Highlight direct updates.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/agent/markdown_highlight.ex`; `lib/minga_editor/handlers/highlight_handler.ex`; `lib/minga_editor/highlight_sync.ex`; `lib/minga_editor/semantic_token_sync.ex`; `lib/minga_editor/ui/highlight.ex`; `test/minga_editor/agent/markdown_highlight_test.exs`; `test/minga_editor/handlers/highlight_handler_test.exs`; `test/minga_editor/handlers/lsp_event_handler_test.exs`; `test/minga_editor/handlers/session_restore_test.exs`; `test/minga_editor/highlight_sync_test.exs`; `test/minga_editor/render_pipeline/content_helpers_test.exs`; `test/minga_editor/ui/highlight_test.exs`; `test/minga_editor/ui/prettify_symbols_effect_test.exs`; `test/minga_editor/user_query_override_test.exs`.
+- **Focused validation:** `mix test --warnings-as-errors test/minga_editor/ui/highlight_test.exs test/minga_editor/ui/highlight_scope_test.exs test/minga_editor/highlight_sync_test.exs test/minga_editor/handlers/highlight_handler_test.exs test/minga_editor/handlers/session_restore_test.exs test/minga_editor/handlers/lsp_event_handler_test.exs test/minga_editor/render_pipeline/content_helpers_test.exs test/minga_editor/ui/prettify_symbols_effect_test.exs test/minga_editor/agent/markdown_highlight_test.exs test/minga_editor/user_query_override_test.exs test/minga_editor/render_model/window/builder_test.exs` passed with 166 tests.
+- **Formatting and diff validation:** `mix format` ran on every touched Elixir source and test path. `git diff --check` passed.
+- **Reference validation:** Focused production residual search found no `normalize_spans`, no `Map.get(span...)` defaulting, no `Map.get(s...)` semantic filtering, no list-resident Highlight query fallback, no `Frontend.Protocol.highlight_span` spec, and no mixed `tuple() | [map()]` Highlight storage type. Remaining `is_list(spans)` matches are the locked public `[Span.t()]` ingest boundary and snippet highlighter result guard; remaining `[map()]` specs in the touched handler are conceal-span maps, a separate shape outside ES08.
+- **Production lines added/removed before roadmap evidence:** `70 added / 86 removed`, net `-16`, within the locked `<= +20` budget; production numstat before this roadmap update: `lib/minga_editor/agent/markdown_highlight.ex 1 2`, `lib/minga_editor/handlers/highlight_handler.ex 2 1`, `lib/minga_editor/highlight_sync.ex 2 4`, `lib/minga_editor/semantic_token_sync.ex 7 11`, `lib/minga_editor/ui/highlight.ex 58 68`.
+- **Test lines added/removed before roadmap evidence:** `89 added / 91 removed`, net `-2`, within the locked `<= +80` budget; test numstat before this roadmap update: `test/minga_editor/agent/markdown_highlight_test.exs 10 14`, `test/minga_editor/handlers/highlight_handler_test.exs 2 1`, `test/minga_editor/handlers/lsp_event_handler_test.exs 1 1`, `test/minga_editor/handlers/session_restore_test.exs 2 1`, `test/minga_editor/highlight_sync_test.exs 7 6`, `test/minga_editor/render_pipeline/content_helpers_test.exs 5 4`, `test/minga_editor/ui/highlight_test.exs 57 61`, `test/minga_editor/ui/prettify_symbols_effect_test.exs 3 2`, `test/minga_editor/user_query_override_test.exs 2 1`.
+- **Concepts added:** 0 runtime or domain concepts. The private accepted-boundary validator is an implementation detail.
+- **Concepts removed:** 2 compatibility concepts: map-shaped Highlight spans and list-resident Highlight storage/query fallback.
+- **Retained contracts:** Tuple residency, stale rejection before payload validation, equal-version replacement, empty `{}` behavior, parser correlation acceptance/rejection, capture-name indexing, internal `_` capture filtering, semantic layer `2` replacement, syntax/semantic merge preservation, layer priority, width ordering, pattern-index tie-breaks, unicode-safe stale byte slicing, markdown fallback behavior, prettify-symbol derivation, and renderer/content fingerprints are unchanged.
+- **Pre-acceptance reviews:** Correctness returned `PASS/Lean` with 0.99 confidence and found no contract drift. Elixir craftsmanship initially required explicit tuple-of-`Span` documentation, a private tuple alias on the two long specs, and restoration of the markdown helper's semantic type; all were corrected, and the targeted recheck returned `RESOLVED/PASS`. Ponytail required the same private type and semantic spec corrections plus removal of six test-fixture tuple adapters so tests enter through the owner pipeline; the targeted recheck returned `RESOLVED/PASS`. The final reviewer then found five markdown fixtures still bypassing the owner API; those fixtures and the helper were routed through `Highlight.new/1`, `put_names/2`, and `put_spans/3`, reducing the final test delta from net `+17` before review to net `-2`.
+- **Findings resolved:** ES08's mixed Highlight map/list storage compatibility is clean-cut to existing `Span` structs without adding a module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, or second representation.
+- **Discoveries affecting later work:** No replan trigger, owner drift, producer emitting maps, live tuple-input need, semantic merge invariant failure, protocol/frontend dependency, production budget miss, test budget miss, or extra runtime concept was found.
+- **Broad validation:** `make lint` passed Credo, compile, formatting, and incremental Dialyzer with zero Dialyzer errors; Credo retained two pre-existing buffer-management refactoring opportunities and one registry-test warning. `ERL_FLAGS='+S 2:2' make test` rebuilt native support and passed 10,297 tests, including 58 doctests and 99 properties, with zero failures, one skipped, and 204 excluded.
+- **Final reviewer verdict:** `RESOLVED/PASS` with 0.99 confidence after the sole blocker was corrected. The reviewer confirmed all markdown fixtures now enter through the Highlight owner pipeline, no tuple fixture or direct `%Highlight{}` construction remains, the roadmap budgets match the diff, and the complete ES08 artifact is merge-safe.
+- **needs_replan:** false.

--- a/lib/minga_editor/agent/markdown_highlight.ex
+++ b/lib/minga_editor/agent/markdown_highlight.ex
@@ -653,8 +653,7 @@ defmodule MingaEditor.Agent.MarkdownHighlight do
 
   @spec has_spans?(Highlight.t() | nil) :: boolean()
   defp has_spans?(nil), do: false
-  defp has_spans?(%Highlight{spans: spans}) when is_tuple(spans), do: tuple_size(spans) > 0
-  defp has_spans?(%Highlight{spans: spans}) when is_list(spans), do: spans != []
+  defp has_spans?(%Highlight{} = highlight), do: Highlight.has_spans?(highlight)
   defp has_spans?(_), do: false
 
   @spec fence_line?(String.t()) :: boolean()

--- a/lib/minga_editor/handlers/highlight_handler.ex
+++ b/lib/minga_editor/handlers/highlight_handler.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.Handlers.HighlightHandler do
   while stale or unknown messages are ignored.
   """
 
+  alias Minga.Language.Highlight.Span
   alias Minga.Parser.EventCorrelation
   alias MingaEditor.HighlightEvents
   alias MingaEditor.HighlightSync
@@ -305,7 +306,7 @@ defmodule MingaEditor.Handlers.HighlightHandler do
     {new_state, []}
   end
 
-  @spec handle_highlight_spans(EditorState.t(), pid(), non_neg_integer(), term()) ::
+  @spec handle_highlight_spans(EditorState.t(), pid(), non_neg_integer(), [Span.t()]) ::
           {EditorState.t(), [highlight_effect()]}
   defp handle_highlight_spans(
          %{parser: %{highlighting: %{highlights: highlights}}} = state,

--- a/lib/minga_editor/highlight_sync.ex
+++ b/lib/minga_editor/highlight_sync.ex
@@ -6,6 +6,7 @@ defmodule MingaEditor.HighlightSync do
   highlight response events back into editor state.
   """
 
+  alias Minga.Language.Highlight.Span
   alias Minga.Buffer
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.State.Highlighting
@@ -319,10 +320,7 @@ defmodule MingaEditor.HighlightSync do
   end
 
   @doc "Handles a highlight_spans event for the active buffer."
-  @spec handle_spans(EditorState.t(), non_neg_integer(), [
-          MingaEditor.Frontend.Protocol.highlight_span()
-        ]) ::
-          EditorState.t()
+  @spec handle_spans(EditorState.t(), non_neg_integer(), [Span.t()]) :: EditorState.t()
   def handle_spans(%EditorState{} = state, version, spans) do
     update_active_highlight(state, &Highlight.put_spans(&1, version, spans))
   end

--- a/lib/minga_editor/semantic_token_sync.ex
+++ b/lib/minga_editor/semantic_token_sync.ex
@@ -25,6 +25,7 @@ defmodule MingaEditor.SemanticTokenSync do
   """
 
   alias Minga.Buffer
+  alias Minga.Language.Highlight.Span
   alias MingaEditor.State, as: EditorState
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
@@ -118,13 +119,12 @@ defmodule MingaEditor.SemanticTokenSync do
         )
 
       # Merge semantic spans with existing tree-sitter spans
-      existing_spans = normalize_spans(hl.spans)
+      ts_spans =
+        hl.spans
+        |> Tuple.to_list()
+        |> Enum.reject(fn %Span{} = span -> span.layer == 2 end)
 
-      # Filter out old semantic token spans (layer 2) before merging new ones
-      ts_spans = Enum.reject(existing_spans, fn s -> Map.get(s, :layer, 0) == 2 end)
-      merged = ts_spans ++ spans
-
-      hl = %{hl | spans: List.to_tuple(merged)}
+      hl = Highlight.put_spans(hl, hl.version, ts_spans ++ spans)
 
       highlights = Map.put(state.parser.highlighting.highlights, buf_pid, hl)
 
@@ -167,7 +167,7 @@ defmodule MingaEditor.SemanticTokenSync do
         end
       end)
 
-    hl = %{hl | capture_names: List.to_tuple(new_list)}
+    hl = Highlight.put_names(hl, new_list)
     {hl, name_map}
   end
 
@@ -181,10 +181,6 @@ defmodule MingaEditor.SemanticTokenSync do
     end)
     |> elem(0)
   end
-
-  @spec normalize_spans(tuple() | [map()]) :: [map()]
-  defp normalize_spans(spans) when is_tuple(spans), do: Tuple.to_list(spans)
-  defp normalize_spans(spans) when is_list(spans), do: spans
 
   @spec find_lsp_client(EditorState.t(), pid()) :: pid() | nil
   defp find_lsp_client(_state, buf_pid) do

--- a/lib/minga_editor/ui/highlight.ex
+++ b/lib/minga_editor/ui/highlight.ex
@@ -2,12 +2,13 @@ defmodule MingaEditor.UI.Highlight do
   @moduledoc """
   Stores and queries tree-sitter highlight state for a buffer.
 
-  Holds the current highlight spans (byte ranges + capture IDs),
-  capture names, version counter, and theme. Provides `styles_for_line/3`
+  Holds the current highlight spans as a tuple of `Minga.Language.Highlight.Span`
+  structs, plus capture names, version counter, and theme. Provides `styles_for_line/3`
   to split a line into styled segments for rendering.
   """
 
   alias Minga.Core.Face
+  alias Minga.Language.Highlight.Span
   alias Minga.Parser.EventCorrelation
   alias MingaEditor.UI.Face.Registry, as: FaceRegistry
   alias MingaEditor.UI.Theme
@@ -15,10 +16,11 @@ defmodule MingaEditor.UI.Highlight do
   @enforce_keys [:version, :spans, :capture_names, :theme, :face_registry]
   defstruct [:version, :spans, :capture_names, :theme, :face_registry, :parser_correlation]
 
+  @typep span_tuple :: tuple()
   @typedoc "Highlight state for a buffer."
   @type t :: %__MODULE__{
           version: non_neg_integer(),
-          spans: tuple() | [map()],
+          spans: span_tuple(),
           capture_names: tuple(),
           theme: Theme.syntax(),
           face_registry: FaceRegistry.t(),
@@ -135,14 +137,14 @@ defmodule MingaEditor.UI.Highlight do
   Only updates if the incoming version is >= the current version,
   preventing stale async results from overwriting newer ones.
   """
-  @spec put_spans(t(), non_neg_integer(), [MingaEditor.Frontend.Protocol.highlight_span()]) :: t()
+  @spec put_spans(t(), non_neg_integer(), [Span.t()]) :: t()
   def put_spans(%__MODULE__{version: current} = hl, version, _spans)
       when version < current do
     hl
   end
 
   def put_spans(%__MODULE__{} = hl, version, spans) when is_list(spans) do
-    %{hl | version: version, spans: List.to_tuple(spans)}
+    %{hl | version: version, spans: spans |> validate_spans() |> List.to_tuple()}
   end
 
   @doc """
@@ -174,20 +176,15 @@ defmodule MingaEditor.UI.Highlight do
   def scope_at(hl, byte_offset, source_text)
 
   def scope_at(%__MODULE__{spans: spans}, _byte_offset, _source_text)
-      when (is_tuple(spans) and tuple_size(spans) == 0) or spans == [] do
+      when tuple_size(spans) == 0 do
     :code
   end
 
   def scope_at(%__MODULE__{spans: spans} = hl, byte_offset, source_text)
-      when is_tuple(spans) and is_integer(byte_offset) and byte_offset >= 0 do
+      when is_integer(byte_offset) and byte_offset >= 0 do
     spans
     |> do_scope_at(tuple_size(spans), 0, byte_offset, hl, nil)
     |> classify_scope(hl, source_text, byte_offset)
-  end
-
-  def scope_at(%__MODULE__{spans: spans} = hl, byte_offset, source_text)
-      when is_list(spans) and is_integer(byte_offset) and byte_offset >= 0 do
-    scope_at(%{hl | spans: List.to_tuple(spans)}, byte_offset, source_text)
   end
 
   def scope_at(_hl, _byte_offset, _source_text), do: :code
@@ -198,7 +195,7 @@ defmodule MingaEditor.UI.Highlight do
             start_byte :: non_neg_integer(), end_byte :: non_neg_integer()}
 
   @spec do_scope_at(
-          tuple(),
+          span_tuple(),
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
@@ -215,7 +212,7 @@ defmodule MingaEditor.UI.Highlight do
     do_scope_at(spans, count, index + 1, byte_offset, hl, winner)
   end
 
-  @spec maybe_scope_winner(boolean(), map(), t(), scope_candidate() | nil) ::
+  @spec maybe_scope_winner(boolean(), Span.t(), t(), scope_candidate() | nil) ::
           scope_candidate() | nil
   defp maybe_scope_winner(false, _span, _hl, winner), do: winner
 
@@ -228,16 +225,14 @@ defmodule MingaEditor.UI.Highlight do
     end
   end
 
-  @spec span_contains?(map(), non_neg_integer()) :: boolean()
-  defp span_contains?(span, byte_offset),
+  @spec span_contains?(Span.t(), non_neg_integer()) :: boolean()
+  defp span_contains?(%Span{} = span, byte_offset),
     do: span.start_byte <= byte_offset and span.end_byte > byte_offset
 
-  @spec scope_entry(map()) :: scope_candidate()
+  @spec scope_entry(Span.t()) :: scope_candidate()
   defp scope_entry(span) do
-    layer = Map.get(span, :layer, 0)
-    width = span.end_byte - span.start_byte
-    pattern_index = Map.get(span, :pattern_index, 0)
-    {layer, width, pattern_index, span.capture_id, span.start_byte, span.end_byte}
+    {span.layer, span.end_byte - span.start_byte, span.pattern_index, span.capture_id,
+     span.start_byte, span.end_byte}
   end
 
   @spec better_scope_candidate(scope_candidate(), scope_candidate() | nil) :: scope_candidate()
@@ -365,14 +360,12 @@ defmodule MingaEditor.UI.Highlight do
   def styles_for_line(hl, line_text, line_start_byte, resolver \\ nil)
 
   def styles_for_line(%__MODULE__{spans: spans}, line_text, _line_start_byte, _resolver)
-      when (is_tuple(spans) and tuple_size(spans) == 0) or spans == [] do
+      when tuple_size(spans) == 0 do
     [{line_text, Face.new()}]
   end
 
-  # Fast path: tuple spans (production path from Zig)
   def styles_for_line(%__MODULE__{spans: spans} = hl, line_text, line_start_byte, resolver)
-      when is_tuple(spans) and is_binary(line_text) and is_integer(line_start_byte) and
-             line_start_byte >= 0 do
+      when is_binary(line_text) and is_integer(line_start_byte) and line_start_byte >= 0 do
     line_end_byte = line_start_byte + byte_size(line_text)
     span_count = tuple_size(spans)
 
@@ -382,13 +375,6 @@ defmodule MingaEditor.UI.Highlight do
       [] -> [{line_text, Face.new()}]
       _ -> build_segments(line_text, line_start_byte, overlapping, hl, resolver)
     end
-  end
-
-  # Fallback: list spans (used by tests that construct Highlight structs directly)
-  def styles_for_line(%__MODULE__{spans: spans} = hl, line_text, line_start_byte, resolver)
-      when is_list(spans) and is_binary(line_text) and is_integer(line_start_byte) and
-             line_start_byte >= 0 do
-    styles_for_line(%{hl | spans: List.to_tuple(spans)}, line_text, line_start_byte, resolver)
   end
 
   @doc """
@@ -407,12 +393,12 @@ defmodule MingaEditor.UI.Highlight do
   def styles_for_visible_lines(hl, lines, resolver \\ nil)
 
   def styles_for_visible_lines(%__MODULE__{spans: spans}, lines, _resolver)
-      when (is_tuple(spans) and tuple_size(spans) == 0) or spans == [] do
+      when tuple_size(spans) == 0 do
     Enum.map(lines, fn {text, _} -> [{text, Face.new()}] end)
   end
 
   def styles_for_visible_lines(%__MODULE__{spans: spans} = hl, lines, resolver)
-      when is_tuple(spans) and is_list(lines) do
+      when is_list(lines) do
     span_count = tuple_size(spans)
     {results_rev, _watermark} = batch_lines(lines, spans, span_count, hl, resolver, 0, [])
     Enum.reverse(results_rev)
@@ -436,7 +422,7 @@ defmodule MingaEditor.UI.Highlight do
         dirty_rows,
         _resolver
       )
-      when (is_tuple(spans) and tuple_size(spans) == 0) or spans == [] do
+      when tuple_size(spans) == 0 do
     lines
     |> Enum.with_index()
     |> Enum.map(fn {text, index} ->
@@ -451,7 +437,7 @@ defmodule MingaEditor.UI.Highlight do
         dirty_rows,
         resolver
       )
-      when is_tuple(spans) and is_list(lines) do
+      when is_list(lines) do
     span_count = tuple_size(spans)
 
     batch = {spans, span_count, hl, resolver, dirty_rows}
@@ -464,16 +450,14 @@ defmodule MingaEditor.UI.Highlight do
 
   @doc "Returns true when this highlight state has at least one tree-sitter span."
   @spec has_spans?(t()) :: boolean()
-  def has_spans?(%__MODULE__{spans: spans}) when is_tuple(spans), do: tuple_size(spans) > 0
-  def has_spans?(%__MODULE__{spans: spans}) when is_list(spans), do: spans != []
+  def has_spans?(%__MODULE__{spans: spans}), do: tuple_size(spans) > 0
 
   @doc "Returns byte ranges within a line that are covered by comment captures."
   @spec comment_ranges_for_line(t(), String.t(), non_neg_integer()) :: [
           {non_neg_integer(), non_neg_integer()}
         ]
   def comment_ranges_for_line(%__MODULE__{spans: spans} = hl, line_text, line_start_byte)
-      when is_tuple(spans) and is_binary(line_text) and is_integer(line_start_byte) and
-             line_start_byte >= 0 do
+      when is_binary(line_text) and is_integer(line_start_byte) and line_start_byte >= 0 do
     line_end_byte = line_start_byte + byte_size(line_text)
     span_count = tuple_size(spans)
 
@@ -484,20 +468,15 @@ defmodule MingaEditor.UI.Highlight do
     |> Enum.reject(fn {start_byte, end_byte} -> end_byte <= start_byte end)
   end
 
-  def comment_ranges_for_line(%__MODULE__{spans: spans} = hl, line_text, line_start_byte)
-      when is_list(spans) do
-    comment_ranges_for_line(%{hl | spans: List.to_tuple(spans)}, line_text, line_start_byte)
-  end
-
-  @spec comment_span?(t(), map()) :: boolean()
-  defp comment_span?(hl, span) do
+  @spec comment_span?(t(), Span.t()) :: boolean()
+  defp comment_span?(hl, %Span{} = span) do
     case capture_name_at(hl, span.capture_id) do
       "comment" <> _rest -> true
       _ -> false
     end
   end
 
-  @spec span_line_range(map(), non_neg_integer(), non_neg_integer()) ::
+  @spec span_line_range(Span.t(), non_neg_integer(), non_neg_integer()) ::
           {non_neg_integer(), non_neg_integer()}
   defp span_line_range(span, line_start_byte, line_end_byte) do
     {max(span.start_byte, line_start_byte) - line_start_byte,
@@ -508,7 +487,7 @@ defmodule MingaEditor.UI.Highlight do
 
   @spec batch_lines(
           [{String.t(), non_neg_integer()}],
-          tuple(),
+          span_tuple(),
           non_neg_integer(),
           t(),
           style_resolver() | nil,
@@ -534,7 +513,8 @@ defmodule MingaEditor.UI.Highlight do
   end
 
   @typep text_mask_batch ::
-           {tuple(), non_neg_integer(), t(), style_resolver() | nil, MapSet.t(non_neg_integer())}
+           {span_tuple(), non_neg_integer(), t(), style_resolver() | nil,
+            MapSet.t(non_neg_integer())}
 
   @spec batch_text_lines_masked(
           [String.t()],
@@ -574,7 +554,7 @@ defmodule MingaEditor.UI.Highlight do
     batch_text_lines_masked(rest, batch, watermark, next_line_start, index + 1, [segments | acc])
   end
 
-  @spec advance_watermark(tuple(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
+  @spec advance_watermark(span_tuple(), non_neg_integer(), non_neg_integer(), non_neg_integer()) ::
           non_neg_integer()
   defp advance_watermark(_spans, count, idx, _line_start) when idx >= count, do: idx
 
@@ -593,13 +573,13 @@ defmodule MingaEditor.UI.Highlight do
   # Collect spans that overlap [line_start, line_end) starting from start_idx.
   # Stops once spans start past the line.
   @spec collect_overlapping(
-          tuple(),
+          span_tuple(),
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
           non_neg_integer(),
-          [map()]
-        ) :: [map()]
+          [Span.t()]
+        ) :: [Span.t()]
   defp collect_overlapping(_spans, count, idx, _line_start, _line_end, acc) when idx >= count do
     Enum.reverse(acc)
   end
@@ -609,9 +589,15 @@ defmodule MingaEditor.UI.Highlight do
     collect_overlapping_by_span(spans, count, idx, line_start, line_end, acc, span)
   end
 
-  defp collect_overlapping_by_span(_spans, _count, _idx, _line_start, line_end, acc, %{
-         start_byte: start_byte
-       })
+  defp collect_overlapping_by_span(
+         _spans,
+         _count,
+         _idx,
+         _line_start,
+         line_end,
+         acc,
+         %Span{start_byte: start_byte}
+       )
        when start_byte >= line_end do
     Enum.reverse(acc)
   end
@@ -623,9 +609,7 @@ defmodule MingaEditor.UI.Highlight do
          line_start,
          line_end,
          acc,
-         %{
-           end_byte: end_byte
-         } = span
+         %Span{end_byte: end_byte} = span
        )
        when end_byte > line_start do
     collect_overlapping(spans, count, idx + 1, line_start, line_end, [span | acc])
@@ -650,7 +634,7 @@ defmodule MingaEditor.UI.Highlight do
   #   4. Priority: layer DESC, width ASC, pattern_index DESC
   #   5. Emit segments at each style-change boundary
 
-  @spec build_segments(String.t(), non_neg_integer(), [map()], t(), style_resolver() | nil) ::
+  @spec build_segments(String.t(), non_neg_integer(), [Span.t()], t(), style_resolver() | nil) ::
           [styled_segment()]
   defp build_segments(line_text, line_start, spans, hl, resolver) do
     # Filter out internal captures (names starting with _) before the sweep.
@@ -685,9 +669,9 @@ defmodule MingaEditor.UI.Highlight do
 
   defp capture_name_at(_hl, _id), do: nil
 
-  @typep span_event :: {non_neg_integer(), :open | :close, map()}
+  @typep span_event :: {non_neg_integer(), :open | :close, Span.t()}
 
-  @spec spans_to_events([map()], non_neg_integer(), non_neg_integer()) :: [span_event()]
+  @spec spans_to_events([Span.t()], non_neg_integer(), non_neg_integer()) :: [span_event()]
   defp spans_to_events(spans, line_start, line_len) do
     spans
     |> Enum.flat_map(fn span ->
@@ -751,11 +735,7 @@ defmodule MingaEditor.UI.Highlight do
 
     new_pos = max(pos, event_pos)
 
-    layer = Map.get(span, :layer, 0)
-    width = span.end_byte - span.start_byte
-    pidx = Map.get(span, :pattern_index, 0)
-    cid = span.capture_id
-    entry = {layer, width, pidx, cid}
+    entry = {span.layer, span.end_byte - span.start_byte, span.pattern_index, span.capture_id}
 
     active =
       case type do
@@ -805,6 +785,16 @@ defmodule MingaEditor.UI.Highlight do
           FaceRegistry.style_for(hl.face_registry, name)
         end
     end
+  end
+
+  @spec validate_spans([Span.t()]) :: [Span.t()]
+  defp validate_spans(spans) do
+    Enum.each(spans, fn
+      %Span{} -> :ok
+      other -> raise ArgumentError, "expected highlight span struct, got: #{inspect(other)}"
+    end)
+
+    spans
   end
 
   @doc """

--- a/test/minga_editor/agent/markdown_highlight_test.exs
+++ b/test/minga_editor/agent/markdown_highlight_test.exs
@@ -9,13 +9,9 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
   defp make_highlight(attrs) do
     theme = Keyword.get(attrs, :theme, %{})
 
-    %Highlight{
-      version: Keyword.get(attrs, :version, 1),
-      spans: Keyword.get(attrs, :spans, {}),
-      capture_names: attrs |> Keyword.get(:capture_names, []) |> List.to_tuple(),
-      theme: theme,
-      face_registry: MingaEditor.UI.Face.Registry.from_syntax(theme)
-    }
+    Highlight.new(theme)
+    |> Highlight.put_names(Keyword.get(attrs, :capture_names, []))
+    |> Highlight.put_spans(Keyword.get(attrs, :version, 1), Keyword.get(attrs, :spans, []))
   end
 
   @theme_syntax %{
@@ -126,7 +122,7 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
       # The code line "def hello" starts at byte 10 (after "```elixir\n")
       highlight =
         make_highlight(
-          spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
+          spans: [Span.new(10, 13, 0)],
           capture_names: ["keyword"],
           theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
         )
@@ -159,7 +155,7 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
       # With buffer_byte_offset=100, the "def" keyword is at bytes 110-113.
       highlight =
         make_highlight(
-          spans: {%{start_byte: 110, end_byte: 113, capture_id: 0}},
+          spans: [Span.new(110, 113, 0)],
           capture_names: ["keyword"],
           theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
         )
@@ -178,7 +174,7 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
       # A header line should NOT be overridden by tree-sitter
       text = "# My Header"
 
-      highlight = make_highlight(spans: {}, capture_names: [], theme: %{})
+      highlight = make_highlight(spans: [], capture_names: [], theme: %{})
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax, 0)
 
@@ -195,7 +191,7 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
 
       highlight =
         make_highlight(
-          spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
+          spans: [Span.new(10, 13, 0)],
           capture_names: ["keyword"],
           theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
         )
@@ -212,7 +208,7 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
     test "falls back when highlight has no spans" do
       text = "**bold**"
 
-      highlight = make_highlight(version: 0, spans: {}, capture_names: [], theme: %{})
+      highlight = make_highlight(version: 0, spans: [], capture_names: [], theme: %{})
 
       result = MarkdownHighlight.stylize(text, highlight, @theme_syntax)
 
@@ -266,7 +262,7 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
 
       highlight =
         make_highlight(
-          spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
+          spans: [Span.new(10, 13, 0)],
           capture_names: ["keyword"],
           theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
         )
@@ -331,7 +327,7 @@ defmodule MingaEditor.Agent.MarkdownHighlightTest do
 
       highlight =
         make_highlight(
-          spans: {%{start_byte: 10, end_byte: 13, capture_id: 0}},
+          spans: [Span.new(10, 13, 0)],
           capture_names: ["keyword"],
           theme: %{"keyword" => [fg: 0xFF0000, bold: true]}
         )

--- a/test/minga_editor/handlers/highlight_handler_test.exs
+++ b/test/minga_editor/handlers/highlight_handler_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.Handlers.HighlightHandlerTest do
   @moduledoc """
   Pure-function tests for `MingaEditor.Handlers.HighlightHandler`.
   """
+  alias Minga.Language.Highlight.Span
 
   use ExUnit.Case, async: true
 
@@ -195,7 +196,7 @@ defmodule MingaEditor.Handlers.HighlightHandlerTest do
     test "queued parser events cannot recreate removed presentation state" do
       state = base_state()
       buffer = active_buffer(state)
-      spans = [%{start_byte: 0, end_byte: 1, capture_id: 0}]
+      spans = [Span.new(0, 1, 0)]
 
       assert {^state, []} =
                HighlightHandler.handle(

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -481,7 +481,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       highlight = Map.fetch!(new_state.parser.highlighting.highlights, buffer)
       assert Tuple.to_list(highlight.capture_names) == ["@lsp.type.variable"]
-      assert [%{layer: 2}] = Tuple.to_list(highlight.spans)
+      assert [%Minga.Language.Highlight.Span{layer: 2}] = Tuple.to_list(highlight.spans)
     end
 
     test "untracked completion response is processed off-thread, then becomes visible" do

--- a/test/minga_editor/handlers/session_restore_test.exs
+++ b/test/minga_editor/handlers/session_restore_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
   # Uses the application-wide buffer supervisor and event registry while restoring real file buffers.
   use ExUnit.Case, async: false
 
+  alias Minga.Language.Highlight.Span
   alias Minga.Parser.Manager
   alias Minga.Session
   alias Minga.Session.BufferEntry
@@ -49,7 +50,7 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
         {:minga_highlight, {:highlight_names, second_buffer, ["keyword"]}}
       )
 
-    spans = [%{start_byte: 0, end_byte: 9, capture_id: 0}]
+    spans = [Span.new(0, 9, 0)]
 
     {with_spans, _effects} =
       HighlightHandler.handle(

--- a/test/minga_editor/highlight_sync_test.exs
+++ b/test/minga_editor/highlight_sync_test.exs
@@ -1,6 +1,7 @@
 defmodule MingaEditor.HighlightSyncTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Language.Highlight.Span
   alias MingaEditor.State.Buffers
   alias MingaEditor.Session.State, as: SessionState
   alias Minga.Buffer.Process, as: BufferProcess
@@ -68,8 +69,8 @@ defmodule MingaEditor.HighlightSyncTest do
   describe "handle_spans/3" do
     test "stores spans with version" do
       spans = [
-        %{start_byte: 0, end_byte: 9, capture_id: 0},
-        %{start_byte: 10, end_byte: 15, capture_id: 1}
+        Span.new(0, 9, 0),
+        Span.new(10, 15, 1)
       ]
 
       state =
@@ -81,8 +82,8 @@ defmodule MingaEditor.HighlightSyncTest do
     end
 
     test "rejects stale spans with older version" do
-      spans1 = [%{start_byte: 0, end_byte: 5, capture_id: 0}]
-      spans2 = [%{start_byte: 0, end_byte: 3, capture_id: 1}]
+      spans1 = [Span.new(0, 5, 0)]
+      spans2 = [Span.new(0, 3, 1)]
 
       state =
         base_state()
@@ -94,8 +95,8 @@ defmodule MingaEditor.HighlightSyncTest do
     end
 
     test "accepts spans with equal version" do
-      spans1 = [%{start_byte: 0, end_byte: 5, capture_id: 0}]
-      spans2 = [%{start_byte: 0, end_byte: 3, capture_id: 1}]
+      spans1 = [Span.new(0, 5, 0)]
+      spans2 = [Span.new(0, 3, 1)]
 
       state =
         base_state()

--- a/test/minga_editor/render_pipeline/content_helpers_test.exs
+++ b/test/minga_editor/render_pipeline/content_helpers_test.exs
@@ -2,6 +2,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
   use ExUnit.Case, async: true
 
   alias Minga.Core.Decorations
+  alias Minga.Language.Highlight.Span
   alias MingaEditor.UI.Theme
   alias MingaEditor.Renderer.Context
   alias MingaEditor.RenderPipeline.ContentHelpers
@@ -27,7 +28,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
       highlight =
         Highlight.new()
         |> Highlight.put_names(["keyword"])
-        |> Highlight.put_spans(1, [%{start_byte: 0, end_byte: 3, capture_id: 0}])
+        |> Highlight.put_spans(1, [Span.new(0, 3, 0)])
 
       after_fp = ContentHelpers.context_fingerprint(%{ctx | highlight: highlight}, true)
 
@@ -38,10 +39,10 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
       highlight_v1 =
         Highlight.new()
         |> Highlight.put_names(["keyword"])
-        |> Highlight.put_spans(1, [%{start_byte: 0, end_byte: 3, capture_id: 0}])
+        |> Highlight.put_spans(1, [Span.new(0, 3, 0)])
 
       highlight_v2 =
-        Highlight.put_spans(highlight_v1, 2, [%{start_byte: 4, end_byte: 7, capture_id: 0}])
+        Highlight.put_spans(highlight_v1, 2, [Span.new(4, 7, 0)])
 
       ctx = %Context{
         viewport: Viewport.new(20, 80),
@@ -58,7 +59,7 @@ defmodule MingaEditor.RenderPipeline.ContentHelpersTest do
       highlight =
         Highlight.new()
         |> Highlight.put_names(["keyword"])
-        |> Highlight.put_spans(1, [%{start_byte: 0, end_byte: 3, capture_id: 0}])
+        |> Highlight.put_spans(1, [Span.new(0, 3, 0)])
 
       themed_highlight = Highlight.new(Theme.get!(:one_light).syntax)
 

--- a/test/minga_editor/ui/highlight_test.exs
+++ b/test/minga_editor/ui/highlight_test.exs
@@ -2,6 +2,7 @@ defmodule Minga.HighlightTest do
   use ExUnit.Case, async: true
 
   alias Minga.Core.Face
+  alias Minga.Language.Highlight.Span
   alias MingaEditor.UI.Highlight
 
   defp assert_segments(result, expected) do
@@ -23,13 +24,9 @@ defmodule Minga.HighlightTest do
   defp highlight_with(attrs) do
     theme = Keyword.get(attrs, :theme, %{})
 
-    %Highlight{
-      version: Keyword.get(attrs, :version, 1),
-      spans: Keyword.get(attrs, :spans, {}),
-      capture_names: attrs |> Keyword.get(:capture_names, []) |> List.to_tuple(),
-      theme: theme,
-      face_registry: MingaEditor.UI.Face.Registry.from_syntax(theme)
-    }
+    Highlight.new(theme)
+    |> Highlight.put_names(Keyword.get(attrs, :capture_names, []))
+    |> Highlight.put_spans(Keyword.get(attrs, :version, 1), Keyword.get(attrs, :spans, []))
   end
 
   describe "state construction and versioning" do
@@ -48,8 +45,8 @@ defmodule Minga.HighlightTest do
              |> Highlight.put_names(["keyword", "string"])
              |> Map.fetch!(:capture_names) == {"keyword", "string"}
 
-      spans1 = [%{start_byte: 0, end_byte: 5, capture_id: 0}]
-      spans2 = [%{start_byte: 0, end_byte: 3, capture_id: 1}]
+      spans1 = [Span.new(0, 5, 0)]
+      spans2 = [Span.new(0, 3, 1)]
 
       stored = Highlight.new() |> Highlight.put_spans(1, spans1)
       assert stored.version == 1
@@ -61,6 +58,10 @@ defmodule Minga.HighlightTest do
 
       equal = Highlight.new() |> Highlight.put_spans(5, spans1) |> Highlight.put_spans(5, spans2)
       assert equal.spans == List.to_tuple(spans2)
+
+      assert_raise ArgumentError, fn ->
+        Highlight.new() |> Highlight.put_spans(6, [%{start_byte: 0, end_byte: 1, capture_id: 0}])
+      end
     end
 
     test "line byte offsets count newlines and unicode bytes" do
@@ -79,7 +80,7 @@ defmodule Minga.HighlightTest do
 
       with_span =
         highlight_with(
-          spans: [%{start_byte: 0, end_byte: 10, capture_id: 0}],
+          spans: [Span.new(0, 10, 0)],
           capture_names: ["keyword"],
           theme: %{"keyword" => [fg: 0xFF0000]}
         )
@@ -88,7 +89,7 @@ defmodule Minga.HighlightTest do
 
       excluded =
         highlight_with(
-          spans: [%{start_byte: 100, end_byte: 110, capture_id: 0}],
+          spans: [Span.new(100, 110, 0)],
           capture_names: ["keyword"],
           theme: %{"keyword" => [fg: 0xFF0000]}
         )
@@ -100,8 +101,8 @@ defmodule Minga.HighlightTest do
       mismatched =
         highlight_with(
           spans: [
-            %{start_byte: 2, end_byte: 5, capture_id: 0},
-            %{start_byte: 10, end_byte: 20, capture_id: 0}
+            Span.new(2, 5, 0),
+            Span.new(10, 20, 0)
           ],
           capture_names: ["keyword"],
           theme: %{"keyword" => [fg: 0xFF0000]}
@@ -114,7 +115,7 @@ defmodule Minga.HighlightTest do
 
       partial =
         highlight_with(
-          spans: [%{start_byte: 0, end_byte: 1, capture_id: 0}],
+          spans: [Span.new(0, 1, 0)],
           capture_names: ["comment"],
           theme: %{"comment" => [fg: 0x888888]}
         )
@@ -124,7 +125,7 @@ defmodule Minga.HighlightTest do
 
       complete =
         highlight_with(
-          spans: [%{start_byte: 0, end_byte: 3, capture_id: 0}],
+          spans: [Span.new(0, 3, 0)],
           capture_names: ["comment"],
           theme: %{"comment" => [fg: 0x888888]}
         )
@@ -139,7 +140,7 @@ defmodule Minga.HighlightTest do
       cases = [
         {
           highlight_with(
-            spans: [%{start_byte: 0, end_byte: 3, capture_id: 0}],
+            spans: [Span.new(0, 3, 0)],
             capture_names: ["keyword"],
             theme: %{"keyword" => [fg: 0xFF0000]}
           ),
@@ -149,7 +150,7 @@ defmodule Minga.HighlightTest do
         },
         {
           highlight_with(
-            spans: [%{start_byte: 4, end_byte: 7, capture_id: 0}],
+            spans: [Span.new(4, 7, 0)],
             capture_names: ["string"],
             theme: %{"string" => [fg: 0x00FF00]}
           ),
@@ -160,8 +161,8 @@ defmodule Minga.HighlightTest do
         {
           highlight_with(
             spans: [
-              %{start_byte: 0, end_byte: 3, capture_id: 0},
-              %{start_byte: 4, end_byte: 7, capture_id: 1}
+              Span.new(0, 3, 0),
+              Span.new(4, 7, 1)
             ],
             capture_names: ["keyword", "function"],
             theme: %{"keyword" => [fg: 0xFF0000], "function" => [fg: 0x00FF00]}
@@ -172,7 +173,7 @@ defmodule Minga.HighlightTest do
         },
         {
           highlight_with(
-            spans: [%{start_byte: 0, end_byte: 20, capture_id: 0}],
+            spans: [Span.new(0, 20, 0)],
             capture_names: ["comment"],
             theme: %{"comment" => [fg: 0x888888, italic: true]}
           ),
@@ -182,7 +183,7 @@ defmodule Minga.HighlightTest do
         },
         {
           highlight_with(
-            spans: [%{start_byte: 0, end_byte: 3, capture_id: 99}],
+            spans: [Span.new(0, 3, 99)],
             capture_names: ["keyword"],
             theme: %{"keyword" => [fg: 0xFF0000]}
           ),
@@ -192,7 +193,7 @@ defmodule Minga.HighlightTest do
         },
         {
           highlight_with(
-            spans: [%{start_byte: 8, end_byte: 11, capture_id: 0}],
+            spans: [Span.new(8, 11, 0)],
             capture_names: ["keyword"],
             theme: %{"keyword" => [fg: 0xFF0000]}
           ),
@@ -211,8 +212,8 @@ defmodule Minga.HighlightTest do
       same_width =
         highlight_with(
           spans: [
-            %{start_byte: 0, end_byte: 9, capture_id: 0, pattern_index: 3},
-            %{start_byte: 0, end_byte: 9, capture_id: 1, pattern_index: 10}
+            Span.new(0, 9, 0, 3),
+            Span.new(0, 9, 1, 10)
           ],
           capture_names: ["keyword", "keyword.function"],
           theme: %{"keyword" => [fg: 0xFF0000], "keyword.function" => [fg: 0x00FF00]}
@@ -226,8 +227,8 @@ defmodule Minga.HighlightTest do
       partial =
         highlight_with(
           spans: [
-            %{start_byte: 0, end_byte: 5, capture_id: 0},
-            %{start_byte: 3, end_byte: 8, capture_id: 1}
+            Span.new(0, 5, 0),
+            Span.new(3, 8, 1)
           ],
           capture_names: ["keyword", "string"],
           theme: %{"keyword" => [fg: 0xFF0000], "string" => [fg: 0x00FF00]}
@@ -238,11 +239,10 @@ defmodule Minga.HighlightTest do
 
       injection =
         highlight_with(
-          spans:
-            List.to_tuple([
-              %{start_byte: 0, end_byte: 5, capture_id: 0, pattern_index: 10, layer: 0},
-              %{start_byte: 0, end_byte: 10, capture_id: 1, pattern_index: 1, layer: 1}
-            ]),
+          spans: [
+            Span.new(0, 5, 0, 10, 0),
+            Span.new(0, 10, 1, 1, 1)
+          ],
           capture_names: ["outer.keyword", "injection.string"],
           theme: %{"outer.keyword" => [fg: 0xFF0000], "injection.string" => [fg: 0x00FF00]}
         )
@@ -258,9 +258,9 @@ defmodule Minga.HighlightTest do
       interpolation =
         highlight_with(
           spans: [
-            %{start_byte: 0, end_byte: 2, capture_id: 1, pattern_index: 10},
-            %{start_byte: 0, end_byte: 10, capture_id: 0, pattern_index: 5},
-            %{start_byte: 9, end_byte: 10, capture_id: 1, pattern_index: 10}
+            Span.new(0, 2, 1, 10),
+            Span.new(0, 10, 0, 5),
+            Span.new(9, 10, 1, 10)
           ],
           capture_names: ["embedded", "punctuation.special"],
           theme: %{"embedded" => [fg: 0xAAAAAA], "punctuation.special" => [fg: 0xFF0000]}
@@ -274,13 +274,12 @@ defmodule Minga.HighlightTest do
 
       attributes =
         highlight_with(
-          spans:
-            List.to_tuple([
-              %{start_byte: 0, end_byte: 44, capture_id: 1, pattern_index: 38},
-              %{start_byte: 18, end_byte: 24, capture_id: 0, pattern_index: 5},
-              %{start_byte: 26, end_byte: 33, capture_id: 0, pattern_index: 5},
-              %{start_byte: 35, end_byte: 43, capture_id: 0, pattern_index: 5}
-            ]),
+          spans: [
+            Span.new(0, 44, 1, 38),
+            Span.new(18, 24, 0, 5),
+            Span.new(26, 33, 0, 5),
+            Span.new(35, 43, 0, 5)
+          ],
           capture_names: ["string.special.symbol", "constant"],
           theme: %{"string.special.symbol" => [fg: 0xAA00FF], "constant" => [fg: 0xDA8548]}
         )
@@ -300,12 +299,11 @@ defmodule Minga.HighlightTest do
 
       three_levels =
         highlight_with(
-          spans:
-            List.to_tuple([
-              %{start_byte: 0, end_byte: 20, capture_id: 0, pattern_index: 1},
-              %{start_byte: 5, end_byte: 15, capture_id: 1, pattern_index: 2},
-              %{start_byte: 8, end_byte: 12, capture_id: 2, pattern_index: 3}
-            ]),
+          spans: [
+            Span.new(0, 20, 0, 1),
+            Span.new(5, 15, 1, 2),
+            Span.new(8, 12, 2, 3)
+          ],
           capture_names: ["outer", "middle", "inner"],
           theme: %{
             "outer" => [fg: 0x111111],
@@ -332,11 +330,10 @@ defmodule Minga.HighlightTest do
 
       hl =
         highlight_with(
-          spans:
-            List.to_tuple([
-              %{start_byte: 0, end_byte: 3, capture_id: 0, pattern_index: 1},
-              %{start_byte: 8, end_byte: 13, capture_id: 1, pattern_index: 2}
-            ]),
+          spans: [
+            Span.new(0, 3, 0, 1),
+            Span.new(8, 13, 1, 2)
+          ],
           capture_names: ["keyword", "string"],
           theme: %{"keyword" => [fg: 0xFF0000], "string" => [fg: 0x00FF00]}
         )
@@ -352,7 +349,7 @@ defmodule Minga.HighlightTest do
     test "batch styling carries multi-line spans and watermark state across visible lines" do
       multiline =
         highlight_with(
-          spans: List.to_tuple([%{start_byte: 0, end_byte: 30, capture_id: 0, pattern_index: 1}]),
+          spans: [Span.new(0, 30, 0, 1)],
           capture_names: ["comment"],
           theme: %{"comment" => [fg: 0x888888]}
         )
@@ -366,11 +363,10 @@ defmodule Minga.HighlightTest do
 
       watermark =
         highlight_with(
-          spans:
-            List.to_tuple([
-              %{start_byte: 0, end_byte: 3, capture_id: 0, pattern_index: 1},
-              %{start_byte: 10, end_byte: 15, capture_id: 1, pattern_index: 2}
-            ]),
+          spans: [
+            Span.new(0, 3, 0, 1),
+            Span.new(10, 15, 1, 2)
+          ],
           capture_names: ["keyword", "string"],
           theme: %{"keyword" => [fg: 0xFF0000], "string" => [fg: 0x00FF00]}
         )
@@ -415,8 +411,8 @@ defmodule Minga.HighlightTest do
       #   `key`     -> @property
       #   `"value"` -> @string
       line = ~s(key: "value")
-      key_span = %{start_byte: 0, end_byte: 3, capture_id: 0}
-      value_span = %{start_byte: 5, end_byte: 12, capture_id: 1}
+      key_span = Span.new(0, 3, 0)
+      value_span = Span.new(5, 12, 1)
 
       hl =
         Highlight.from_theme(theme)
@@ -444,7 +440,7 @@ defmodule Minga.HighlightTest do
 
   describe "retheme/2" do
     test "swaps colors to the new theme while preserving spans, version, and capture names" do
-      spans = [%{start_byte: 0, end_byte: 7, capture_id: 0}]
+      spans = [Span.new(0, 7, 0)]
 
       hl =
         Highlight.from_theme(MingaEditor.UI.Theme.get!(:doom_one))

--- a/test/minga_editor/ui/prettify_symbols_effect_test.exs
+++ b/test/minga_editor/ui/prettify_symbols_effect_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.UI.PrettifySymbolsEffectTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Language.Highlight.Span
   alias Minga.Buffer
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Config
@@ -39,7 +40,7 @@ defmodule MingaEditor.UI.PrettifySymbolsEffectTest do
     highlight =
       Highlight.new()
       |> Highlight.put_names(["operator"])
-      |> Highlight.put_spans(7, [%{start_byte: 0, end_byte: 2, capture_id: 0}])
+      |> Highlight.put_spans(7, [Span.new(0, 2, 0)])
 
     request = PrettifySymbolsEffect.request(buffer, highlight, :elixir)
 
@@ -183,7 +184,7 @@ defmodule MingaEditor.UI.PrettifySymbolsEffectTest do
   defp operator_highlight do
     Highlight.new()
     |> Highlight.put_names(["operator"])
-    |> Highlight.put_spans(1, [%{start_byte: 0, end_byte: 2, capture_id: 0}])
+    |> Highlight.put_spans(1, [Span.new(0, 2, 0)])
   end
 
   defp conceal_groups(buffer) do

--- a/test/minga_editor/user_query_override_test.exs
+++ b/test/minga_editor/user_query_override_test.exs
@@ -7,6 +7,7 @@ defmodule MingaEditor.UserQueryOverrideTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Language.Highlight.Span
   alias MingaEditor.Commands.BufferManagement
   alias MingaEditor.HighlightSync
   alias MingaEditor.RenderPipeline.TestHelpers
@@ -31,7 +32,7 @@ defmodule MingaEditor.UserQueryOverrideTest do
       state =
         state
         |> HighlightSync.handle_names(["keyword"])
-        |> HighlightSync.handle_spans(1, [%{start_byte: 0, end_byte: 9, capture_id: 0}])
+        |> HighlightSync.handle_spans(1, [Span.new(0, 9, 0)])
 
       refute HighlightSync.get_active_highlight(state).spans == {}
 


### PR DESCRIPTION
## TL;DR

Highlight state now has one resident representation: a tuple of `Minga.Language.Highlight.Span` values owned by `MingaEditor.UI.Highlight`.

## Changes

- Tighten `Highlight.t()` and parser update specs to semantic `Span` values.
- Validate accepted payloads in `put_spans/3`, then store them as tuples.
- Remove list-resident and map-shaped query compatibility paths.
- Route semantic-token merge through Highlight owner APIs.
- Replace map default reads with direct `Span` fields while preserving ordering, layering, capture IDs, and parser correlation.
- Route true-highlight fixtures through `Highlight.new/1`, `put_names/2`, and `put_spans/3`.
- Record W105/ES08 evidence and review results in the lifecycle roadmap.

## Validation

- Focused ES08 suite: 166 passed.
- `make lint`: passed; zero Dialyzer errors, with two pre-existing buffer-management Credo refactoring opportunities and one pre-existing registry-test warning.
- `ERL_FLAGS='+S 2:2' make test`: 10,297 passed, 1 skipped, 204 excluded.
- `git diff --check`: passed.
- Correctness: PASS/Lean, 0.99.
- Elixir craftsmanship: RESOLVED/PASS.
- Ponytail: RESOLVED/PASS.
- Final reviewer: RESOLVED/PASS, 0.99.

## Scope

Production delta: 70 added / 86 removed, net -16. Test delta: 89 added / 91 removed, net -2. No new module, process, dependency, protocol, registry, public API, configuration, compatibility shim, or runtime concept.
