### PR TITLE
docs(editor): close lifecycle execution ledger

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -25,14 +25,14 @@ The independent Ponytail gate produced 91 `ACCEPT`, 28 `ROUTE`, 11 `PRESERVE`, a
 
 Current accepted inventory:
 
-- **VERIFIED:** L01, L02, L04, L05, L10, L12, ES21, ES24
-- **IMPLEMENTED:** S34, S35, E02, E03, E05, E08, ES03, ES05, ES07, ES08, ES12, ES17, ES18
-- **CANDIDATE, lifecycle:** L11, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30
-- **CANDIDATE, deletion:** D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40
-- **CANDIDATE, shrink:** S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S21, S22, S23, S25, S26, S29, S32, S33
+- **VERIFIED:** L01, L02, L04, L05, L10, L11, L12, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30; D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40; S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S22, S23, S25, S26, S28, S29, S32, S33, S34, S35; E02, E03, E05, E08; ES03, ES05, ES07, ES08, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES21, ES24.
+- **DROPPED:** S21. W088 records the merged decision and evidence.
+- **IMPLEMENTED:** (none)
+- **CANDIDATE, lifecycle:** (none)
+- **CANDIDATE, deletion:** (none)
+- **CANDIDATE, shrink:** (none)
 - **CANDIDATE, craftsmanship:** (none)
-- **READY, data shape:** (none)
-- **CANDIDATE, data shape:** ES09, ES10, ES14, ES16
+- **READY or CANDIDATE, data shape:** (none)
 
 ### Freshness wave at `6e175b87764145577999a1c04a532960cb89222f`
 
@@ -45,7 +45,17 @@ Eleven independent read-only GPT-5.5 `medium` batches checked all 85 remaining `
 - **STILL_REPRODUCIBLE, data shape:** ES05, ES07, ES09, ES10, ES12, ES14, ES16
 - **DRIFTED:** D13, D36, D40, S14
 
-Drift evidence:
+### Terminal ACCEPT reconciliation at `48111abe5db3a736b1f046d2e89b54e069a2a20e`
+
+The immutable FINDINGS.md decision inventory contains 91 unique `ACCEPT` IDs. The final ledger contains the same 91 unique IDs with no omission or extra entry: 90 are `VERIFIED`, and S21 is `DROPPED` by the merged W088 decision. Category totals are lifecycle 22 verified, deletion 29 verified, shrink 22 verified plus one dropped, craftsmanship four verified, and data shape 13 verified.
+
+Five independent read-only category audits traced every ID through its terminal work-unit section, reviewer verdict, PR, implementation or decision SHA, and merge evidence. All 115 roadmap work-unit sections are terminal: 114 are `VERIFIED`, including follow-on and split slices, and one is `DROPPED`. The current inventory above is the authority for audit findings; the work-unit sections retain the detailed evidence.
+
+Repository token search found no reference to the removed directory editor or its alias in production code, tests, configuration, or current user documentation. Remaining references are confined to the immutable FINDINGS.md evidence and the W041/W042 historical roadmap record of the completed deletion.
+
+Closure validation: `git diff --check` passed; `make lint` passed compile, formatting, and incremental Dialyzer; and low-concurrency `mix test.llm` passed 58 doctests, 98 properties, and 9,786 tests with zero failures, one skipped, and 616 excluded. The adversarial correctness and Ponytail reviews found the historical freshness overwrite and an off-by-one work-unit count; both were corrected, and targeted rechecks returned `RESOLVED/PASS` and `RESOLVED/LEAN`.
+
+Historical drift evidence used for replanning:
 
 - **D13:** No-op compatibility paths remain, but the live `MingaEditor.State.BufferLifecycle` owner now shares the old module name and the highlight call path changed. Rescope without touching the live owner.
 - **D36:** Dormant Tool Manager placement remains, but the shared footer surface registry is now an explicit numbered placement and focus contract. Rescope the removable local branch.
@@ -53,7 +63,7 @@ Drift evidence:
 - **S14:** Several picker preview callbacks are already optional, while cancel, prompt, effect, and input callbacks remain mandatory. Re-evaluate each remaining callback separately.
 - **ES08:** Parser and semantic-token producers now construct `Minga.Language.Highlight.Span`; only mixed map acceptance in editor highlight storage remains. Relock the remaining conversion boundary.
 
-Implemented evidence:
+Pre-merge ES21 implementation evidence:
 
 - **ES21 / W114:** IMPLEMENTED in worktree `refactor-editor-lifecycle-next-76` from locked plan `local://es21-plan-v5.json` and post-review correction `local://es21-review-fix-plan.json` at baseline `73bdfd3f303d1443e665c03d1deeabe5f14aaadc`. Changed files in the current diff: `docs/workstreams/editor-lifecycle-roadmap.md`, `lib/minga_editor/status_bar/data.ex`, `lib/minga_editor/status_bar/data/common.ex`, `lib/minga_editor/status_bar/data/buffer.ex`, `lib/minga_editor/status_bar/data/agent.ex`, `lib/minga_editor/render_model/ui/status_bar_builder.ex`, `test/minga_editor/status_bar/data_test.exs`, `test/minga_editor/status_bar/data_safe_mode_test.exs`, `test/minga_editor/render_model/ui/status_bar_builder_test.exs`, `test/minga_editor/render_pipeline/chrome_test.exs`, `test/minga_editor/shell/traditional/chrome/gui_test.exs`, and `test/minga_editor/render_pipeline/chrome_dirty_test.exs`; `test/minga_editor/frontend/emit/gui_chrome_cache_test.exs` was touched only to apply the safe cut and has no remaining diff. Observable result: `MingaEditor.StatusBar.Data.from_state/1` now returns `%MingaEditor.StatusBar.Data{common: %Common{}, content: %Buffer{} | %Agent{}}`; `Common.raw_diagnostic_counts` preserves raw pathless `nil` for legacy modeline/custom segments while `common.status.diagnostics.counts` remains normalized to `{0, 0, 0, 0}` for semantic status and opcode `0x76`; `StatusBarBuilder.build/3` projects the typed snapshot to the unchanged semantic `%Minga.RenderModel.UI.StatusBar{}`; byte-parity tests keep `0x76` unchanged for buffer and agent snapshots with independent workspace and exact final agent-section assertions. Validation: focused correction tests `35 passed`; focused owner/builder/modeline/encoder/protocol tests `77 passed, 21 excluded`; focused chrome/cache tests `27 passed`; `mix format --check-formatted` passed for the locked file list; `mix compile --warnings-as-errors` passed; `git diff --check` passed; `make lint` passed with Credo clean and Dialyzer `Total errors: 0`; `mix test.llm --max-cases 4` passed with `58 doctests, 98 properties, 9764 tests, 0 failures, 1 skipped, 616 excluded`; default-concurrency `mix test.llm` was also run and exposed unrelated async timeouts/flakes in `agent/ingest`, `commands/agent_commands`, `providers/native_mcp`, and `session_manager`, with each failed location passing when re-run directly; focused Go status tests passed for 3 packages; `go test ./...` passed for 7 packages with 1 no-tests package; `mix swift.build` skipped because `xcodebuild` is unavailable on this Linux workstation. Budgets before roadmap evidence: production net `-13` lines (`lib/minga_editor/render_model/ui/status_bar_builder.ex` `+55/-79`, `lib/minga_editor/status_bar/data.ex` `+183/-233`, untracked value modules `+61`), test net `+173` lines, both within locked limits. Concepts added by the full ES21 implementation: the typed `Data` aggregate plus the new `Common`, `Buffer`, and `Agent` value modules; the post-review correction added exactly one enforced modeline-only `Common.raw_diagnostic_counts` field and no additional module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, parallel shape, wire shape, or frontend/generated path. Concepts removed: unused `MingaEditor.StatusBar.Data.lsp_status/0` alias and obsolete self-copy/test-only assertions. Discoveries: no `NEEDS_REPLAN`; Swift validation surface is unavailable here because Xcode is not installed; default-concurrency `mix test.llm` has unrelated async/resource flakes in this worktree, but low-concurrency full LLM validation and every failed location passed.
 - **ES21 / W114 review evidence:** Correctness initially found the raw diagnostic `nil` normalization regression, then returned `PASS / RESOLVED` after the locked correction and targeted roadmap-truthfulness fix. Ponytail's three test-strengthening findings and two safe cuts were applied; its targeted recheck confirmed the tests are lean and independent after the roadmap correction. Elixir craftsmanship returned `PASS / RESOLVED / LEAN`; the type-design specialist was unavailable because its runtime had no model configured, so the correctness and Elixir passes covered the new struct invariants. Final reviewer verdict: `PASS` with 0.99 confidence.


