### PR TITLE
refactor(editor): give recorders explicit lifecycle phases

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -26,12 +26,12 @@ The independent Ponytail gate produced 91 `ACCEPT`, 28 `ROUTE`, 11 `PRESERVE`, a
 Current accepted inventory:
 
 - **VERIFIED:** L01, L02, L04, L05, L10, L12, ES21
-- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08, ES03, ES05, ES07, ES08, ES12, ES17, ES18
+- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08, ES03, ES05, ES07, ES08, ES12, ES17, ES18, ES24
 - **CANDIDATE, lifecycle:** L11, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30
 - **CANDIDATE, deletion:** D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40
 - **CANDIDATE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
 - **CANDIDATE, craftsmanship:** (none)
-- **READY, data shape:** ES24
+- **READY, data shape:** (none)
 - **CANDIDATE, data shape:** ES09, ES10, ES14, ES16
 
 ### Freshness wave at `6e175b87764145577999a1c04a532960cb89222f`
@@ -4653,7 +4653,7 @@ New split and float popup windows initialize their viewport metadata from `state
 
 ### W115/ES24: Give each recorder one explicit lifecycle phase
 
-- **Status:** READY
+- **Status:** IMPLEMENTED
 - **Audit ID:** ES24
 - **Planning profile:** `ES24Planner`, `ES24Replanner`, `ES24ReplayReplanner`, and `ES24EquivalenceReplanner` at medium; `ES24PlanVerifier`, `ES24FinalVerifier`, `ES24PostMergeVerifier`, `ES24ReplayVerifier`, and `ES24V4FinalVerifier` at high, all read-only.
 - **Implementation profile:** `ES24Worker`, editor-lifecycle-worker, no delegation.
@@ -4679,4 +4679,5 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Dependencies and overlap:** ADR-0002 already fixes ownership. No architecture decision or external dependency remains. ES21 status projection consumes only the stable facade shape and does not overlap this owner area. One PR must migrate every direct reader/writer and fully resolve ES24.
 - **Unresolved questions:** None.
 - **needs_replan:** false.
-- **Completion evidence reserved:** PR URL, implementation commit SHA, merge SHA, focused tests, broad validation, reviewer verdict, findings resolved, discoveries affecting later work, and completion date remain empty until implementation and merge.
+- **Completion evidence:** Implemented in worktree `refactor-editor-lifecycle-next-77` from locked plan `local://es24-plan-v4.json` at baseline `ee88b3834909fd95ad097949de44b795602d8000`; no commit, push, or PR. Changed files: `docs/workstreams/editor-lifecycle-roadmap.md`, `lib/minga_editor/change_recorder.ex`, `lib/minga_editor/change_tracking.ex`, `lib/minga_editor/commands.ex`, `lib/minga_editor/commands/macros.ex`, `lib/minga_editor/editing.ex`, `lib/minga_editor/macro_recorder.ex`, `lib/minga_editor/macro_replay.ex`, `test/minga_editor/change_recorder_test.exs`, `test/minga_editor/change_tracking_test.exs`, `test/minga_editor/commands/macro_commands_test.exs`, `test/minga_editor/editing_test.exs`, and `test/minga_editor/macro_recorder_test.exs`. Observable result: recorder lifecycle fields are replaced by owner-owned replay-depth/post-phase transitions; foreign production readers/writers use owner APIs; macro and dot-repeat replay keep suppression through `q a x`, `q a q`, `q a q b`, nested macro replay, missing nested macro replay, and nested dot-repeat. Focused validation after review corrections: the five recorder, facade, command, and change-tracking files passed `83 tests`; `mix test --include conformance test/conformance/macros_test.exs` passed `7 tests`; the final command workflow rerun passed `8 tests`. Project-required validation: `make lint` passed changed-file Credo, compile, and incremental Dialyzer; `git diff --check` passed; low-concurrency `ELIXIR_ERL_OPTIONS='+S 4:4' mix test.llm` passed `58 doctests, 98 properties, 9,786 tests`, with `0 failures`, `1 skipped`, and `616 excluded`. Earlier default-concurrency `mix test` and `make test` attempts exposed unrelated load-sensitive agent/session/native-support failures; every observed failed location was isolated where practical, the later required low-concurrency suite passed, and ES24 does not touch those areas. Exhaustive obsolete-field search over `lib/minga_editor`, `lib/minga`, `test/minga_editor`, `test/conformance`, and `test/support` found no obsolete executable recorder field access; surviving hits are owner API calls or unrelated status/render data fields. Production lines added/removed: `143/131`, net `+12`, within the `<= +50` budget. Test lines added/removed: `406/100`, including the new focused workflow files. Concepts added: recorder-local `phase`, replay depth, post-replay phase, `MacroRecorder.select_replay_register/2`, and `MacroRecorder.last_register/1`. Concepts removed: companion `recording`, `keys`, and `replaying` fields on `ChangeRecorder`, companion `recording` and `replaying` fields on `MacroRecorder`, and foreign direct last-register mutation. Retained constraints: no shared abstraction, compatibility shape, new process, dependency, behaviour, protocol, registry, configuration, root forwarding API, key-dispatch ordering change, status facade change, persistence migration, `replace_count/2` change, or crash-safe replay cleanup. Review evidence: the correctness bug hunt returned `PASS / LEAN`; Ponytail returned `LEAN` and its safe identity-helper and duplicate-test cuts were applied; Elixir craftsmanship returned `LEAN` after tightening the `set_change_recorder/2` type and that correction was applied; the type-design specialist was unavailable because its runtime had no configured model. Final acceptance reviewer verdict is reserved for the commit gate. Findings resolved: ES24/W115. Completion date: 2026-07-23. needs_replan: false.
+- **Final acceptance reviewer:** PASS with `0.98` confidence. The reviewer confirmed the full tracked diff plus two new workflow test files satisfies the locked owner phases, replay equivalence, direct-field cutover, stable facade, clean cutover, roadmap truthfulness, and `+12` production-line budget with no mandatory defect.

--- a/lib/minga_editor/change_recorder.ex
+++ b/lib/minga_editor/change_recorder.ex
@@ -2,126 +2,113 @@ defmodule MingaEditor.ChangeRecorder do
   @moduledoc """
   Records editing changes as raw key sequences for dot repeat.
 
-  A pure functional module — no GenServer. The struct is embedded in
-  `MingaEditor.State` and threaded through the editor's key dispatch.
-
-  ## Recording lifecycle
-
-  1. A change begins (insert mode entry, operator key, single-key edit) →
-     `start_recording/1` clears the key buffer and sets `recording: true`.
-  2. Each key event during the change → `record_key/2` appends to the buffer.
-  3. The change ends (Escape back to Normal, or operator completes) →
-     `stop_recording/1` copies the buffer into `last_change`.
-
-  During replay (`replaying: true`), the editor suppresses recording so
-  the replayed keys don't overwrite the stored change.
+  The `phase` carries exactly one active lifecycle, while replay can preserve a post-replay recording phase that is restored after the outermost replay returns normally.
   """
 
-  defstruct recording: false,
-            keys: [],
+  defstruct phase: :idle,
             pending_keys: [],
-            last_change: nil,
-            replaying: false
+            last_change: nil
 
-  @typedoc "A key event: `{codepoint, modifiers}`."
   @type key :: {non_neg_integer(), non_neg_integer()}
 
