### PR TITLE
refactor(editor): type status bar snapshots

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -26,12 +26,12 @@ The independent Ponytail gate produced 91 `ACCEPT`, 28 `ROUTE`, 11 `PRESERVE`, a
 Current accepted inventory:
 
 - **VERIFIED:** L01, L02, L04, L05, L10, L12
-- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08, ES03, ES05, ES07, ES08, ES12, ES17, ES18
+- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08, ES03, ES05, ES07, ES08, ES12, ES17, ES18, ES21
 - **CANDIDATE, lifecycle:** L11, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30
 - **CANDIDATE, deletion:** D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40
 - **CANDIDATE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
 - **CANDIDATE, craftsmanship:** (none)
-- **CANDIDATE, data shape:** ES09, ES10, ES14, ES16, ES21, ES24
+- **CANDIDATE, data shape:** ES09, ES10, ES14, ES16, ES24
 
 ### Freshness wave at `6e175b87764145577999a1c04a532960cb89222f`
 
@@ -42,7 +42,7 @@ Eleven independent read-only GPT-5.5 `medium` batches checked all 85 remaining `
 - **STILL_REPRODUCIBLE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
 - **STILL_REPRODUCIBLE, craftsmanship:** E02, E03
 - **STILL_REPRODUCIBLE, data shape:** ES05, ES07, ES09, ES10, ES12, ES14, ES16, ES24
-- **DRIFTED:** D13, D36, D40, S14, ES21
+- **DRIFTED:** D13, D36, D40, S14
 
 Drift evidence:
 
@@ -51,7 +51,12 @@ Drift evidence:
 - **D40:** Agent-chat prefetch and `WindowCache.boundary_snapshot/1` remain dead, while `DisplayMap` queries and row-rasterization telemetry named by the old aggregate are now live. Split only current dead surfaces.
 - **S14:** Several picker preview callbacks are already optional, while cancel, prompt, effect, and input callbacks remain mandatory. Re-evaluate each remaining callback separately.
 - **ES08:** Parser and semantic-token producers now construct `Minga.Language.Highlight.Span`; only mixed map acceptance in editor highlight storage remains. Relock the remaining conversion boundary.
-- **ES21:** Typed semantic status-bar structs now exist beside the legacy snapshot maps. Relock which projection remains redundant instead of introducing a second typed model.
+
+Implemented evidence:
+
+- **ES21 / W114:** IMPLEMENTED in worktree `refactor-editor-lifecycle-next-76` from locked plan `local://es21-plan-v5.json` and post-review correction `local://es21-review-fix-plan.json` at baseline `73bdfd3f303d1443e665c03d1deeabe5f14aaadc`. Changed files in the current diff: `docs/workstreams/editor-lifecycle-roadmap.md`, `lib/minga_editor/status_bar/data.ex`, `lib/minga_editor/status_bar/data/common.ex`, `lib/minga_editor/status_bar/data/buffer.ex`, `lib/minga_editor/status_bar/data/agent.ex`, `lib/minga_editor/render_model/ui/status_bar_builder.ex`, `test/minga_editor/status_bar/data_test.exs`, `test/minga_editor/status_bar/data_safe_mode_test.exs`, `test/minga_editor/render_model/ui/status_bar_builder_test.exs`, `test/minga_editor/render_pipeline/chrome_test.exs`, `test/minga_editor/shell/traditional/chrome/gui_test.exs`, and `test/minga_editor/render_pipeline/chrome_dirty_test.exs`; `test/minga_editor/frontend/emit/gui_chrome_cache_test.exs` was touched only to apply the safe cut and has no remaining diff. Observable result: `MingaEditor.StatusBar.Data.from_state/1` now returns `%MingaEditor.StatusBar.Data{common: %Common{}, content: %Buffer{} | %Agent{}}`; `Common.raw_diagnostic_counts` preserves raw pathless `nil` for legacy modeline/custom segments while `common.status.diagnostics.counts` remains normalized to `{0, 0, 0, 0}` for semantic status and opcode `0x76`; `StatusBarBuilder.build/3` projects the typed snapshot to the unchanged semantic `%Minga.RenderModel.UI.StatusBar{}`; byte-parity tests keep `0x76` unchanged for buffer and agent snapshots with independent workspace and exact final agent-section assertions. Validation: focused correction tests `35 passed`; focused owner/builder/modeline/encoder/protocol tests `77 passed, 21 excluded`; focused chrome/cache tests `27 passed`; `mix format --check-formatted` passed for the locked file list; `mix compile --warnings-as-errors` passed; `git diff --check` passed; `make lint` passed with Credo clean and Dialyzer `Total errors: 0`; `mix test.llm --max-cases 4` passed with `58 doctests, 98 properties, 9764 tests, 0 failures, 1 skipped, 616 excluded`; default-concurrency `mix test.llm` was also run and exposed unrelated async timeouts/flakes in `agent/ingest`, `commands/agent_commands`, `providers/native_mcp`, and `session_manager`, with each failed location passing when re-run directly; focused Go status tests passed for 3 packages; `go test ./...` passed for 7 packages with 1 no-tests package; `mix swift.build` skipped because `xcodebuild` is unavailable on this Linux workstation. Budgets before roadmap evidence: production net `-13` lines (`lib/minga_editor/render_model/ui/status_bar_builder.ex` `+55/-79`, `lib/minga_editor/status_bar/data.ex` `+183/-233`, untracked value modules `+61`), test net `+173` lines, both within locked limits. Concepts added by the full ES21 implementation: the typed `Data` aggregate plus the new `Common`, `Buffer`, and `Agent` value modules; the post-review correction added exactly one enforced modeline-only `Common.raw_diagnostic_counts` field and no additional module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, parallel shape, wire shape, or frontend/generated path. Concepts removed: unused `MingaEditor.StatusBar.Data.lsp_status/0` alias and obsolete self-copy/test-only assertions. Discoveries: no `NEEDS_REPLAN`; Swift validation surface is unavailable here because Xcode is not installed; default-concurrency `mix test.llm` has unrelated async/resource flakes in this worktree, but low-concurrency full LLM validation and every failed location passed.
+- **ES21 / W114 review evidence:** Correctness initially found the raw diagnostic `nil` normalization regression, then returned `PASS / RESOLVED` after the locked correction and targeted roadmap-truthfulness fix. Ponytail's three test-strengthening findings and two safe cuts were applied; its targeted recheck confirmed the tests are lean and independent after the roadmap correction. Elixir craftsmanship returned `PASS / RESOLVED / LEAN`; the type-design specialist was unavailable because its runtime had no model configured, so the correctness and Elixir passes covered the new struct invariants. Final reviewer verdict: `PASS` with 0.99 confidence.
+- **ES21 / W114 CI stabilization:** The first required CI run passed every job except one unrelated load-sensitive `SessionRestoreTest` assertion whose expected refresh message arrived at the exact 1-second timeout. Both equivalent post-batch refresh assertions now allow 5 seconds while retaining the 900 ms duplicate-message rejection; the focused file passed `7 tests` at the failing CI seed `443303`. This test-only stabilization adds `test/minga_editor/handlers/session_restore_test.exs` to the changed-file ledger without changing ES21 production scope.
 
 Decision inventory:
 

--- a/lib/minga_editor/render_model/ui/status_bar_builder.ex
+++ b/lib/minga_editor/render_model/ui/status_bar_builder.ex
@@ -1,103 +1,88 @@
 defmodule MingaEditor.RenderModel.UI.StatusBarBuilder do
   @moduledoc false
 
+  alias Minga.Language.Devicon
   alias Minga.RenderModel.UI.StatusBar
-  alias Minga.RenderModel.UI.StatusBar.Agent
-  alias Minga.RenderModel.UI.StatusBar.Cursor
-  alias Minga.RenderModel.UI.StatusBar.Data, as: StatusData
-  alias Minga.RenderModel.UI.StatusBar.Diagnostics
+  alias Minga.RenderModel.UI.StatusBar.Agent, as: SemanticStatusAgent
+  alias Minga.RenderModel.UI.StatusBar.Data, as: SemanticStatusData
   alias Minga.RenderModel.UI.StatusBar.File, as: StatusFile
-  alias Minga.RenderModel.UI.StatusBar.Git
-  alias Minga.RenderModel.UI.StatusBar.Indent
-  alias Minga.RenderModel.UI.StatusBar.Language
   alias Minga.RenderModel.UI.StatusBar.Operation, as: StatusOperation
-  alias Minga.RenderModel.UI.StatusBar.Selection
   alias Minga.RenderModel.UI.StatusBar.Workspace, as: StatusWorkspace
   alias MingaEditor.Session.ChromeState
   alias MingaEditor.Session.ChromeState.WorkspaceSummary
   alias MingaEditor.State.Operation, as: EditorOperation
   alias MingaEditor.StatusBar.Data, as: StatusBarData
-  alias Minga.Language.Devicon
+  alias MingaEditor.StatusBar.Data.Agent, as: EditorStatusAgent
+  alias MingaEditor.StatusBar.Data.Buffer, as: EditorStatusBuffer
+  alias MingaEditor.StatusBar.Data.Common, as: EditorStatusCommon
 
   @spec build(StatusBarData.t(), term(), term()) :: StatusBar.t()
   def build(status_bar_data, theme, ctx) do
-    {content_kind, data} = StatusBarData.with_modeline_segments(status_bar_data, theme)
+    %StatusBarData{common: %EditorStatusCommon{} = common, content: content} =
+      StatusBarData.with_modeline_segments(status_bar_data, theme)
+
     chrome_state = ChromeState.from_editor_state(ctx)
 
     %StatusBar{
-      content_kind: content_kind,
-      data: data_model(data),
+      content_kind: content_kind(content),
+      data: data_model(common, content),
       workspace: active_workspace_model(chrome_state),
-      operation: operation_model(Map.get(data, :selected_operation))
+      operation: operation_model(common.selected_operation)
     }
   end
 
-  @spec data_model(map()) :: StatusData.t()
-  defp data_model(data) do
-    {icon, icon_color} = Devicon.icon_and_color(Map.get(data, :filetype, :text))
+  @spec content_kind(EditorStatusBuffer.t() | EditorStatusAgent.t()) :: StatusBar.content_kind()
+  defp content_kind(%EditorStatusBuffer{}), do: :buffer
+  defp content_kind(%EditorStatusAgent{}), do: :agent
 
