### PR TITLE
fix(agent): widen subagent context timeout

### DIFF
--- a/lib/minga_agent/session.ex
+++ b/lib/minga_agent/session.ex
@@ -185,7 +185,7 @@ defmodule MingaAgent.Session do
   @doc "Returns the provider context that should be inherited by a subagent."
   @spec subagent_context(GenServer.server()) :: subagent_context()
   def subagent_context(session) do
-    GenServer.call(session, :subagent_context)
+    GenServer.call(session, :subagent_context, 15_000)
   end
 
   @doc "Returns the conversation messages."


### PR DESCRIPTION
# TL;DR

Give parent-session context lookup a larger timeout than its nested provider-state query so provider timeout recovery can return inherited context instead of racing into the default-context fallback.

## Context

CI observed `inherits parent provider context by default` fail with `:credentials_not_configured`. `Session.subagent_context/1` used the default 5-second call timeout while its handler synchronously queried provider state with the same timeout. Under load, the outer call exited before the handler could catch the provider timeout and return lifecycle metadata, so the subagent silently selected default native context.

## Change

Set the outer Session context query timeout to 15 seconds. The nested provider query remains bounded at 5 seconds, preserving its existing warning and metadata fallback. A genuinely unresponsive Session remains bounded and reaches the existing caller fallback.

## Verification

- `mix test.debug test/minga_agent/tools/subagent_test.exs`: 4 passed.
- `make lint`: passed with zero Dialyzer errors.
- Native-helper-dependent failures after a fresh worktree: 36/36 passed after `mix compile.minga_zig`.
- `ELIXIR_ERL_OPTIONS='+S 4:4' mix test --warnings-as-errors --exclude conformance`: 10,329 passed, including 58 doctests and 99 properties; 1 skipped, 204 excluded.
- `git diff --check`: passed.
- Correctness review: PASS.
- Final reviewer: PASS with 0.99 confidence.