+  @type post_phase :: :idle | {:recording, [key()]}
+  @type phase :: :idle | {:recording, [key()]} | {:replaying, pos_integer(), post_phase()}
+
   @type t :: %__MODULE__{
-          recording: boolean(),
-          keys: [key()],
+          phase: phase(),
           pending_keys: [key()],
-          last_change: [key()] | nil,
-          replaying: boolean()
+          last_change: [key()] | nil
         }
 
-  @doc "Returns a fresh recorder with no recorded change."
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
-  @doc "Begins recording a new change. Promotes any pending keys into the recording."
   @spec start_recording(t()) :: t()
-  def start_recording(%__MODULE__{pending_keys: pending} = rec) do
-    %{rec | recording: true, keys: Enum.reverse(pending), pending_keys: []}
+  def start_recording(%__MODULE__{phase: {:replaying, depth, _post}, pending_keys: pending} = rec) do
+    %{rec | phase: {:replaying, depth, {:recording, Enum.reverse(pending)}}, pending_keys: []}
   end
 
-  @doc "Begins recording only if not already recording. Preserves existing keys."
+  def start_recording(%__MODULE__{pending_keys: pending} = rec) do
+    %{rec | phase: {:recording, Enum.reverse(pending)}, pending_keys: []}
+  end
+
   @spec start_recording_if_not(t()) :: t()
-  def start_recording_if_not(%__MODULE__{recording: true} = rec), do: rec
+  def start_recording_if_not(%__MODULE__{phase: {:recording, _keys}} = rec), do: rec
+
+  def start_recording_if_not(%__MODULE__{phase: {:replaying, _depth, {:recording, _keys}}} = rec),
+    do: rec
+
   def start_recording_if_not(%__MODULE__{} = rec), do: start_recording(rec)
 
-  @doc "Buffers a key as a potential part of a future change (e.g., count digits, `r` prefix)."
   @spec buffer_pending_key(t(), key()) :: t()
   def buffer_pending_key(%__MODULE__{} = rec, key) do
     %{rec | pending_keys: [key | rec.pending_keys]}
   end
 
-  @doc "Clears pending keys without saving them."
   @spec clear_pending(t()) :: t()
   def clear_pending(%__MODULE__{} = rec) do
     %{rec | pending_keys: []}
   end
 
-  @doc """
-  Appends a key to the current recording.
-
-  No-op if not currently recording.
-  """
   @spec record_key(t(), key()) :: t()
-  def record_key(%__MODULE__{recording: true} = rec, key) do
-    %{rec | keys: [key | rec.keys]}
+  def record_key(%__MODULE__{phase: {:recording, keys}} = rec, key) do
+    %{rec | phase: {:recording, [key | keys]}}
   end
 
   def record_key(%__MODULE__{} = rec, _key), do: rec
 
-  @doc """
-  Finalizes the current recording into `last_change`.
-
-  The key buffer is moved to `last_change` and recording stops.
-  """
   @spec stop_recording(t()) :: t()
-  def stop_recording(%__MODULE__{recording: true, keys: keys} = rec) do
-    %{rec | recording: false, keys: [], last_change: Enum.reverse(keys)}
+  def stop_recording(%__MODULE__{phase: {:recording, keys}} = rec) do
+    %{rec | phase: :idle, last_change: Enum.reverse(keys)}
+  end
+
+  def stop_recording(%__MODULE__{phase: {:replaying, depth, {:recording, keys}}} = rec) do
+    %{rec | phase: {:replaying, depth, :idle}, last_change: Enum.reverse(keys)}
   end
 
   def stop_recording(%__MODULE__{} = rec), do: rec
 
-  @doc """
-  Cancels the current recording without saving.
-
-  Discards the key buffer and stops recording. `last_change` is preserved.
-  """
   @spec cancel_recording(t()) :: t()
-  def cancel_recording(%__MODULE__{} = rec) do
-    %{rec | recording: false, keys: [], pending_keys: []}
+  def cancel_recording(%__MODULE__{phase: {:replaying, depth, _post}} = rec) do
+    %{rec | phase: {:replaying, depth, :idle}, pending_keys: []}
   end
 
-  @doc "Returns the stored last-change key sequence, or `nil` if none."
+  def cancel_recording(%__MODULE__{} = rec) do
+    %{rec | phase: :idle, pending_keys: []}
+  end
+
   @spec get_last_change(t()) :: [key()] | nil
   def get_last_change(%__MODULE__{last_change: lc}), do: lc
 
-  @doc "Sets the replaying flag. Recording is suppressed during replay."
   @spec start_replay(t()) :: t()
-  def start_replay(%__MODULE__{} = rec), do: %{rec | replaying: true}
+  def start_replay(%__MODULE__{phase: {:replaying, depth, post}} = rec) do
+    %{rec | phase: {:replaying, depth + 1, post}}
+  end
 
-  @doc "Clears the replaying flag."
+  def start_replay(%__MODULE__{phase: phase} = rec) do
+    %{rec | phase: {:replaying, 1, phase}}
+  end
+
   @spec stop_replay(t()) :: t()
-  def stop_replay(%__MODULE__{} = rec), do: %{rec | replaying: false}
+  def stop_replay(%__MODULE__{phase: {:replaying, depth, post}} = rec) when depth > 1 do
+    %{rec | phase: {:replaying, depth - 1, post}}
+  end
 
-  @doc "Returns `true` if currently recording a change."
+  def stop_replay(%__MODULE__{phase: {:replaying, 1, post}} = rec) do
+    %{rec | phase: post}
+  end
+
+  def stop_replay(%__MODULE__{} = rec), do: rec
+
   @spec recording?(t()) :: boolean()
-  def recording?(%__MODULE__{recording: r}), do: r
+  def recording?(%__MODULE__{phase: {:recording, _keys}}), do: true
+  def recording?(%__MODULE__{phase: {:replaying, _depth, {:recording, _keys}}}), do: true
+  def recording?(%__MODULE__{}), do: false
 
-  @doc "Returns `true` if currently replaying a change."
   @spec replaying?(t()) :: boolean()
-  def replaying?(%__MODULE__{replaying: r}), do: r
+  def replaying?(%__MODULE__{phase: {:replaying, _depth, _post}}), do: true
+  def replaying?(%__MODULE__{}), do: false
 
-  @doc """
-  Replaces the count prefix in a recorded key sequence.
-
-  Strips any leading digit keys (the original count) and prepends
-  digit keys for the new count. If `new_count` is `nil` or `1`,
-  returns the sequence with the original count stripped.
-  """
   @spec replace_count([key()], non_neg_integer() | nil) :: [key()]
   def replace_count(keys, nil), do: keys
   def replace_count(keys, 1), do: strip_leading_digits(keys)
@@ -132,16 +119,12 @@ defmodule MingaEditor.ChangeRecorder do
     digit_keys ++ stripped
   end
 
-  # ── Private ──────────────────────────────────────────────────────────────
-
-  @spec strip_leading_digits([key()]) :: [key()]
   defp strip_leading_digits([{digit, 0} | rest]) when digit in ?0..?9 do
     strip_leading_digits(rest)
   end
 
   defp strip_leading_digits(keys), do: keys
 
-  @spec count_to_digit_keys(pos_integer()) :: [key()]
   defp count_to_digit_keys(n) when is_integer(n) and n > 0 do
     n
     |> Integer.to_string()