-    %StatusData{
-      mode: Map.get(data, :mode, :normal),
-      safe_mode?: Map.get(data, :safe_mode, false),
-      dirty?: Map.get(data, :dirty, false),
-      cursor: %Cursor{
-        line: Map.get(data, :cursor_line, 0),
-        col: Map.get(data, :cursor_col, 0),
-        line_count: Map.get(data, :line_count, 1)
-      },
-      diagnostics: %Diagnostics{
-        counts: diagnostic_counts(Map.get(data, :diagnostic_counts)),
-        hint: Map.get(data, :diagnostic_hint)
-      },
-      language: %Language{
-        lsp_status: Map.get(data, :lsp_status, :none),
-        parser_status: Map.get(data, :parser_status, :available)
-      },
-      git: %Git{
-        branch: Map.get(data, :git_branch),
-        diff_summary: Map.get(data, :git_diff_summary)
-      },
-      file: %StatusFile{
-        name: Map.get(data, :file_name, ""),
-        filetype: Map.get(data, :filetype, :text),
-        icon: icon,
-        icon_color: icon_color
-      },
-      # Macro recording is emitted independently and the frontend gives it
-      # first priority. The text projection selects an active structured operation over
-      # an ordinary notice; terminal operation dwell remains frontend-owned.
-      message: projected_message(data),
-      recording: Map.get(data, :macro_recording, false),
-      indent: %Indent{
-        type: Map.get(data, :indent_type, :spaces),
-        size: Map.get(data, :indent_size, 2)
-      },
-      selection: selection_model(Map.get(data, :selection_info)),
-      agent: %Agent{
-        model_name: Map.get(data, :model_name, "Agent"),
-        message_count: Map.get(data, :message_count, 0),
-        session_status: Map.get(data, :session_status),
-        agent_status: Map.get(data, :agent_status),
-        background_count: Map.get(data, :background_subagent_count, 0),
-        background_label: Map.get(data, :active_background_subagent_label),
-        active_tool_name: Map.get(data, :active_tool_name)
-      },
-      modeline_segments: Map.get(data, :modeline_segments),
-      pending_keys: Map.get(data, :pending_keys, "")
+  @spec data_model(EditorStatusCommon.t(), EditorStatusBuffer.t() | EditorStatusAgent.t()) ::
+          SemanticStatusData.t()
+  defp data_model(
+         %EditorStatusCommon{
+           status: %SemanticStatusData{file: %StatusFile{} = file} = status
+         } = common,
+         content
+       ) do
+    {icon, icon_color} = Devicon.icon_and_color(file.filetype)
+
+    %{
+      status
+      | file: %StatusFile{file | icon: icon, icon_color: icon_color},
+        message: projected_message(common),
+        agent: agent_model(status.agent, content)
     }
   end
 
-  @spec projected_message(map()) :: String.t() | nil
-  defp projected_message(%{macro_recording: {true, register}}), do: "recording @#{register}"
+  @spec agent_model(SemanticStatusAgent.t(), EditorStatusBuffer.t() | EditorStatusAgent.t()) ::
+          SemanticStatusAgent.t()
+  defp agent_model(%SemanticStatusAgent{} = agent, %EditorStatusBuffer{}), do: agent
 
-  defp projected_message(%{
+  defp agent_model(%SemanticStatusAgent{} = agent, %EditorStatusAgent{} = content) do
+    %{
+      agent
+      | model_name: content.model_name,
+        session_status: content.session_status,
+        message_count: content.message_count
+    }
+  end
+
+  @spec projected_message(EditorStatusCommon.t()) :: String.t() | nil
+  defp projected_message(%EditorStatusCommon{
+         status: %SemanticStatusData{recording: {true, register}}
+       }),
+       do: "recording @#{register}"
+
+  defp projected_message(%EditorStatusCommon{
          selected_operation: %EditorOperation{status: status, message: message}
        })
        when status in [:pending, :queued, :running],
        do: message
 
-  defp projected_message(%{notice: message}) when is_binary(message), do: message
-  defp projected_message(data), do: Map.get(data, :diagnostic_hint)
+  defp projected_message(%EditorStatusCommon{notice: message}) when is_binary(message),
+    do: message
+
+  defp projected_message(%EditorStatusCommon{status: %SemanticStatusData{} = status}),
+    do: status.diagnostics.hint
 
   @spec operation_model(EditorOperation.t() | nil) :: StatusOperation.t() | nil
   defp operation_model(nil), do: nil
@@ -119,15 +104,6 @@ defmodule MingaEditor.RenderModel.UI.StatusBarBuilder do
   @spec nested_value(struct() | nil, atom()) :: term() | nil
   defp nested_value(nil, _field), do: nil
   defp nested_value(value, field), do: Map.fetch!(value, field)
-
-  @spec diagnostic_counts(term()) :: Diagnostics.counts()
-  defp diagnostic_counts({errors, warnings, info, hints}), do: {errors, warnings, info, hints}
-  defp diagnostic_counts(_counts), do: {0, 0, 0, 0}
-
-  @spec selection_model(StatusBarData.selection_info()) :: Selection.t()
-  defp selection_model({:chars, count}), do: %Selection{mode: :chars, size: count}
-  defp selection_model({:lines, count}), do: %Selection{mode: :lines, size: count}
-  defp selection_model(_selection_info), do: %Selection{}
 
   @spec active_workspace_model(ChromeState.t()) :: StatusWorkspace.t() | nil
   defp active_workspace_model(%ChromeState{} = chrome_state) do

--- a/lib/minga_editor/status_bar/data.ex
+++ b/lib/minga_editor/status_bar/data.ex
@@ -1,44 +1,47 @@
 defmodule MingaEditor.StatusBar.Data do
   @moduledoc """
-  Tagged-union data struct for the global status bar.
+  Typed editor snapshot for the global status bar.
 
   Computed once per frame from editor state and consumed by the semantic emit
   path, which encodes it as the 0x76 (`gui_status_bar`) structured opcode for
   every live frontend.
-
-  The two variants reflect the two kinds of focused window content:
-  - `{:buffer, t:buffer_data()}` — a normal buffer window
-  - `{:agent, t:agent_data()}` — an agent chat window
   """
 
-  alias Minga.Buffer
-  alias Minga.Diagnostics
+  alias Minga.Buffer, as: BufferAPI
   alias Minga.Config.ModelineSegments
-  alias MingaEditor.Editing
-  alias MingaEditor.State, as: EditorState
-  alias MingaEditor.State.Agent, as: AgentState
-  alias MingaEditor.State.Operation
-  alias MingaEditor.State.OperationFeedback
-  alias MingaEditor.Window.Content
   alias Minga.Config.Options
+  alias Minga.Diagnostics
   alias Minga.Git
   alias Minga.Git.MergeConflict
   alias Minga.Git.Repo, as: GitRepo
   alias Minga.LSP.SyncServer
-  alias MingaEditor.Shell.Traditional.Modeline
-  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
-  alias MingaEditor.Shell.Traditional.Notice
+  alias Minga.RenderModel.UI.StatusBar.Agent, as: SemanticStatusAgent
+  alias Minga.RenderModel.UI.StatusBar.Cursor, as: StatusCursor
+  alias Minga.RenderModel.UI.StatusBar.Data, as: SemanticStatusData
+  alias Minga.RenderModel.UI.StatusBar.Diagnostics, as: StatusDiagnostics
+  alias Minga.RenderModel.UI.StatusBar.File, as: StatusFile
+  alias Minga.RenderModel.UI.StatusBar.Git, as: StatusGit
+  alias Minga.RenderModel.UI.StatusBar.Indent, as: StatusIndent
+  alias Minga.RenderModel.UI.StatusBar.Language, as: StatusLanguage
+  alias Minga.RenderModel.UI.StatusBar.Selection, as: StatusSelection
+  alias Minga.RenderModel.UI.StatusBar.Workspace, as: StatusWorkspace
   alias MingaAgent.StatusCommand
-  alias MingaEditor.UI.Theme
+  alias MingaEditor.Editing
   alias MingaEditor.Session.ChromeState
-
-  # ── Types ──────────────────────────────────────────────────────────────────
+  alias MingaEditor.Shell.Traditional.Modeline
+  alias MingaEditor.Shell.Traditional.Notice
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Agent, as: AgentState
+  alias MingaEditor.State.OperationFeedback
+  alias MingaEditor.StatusBar.Data.Agent, as: StatusAgent
+  alias MingaEditor.StatusBar.Data.Buffer, as: StatusBuffer
+  alias MingaEditor.StatusBar.Data.Common
+  alias MingaEditor.UI.Theme
+  alias MingaEditor.Window.Content
 
   @typedoc "Git diff summary: {added, modified, deleted} line counts."
   @type git_diff_summary :: {non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil
-
-  @typedoc "LSP connection status."
-  @type lsp_status :: :ready | :initializing | :starting | :error | :none
 
   @typedoc "Parser availability status."
   @type parser_status :: :available | :unavailable | :restarting
@@ -49,111 +52,28 @@ defmodule MingaEditor.StatusBar.Data do
   @typedoc "Visual selection size display information."
   @type selection_info :: {:chars, non_neg_integer()} | {:lines, pos_integer()} | nil
 
-  @typedoc "Data for a focused buffer window."
-  @type buffer_data :: %{
-          optional(:modeline_segments) => Modeline.gui_segments(),
-          mode: Minga.Mode.mode(),
-          mode_state: Minga.Mode.state() | nil,
-          safe_mode: boolean(),
-          cursor_line: non_neg_integer(),
-          cursor_col: non_neg_integer(),
-          line_count: non_neg_integer(),
-          file_name: String.t(),
-          filetype: atom(),
-          dirty: boolean(),
-          git_branch: String.t() | nil,
-          git_diff_summary: git_diff_summary(),
-          git_degraded: boolean(),
-          diagnostic_counts:
-            {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil,
-          diagnostic_hint: String.t() | nil,
-          indent_type: indent_type(),
-          indent_size: pos_integer(),
-          selection_info: selection_info(),
-          lsp_status: lsp_status(),
-          parser_status: parser_status(),
-          buf_index: pos_integer(),
-          buf_count: non_neg_integer(),
-          macro_recording: {true, String.t()} | false,
-          agent_status: AgentState.status(),
-          active_tool_name: String.t() | nil,
-          agent_status_command: String.t() | nil,
-          agent_theme_colors: Theme.Agent.t() | nil,
-          background_subagent_count: non_neg_integer(),
-          active_background_subagent_label: String.t() | nil,
-          notice: String.t() | nil,
-          selected_operation: Operation.t() | nil,
-          pending_keys: String.t(),
-          workspace_label: String.t(),
-          workspace_draft_count: non_neg_integer(),
-          workspace_conflict_count: non_neg_integer(),
-          merge_conflict_count: non_neg_integer()
+  @type t :: %__MODULE__{
+          common: Common.t(),
+          content: StatusBuffer.t() | StatusAgent.t()
         }
 
-  @typedoc "Data for a focused agent chat window. Includes background buffer context so the status bar layout stays stable across mode switches."
-  @type agent_data :: %{
-          optional(:modeline_segments) => Modeline.gui_segments(),
-          mode: Minga.Mode.mode(),
-          mode_state: Minga.Mode.state() | nil,
-          safe_mode: boolean(),
-          model_name: String.t(),
-          session_status: AgentState.status(),
-          message_count: non_neg_integer(),
-          macro_recording: {true, String.t()} | false,
-          agent_status: AgentState.status(),
-          active_tool_name: String.t() | nil,
-          agent_status_command: String.t() | nil,
-          agent_theme_colors: Theme.Agent.t() | nil,
-          # Background buffer context (same fields as buffer_data)
-          cursor_line: non_neg_integer(),
-          cursor_col: non_neg_integer(),
-          line_count: non_neg_integer(),
-          file_name: String.t(),
-          filetype: atom(),
-          dirty: boolean(),
-          git_branch: String.t() | nil,
-          git_diff_summary: git_diff_summary(),
-          git_degraded: boolean(),
-          diagnostic_counts:
-            {non_neg_integer(), non_neg_integer(), non_neg_integer(), non_neg_integer()} | nil,
-          diagnostic_hint: String.t() | nil,
-          indent_type: indent_type(),
-          indent_size: pos_integer(),
-          selection_info: selection_info(),
-          lsp_status: lsp_status(),
-          parser_status: parser_status(),
-          buf_index: pos_integer(),
-          buf_count: non_neg_integer(),
-          background_subagent_count: non_neg_integer(),
-          active_background_subagent_label: String.t() | nil,
-          notice: String.t() | nil,
-          selected_operation: Operation.t() | nil,
-          pending_keys: String.t(),
-          workspace_label: String.t(),
-          workspace_draft_count: non_neg_integer(),
-          workspace_conflict_count: non_neg_integer(),
-          merge_conflict_count: non_neg_integer()
-        }
-
-  @typedoc "Tagged union: buffer or agent variant."
-  @type t :: {:buffer, buffer_data()} | {:agent, agent_data()}
-
-  # ── Public API ─────────────────────────────────────────────────────────────
+  @enforce_keys [:common, :content]
+  defstruct @enforce_keys
 
   @doc """
   Builds the status bar data from the current editor state.
 
-  Inspects the active window's content type and returns the appropriate
-  tagged variant. Called once per render frame before the Chrome stage.
+  Inspects the active window's content type and returns the appropriate typed
+  content marker. Called once per render frame before the Chrome stage.
   """
   @spec from_state(EditorState.t() | map()) :: t()
   def from_state(state) do
     active_window = Map.get(state.workspace.windows.map, state.workspace.windows.active)
 
     if active_window != nil and Content.agent_chat?(active_window.content) do
-      {:agent, build_agent_data(state)}
+      build_agent_data(state)
     else
-      {:buffer, build_buffer_data(state)}
+      build_buffer_data(state)
     end
   end
 
@@ -162,33 +82,40 @@ defmodule MingaEditor.StatusBar.Data do
   @spec with_modeline_segments(t(), Theme.t(), ModelineSegments.table()) :: t()
   def with_modeline_segments(status_bar_data, theme, modeline_segments_table \\ ModelineSegments)
 
-  def with_modeline_segments({:buffer, data}, theme, modeline_segments_table),
-    do: {:buffer, attach_modeline_segments(data, theme, modeline_segments_table)}
+  def with_modeline_segments(
+        %__MODULE__{common: %Common{status: %SemanticStatusData{} = status} = common} = data,
+        theme,
+        modeline_segments_table
+      ) do
+    segments =
+      Modeline.gui_segments(data_to_modeline_data(common), theme, modeline_segments_table)
 
-  def with_modeline_segments({:agent, data}, theme, modeline_segments_table),
-    do: {:agent, attach_modeline_segments(data, theme, modeline_segments_table)}
+    %{data | common: %{common | status: %{status | modeline_segments: segments}}}
+  end
 
   # ── Buffer variant ─────────────────────────────────────────────────────────
 
-  @spec build_buffer_data(EditorState.t() | map()) :: buffer_data()
-  defp build_buffer_data(state), do: build_buffer_status_data(state, no_buffer_file_name(state))
+  @spec build_buffer_data(EditorState.t() | map()) :: t()
+  defp build_buffer_data(state) do
+    %__MODULE__{
+      common: build_common_data(state, no_buffer_file_name(state)),
+      content: %StatusBuffer{}
+    }
+  end
 
-  @spec build_buffer_status_data(EditorState.t() | map(), String.t()) :: buffer_data()
-  defp build_buffer_status_data(state, no_buffer_file_name) do
+  @spec build_common_data(EditorState.t() | map(), String.t()) :: Common.t()
+  defp build_common_data(state, no_buffer_file_name) do
     buf = state.workspace.buffers.active
-    {line, col} = if buf, do: Buffer.cursor(buf), else: {0, 0}
-    line_count = if buf, do: Buffer.line_count(buf), else: 1
+    {line, col} = if buf, do: BufferAPI.cursor(buf), else: {0, 0}
+    line_count = if buf, do: BufferAPI.line_count(buf), else: 1
     file_name = if buf, do: buf_display_name(buf), else: no_buffer_file_name
-    dirty = buf != nil and Buffer.dirty?(buf)
+    dirty? = buf != nil and BufferAPI.dirty?(buf)
     filetype = if buf, do: buffer_filetype(buf), else: :text
     file_path = if buf, do: buffer_file_path(buf), else: nil
 
     {git_branch, git_diff_summary} = git_modeline_data(buf)
-    git_degraded = git_degraded?(file_path)
+    git_degraded? = git_degraded?(file_path)
     diagnostic_counts = diagnostic_modeline_data_from_path(file_path)
-
-    # Fetch diagnostic hint for the current cursor line (shown in status bar
-    # center segment when idle, replaces the old cell-grid minibuffer hint)
     diagnostic_hint = cursor_line_diagnostic_hint_from_path(file_path, line)
 
     mode = Minga.Editing.mode(state)
@@ -200,42 +127,45 @@ defmodule MingaEditor.StatusBar.Data do
     background = background_subagent_summary(state)
     workspace = workspace_modeline_summary(state)
 
-    %{
-      mode: mode,
+    %Common{
+      status: %SemanticStatusData{
+        mode: mode,
+        safe_mode?: Minga.SafeMode.active?(),
+        dirty?: dirty?,
+        cursor: %StatusCursor{line: line, col: col, line_count: line_count},
+        diagnostics: %StatusDiagnostics{
+          counts: diagnostic_counts || {0, 0, 0, 0},
+          hint: diagnostic_hint
+        },
+        language: %StatusLanguage{
+          lsp_status: state.lsp.status,
+          parser_status: parser_status(state)
+        },
+        git: %StatusGit{branch: git_branch, diff_summary: git_diff_summary},
+        file: %StatusFile{name: file_name, filetype: filetype},
+        message: nil,
+        recording: Minga.Editing.macro_recording_status(state),
+        indent: %StatusIndent{type: indent_type, size: indent_size},
+        selection: selection_model(selection_info),
+        agent: %SemanticStatusAgent{
+          agent_status: agent.runtime.status,
+          background_count: background.count,
+          background_label: background.label,
+          active_tool_name: agent.runtime.active_tool_name
+        },
+        pending_keys: pending_keys(state, mode, mode_state)
+      },
+      raw_diagnostic_counts: diagnostic_counts,
       mode_state: mode_state,
-      safe_mode: Minga.SafeMode.active?(),
-      cursor_line: line,
-      cursor_col: col,
-      line_count: line_count,
-      file_name: file_name,
-      filetype: filetype,
-      dirty: dirty,
-      git_branch: git_branch,
-      git_diff_summary: git_diff_summary,
-      git_degraded: git_degraded,
-      diagnostic_counts: diagnostic_counts,
-      diagnostic_hint: diagnostic_hint,
-      indent_type: indent_type,
-      indent_size: indent_size,
-      selection_info: selection_info,
-      lsp_status: state.lsp.status,
-      parser_status: parser_status(state),
       buf_index: state.workspace.buffers.active_index + 1,
       buf_count: Enum.count(state.workspace.buffers.list),
-      macro_recording: Minga.Editing.macro_recording_status(state),
-      agent_status: agent.runtime.status,
-      active_tool_name: agent.runtime.active_tool_name,
+      notice: notice_message(state),
+      selected_operation: OperationFeedback.selected(state.feedback.operation_feedback),
       agent_status_command: agent_status_command_content(state, agent),
       agent_theme_colors:
         if(agent.runtime.status, do: Theme.agent_theme(theme(state)), else: nil),
-      background_subagent_count: background.count,
-      active_background_subagent_label: background.label,
-      notice: notice_message(state),
-      selected_operation: OperationFeedback.selected(state.feedback.operation_feedback),
-      pending_keys: pending_keys(state, mode, mode_state),
-      workspace_label: workspace.label,
-      workspace_draft_count: workspace.draft_count,
-      workspace_conflict_count: workspace.conflict_count,
+      git_degraded: git_degraded?,
+      workspace: workspace,
       merge_conflict_count: merge_conflict_count(buf)
     }
   end
@@ -308,21 +238,21 @@ defmodule MingaEditor.StatusBar.Data do
 
   @spec buf_display_name(pid()) :: String.t()
   defp buf_display_name(buf) do
-    Buffer.display_name(buf)
+    BufferAPI.display_name(buf)
   catch
     :exit, _ -> "[no file]"
   end
 
   @spec buffer_filetype(pid()) :: atom()
   defp buffer_filetype(buf) do
-    Buffer.filetype(buf) || :text
+    BufferAPI.filetype(buf) || :text
   catch
     :exit, _ -> :text
   end
 
   @spec buffer_file_path(pid()) :: String.t() | nil
   defp buffer_file_path(buf) do
-    Buffer.file_path(buf)
+    BufferAPI.file_path(buf)
   catch
     :exit, _ -> nil
   end
@@ -338,7 +268,7 @@ defmodule MingaEditor.StatusBar.Data do
 
   @spec buffer_option(pid() | nil, Options.server(), atom(), Options.option_name()) :: term()
   defp buffer_option(buf, options_server, filetype, option) when is_pid(buf) do
-    case Buffer.get_option(buf, option) do
+    case BufferAPI.get_option(buf, option) do
       :error -> Options.get_for_filetype(options_server, option, filetype)
       value -> value
     end
@@ -375,7 +305,7 @@ defmodule MingaEditor.StatusBar.Data do
           Minga.Mode.mode(),
           Minga.Mode.state() | nil,
           pid() | nil,
-          Buffer.position()
+          BufferAPI.position()
         ) ::
           selection_info()
   defp selection_info(
@@ -389,29 +319,39 @@ defmodule MingaEditor.StatusBar.Data do
 
   defp selection_info(:visual, %{visual_type: :char, visual_anchor: anchor}, buf, cursor)
        when is_pid(buf) do
-    {:chars, Buffer.content_range_length(buf, anchor, cursor)}
+    {:chars, BufferAPI.content_range_length(buf, anchor, cursor)}
   catch
     :exit, _ -> nil
   end
 
   defp selection_info(_mode, _mode_state, _buf, _cursor), do: nil
 
+  @spec selection_model(selection_info()) :: StatusSelection.t()
+  defp selection_model({:chars, count}), do: %StatusSelection{mode: :chars, size: count}
+  defp selection_model({:lines, count}), do: %StatusSelection{mode: :lines, size: count}
+  defp selection_model(nil), do: %StatusSelection{}
+
   # ── Agent variant ──────────────────────────────────────────────────────────
 
-  @spec build_agent_data(EditorState.t() | map()) :: agent_data()
+  @spec build_agent_data(EditorState.t() | map()) :: t()
   defp build_agent_data(state) do
     agent = agent_state(state)
     panel = state.workspace.agent_ui.panel
     session = agent_session(state)
 
-    state
-    |> build_buffer_status_data("[no file]")
-    |> Map.merge(%{
-      model_name: if(panel.model_name != "", do: panel.model_name, else: "Agent"),
-      session_status: agent.runtime.status,
-      message_count: agent_message_count(session),
-      agent_theme_colors: Theme.agent_theme(theme(state))
-    })
+    %__MODULE__{
+      common: state |> build_common_data("[no file]") |> apply_agent_modeline_theme(state),
+      content: %StatusAgent{
+        model_name: if(panel.model_name != "", do: panel.model_name, else: "Agent"),
+        session_status: agent.runtime.status,
+        message_count: agent_message_count(session)
+      }
+    }
+  end
+
+  @spec apply_agent_modeline_theme(Common.t(), EditorState.t() | map()) :: Common.t()
+  defp apply_agent_modeline_theme(%Common{} = common, state) do
+    %{common | agent_theme_colors: Theme.agent_theme(theme(state))}
   end
 
   @spec agent_message_count(pid() | nil) :: non_neg_integer()
@@ -478,16 +418,6 @@ defmodule MingaEditor.StatusBar.Data do
 
   defp model_name(_panel_model, _session_model), do: "No model configured"
 
-  @spec attach_modeline_segments(map(), Theme.t(), ModelineSegments.table()) ::
-          buffer_data() | agent_data()
-  defp attach_modeline_segments(data, theme, modeline_segments_table) do
-    Map.put(
-      data,
-      :modeline_segments,
-      Modeline.gui_segments(data_to_modeline_data(data), theme, modeline_segments_table)
-    )
-  end
-
   # ── Git helpers ────────────────────────────────────────────────────────────
 
   @doc "Returns {branch_name | nil, diff_summary | nil} for the status bar."
@@ -530,7 +460,7 @@ defmodule MingaEditor.StatusBar.Data do
 
   defp merge_conflict_count(buf) when is_pid(buf) do
     case Git.tracking_pid(buf) do
-      nil -> buf |> Buffer.content() |> MergeConflict.parse() |> Enum.count()
+      nil -> buf |> BufferAPI.content() |> MergeConflict.parse() |> Enum.count()
       git_pid -> Git.conflict_count(git_pid)
     end
   catch
@@ -545,7 +475,7 @@ defmodule MingaEditor.StatusBar.Data do
   def diagnostic_modeline_data(buf) when is_pid(buf) do
     path =
       try do
-        Buffer.file_path(buf)
+        BufferAPI.file_path(buf)
       catch
         :exit, _ -> nil
       end
@@ -577,7 +507,7 @@ defmodule MingaEditor.StatusBar.Data do
   def cursor_line_diagnostic_hint(buf, line) when is_pid(buf) do
     file_path =
       try do
-        Buffer.file_path(buf)
+        BufferAPI.file_path(buf)
       catch
         :exit, _ -> nil
       end
@@ -617,65 +547,85 @@ defmodule MingaEditor.StatusBar.Data do
   @doc """
   Converts a `StatusBar.Data.t()` to the map shape expected by `Modeline.render/5`.
 
-  Both variants carry the same buffer fields and produce identical modeline data.
+  Both variants carry the same common fields and produce identical modeline data.
   """
   @spec to_modeline_data(t()) :: MingaEditor.Shell.Traditional.Modeline.modeline_data()
-  def to_modeline_data({_variant, d}), do: data_to_modeline_data(d)
+  def to_modeline_data(%__MODULE__{common: %Common{} = common}), do: data_to_modeline_data(common)
 
-  @spec data_to_modeline_data(map()) :: MingaEditor.Shell.Traditional.Modeline.modeline_data()
-  defp data_to_modeline_data(d) do
+  @spec data_to_modeline_data(Common.t()) ::
+          MingaEditor.Shell.Traditional.Modeline.modeline_data()
+  defp data_to_modeline_data(%Common{status: %SemanticStatusData{} = status} = common) do
+    workspace =
+      common.workspace || %StatusWorkspace{id: 0, kind: :manual, label: "Files", icon: ""}
+
+    selection_info = modeline_selection_info(status.selection)
+
     %{
-      mode: d.mode,
-      mode_state: d.mode_state,
-      safe_mode: Map.get(d, :safe_mode, false),
-      file_name: d.file_name,
-      filetype: d.filetype,
-      dirty_marker: if(d.dirty, do: " ● ", else: ""),
-      cursor_line: d.cursor_line,
-      cursor_col: d.cursor_col,
-      line_count: d.line_count,
-      buf_index: d.buf_index,
-      buf_count: d.buf_count,
-      macro_recording: d.macro_recording,
-      agent_status: d.agent_status,
-      active_tool_name: Map.get(d, :active_tool_name),
-      agent_status_command: Map.get(d, :agent_status_command),
-      agent_theme_colors: d.agent_theme_colors,
-      lsp_status: d.lsp_status,
-      parser_status: d.parser_status,
-      git_branch: d.git_branch,
-      git_diff_summary: d.git_diff_summary,
-      git_degraded: Map.get(d, :git_degraded, false),
-      diagnostic_counts: d.diagnostic_counts,
-      indent_type: d.indent_type,
-      indent_size: d.indent_size,
-      selection_info: d.selection_info,
-      background_subagent_count: d.background_subagent_count,
-      active_background_subagent_label: d.active_background_subagent_label,
-      workspace_label: d.workspace_label,
-      workspace_draft_count: d.workspace_draft_count,
-      workspace_conflict_count: d.workspace_conflict_count,
-      merge_conflict_count: d.merge_conflict_count
+      mode: status.mode,
+      mode_state: common.mode_state,
+      safe_mode: status.safe_mode?,
+      file_name: status.file.name,
+      filetype: status.file.filetype,
+      dirty_marker: if(status.dirty?, do: " ● ", else: ""),
+      cursor_line: status.cursor.line,
+      cursor_col: status.cursor.col,
+      line_count: status.cursor.line_count,
+      buf_index: common.buf_index,
+      buf_count: common.buf_count,
+      macro_recording: status.recording,
+      agent_status: status.agent.agent_status,
+      active_tool_name: status.agent.active_tool_name,
+      agent_status_command: common.agent_status_command,
+      agent_theme_colors: common.agent_theme_colors,
+      lsp_status: status.language.lsp_status,
+      parser_status: status.language.parser_status,
+      git_branch: status.git.branch,
+      git_diff_summary: status.git.diff_summary,
+      git_degraded: common.git_degraded,
+      diagnostic_counts: common.raw_diagnostic_counts,
+      indent_type: status.indent.type,
+      indent_size: status.indent.size,
+      selection_info: selection_info,
+      background_subagent_count: status.agent.background_count,
+      active_background_subagent_label: status.agent.background_label,
+      workspace_label: workspace.label,
+      workspace_draft_count: workspace.draft_count,
+      workspace_conflict_count: workspace.conflict_count,
+      merge_conflict_count: common.merge_conflict_count
     }
   end
 
-  @spec workspace_modeline_summary(EditorState.t() | map()) :: %{
-          label: String.t(),
-          draft_count: non_neg_integer(),
-          conflict_count: non_neg_integer()
-        }
+  @spec modeline_selection_info(StatusSelection.t()) :: selection_info()
+  defp modeline_selection_info(%StatusSelection{mode: :chars, size: count}), do: {:chars, count}
+  defp modeline_selection_info(%StatusSelection{mode: :lines, size: count}), do: {:lines, count}
+  defp modeline_selection_info(%StatusSelection{}), do: nil
+
+  @spec workspace_modeline_summary(EditorState.t() | map()) :: StatusWorkspace.t() | nil
   defp workspace_modeline_summary(state) do
     chrome_state = ChromeState.from_editor_state(state)
 
-    active_workspace =
-      Enum.find(chrome_state.workspaces, fn workspace ->
-        workspace.id == chrome_state.active_workspace_id
-      end)
+    chrome_state.workspaces
+    |> Enum.find(fn workspace -> workspace.id == chrome_state.active_workspace_id end)
+    |> workspace_model(chrome_state)
+  end
 
-    %{
-      label: if(active_workspace, do: active_workspace.label, else: "Files"),
+  @spec workspace_model(ChromeState.WorkspaceSummary.t() | nil, ChromeState.t()) ::
+          StatusWorkspace.t() | nil
+  defp workspace_model(nil, _chrome_state), do: nil
+
+  defp workspace_model(%ChromeState.WorkspaceSummary{} = workspace, %ChromeState{} = chrome_state) do
+    %StatusWorkspace{
+      id: workspace.id,
+      kind: workspace.kind,
+      label: workspace.label,
+      icon: workspace.icon,
+      status: workspace.status,
+      attention_count: chrome_state.attention_count,
       draft_count: chrome_state.draft_count,
-      conflict_count: chrome_state.conflict_count
+      conflict_count: chrome_state.conflict_count,
+      running_background_count: workspace.running_background_count,
+      closeable?: workspace.closeable?,
+      attention?: workspace.attention?
     }
   end
 

--- a/lib/minga_editor/status_bar/data/agent.ex
+++ b/lib/minga_editor/status_bar/data/agent.ex
@@ -1,0 +1,14 @@
+defmodule MingaEditor.StatusBar.Data.Agent do
+  @moduledoc false
+
+  alias MingaEditor.State.Agent, as: AgentState
+
+  @type t :: %__MODULE__{
+          model_name: String.t(),
+          session_status: AgentState.status(),
+          message_count: non_neg_integer()
+        }
+
+  @enforce_keys [:model_name, :session_status, :message_count]
+  defstruct @enforce_keys
+end

--- a/lib/minga_editor/status_bar/data/buffer.ex
+++ b/lib/minga_editor/status_bar/data/buffer.ex
@@ -1,0 +1,7 @@
+defmodule MingaEditor.StatusBar.Data.Buffer do
+  @moduledoc false
+
+  @type t :: %__MODULE__{}
+
+  defstruct []
+end

--- a/lib/minga_editor/status_bar/data/common.ex
+++ b/lib/minga_editor/status_bar/data/common.ex
@@ -1,0 +1,40 @@
+defmodule MingaEditor.StatusBar.Data.Common do
+  @moduledoc false
+
+  alias Minga.RenderModel.UI.StatusBar.Data, as: StatusData
+  alias Minga.RenderModel.UI.StatusBar.Diagnostics
+  alias Minga.RenderModel.UI.StatusBar.Workspace
+  alias MingaEditor.State.Operation
+  alias MingaEditor.UI.Theme
+
+  @type t :: %__MODULE__{
+          status: StatusData.t(),
+          raw_diagnostic_counts: Diagnostics.counts() | nil,
+          mode_state: Minga.Mode.state() | nil,
+          buf_index: pos_integer(),
+          buf_count: non_neg_integer(),
+          notice: String.t() | nil,
+          selected_operation: Operation.t() | nil,
+          agent_status_command: String.t() | nil,
+          agent_theme_colors: Theme.Agent.t() | nil,
+          git_degraded: boolean(),
+          workspace: Workspace.t() | nil,
+          merge_conflict_count: non_neg_integer()
+        }
+
+  @enforce_keys [
+    :status,
+    :raw_diagnostic_counts,
+    :mode_state,
+    :buf_index,
+    :buf_count,
+    :notice,
+    :selected_operation,
+    :agent_status_command,
+    :agent_theme_colors,
+    :git_degraded,
+    :workspace,
+    :merge_conflict_count
+  ]
+  defstruct @enforce_keys
+end

--- a/test/minga_editor/handlers/session_restore_test.exs
+++ b/test/minga_editor/handlers/session_restore_test.exs
@@ -88,7 +88,7 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
 
     assert [_, _] = TabBar.visible_file_tabs(restored.shell_runtime.state.tab_bar)
     assert Minga.Buffer.file_path(restored.workspace.buffers.active) == first_path
-    assert_receive :request_code_lens_and_inlay_hints, 1_000
+    assert_receive :request_code_lens_and_inlay_hints, 5_000
     refute_receive :request_code_lens_and_inlay_hints, 900
   end
 
@@ -111,7 +111,7 @@ defmodule MingaEditor.Handlers.SessionRestoreTest do
 
     assert [_] = TabBar.visible_file_tabs(restored.shell_runtime.state.tab_bar)
     assert Minga.Buffer.file_path(restored.workspace.buffers.active) == existing_path
-    assert_receive :request_code_lens_and_inlay_hints, 1_000
+    assert_receive :request_code_lens_and_inlay_hints, 5_000
     refute_receive :request_code_lens_and_inlay_hints, 900
   end
 

--- a/test/minga_editor/render_model/ui/status_bar_builder_test.exs
+++ b/test/minga_editor/render_model/ui/status_bar_builder_test.exs
@@ -1,54 +1,78 @@
 defmodule MingaEditor.RenderModel.UI.StatusBarBuilderTest do
   use ExUnit.Case, async: true
 
+  alias Minga.Language.Devicon
+  alias Minga.Frontend.Adapter.GUI.StatusBarEncoder
   alias Minga.RenderModel.UI.StatusBar
+  alias Minga.RenderModel.UI.StatusBar.Agent, as: SemanticStatusAgent
+  alias Minga.RenderModel.UI.StatusBar.Cursor
+  alias Minga.RenderModel.UI.StatusBar.Data, as: SemanticStatusData
+  alias Minga.RenderModel.UI.StatusBar.Diagnostics
+  alias Minga.RenderModel.UI.StatusBar.File, as: StatusFile
+  alias Minga.RenderModel.UI.StatusBar.Git
+  alias Minga.RenderModel.UI.StatusBar.Indent
+  alias Minga.RenderModel.UI.StatusBar.Language
   alias Minga.RenderModel.UI.StatusBar.Operation, as: StatusOperation
+  alias Minga.RenderModel.UI.StatusBar.Selection
   alias Minga.RenderModel.UI.StatusBar.Workspace
+  alias MingaEditor.RenderModel.UI.StatusBarBuilder
   alias MingaEditor.State.Operation
   alias MingaEditor.State.OperationProgress
   alias MingaEditor.State.OperationQueue
-  alias MingaEditor.RenderModel.UI.StatusBarBuilder
+  alias MingaEditor.StatusBar.Data, as: EditorStatusData
+  alias MingaEditor.StatusBar.Data.Agent, as: EditorStatusAgent
+  alias MingaEditor.StatusBar.Data.Buffer, as: EditorStatusBuffer
+  alias MingaEditor.StatusBar.Data.Common
 
   defp minimal_buffer_data do
-    {:buffer,
-     %{
-       mode: :normal,
-       mode_state: nil,
-       safe_mode: false,
-       cursor_line: 0,
-       cursor_col: 0,
-       line_count: 1,
-       file_name: "test.ex",
-       filetype: :elixir,
-       dirty: false,
-       git_branch: nil,
-       git_diff_summary: nil,
-       diagnostic_counts: nil,
-       diagnostic_hint: nil,
-       indent_type: :spaces,
-       indent_size: 2,
-       selection_info: nil,
-       lsp_status: :none,
-       parser_status: :available,
-       buf_index: 1,
-       buf_count: 1,
-       macro_recording: false,
-       agent_status: :inactive,
-       active_tool_name: nil,
-       agent_theme_colors: nil,
-       background_subagent_count: 0,
-       active_background_subagent_label: nil,
-       notice: nil,
-       workspace_label: "Default",
-       workspace_draft_count: 0,
-       workspace_conflict_count: 0,
-       merge_conflict_count: 0
-     }}
+    %EditorStatusData{common: minimal_common(), content: %EditorStatusBuffer{}}
   end
 
-  defp minimal_theme do
-    MingaEditor.UI.Theme.get!(:doom_one)
+  defp minimal_agent_data do
+    %EditorStatusData{
+      common: minimal_common(),
+      content: %EditorStatusAgent{
+        model_name: "Codex",
+        session_status: :thinking,
+        message_count: 3
+      }
+    }
   end
+
+  defp minimal_common do
+    %Common{
+      status: %SemanticStatusData{
+        mode: :normal,
+        safe_mode?: false,
+        dirty?: false,
+        cursor: %Cursor{line: 0, col: 0, line_count: 1},
+        diagnostics: %Diagnostics{},
+        language: %Language{lsp_status: :none, parser_status: :available},
+        git: %Git{},
+        file: %StatusFile{name: "test.ex", filetype: :elixir},
+        recording: false,
+        indent: %Indent{type: :spaces, size: 2},
+        selection: %Selection{},
+        agent: %SemanticStatusAgent{agent_status: :inactive},
+        pending_keys: ""
+      },
+      raw_diagnostic_counts: {0, 0, 0, 0},
+      mode_state: nil,
+      buf_index: 1,
+      buf_count: 1,
+      notice: nil,
+      selected_operation: nil,
+      agent_status_command: nil,
+      agent_theme_colors: nil,
+      git_degraded: false,
+      workspace: %Workspace{id: 0, kind: :manual, label: "Default", icon: ""},
+      merge_conflict_count: 0
+    }
+  end
+
+  defp put_common(%EditorStatusData{} = data, fun), do: %{data | common: fun.(data.common)}
+  defp put_status(%Common{} = common, fun), do: %{common | status: fun.(common.status)}
+  defp minimal_theme, do: MingaEditor.UI.Theme.get!(:doom_one)
 
   defp minimal_ctx do
     %{
@@ -66,14 +90,48 @@ defmodule MingaEditor.RenderModel.UI.StatusBarBuilderTest do
     }
   end
 
-  describe "build/3" do
-    test "returns a semantic StatusBar model" do
-      model = StatusBarBuilder.build(minimal_buffer_data(), minimal_theme(), minimal_ctx())
+  defp expected_buffer_model(%EditorStatusData{common: %Common{status: status}}, workspace) do
+    %StatusBar{content_kind: :buffer, data: semantic_expected_data(status), workspace: workspace}
+  end
 
-      assert %StatusBar{content_kind: :buffer, data: data} = model
-      assert data.file.name == "test.ex"
-      assert is_binary(data.file.icon)
-      assert is_integer(data.file.icon_color)
+  defp expected_agent_model(
+         %EditorStatusData{
+           common: %Common{status: status},
+           content: %EditorStatusAgent{} = content
+         },
+         workspace
+       ) do
+    data = %{
+      semantic_expected_data(status)
+      | agent: %{
+          status.agent
+          | model_name: content.model_name,
+            session_status: content.session_status,
+            message_count: content.message_count
+        }
+    }
+
+    %StatusBar{content_kind: :agent, data: data, workspace: workspace}
+  end
+
+  defp semantic_expected_data(%SemanticStatusData{file: %StatusFile{} = file} = status) do
+    {icon, icon_color} = Devicon.icon_and_color(file.filetype)
+    %SemanticStatusData{status | file: %StatusFile{file | icon: icon, icon_color: icon_color}}
+  end
+
+  describe "build/3" do
+    test "returns semantic StatusBar models for buffer and agent content" do
+      buffer_model = StatusBarBuilder.build(minimal_buffer_data(), minimal_theme(), minimal_ctx())
+      agent_model = StatusBarBuilder.build(minimal_agent_data(), minimal_theme(), minimal_ctx())
+
+      assert %StatusBar{content_kind: :buffer, data: buffer_data} = buffer_model
+      assert %StatusBar{content_kind: :agent, data: agent_data} = agent_model
+      assert buffer_data.file.name == "test.ex"
+      assert is_binary(buffer_data.file.icon)
+      assert is_integer(buffer_data.file.icon_color)
+      assert agent_data.agent.model_name == "Codex"
+      assert agent_data.agent.session_status == :thinking
+      assert agent_data.agent.message_count == 3
     end
 
     test "projects every selected operation field without interpreting punctuation" do
@@ -82,8 +140,7 @@ defmodule MingaEditor.RenderModel.UI.StatusBarBuilderTest do
         |> Operation.queued("Committing...", OperationQueue.new!(2, 3))
         |> Operation.report_progress(OperationProgress.new!(4, 10))
 
-      {:buffer, data} = minimal_buffer_data()
-      status_data = {:buffer, Map.put(data, :selected_operation, operation)}
+      status_data = put_common(minimal_buffer_data(), &%{&1 | selected_operation: operation})
       model = StatusBarBuilder.build(status_data, minimal_theme(), minimal_ctx())
 
       assert %StatusOperation{
@@ -103,7 +160,9 @@ defmodule MingaEditor.RenderModel.UI.StatusBarBuilderTest do
         |> Operation.queued("Committing", OperationQueue.new!(2, 3))
         |> Operation.report_progress(OperationProgress.new!(4, 10))
 
-      status_data = {:buffer, Map.put(data, :selected_operation, without_ellipsis)}
+      status_data =
+        put_common(minimal_buffer_data(), &%{&1 | selected_operation: without_ellipsis})
+
       without_ellipsis_model = StatusBarBuilder.build(status_data, minimal_theme(), minimal_ctx())
 
       assert without_ellipsis_model.operation.status == model.operation.status
@@ -111,52 +170,53 @@ defmodule MingaEditor.RenderModel.UI.StatusBarBuilderTest do
     end
 
     test "arbitrates macro, operation, notice, then diagnostic while retaining operation data" do
-      {:buffer, base} = minimal_buffer_data()
       operation = Operation.new(7, :lsp_rename, "main.ex", "Renaming", true, 7)
 
       data =
-        Map.merge(base, %{
-          macro_recording: {true, "q"},
-          selected_operation: operation,
-          notice: "ordinary notice",
-          diagnostic_hint: "diagnostic hint"
-        })
+        put_common(minimal_buffer_data(), fn common ->
+          common
+          |> put_status(
+            &%{
+              &1
+              | recording: {true, "q"},
+                diagnostics: %{&1.diagnostics | hint: "diagnostic hint"}
+            }
+          )
+          |> then(&%{&1 | selected_operation: operation, notice: "ordinary notice"})
+        end)
 
-      model = StatusBarBuilder.build({:buffer, data}, minimal_theme(), minimal_ctx())
+      model = StatusBarBuilder.build(data, minimal_theme(), minimal_ctx())
       assert model.data.message == "recording @q"
       assert %StatusOperation{id: 7, message: "Renaming"} = model.operation
 
       operation_model =
-        StatusBarBuilder.build(
-          {:buffer, %{data | macro_recording: false}},
-          minimal_theme(),
-          minimal_ctx()
-        )
+        data
+        |> put_common(&put_status(&1, fn status -> %{status | recording: false} end))
+        |> StatusBarBuilder.build(minimal_theme(), minimal_ctx())
 
       assert operation_model.data.message == "Renaming"
 
       notice_model =
-        StatusBarBuilder.build(
-          {:buffer, %{data | macro_recording: false, selected_operation: nil}},
-          minimal_theme(),
-          minimal_ctx()
-        )
+        data
+        |> put_common(fn common ->
+          common
+          |> put_status(&%{&1 | recording: false})
+          |> then(&%{&1 | selected_operation: nil})
+        end)
+        |> StatusBarBuilder.build(minimal_theme(), minimal_ctx())
 
       assert notice_model.data.message == "ordinary notice"
 
       terminal_operation = Operation.finish(operation, :success, "Renamed")
 
       terminal_dwell_model =
-        StatusBarBuilder.build(
-          {:buffer,
-           %{
-             data
-             | macro_recording: false,
-               selected_operation: terminal_operation
-           }},
-          minimal_theme(),
-          minimal_ctx()
-        )
+        data
+        |> put_common(fn common ->
+          common
+          |> put_status(&%{&1 | recording: false})
+          |> then(&%{&1 | selected_operation: terminal_operation})
+        end)
+        |> StatusBarBuilder.build(minimal_theme(), minimal_ctx())
 
       assert terminal_dwell_model.data.message == "ordinary notice"
 
@@ -164,41 +224,35 @@ defmodule MingaEditor.RenderModel.UI.StatusBarBuilderTest do
                terminal_dwell_model.operation
 
       diagnostic_model =
-        StatusBarBuilder.build(
-          {:buffer, %{data | macro_recording: false, selected_operation: nil, notice: nil}},
-          minimal_theme(),
-          minimal_ctx()
-        )
+        data
+        |> put_common(fn common ->
+          common
+          |> put_status(&%{&1 | recording: false})
+          |> then(&%{&1 | selected_operation: nil, notice: nil})
+        end)
+        |> StatusBarBuilder.build(minimal_theme(), minimal_ctx())
 
       assert diagnostic_model.data.message == "diagnostic hint"
 
       terminal_with_diagnostic =
-        StatusBarBuilder.build(
-          {:buffer,
-           %{
-             data
-             | macro_recording: false,
-               selected_operation: terminal_operation,
-               notice: nil
-           }},
-          minimal_theme(),
-          minimal_ctx()
-        )
+        data
+        |> put_common(fn common ->
+          common
+          |> put_status(&%{&1 | recording: false})
+          |> then(&%{&1 | selected_operation: terminal_operation, notice: nil})
+        end)
+        |> StatusBarBuilder.build(minimal_theme(), minimal_ctx())
 
       assert terminal_with_diagnostic.data.message == "diagnostic hint"
       assert terminal_with_diagnostic.operation.status == :success
     end
 
     test "ordinary notice punctuation has no operation semantics" do
-      {:buffer, data} = minimal_buffer_data()
-
       for message <- ["Saved", "Saved…", "Saved..."] do
         model =
-          StatusBarBuilder.build(
-            {:buffer, %{data | notice: message}},
-            minimal_theme(),
-            minimal_ctx()
-          )
+          minimal_buffer_data()
+          |> put_common(&%{&1 | notice: message})
+          |> StatusBarBuilder.build(minimal_theme(), minimal_ctx())
 
         assert model.data.message == message
         assert model.operation == nil
@@ -209,6 +263,34 @@ defmodule MingaEditor.RenderModel.UI.StatusBarBuilderTest do
       model = StatusBarBuilder.build(minimal_buffer_data(), minimal_theme(), minimal_ctx())
 
       assert %Workspace{id: 0, kind: :manual} = model.workspace
+    end
+
+    test "encodes typed buffer and agent snapshots with byte parity" do
+      theme = minimal_theme()
+      ctx = minimal_ctx()
+      buffer_snapshot = EditorStatusData.with_modeline_segments(minimal_buffer_data(), theme)
+      agent_snapshot = EditorStatusData.with_modeline_segments(minimal_agent_data(), theme)
+      buffer_model = StatusBarBuilder.build(minimal_buffer_data(), theme, ctx)
+      agent_model = StatusBarBuilder.build(minimal_agent_data(), theme, ctx)
+
+      buffer_cmd = StatusBarEncoder.encode_command(buffer_model)
+      agent_cmd = StatusBarEncoder.encode_command(agent_model)
+      expected_workspace = %Workspace{id: 0, kind: :manual, label: "Files", icon: "folder"}
+
+      expected_buffer_cmd =
+        StatusBarEncoder.encode_command(
+          expected_buffer_model(buffer_snapshot, expected_workspace)
+        )
+
+      expected_agent_cmd =
+        StatusBarEncoder.encode_command(expected_agent_model(agent_snapshot, expected_workspace))
+
+      assert buffer_cmd == expected_buffer_cmd
+      assert agent_cmd == expected_agent_cmd
+      assert <<0x76, _section_count, 0x01, 0, 3, 1, _::binary>> = agent_cmd
+
+      assert <<0x09, 17::16, 5, "Codex", 3::32, 1, 0, 0::16, 0::16, 0>> =
+               :binary.part(agent_cmd, byte_size(agent_cmd) - 20, 20)
     end
   end
 end

--- a/test/minga_editor/render_pipeline/chrome_dirty_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_dirty_test.exs
@@ -302,10 +302,14 @@ defmodule MingaEditor.RenderPipeline.ChromeDirtyTest do
       state2 = TestHelpers.run_pipeline(switched)
       renderer_cache = :sys.get_state(state2.render.renderer).caches
       fp_after = renderer_cache.chrome_prev_fingerprint
-      {:buffer, status_bar_data} = renderer_cache.chrome_prev_result.status_bar_data
+
+      assert %MingaEditor.StatusBar.Data{
+               common: %MingaEditor.StatusBar.Data.Common{status: status},
+               content: %MingaEditor.StatusBar.Data.Buffer{}
+             } = renderer_cache.chrome_prev_result.status_bar_data
 
       assert fp_before != fp_after
-      assert status_bar_data.file_name == "second.ex"
+      assert status.file.name == "second.ex"
     end
   end
 end

--- a/test/minga_editor/render_pipeline/chrome_test.exs
+++ b/test/minga_editor/render_pipeline/chrome_test.exs
@@ -49,7 +49,8 @@ defmodule MingaEditor.RenderPipeline.ChromeTest do
 
       chrome = state.shell.build_chrome(state, layout, scrolls, cursor_info)
 
-      assert {:buffer, _} = chrome.status_bar_data
+      assert %MingaEditor.StatusBar.Data{content: %MingaEditor.StatusBar.Data.Buffer{}} =
+               chrome.status_bar_data
     end
   end
 end

--- a/test/minga_editor/shell/traditional/chrome/gui_test.exs
+++ b/test/minga_editor/shell/traditional/chrome/gui_test.exs
@@ -45,7 +45,8 @@ defmodule MingaEditor.Shell.Traditional.Chrome.GUITest do
 
       chrome = ChromeGUI.build(state, layout, scrolls, cursor_info)
 
-      assert {:buffer, _} = chrome.status_bar_data
+      assert %MingaEditor.StatusBar.Data{content: %MingaEditor.StatusBar.Data.Buffer{}} =
+               chrome.status_bar_data
     end
   end
 end

--- a/test/minga_editor/status_bar/data_safe_mode_test.exs
+++ b/test/minga_editor/status_bar/data_safe_mode_test.exs
@@ -6,6 +6,8 @@ defmodule MingaEditor.StatusBar.DataSafeModeTest do
 
   alias Minga.Config.Options
   alias MingaEditor.StatusBar.Data
+  alias MingaEditor.StatusBar.Data.Buffer, as: StatusBuffer
+  alias MingaEditor.StatusBar.Data.Common
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
   alias MingaEditor.Session.State, as: SessionState
@@ -23,10 +25,12 @@ defmodule MingaEditor.StatusBar.DataSafeModeTest do
       shell_runtime: Runtime.new(Runtime.default_entry(), %MingaEditor.Shell.Traditional.State{})
     }
 
-    {:buffer, buffer_data} = Data.from_state(state)
-    modeline_data = Data.to_modeline_data({:buffer, buffer_data})
+    %Data{common: %Common{status: status}, content: %StatusBuffer{}} =
+      data = Data.from_state(state)
 
-    assert buffer_data.safe_mode == true
+    modeline_data = Data.to_modeline_data(data)
+
+    assert status.safe_mode? == true
     assert modeline_data.safe_mode == true
   end
 end

--- a/test/minga_editor/status_bar/data_test.exs
+++ b/test/minga_editor/status_bar/data_test.exs
@@ -11,6 +11,12 @@ defmodule MingaEditor.StatusBar.DataTest do
   alias MingaAgent.Subagent.Handle
   alias MingaEditor.Shell.Traditional.WhichKeyWorkflow
   alias MingaEditor.StatusBar.Data
+  alias Minga.RenderModel.UI.StatusBar.Cursor, as: StatusCursor
+  alias Minga.RenderModel.UI.StatusBar.Data, as: SemanticStatusData
+  alias Minga.RenderModel.UI.StatusBar.File, as: StatusFile
+  alias MingaEditor.StatusBar.Data.Agent, as: StatusAgent
+  alias MingaEditor.StatusBar.Data.Buffer, as: StatusBuffer
+  alias MingaEditor.StatusBar.Data.Common
   alias MingaEditor.Shell.Registry
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.State, as: EditorState
@@ -66,24 +72,28 @@ defmodule MingaEditor.StatusBar.DataTest do
       | feedback: Feedback.accept_operation_feedback(state.feedback, operation_feedback)
     }
 
-    assert {:buffer, data} = Data.from_state(state)
-    assert data.selected_operation == operation
-    assert data.notice == nil
+    assert %Data{common: %Common{} = common, content: %StatusBuffer{}} = Data.from_state(state)
+    assert common.selected_operation == operation
+    assert common.notice == nil
   end
 
   test "from_state leaves GUI modeline segments detached by default" do
     state = state_with_tab_bar(TabBar.new(Tab.new_file(1, "main.ex")))
     data = Data.from_state(state)
 
-    assert {:buffer, buffer_data} = data
-    refute Map.has_key?(buffer_data, :modeline_segments)
+    assert %Data{
+             common: %Common{status: %SemanticStatusData{} = status},
+             content: %StatusBuffer{}
+           } = data
+
+    assert status.modeline_segments == nil
   end
 
   describe "pending_keys (showcmd)" do
     test "is empty in a fresh normal-mode state" do
       state = state_with_tab_bar(TabBar.new(Tab.new_file(1, "main.ex")))
-      {:buffer, data} = Data.from_state(state)
-      assert data.pending_keys == ""
+      %Data{common: %Common{status: status}, content: %StatusBuffer{}} = Data.from_state(state)
+      assert status.pending_keys == ""
     end
 
     test "echoes an accumulated count from FSM state" do
@@ -108,8 +118,8 @@ defmodule MingaEditor.StatusBar.DataTest do
           end)
         end)
 
-      {:buffer, data} = Data.from_state(state)
-      assert data.pending_keys == "2"
+      %Data{common: %Common{status: status}, content: %StatusBuffer{}} = Data.from_state(state)
+      assert status.pending_keys == "2"
     end
 
     test "prefixes the active register selection" do
@@ -117,8 +127,8 @@ defmodule MingaEditor.StatusBar.DataTest do
         state_with_tab_bar(TabBar.new(Tab.new_file(1, "main.ex")))
         |> MingaEditor.Editing.set_active_register("a")
 
-      {:buffer, data} = Data.from_state(state)
-      assert data.pending_keys == "\"a"
+      %Data{common: %Common{status: status}, content: %StatusBuffer{}} = Data.from_state(state)
+      assert status.pending_keys == "\"a"
     end
 
     test "echoes a pending operator in operator-pending mode" do
@@ -140,8 +150,8 @@ defmodule MingaEditor.StatusBar.DataTest do
           }
         end)
 
-      {:buffer, data} = Data.from_state(state)
-      assert data.pending_keys == "d"
+      %Data{common: %Common{status: status}, content: %StatusBuffer{}} = Data.from_state(state)
+      assert status.pending_keys == "d"
     end
 
     test "composes the register prefix with operator-pending FSM state" do
@@ -164,8 +174,8 @@ defmodule MingaEditor.StatusBar.DataTest do
           }
         end)
 
-      {:buffer, data} = Data.from_state(state)
-      assert data.pending_keys == "\"a2d"
+      %Data{common: %Common{status: status}, content: %StatusBuffer{}} = Data.from_state(state)
+      assert status.pending_keys == "\"a2d"
     end
 
     test "clears when the which-key popup is showing" do
@@ -192,21 +202,23 @@ defmodule MingaEditor.StatusBar.DataTest do
         |> WhichKeyWorkflow.begin(%{}, [])
 
       state = WhichKeyWorkflow.reveal(state, state.shell_runtime.state.whichkey.generation)
-      {:buffer, data} = Data.from_state(state)
-      assert data.pending_keys == ""
+      %Data{common: %Common{status: status}, content: %StatusBuffer{}} = Data.from_state(state)
+      assert status.pending_keys == ""
     end
   end
 
   test "with_modeline_segments preserves agent status command output" do
     state = state_with_tab_bar(TabBar.new(Tab.new_file(1, "main.ex")))
     state = MingaEditor.Shell.Traditional.Workflow.install_agent_status(state, :thinking)
-    {:buffer, data} = Data.from_state(state)
-    data = Map.put(data, :agent_status_command, "sonnet | thinking")
+    %Data{common: %Common{} = common, content: %StatusBuffer{}} = data = Data.from_state(state)
+    data = %{data | common: %{common | agent_status_command: "sonnet | thinking"}}
 
-    assert {:buffer, buffer_data} =
-             Data.with_modeline_segments({:buffer, data}, state.appearance.theme)
+    assert %Data{
+             common: %Common{status: %SemanticStatusData{modeline_segments: segments}},
+             content: %StatusBuffer{}
+           } = Data.with_modeline_segments(data, state.appearance.theme)
 
-    text = modeline_text(buffer_data.modeline_segments)
+    text = modeline_text(segments)
 
     assert String.contains?(text, "sonnet | thinking")
     refute String.contains?(text, "Thinking")
@@ -221,21 +233,69 @@ defmodule MingaEditor.StatusBar.DataTest do
                table,
                :status_bar_data_modeline_test,
                [side: :left],
-               fn ctx -> {" GUI_ONLY ", ctx.info_fg, ctx.bar_bg, [], nil} end,
+               fn ctx ->
+                 text =
+                   if ctx.data.diagnostic_counts == nil, do: " NIL_DIAGS ", else: " ZERO_DIAGS "
+
+                 {text, ctx.info_fg, ctx.bar_bg, [], nil}
+               end,
                :config
              )
 
     state = state_with_tab_bar(TabBar.new(Tab.new_file(1, "main.ex")))
     data = Data.from_state(state)
 