### PR DESCRIPTION
## TL;DR

Close the editor lifecycle execution ledger: all 91 accepted audit findings now have terminal dispositions, with 90 verified and S21 dropped by a merged decision.

## Context

The detailed W001-W115 sections already contained terminal implementation and decision evidence, but the top accepted inventory still showed completed work as candidate or implemented. This reconciliation makes the current inventory truthful without rewriting the SHA-pinned freshness history or the immutable FINDINGS.md audit record.

## What changed

- Reconcile all 91 unique ACCEPT IDs against FINDINGS.md with no omissions or extras.
- Record 90 IDs as VERIFIED and S21 as DROPPED through W088.
- Clear every current nonterminal accepted bucket.
- Record exact category totals and terminal work-unit totals: W001-W115, 114 VERIFIED and one DROPPED.
- Record the final residual-reference search for the removed directory editor and its alias.
- Preserve the historical freshness, drift, implementation, ROUTE, PRESERVE, and REJECT evidence.
- Record cumulative validation and adversarial review corrections.

## Verification

- [x] Five independent category audits traced every ACCEPT ID to terminal work-unit evidence
- [x] Programmatic inventory check: 91 FINDINGS IDs = 90 unique VERIFIED + S21 DROPPED, no missing or extra IDs
- [x] Programmatic work-unit check: W001-W115 contiguous and unique, 114 VERIFIED + W088 DROPPED
- [x] Residual token search: only immutable FINDINGS.md and W041/W042 historical roadmap evidence
- [x] `git diff --check`
- [x] `make lint`
- [x] `ELIXIR_ERL_OPTIONS='+S 4:4' mix test.llm`: 58 doctests, 98 properties, 9,786 tests, 0 failures, 1 skipped, 616 excluded
- [x] Correctness blocker recheck: RESOLVED/PASS
- [x] Ponytail blocker recheck: RESOLVED/LEAN
- [x] Final targeted reviewer: RESOLVED/PASS with 0.99 confidence

FINDINGS.md is unchanged.