--- a/lib/minga_editor/change_tracking.ex
+++ b/lib/minga_editor/change_tracking.ex
@@ -30,7 +30,7 @@ defmodule MingaEditor.ChangeTracking do
   def maybe_record_change(state, old_mode, new_mode, commands, key) do
     rec = Editing.change_recorder(state)
 
-    if rec.replaying do
+    if ChangeRecorder.replaying?(rec) do
       state
     else
       rec = update_recorder(rec, old_mode, new_mode, commands, key)
@@ -78,13 +78,13 @@ defmodule MingaEditor.ChangeTracking do
           [Mode.command()],
           ChangeRecorder.key()
         ) :: ChangeRecorder.t()
-  defp update_recorder(%{recording: true} = rec, old_mode, :normal, _commands, key)
-       when old_mode in [:insert, :replace, :operator_pending] do
-    rec |> ChangeRecorder.record_key(key) |> ChangeRecorder.stop_recording()
-  end
-
-  defp update_recorder(%{recording: true} = rec, _old_mode, _new_mode, _commands, key) do
-    ChangeRecorder.record_key(rec, key)
+  defp update_recorder(rec, old_mode, :normal, _commands, key)
+       when old_mode in [:insert, :replace] do
+    if ChangeRecorder.recording?(rec) do
+      rec |> ChangeRecorder.record_key(key) |> ChangeRecorder.stop_recording()
+    else
+      rec
+    end
   end
 
   # From Normal: mode transition starts recording.
@@ -122,8 +122,13 @@ defmodule MingaEditor.ChangeTracking do
     ChangeRecorder.cancel_recording(rec)
   end
 
-  # All other mode transitions: no recording changes.
-  defp update_recorder(rec, _old_mode, _new_mode, _commands, _key), do: rec
+  defp update_recorder(rec, _old_mode, _new_mode, _commands, key) do
+    if ChangeRecorder.recording?(rec) do
+      ChangeRecorder.record_key(rec, key)
+    else
+      rec
+    end
+  end
 
   # Handle Normal → Normal: detect edits, pending keys, or motions.
   @spec do_update_normal_to_normal(ChangeRecorder.t(), [Mode.command()], ChangeRecorder.key()) ::

--- a/lib/minga_editor/commands.ex
+++ b/lib/minga_editor/commands.ex
@@ -518,7 +518,6 @@ defmodule MingaEditor.Commands do
     rec =
       Editing.macro_recorder(state)
       |> MacroRecorder.start_recording(register)
-      |> Map.put(:last_register, register)
 
     Editing.set_macro_recorder(state, rec)
   end
@@ -534,7 +533,10 @@ defmodule MingaEditor.Commands do
         )
 
       _keys ->
-        rec = %{Editing.macro_recorder(state) | last_register: register}
+        rec =
+          Editing.macro_recorder(state)
+          |> MacroRecorder.select_replay_register(register)
+
         {Editing.set_macro_recorder(state, rec), {:replay_macro, register}}
     end
   end

--- a/lib/minga_editor/commands/macros.ex
+++ b/lib/minga_editor/commands/macros.ex
@@ -32,11 +32,13 @@ defmodule MingaEditor.Commands.Macros do
 
   @spec replay_last(state()) :: state() | {state(), action()}
   def replay_last(state) do
-    case Editing.macro_recorder(state) do
-      %{last_register: nil} ->
+    rec = Editing.macro_recorder(state)
+
+    case MacroRecorder.last_register(rec) do
+      nil ->
         MingaEditor.Shell.Traditional.NoticeWorkflow.publish(state, "No previous macro")
 
-      %{last_register: reg} ->
+      reg ->
         {state, {:replay_macro, reg}}
     end
   end

--- a/lib/minga_editor/editing.ex
+++ b/lib/minga_editor/editing.ex
@@ -38,7 +38,7 @@ defmodule MingaEditor.Editing do
   def macro_recorder(%EditorState{workspace: %{editing: vim}}), do: vim.macro_recorder
 
   @doc "Returns the change recorder struct."
-  @spec change_recorder(EditorState.t()) :: term()
+  @spec change_recorder(EditorState.t()) :: MingaEditor.ChangeRecorder.t()
   def change_recorder(%EditorState{workspace: %{editing: vim}}), do: vim.change_recorder
 
   @doc "Returns `{true, register_name}` when recording, `false` otherwise."
@@ -147,7 +147,7 @@ defmodule MingaEditor.Editing do
   end
 
   @doc "Replaces the change recorder."