-    assert {:buffer, buffer_data} =
-             Data.with_modeline_segments(data, state.appearance.theme, table)
+    assert %Data{
+             common: %Common{
+               status: %SemanticStatusData{modeline_segments: %{left: left, right: right}}
+             },
+             content: same_content
+           } = Data.with_modeline_segments(data, state.appearance.theme, table)
 
-    assert %{left: left, right: right} = buffer_data.modeline_segments
+    assert same_content == data.content
 
-    assert Enum.any?(left ++ right, fn {_name, text, _fg, _bg, _opts, _target} ->
-             text == " GUI_ONLY "
-           end)
+    assert Enum.find_value(left ++ right, fn
+             {:status_bar_data_modeline_test, text, _fg, _bg, _opts, _target} -> text
+             _segment -> nil
+           end) == " NIL_DIAGS "
+  end
+
+  test "multi-buffer modeline uses typed buffer index and count from common data" do
+    first = start_buffer("first", :text)
+    second = start_buffer("second", :text)
+
+    state =
+      state_with_tab_bar(TabBar.new(Tab.new_file(1, "second.txt")))
+      |> then(fn %{workspace: %SessionState{} = workspace} = state ->
+        %{
+          state
+          | workspace: %SessionState{
+              workspace
+              | buffers: %Buffers{list: [first, second], active_index: 1, active: second},
+                windows: %Windows{
+                  tree: WindowTree.new(1),
+                  map: %{1 => Window.new(1, second, 24, 80)},
+                  active: 1,
+                  next_id: 2
+                }
+            }
+        }
+      end)
+
+    data = Data.from_state(state)
+    modeline_data = Data.to_modeline_data(data)
+
+    assert %Data{common: %Common{buf_index: 2, buf_count: 2}, content: %StatusBuffer{}} = data
+    assert %{buf_index: 2, buf_count: 2} = modeline_data
+
+    segmented = Data.with_modeline_segments(data, state.appearance.theme)
+
+    assert %Data{
+             common: %Common{status: %SemanticStatusData{modeline_segments: segments}},
+             content: %StatusBuffer{}
+           } = segmented
+
+    assert String.contains?(modeline_text(segments), "[2/2]")
   end
 
   test "projects running background subagent count and active label" do
