### PR TITLE
refactor(editor): own compaction lifecycle

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -26,12 +26,12 @@ The independent Ponytail gate produced 91 `ACCEPT`, 28 `ROUTE`, 11 `PRESERVE`, a
 Current accepted inventory:
 
 - **VERIFIED:** L01, L02, L04, L05, L10, L12
-- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08, ES03, ES05, ES07, ES08, ES12
+- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08, ES03, ES05, ES07, ES08, ES12, ES17
 - **CANDIDATE, lifecycle:** L11, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30
 - **CANDIDATE, deletion:** D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40
 - **CANDIDATE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
 - **CANDIDATE, craftsmanship:** (none)
-- **CANDIDATE, data shape:** ES09, ES10, ES14, ES16, ES17, ES18, ES21, ES24
+- **CANDIDATE, data shape:** ES09, ES10, ES14, ES16, ES18, ES21, ES24
 
 ### Freshness wave at `6e175b87764145577999a1c04a532960cb89222f`
 
@@ -41,7 +41,7 @@ Eleven independent read-only GPT-5.5 `medium` batches checked all 85 remaining `
 - **STILL_REPRODUCIBLE, deletion:** D05, D06, D08, D09, D10, D11, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D39
 - **STILL_REPRODUCIBLE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
 - **STILL_REPRODUCIBLE, craftsmanship:** E02, E03
-- **STILL_REPRODUCIBLE, data shape:** ES05, ES07, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES24
+- **STILL_REPRODUCIBLE, data shape:** ES05, ES07, ES09, ES10, ES12, ES14, ES16, ES18, ES24
 - **DRIFTED:** D13, D36, D40, S14, ES21
 
 Drift evidence:
@@ -4549,3 +4549,31 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Findings resolved:** ES16 is fully resolved.
 - **Completion date:** 2026-07-23
 - **Ledger reviewer verdict:** Initial review required explicit post-merge full-resolution evidence. After correction, PR URL, implementation SHA, merge SHA, successful CI run, completion date, and full ES16 resolution are all recorded.
+
+### W112/ES17: Make agent compaction UI lifecycle a tagged owner value
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** ES17
+- **Planning profile:** `ES17Planner`, editor-lifecycle-planner, read-only.
+- **Implementation profile:** `ES17Worker`, no delegation.
+- **Current baseline:** `e58c66d53061bdcac02a750714d5b41d6d0b1441`.
+- **Ready provenance:** Locked by `local://es17-plan.json` with status `READY`; scope was exactly one pure `MingaEditor.Agent.UIState.Compaction` owner with `%Compaction{threshold, execution}`, View/UIState aggregate APIs, StatusEventWorkflow threshold and execution migration, compaction terminal outcome migration, named owner/workflow/routing/outcome tests, exhaustive old-field search, formatting, `git diff --check`, `make lint`, full-suite validation, production net `<= +50`, test net `<= +160`, and this W112 evidence. Scheduler execution remained owned by `MingaEditor.EffectScheduler` and `MingaEditor.Agent.Compaction`.
+- **Failure reproduction:** Baseline source still stored four independent `MingaEditor.Agent.UIState.View` fields: `compact_warned`, `compact_triggered`, `compact_pending_fill_pct`, and `compaction_in_progress`. `StatusEventWorkflow` directly produced, consumed, and reset those fields across context usage, busy deferral, idle reset, warning, auto-trigger, and pending-fill application; terminal compaction outcomes cleared only the progress boolean through `UIState.finish_compaction/1`. The pre-change search reproduced old-field production and consumption in `lib/minga_editor/agent/status_event_workflow.ex`, `lib/minga_editor/agent/ui_state/view.ex`, and the named agent tests.
+- **Observable result:** Agent context-compaction UI state is now represented by one `%MingaEditor.Agent.UIState.Compaction{threshold, execution}` value. `threshold` is `:fresh | :warned | :triggered`; `execution` is `:idle | {:deferred, fill_pct} | :requested`. The owner returns only `:none | {:warn, fill_pct} | :schedule`; warning toasts, render scheduling, active-session lookup, scheduler admission, and terminal outcome effects stay in `StatusEventWorkflow` or `MingaEditor.Agent.Compaction`.
+- **Implementation result:** Added the pure Compaction owner with `new/0`, `record_context_usage/6`, `status_changed/5`, `finish/1`, and `requested?/1`; replaced the four View fields with `compaction: Compaction.new()`; added `View.replace_compaction/2`, `View.record_context_estimate/2`, and `UIState.replace_compaction/2`; changed `View.finish_compaction/1` and `UIState.finish_compaction/1` to clear only `execution`; migrated `StatusEventWorkflow.context_usage/3` and `status_changed/2` to install owner-returned state and map local actions after render; preserved shell-registration normalization before idle deferred action evaluation; captured the active session once for owner admission and scheduler mapping; renamed the scheduler effect alias to `AgentCompaction`; and migrated compaction outcome, routing, and focused workflow assertions to the tagged value.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/agent/status_event_workflow.ex`; `lib/minga_editor/agent/ui_state.ex`; `lib/minga_editor/agent/ui_state/view.ex`; `lib/minga_editor/agent/ui_state/compaction.ex`; `test/minga_editor/agent/ui_state/compaction_test.exs`; `test/minga_editor/agent/focused_event_workflows_test.exs`; `test/minga_editor/agent/event_routing_test.exs`; `test/minga_editor/agent/compaction_test.exs`.
+- **Focused validation:** `mix test test/minga_editor/agent/ui_state/compaction_test.exs test/minga_editor/agent/focused_event_workflows_test.exs test/minga_editor/agent/event_routing_test.exs test/minga_editor/agent/compaction_test.exs` passed 49 tests.
+- **Reference validation:** Exhaustive grep over `lib/minga_editor` and `test/minga_editor` found no executable `compact_warned`, `compact_triggered`, `compact_pending_fill_pct`, or `compaction_in_progress` references after cutover.
+- **Formatting and diff validation:** `mix format` ran on every touched Elixir source and test path. `mix format --check-formatted` passed. `git diff --check` passed.
+- **Broad validation:** `make lint` passed Credo on 8 changed source files, compile with warnings as errors, formatting, and incremental Dialyzer with zero Dialyzer errors. Final `mix test --max-cases 1` passed 10,326 tests, including 58 doctests and 99 properties, with 1 skipped and 204 excluded. Exact parallel `mix test` retries exposed unrelated async flakes in `MingaAgent.Providers.NativeTest`, `MingaAgent.Tools.SubagentTest`, `MingaAgent.SessionManagerTest`, and `MingaAgent.Providers.NativeMCPTest`; each named failure passed when rerun directly.
+- **Production lines added/removed before roadmap evidence:** `155 added / 136 removed`, net `+19`, within the locked production net `<= +50`; production numstat before this roadmap update: `lib/minga_editor/agent/status_event_workflow.ex 50 126`, `lib/minga_editor/agent/ui_state.ex 7 0`, `lib/minga_editor/agent/ui_state/view.ex 19 10`, `lib/minga_editor/agent/ui_state/compaction.ex 79 0`.
+- **Test lines added/removed before roadmap evidence:** `137 added / 12 removed`, net `+125`, within the locked test net `<= +160`; test numstat before this roadmap update: `test/minga_editor/agent/ui_state/compaction_test.exs 59 0`, `test/minga_editor/agent/focused_event_workflows_test.exs 69 4`, `test/minga_editor/agent/event_routing_test.exs 2 2`, `test/minga_editor/agent/compaction_test.exs 7 6`.
+- **Concepts added:** One pure UI lifecycle value, `MingaEditor.Agent.UIState.Compaction`; one workflow-local action union, `:none | {:warn, fill_pct} | :schedule`.
+- **Concepts removed:** Four independent View compaction fields and direct `StatusEventWorkflow` mutation ownership for compaction threshold/execution flags.
+- **Retained contracts:** Event order, context estimate display, nil/zero context-limit no-op behavior, warning threshold fallback and disabling, warning toast text and single-emission gate, auto threshold and active-session scheduling, busy `:thinking` and `:tool_executing` deferred latest-fill behavior, idle reset before deferred-fill evaluation, one requested compaction at a time, scheduler-owned admission/execution, terminal outcome progress clearing, admission-failure toast/render behavior, and stale/background outcome handling remain unchanged.
+- **Findings resolved:** ES17 is implemented as the locked `%Compaction{threshold, execution}` lifecycle owner without a process, dependency, behaviour, protocol, registry, configuration, compatibility shim, parallel fields, universal interpreter, or scheduler lifecycle copy.
+- **Mandatory review corrections:** Applied the required stale shell-registration ordering fix, single active-session capture and explicit local action mapping, consolidated one-shot agent UI installation, fixture owner-helper cleanup, latest-fill deferred owner test correction, and removal of the impossible schedule-without-session fallback so such a regression fails visibly instead of silently stranding `execution: :requested`. The stale registration regression proves idle deferred compaction does not schedule an old session and does not strand `execution: :requested` after shell normalization removes the stale session.
+- **Discoveries affecting later work:** The exact parallel `mix test` command remains susceptible to unrelated async timeouts/flakes in agent native/provider/session/extension tests in this worktree; direct reruns of the observed failures passed, and the final serial full suite passed. No replan trigger, owner drift, production budget issue, test budget issue, dependency, protocol/frontend dependency, compatibility need, or wider scope requirement was found.
+- **needs_replan:** false.
+- **Pre-acceptance reviews:** Correctness found stale shell-registration ordering and a missing latest-fill replacement regression; both were corrected and rechecked `RESOLVED/PASS`. Elixir craftsmanship required one captured session, exhaustive action mapping without silent impossible-state fallback, and aggregate-owner test fixtures; all were corrected and the final recheck returned `PASS`. Ponytail removed duplicate UI installation and fixture ceremony, then returned `RESOLVED`.
+- **Final reviewer verdict:** `PASS` with 0.99 confidence. The reviewer confirmed the locked owner shape, preserved event order and active-session identity, exhaustive owner-action consumption, terminal and old-field migration, budgets, validation evidence, and merge safety with no findings.

--- a/lib/minga_editor/agent/status_event_workflow.ex
+++ b/lib/minga_editor/agent/status_event_workflow.ex
@@ -6,14 +6,14 @@ defmodule MingaEditor.Agent.StatusEventWorkflow do
   """
 
   alias MingaEditor.Agent.Activity
-  alias MingaEditor.Agent.Compaction
+  alias MingaEditor.Agent.Compaction, as: AgentCompaction
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.Compaction
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
   alias MingaEditor.Shell.Workflow
   alias MingaEditor.State, as: EditorState
-  alias MingaEditor.State.Agent, as: AgentState
   alias MingaEditor.State.Tab
   alias MingaEditor.State.TabBar
   alias MingaEditor.State.Workspace
@@ -23,8 +23,7 @@ defmodule MingaEditor.Agent.StatusEventWorkflow do
   @doc "Synchronizes a foreground agent status and its dependent UI state."
   @spec status_changed(EditorState.t(), Tab.agent_status()) :: EditorState.t()
   def status_changed(%EditorState{} = state, status) do
-    state = transition_status(state, status)
-    {state, compaction_action} = apply_pending_auto_compact(state, status)
+    {state, compaction_action} = transition_status(state, status)
     state = MingaEditor.schedule_render(state, 16)
     state = log_status(state, status)
     apply_compaction_action(state, compaction_action)
@@ -37,9 +36,7 @@ defmodule MingaEditor.Agent.StatusEventWorkflow do
     state =
       TraditionalWorkflow.install_agent_view(
         state,
-        (fn view -> %{view | context_estimate: estimated_tokens} end).(
-          state.workspace.agent_ui.view
-        )
+        UIState.View.record_context_estimate(state.workspace.agent_ui.view, estimated_tokens)
       )
 
     {state, compaction_action} = maybe_auto_compact(state, estimated_tokens, context_limit)
@@ -49,15 +46,16 @@ defmodule MingaEditor.Agent.StatusEventWorkflow do
     |> apply_compaction_action(compaction_action)
   end
 
-  @spec transition_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
+  @spec transition_status(EditorState.t(), Tab.agent_status()) ::
+          {EditorState.t(), compaction_action()}
   defp transition_status(state, status) do
     state = TraditionalWorkflow.install_agent_status(state, status)
     state = engage_scroll(state, status)
     state = update_turn_activity(state, status)
     state = update_spinner(state, status)
-    state = reset_compact_state(state, status)
     state = sync_tab_agent_status(state, status)
-    sync_active_shell_agent_status(state, status)
+    state = sync_active_shell_agent_status(state, status)
+    apply_status_compaction(state, status)
   end
 
   @spec engage_scroll(EditorState.t(), Tab.agent_status()) :: EditorState.t()
@@ -79,19 +77,22 @@ defmodule MingaEditor.Agent.StatusEventWorkflow do
 
   defp update_spinner(state, _status), do: TraditionalWorkflow.install_agent_spinner_stop(state)
 
-  @spec reset_compact_state(EditorState.t(), Tab.agent_status()) :: EditorState.t()
-  defp reset_compact_state(state, :idle) do
-    TraditionalWorkflow.install_agent_view(
-      state,
-      (fn view -> %{view | compact_warned: false, compact_triggered: false} end).(
-        state.workspace.agent_ui.view
-      )
-    )
-  rescue
-    _error -> state
-  end
+  @spec apply_status_compaction(EditorState.t(), Tab.agent_status()) ::
+          {EditorState.t(), compaction_action()}
+  defp apply_status_compaction(state, status) do
+    session = Runtime.active_session(state.shell_runtime)
 
-  defp reset_compact_state(state, _status), do: state
+    {compaction, action} =
+      Compaction.status_changed(
+        state.workspace.agent_ui.view.compaction,
+        status,
+        compact_warn_threshold(),
+        compact_auto_threshold(),
+        is_pid(session)
+      )
+
+    {install_compaction_action(state, compaction, action), map_compaction_action(action, session)}
+  end
 
   @spec log_status(EditorState.t(), Tab.agent_status()) :: EditorState.t()
   defp log_status(state, :error) do
@@ -112,125 +113,48 @@ defmodule MingaEditor.Agent.StatusEventWorkflow do
          context_limit
        ) do
     fill_pct = min(round(estimated_tokens / context_limit * 100), 100)
-    view = state.workspace.agent_ui.view
     agent_status = TraditionalState.agent(shell_state).runtime.status
-    compact_when_ready(state, view, agent_status, fill_pct)
+
+    session = Runtime.active_session(state.shell_runtime)
+
+    {compaction, action} =
+      Compaction.record_context_usage(
+        state.workspace.agent_ui.view.compaction,
+        fill_pct,
+        agent_status,
+        compact_warn_threshold(),
+        compact_auto_threshold(),
+        is_pid(session)
+      )
+
+    {install_compaction_action(state, compaction, action), map_compaction_action(action, session)}
   end
 
   defp maybe_auto_compact(%EditorState{} = state, _estimated_tokens, _context_limit),
     do: {state, :none}
 
-  @spec compact_when_ready(EditorState.t(), term(), AgentState.status(), non_neg_integer()) ::
-          {EditorState.t(), compaction_action()}
-  defp compact_when_ready(state, _view, status, fill_pct)
-       when status in [:thinking, :tool_executing] do
-    state =
-      TraditionalWorkflow.install_agent_view(
-        state,
-        (&%{&1 | compact_pending_fill_pct: fill_pct}).(state.workspace.agent_ui.view)
-      )
-
-    {state, :none}
+  @spec install_compaction_action(EditorState.t(), Compaction.t(), Compaction.action()) ::
+          EditorState.t()
+  defp install_compaction_action(state, compaction, action) do
+    ui = UIState.replace_compaction(state.workspace.agent_ui, compaction)
+    ui = maybe_push_compaction_warning(ui, action)
+    TraditionalWorkflow.install_agent_ui(state, ui)
   end
 
-  defp compact_when_ready(state, %{compaction_in_progress: true}, _status, _fill_pct),
-    do: {state, :none}
-
-  defp compact_when_ready(state, view, _status, fill_pct),
-    do: apply_compact_threshold(state, view, fill_pct)
-
-  @spec apply_pending_auto_compact(EditorState.t(), Tab.agent_status()) ::
-          {EditorState.t(), compaction_action()}
-  defp apply_pending_auto_compact(state, :idle) do
-    case state.workspace.agent_ui.view.compact_pending_fill_pct do
-      nil ->
-        {state, :none}
-
-      fill_pct ->
-        state =
-          TraditionalWorkflow.install_agent_view(
-            state,
-            (&%{&1 | compact_pending_fill_pct: nil}).(state.workspace.agent_ui.view)
-          )
-
-        apply_compact_threshold(state, state.workspace.agent_ui.view, fill_pct)
-    end
+  @spec maybe_push_compaction_warning(UIState.t(), Compaction.action()) :: UIState.t()
+  defp maybe_push_compaction_warning(ui, {:warn, fill_pct}) do
+    UIState.push_toast(ui, "Context at #{fill_pct}%. Run /compact to free space.", :warning)
   end
 
-  defp apply_pending_auto_compact(state, _status), do: {state, :none}
+  defp maybe_push_compaction_warning(ui, :none), do: ui
+  defp maybe_push_compaction_warning(ui, :schedule), do: ui
 
-  @spec apply_compact_threshold(EditorState.t(), term(), non_neg_integer()) ::
-          {EditorState.t(), compaction_action()}
-  defp apply_compact_threshold(state, view, fill_pct) do
-    compact_threshold_result(
-      state,
-      view,
-      fill_pct,
-      compact_auto_threshold(),
-      compact_warn_threshold()
-    )
-  end
+  @spec map_compaction_action(Compaction.action(), pid() | nil) :: compaction_action()
+  defp map_compaction_action(:schedule, session) when is_pid(session),
+    do: {:compact_session, session}
 
-  @spec compact_threshold_result(
-          EditorState.t(),
-          term(),
-          non_neg_integer(),
-          non_neg_integer(),
-          non_neg_integer()
-        ) :: {EditorState.t(), compaction_action()}
-  defp compact_threshold_result(state, %{compact_triggered: false}, fill_pct, auto_pct, _warn_pct)
-       when auto_pct > 0 and fill_pct >= auto_pct,
-       do: trigger_auto_compact(state)
-
-  defp compact_threshold_result(state, %{compact_warned: false}, fill_pct, _auto_pct, warn_pct)
-       when warn_pct > 0 and fill_pct >= warn_pct,
-       do: warn_context_pressure(state, fill_pct)
-
-  defp compact_threshold_result(state, _view, _fill_pct, _auto_pct, _warn_pct),
-    do: {state, :none}
-
-  @spec trigger_auto_compact(EditorState.t()) :: {EditorState.t(), compaction_action()}
-  defp trigger_auto_compact(state) do
-    case Runtime.active_session(state.shell_runtime) do
-      session when is_pid(session) ->
-        state =
-          TraditionalWorkflow.install_agent_view(
-            state,
-            (fn view ->
-               %{view | compact_triggered: true, compaction_in_progress: true}
-             end).(state.workspace.agent_ui.view)
-          )
-
-        {state, {:compact_session, session}}
-
-      _session ->
-        {state, :none}
-    end
-  end
-
-  @spec warn_context_pressure(EditorState.t(), non_neg_integer()) ::
-          {EditorState.t(), compaction_action()}
-  defp warn_context_pressure(state, fill_pct) do
-    state =
-      TraditionalWorkflow.install_agent_view(
-        state,
-        (fn view -> %{view | compact_warned: true} end).(state.workspace.agent_ui.view)
-      )
-
-    state =
-      TraditionalWorkflow.install_agent_ui(
-        state,
-        (fn ui ->
-           UIState.push_toast(
-             ui,
-             "Context at #{fill_pct}%. Run /compact to free space.",
-             :warning
-           )
-         end).(state.workspace.agent_ui)
-      )
-
-    {state, :none}
-  end
+  defp map_compaction_action(:none, _session), do: :none
+  defp map_compaction_action({:warn, _fill_pct}, _session), do: :none
 
   @spec compact_warn_threshold() :: non_neg_integer()
   defp compact_warn_threshold do
@@ -253,7 +177,7 @@ defmodule MingaEditor.Agent.StatusEventWorkflow do
   defp apply_compaction_action(state, :none), do: state
 
   defp apply_compaction_action(state, {:compact_session, session}),
-    do: Compaction.schedule(state, session)
+    do: AgentCompaction.schedule(state, session)
 
   @spec update_activity(EditorState.t(), (Activity.t() -> Activity.t())) :: EditorState.t()
   defp update_activity(state, fun) when is_function(fun, 1) do

--- a/lib/minga_editor/agent/ui_state.ex
+++ b/lib/minga_editor/agent/ui_state.ex
@@ -14,6 +14,7 @@ defmodule MingaEditor.Agent.UIState do
 
   alias MingaEditor.Agent.UIState.Panel
   alias MingaEditor.Agent.UIState.View
+  alias MingaEditor.Agent.UIState.Compaction
   alias MingaEditor.Agent.Activity
   alias MingaEditor.Agent.EditTimeline
   alias MingaEditor.Agent.View.Preview
@@ -138,6 +139,12 @@ defmodule MingaEditor.Agent.UIState do
   @spec replace_edit_timeline(t(), EditTimeline.t()) :: t()
   def replace_edit_timeline(%__MODULE__{view: view} = state, %EditTimeline{} = timeline) do
     %{state | view: View.replace_edit_timeline(view, timeline)}
+  end
+
+  @doc "Installs the compaction lifecycle produced by a Compaction transition."
+  @spec replace_compaction(t(), Compaction.t()) :: t()
+  def replace_compaction(%__MODULE__{view: view} = state, %Compaction{} = compaction) do
+    %{state | view: View.replace_compaction(view, compaction)}
   end
 
   @doc "Marks compaction as no longer running."

--- a/lib/minga_editor/agent/ui_state/compaction.ex
+++ b/lib/minga_editor/agent/ui_state/compaction.ex
@@ -1,0 +1,79 @@
+defmodule MingaEditor.Agent.UIState.Compaction do
+  @moduledoc "Pure owner for agent context-compaction threshold and execution state."
+
+  @type threshold :: :fresh | :warned | :triggered
+  @type execution :: :idle | {:deferred, pct()} | :requested
+  @type action :: :none | {:warn, pct()} | :schedule
+  @type pct :: non_neg_integer()
+  @type t :: %__MODULE__{threshold: threshold(), execution: execution()}
+
+  defstruct threshold: :fresh,
+            execution: :idle
+
+  @spec new() :: t()
+  def new, do: %__MODULE__{}
+
+  @spec record_context_usage(t(), pct(), atom(), pct(), pct(), boolean()) :: {t(), action()}
+  def record_context_usage(%__MODULE__{execution: :requested} = compaction, _, _, _, _, _),
+    do: {compaction, :none}
+
+  def record_context_usage(%__MODULE__{} = compaction, fill_pct, status, _, _, _)
+      when status in [:thinking, :tool_executing] do
+    {%{compaction | execution: {:deferred, fill_pct}}, :none}
+  end
+
+  def record_context_usage(%__MODULE__{} = state, fill, _status, warn, auto, schedulable?) do
+    apply_thresholds(state, fill, warn, auto, schedulable?)
+  end
+
+  @spec status_changed(t(), atom(), pct(), pct(), boolean()) :: {t(), action()}
+  def status_changed(
+        %__MODULE__{execution: {:deferred, fill}} = state,
+        :idle,
+        warn,
+        auto,
+        schedulable?
+      ) do
+    state
+    |> reset_threshold()
+    |> finish()
+    |> apply_thresholds(fill, warn, auto, schedulable?)
+  end
+
+  def status_changed(%__MODULE__{} = compaction, :idle, _, _, _),
+    do: {reset_threshold(compaction), :none}
+
+  def status_changed(%__MODULE__{} = compaction, _status, _, _, _), do: {compaction, :none}
+
+  @spec finish(t()) :: t()
+  def finish(%__MODULE__{} = compaction), do: %{compaction | execution: :idle}
+
+  @spec requested?(t()) :: boolean()
+  def requested?(%__MODULE__{execution: :requested}), do: true
+  def requested?(%__MODULE__{}), do: false
+
+  defp apply_thresholds(
+         %__MODULE__{threshold: threshold} = state,
+         fill,
+         _warn,
+         auto,
+         schedulable?
+       )
+       when auto > 0 and fill >= auto and threshold != :triggered do
+    auto_threshold_result(state, schedulable?)
+  end
+
+  defp apply_thresholds(%__MODULE__{threshold: :fresh} = state, fill, warn, _auto, _schedulable?)
+       when warn > 0 and fill >= warn do
+    {%{state | threshold: :warned}, {:warn, fill}}
+  end
+
+  defp apply_thresholds(%__MODULE__{} = state, _, _, _, _), do: {state, :none}
+
+  defp auto_threshold_result(%__MODULE__{} = compaction, true),
+    do: {%{compaction | threshold: :triggered, execution: :requested}, :schedule}
+
+  defp auto_threshold_result(%__MODULE__{} = compaction, false), do: {compaction, :none}
+
+  defp reset_threshold(%__MODULE__{} = compaction), do: %{compaction | threshold: :fresh}
+end

--- a/lib/minga_editor/agent/ui_state/view.ex
+++ b/lib/minga_editor/agent/ui_state/view.ex
@@ -16,6 +16,7 @@ defmodule MingaEditor.Agent.UIState.View do
   alias MingaEditor.Agent.Activity
   alias MingaEditor.Agent.UIState.Presentation
   alias MingaEditor.Agent.UIState.ReturnTarget
+  alias MingaEditor.Agent.UIState.Compaction
   alias MingaEditor.Agent.View.Preview
   alias Minga.Config
   alias MingaEditor.State.FileTree, as: FileTreeState
@@ -59,10 +60,7 @@ defmodule MingaEditor.Agent.UIState.View do
           edit_timeline: EditTimeline.t(),
           activity: Activity.t(),
           context_estimate: non_neg_integer(),
-          compact_warned: boolean(),
-          compact_triggered: boolean(),
-          compact_pending_fill_pct: non_neg_integer() | nil,
-          compaction_in_progress: boolean()
+          compaction: Compaction.t()
         }
 
   @min_chat_pct 30
@@ -77,10 +75,7 @@ defmodule MingaEditor.Agent.UIState.View do
             toast: nil,
             toast_queue: :queue.new(),
             context_estimate: 0,
-            compact_warned: false,
-            compact_triggered: false,
-            compact_pending_fill_pct: nil,
-            compaction_in_progress: false,
+            compaction: Compaction.new(),
             edit_timeline: EditTimeline.new(),
             activity: Activity.new()
 
@@ -88,9 +83,23 @@ defmodule MingaEditor.Agent.UIState.View do
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
-  @doc "Marks compaction as no longer running."
+  @doc "Installs terminal compaction lifecycle state."
   @spec finish_compaction(t()) :: t()
-  def finish_compaction(%__MODULE__{} = view), do: %{view | compaction_in_progress: false}
+  def finish_compaction(%__MODULE__{compaction: compaction} = view) do
+    %{view | compaction: Compaction.finish(compaction)}
+  end
+
+  @doc "Installs the compaction value produced by a Compaction transition."
+  @spec replace_compaction(t(), Compaction.t()) :: t()
+  def replace_compaction(%__MODULE__{} = view, %Compaction{} = compaction) do
+    %{view | compaction: compaction}
+  end
+
+  @doc "Records the latest displayed context estimate."
+  @spec record_context_estimate(t(), non_neg_integer()) :: t()
+  def record_context_estimate(%__MODULE__{} = view, estimated_tokens) do
+    %{view | context_estimate: estimated_tokens}
+  end
 
   @doc "Installs the activity value produced by an Activity transition."
   @spec replace_activity(t(), Activity.t()) :: t()

--- a/test/minga_editor/agent/compaction_test.exs
+++ b/test/minga_editor/agent/compaction_test.exs
@@ -5,6 +5,7 @@ defmodule MingaEditor.Agent.CompactionTest do
 
   alias MingaEditor.Agent.Compaction
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.Compaction, as: CompactionState
   alias MingaEditor.Effect.Outcome
   alias MingaEditor.Session.State, as: WorkspaceState
   alias MingaEditor.Shell.Runtime
@@ -30,7 +31,7 @@ defmodule MingaEditor.Agent.CompactionTest do
     {failed, %Outcome{value: {:failed, _reason}}} =
       Compaction.apply(state, Outcome.failed(request, :provider_error))
 
-    refute failed.workspace.agent_ui.view.compaction_in_progress
+    assert failed.workspace.agent_ui.view.compaction.execution == :idle
     assert failed.workspace.agent_ui.view.toast.message == "Auto-compact failed: :provider_error"
 
     state = state_for(session)
@@ -38,7 +39,7 @@ defmodule MingaEditor.Agent.CompactionTest do
     {canceled, %Outcome{value: {:canceled, _reason}}} =
       Compaction.apply(state, Outcome.canceled(request, :requested))
 
-    refute canceled.workspace.agent_ui.view.compaction_in_progress
+    assert canceled.workspace.agent_ui.view.compaction.execution == :idle
 
     other_session = fake_session()
     stale_state = state_for(other_session)
@@ -60,7 +61,7 @@ defmodule MingaEditor.Agent.CompactionTest do
 
     background_ui =
       UIState.new()
-      |> then(fn ui -> %{ui | view: %{ui.view | compaction_in_progress: true}} end)
+      |> UIState.replace_compaction(%CompactionState{execution: :requested})
 
     tab_bar =
       TabBar.set_workspace_agent_ui(tab_bar, background_workspace.id, background_ui)
@@ -89,7 +90,7 @@ defmodule MingaEditor.Agent.CompactionTest do
       updated.shell_runtime.state.tab_bar
       |> TabBar.find_workspace_by_session(background_session)
 
-    refute background.agent_ui.view.compaction_in_progress
+    assert background.agent_ui.view.compaction.execution == :idle
     assert background.agent_ui.view.toast.message == "Auto-compact failed: :provider_error"
     assert MingaEditor.Shell.Runtime.active_session(updated.shell_runtime) == active_session
   end
@@ -100,7 +101,7 @@ defmodule MingaEditor.Agent.CompactionTest do
 
     updated = Compaction.schedule(state, session)
 
-    refute updated.workspace.agent_ui.view.compaction_in_progress
+    assert updated.workspace.agent_ui.view.compaction.execution == :idle
     assert updated.workspace.agent_ui.view.toast.level == :error
     assert updated.workspace.agent_ui.view.toast.message =~ "admission_failed"
     assert updated.render.render_correlation.timer != nil
@@ -115,7 +116,7 @@ defmodule MingaEditor.Agent.CompactionTest do
 
     agent_ui =
       UIState.new()
-      |> then(fn ui -> %{ui | view: %{ui.view | compaction_in_progress: true}} end)
+      |> UIState.replace_compaction(%CompactionState{execution: :requested})
 
     %EditorState{
       frontend: %MingaEditor.State.Frontend{port_manager: self(), backend: :tui},

--- a/test/minga_editor/agent/event_routing_test.exs
+++ b/test/minga_editor/agent/event_routing_test.exs
@@ -300,8 +300,8 @@ defmodule MingaEditor.Agent.EventRoutingTest do
       }
 
       state = Events.dispatch(state, {:context_usage, 95, 100})
-      assert state.workspace.agent_ui.view.compact_pending_fill_pct == 95
-      refute state.workspace.agent_ui.view.compaction_in_progress
+      assert state.workspace.agent_ui.view.compaction.execution == {:deferred, 95}
+      assert state.workspace.agent_ui.view.compaction.threshold == :fresh
     end
   end
 

--- a/test/minga_editor/agent/focused_event_workflows_test.exs
+++ b/test/minga_editor/agent/focused_event_workflows_test.exs
@@ -12,8 +12,10 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
   alias MingaEditor.Agent.StreamEventWorkflow
   alias MingaEditor.Agent.ToolEventWorkflow
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Agent.UIState.Compaction, as: CompactionState
   alias MingaEditor.Commands.AgentSubStates
   alias MingaEditor.Shell.Entry
+  alias MingaEditor.Shell.Registry, as: ShellRegistry
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.Shell.Traditional.Workflow, as: TraditionalWorkflow
@@ -366,14 +368,77 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
     state = StatusEventWorkflow.status_changed(state, :thinking)
     state = StatusEventWorkflow.context_usage(state, 95, 100)
 
-    assert state.workspace.agent_ui.view.compact_pending_fill_pct == 95
-    refute state.workspace.agent_ui.view.compaction_in_progress
+    assert state.workspace.agent_ui.view.compaction.execution == {:deferred, 95}
+    refute CompactionState.requested?(state.workspace.agent_ui.view.compaction)
 
     state = StatusEventWorkflow.status_changed(state, :idle)
 
-    assert state.workspace.agent_ui.view.compact_pending_fill_pct == nil
-    assert state.workspace.agent_ui.view.compaction_in_progress
+    assert state.workspace.agent_ui.view.compaction.execution == :requested
+    assert state.workspace.agent_ui.view.compaction.threshold == :triggered
     assert EffectScheduler.active?(effect_scheduler, Compaction)
+  end
+
+  test "idle deferred compaction ignores stale shell session after registration fallback" do
+    ShellRegistry.seed_builtin()
+
+    old_session =
+      spawn(fn ->
+        receive do
+          :stop -> :ok
+        end
+      end)
+
+    on_exit(fn -> send(old_session, :stop) end)
+    task_supervisor = start_supervised!({Task.Supervisor, []})
+
+    effect_scheduler =
+      start_supervised!({EffectScheduler, task_supervisor: task_supervisor})
+
+    agent_ui =
+      UIState.new()
+      |> UIState.replace_compaction(%CompactionState{
+        threshold: :warned,
+        execution: {:deferred, 95}
+      })
+
+    stale_entry = Entry.builtin!(:stale_fake, FakeShell, "Stale fake", "Stale fake shell", false)
+
+    state = %{
+      event_state(nil, effect_scheduler)
+      | workspace: %SessionState{agent_ui: agent_ui},
+        shell_runtime: Runtime.new(stale_entry, %{session: old_session})
+    }
+
+    state = StatusEventWorkflow.status_changed(state, :idle)
+
+    assert Runtime.active_session(state.shell_runtime) == nil
+    assert state.workspace.agent_ui.view.compaction.execution == :idle
+    assert state.workspace.agent_ui.view.compaction.threshold == :fresh
+    refute EffectScheduler.active?(effect_scheduler, Compaction)
+  end
+
+  test "context warning toast is emitted once without scheduling compaction" do
+    {:ok, session} = start_supervised({Session, provider_opts: []})
+    task_supervisor = start_supervised!({Task.Supervisor, []})
+
+    effect_scheduler =
+      start_supervised!({EffectScheduler, task_supervisor: task_supervisor})
+
+    state = event_state(session, effect_scheduler)
+    state = StatusEventWorkflow.context_usage(state, 80, 100)
+
+    assert state.workspace.agent_ui.view.compaction.threshold == :warned
+
+    assert state.workspace.agent_ui.view.toast.message ==
+             "Context at 80%. Run /compact to free space."
+
+    refute EffectScheduler.active?(effect_scheduler, Compaction)
+
+    state = StatusEventWorkflow.context_usage(state, 85, 100)
+
+    assert state.workspace.agent_ui.view.compaction.threshold == :warned
+    assert state.workspace.agent_ui.view.toast_queue == :queue.new()
+    refute EffectScheduler.active?(effect_scheduler, Compaction)
   end
 
   test "session error cancellation path tolerates a session that exited before queue recall" do

--- a/test/minga_editor/agent/ui_state/compaction_test.exs
+++ b/test/minga_editor/agent/ui_state/compaction_test.exs
@@ -1,0 +1,59 @@
+defmodule MingaEditor.Agent.UIState.CompactionTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Agent.UIState.Compaction
+
+  test "new state starts fresh and idle" do
+    assert Compaction.new() == %Compaction{threshold: :fresh, execution: :idle}
+  end
+
+  test "context usage below thresholds leaves state unchanged" do
+    compaction = Compaction.new()
+
+    assert Compaction.record_context_usage(compaction, 79, :idle, 80, 90, true) ==
+             {compaction, :none}
+  end
+
+  test "warning threshold warns once" do
+    compaction = Compaction.new()
+
+    assert {%Compaction{threshold: :warned, execution: :idle} = warned, {:warn, 80}} =
+             Compaction.record_context_usage(compaction, 80, :idle, 80, 90, true)
+
+    assert Compaction.record_context_usage(warned, 85, :idle, 80, 90, true) == {warned, :none}
+  end
+
+  test "busy statuses defer the latest fill percentage" do
+    assert {%Compaction{threshold: :fresh, execution: {:deferred, 95}} = deferred, :none} =
+             Compaction.record_context_usage(Compaction.new(), 95, :thinking, 80, 90, true)
+
+    assert {%Compaction{threshold: :fresh, execution: {:deferred, 96}}, :none} =
+             Compaction.record_context_usage(deferred, 96, :tool_executing, 80, 90, true)
+  end
+
+  test "idle consumes deferred fill after resetting threshold gates" do
+    compaction = %Compaction{threshold: :warned, execution: {:deferred, 95}}
+
+    assert {%Compaction{threshold: :triggered, execution: :requested}, :schedule} =
+             Compaction.status_changed(compaction, :idle, 80, 90, true)
+  end
+
+  test "auto threshold requires an active schedulable session" do
+    compaction = Compaction.new()
+
+    assert Compaction.record_context_usage(compaction, 95, :idle, 80, 90, false) ==
+             {compaction, :none}
+  end
+
+  test "requested execution admits only one request at a time" do
+    compaction = %Compaction{threshold: :triggered, execution: :requested}
+
+    assert Compaction.record_context_usage(compaction, 95, :idle, 80, 90, true) ==
+             {compaction, :none}
+  end
+
+  test "finish clears execution and preserves threshold" do
+    assert Compaction.finish(%Compaction{threshold: :triggered, execution: :requested}) ==
+             %Compaction{threshold: :triggered, execution: :idle}
+  end
+end


### PR DESCRIPTION
# TL;DR

Give agent context compaction one explicit lifecycle owner so warning, deferral, and requested execution cannot drift across independent fields.

## Context

The agent view previously stored four compaction fields that `StatusEventWorkflow` coordinated through branch order. That shape could represent deferred and requested work together, reset warning and trigger gates independently, or detach progress from the request lifecycle.

## Changes

- Add a pure `%UIState.Compaction{threshold, execution}` owner with explicit transition actions.
- Replace four independent view fields and migrate workflow, terminal outcome, and test consumers without compatibility fields.
- Preserve shell normalization and active-session identity before deferred idle scheduling.
- Keep warning toasts, rendering, scheduler admission, and execution in their existing workflow and scheduler owners.
- Add owner and workflow regressions for warning gates, latest busy fill, deferred idle application, one-request admission, stale shell registration, and terminal cleanup.
- Record W112/ES17 implementation, validation, budget, and review evidence.

## Verification

- Focused owner, workflow, routing, and outcome suite: 49 passed.
- `make lint`: passed Credo, warnings-as-errors compilation, formatting, and incremental Dialyzer with zero errors.
- `mix test --max-cases 1`: 10,326 tests, including 58 doctests and 99 properties, passed with one skipped and 204 excluded.
- Exact parallel `mix test` retries exposed unrelated asynchronous agent test timeouts; each observed failure passed directly.
- Deleted-field search, `mix format --check-formatted`, and `git diff --check`: passed.

## Compatibility

No frontend protocol, renderer, threshold configuration, transcript compaction, scheduler resource, queue policy, or effect outcome contract changed. No shim or parallel state representation remains.