-  @spec set_change_recorder(EditorState.t(), term()) :: EditorState.t()
+  @spec set_change_recorder(EditorState.t(), MingaEditor.ChangeRecorder.t()) :: EditorState.t()
   def set_change_recorder(%EditorState{} = state, rec) do
     install_editing(
       state,

--- a/lib/minga_editor/macro_recorder.ex
+++ b/lib/minga_editor/macro_recorder.ex
@@ -2,84 +2,107 @@ defmodule MingaEditor.MacroRecorder do
   @moduledoc """
   Records and replays named keystroke macros.
 
-  A pure functional module — no GenServer. The struct is embedded in
-  `MingaEditor.State` and threaded through the editor's key dispatch.
-
-  Macros are stored in named registers (`a`–`z`), separate from text
-  registers. Each register holds a list of key tuples that can be
-  replayed through the editor's `handle_key` pipeline.
+  The `phase` carries exactly one active lifecycle, while replay can preserve a post-replay recording phase that is restored after the outermost replay returns normally.
   """
 
-  defstruct recording: nil,
+  defstruct phase: :idle,
             registers: %{},
-            replaying: false,
             last_register: nil
 
-  @typedoc "A key event: `{codepoint, modifiers}`."
   @type key :: {non_neg_integer(), non_neg_integer()}
 
-  @typedoc "Recording state: `{register_name, accumulated_keys}` or nil."
-  @type recording :: {String.t(), [key()]} | nil
+  @type post_phase :: :idle | {:recording, String.t(), [key()]}
+  @type phase ::
+          :idle | {:recording, String.t(), [key()]} | {:replaying, pos_integer(), post_phase()}
 
   @type t :: %__MODULE__{
-          recording: recording(),
+          phase: phase(),
           registers: %{String.t() => [key()]},
-          replaying: boolean(),
           last_register: String.t() | nil
         }
 
-  @doc "Returns a fresh macro recorder with no recorded macros."
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
-  @doc "Begins recording into the named register."
   @spec start_recording(t(), String.t()) :: t()
-  def start_recording(%__MODULE__{} = rec, register) when is_binary(register) do
-    %{rec | recording: {register, []}}
+  def start_recording(%__MODULE__{phase: {:replaying, depth, _post}} = rec, register)
+      when is_binary(register) do
+    %{rec | phase: {:replaying, depth, {:recording, register, []}}, last_register: register}
   end
 
-  @doc "Appends a key to the active recording. No-op if not recording."
+  def start_recording(%__MODULE__{} = rec, register) when is_binary(register) do
+    %{rec | phase: {:recording, register, []}, last_register: register}
+  end
+
   @spec record_key(t(), key()) :: t()
-  def record_key(%__MODULE__{recording: {reg, keys}} = rec, key) do
-    %{rec | recording: {reg, [key | keys]}}
+  def record_key(%__MODULE__{phase: {:recording, reg, keys}} = rec, key) do
+    %{rec | phase: {:recording, reg, [key | keys]}}
   end
 
   def record_key(%__MODULE__{} = rec, _key), do: rec
 
-  @doc "Finalizes the current recording, storing the key sequence in the register."
   @spec stop_recording(t()) :: t()
-  def stop_recording(%__MODULE__{recording: {reg, keys}} = rec) do
-    %{rec | recording: nil, registers: Map.put(rec.registers, reg, Enum.reverse(keys))}
+  def stop_recording(%__MODULE__{phase: {:recording, reg, keys}} = rec) do
+    %{rec | phase: :idle, registers: Map.put(rec.registers, reg, Enum.reverse(keys))}
+  end
+
+  def stop_recording(%__MODULE__{phase: {:replaying, depth, {:recording, reg, keys}}} = rec) do
+    %{
+      rec
+      | phase: {:replaying, depth, :idle},
+        registers: Map.put(rec.registers, reg, Enum.reverse(keys))
+    }
   end
 
   def stop_recording(%__MODULE__{} = rec), do: rec
 
-  @doc "Stores a pre-built key sequence in a register."
   @spec put_macro(t(), String.t(), [key()]) :: t()
   def put_macro(%__MODULE__{} = rec, register, keys) when is_binary(register) and is_list(keys) do
     %{rec | registers: Map.put(rec.registers, register, keys)}
   end
 
-  @doc "Returns the stored key sequence for a register, or nil."
   @spec get_macro(t(), String.t()) :: [key()] | nil
   def get_macro(%__MODULE__{registers: regs}, register) do
     Map.get(regs, register)
   end
 
-  @doc "Returns `{true, register_name}` if recording, or `false`."
   @spec recording?(t()) :: {true, String.t()} | false
-  def recording?(%__MODULE__{recording: {reg, _keys}}), do: {true, reg}
+  def recording?(%__MODULE__{phase: {:recording, reg, _keys}}), do: {true, reg}
+
+  def recording?(%__MODULE__{phase: {:replaying, _depth, {:recording, reg, _keys}}}),
+    do: {true, reg}
+
   def recording?(%__MODULE__{}), do: false
 
-  @doc "Returns true if currently replaying a macro."
   @spec replaying?(t()) :: boolean()
-  def replaying?(%__MODULE__{replaying: r}), do: r
+  def replaying?(%__MODULE__{phase: {:replaying, _depth, _post}}), do: true
+  def replaying?(%__MODULE__{}), do: false
 
-  @doc "Sets the replaying flag."
   @spec start_replay(t()) :: t()
-  def start_replay(%__MODULE__{} = rec), do: %{rec | replaying: true}
+  def start_replay(%__MODULE__{phase: {:replaying, depth, post}} = rec) do
+    %{rec | phase: {:replaying, depth + 1, post}}
+  end
 
-  @doc "Clears the replaying flag."
+  def start_replay(%__MODULE__{phase: phase} = rec) do
+    %{rec | phase: {:replaying, 1, phase}}
+  end
+
   @spec stop_replay(t()) :: t()
-  def stop_replay(%__MODULE__{} = rec), do: %{rec | replaying: false}
+  def stop_replay(%__MODULE__{phase: {:replaying, depth, post}} = rec) when depth > 1 do
+    %{rec | phase: {:replaying, depth - 1, post}}
+  end
+
+  def stop_replay(%__MODULE__{phase: {:replaying, 1, post}} = rec) do
+    %{rec | phase: post}
+  end
+
+  def stop_replay(%__MODULE__{} = rec), do: rec
+
+  @spec select_replay_register(t(), String.t()) :: t()
+  def select_replay_register(%__MODULE__{} = rec, register) when is_binary(register) do
+    %{rec | last_register: register}
+  end
+
+  @spec last_register(t()) :: String.t() | nil
+  def last_register(%__MODULE__{last_register: register}), do: register
 end

--- a/lib/minga_editor/macro_replay.ex
+++ b/lib/minga_editor/macro_replay.ex
@@ -27,23 +27,20 @@ defmodule MingaEditor.MacroReplay do
         ) :: state()
   def maybe_record_key(state, key, commands) do
     rec = Editing.macro_recorder(state)
-    do_maybe_record_key(state, rec, key, commands)
-  end
+    toggle? = Enum.any?(commands, &match?(:toggle_macro_recording, &1))
 
-  @spec do_maybe_record_key(state(), MacroRecorder.t(), term(), [Mode.command()]) :: state()
-  defp do_maybe_record_key(state, %{replaying: true}, _key, _commands), do: state
-
-  defp do_maybe_record_key(state, rec, key, commands) do
-    case MacroRecorder.recording?(rec) do
-      {true, _reg} ->
-        if Enum.any?(commands, &match?(:toggle_macro_recording, &1)) do
-          state
-        else
-          Editing.set_macro_recorder(state, MacroRecorder.record_key(rec, key))
-        end
-
-      false ->
+    case {MacroRecorder.replaying?(rec), MacroRecorder.recording?(rec), toggle?} do
+      {true, _recording, _toggle?} ->
         state
+
+      {false, false, _toggle?} ->
+        state
+
+      {false, {true, _register}, true} ->
+        state
+
+      {false, {true, _register}, false} ->
+        Editing.set_macro_recorder(state, MacroRecorder.record_key(rec, key))
     end
   end
 

--- a/test/minga_editor/change_recorder_test.exs
+++ b/test/minga_editor/change_recorder_test.exs
@@ -6,38 +6,55 @@ defmodule MingaEditor.ChangeRecorderTest do
   describe "new/0" do
     test "returns a fresh recorder" do
       rec = ChangeRecorder.new()
+
+      assert rec.phase == :idle
+      assert rec.pending_keys == []
+      assert ChangeRecorder.get_last_change(rec) == nil
       refute ChangeRecorder.recording?(rec)
       refute ChangeRecorder.replaying?(rec)
-      assert ChangeRecorder.get_last_change(rec) == nil
     end
   end
 
   describe "recording lifecycle" do
-    test "start_recording enables recording and clears keys" do
-      rec = ChangeRecorder.new()
-      rec = ChangeRecorder.start_recording(rec)
+    test "start_recording promotes pending keys in original order" do
+      rec =
+        ChangeRecorder.new()
+        |> ChangeRecorder.buffer_pending_key({?d, 0})
+        |> ChangeRecorder.buffer_pending_key({?w, 0})
+        |> ChangeRecorder.start_recording()
+
+      assert rec.phase == {:recording, [{?d, 0}, {?w, 0}]}
+      assert rec.pending_keys == []
       assert ChangeRecorder.recording?(rec)
-      assert rec.keys == []
     end
 
-    test "record_key appends keys while recording" do
+    test "record_key prepends keys while top-level recording" do
+      rec =
+        ChangeRecorder.new()
+        |> ChangeRecorder.start_recording()
+        |> ChangeRecorder.record_key({?j, 0})
+        |> ChangeRecorder.record_key({?k, 0})
+
+      assert rec.phase == {:recording, [{?k, 0}, {?j, 0}]}
+    end
+
+    test "record_key is no-op when idle" do
+      rec = ChangeRecorder.new() |> ChangeRecorder.record_key({?j, 0})
+      assert rec.phase == :idle
+    end
+
+    test "record_key is no-op during top-level replay" do
       rec =
         ChangeRecorder.new()
         |> ChangeRecorder.start_recording()
         |> ChangeRecorder.record_key({?d, 0})