@@ -285,8 +345,8 @@ defmodule MingaEditor.StatusBar.DataTest do
 
     state = state_with_agent_window(tb)
 
-    assert {:agent, data} = Data.from_state(state)
-    assert data.message_count == 1
+    assert %Data{content: %StatusAgent{} = agent} = Data.from_state(state)
+    assert agent.message_count == 1
   end
 
   test "agent status data reuses the same background buffer semantics as buffer status data" do
@@ -297,15 +357,15 @@ defmodule MingaEditor.StatusBar.DataTest do
       |> MingaEditor.Shell.Traditional.Workflow.install_agent_status(:thinking)
       |> MingaEditor.Shell.Traditional.Workflow.install_agent_tool("read_file")
 
-    assert {:buffer, buffer_data} = Data.from_state(state)
-    assert {:agent, agent_data} = Data.from_state(with_agent_chat_window(state))
+    assert %Data{common: buffer_common, content: %StatusBuffer{}} = Data.from_state(state)
 
-    common_keys =
-      ~w(active_background_subagent_label active_tool_name agent_status agent_status_command agent_theme_colors background_subagent_count buf_count buf_index cursor_col cursor_line diagnostic_counts diagnostic_hint dirty file_name filetype git_branch git_degraded git_diff_summary indent_size indent_type line_count lsp_status macro_recording merge_conflict_count mode mode_state notice parser_status pending_keys safe_mode selected_operation selection_info workspace_conflict_count workspace_draft_count workspace_label)a
+    assert %Data{common: agent_common, content: %StatusAgent{} = agent_data} =
+             Data.from_state(with_agent_chat_window(state))
 
