### PR TITLE
docs(editor): verify W106 lifecycle fix

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -4344,7 +4344,7 @@ New split and float popup windows initialize their viewport metadata from `state
 
 ### W106/ES09.1: Cut over FileTree visibility and interaction tags
 
-- **Status:** IMPLEMENTED
+- **Status:** VERIFIED
 - **Audit ID:** ES09.1
 - **Planning profile:** `ES09Planner`, editor-lifecycle-planner, read-only.
 - **Implementation profile:** `ES09Worker`, no delegation.
@@ -4368,3 +4368,10 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Remaining ES09 scope:** Full content lifecycle tagging that would replace `tree` plus `tree_status` remains explicitly deferred for a fresh follow-up planner after this slice merges. This entry implements only ES09.1 visibility/interaction cutover and must not be read as resolving the full ES09 finding.
 - **Discoveries affecting later work:** No replan trigger, owner drift, production budget issue, test budget issue, new dependency, protocol/frontend dependency, persisted tab migration need, ES10 refresh/watcher dependency, or compatibility need was found.
 - **needs_replan:** false.
+- **PR URL:** https://github.com/jsmestad/minga/pull/3206
+- **Implementation commit SHA:** `6f19d72a177170886f43a886128e167c3cd31bc3`
+- **Merge SHA:** `fb1a6ba3a5a37cc682cced8d29915953971e39c3`
+- **Merge evidence:** PR #3206 merged after CI run `29976292781` passed Elixir, Swift macOS, Swift protocol integration, Go TUI, Zig, Dialyzer, lint/format, Neovim conformance, Go TUI boot smoke, and keystroke latency checks.
+- **Findings resolved:** ES09.1 visibility and interaction state is resolved. The separate `tree` plus `tree_status` content lifecycle concern remains open under ES09 and requires a fresh planner.
+- **Completion date:** 2026-07-23
+- **Ledger reviewer verdict:** `PASS` with 0.99 confidence. PR, commit, merge, CI, completion, and deferred-scope evidence were confirmed.


### PR DESCRIPTION
# TL;DR

Record W106/ES09.1 as VERIFIED after the FileTree tagged-state cutover merged in PR #3206 with all CI checks passing.

## Context

The editor lifecycle roadmap is the repository-local execution ledger. Implementation PRs remain IMPLEMENTED until merge evidence is recorded separately against current `main`.

## Changes

- Promote W106/ES09.1 from IMPLEMENTED to VERIFIED.
- Record implementation and merge SHAs, CI run, completion date, and reviewer confirmation.
- Mark only the visibility/interaction slice resolved.
- Preserve full `tree` plus `tree_status` content lifecycle tagging as unresolved ES09 scope for a fresh planner.

## Verification

- `git diff --check`: passed.
- `make lint`: passed Credo, compile, formatting, and incremental Dialyzer with zero Dialyzer errors.
- Ledger reviewer: PASS with 0.99 confidence.
- PR #3206: merged at `fb1a6ba3a5a37cc682cced8d29915953971e39c3` after CI run `29976292781` passed.