-        |> ChangeRecorder.record_key({?w, 0})
+        |> ChangeRecorder.start_replay()
+        |> ChangeRecorder.record_key({?x, 0})
 
-      # Keys are stored in reverse internally; stop_recording reverses them.
-      assert Enum.reverse(rec.keys) == [{?d, 0}, {?w, 0}]
+      assert rec.phase == {:replaying, 1, {:recording, [{?d, 0}]}}
     end
 
-    test "record_key is no-op when not recording" do
-      rec = ChangeRecorder.new()
-      rec = ChangeRecorder.record_key(rec, {?x, 0})
-      assert rec.keys == []
-    end
-
-    test "stop_recording moves keys to last_change" do
+    test "stop_recording moves keys to last_change and returns idle" do
       rec =
         ChangeRecorder.new()
         |> ChangeRecorder.start_recording()
@@ -45,28 +62,28 @@ defmodule MingaEditor.ChangeRecorderTest do
         |> ChangeRecorder.record_key({?w, 0})
         |> ChangeRecorder.stop_recording()
 
-      refute ChangeRecorder.recording?(rec)
+      assert rec.phase == :idle
       assert ChangeRecorder.get_last_change(rec) == [{?d, 0}, {?w, 0}]
-      assert rec.keys == []
     end
 
     test "stop_recording is no-op when not recording" do
-      rec = ChangeRecorder.new()
-      rec = ChangeRecorder.stop_recording(rec)
-      refute ChangeRecorder.recording?(rec)
+      rec = ChangeRecorder.new() |> ChangeRecorder.stop_recording()
+
+      assert rec.phase == :idle
       assert ChangeRecorder.get_last_change(rec) == nil
     end
 
-    test "cancel_recording discards keys without saving" do
+    test "cancel_recording discards active and pending state without saving" do
       rec =
         ChangeRecorder.new()
+        |> ChangeRecorder.buffer_pending_key({?2, 0})
         |> ChangeRecorder.start_recording()
         |> ChangeRecorder.record_key({?d, 0})
         |> ChangeRecorder.cancel_recording()
 
-      refute ChangeRecorder.recording?(rec)
+      assert rec.phase == :idle
+      assert rec.pending_keys == []
       assert ChangeRecorder.get_last_change(rec) == nil
-      assert rec.keys == []
     end
 
     test "cancel_recording preserves previous last_change" do
@@ -75,89 +92,136 @@ defmodule MingaEditor.ChangeRecorderTest do
         |> ChangeRecorder.start_recording()
         |> ChangeRecorder.record_key({?x, 0})
         |> ChangeRecorder.stop_recording()
+
+      rec =
+        rec
         |> ChangeRecorder.start_recording()
-        |> ChangeRecorder.record_key({?y, 0})
+        |> ChangeRecorder.record_key({?d, 0})
         |> ChangeRecorder.cancel_recording()
 
       assert ChangeRecorder.get_last_change(rec) == [{?x, 0}]
-    end
-
-    test "successive recordings overwrite last_change" do
-      rec =
-        ChangeRecorder.new()
-        |> ChangeRecorder.start_recording()
-        |> ChangeRecorder.record_key({?x, 0})
-        |> ChangeRecorder.stop_recording()
-        |> ChangeRecorder.start_recording()
-        |> ChangeRecorder.record_key({?d, 0})
-        |> ChangeRecorder.record_key({?w, 0})
-        |> ChangeRecorder.stop_recording()
-
-      assert ChangeRecorder.get_last_change(rec) == [{?d, 0}, {?w, 0}]
     end
   end
 
   describe "start_recording_if_not/1" do
     test "starts recording when not already recording" do
-      rec = ChangeRecorder.new()
-      rec = ChangeRecorder.start_recording_if_not(rec)
-      assert ChangeRecorder.recording?(rec)
+      rec = ChangeRecorder.new() |> ChangeRecorder.start_recording_if_not()
+      assert rec.phase == {:recording, []}
     end
 
-    test "preserves existing keys when already recording" do
+    test "preserves existing top-level recording" do
       rec =
         ChangeRecorder.new()
         |> ChangeRecorder.start_recording()
         |> ChangeRecorder.record_key({?d, 0})
         |> ChangeRecorder.start_recording_if_not()
 
+      assert rec.phase == {:recording, [{?d, 0}]}
+    end
+
+    test "preserves replay post recording" do
+      rec =
+        ChangeRecorder.new()
+        |> ChangeRecorder.start_replay()
+        |> ChangeRecorder.start_recording()
+        |> ChangeRecorder.start_recording_if_not()
+
+      assert rec.phase == {:replaying, 1, {:recording, []}}
       assert ChangeRecorder.recording?(rec)
-      assert rec.keys == [{?d, 0}]
+      assert ChangeRecorder.replaying?(rec)
     end
   end
 
-  describe "replay flag" do
-    test "start_replay / stop_replay toggle the flag" do
-      rec = ChangeRecorder.new()
-      refute ChangeRecorder.replaying?(rec)
-
-      rec = ChangeRecorder.start_replay(rec)
+  describe "replay phase" do
+    test "start_replay wraps idle and stop_replay restores it" do
+      rec = ChangeRecorder.new() |> ChangeRecorder.start_replay()
+      assert rec.phase == {:replaying, 1, :idle}
       assert ChangeRecorder.replaying?(rec)
 
       rec = ChangeRecorder.stop_replay(rec)
+      assert rec.phase == :idle
       refute ChangeRecorder.replaying?(rec)
+    end
+
+    test "start_replay wraps recording and restores after outer stop" do
+      rec =
+        ChangeRecorder.new()
+        |> ChangeRecorder.start_recording()
+        |> ChangeRecorder.record_key({?d, 0})
+        |> ChangeRecorder.start_replay()
+
+      assert rec.phase == {:replaying, 1, {:recording, [{?d, 0}]}}
+      assert ChangeRecorder.recording?(rec)
+      assert ChangeRecorder.replaying?(rec)
+
+      rec = ChangeRecorder.stop_replay(rec)
+      assert rec.phase == {:recording, [{?d, 0}]}
+    end
+
+    test "nested replay decrements depth before restoring post phase" do
+      rec =
+        ChangeRecorder.new()
+        |> ChangeRecorder.start_recording()
+        |> ChangeRecorder.start_replay()
+        |> ChangeRecorder.start_replay()
+
+      assert rec.phase == {:replaying, 2, {:recording, []}}
+
+      rec = ChangeRecorder.stop_replay(rec)
+      assert rec.phase == {:replaying, 1, {:recording, []}}
+
+      rec = ChangeRecorder.stop_replay(rec)
+      assert rec.phase == {:recording, []}
+    end
+
+    test "stop_recording during replay stores post recording and preserves replay depth" do
+      rec =
+        ChangeRecorder.new()
+        |> ChangeRecorder.start_replay()
+        |> ChangeRecorder.start_recording()
+        |> ChangeRecorder.stop_recording()
+
+      assert rec.phase == {:replaying, 1, :idle}
+      assert ChangeRecorder.get_last_change(rec) == []
+      assert ChangeRecorder.replaying?(rec)
+      refute ChangeRecorder.recording?(rec)
     end
   end
 
   describe "replace_count/2" do