-    assert buffer_data |> Map.keys() |> Enum.sort() == common_keys
-
-    assert Map.drop(agent_data, [:model_name, :session_status, :message_count]) == buffer_data
+    assert agent_common == %{
+             buffer_common
+             | agent_theme_colors: MingaEditor.UI.Theme.agent_theme(state.appearance.theme)
+           }
 
     assert {agent_data.model_name, agent_data.session_status, agent_data.message_count} ==
              {"unknown", :thinking, 0}
@@ -318,12 +378,26 @@ defmodule MingaEditor.StatusBar.DataTest do
         MingaEditor.State.Launchpad.new(session_file_count: 0, recents: [])
       )
 
-    assert {:buffer, %{file_name: ""}} = Data.from_state(buffer_state)
+    assert %Data{
+             common: %Common{status: %SemanticStatusData{file: %StatusFile{name: ""}}},
+             content: %StatusBuffer{}
+           } = Data.from_state(buffer_state)
 
-    assert {:agent, agent_data} = Data.from_state(with_agent_chat_window(buffer_state))
+    agent_data = Data.from_state(with_agent_chat_window(buffer_state))
 
-    assert {agent_data.file_name, agent_data.cursor_line, agent_data.cursor_col,
-            agent_data.line_count, agent_data.filetype} == {"[no file]", 0, 0, 1, :text}
+    assert %Data{
+             common: %Common{
+               status: %SemanticStatusData{
+                 file: %StatusFile{name: "[no file]", filetype: :text},
+                 cursor: %StatusCursor{line: 0, col: 0, line_count: 1}
+               }
+             },
+             content: %StatusAgent{}
+           } = agent_data
+
+    assert agent_data.common.raw_diagnostic_counts == nil
+    assert agent_data.common.status.diagnostics.counts == {0, 0, 0, 0}
+    assert Data.to_modeline_data(agent_data).diagnostic_counts == nil
   end
 
   test "threads active_tool_name from state into modeline data and clears it on status changes" do
