### PR TITLE
test: allow loaded asynchronous delivery

### DIFF
--- a/test/minga_agent/providers/native_mcp_test.exs
+++ b/test/minga_agent/providers/native_mcp_test.exs
@@ -9,7 +9,7 @@ defmodule MingaAgent.Providers.NativeMCPTest do
   alias ReqLLM.StreamResponse.MetadataHandle
 
   @moduletag :tmp_dir
-  @receive_timeout 5_000
+  @receive_timeout 10_000
 
   defp server_config(name \\ "Local Tools") do
     %ServerConfig{name: name, command: "ignored"}

--- a/test/minga_agent/tools/shell_test.exs
+++ b/test/minga_agent/tools/shell_test.exs
@@ -241,7 +241,7 @@ defmodule MingaAgent.Tools.ShellTest do
       command =
         "elixir -e 'IO.write(String.duplicate(\"x\", 51199)); IO.binwrite(:stdio, <<226>>); Process.sleep(50); IO.binwrite(:stdio, <<130, 172>>)'"
 
-      assert {:ok, output} = Shell.execute(command, dir, 5)
+      assert {:ok, output} = Shell.execute(command, dir, 15)
 
       assert String.valid?(output)
       assert output =~ "[truncated at 51KB]"

--- a/test/minga_editor/completion_trigger_test.exs
+++ b/test/minga_editor/completion_trigger_test.exs
@@ -117,7 +117,7 @@ defmodule MingaEditor.CompletionTriggerTest do
         assert completion == nil
         assert %CompletionTrigger{phase: {:debounced, timer, {0, 0}}, gen: 0} = result
         assert is_reference(timer)
-        assert_receive {:completion_debounce, ^clients, ^buf}, 200
+        assert_receive {:completion_debounce, ^clients, ^buf}, 1_000
       after
         Minga.LSP.SyncServer.remove_buffer(buf)
         GenServer.stop(buf)


### PR DESCRIPTION
## TL;DR

Three asynchronous tests keep their exact behavior assertions but allow loaded CI enough time to deliver successful work.

## Evidence

- CI run `29970997287` delivered the expected 100 ms completion debounce message at exactly the former 200 ms assertion boundary.
- CI run `29971855712` exceeded the Native MCP module's 5-second positive-event deadline and the successful child-Elixir command's 5-second deadline under full-suite load.

## Changes

- Allow one second for the exact completion debounce message.
- Allow ten seconds for positive Native MCP provider events; 50 ms negative assertions remain unchanged.
- Allow fifteen seconds for the successful split-codepoint shell command; intentional one-second timeout tests remain unchanged.

## Validation

- Focused three-file suite under failing seed `705552`: 43 passed
- `make lint`: passed, zero Dialyzer errors
- `ERL_FLAGS='+S 2:2' make test`: 10,297 passed, 1 skipped, 204 excluded
- `git diff --check`: passed
- Final reviewer: PASS, 0.99 confidence