-    test "nil count returns keys unchanged" do
+    test "returns keys unchanged when count is nil" do
       keys = [{?d, 0}, {?w, 0}]
       assert ChangeRecorder.replace_count(keys, nil) == keys
     end
 
-    test "count of 1 strips leading digits" do
+    test "strips leading count when count is 1" do
       keys = [{?3, 0}, {?d, 0}, {?w, 0}]
       assert ChangeRecorder.replace_count(keys, 1) == [{?d, 0}, {?w, 0}]
     end
 
-    test "new count replaces original count" do
-      keys = [{?3, 0}, {?d, 0}, {?w, 0}]
-      assert ChangeRecorder.replace_count(keys, 5) == [{?5, 0}, {?d, 0}, {?w, 0}]
+    test "prepends single-digit count" do
+      keys = [{?d, 0}, {?w, 0}]
+      assert ChangeRecorder.replace_count(keys, 3) == [{?3, 0}, {?d, 0}, {?w, 0}]
     end
 
-    test "multi-digit count" do
+    test "prepends multi-digit count" do
       keys = [{?d, 0}, {?w, 0}]
       assert ChangeRecorder.replace_count(keys, 12) == [{?1, 0}, {?2, 0}, {?d, 0}, {?w, 0}]
     end
 
-    test "strips multi-digit original count" do
-      keys = [{?1, 0}, {?5, 0}, {?x, 0}]
-      assert ChangeRecorder.replace_count(keys, 3) == [{?3, 0}, {?x, 0}]
+    test "replaces existing leading digits" do
+      keys = [{?3, 0}, {?d, 0}, {?w, 0}]
+      assert ChangeRecorder.replace_count(keys, 5) == [{?5, 0}, {?d, 0}, {?w, 0}]
     end
 
-    test "no leading digits with new count prepends digits" do
-      keys = [{?x, 0}]
-      assert ChangeRecorder.replace_count(keys, 3) == [{?3, 0}, {?x, 0}]
+    test "strips multiple leading digits" do
+      keys = [{?1, 0}, {?2, 0}, {?d, 0}, {?w, 0}]
+      assert ChangeRecorder.replace_count(keys, 4) == [{?4, 0}, {?d, 0}, {?w, 0}]
+    end
+
+    test "does not strip non-digit leading key" do
+      keys = [{?d, 0}, {?3, 0}, {?w, 0}]
+      assert ChangeRecorder.replace_count(keys, 2) == [{?2, 0}, {?d, 0}, {?3, 0}, {?w, 0}]
     end
   end
 end

--- a/test/minga_editor/change_tracking_test.exs
+++ b/test/minga_editor/change_tracking_test.exs
@@ -1,0 +1,33 @@
+defmodule MingaEditor.ChangeTrackingTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.ChangeRecorder
+  alias MingaEditor.ChangeTracking
+  alias MingaEditor.Editing
+  alias MingaEditor.RenderPipeline.TestHelpers
+
+  defp state_with_recorder(recorder) do
+    TestHelpers.base_state(rendering: :disabled)
+    |> Editing.set_change_recorder(recorder)
+  end
+
+  test "nested counted dot-repeat preserves outer replay and last change" do
+    rec =
+      ChangeRecorder.new()
+      |> ChangeRecorder.start_recording()
+      |> ChangeRecorder.record_key({?x, 0})
+      |> ChangeRecorder.stop_recording()
+      |> ChangeRecorder.start_replay()
+
+    state = state_with_recorder(rec) |> ChangeTracking.replay_last_change(3)
+    rec = Editing.change_recorder(state)
+
+    assert rec.phase == {:replaying, 1, :idle}
+    assert ChangeRecorder.replaying?(rec)
+    assert ChangeRecorder.get_last_change(rec) == [{?x, 0}]
+
+    rec = ChangeRecorder.stop_replay(rec)
+    assert rec.phase == :idle
+    assert ChangeRecorder.get_last_change(rec) == [{?x, 0}]
+  end
+end

--- a/test/minga_editor/commands/macro_commands_test.exs
+++ b/test/minga_editor/commands/macro_commands_test.exs
@@ -1,0 +1,123 @@
+defmodule MingaEditor.Commands.MacroCommandsTest do
+  use ExUnit.Case, async: true
+
+  alias MingaEditor.Commands
+  alias MingaEditor.Commands.Macros
+  alias MingaEditor.Editing
+  alias MingaEditor.MacroRecorder
+  alias MingaEditor.MacroReplay
+  alias MingaEditor.RenderPipeline.TestHelpers
+  alias MingaEditor.Shell.Traditional.NoticeWorkflow
+
+  defp state_with_recorder(recorder) do
+    TestHelpers.base_state(rendering: :disabled)
+    |> Editing.set_macro_recorder(recorder)
+  end
+
+  defp recorder(state), do: Editing.macro_recorder(state)
+
+  describe "command selection" do
+    test "successful replay selection updates last register and returns replay action" do
+      state = state_with_recorder(MacroRecorder.put_macro(MacroRecorder.new(), "a", [{?x, 0}]))
+
+      {updated, {:replay_macro, "a"}} = Commands.execute(state, {:replay_macro, "a"})
+
+      assert MacroRecorder.last_register(recorder(updated)) == "a"
+      refute MacroRecorder.replaying?(recorder(updated))
+    end
+
+    test "missing register leaves previous last register unchanged" do
+      rec =
+        MacroRecorder.new()
+        |> MacroRecorder.select_replay_register("a")
+
+      updated = state_with_recorder(rec) |> Commands.execute({:replay_macro, "z"})
+
+      assert NoticeWorkflow.message(updated) == "No macro in register @z"
+      assert MacroRecorder.last_register(recorder(updated)) == "a"
+    end
+
+    test "replay_last reports nil last register and replays non-nil last register" do
+      state = state_with_recorder(MacroRecorder.new())
+      assert NoticeWorkflow.message(Macros.replay_last(state)) == "No previous macro"
+
+      rec = MacroRecorder.new() |> MacroRecorder.select_replay_register("b")
+      state = state_with_recorder(rec)
+      assert Macros.replay_last(state) == {state, {:replay_macro, "b"}}
+    end
+  end
+
+  describe "workflow replay transition equivalence" do
+    test "q a x restores active recording without recording replayed x" do
+      rec = MacroRecorder.new() |> MacroRecorder.put_macro("a", [{?q, 0}, {?a, 0}, {?x, 0}])
+      state = state_with_recorder(rec) |> MacroReplay.replay("a")
+      rec = recorder(state)
+
+      refute MacroRecorder.replaying?(rec)
+      assert MacroRecorder.recording?(rec) == {true, "a"}
+      assert rec.phase == {:recording, "a", []}
+      assert MacroRecorder.last_register(rec) == "a"
+    end
+
+    test "q a q stores an empty macro and clears post recording" do
+      rec = MacroRecorder.new() |> MacroRecorder.put_macro("a", [{?q, 0}, {?a, 0}, {?q, 0}])
+      state = state_with_recorder(rec) |> MacroReplay.replay("a")
+      rec = recorder(state)
+
+      refute MacroRecorder.replaying?(rec)
+      assert MacroRecorder.recording?(rec) == false
+      assert MacroRecorder.get_macro(rec, "a") == []
+      assert MacroRecorder.last_register(rec) == "a"
+      assert Editing.mode_state(state).pending == nil
+    end
+
+    test "q a q b does not treat trailing b as a register selection" do
+      rec =
+        MacroRecorder.new()
+        |> MacroRecorder.put_macro("a", [{?q, 0}, {?a, 0}, {?q, 0}, {?b, 0}])
+
+      state = state_with_recorder(rec) |> MacroReplay.replay("a")
+      rec = recorder(state)
+
+      refute MacroRecorder.replaying?(rec)
+      assert MacroRecorder.recording?(rec) == false
+      assert MacroRecorder.get_macro(rec, "a") == []
+      assert MacroRecorder.last_register(rec) == "a"
+      assert Editing.mode_state(state).pending == nil
+    end
+
+    test "nested successful macro replay remains suppressed through outer trailing keys" do
+      rec =
+        MacroRecorder.new()
+        |> MacroRecorder.put_macro("b", [{?h, 0}])
+        |> MacroRecorder.put_macro("a", [{?q, 0}, {?c, 0}, {?@, 0}, {?b, 0}, {?x, 0}])
+
+      state = state_with_recorder(rec) |> MacroReplay.replay("a")
+      rec = recorder(state)
+
+      refute MacroRecorder.replaying?(rec)
+      assert MacroRecorder.recording?(rec) == {true, "c"}
+      assert MacroRecorder.last_register(rec) == "b"
+
+      stopped = MacroRecorder.stop_recording(rec)
+      assert MacroRecorder.get_macro(stopped, "c") == []
+    end
+
+    test "nested missing macro preserves post-recording register and reports notice" do
+      rec =
+        MacroRecorder.new()
+        |> MacroRecorder.put_macro("a", [{?q, 0}, {?c, 0}, {?@, 0}, {?z, 0}, {?x, 0}])
+
+      state = state_with_recorder(rec) |> MacroReplay.replay("a")
+      rec = recorder(state)
+
+      assert NoticeWorkflow.message(state) == "No macro in register @z"
+      refute MacroRecorder.replaying?(rec)
+      assert MacroRecorder.recording?(rec) == {true, "c"}
+      assert MacroRecorder.last_register(rec) == "c"
+
+      stopped = MacroRecorder.stop_recording(rec)
+      assert MacroRecorder.get_macro(stopped, "c") == []
+    end
+  end
+end