@@ -359,10 +433,10 @@ defmodule MingaEditor.StatusBar.DataTest do
         Runtime.new(Registry.get(:traditional), %MingaEditor.Shell.Traditional.State{})
     }
 
-    {:buffer, data} = Data.from_state(state)
+    %Data{common: %Common{status: status}, content: %StatusBuffer{}} = Data.from_state(state)
 
-    assert data.indent_type == :tabs
-    assert data.indent_size == 4
+    assert status.indent.type == :tabs
+    assert status.indent.size == 4
   end
 
   test "buffer-local indent options override filetype defaults" do
@@ -374,10 +448,10 @@ defmodule MingaEditor.StatusBar.DataTest do
     BufferProcess.set_option(buf, :indent_with, :tabs)
     BufferProcess.set_option(buf, :tab_width, 4)
 
-    {:buffer, data} = Data.from_state(state)
+    %Data{common: %Common{status: status}, content: %StatusBuffer{}} = Data.from_state(state)
 
-    assert data.indent_type == :tabs
-    assert data.indent_size == 4
+    assert status.indent.type == :tabs
+    assert status.indent.size == 4
   end
 
   test "active buffer merge conflict count appears in modeline data" do
@@ -429,9 +503,12 @@ defmodule MingaEditor.StatusBar.DataTest do
         }
       end)
 
-    {:buffer, data} = Data.from_state(state)
+    %Data{common: %Common{status: status}, content: %StatusBuffer{}} =
+      data = Data.from_state(state)
 
-    assert data.selection_info == {:chars, 5}
+    assert status.selection.mode == :chars
+    assert status.selection.size == 5
+    assert Data.to_modeline_data(data).selection_info == {:chars, 5}
   end
 
   test "visual line selection reports selected line count" do
@@ -451,9 +528,12 @@ defmodule MingaEditor.StatusBar.DataTest do
         }
       end)
 
-    {:buffer, data} = Data.from_state(state)
+    %Data{common: %Common{status: status}, content: %StatusBuffer{}} =
+      data = Data.from_state(state)
 
-    assert data.selection_info == {:lines, 3}
+    assert status.selection.mode == :lines
+    assert status.selection.size == 3
+    assert Data.to_modeline_data(data).selection_info == {:lines, 3}
   end
 
   defp state_with_tab_bar(tab_bar) do
@@ -533,7 +613,8 @@ defmodule MingaEditor.StatusBar.DataTest do
 
     buf =
       start_supervised!(
-        {BufferProcess, [content: "", filetype: filetype, events_registry: registry]}
+        {BufferProcess, [content: "", filetype: filetype, events_registry: registry]},
+        id: {:data_test_buffer, System.unique_integer([:positive])}
       )
 
     :ok = BufferProcess.insert_text(buf, content)