--- a/test/minga_editor/editing_test.exs
+++ b/test/minga_editor/editing_test.exs
@@ -171,6 +171,16 @@ defmodule MingaEditor.EditingTest do
     test "returns false when not recording" do
       assert Editing.macro_recording?(build_state()) == false
     end
+
+    test "returns the active macro register when recording" do
+      vim = %VimState{
+        mode: :normal,
+        mode_state: Mode.initial_state(),
+        macro_recorder: MacroRecorder.start_recording(MacroRecorder.new(), "a")
+      }
+
+      assert Editing.macro_recording?(build_state(editing: vim)) == {true, "a"}
+    end
   end
 
   describe "active_register/1" do

--- a/test/minga_editor/macro_recorder_test.exs
+++ b/test/minga_editor/macro_recorder_test.exs
@@ -10,36 +10,49 @@ defmodule MingaEditor.MacroRecorderTest do
   describe "new/0" do
     test "returns a fresh recorder with no macros" do
       rec = MacroRecorder.new()
-      assert rec.recording == nil
+
+      assert rec.phase == :idle
       assert rec.registers == %{}
-      assert rec.replaying == false
-      assert rec.last_register == nil
+      assert MacroRecorder.last_register(rec) == nil
+      assert MacroRecorder.recording?(rec) == false
+      assert MacroRecorder.replaying?(rec) == false
     end
   end
 
   describe "start_recording/2" do
     test "begins recording into the named register" do
       rec = MacroRecorder.new() |> MacroRecorder.start_recording("a")
-      assert rec.recording == {"a", []}
+
+      assert rec.phase == {:recording, "a", []}
+      assert MacroRecorder.last_register(rec) == "a"
     end
   end
 
   describe "record_key/2" do
-    test "appends key to active recording" do
+    test "appends key to active top-level recording" do
       rec =
         MacroRecorder.new()
         |> MacroRecorder.start_recording("a")
         |> MacroRecorder.record_key({?j, 0})
         |> MacroRecorder.record_key({?k, 0})
 
-      {_reg, keys} = rec.recording
-      # Keys are stored in reverse (prepended)
-      assert keys == [{?k, 0}, {?j, 0}]
+      assert rec.phase == {:recording, "a", [{?k, 0}, {?j, 0}]}
     end
 
     test "no-op when not recording" do
       rec = MacroRecorder.new() |> MacroRecorder.record_key({?j, 0})
-      assert rec.recording == nil
+      assert rec.phase == :idle
+    end
+
+    test "no-op during top-level replay" do
+      rec =
+        MacroRecorder.new()
+        |> MacroRecorder.start_recording("a")
+        |> MacroRecorder.record_key({?j, 0})
+        |> MacroRecorder.start_replay()
+        |> MacroRecorder.record_key({?x, 0})
+
+      assert rec.phase == {:replaying, 1, {:recording, "a", [{?j, 0}]}}
     end
   end
 
@@ -52,43 +65,63 @@ defmodule MingaEditor.MacroRecorderTest do
         |> MacroRecorder.record_key({?x, 0})
         |> MacroRecorder.stop_recording()
 
-      assert rec.recording == nil
+      assert rec.phase == :idle
       assert MacroRecorder.get_macro(rec, "a") == [{?j, 0}, {?x, 0}]
+      assert MacroRecorder.last_register(rec) == "a"
     end
 
     test "no-op when not recording" do
       rec = MacroRecorder.new() |> MacroRecorder.stop_recording()
-      assert rec.recording == nil
+      assert rec.phase == :idle
     end
 
     test "overwrites previous macro in same register" do
       rec =
         MacroRecorder.new()
+        |> MacroRecorder.put_macro("a", [{?o, 0}])
         |> MacroRecorder.start_recording("a")
-        |> MacroRecorder.record_key({?j, 0})
-        |> MacroRecorder.stop_recording()
-        |> MacroRecorder.start_recording("a")
-        |> MacroRecorder.record_key({?k, 0})
+        |> MacroRecorder.record_key({?n, 0})
         |> MacroRecorder.stop_recording()
 
-      assert MacroRecorder.get_macro(rec, "a") == [{?k, 0}]
+      assert MacroRecorder.get_macro(rec, "a") == [{?n, 0}]
+    end
+
+    test "q a q stores post recording and preserves replay depth" do
+      rec =
+        MacroRecorder.new()
+        |> MacroRecorder.start_replay()
+        |> MacroRecorder.start_recording("a")
+        |> MacroRecorder.stop_recording()
+
+      assert rec.phase == {:replaying, 1, :idle}
+      assert MacroRecorder.get_macro(rec, "a") == []
+      assert MacroRecorder.last_register(rec) == "a"
+      assert MacroRecorder.replaying?(rec)
+      assert MacroRecorder.recording?(rec) == false
     end
   end
 
-  describe "get_macro/2" do
-    test "returns nil for unrecorded register" do
-      rec = MacroRecorder.new()
-      assert MacroRecorder.get_macro(rec, "z") == nil
+  describe "get_macro/2 and put_macro/3" do
+    test "returns nil for missing register" do
+      assert MacroRecorder.get_macro(MacroRecorder.new(), "z") == nil
     end
 