### PR DESCRIPTION
# TL;DR

Replace the status bar's raw tagged tuple/map snapshot with a typed common-and-content model while preserving modeline behavior and byte-identical opcode `0x76` output.

## Context

The editor built the same status facts as large raw maps, merged agent-specific fields into those maps, then normalized them again into the existing semantic status bar structs. That left misspelled or omitted fields vulnerable to silent defaults at the render-model boundary.

This change resolves audit finding ES21 and records the implementation evidence in the editor lifecycle roadmap.

## Changes

- Add typed `Data`, `Common`, `Buffer`, and `Agent` value shapes for the editor-owned status snapshot.
- Reuse the existing semantic status substructures inside `Common` instead of adding another parallel group of cursor, diagnostic, file, git, language, indent, selection, or agent types.
- Keep process-backed reads, fallbacks, modeline projection, and once-per-frame construction in `MingaEditor.StatusBar.Data`.
- Make `StatusBarBuilder` dispatch explicitly on buffer versus agent content and retain Devicon enrichment, operation projection, and message precedence.
- Preserve raw `nil` diagnostic counts for custom modeline segments while keeping semantic diagnostic counts normalized for the wire model.
- Replace legacy tuple/map tests with typed contract assertions and independent buffer/agent opcode `0x76` byte-parity coverage.

## Compatibility

No opcode, section ID, wire field, frontend decoder, protocol schema, generated code, Swift path, or Go path changes. The legacy editor-internal tuple/map shape is removed without a compatibility shim.

## Verification

- Focused correction tests: 35 passed.
- Status owner, builder, modeline, encoder, schema, and integration tests: 77 passed, 21 excluded.
- Chrome and cache tests: 27 passed.
- `make lint`: passed with Credo clean and zero Dialyzer errors.
- `mix test.llm --max-cases 4`: 9,764 tests passed, plus 58 doctests and 98 properties; 1 skipped and 616 excluded.
- Focused and full Go TUI tests: passed.
- `mix swift.build`: project task skipped because `xcodebuild` is unavailable on Linux.
- Final acceptance review: PASS with 0.99 confidence.

## Acceptance Criteria Addressed

- Status snapshots use a real typed product/sum shape with an explicit shared common value.
- Every existing producer and consumer migrates in one clean cutover.
- Modeline fallback and custom-segment behavior remain unchanged.
- Buffer and agent semantic models retain byte-identical opcode `0x76` encoding.
- No compatibility path, protocol change, or frontend production change is introduced.