-    test "returns stored key sequence" do
+    test "stores and retrieves pre-built macros without phase or last-register changes" do
+      rec = MacroRecorder.new() |> MacroRecorder.put_macro("a", [{?x, 0}])
+
+      assert MacroRecorder.get_macro(rec, "a") == [{?x, 0}]
+      assert rec.phase == :idle
+      assert MacroRecorder.last_register(rec) == nil
+    end
+
+    test "keeps multiple registers separate" do
       rec =
         MacroRecorder.new()
-        |> MacroRecorder.start_recording("b")
-        |> MacroRecorder.record_key({?w, 0})
-        |> MacroRecorder.stop_recording()
+        |> MacroRecorder.put_macro("a", [{?a, 0}])
+        |> MacroRecorder.put_macro("b", [{?b, 0}])
 
-      assert MacroRecorder.get_macro(rec, "b") == [{?w, 0}]
+      assert MacroRecorder.get_macro(rec, "a") == [{?a, 0}]
+      assert MacroRecorder.get_macro(rec, "b") == [{?b, 0}]
     end
   end
 
@@ -97,38 +130,81 @@ defmodule MingaEditor.MacroRecorderTest do
       assert MacroRecorder.recording?(MacroRecorder.new()) == false
     end
 
-    test "returns {true, register} when recording" do
+    test "returns {true, register} when top-level recording" do
       rec = MacroRecorder.new() |> MacroRecorder.start_recording("c")
       assert MacroRecorder.recording?(rec) == {true, "c"}
     end
-  end
 
-  describe "multiple registers" do
-    test "different registers store independent macros" do
+    test "exposes post recording while replaying" do
       rec =
-        MacroRecorder.new()
-        |> MacroRecorder.start_recording("a")
-        |> MacroRecorder.record_key({?j, 0})
-        |> MacroRecorder.stop_recording()
-        |> MacroRecorder.start_recording("b")
-        |> MacroRecorder.record_key({?k, 0})
-        |> MacroRecorder.stop_recording()
+        MacroRecorder.new() |> MacroRecorder.start_replay() |> MacroRecorder.start_recording("c")
 
-      assert MacroRecorder.get_macro(rec, "a") == [{?j, 0}]
-      assert MacroRecorder.get_macro(rec, "b") == [{?k, 0}]
+      assert MacroRecorder.recording?(rec) == {true, "c"}
+      assert MacroRecorder.replaying?(rec) == true
     end
   end
 
-  describe "replay flags" do
-    test "start_replay/stop_replay toggle the flag" do
-      rec = MacroRecorder.new()
-      assert MacroRecorder.replaying?(rec) == false
-
-      rec = MacroRecorder.start_replay(rec)
+  describe "replay phase" do
+    test "start_replay wraps idle and stop_replay restores it" do
+      rec = MacroRecorder.new() |> MacroRecorder.start_replay()
+      assert rec.phase == {:replaying, 1, :idle}
       assert MacroRecorder.replaying?(rec) == true
 
       rec = MacroRecorder.stop_replay(rec)
+      assert rec.phase == :idle
       assert MacroRecorder.replaying?(rec) == false
+    end
+
+    test "start_replay wraps recording and restores after outer stop" do
+      rec =
+        MacroRecorder.new()
+        |> MacroRecorder.start_recording("a")
+        |> MacroRecorder.record_key({?x, 0})
+        |> MacroRecorder.start_replay()
+
+      assert rec.phase == {:replaying, 1, {:recording, "a", [{?x, 0}]}}
+
+      rec = MacroRecorder.stop_replay(rec)
+      assert rec.phase == {:recording, "a", [{?x, 0}]}
+    end
+
+    test "nested replay decrements depth before restoring post phase" do
+      rec =
+        MacroRecorder.new()
+        |> MacroRecorder.start_recording("a")
+        |> MacroRecorder.start_replay()
+        |> MacroRecorder.start_replay()
+
+      assert rec.phase == {:replaying, 2, {:recording, "a", []}}
+
+      rec = MacroRecorder.stop_replay(rec)
+      assert rec.phase == {:replaying, 1, {:recording, "a", []}}
+
+      rec = MacroRecorder.stop_replay(rec)
+      assert rec.phase == {:recording, "a", []}
+    end
+  end
+
+  describe "replay-time owner transitions" do
+    test "q a x leaves active recording without recording replayed x" do
+      rec =
+        MacroRecorder.new()
+        |> MacroRecorder.start_replay()
+        |> MacroRecorder.start_recording("a")
+        |> MacroRecorder.record_key({?x, 0})
+        |> MacroRecorder.stop_replay()
+
+      assert rec.phase == {:recording, "a", []}
+      assert MacroRecorder.last_register(rec) == "a"
+    end
+
+    test "select_replay_register changes only last register" do
+      rec = MacroRecorder.new() |> MacroRecorder.put_macro("a", [{?x, 0}])
+      updated = MacroRecorder.select_replay_register(rec, "a")
+
+      assert MacroRecorder.last_register(updated) == "a"
+      assert updated.phase == rec.phase
+      assert updated.registers == rec.registers
     end
   end
 end


### PR DESCRIPTION
## TL;DR

Give `ChangeRecorder` and `MacroRecorder` one owner-owned lifecycle phase while preserving macro and dot-repeat behavior through replay-time transitions and nested replay.

## Context

The editor lifecycle audit accepted ES24 because both recorder structs encoded lifecycle with independent booleans and companion fields. Those shapes admitted impossible states and forced workflow modules to inspect or mutate recorder internals.

This implements roadmap work unit W115 from the locked `local://es24-plan-v4.json` specification. The roadmap entry records the owner contracts, replay-equivalence cases, validation evidence, and retained constraints.

## What changed

- Replace change-recorder `recording`, `keys`, and `replaying` companions with `:idle`, recording, and replay-wrapper phases.
- Replace macro-recorder `recording` and `replaying` companions with owner-owned phases that retain replay depth and post-replay recording state.
- Route replay-register selection and last-register reads through `MacroRecorder` APIs.
- Keep replay suppression authoritative even when a replayed `q a` starts a recording that must remain visible to the following replayed `q`.
- Add focused workflow coverage for `q a x`, `q a q`, `q a q b`, nested successful and missing macro replay, replay-last selection, and nested dot-repeat cleanup.
- Update the repository-local lifecycle roadmap with W115 implementation and review evidence.

## Retained behavior

- Macro and dot-repeat key dispatch ordering is unchanged.
- Replayed keys never enter active or deferred recordings.
- Nested replay unwinds only at the outer normal-return boundary.
- Registers, pending keys, `last_change`, last-register behavior, command notices, status facade output, and `replace_count/2` remain unchanged.
- No compatibility shape, shared recorder abstraction, process, dependency, protocol, configuration, persistence migration, or crash-safe exception cleanup was added.

## Verification

- [x] Focused recorder, facade, command, and change-tracking tests: 83 passed
- [x] Macro conformance suite: 7 passed
- [x] Final macro workflow rerun: 8 passed
- [x] `make lint`
- [x] `git diff --check`
- [x] `ELIXIR_ERL_OPTIONS='+S 4:4' mix test.llm`: 58 doctests, 98 properties, 9,786 tests, 0 failures, 1 skipped, 616 excluded
- [x] Final reviewer: PASS with 0.98 confidence

Production change: +143/-131, net +12, within the locked +50 budget.
