### PR TITLE
fix(lsp): validate completion request identity

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -4755,3 +4755,34 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Merge evidence:** PR #3230 merged on 2026-07-24 after required CI passed. Current main contains the same implementation and test tree reviewed at `8eb1de1476a45ca87056a858435a508f3f9daa37`.
 - **Findings resolved:** L06 is fully resolved as the approved ROUTE follow-on.
 - **Completion date:** 2026-07-24
+
+### W118/L07: Validate completion and signature identity through processing
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** L07
+- **Decision:** APPROVE_REVISED_CAP, one Editor-global `MingaEditor.State.LSP.PendingRequests` owner carries exactly three L07 typed variants for completion result, completion resolve, and signature help. Completion debounce uses the existing completion generation as its only semantic identity.
+- **Planning profile:** `L07RoutePlanner`, editor-lifecycle-planner, read-only; superseded where corrected by `L07PlanVerifier`.
+- **Implementation profile:** `L07RouteWorker`, editor-lifecycle-worker, no delegation.
+- **Baseline:** `39f395e6f5a344dd00e6a93da35e1d53e7338ac2`.
+- **Ready provenance:** Corrected lock from `agent://L07PlanVerifier`; the initial route plan was not locked where it duplicated debounce identity or left trigger-local response classification ambiguous. `agent://L07BudgetDecision` approved the atomic clean cutover with exact hard caps of net `+170` formatted production lines and net `+360` formatted test lines.
+- **Observable result:** Completion debounce messages carry only `{:completion_debounce, gen}` and stale generations send no LSP requests. Completion results are taken once from `PendingRequests`, validated against captured client membership, buffer PID, buffer version, completion generation, and trigger position before async processing, and processed results also reject active-buffer/version drift. Completion resolve uses exact raw LSP item equality for timer, pending request, and response update identity. Signature help responses validate client, buffer, version, and captured cursor before opening or dismissing popup state.
+- **Implementation result:** Added exactly three L07 typed pending variants; removed completion resolve and signature help from the legacy atom API while preserving L08 `:code_lens`, `:code_lens_resolve`, and `:inlay_hint`; deleted trigger-local response ref classification and untracked completion-response fallback; replaced selected-index resolve identity with raw LSP item identity; updated Editor mailbox shapes for debounce, resolve, and processed completion results.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`, `lib/minga/editing/completion.ex`, `lib/minga_editor.ex`, `lib/minga_editor/completion_handling.ex`, `lib/minga_editor/completion_trigger.ex`, `lib/minga_editor/handlers/lsp_event_handler.ex`, `lib/minga_editor/state/lsp.ex`, `lib/minga_editor/state/lsp/pending_requests.ex`, `lib/minga_editor/state/modal_overlay.ex`, `test/minga_editor/completion_async_test.exs`, `test/minga_editor/completion_doc_preview_test.exs`, `test/minga_editor/completion_trigger_test.exs`, `test/minga_editor/handlers/lsp_event_handler_test.exs`, `test/minga_editor/state/lsp/pending_requests_test.exs`, and `test/minga_editor/state/tab_switch_test.exs`.
+- **Focused validation:** `make lint` passed; the locked L07 suite across pending requests, trigger, handler, documentation preview, async processing, signature help, and tab switching passed `124 tests`; after the deterministic dead-between-validation regression replaced the weaker early-death setup, `mix test test/minga_editor/handlers/lsp_event_handler_test.exs` passed `44 tests`.
+- **Production lines added/removed before roadmap evidence:** `+637/-477`, net `+160`, within the architecture-approved `+170` cap from `agent://L07BudgetDecision`.
+- **Test lines added/removed before roadmap evidence:** `+509/-379`, net `+130`, within the architecture-approved `+360` cap from `agent://L07BudgetDecision`.
+- **Broad validation:** `git diff --check` and `make lint` passed. Default-concurrency `mix test.llm` exposed an unrelated five-second `MingaAgent.SessionManager.list_sessions/0` timeout in `MingaAgent.Gateway.JsonRpcTest`; that exact test passed alone. `mix test.llm --max-cases 8` exposed a different five-second timeout in the unchanged `MingaAgent.SessionManagerTest` restart path; that exact test also passed alone. No L07-focused test failed.
+- **Pre-acceptance reviews:** Correctness returned `PASS` after deterministic coverage of the buffer-death window; Ponytail returned `RESOLVED/LEAN`; Elixir craftsmanship returned `RESOLVED/PASS`.
+- **Final reviewer:** `PASS`, confidence `0.98`; the one-owner cutover, take-once dispatch, stale/dead-origin rejection, primary/merge behavior, resolve identity, signature validation, L08 preservation, tests, line caps, and qualified validation evidence are accepted.
+- **Concepts added:** L07 completion-result, completion-resolve, and signature-help typed pending request variants; raw LSP completion item resolve identity.
+- **Concepts removed:** CompletionTrigger response-ref authority (`refs_by_role`, classifier, classification role, pending-ref removal), untracked completion-response fallback, legacy completion/signature atom tracking, and selected-index completion resolve identity.
+- **Retained constraints:** One Editor mailbox, one completion generation identity, no debounce token, no new module/process/registry/dependency/behaviour/protocol/configuration/shim/metadata map, no frontend protocol change, async completion processing under the existing task supervisor, and L08 legacy atoms unchanged.
+- **Discoveries affecting later work:** L08 code-lens, codeLens/resolve, and inlay hint remain on the legacy atom variant and still need their own origin-safe stale rejection plus empty-result clearing.
+- **Unresolved questions:** None.
+- **needs_replan:** false.
+- **PR URL:** reserved.
+- **Implementation commit SHA:** reserved.
+- **Merge SHA:** reserved.
+- **Merge evidence:** reserved.
+- **Findings resolved:** L07 implementation plus every mandatory correction from the correctness, Ponytail, and Elixir reviews are applied; final acceptance passed with no findings.
+- **Completion date:** reserved.

--- a/lib/minga/editing/completion.ex
+++ b/lib/minga/editing/completion.ex
@@ -23,7 +23,7 @@ defmodule Minga.Editing.Completion do
             trigger_position: {0, 0},
             max_visible: 10,
             resolve_timer: nil,
-            last_resolved_index: -1
+            last_resolved_identity: nil
 
   @typedoc "LSP CompletionItemKind as an atom."
   @type item_kind ::
@@ -85,7 +85,7 @@ defmodule Minga.Editing.Completion do
           trigger_position: {non_neg_integer(), non_neg_integer()},
           max_visible: pos_integer(),
           resolve_timer: reference() | nil,
-          last_resolved_index: integer()
+          last_resolved_identity: map() | nil
         }
 
   # ── Constructor ──────────────────────────────────────────────────────────────
@@ -273,31 +273,48 @@ defmodule Minga.Editing.Completion do
     }
   end
 
+  @doc "Returns true when the selected item's raw identity equals the expected raw item."
+  @spec selected_raw?(t(), map()) :: boolean()
+  def selected_raw?(%__MODULE__{} = completion, raw_item) when is_map(raw_item) do
+    case selected_item(completion) do
+      %{raw: ^raw_item} -> true
+      _ -> false
+    end
+  end
+
   @doc """
-  Updates the documentation for the currently selected item.
+  Updates documentation only when the currently selected item matches the expected raw identity.
 
-  Called when a `completionItem/resolve` response arrives with
-  the full documentation text.
+  Called when a `completionItem/resolve` response arrives with the full documentation text.
   """
-  @spec update_selected_documentation(t(), String.t()) :: t()
-  def update_selected_documentation(%__MODULE__{} = completion, doc_text) do
-    item = selected_item(completion)
-
-    if item do
-      updated = %{item | documentation: doc_text}
-      idx = absolute_selected_index(completion)
-
-      filtered =
-        List.update_at(completion.filtered, idx, fn _ -> updated end)
-
-      %{completion | filtered: filtered}
+  @spec update_selected_documentation(t(), map(), String.t()) :: t()
+  def update_selected_documentation(%__MODULE__{} = completion, raw_item, doc_text)
+      when is_map(raw_item) do
+    if selected_raw?(completion, raw_item) do
+      completion
+      |> update_documentation_for_raw(raw_item, doc_text)
+      |> Map.put(:last_resolved_identity, raw_item)
     else
       completion
     end
   end
 
-  @spec absolute_selected_index(t()) :: non_neg_integer()
-  defp absolute_selected_index(%__MODULE__{selected: sel}), do: sel
+  @spec update_documentation_for_raw(t(), map(), String.t()) :: t()
+  defp update_documentation_for_raw(%__MODULE__{} = completion, raw_item, doc_text) do
+    %{
+      completion
+      | items: update_documentation_items(completion.items, raw_item, doc_text),
+        filtered: update_documentation_items(completion.filtered, raw_item, doc_text)
+    }
+  end
+
+  @spec update_documentation_items([item()], map(), String.t()) :: [item()]
+  defp update_documentation_items(items, raw_item, doc_text) do
+    Enum.map(items, fn
+      %{raw: ^raw_item} = item -> %{item | documentation: doc_text}
+      item -> item
+    end)
+  end
 
   @spec extract_documentation(term()) :: String.t()
   defp extract_documentation(nil), do: ""

--- a/lib/minga_editor.ex
+++ b/lib/minga_editor.ex
@@ -846,7 +846,7 @@ defmodule MingaEditor do
   end
 
   # LSP/completion timer events routed through a focused handler.
-  def handle_info({:completion_debounce, _clients, _buffer_pid} = msg, state) do
+  def handle_info({:completion_debounce, _gen} = msg, state) do
     {:noreply, LspEventHandler.dispatch(state, msg)}
   end
 
@@ -866,7 +866,7 @@ defmodule MingaEditor do
     {:noreply, LspEventHandler.dispatch(state, msg)}
   end
 
-  def handle_info({:completion_resolve, _index} = msg, state) do
+  def handle_info({:completion_resolve, _gen, _raw_item} = msg, state) do
     {:noreply, LspEventHandler.dispatch(state, msg)}
   end
 
@@ -997,12 +997,16 @@ defmodule MingaEditor do
 
   # ── Async completion processing result ──────────────────────────────────
   # LSP completion responses are parsed/sorted/filtered in a Task off the
-  # Editor hot path (CompletionHandling.handle_response/3). The Task sends this
-  # message back with the processed menu. apply_processed/5 applies it cheaply
-  # and uses the generation token to discard a stale, superseded result
-  # (latest-wins), so large completion sets never block input.
-  def handle_info({:completion_processed, gen, mode, payload, trigger_pos}, state) do
-    new_state = CompletionHandling.apply_processed(state, gen, mode, payload, trigger_pos)
+  # Editor hot path. The Task sends this message back with the processed menu.
+  # apply_processed/7 applies it cheaply and uses the generation and buffer
+  # identity to discard stale, superseded results.
+  def handle_info(
+        {:completion_processed, gen, mode, payload, trigger_pos, buffer, version},
+        state
+      ) do
+    new_state =
+      CompletionHandling.apply_processed(state, gen, mode, payload, trigger_pos, buffer, version)
+
     {:noreply, Renderer.render_or_async(new_state)}
   end
 

--- a/lib/minga_editor/completion_handling.ex
+++ b/lib/minga_editor/completion_handling.ex
@@ -25,13 +25,6 @@ defmodule MingaEditor.CompletionHandling do
 
   @resolve_debounce_ms 150
 
-  @doc """
-  Triggers a `completionItem/resolve` request for the selected item.
-
-  Called when C-n/C-p moves the selection. Debounces to avoid flooding
-  the server when navigating rapidly. Only triggers if the selected
-  item doesn't already have documentation and the server supports resolve.
-  """
   @spec maybe_resolve_selected(EditorState.t()) :: EditorState.t()
   def maybe_resolve_selected(%{shell_runtime: %{state: %ShellState{}}} = state) do
     case ModalWorkflow.completion(state) do
@@ -48,21 +41,20 @@ defmodule MingaEditor.CompletionHandling do
   @spec do_maybe_resolve_selected(EditorState.t(), Completion.t()) :: EditorState.t()
   defp do_maybe_resolve_selected(state, completion) do
     item = Completion.selected_item(completion)
-    selected_idx = completion.selected
+    raw_item = if item, do: item.raw
+    gen = CompletionTrigger.generation(ModalWorkflow.completion_trigger(state))
 
-    # Skip if already resolved for this index, or if doc is already present
-    if item == nil or selected_idx == completion.last_resolved_index or
+    if item == nil or raw_item == nil or raw_item == completion.last_resolved_identity or
          item.documentation != "" do
       state
     else
-      # Cancel previous resolve timer
       if completion.resolve_timer do
         Process.cancel_timer(completion.resolve_timer)
       end
 
       timer =
         if state.frontend.backend != :headless do
-          Process.send_after(self(), {:completion_resolve, selected_idx}, @resolve_debounce_ms)
+          Process.send_after(self(), {:completion_resolve, gen, raw_item}, @resolve_debounce_ms)
         end
 
       ModalWorkflow.update_completion(state, fn _ ->
@@ -71,54 +63,56 @@ defmodule MingaEditor.CompletionHandling do
     end
   end
 
-  @doc """
-  Sends the actual `completionItem/resolve` request after debounce.
-
-  Called from MingaEditor.handle_info({:completion_resolve, index}).
-  """
-  @spec flush_resolve(EditorState.t(), non_neg_integer()) :: EditorState.t()
-  def flush_resolve(%{shell_runtime: %{state: %ShellState{}}} = state, index) do
+  @spec flush_resolve(EditorState.t(), non_neg_integer(), map()) :: EditorState.t()
+  def flush_resolve(%{shell_runtime: %{state: %ShellState{}}} = state, gen, raw_item) do
     case ModalWorkflow.completion(state) do
       nil -> state
-      completion -> do_flush_resolve(state, completion, index)
+      completion -> do_flush_resolve(state, completion, gen, raw_item)
     end
   end
 
-  def flush_resolve(state, _index), do: state
+  def flush_resolve(state, _gen, _raw_item), do: state
 
-  @spec do_flush_resolve(EditorState.t(), Completion.t(), non_neg_integer()) :: EditorState.t()
-  defp do_flush_resolve(%{workspace: %{buffers: %{active: buf}}} = state, completion, index) do
-    item = Enum.at(completion.filtered, index)
-
-    if item == nil or item.raw == nil do
-      state
-    else
-      case lsp_client_for(state, buf) do
-        nil ->
-          state
-
-        client ->
-          ref = Client.request(client, "completionItem/resolve", item.raw)
-
-          track_response_request(state, ref, :completion_resolve)
-      end
-    end
-  end
-
-  @doc """
-  Handles a `completionItem/resolve` response.
-
-  Updates the selected completion item's documentation with the
-  resolved content.
-  """
-  @spec handle_resolve_response(EditorState.t(), {:ok, term()} | {:error, term()}) ::
+  @spec do_flush_resolve(EditorState.t(), Completion.t(), non_neg_integer(), map()) ::
           EditorState.t()
-  def handle_resolve_response(state, {:error, _error}), do: state
+  defp do_flush_resolve(
+         %{workspace: %{buffers: %{active: buf}}} = state,
+         completion,
+         gen,
+         raw_item
+       ) do
+    trigger = ModalWorkflow.completion_trigger(state)
+
+    if CompletionTrigger.generation(trigger) == gen and
+         Completion.selected_raw?(completion, raw_item) do
+      flush_resolve_request(state, buf, gen, raw_item)
+    else
+      state
+    end
+  end
+
+  @spec flush_resolve_request(EditorState.t(), pid(), non_neg_integer(), map()) :: EditorState.t()
+  defp flush_resolve_request(state, buf, gen, raw_item) do
+    case {lsp_client_for(state, buf), buffer_value(buf, &Buffer.version/1)} do
+      {client, version} when is_pid(client) and is_integer(version) and version >= 0 ->
+        ref = Client.request(client, "completionItem/resolve", raw_item)
+        track_completion_resolve_request(state, ref, client, buf, version, gen, raw_item)
+
+      _ ->
+        state
+    end
+  end
+
+  @spec handle_resolve_response(EditorState.t(), map(), {:ok, term()} | {:error, term()}) ::
+          EditorState.t()
+  def handle_resolve_response(state, _raw_item, {:error, _error}), do: state
 
   def handle_resolve_response(
         %{shell_runtime: %{state: %ShellState{}}} = state,
+        raw_item,
         {:ok, resolved}
-      ) do
+      )
+      when is_map(raw_item) do
     case ModalWorkflow.completion(state) do
       nil ->
         state
@@ -127,21 +121,13 @@ defmodule MingaEditor.CompletionHandling do
         doc_text = extract_resolve_documentation(resolved)
 
         ModalWorkflow.update_completion(state, fn completion ->
-          completion
-          |> Completion.update_selected_documentation(doc_text)
-          |> Map.put(:last_resolved_index, completion.selected)
+          Completion.update_selected_documentation(completion, raw_item, doc_text)
         end)
     end
   end
 
-  def handle_resolve_response(state, {:ok, _resolved}), do: state
+  def handle_resolve_response(state, _raw_item, {:ok, _resolved}), do: state
 
-  @doc """
-  Accepts the currently selected completion item.
-
-  Routes to insert-text or text-edit depending on the completion type,
-  then dismisses the completion popup.
-  """
   @spec accept(EditorState.t(), Completion.t()) :: EditorState.t()
   def accept(state, completion) do
     case Completion.accept(completion) do
@@ -156,13 +142,6 @@ defmodule MingaEditor.CompletionHandling do
     end
   end
 
-  @doc """
-  Updates or dismisses completion after a key press.
-
-  Called after every key in insert mode. If the mode changed away from
-  insert, dismisses completion. Otherwise updates the filter prefix
-  and possibly triggers new completion.
-  """
   @spec maybe_handle(EditorState.t(), boolean(), non_neg_integer(), non_neg_integer()) ::
           EditorState.t()
   def maybe_handle(
@@ -182,13 +161,6 @@ defmodule MingaEditor.CompletionHandling do
 
   def maybe_handle(state, _was_inserting, _codepoint, _modifiers), do: state
 
-  @doc """
-  Dismisses the active completion popup and resets trigger state.
-
-  No-op when the active modal is something other than `:completion` — the
-  caller may invoke this on every non-insert keypress, so we mustn't
-  displace the picker / prompt / etc.
-  """
   @spec dismiss(EditorState.t()) :: EditorState.t()
   def dismiss(%{shell_runtime: %{state: %ShellState{}}} = state) do
     if ModalOverlay.match(state.shell_runtime.state.modal, :completion) do
@@ -215,10 +187,66 @@ defmodule MingaEditor.CompletionHandling do
 
   # ── Private helpers ────────────────────────────────────────────────────────
 
-  @spec track_response_request(EditorState.t(), reference(), LSPState.legacy_response_kind()) ::
+  @spec install_completion_tracking(EditorState.t(), [CompletionTrigger.tracking_fact()]) ::
           EditorState.t()
-  defp track_response_request(state, ref, kind) do
-    %{state | lsp: LSPState.track_response_request(state.lsp, ref, kind)}
+  def install_completion_tracking(state, facts) do
+    Enum.reduce(facts, state, fn {ref, role, client, buffer, version, gen, pos}, state ->
+      %{
+        state
+        | lsp:
+            LSPState.track_completion_result_request(
+              state.lsp,
+              ref,
+              role,
+              client,
+              buffer,
+              version,
+              gen,
+              pos
+            )
+      }
+    end)
+  end
+
+  @spec track_completion_resolve_request(
+          EditorState.t(),
+          reference(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          map()
+        ) :: EditorState.t()
+  defp track_completion_resolve_request(state, ref, client, buffer, version, gen, raw_item) do
+    %{
+      state
+      | lsp:
+          LSPState.track_completion_resolve_request(
+            state.lsp,
+            ref,
+            client,
+            buffer,
+            version,
+            gen,
+            raw_item
+          )
+    }
+  end
+
+  @spec track_signature_help_request(
+          EditorState.t(),
+          reference(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          {non_neg_integer(), non_neg_integer()}
+        ) :: EditorState.t()
+  defp track_signature_help_request(state, ref, client, buffer, version, cursor) do
+    %{
+      state
+      | lsp:
+          LSPState.track_signature_help_request(state.lsp, ref, client, buffer, version, cursor)
+    }
   end
 
   @spec accept_text(EditorState.t(), Completion.t(), String.t()) :: EditorState.t()
@@ -312,14 +340,16 @@ defmodule MingaEditor.CompletionHandling do
         state
 
       char ->
-        {new_bridge, _comp} =
+        {new_bridge, facts} =
           CompletionTrigger.maybe_trigger(
             ModalWorkflow.completion_trigger(state),
             char,
             buf
           )
 
-        ModalWorkflow.put_completion_trigger(state, new_bridge)
+        state
+        |> ModalWorkflow.put_completion_trigger(new_bridge)
+        |> install_completion_tracking(facts)
     end
   end
 
@@ -547,78 +577,65 @@ defmodule MingaEditor.CompletionHandling do
     end
   end
 
-  @doc """
-  Handles an LSP completion response off the Editor hot path.
+  @spec handle_completion_result(
+          EditorState.t(),
+          CompletionTrigger.response_role(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          {non_neg_integer(), non_neg_integer()},
+          term()
+        ) :: EditorState.t()
+  def handle_completion_result(state, role, client, buffer, version, gen, trigger_pos, result) do
+    with true <- completion_result_current?(state, client, buffer, version, gen),
+         {:ok, prefix} <- completion_prefix_from_trigger(buffer, trigger_pos),
+         true <- buffer_value(buffer, &Buffer.version/1) == version do
+      mode = if role == :primary, do: :primary, else: :merge
+      start_completion_task(self(), mode, result, trigger_pos, prefix, gen, buffer, version)
+    end
 
-  Only the cheap bookkeeping runs on the Editor: `CompletionTrigger.classify_response/4`
-  matches the response `ref` against the pending request and decides whether it
-  is the primary response, a secondary one to merge, or stale. The expensive
-  work (parsing every item, sorting, and prefix-filtering) is then handed to a
-  Task under `Minga.Eval.TaskSupervisor`, which sends the processed result back
-  as `{:completion_processed, gen, mode, payload, trigger_pos}`. The Editor
-  applies that via `apply_processed/5` with a cheap state assignment.
-
-  This keeps the Editor mailbox responsive even when a server returns 1000+
-  completion items.
-  """
-  @spec handle_response(EditorState.t(), reference(), term()) :: EditorState.t()
-  def handle_response(
-        %{
-          shell_runtime: %{state: %ShellState{}},
-          workspace: %{buffers: %{active: nil}}
-        } = state,
-        _ref,
-        _result
-      ),
-      do: state
-
-  def handle_response(%{shell_runtime: %{state: %ShellState{}}} = state, ref, result) do
-    buffer_pid = state.workspace.buffers.active
-
-    {new_bridge, classification} =
-      CompletionTrigger.classify_response(
-        ModalWorkflow.completion_trigger(state),
-        ref,
-        result,
-        buffer_pid
-      )
-
-    new_state =
-      ModalWorkflow.put_completion_trigger(state, new_bridge)
-
-    dispatch_processing(new_state, classification, result)
-  end
-
-  def handle_response(state, _ref, _result), do: state
-
-  @spec dispatch_processing(EditorState.t(), CompletionTrigger.classification(), term()) ::
-          EditorState.t()
-  defp dispatch_processing(state, :ignore, _result), do: state
-
-  defp dispatch_processing(state, {mode, trigger_pos, prefix, gen}, result) do
-    start_completion_task(self(), mode, result, trigger_pos, prefix, gen)
     state
   end
 
-  # Spawns the parse/sort/filter work in a supervised Task so it never blocks
-  # the Editor GenServer. The Task sends the processed result back to `editor`.
-  #
-  # The Task ALWAYS sends a terminal {:completion_processed, ...} message: on
-  # success with the built menu, on any crash (e.g. a malformed LSP item that
-  # FunctionClauseErrors in parse_item/1) with the `:failed` sentinel. If the
-  # Task cannot even be started, we send `:failed` directly. Either way the
-  # pending modal is never left stuck waiting on a message that never arrives.
+  defp completion_result_current?(
+         %{shell_runtime: %{state: %ShellState{}}} = state,
+         client,
+         buffer,
+         version,
+         gen
+       ) do
+    trigger = ModalWorkflow.completion_trigger(state)
+
+    ModalOverlay.match(state.shell_runtime.state.modal, :completion) and
+      CompletionTrigger.generation(trigger) == gen and state.workspace.buffers.active == buffer and
+      buffer_value(buffer, &Buffer.version/1) == version and
+      client in SyncServer.clients_for_buffer(buffer)
+  end
+
+  defp completion_result_current?(_state, _client, _buffer, _version, _gen), do: false
+
+  @spec completion_prefix_from_trigger(pid(), CompletionTrigger.position()) ::
+          {:ok, String.t()} | :stale
+  defp completion_prefix_from_trigger(buffer, trigger_pos) do
+    {:ok, CompletionTrigger.get_typed_since_trigger(buffer, trigger_pos)}
+  catch
+    :exit, _ -> :stale
+  end
+
   @spec start_completion_task(
           pid(),
           :primary | :merge,
           term(),
           {non_neg_integer(), non_neg_integer()},
           String.t(),
+          non_neg_integer(),
+          pid(),
           non_neg_integer()
         ) :: :ok
-  defp start_completion_task(editor, mode, result, trigger_pos, prefix, gen) do
+  defp start_completion_task(editor, mode, result, trigger_pos, prefix, gen, buffer, version) do
     case Task.Supervisor.start_child(Minga.Eval.TaskSupervisor, fn ->
-           run_completion_task(editor, mode, result, trigger_pos, prefix, gen)
+           run_completion_task(editor, mode, result, trigger_pos, prefix, gen, buffer, version)
          end) do
       {:ok, _pid} ->
         :ok
@@ -630,7 +647,7 @@ defmodule MingaEditor.CompletionHandling do
           "Completion Task failed to start (gen=#{gen}, mode=#{mode}): #{inspect(reason)}"
         end)
 
-        send(editor, {:completion_processed, gen, mode, :failed, trigger_pos})
+        send(editor, {:completion_processed, gen, mode, :failed, trigger_pos, buffer, version})
         :ok
     end
   end
@@ -641,9 +658,11 @@ defmodule MingaEditor.CompletionHandling do
           term(),
           {non_neg_integer(), non_neg_integer()},
           String.t(),
+          non_neg_integer(),
+          pid(),
           non_neg_integer()
         ) :: :ok
-  defp run_completion_task(editor, mode, result, trigger_pos, prefix, gen) do
+  defp run_completion_task(editor, mode, result, trigger_pos, prefix, gen, buffer, version) do
     payload =
       try do
         build_processed(mode, result, trigger_pos, prefix)
@@ -663,13 +682,10 @@ defmodule MingaEditor.CompletionHandling do
           :failed
       end
 
-    send(editor, {:completion_processed, gen, mode, payload, trigger_pos})
+    send(editor, {:completion_processed, gen, mode, payload, trigger_pos, buffer, version})
     :ok
   end
 
-  # Primary: build the full sorted+filtered menu in the Task so the Editor only
-  # has to assign it. Merge: parse to items only; the (rare) merge math runs on
-  # the Editor at apply time against the live menu so ordering stays correct.
   @spec build_processed(
           :primary,
           term(),
@@ -689,48 +705,36 @@ defmodule MingaEditor.CompletionHandling do
     Completion.parse_response(result)
   end
 
-  @doc """
-  Applies a completion result that was processed off the Editor in a Task.
-
-  Discards the result unless a completion modal is still open *and* it carries
-  the current request generation (`gen`). This latest-wins guard drops a stale
-  Task result from a request batch that was superseded by newer typing, so an
-  out-of-order or slow Task can never overwrite a fresher menu.
-
-  For a `:primary` result the Task already produced a fully sorted+filtered
-  `Completion`, so the common single-server path is a cheap assignment. If a
-  secondary server's `:merge` result happened to land first, the primary result
-  is unioned into it (rather than replacing it) so no server's items are lost.
-
-  A `:failed` payload (the Task crashed or could not start) clears a still-pending
-  menu so it is not left stuck, while leaving an already-populated menu intact.
-  """
   @spec apply_processed(
           EditorState.t(),
           non_neg_integer(),
           :primary | :merge,
           Completion.t() | [Completion.item()] | :failed,
-          {non_neg_integer(), non_neg_integer()}
+          {non_neg_integer(), non_neg_integer()},
+          pid(),
+          non_neg_integer()
         ) :: EditorState.t()
   def apply_processed(
         %{shell_runtime: %{state: %ShellState{}}} = state,
         gen,
         mode,
         payload,
-        trigger_pos
+        trigger_pos,
+        buffer,
+        version
       ) do
     trigger = ModalWorkflow.completion_trigger(state)
 
     if ModalOverlay.match(state.shell_runtime.state.modal, :completion) and
-         CompletionTrigger.generation(trigger) == gen do
+         CompletionTrigger.generation(trigger) == gen and state.workspace.buffers.active == buffer and
+         buffer_value(buffer, &Buffer.version/1) == version do
       apply_processed_current(state, mode, payload, trigger_pos)
     else
-      # Stale generation or the menu was dismissed/replaced; discard.
       state
     end
   end
 
-  def apply_processed(state, _gen, _mode, _payload, _trigger_pos), do: state
+  def apply_processed(state, _gen, _mode, _payload, _trigger_pos, _buffer, _version), do: state
 
   @spec apply_processed_current(
           EditorState.t(),
@@ -738,34 +742,25 @@ defmodule MingaEditor.CompletionHandling do
           Completion.t() | [Completion.item()] | :failed,
           {non_neg_integer(), non_neg_integer()}
         ) :: EditorState.t()
-  defp apply_processed_current(state, _mode, :failed, _trigger_pos) do
-    # Processing failed (crash or Task could not start). Don't leave the modal
-    # stuck waiting on a menu that will never arrive: dismiss it if it is still
-    # pending, but keep an already-populated menu (e.g. primary succeeded and a
-    # secondary merge failed) intact. A dropped completion self-heals on the
-    # next keystroke.
+  defp apply_processed_current(state, :primary, :failed, _trigger_pos) do
     case ModalWorkflow.completion(state) do
       nil -> dismiss(state)
       %Completion{} -> state
     end
   end
 
+  defp apply_processed_current(state, :merge, :failed, _trigger_pos), do: state
+
   defp apply_processed_current(state, :primary, %Completion{items: []}, _trigger_pos) do
-    # No items: matches the old behaviour of leaving the pending menu empty
-    # rather than showing an empty popup.
     state
   end
 
   defp apply_processed_current(state, :primary, %Completion{} = built, _trigger_pos) do
     case ModalWorkflow.completion(state) do
       nil ->
-        # Fast path (single server / primary lands first): just assign the
-        # already-sorted, already-filtered menu the Task produced.
         ModalWorkflow.update_completion(state, fn _ -> built end)
 
       %Completion{} ->
-        # A secondary :merge result landed first; union the primary items in so
-        # neither server's items are dropped.
         merge_completion_items(state, built.items, built.trigger_position)
     end
   end
@@ -784,7 +779,6 @@ defmodule MingaEditor.CompletionHandling do
   defp merge_completion_items(state, new_items, trigger_pos) do
     case ModalWorkflow.completion(state) do
       nil ->
-        # No existing completion; create a new one from the merged items
         completion = Completion.new(new_items, trigger_pos)
 
         prefix =
@@ -794,7 +788,6 @@ defmodule MingaEditor.CompletionHandling do
         open_completion(state, completion)
 
       %Completion{} = existing ->
-        # Merge into existing completion
         merged_items = existing.items ++ new_items
         completion = Completion.new(merged_items, existing.trigger_position)
 
@@ -821,14 +814,6 @@ defmodule MingaEditor.CompletionHandling do
 
   defp codepoint_to_char(_), do: nil
 
-  # ── Signature help ───────────────────────────────────────────────────────
-
-  @doc """
-  Handles a `textDocument/signatureHelp` response.
-
-  Creates a `SignatureHelp` struct from the response and stores it
-  in editor state. Returns state unchanged on error or empty response.
-  """
   @spec handle_signature_help_response(EditorState.t(), {:ok, term()} | {:error, term()}) ::
           EditorState.t()
   def handle_signature_help_response(state, {:error, _}), do: state
@@ -864,11 +849,9 @@ defmodule MingaEditor.CompletionHandling do
       codepoint == ?) ->
         SignatureHelpWorkflow.dismiss(state)
 
-      # Check if the character is a server-declared signature trigger
       char != nil and signature_trigger_char?(state, buf, char) ->
         send_signature_help_request(state, buf)
 
-      # Fallback: ( and , are universal signature triggers
       codepoint in [?(, ?,] ->
         send_signature_help_request(state, buf)
 
@@ -894,28 +877,35 @@ defmodule MingaEditor.CompletionHandling do
 
   @spec send_signature_help_request(EditorState.t(), pid()) :: EditorState.t()
   defp send_signature_help_request(state, buf) do
-    case lsp_client_for(state, buf) do
-      nil ->
+    case {lsp_client_for(state, buf), signature_help_origin(buf)} do
+      {client, {:ok, uri, {line, col}, version}} when is_pid(client) ->
+        params = %{
+          "textDocument" => %{"uri" => uri},
+          "position" => %{"line" => line, "character" => col}
+        }
+
+        ref = Client.request(client, "textDocument/signatureHelp", params)
+        track_signature_help_request(state, ref, client, buf, version, {line, col})
+
+      _ ->
         state
+    end
+  end
 
-      client ->
-        file_path = Buffer.file_path(buf)
+  @spec signature_help_origin(pid()) ::
+          {:ok, String.t(), {non_neg_integer(), non_neg_integer()}, non_neg_integer()} | :stale
+  defp signature_help_origin(buf) do
+    case {
+      buffer_value(buf, &Buffer.file_path/1),
+      buffer_value(buf, &Buffer.cursor/1),
+      buffer_value(buf, &Buffer.version/1)
+    } do
+      {path, {line, col}, version}
+      when is_binary(path) and is_integer(version) and version >= 0 ->
+        {:ok, SyncServer.path_to_uri(path), {line, col}, version}
 
-        if file_path do
-          uri = SyncServer.path_to_uri(file_path)
-          {line, col} = Buffer.cursor(buf)
-
-          params = %{
-            "textDocument" => %{"uri" => uri},
-            "position" => %{"line" => line, "character" => col}
-          }
-
-          ref = Client.request(client, "textDocument/signatureHelp", params)
-
-          track_response_request(state, ref, :signature_help)
-        else
-          state
-        end
+      _ ->
+        :stale
     end
   end
 
@@ -942,6 +932,13 @@ defmodule MingaEditor.CompletionHandling do
       [client | _] -> client
       [] -> nil
     end
+  end
+
+  @spec buffer_value(pid(), (pid() -> term())) :: term() | :stale
+  defp buffer_value(buffer, fun) do
+    fun.(buffer)
+  catch
+    :exit, _ -> :stale
   end
 
   @spec extract_resolve_documentation(map()) :: String.t()

--- a/lib/minga_editor/completion_trigger.ex
+++ b/lib/minga_editor/completion_trigger.ex
@@ -1,27 +1,9 @@
 defmodule MingaEditor.CompletionTrigger do
   @moduledoc """
   Manages LSP completion request lifecycle.
-
-  Manages the lifecycle of completion requests: deciding when to trigger,
-  sending async requests to the LSP client, handling responses, and
-  debouncing rapid keystrokes.
-
-  ## Trigger Rules
-
-  Completion fires in two cases:
-  1. **Trigger character** (`.`, `:`, etc.) — fires immediately
-  2. **Identifier typing** — fires after a debounce delay when the user
-     has typed 2+ identifier characters since the last non-identifier
-
-  ## Debouncing
-
-  Character-triggered completions are instant. Identifier-triggered
-  completions are debounced at 100ms to avoid flooding the server while
-  the user is typing quickly.
   """
 
   alias Minga.Buffer
-  alias Minga.Editing.Completion
   alias Minga.LSP.Client
   alias Minga.LSP.SyncServer
 
@@ -33,285 +15,69 @@ defmodule MingaEditor.CompletionTrigger do
   @typedoc "Role assigned to a completion request reference within a batch."
   @type response_role :: :primary | :secondary
 
+  @typedoc "Request tracking fact returned to the Editor-global LSP owner."
+  @type tracking_fact ::
+          {reference(), response_role(), pid(), pid(), non_neg_integer(), non_neg_integer(),
+           position()}
+
   @typedoc "Exclusive completion trigger phase tracked in the Editor."
   @type phase ::
           :idle
-          | {:debounced, reference(), position()}
-          | {:pending, %{reference() => response_role()}, position()}
-
-  @typedoc "Completion bridge state tracked in the Editor."
-  @type t :: %__MODULE__{phase: phase(), gen: non_neg_integer()}
+          | {:debounced, reference(), [pid()], pid(), non_neg_integer(), position()}
+          | {:pending, position()}
 
   defstruct phase: :idle, gen: 0
 
-  @typedoc """
-  Result of classifying an incoming LSP completion response without parsing.
-
-  The heavy parse/sort/filter is deferred to a Task (see
-  `MingaEditor.CompletionHandling`); classification only decides whether the
-  response is the primary one (replaces the menu), a secondary one to merge,
-  or stale/ignorable. `gen` lets a late processed result be discarded if a
-  newer request batch has superseded it (latest-wins).
-  """
-  @type classification ::
-          {:primary | :merge, position(), String.t(), non_neg_integer()}
-          | :ignore
+  @typedoc "Completion bridge state tracked in the Editor."
+  @type t :: %__MODULE__{phase: phase(), gen: non_neg_integer()}
 
   @doc "Returns initial completion bridge state."
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
-  @doc "Returns whether a completion trigger has debounced or pending work."
-  @spec active?(t()) :: boolean()
-  def active?(%__MODULE__{phase: :idle}), do: false
-  def active?(%__MODULE__{}), do: true
-
   @doc "Returns the latest-wins request generation."
   @spec generation(t()) :: non_neg_integer()
   def generation(%__MODULE__{gen: gen}), do: gen
 
-  @doc """
-  Checks whether the given character should trigger completion and,
-  if so, sends the request (possibly after a debounce delay).
-
-  `char` is the character just inserted (a single-character string).
-  Returns `{updated_bridge_state, updated_completion}` where completion
-  may be unchanged (if debouncing) or nil (if dismissed).
-  """
-  @spec maybe_trigger(t(), String.t(), pid()) ::
-          {t(), Completion.t() | nil}
+  @doc "Checks whether the given character should trigger completion."
+  @spec maybe_trigger(t(), String.t(), pid()) :: {t(), [tracking_fact()]}
   def maybe_trigger(%__MODULE__{} = bridge, char, buffer_pid) do
     clients = SyncServer.clients_for_buffer(buffer_pid)
 
     case clients do
       [] ->
-        {bridge, nil}
+        {bridge, []}
 
       _ ->
-        all_trigger_chars =
-          clients
-          |> Enum.flat_map(&get_trigger_characters/1)
-          |> Enum.uniq()
-
+        trigger_chars = clients |> Enum.flat_map(&get_trigger_characters/1) |> Enum.uniq()
         [first_client | _] = clients
-
-        handle_char_type(bridge, char, all_trigger_chars, clients, first_client, buffer_pid)
+        handle_char_type(bridge, char, trigger_chars, clients, first_client, buffer_pid)
     end
   end
 
-  @doc """
-  Called when the debounce timer fires. Sends completion requests to all
-  LSP servers attached to the buffer.
-  """
-  @spec flush_debounce(t(), [pid()], pid()) :: t()
-  def flush_debounce(%__MODULE__{} = bridge, clients, buffer_pid) when is_list(clients) do
-    {bridge, _completion} = send_completion_requests(bridge, clients, buffer_pid)
-    bridge
-  end
-
-  @spec flush_debounce(t(), pid(), pid()) :: t()
-  def flush_debounce(%__MODULE__{} = bridge, client, buffer_pid) when is_pid(client) do
-    {bridge, _completion} = send_completion_requests(bridge, [client], buffer_pid)
-    bridge
-  end
-
-  @doc """
-  Classifies an incoming LSP completion response and updates the bridge's
-  pending-ref bookkeeping, *without* parsing the (potentially huge) item list.
-
-  This is the cheap, on-the-Editor half of completion handling: it matches the
-  response `ref` against the bridge's pending refs and decides what the caller
-  should do, then returns the trigger position, the prefix typed since the
-  trigger, and the current request generation. The expensive parse/sort/filter
-  is performed by the caller in a Task (see `MingaEditor.CompletionHandling`).
-
-  Returns `{updated_bridge, classification}` where classification is one of:
-
-    * `{:primary, trigger_pos, prefix, gen}` — the authoritative response for
-      the request batch; the processed result replaces the menu.
-    * `{:merge, trigger_pos, prefix, gen}` — a secondary server's response to
-      merge into the existing menu.
-    * `:ignore` — stale ref, error, or no live request.
-  """
-  @spec classify_response(t(), reference(), {:ok, term()} | {:error, term()}, pid()) ::
-          {t(), classification()}
-  def classify_response(bridge, ref, result, buffer_pid)
-
-  def classify_response(
-        %__MODULE__{phase: {:pending, refs_by_role, trigger_pos}, gen: gen} = bridge,
-        ref,
-        {:ok, _result},
-        buffer_pid
+  @doc "Called when the debounce timer fires."
+  @spec flush_debounce(t(), non_neg_integer()) :: {t(), [tracking_fact()]}
+  def flush_debounce(
+        %__MODULE__{
+          phase: {:debounced, _timer, clients, buffer_pid, version, trigger_pos},
+          gen: gen
+        } = bridge,
+        gen
       ) do
-    case Map.fetch(refs_by_role, ref) do
-      {:ok, role} ->
-        prefix = get_typed_since_trigger(buffer_pid, trigger_pos)
-        bridge = remove_pending_ref(bridge, refs_by_role, ref, trigger_pos)
-        {bridge, {classification_role(role), trigger_pos, prefix, gen}}
-
-      :error ->
-        {bridge, :ignore}
+    if buffer_version(buffer_pid) == version do
+      send_completion_requests(bridge, clients, buffer_pid, gen, trigger_pos)
+    else
+      {%__MODULE__{bridge | phase: :idle}, []}
     end
   end
 
-  def classify_response(
-        %__MODULE__{phase: {:pending, refs_by_role, trigger_pos}} = bridge,
-        ref,
-        {:error, error},
-        _buffer_pid
-      ) do
-    Minga.Log.debug(:lsp, "Completion request failed: #{inspect(error)}")
+  def flush_debounce(%__MODULE__{} = bridge, _gen), do: {bridge, []}
 
-    bridge =
-      if Map.has_key?(refs_by_role, ref) do
-        remove_pending_ref(bridge, refs_by_role, ref, trigger_pos)
-      else
-        bridge
-      end
-
-    {bridge, :ignore}
-  end
-
-  def classify_response(%__MODULE__{} = bridge, _ref, {:error, error}, _buffer_pid) do
-    Minga.Log.debug(:lsp, "Completion request failed: #{inspect(error)}")
-    {bridge, :ignore}
-  end
-
-  def classify_response(%__MODULE__{} = bridge, _ref, _result, _buffer_pid) do
-    {bridge, :ignore}
-  end
-
-  @doc """
-  Dismisses any active completion state and cancels pending requests.
-  """
+  @doc "Dismisses any active completion state and cancels debounce timer ownership."
   @spec dismiss(t()) :: t()
   def dismiss(%__MODULE__{} = bridge) do
     bridge = cancel_debounce(bridge)
     %__MODULE__{bridge | phase: :idle}
-  end
-
-  # ── Private ────────────────────────────────────────────────────────────────
-
-  @spec handle_char_type(t(), String.t(), [String.t()], [pid()], pid(), pid()) ::
-          {t(), Completion.t() | nil}
-  defp handle_char_type(bridge, char, trigger_chars, clients, first_client, buffer_pid) do
-    classify_char(bridge, char, char in trigger_chars, clients, first_client, buffer_pid)
-  end
-
-  defp classify_char(bridge, _char, true = _is_trigger, clients, _first_client, buffer_pid) do
-    bridge = cancel_debounce(bridge)
-    send_completion_requests(bridge, clients, buffer_pid)
-  end
-
-  defp classify_char(bridge, char, false = _is_trigger, clients, _first_client, buffer_pid) do
-    if identifier_char?(char) do
-      schedule_debounced_trigger(bridge, clients, buffer_pid)
-    else
-      {dismiss(bridge), nil}
-    end
-  end
-
-  @spec send_completion_requests(t(), [pid()], pid()) :: {t(), nil}
-  defp send_completion_requests(%__MODULE__{} = bridge, [], _buffer_pid), do: {bridge, nil}
-
-  defp send_completion_requests(%__MODULE__{} = bridge, clients, buffer_pid) do
-    file_path = Buffer.file_path(buffer_pid)
-
-    case file_path do
-      nil ->
-        {bridge, nil}
-
-      path ->
-        uri = SyncServer.path_to_uri(path)
-        {line, col} = get_cursor_position(buffer_pid)
-
-        params = %{
-          "textDocument" => %{"uri" => uri},
-          "position" => %{"line" => line, "character" => col}
-        }
-
-        refs =
-          Enum.map(clients, fn client ->
-            Client.request(client, "textDocument/completion", params)
-          end)
-
-        refs_by_role = refs_by_role(refs)
-
-        {%__MODULE__{
-           bridge
-           | phase: {:pending, refs_by_role, {line, col}},
-             gen: bridge.gen + 1
-         }, nil}
-    end
-  end
-
-  @spec refs_by_role([reference()]) :: %{reference() => response_role()}
-  defp refs_by_role([primary_ref | secondary_refs]) do
-    secondary_roles = Map.new(secondary_refs, &{&1, :secondary})
-    Map.put(secondary_roles, primary_ref, :primary)
-  end
-
-  @spec schedule_debounced_trigger(t(), [pid()], pid()) :: {t(), nil}
-  defp schedule_debounced_trigger(%__MODULE__{} = bridge, clients, buffer_pid) do
-    bridge = cancel_debounce(bridge)
-
-    {line, col} = get_cursor_position(buffer_pid)
-    prefix_len = identifier_prefix_length(buffer_pid, line, col)
-
-    if prefix_len >= 2 do
-      trigger_pos = {line, col - prefix_len}
-
-      timer =
-        Process.send_after(
-          self(),
-          {:completion_debounce, clients, buffer_pid},
-          @debounce_ms
-        )
-
-      {%__MODULE__{bridge | phase: {:debounced, timer, trigger_pos}}, nil}
-    else
-      {bridge, nil}
-    end
-  end
-
-  @spec cancel_debounce(t()) :: t()
-  defp cancel_debounce(%__MODULE__{phase: {:debounced, timer, _position}} = bridge) do
-    Process.cancel_timer(timer)
-    %__MODULE__{bridge | phase: :idle}
-  end
-
-  defp cancel_debounce(%__MODULE__{} = bridge), do: bridge
-
-  @spec classification_role(response_role()) :: :primary | :merge
-  defp classification_role(:primary), do: :primary
-  defp classification_role(:secondary), do: :merge
-
-  @spec remove_pending_ref(t(), %{reference() => response_role()}, reference(), position()) :: t()
-  defp remove_pending_ref(%__MODULE__{} = bridge, refs_by_role, ref, trigger_pos) do
-    case Map.delete(refs_by_role, ref) do
-      remaining_refs_by_role when map_size(remaining_refs_by_role) == 0 ->
-        %__MODULE__{bridge | phase: :idle}
-
-      remaining_refs_by_role ->
-        %__MODULE__{bridge | phase: {:pending, remaining_refs_by_role, trigger_pos}}
-    end
-  end
-
-  @spec get_trigger_characters(pid()) :: [String.t()]
-  defp get_trigger_characters(client) do
-    caps = Client.capabilities(client)
-
-    caps
-    |> get_in(["completionProvider", "triggerCharacters"])
-    |> List.wrap()
-  catch
-    :exit, _ -> ["."]
-  end
-
-  @spec get_cursor_position(pid()) :: position()
-  defp get_cursor_position(buffer_pid) do
-    {_content, {line, col}} = Buffer.content_and_cursor(buffer_pid)
-    {line, col}
   end
 
   @doc "Returns the text typed since the trigger position (for prefix filtering)."
@@ -329,10 +95,165 @@ defmodule MingaEditor.CompletionTrigger do
     else
       ""
     end
+  catch
+    :exit, _ -> ""
   end
 
-  @spec identifier_prefix_length(pid(), non_neg_integer(), non_neg_integer()) ::
-          non_neg_integer()
+  @spec handle_char_type(t(), String.t(), [String.t()], [pid()], pid(), pid()) ::
+          {t(), [tracking_fact()]}
+  defp handle_char_type(bridge, char, trigger_chars, clients, first_client, buffer_pid) do
+    classify_char(bridge, char, char in trigger_chars, clients, first_client, buffer_pid)
+  end
+
+  defp classify_char(bridge, _char, true = _is_trigger, clients, _first_client, buffer_pid) do
+    bridge = cancel_debounce(bridge)
+    send_completion_requests(bridge, clients, buffer_pid, bridge.gen + 1, nil)
+  end
+
+  defp classify_char(bridge, char, false = _is_trigger, clients, _first_client, buffer_pid) do
+    if identifier_char?(char) do
+      schedule_debounced_trigger(bridge, clients, buffer_pid)
+    else
+      {dismiss(bridge), []}
+    end
+  end
+
+  @spec send_completion_requests(t(), [pid()], pid(), non_neg_integer(), position() | nil) ::
+          {t(), [tracking_fact()]}
+  defp send_completion_requests(%__MODULE__{} = bridge, [], _buffer_pid, _gen, _trigger_pos),
+    do: {bridge, []}
+
+  defp send_completion_requests(
+         %__MODULE__{} = bridge,
+         clients,
+         buffer_pid,
+         gen,
+         captured_trigger_pos
+       ) do
+    file_path = Buffer.file_path(buffer_pid)
+    version = buffer_version(buffer_pid)
+
+    case {file_path, version} do
+      {nil, _version} ->
+        {bridge, []}
+
+      {_path, :stale} ->
+        {bridge, []}
+
+      {path, version} ->
+        uri = SyncServer.path_to_uri(path)
+        {line, col} = get_cursor_position(buffer_pid)
+        trigger_pos = captured_trigger_pos || {line, col}
+
+        params = %{
+          "textDocument" => %{"uri" => uri},
+          "position" => %{"line" => line, "character" => col}
+        }
+
+        refs = Enum.map(clients, &Client.request(&1, "textDocument/completion", params))
+        facts = tracking_facts(refs, clients, buffer_pid, version, gen, trigger_pos)
+
+        {%__MODULE__{bridge | phase: {:pending, trigger_pos}, gen: gen}, facts}
+    end
+  end
+
+  @spec tracking_facts(
+          [reference()],
+          [pid()],
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          position()
+        ) :: [tracking_fact()]
+  defp tracking_facts(refs, clients, buffer, version, gen, trigger_pos) do
+    refs
+    |> Enum.zip(clients)
+    |> Enum.with_index()
+    |> Enum.map(fn {{ref, client}, index} ->
+      role = if index == 0, do: :primary, else: :secondary
+      {ref, role, client, buffer, version, gen, trigger_pos}
+    end)
+  end
+
+  @spec schedule_debounced_trigger(t(), [pid()], pid()) :: {t(), [tracking_fact()]}
+  defp schedule_debounced_trigger(%__MODULE__{} = bridge, clients, buffer_pid) do
+    bridge = cancel_debounce(bridge)
+    {line, col} = get_cursor_position(buffer_pid)
+    prefix_len = identifier_prefix_length(buffer_pid, line, col)
+    schedule_debounced_trigger(bridge, clients, buffer_pid, {line, col}, prefix_len)
+  end
+
+  @spec schedule_debounced_trigger(t(), [pid()], pid(), position(), non_neg_integer()) ::
+          {t(), [tracking_fact()]}
+  defp schedule_debounced_trigger(
+         %__MODULE__{} = bridge,
+         clients,
+         buffer_pid,
+         {line, col},
+         prefix_len
+       )
+       when is_integer(prefix_len) and prefix_len >= 2 do
+    gen = bridge.gen + 1
+    trigger_pos = {line, col - prefix_len}
+
+    case buffer_version(buffer_pid) do
+      :stale ->
+        {bridge, []}
+
+      version ->
+        timer = Process.send_after(self(), {:completion_debounce, gen}, @debounce_ms)
+
+        {%__MODULE__{
+           bridge
+           | phase: {:debounced, timer, clients, buffer_pid, version, trigger_pos},
+             gen: gen
+         }, []}
+    end
+  end
+
+  defp schedule_debounced_trigger(
+         %__MODULE__{} = bridge,
+         _clients,
+         _buffer_pid,
+         _position,
+         _prefix_len
+       ),
+       do: {bridge, []}
+
+  @spec cancel_debounce(t()) :: t()
+  defp cancel_debounce(
+         %__MODULE__{phase: {:debounced, timer, _clients, _buffer, _version, _position}} = bridge
+       ) do
+    Process.cancel_timer(timer)
+    %__MODULE__{bridge | phase: :idle}
+  end
+
+  defp cancel_debounce(%__MODULE__{} = bridge), do: bridge
+
+  @spec get_trigger_characters(pid()) :: [String.t()]
+  defp get_trigger_characters(client) do
+    client
+    |> Client.capabilities()
+    |> get_in(["completionProvider", "triggerCharacters"])
+    |> List.wrap()
+  catch
+    :exit, _ -> ["."]
+  end
+
+  @spec get_cursor_position(pid()) :: position()
+  defp get_cursor_position(buffer_pid) do
+    {_content, {line, col}} = Buffer.content_and_cursor(buffer_pid)
+    {line, col}
+  end
+
+  @spec buffer_version(pid()) :: non_neg_integer() | :stale
+  defp buffer_version(buffer_pid) do
+    Buffer.version(buffer_pid)
+  catch
+    :exit, _ -> :stale
+  end
+
+  @spec identifier_prefix_length(pid(), non_neg_integer(), non_neg_integer()) :: non_neg_integer()
   defp identifier_prefix_length(buffer_pid, line, col) do
     {content, _cursor} = Buffer.content_and_cursor(buffer_pid)
     lines = String.split(content, "\n")

--- a/lib/minga_editor/handlers/lsp_event_handler.ex
+++ b/lib/minga_editor/handlers/lsp_event_handler.ex
@@ -40,21 +40,22 @@ defmodule MingaEditor.Handlers.LspEventHandler do
   """
   @spec handle(EditorState.t(), term()) :: {EditorState.t(), [lsp_effect()]}
 
-  def handle(
-        %{shell_runtime: %{state: %ShellState{}}} = state,
-        {:completion_debounce, clients, buffer_pid}
-      ) do
-    new_bridge =
+  def handle(%{shell_runtime: %{state: %ShellState{}}} = state, {:completion_debounce, gen}) do
+    {new_bridge, facts} =
       CompletionTrigger.flush_debounce(
         MingaEditor.Shell.Traditional.ModalWorkflow.completion_trigger(state),
-        clients,
-        buffer_pid
+        gen
       )
 
-    {MingaEditor.Shell.Traditional.ModalWorkflow.put_completion_trigger(state, new_bridge), []}
+    state =
+      state
+      |> MingaEditor.Shell.Traditional.ModalWorkflow.put_completion_trigger(new_bridge)
+      |> CompletionHandling.install_completion_tracking(facts)
+
+    {state, []}
   end
 
-  def handle(state, {:completion_debounce, _clients, _buffer_pid}), do: {state, []}
+  def handle(state, {:completion_debounce, _gen}), do: {state, []}
 
   def handle(state, {:lsp_response, ref, result}) do
     case LSPState.take_pending_request(state.lsp, ref) do
@@ -63,7 +64,7 @@ defmodule MingaEditor.Handlers.LspEventHandler do
         {dispatch_pending_response(request, state, result), [:render_now]}
 
       :error ->
-        {CompletionHandling.handle_response(state, ref, result), [:render_now]}
+        {state, [:render_now]}
     end
   end
 
@@ -77,11 +78,14 @@ defmodule MingaEditor.Handlers.LspEventHandler do
     {LspActions.document_highlight(state), []}
   end
 
-  def handle(%{shell_runtime: %{state: %ShellState{}}} = state, {:completion_resolve, index}) do
-    {CompletionHandling.flush_resolve(state, index), []}
+  def handle(
+        %{shell_runtime: %{state: %ShellState{}}} = state,
+        {:completion_resolve, gen, raw_item}
+      ) do
+    {CompletionHandling.flush_resolve(state, gen, raw_item), []}
   end
 
-  def handle(state, {:completion_resolve, _index}), do: {state, []}
+  def handle(state, {:completion_resolve, _gen, _raw_item}), do: {state, []}
 
   def handle(state, :request_code_lens_and_inlay_hints) do
     state = LspActions.code_lens(state)
@@ -148,12 +152,41 @@ defmodule MingaEditor.Handlers.LspEventHandler do
     dispatch_lsp_response({kind, operation_id, origin_tab_id}, state, result)
   end
 
-  defp dispatch_pending_response({:response, :completion_resolve}, state, result) do
-    apply_completion_resolve_response(state, result)
+  defp dispatch_pending_response(
+         {:completion_result, role, client, buffer, version, gen, trigger_pos},
+         state,
+         result
+       ) do
+    CompletionHandling.handle_completion_result(
+      state,
+      role,
+      client,
+      buffer,
+      version,
+      gen,
+      trigger_pos,
+      result
+    )
   end
 
-  defp dispatch_pending_response({:response, :signature_help}, state, result) do
-    apply_signature_help_response(state, result)
+  defp dispatch_pending_response(
+         {:completion_resolve, client, buffer, version, gen, raw_item},
+         state,
+         result
+       ) do
+    if completion_resolve_current?(state, client, buffer, version, gen, raw_item),
+      do: apply_completion_resolve_response(state, raw_item, result),
+      else: state
+  end
+
+  defp dispatch_pending_response(
+         {:signature_help, client, buffer, version, cursor},
+         state,
+         result
+       ) do
+    if signature_help_current?(state, client, buffer, version, cursor),
+      do: apply_signature_help_response(state, result),
+      else: state
   end
 
   defp dispatch_pending_response(
@@ -188,14 +221,15 @@ defmodule MingaEditor.Handlers.LspEventHandler do
     state
   end
 
-  @spec apply_completion_resolve_response(EditorState.t(), term()) :: EditorState.t()
+  @spec apply_completion_resolve_response(EditorState.t(), map(), term()) :: EditorState.t()
   defp apply_completion_resolve_response(
          %{shell_runtime: %{state: %ShellState{}}} = state,
+         raw_item,
          result
        ),
-       do: CompletionHandling.handle_resolve_response(state, result)
+       do: CompletionHandling.handle_resolve_response(state, raw_item, result)
 
-  defp apply_completion_resolve_response(state, _result), do: state
+  defp apply_completion_resolve_response(state, _raw_item, _result), do: state
 
   @spec apply_signature_help_response(EditorState.t(), term()) :: EditorState.t()
   defp apply_signature_help_response(%{shell_runtime: %{state: %ShellState{}}} = state, result),
@@ -324,6 +358,48 @@ defmodule MingaEditor.Handlers.LspEventHandler do
 
   defp dispatch_current_response(kind, state, result),
     do: dispatch_lsp_response(kind, state, result)
+
+  @spec completion_resolve_current?(
+          EditorState.t(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          map()
+        ) :: boolean()
+  defp completion_resolve_current?(state, client, buffer, version, gen, raw_item) do
+    state.workspace.buffers.active == buffer and
+      buffer_value(buffer, &Minga.Buffer.version/1) == version and
+      match?([^client | _], Minga.LSP.SyncServer.clients_for_buffer(buffer)) and
+      MingaEditor.Shell.Traditional.ModalWorkflow.completion_trigger(state)
+      |> CompletionTrigger.generation()
+      |> Kernel.==(gen) and
+      completion_selected_raw?(state, raw_item)
+  end
+
+  @spec completion_selected_raw?(EditorState.t(), map()) :: boolean()
+  defp completion_selected_raw?(%{shell_runtime: %{state: %ShellState{}}} = state, raw_item) do
+    case MingaEditor.Shell.Traditional.ModalWorkflow.completion(state) do
+      nil -> false
+      completion -> Minga.Editing.Completion.selected_raw?(completion, raw_item)
+    end
+  end
+
+  defp completion_selected_raw?(_state, _raw_item), do: false
+
+  @spec signature_help_current?(
+          EditorState.t(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          {non_neg_integer(), non_neg_integer()}
+        ) :: boolean()
+  defp signature_help_current?(state, client, buffer, version, cursor) do
+    state.workspace.buffers.active == buffer and
+      buffer_value(buffer, &Minga.Buffer.version/1) == version and
+      match?([^client | _], Minga.LSP.SyncServer.clients_for_buffer(buffer)) and
+      buffer_value(buffer, &Minga.Buffer.cursor/1) == cursor
+  end
 
   defp response_current?(state, client, buffer, version, tab_id, cursor) do
     active_tab = MingaEditor.Shell.Runtime.active_tab(state.shell_runtime)

--- a/lib/minga_editor/state/lsp.ex
+++ b/lib/minga_editor/state/lsp.ex
@@ -15,8 +15,7 @@ defmodule MingaEditor.State.LSP do
   alias MingaEditor.State.LSP.PendingRequests
 
   @type server_status :: :starting | :initializing | :ready | :crashed
-  @type legacy_response_kind ::
-          :completion_resolve | :signature_help | :code_lens | :code_lens_resolve | :inlay_hint
+  @type legacy_response_kind :: :code_lens | :code_lens_resolve | :inlay_hint
   @type current_origin_response_kind ::
           :definition
           | :peek_definition
@@ -170,6 +169,95 @@ defmodule MingaEditor.State.LSP do
       )
 
     %{lsp | pending_requests: pending_requests}
+  end
+
+  @spec track_completion_result_request(
+          t(),
+          reference(),
+          MingaEditor.CompletionTrigger.response_role(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          {non_neg_integer(), non_neg_integer()}
+        ) :: t()
+  def track_completion_result_request(
+        %__MODULE__{} = lsp,
+        ref,
+        role,
+        client,
+        buffer,
+        version,
+        gen,
+        pos
+      ) do
+    accept_pending(
+      lsp,
+      PendingRequests.track_completion_result(
+        lsp.pending_requests,
+        ref,
+        role,
+        client,
+        buffer,
+        version,
+        gen,
+        pos
+      )
+    )
+  end
+
+  @spec track_completion_resolve_request(
+          t(),
+          reference(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          map()
+        ) :: t()
+  def track_completion_resolve_request(
+        %__MODULE__{} = lsp,
+        ref,
+        client,
+        buffer,
+        version,
+        gen,
+        raw_item
+      ) do
+    accept_pending(
+      lsp,
+      PendingRequests.track_completion_resolve(
+        lsp.pending_requests,
+        ref,
+        client,
+        buffer,
+        version,
+        gen,
+        raw_item
+      )
+    )
+  end
+
+  @spec track_signature_help_request(
+          t(),
+          reference(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          {non_neg_integer(), non_neg_integer()}
+        ) :: t()
+  def track_signature_help_request(%__MODULE__{} = lsp, ref, client, buffer, version, cursor) do
+    accept_pending(
+      lsp,
+      PendingRequests.track_signature_help(
+        lsp.pending_requests,
+        ref,
+        client,
+        buffer,
+        version,
+        cursor
+      )
+    )
   end
 
   @doc "Tracks an Editor-global mouse hover request."
@@ -340,6 +428,10 @@ defmodule MingaEditor.State.LSP do
   def clear_inlay_hint_timer(%__MODULE__{} = lsp) do
     %{lsp | inlay_hint_debounce_timer: nil}
   end
+
+  @spec accept_pending(t(), {:ok, PendingRequests.t()}) :: t()
+  defp accept_pending(%__MODULE__{} = lsp, {:ok, pending_requests}),
+    do: %{lsp | pending_requests: pending_requests}
 
   @doc "Clears the highlight debounce timer reference without cancelling it."
   @spec clear_highlight_timer(t()) :: t()

--- a/lib/minga_editor/state/lsp/pending_requests.ex
+++ b/lib/minga_editor/state/lsp/pending_requests.ex
@@ -10,11 +10,15 @@ defmodule MingaEditor.State.LSP.PendingRequests do
   defstruct by_ref: %{}, format_by_buffer: %{}, newest_formats: []
 
   @type operation_kind :: :references | :rename
+  @type position :: {non_neg_integer(), non_neg_integer()}
   @type request ::
           {:response, MingaEditor.State.LSP.legacy_response_kind()}
           | {:response, MingaEditor.State.LSP.current_origin_response_kind(), pid(), pid(),
-             non_neg_integer(), MingaEditor.State.Tab.id() | nil,
-             {non_neg_integer(), non_neg_integer()} | nil}
+             non_neg_integer(), MingaEditor.State.Tab.id() | nil, position() | nil}
+          | {:completion_result, MingaEditor.CompletionTrigger.response_role(), pid(), pid(),
+             non_neg_integer(), non_neg_integer(), position()}
+          | {:completion_resolve, pid(), pid(), non_neg_integer(), non_neg_integer(), map()}
+          | {:signature_help, pid(), pid(), non_neg_integer(), position()}
           | {:hover_mouse, non_neg_integer(), non_neg_integer(), pid(), non_neg_integer(),
              non_neg_integer(), non_neg_integer()}
           | {:semantic_tokens, pid()}
@@ -31,23 +35,73 @@ defmodule MingaEditor.State.LSP.PendingRequests do
   @spec new() :: t()
   def new, do: %__MODULE__{}
 
-  @spec track_response(t(), reference(), MingaEditor.State.LSP.legacy_response_kind()) ::
-          {:ok, t()} | {:error, :duplicate_ref}
-  def track_response(%__MODULE__{} = pending, ref, kind)
-      when is_reference(ref) and
-             kind in [
-               :completion_resolve,
-               :signature_help,
-               :code_lens,
-               :code_lens_resolve,
-               :inlay_hint
-             ] do
-    track_request(pending, ref, {:response, kind})
-  end
-
   defguardp valid_cursor_guard(cursor)
             when is_tuple(cursor) and tuple_size(cursor) == 2 and is_integer(elem(cursor, 0)) and
                    elem(cursor, 0) >= 0 and is_integer(elem(cursor, 1)) and elem(cursor, 1) >= 0
+
+  @spec track_response(t(), reference(), MingaEditor.State.LSP.legacy_response_kind()) ::
+          {:ok, t()} | {:error, :duplicate_ref}
+  def track_response(%__MODULE__{} = pending, ref, kind)
+      when is_reference(ref) and kind in [:code_lens, :code_lens_resolve, :inlay_hint] do
+    track_request(pending, ref, {:response, kind})
+  end
+
+  @spec track_completion_result(
+          t(),
+          reference(),
+          MingaEditor.CompletionTrigger.response_role(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          position()
+        ) :: {:ok, t()} | {:error, :duplicate_ref}
+  def track_completion_result(
+        %__MODULE__{} = pending,
+        ref,
+        role,
+        client,
+        buffer,
+        version,
+        gen,
+        pos
+      )
+      when is_reference(ref) and role in [:primary, :secondary] and is_pid(client) and
+             is_pid(buffer) and is_integer(version) and version >= 0 and is_integer(gen) and
+             gen >= 0 and valid_cursor_guard(pos) do
+    track_request(pending, ref, {:completion_result, role, client, buffer, version, gen, pos})
+  end
+
+  @spec track_completion_resolve(
+          t(),
+          reference(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          non_neg_integer(),
+          map()
+        ) :: {:ok, t()} | {:error, :duplicate_ref}
+  def track_completion_resolve(
+        %__MODULE__{} = pending,
+        ref,
+        client,
+        buffer,
+        version,
+        gen,
+        raw_item
+      )
+      when is_reference(ref) and is_pid(client) and is_pid(buffer) and is_integer(version) and
+             version >= 0 and is_integer(gen) and gen >= 0 and is_map(raw_item) do
+    track_request(pending, ref, {:completion_resolve, client, buffer, version, gen, raw_item})
+  end
+
+  @spec track_signature_help(t(), reference(), pid(), pid(), non_neg_integer(), position()) ::
+          {:ok, t()} | {:error, :duplicate_ref}
+  def track_signature_help(%__MODULE__{} = pending, ref, client, buffer, version, cursor)
+      when is_reference(ref) and is_pid(client) and is_pid(buffer) and is_integer(version) and
+             version >= 0 and valid_cursor_guard(cursor) do
+    track_request(pending, ref, {:signature_help, client, buffer, version, cursor})
+  end
 
   @spec track_response(
           t(),

--- a/lib/minga_editor/state/modal_overlay.ex
+++ b/lib/minga_editor/state/modal_overlay.ex
@@ -158,12 +158,11 @@ defmodule MingaEditor.State.ModalOverlay do
        ),
        do: {:completion, CompletionPayload.put_trigger(payload, trigger)}
 
+  defp do_put_completion_trigger(:none, %CompletionTrigger{phase: :idle}, _active_tab_id),
+    do: :none
+
   defp do_put_completion_trigger(:none, trigger, active_tab_id) do
-    if CompletionTrigger.active?(trigger) do
-      {:completion, CompletionPayload.new(active_tab_id, trigger: trigger)}
-    else
-      :none
-    end
+    {:completion, CompletionPayload.new(active_tab_id, trigger: trigger)}
   end
 
   defp do_put_completion_trigger({:picker, %PickerPayload{}} = modal, _trigger, _active_tab_id),

--- a/test/minga_editor/completion_async_test.exs
+++ b/test/minga_editor/completion_async_test.exs
@@ -1,35 +1,18 @@
 defmodule MingaEditor.CompletionAsyncTest do
-  @moduledoc """
-  Coverage for processing LSP completion responses off the Editor hot path
-  (ticket #2633).
-
-  The Editor only does cheap ref bookkeeping when a completion response
-  arrives; the parse/sort/filter runs in a Task that sends the processed menu
-  back as `{:completion_processed, gen, mode, payload, trigger_pos}`. These
-  tests prove:
-
-    * (a) the parse/sort/filter does not run on the Editor path — the
-      synchronous handler leaves the menu pending and the built menu only
-      arrives later, as a message, already sorted and filtered;
-    * (b) a stale processed result (older generation) is discarded latest-wins
-      so a superseded Task can never overwrite a fresher menu;
-    * (c) the merge path still unions a secondary server's items into the live
-      menu and re-applies the prefix filter correctly;
-    * (d) end-to-end through the live Editor: a completion response drives the
-      real `handle_info({:completion_processed, ...})` clause and the menu
-      becomes visible — and a malformed item that crashes the Task clears the
-      pending menu instead of leaving it stuck.
-  """
+  @moduledoc "Coverage for processing LSP completion responses off the Editor hot path."
 
   use Minga.Test.EditorCase, async: true, rendering: :disabled
 
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Editing.Completion
   alias MingaEditor.CompletionHandling
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.State.Buffers
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.Shell.Traditional.ModalWorkflow
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
+  alias MingaEditor.State.LSP, as: LSPState
 
   @sync_timeout 15_000
 
@@ -44,7 +27,7 @@ defmodule MingaEditor.CompletionAsyncTest do
 
   defp open_completion_modal(state, completion, gen) do
     owner = state.shell_runtime.state.tab_bar.active_id
-    trigger = %CompletionTrigger{gen: gen}
+    trigger = %CompletionTrigger{gen: gen, phase: {:pending, {0, 0}}}
     payload = CompletionPayload.new(owner, completion: completion, trigger: trigger)
     ModalWorkflow.open(state, {:completion, payload})
   end
@@ -55,20 +38,12 @@ defmodule MingaEditor.CompletionAsyncTest do
     test "the synchronous handler leaves the menu pending and the built menu arrives async" do
       ctx = start_editor("hello")
       state = editor_state(ctx)
-
-      # Open a pending completion modal with a primary request in flight. `self()`
-      # is the test process, so the Task will send the processed menu back to us.
-      ref = make_ref()
-
-      trigger = %CompletionTrigger{
-        phase: {:pending, %{ref => :primary}, {0, 0}},
-        gen: 1
-      }
-
+      buffer = state.workspace.buffers.active
+      Minga.LSP.SyncServer.put_clients(buffer, [self()])
+      version = Minga.Buffer.version(buffer)
+      trigger = %CompletionTrigger{phase: {:pending, {0, 0}}, gen: 1}
       state = ModalWorkflow.put_completion_trigger(state, trigger)
 
-      # sortText is deliberately out of label order to prove sorting happened in
-      # the Task, not on the Editor.
       result =
         {:ok,
          %{
@@ -78,13 +53,22 @@ defmodule MingaEditor.CompletionAsyncTest do
            ]
          }}
 
-      returned = CompletionHandling.handle_response(state, ref, result)
+      returned =
+        CompletionHandling.handle_completion_result(
+          state,
+          :primary,
+          self(),
+          buffer,
+          version,
+          1,
+          {0, 0},
+          result
+        )
 
-      # The Editor path itself never parsed/built the menu: it is still pending.
       assert MingaEditor.Shell.Traditional.ModalWorkflow.completion(returned) == nil
 
-      # The built menu arrives later, off-process, already sorted and filtered.
-      assert_receive {:completion_processed, 1, :primary, %Completion{} = built, {0, 0}},
+      assert_receive {:completion_processed, 1, :primary, %Completion{} = built, {0, 0}, ^buffer,
+                      ^version},
                      @sync_timeout
 
       assert labels(built) == ["apple", "banana"]
@@ -95,6 +79,8 @@ defmodule MingaEditor.CompletionAsyncTest do
     test "a result tagged with an older generation never overwrites the live menu" do
       ctx = start_editor("hello")
       state = editor_state(ctx)
+      buffer = state.workspace.buffers.active
+      version = Minga.Buffer.version(buffer)
 
       existing = completion_from([%{"label" => "keep", "filterText" => "keep"}], {0, 0}, "")
       state = open_completion_modal(state, existing, 5)
@@ -106,37 +92,46 @@ defmodule MingaEditor.CompletionAsyncTest do
           ""
         )
 
-      # Generation 4 is stale relative to the live generation 5: discard it.
-      discarded = CompletionHandling.apply_processed(state, 4, :primary, stale, {0, 0})
+      discarded =
+        CompletionHandling.apply_processed(state, 4, :primary, stale, {0, 0}, buffer, version)
+
       assert labels(MingaEditor.Shell.Traditional.ModalWorkflow.completion(discarded)) == ["keep"]
 
-      # The same result on the live generation 5 is applied (sanity check that the
-      # guard is about the generation, not the payload).
-      applied = CompletionHandling.apply_processed(state, 5, :primary, stale, {0, 0})
+      applied =
+        CompletionHandling.apply_processed(state, 5, :primary, stale, {0, 0}, buffer, version)
 
       assert "stale-sentinel" in labels(
                MingaEditor.Shell.Traditional.ModalWorkflow.completion(applied)
              )
     end
 
-    test "a result is discarded when the completion menu has been dismissed" do
+    test "a result is discarded when the active buffer changed even on the same generation" do
       ctx = start_editor("hello")
       state = editor_state(ctx)
+      buffer = state.workspace.buffers.active
+      version = Minga.Buffer.version(buffer)
+      existing = completion_from([%{"label" => "keep", "filterText" => "keep"}], {0, 0}, "")
+      state = open_completion_modal(state, existing, 5)
+      other = start_supervised!({BufferProcess, content: "other"}, id: {:buffer, make_ref()})
+      stale = completion_from([%{"label" => "stale", "filterText" => "stale"}], {0, 0}, "")
 
-      # No completion modal is open (modal is :none), so any processed result is stale.
-      built = completion_from([%{"label" => "ghost", "filterText" => "ghost"}], {0, 0}, "")
-      result = CompletionHandling.apply_processed(state, 1, :primary, built, {0, 0})
+      buffers = Buffers.set_active_override(state.workspace.buffers, other)
+      changed = %{state | workspace: SessionState.set_buffers(state.workspace, buffers)}
 
-      assert MingaEditor.Shell.Traditional.ModalWorkflow.completion(result) == nil
+      result =
+        CompletionHandling.apply_processed(changed, 5, :primary, stale, {0, 0}, buffer, version)
+
+      assert labels(MingaEditor.Shell.Traditional.ModalWorkflow.completion(result)) == ["keep"]
     end
   end
 
   describe "(c) merge path still produces correct merged+filtered completions" do
     test "secondary server items are unioned in, sorted, and prefix-filtered" do
       ctx = start_editor("hello")
-      # Cursor at end of "hello" so the prefix typed since trigger {0, 0} is "hello".
       BufferProcess.move_to(ctx.buffer, {0, 5})
       state = editor_state(ctx)
+      buffer = state.workspace.buffers.active
+      version = Minga.Buffer.version(buffer)
 
       existing =
         completion_from(
@@ -153,11 +148,11 @@ defmodule MingaEditor.CompletionAsyncTest do
           %{"label" => "goodbye", "filterText" => "goodbye", "sortText" => "0"}
         ])
 
-      merged = CompletionHandling.apply_processed(state, 5, :merge, merge_items, {0, 0})
+      merged =
+        CompletionHandling.apply_processed(state, 5, :merge, merge_items, {0, 0}, buffer, version)
+
       completion = MingaEditor.Shell.Traditional.ModalWorkflow.completion(merged)
 
-      # Union of both servers, sorted by sortText, with "goodbye" filtered out by
-      # the "hello" prefix.
       assert labels(completion) == ["helloThere", "helloWorld"]
       refute "goodbye" in labels(completion)
     end
@@ -165,16 +160,15 @@ defmodule MingaEditor.CompletionAsyncTest do
     test "a primary result that lands after a secondary merge unions instead of replacing" do
       ctx = start_editor("hello")
       state = editor_state(ctx)
-
-      # A secondary :merge already populated the menu first.
+      buffer = state.workspace.buffers.active
+      version = Minga.Buffer.version(buffer)
       secondary = completion_from([%{"label" => "from_secondary"}], {0, 0}, "")
       state = open_completion_modal(state, secondary, 5)
+      primary = completion_from([%{"label" => "from_primary"}], {0, 0}, "")
 
-      # The slower primary result lands afterwards; its items must be unioned in.
-      primary =
-        completion_from([%{"label" => "from_primary"}], {0, 0}, "")
+      merged =
+        CompletionHandling.apply_processed(state, 5, :primary, primary, {0, 0}, buffer, version)
 
-      merged = CompletionHandling.apply_processed(state, 5, :primary, primary, {0, 0})
       result_labels = labels(MingaEditor.Shell.Traditional.ModalWorkflow.completion(merged))
 
       assert "from_secondary" in result_labels
@@ -183,28 +177,36 @@ defmodule MingaEditor.CompletionAsyncTest do
   end
 
   describe "(d) end-to-end through the live Editor handle_info" do
-    # Inject a pending completion modal whose bridge expects `ref`, so a real
-    # {:lsp_response, ref, ...} sent to the live Editor drives the whole async
-    # pipeline: handle_info -> CompletionHandling.handle_response -> Task ->
-    # {:completion_processed, ...} -> the Editor's handle_info apply clause.
-    defp inject_pending_completion(ctx, ref) do
+    defp inject_pending_completion(ctx, ref, client) do
       :sys.replace_state(ctx.editor, fn state ->
         owner = state.shell_runtime.state.tab_bar.active_id
-
-        trigger = %CompletionTrigger{
-          phase: {:pending, %{ref => :primary}, {0, 0}},
-          gen: 1
-        }
-
+        buffer = state.workspace.buffers.active
+        version = Minga.Buffer.version(buffer)
+        trigger = %CompletionTrigger{phase: {:pending, {0, 0}}, gen: 1}
         payload = CompletionPayload.new(owner, trigger: trigger)
-        ModalWorkflow.open(state, {:completion, payload})
+
+        state
+        |> ModalWorkflow.open({:completion, payload})
+        |> Map.update!(:lsp, fn lsp ->
+          LSPState.track_completion_result_request(
+            lsp,
+            ref,
+            :primary,
+            client,
+            buffer,
+            version,
+            1,
+            {0, 0}
+          )
+        end)
       end)
     end
 
     test "a real LSP completion response routes through handle_info and becomes visible" do
       ctx = start_editor("hello")
       ref = make_ref()
-      inject_pending_completion(ctx, ref)
+      Minga.LSP.SyncServer.put_clients(ctx.buffer, [self()])
+      inject_pending_completion(ctx, ref, self())
 
       result =
         {:ok,
@@ -215,9 +217,6 @@ defmodule MingaEditor.CompletionAsyncTest do
            ]
          }}
 
-      # Drive the real Editor mailbox: this exercises the actual
-      # handle_info({:completion_processed, ...}) dispatch clause, which the
-      # unit tests bypass by calling apply_processed/5 directly.
       send(ctx.editor, {:lsp_response, ref, result})
 
       final =
@@ -232,22 +231,16 @@ defmodule MingaEditor.CompletionAsyncTest do
         )
 
       completion = MingaEditor.Shell.Traditional.ModalWorkflow.completion(final)
-      assert %Completion{} = completion
-      # Sorted in the Task (sortText order), not response order.
       assert Enum.map(completion.filtered, & &1.label) == ["alpha", "zeta"]
     end
 
     test "a malformed item crashes the Task but clears the stuck pending menu" do
       ctx = start_editor("hello")
       ref = make_ref()
-      inject_pending_completion(ctx, ref)
+      Minga.LSP.SyncServer.put_clients(ctx.buffer, [self()])
+      inject_pending_completion(ctx, ref, self())
 
-      # A bare `null` in the items list FunctionClauseErrors in parse_item/1.
-      # The Task must still report (with :failed) so the pending modal is
-      # dismissed rather than left stuck on a never-arriving menu.
-      result = {:ok, %{"items" => [nil]}}
-
-      send(ctx.editor, {:lsp_response, ref, result})
+      send(ctx.editor, {:lsp_response, ref, {:ok, %{"items" => [nil]}}})
 
       _ =
         wait_until(
@@ -266,6 +259,24 @@ defmodule MingaEditor.CompletionAsyncTest do
       final = editor_state(ctx)
       refute ModalOverlay.match(final.shell_runtime.state.modal, :completion)
       assert MingaEditor.Shell.Traditional.ModalWorkflow.completion(final) == nil
+    end
+
+    test "a malformed secondary merge keeps the primary batch pending" do
+      ctx = start_editor("hello")
+      state = editor_state(ctx)
+      buffer = state.workspace.buffers.active
+      version = Minga.Buffer.version(buffer)
+
+      owner = state.shell_runtime.state.tab_bar.active_id
+      trigger = %CompletionTrigger{phase: {:pending, {0, 0}}, gen: 1}
+      payload = CompletionPayload.new(owner, trigger: trigger)
+      state = ModalWorkflow.open(state, {:completion, payload})
+
+      result =
+        CompletionHandling.apply_processed(state, 1, :merge, :failed, {0, 0}, buffer, version)
+
+      assert ModalOverlay.match(result.shell_runtime.state.modal, :completion)
+      assert MingaEditor.Shell.Traditional.ModalWorkflow.completion(result) == nil
     end
   end
 end

--- a/test/minga_editor/completion_doc_preview_test.exs
+++ b/test/minga_editor/completion_doc_preview_test.exs
@@ -71,23 +71,38 @@ defmodule MingaEditor.CompletionDocPreviewTest do
 
   # ── Documentation update ─────────────────────────────────────────────────
 
-  describe "update_selected_documentation/2" do
-    test "updates the selected item's documentation" do
-      items = [
-        Completion.parse_item(%{"label" => "a"}),
-        Completion.parse_item(%{"label" => "b"}),
-        Completion.parse_item(%{"label" => "c"})
-      ]
+  describe "update_selected_documentation/3" do
+    test "updates the selected item's documentation for matching raw identity" do
+      raw = %{"label" => "a"}
+      items = [Completion.parse_item(raw), Completion.parse_item(%{"label" => "b"})]
 
       completion = Completion.new(items, {0, 0})
-      updated = Completion.update_selected_documentation(completion, "New docs for a")
-      selected = Completion.selected_item(updated)
-      assert selected.documentation == "New docs for a"
+      updated = Completion.update_selected_documentation(completion, raw, "New docs for a")
+
+      assert Completion.selected_item(updated).documentation == "New docs for a"
+      assert updated.last_resolved_identity == raw
     end
 
-    test "returns unchanged when no selected item" do
-      completion = Completion.new([], {0, 0})
-      result = Completion.update_selected_documentation(completion, "docs")
+    test "keeps resolved documentation after the filtered projection rebuilds" do
+      raw = %{"label" => "apple", "filterText" => "apple"}
+      items = [Completion.parse_item(raw), Completion.parse_item(%{"label" => "banana"})]
+
+      updated =
+        items
+        |> Completion.new({0, 0})
+        |> Completion.update_selected_documentation(raw, "Apple docs")
+        |> Completion.filter("app")
+
+      assert Completion.selected_item(updated).documentation == "Apple docs"
+      assert updated.last_resolved_identity == raw
+    end
+
+    test "returns unchanged when selected raw identity differs" do
+      raw = %{"label" => "a"}
+      completion = Completion.new([Completion.parse_item(raw)], {0, 0})
+
+      result = Completion.update_selected_documentation(completion, %{"label" => "other"}, "docs")
+
       assert result == completion
     end
   end
@@ -125,9 +140,15 @@ defmodule MingaEditor.CompletionDocPreviewTest do
       assert completion_from(result).resolve_timer == nil
     end
 
-    test "skips when already resolved for this index" do
-      items = [Completion.parse_item(%{"label" => "a"})]
-      completion = %{Completion.new(items, {0, 0}) | last_resolved_index: 0}
+    test "skips when already resolved for this raw item" do
+      raw = %{"label" => "a"}
+      items = [Completion.parse_item(raw)]
+
+      completion =
+        items
+        |> Completion.new({0, 0})
+        |> Completion.update_selected_documentation(raw, "")
+
       state = make_state(completion)
       result = CompletionHandling.maybe_resolve_selected(state)
       assert completion_from(result).resolve_timer == nil
@@ -136,44 +157,45 @@ defmodule MingaEditor.CompletionDocPreviewTest do
 
   # ── Resolve response handling ───────────────────────────────────────────
 
-  describe "handle_resolve_response/2" do
-    test "updates selected item documentation on success" do
-      items = [Completion.parse_item(%{"label" => "a"})]
-      completion = Completion.new(items, {0, 0})
+  describe "handle_resolve_response/3" do
+    test "updates selected item documentation on success for matching raw item" do
+      raw = %{"label" => "a"}
+      completion = Completion.new([Completion.parse_item(raw)], {0, 0})
       state = make_state(completion)
 
       resolved = %{"documentation" => %{"kind" => "markdown", "value" => "Full docs"}}
-      result = CompletionHandling.handle_resolve_response(state, {:ok, resolved})
+      result = CompletionHandling.handle_resolve_response(state, raw, {:ok, resolved})
 
       selected = Completion.selected_item(completion_from(result))
       assert selected.documentation == "Full docs"
-      assert completion_from(result).last_resolved_index == 0
+      assert completion_from(result).last_resolved_identity == raw
     end
 
     test "handles plain string documentation in resolve response" do
-      items = [Completion.parse_item(%{"label" => "a"})]
-      completion = Completion.new(items, {0, 0})
+      raw = %{"label" => "a"}
+      completion = Completion.new([Completion.parse_item(raw)], {0, 0})
       state = make_state(completion)
 
       resolved = %{"documentation" => "Plain text docs"}
-      result = CompletionHandling.handle_resolve_response(state, {:ok, resolved})
+      result = CompletionHandling.handle_resolve_response(state, raw, {:ok, resolved})
 
       selected = Completion.selected_item(completion_from(result))
       assert selected.documentation == "Plain text docs"
     end
 
     test "returns state unchanged on error" do
-      items = [Completion.parse_item(%{"label" => "a"})]
-      completion = Completion.new(items, {0, 0})
+      raw = %{"label" => "a"}
+      completion = Completion.new([Completion.parse_item(raw)], {0, 0})
       state = make_state(completion)
 
-      result = CompletionHandling.handle_resolve_response(state, {:error, "timeout"})
+      result = CompletionHandling.handle_resolve_response(state, raw, {:error, "timeout"})
       assert result == state
     end
 
     test "returns state unchanged when completion is nil" do
+      raw = %{"label" => "a"}
       state = make_state(nil)
-      result = CompletionHandling.handle_resolve_response(state, {:ok, %{}})
+      result = CompletionHandling.handle_resolve_response(state, raw, {:ok, %{}})
       assert result == state
     end
   end

--- a/test/minga_editor/completion_trigger_test.exs
+++ b/test/minga_editor/completion_trigger_test.exs
@@ -12,112 +12,55 @@ defmodule MingaEditor.CompletionTriggerTest do
 
       assert trigger == %CompletionTrigger{phase: :idle, gen: 0}
       assert Map.keys(Map.from_struct(trigger)) |> Enum.sort() == [:gen, :phase]
-      refute CompletionTrigger.active?(trigger)
       assert CompletionTrigger.generation(trigger) == 0
     end
   end
 
-  describe "flush_debounce/3" do
-    test "sends completion requests to multiple clients and records roles" do
-      trigger = CompletionTrigger.new()
-
-      {:ok, buf} =
-        BufferProcess.start_link(file_path: "/tmp/test_completion.ex", content: "hello")
-
-      BufferProcess.move_to(buf, {0, 5})
-
-      result = CompletionTrigger.flush_debounce(trigger, [self(), self()], buf)
-
-      assert %CompletionTrigger{phase: {:pending, refs_by_role, {0, 0}}, gen: 1} = result
-      assert map_size(refs_by_role) == 2
-      assert [{primary_ref, :primary}] = Enum.filter(refs_by_role, &match?({_ref, :primary}, &1))
-
-      assert [{secondary_ref, :secondary}] =
-               Enum.filter(refs_by_role, &match?({_ref, :secondary}, &1))
-
-      assert_receive {:"$gen_cast",
-                      {:async_request, "textDocument/completion", _params, _caller, ^primary_ref}}
-
-      assert_receive {:"$gen_cast",
-                      {:async_request, "textDocument/completion", _params, _caller,
-                       ^secondary_ref}}
-    end
-
-    test "accepts a single client pid" do
-      trigger = CompletionTrigger.new()
-      {:ok, buf} = BufferProcess.start_link(file_path: "/tmp/test_single.ex", content: "hello")
-
-      result = CompletionTrigger.flush_debounce(trigger, self(), buf)
-
-      assert %CompletionTrigger{phase: {:pending, refs_by_role, {0, 0}}, gen: 1} = result
-      assert [_] = Map.keys(refs_by_role)
-      assert [:primary] == Map.values(refs_by_role)
-    end
-
-    test "preserves the trigger without a file path or LSP clients" do
-      trigger = %CompletionTrigger{phase: :idle, gen: 3}
-      {:ok, pathless_buf} = BufferProcess.start_link(content: "hello")
-
-      {:ok, clientless_buf} =
-        BufferProcess.start_link(file_path: "/tmp/test_no_clients.ex", content: "ab")
-
-      assert CompletionTrigger.flush_debounce(trigger, self(), pathless_buf) == trigger
-      assert {^trigger, nil} = CompletionTrigger.maybe_trigger(trigger, "b", clientless_buf)
-      refute_receive {:"$gen_cast", {:async_request, "textDocument/completion", _, _, _}}
-
-      GenServer.stop(pathless_buf)
-      GenServer.stop(clientless_buf)
-    end
-  end
-
   describe "maybe_trigger/3" do
-    test "trigger character cancels a debounce and replaces pending refs with newer batches" do
+    test "trigger character sends completion requests and returns typed tracking facts" do
       {:ok, buf} =
         BufferProcess.start_link(file_path: "/tmp/test_replace_trigger.ex", content: "ab")
 
-      Minga.LSP.SyncServer.put_clients(buf, [self()])
-      timer = Process.send_after(self(), :old_debounce, 10_000)
-      debounced = %CompletionTrigger{phase: {:debounced, timer, {0, 0}}, gen: 4}
+      me = self()
+      BufferProcess.move_to(buf, {0, 2})
+      Minga.LSP.SyncServer.put_clients(buf, [self(), self()])
 
       try do
-        assert {%CompletionTrigger{phase: {:pending, first_roles, _position}, gen: 5} = pending,
-                nil} = CompletionTrigger.maybe_trigger(debounced, ".", buf)
-
-        assert [{first_ref, :primary}] = Map.to_list(first_roles)
-        assert Process.read_timer(timer) == false
-
-        assert_receive {:"$gen_cast",
-                        {:async_request, "textDocument/completion", _params, _caller, ^first_ref}}
-
-        assert {%CompletionTrigger{phase: {:pending, second_roles, _position}, gen: 6}, nil} =
-                 CompletionTrigger.maybe_trigger(pending, ".", buf)
-
-        refute Map.has_key?(second_roles, first_ref)
-        assert [{second_ref, :primary}] = Map.to_list(second_roles)
+        assert {%CompletionTrigger{phase: {:pending, {0, 0}}, gen: 1},
+                [
+                  {primary_ref, :primary, ^me, ^buf, version, 1, {0, 0}},
+                  {secondary_ref, :secondary, ^me, ^buf, version, 1, {0, 0}}
+                ]} = CompletionTrigger.maybe_trigger(CompletionTrigger.new(), ".", buf)
 
         assert_receive {:"$gen_cast",
-                        {:async_request, "textDocument/completion", _params, _caller, ^second_ref}}
+                        {:async_request, "textDocument/completion", _params, _caller,
+                         ^primary_ref}}
+
+        assert_receive {:"$gen_cast",
+                        {:async_request, "textDocument/completion", _params, _caller,
+                         ^secondary_ref}}
       after
         Minga.LSP.SyncServer.remove_buffer(buf)
         GenServer.stop(buf)
       end
     end
 
-    test "identifier debounce phase sends the existing timer message" do
+    test "identifier debounce phase sends only the generation message" do
       {:ok, buf} = BufferProcess.start_link(file_path: "/tmp/test_debounce.ex", content: "")
       :ok = BufferProcess.insert_char(buf, "a")
       :ok = BufferProcess.insert_char(buf, "b")
       clients = [self()]
-
+      version = Minga.Buffer.version(buf)
       Minga.LSP.SyncServer.put_clients(buf, clients)
 
       try do
-        {result, completion} = CompletionTrigger.maybe_trigger(CompletionTrigger.new(), "b", buf)
+        assert {%CompletionTrigger{
+                  phase: {:debounced, timer, ^clients, ^buf, ^version, {0, 0}},
+                  gen: 1
+                }, []} = CompletionTrigger.maybe_trigger(CompletionTrigger.new(), "b", buf)
 
-        assert completion == nil
-        assert %CompletionTrigger{phase: {:debounced, timer, {0, 0}}, gen: 0} = result
         assert is_reference(timer)
-        assert_receive {:completion_debounce, ^clients, ^buf}, 1_000
+        assert_receive {:completion_debounce, 1}, 1_000
       after
         Minga.LSP.SyncServer.remove_buffer(buf)
         GenServer.stop(buf)
@@ -125,152 +68,76 @@ defmodule MingaEditor.CompletionTriggerTest do
     end
   end
 
-  describe "dismiss/1" do
-    test "clears pending refs and keeps gen" do
-      primary_ref = make_ref()
-      secondary_ref = make_ref()
+  describe "flush_debounce/2" do
+    test "wrong generation debounce flush sends no LSP request" do
+      {:ok, buf} = BufferProcess.start_link(file_path: "/tmp/test_wrong_gen.ex", content: "ab")
+      timer = Process.send_after(self(), :old_debounce, 10_000)
 
       trigger = %CompletionTrigger{
-        phase: {:pending, %{primary_ref => :primary, secondary_ref => :secondary}, {5, 10}},
-        gen: 4
-      }
-
-      result = CompletionTrigger.dismiss(trigger)
-
-      assert result == %CompletionTrigger{phase: :idle, gen: 4}
-
-      for ref <- [primary_ref, secondary_ref] do
-        assert {^result, :ignore} =
-                 CompletionTrigger.classify_response(result, ref, {:ok, %{"items" => []}}, self())
-      end
-    end
-
-    test "clears a debounced timer phase and keeps gen" do
-      timer = Process.send_after(self(), :dismissed_debounce, 10_000)
-      trigger = %CompletionTrigger{phase: {:debounced, timer, {0, 0}}, gen: 6}
-
-      assert CompletionTrigger.dismiss(trigger) == %CompletionTrigger{phase: :idle, gen: 6}
-      assert Process.read_timer(timer) == false
-    end
-  end
-
-  describe "classify_response/4" do
-    test "stale response is ignored without mutating pending refs" do
-      ref = make_ref()
-      tracked_ref = make_ref()
-      trigger = %CompletionTrigger{phase: {:pending, %{tracked_ref => :primary}, {0, 0}}, gen: 0}
-      {:ok, buf} = BufferProcess.start_link(content: "hello")
-
-      assert {^trigger, :ignore} =
-               CompletionTrigger.classify_response(trigger, ref, {:ok, nil}, buf)
-    end
-
-    test "error response removes only the tracked ref" do
-      primary_ref = make_ref()
-      secondary_ref = make_ref()
-
-      trigger = %CompletionTrigger{
-        phase: {:pending, %{primary_ref => :primary, secondary_ref => :secondary}, {0, 0}},
-        gen: 2
-      }
-
-      {:ok, buf} = BufferProcess.start_link(content: "hello")
-
-      assert {%CompletionTrigger{phase: {:pending, remaining, {0, 0}}, gen: 2} = remaining_trigger,
-              :ignore} =
-               CompletionTrigger.classify_response(trigger, primary_ref, {:error, "timeout"}, buf)
-
-      assert remaining == %{secondary_ref => :secondary}
-
-      assert {%CompletionTrigger{phase: :idle, gen: 2}, :ignore} =
-               CompletionTrigger.classify_response(
-                 remaining_trigger,
-                 secondary_ref,
-                 {:error, "timeout"},
-                 buf
-               )
-
-      unknown_ref = make_ref()
-
-      assert {^trigger, :ignore} =
-               CompletionTrigger.classify_response(trigger, unknown_ref, {:error, "timeout"}, buf)
-    end
-
-    test "primary response classifies as primary and preserves secondary refs" do
-      primary_ref = make_ref()
-      secondary_ref = make_ref()
-
-      trigger = %CompletionTrigger{
-        phase: {:pending, %{primary_ref => :primary, secondary_ref => :secondary}, {0, 0}},
-        gen: 7
-      }
-
-      {:ok, buf} = BufferProcess.start_link(content: "hello")
-
-      assert {%CompletionTrigger{phase: {:pending, remaining, {0, 0}}, gen: 7} =
-                remaining_trigger, {:primary, {0, 0}, _prefix, 7}} =
-               CompletionTrigger.classify_response(
-                 trigger,
-                 primary_ref,
-                 {:ok, %{"items" => []}},
-                 buf
-               )
-
-      assert remaining == %{secondary_ref => :secondary}
-
-      assert {%CompletionTrigger{phase: :idle, gen: 7}, {:merge, {0, 0}, _prefix, 7}} =
-               CompletionTrigger.classify_response(
-                 remaining_trigger,
-                 secondary_ref,
-                 {:ok, %{"items" => []}},
-                 buf
-               )
-    end
-
-    test "secondary response can arrive before primary and preserve primary ref" do
-      primary_ref = make_ref()
-      secondary_ref = make_ref()
-
-      trigger = %CompletionTrigger{
-        phase: {:pending, %{primary_ref => :primary, secondary_ref => :secondary}, {0, 0}},
+        phase: {:debounced, timer, [self()], buf, Minga.Buffer.version(buf), {0, 0}},
         gen: 3
       }
 
-      {:ok, buf} = BufferProcess.start_link(content: "hello")
-
-      assert {%CompletionTrigger{phase: {:pending, remaining, {0, 0}}, gen: 3},
-              {:merge, {0, 0}, _prefix, 3}} =
-               CompletionTrigger.classify_response(
-                 trigger,
-                 secondary_ref,
-                 {:ok, %{"items" => []}},
-                 buf
-               )
-
-      assert remaining == %{primary_ref => :primary}
+      assert {^trigger, []} = CompletionTrigger.flush_debounce(trigger, 2)
+      refute_receive {:"$gen_cast", {:async_request, "textDocument/completion", _, _, _}}
+      GenServer.stop(buf)
     end
 
-    test "last pending response returns idle" do
-      ref = make_ref()
-      trigger = %CompletionTrigger{phase: {:pending, %{ref => :primary}, {0, 0}}, gen: 9}
-      {:ok, buf} = BufferProcess.start_link(content: "hello")
+    test "current debounce flush sends requests and returns captured origin facts" do
+      {:ok, buf} =
+        BufferProcess.start_link(file_path: "/tmp/test_completion.ex", content: "hello")
 
-      assert {%CompletionTrigger{phase: :idle, gen: 9}, {:primary, {0, 0}, _prefix, 9}} =
-               CompletionTrigger.classify_response(trigger, ref, {:ok, %{"items" => []}}, buf)
+      me = self()
+      BufferProcess.move_to(buf, {0, 5})
+      version = Minga.Buffer.version(buf)
+      timer = Process.send_after(self(), :old_debounce, 10_000)
+      trigger = %CompletionTrigger{phase: {:debounced, timer, [me], buf, version, {0, 3}}, gen: 4}
+
+      assert {%CompletionTrigger{phase: {:pending, {0, 3}}, gen: 4},
+              [{ref, :primary, ^me, ^buf, ^version, 4, {0, 3}}]} =
+               CompletionTrigger.flush_debounce(trigger, 4)
+
+      assert_receive {:"$gen_cast",
+                      {:async_request, "textDocument/completion", _params, _caller, ^ref}}
+
+      GenServer.stop(buf)
+    end
+
+    test "newer generation makes an older debounce message inert" do
+      {:ok, buf} =
+        BufferProcess.start_link(file_path: "/tmp/test_stale_debounce.ex", content: "ab")
+
+      old_timer = Process.send_after(self(), :old_debounce, 10_000)
+      new_timer = Process.send_after(self(), :new_debounce, 10_000)
+
+      trigger = %CompletionTrigger{
+        phase: {:debounced, new_timer, [self()], buf, Minga.Buffer.version(buf), {0, 0}},
+        gen: 6
+      }
+
+      assert {^trigger, []} = CompletionTrigger.flush_debounce(trigger, 5)
+      assert Process.cancel_timer(old_timer) != false
+      refute_receive {:"$gen_cast", {:async_request, "textDocument/completion", _, _, _}}
+      GenServer.stop(buf)
     end
   end
 
-  describe "generation bumping" do
-    test "each request batch mints a strictly newer generation" do
-      {:ok, buf} = BufferProcess.start_link(file_path: "/tmp/test_gen.ex", content: "hello")
-      BufferProcess.move_to(buf, {0, 5})
+  describe "dismiss/1" do
+    test "clears pending state and keeps generation" do
+      trigger = %CompletionTrigger{phase: {:pending, {5, 10}}, gen: 4}
+      assert CompletionTrigger.dismiss(trigger) == %CompletionTrigger{phase: :idle, gen: 4}
+    end
 
-      trigger0 = CompletionTrigger.new()
-      trigger1 = CompletionTrigger.flush_debounce(trigger0, [self()], buf)
-      trigger2 = CompletionTrigger.flush_debounce(trigger1, [self()], buf)
+    test "clears a debounced timer phase and keeps generation" do
+      timer = Process.send_after(self(), :dismissed_debounce, 10_000)
 
-      assert CompletionTrigger.generation(trigger1) == CompletionTrigger.generation(trigger0) + 1
-      assert CompletionTrigger.generation(trigger2) == CompletionTrigger.generation(trigger1) + 1
+      trigger = %CompletionTrigger{
+        phase: {:debounced, timer, [self()], self(), 1, {0, 0}},
+        gen: 6
+      }
+
+      assert CompletionTrigger.dismiss(trigger) == %CompletionTrigger{phase: :idle, gen: 6}
+      assert Process.read_timer(timer) == false
     end
   end
 end

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -10,6 +10,7 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Editing.Completion
   alias MingaEditor.CompletionHandling
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.CompletionTrigger
   alias MingaEditor.Handlers.LspEventHandler
   alias MingaEditor.Shell.Registry, as: ShellRegistry
@@ -506,21 +507,29 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
     test "completion debounce writes the flushed completion trigger back and sends a request" do
       state = file_buffer_state("foo_bar\n")
       client = start_fake_lsp_client()
-      trigger = %CompletionTrigger{phase: {:debounced, make_ref(), {0, 0}}}
+      buffer = state.workspace.buffers.active
+      version = Minga.Buffer.version(buffer)
+      timer = Process.send_after(self(), :unused, 10_000)
+
+      trigger = %CompletionTrigger{
+        phase: {:debounced, timer, [client], buffer, version, {0, 0}},
+        gen: 1
+      }
+
       payload = CompletionPayload.new(1, trigger: trigger)
       state = ModalWorkflow.transition(state, {:completion, payload})
-      buffer = state.workspace.buffers.active
 
-      {new_state, effects} =
-        LspEventHandler.handle(state, {:completion_debounce, [client], buffer})
+      {new_state, effects} = LspEventHandler.handle(state, {:completion_debounce, 1})
 
       assert effects == []
       assert_receive {:lsp_request, "textDocument/completion", _params, caller, ref}
       assert caller == self()
 
       new_trigger = ModalWorkflow.completion_trigger(new_state)
-      assert %CompletionTrigger{phase: {:pending, refs_by_role, {0, 0}}, gen: 1} = new_trigger
-      assert refs_by_role == %{ref => :primary}
+      assert %CompletionTrigger{phase: {:pending, {0, 0}}, gen: 1} = new_trigger
+
+      assert LSPState.fetch_pending_request(new_state.lsp, ref) ==
+               {:ok, {:completion_result, :primary, client, buffer, version, 1, {0, 0}}}
     end
 
     test "completion resolve routes the request and records the pending ref" do
@@ -537,11 +546,12 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       }
 
       completion = Completion.new(Completion.parse_response(%{"items" => [item]}), {0, 0})
-      trigger = %CompletionTrigger{phase: {:pending, %{make_ref() => :primary}, {0, 0}}}
+      trigger = %CompletionTrigger{phase: {:pending, {0, 0}}, gen: 2}
       payload = CompletionPayload.new(1, completion: completion, trigger: trigger)
       state = ModalWorkflow.transition(state, {:completion, payload})
+      version = Minga.Buffer.version(buffer)
 
-      {new_state, effects} = LspEventHandler.handle(state, {:completion_resolve, 0})
+      {new_state, effects} = LspEventHandler.handle(state, {:completion_resolve, 2, item})
 
       assert effects == []
 
@@ -551,13 +561,94 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       assert caller == self()
 
       assert LSPState.fetch_pending_request(new_state.lsp, ref) ==
-               {:ok, {:response, :completion_resolve}}
+               {:ok, {:completion_resolve, client, buffer, version, 2, item}}
+    end
+
+    test "completion resolve sends and tracks nothing when the origin buffer is stale" do
+      state = buffer_state("hello\n")
+      client = start_fake_lsp_client()
+      buffer = state.workspace.buffers.active
+      register_lsp_client(buffer, client)
+      item = %{"label" => "resolve-me", "sortText" => "resolve-me"}
+      completion = Completion.new(Completion.parse_response(%{"items" => [item]}), {0, 0})
+      trigger = %CompletionTrigger{phase: {:pending, {0, 0}}, gen: 2}
+      payload = CompletionPayload.new(1, completion: completion, trigger: trigger)
+      state = ModalWorkflow.transition(state, {:completion, payload})
+
+      monitor = Process.monitor(buffer)
+      Process.exit(buffer, :kill)
+      assert_receive {:DOWN, ^monitor, :process, ^buffer, _}
+
+      {new_state, effects} = LspEventHandler.handle(state, {:completion_resolve, 2, item})
+
+      assert effects == []
+      assert new_state == state
+      refute_receive {:lsp_request, "completionItem/resolve", _, _, _}, 50
+    end
+
+    test "signature help sends and tracks nothing when version capture is stale" do
+      state = file_buffer_state("call(")
+      client = start_fake_lsp_client()
+      buffer = buffer_that_dies_on_version(tmp_lsp_path("signature-stale"))
+      register_lsp_client(buffer, client)
+
+      buffers = Buffers.set_active_override(state.workspace.buffers, buffer)
+
+      workspace =
+        state.workspace
+        |> SessionState.set_buffers(buffers)
+        |> SessionState.transition_mode(:insert)
+
+      state = %{state | workspace: workspace}
+
+      new_state = CompletionHandling.maybe_handle(state, true, ?(, 0)
+
+      assert new_state == state
+      refute_receive {:lsp_request, "textDocument/signatureHelp", _, _, _}, 50
+    end
+
+    test "completion result that dies during prefix extraction is taken without processing" do
+      state = buffer_state("hello\n")
+      client = start_fake_lsp_client()
+      buffer = buffer_that_dies_on_content_and_cursor(7)
+      register_lsp_client(buffer, client)
+      ref = make_ref()
+      trigger = %CompletionTrigger{phase: {:pending, {0, 0}}, gen: 1}
+      payload = CompletionPayload.new(1, trigger: trigger)
+      buffers = Buffers.set_active_override(state.workspace.buffers, buffer)
+      state = %{state | workspace: SessionState.set_buffers(state.workspace, buffers)}
+
+      state =
+        state
+        |> ModalWorkflow.transition({:completion, payload})
+        |> track_pending_request(
+          ref,
+          {:completion_result, :primary, client, buffer, 7, 1, {0, 0}}
+        )
+
+      {new_state, effects} =
+        LspEventHandler.handle(state, {:lsp_response, ref, {:ok, %{"items" => []}}})
+
+      assert effects == [:render_now]
+      assert LSPState.fetch_pending_request(new_state.lsp, ref) == :error
+      assert_receive {:buffer_content_and_cursor_requested, ^buffer}
+      refute_receive {:completion_processed, _, _, _, _, _, _}, 50
     end
 
     test "tracked signature help response updates state and returns render_now" do
       state = base_state()
       ref = make_ref()
-      state = track_pending_request(state, ref, :signature_help)
+      buffer = state.workspace.buffers.active
+      client = start_fake_lsp_client()
+      register_lsp_client(buffer, client)
+
+      state =
+        track_pending_request(
+          state,
+          ref,
+          {:signature_help, client, buffer, Minga.Buffer.version(buffer),
+           Minga.Buffer.cursor(buffer)}
+        )
 
       response = %{
         "signatures" => [
@@ -611,9 +702,16 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
     test "delayed signature help clears pending without touching or replaying a foreign shell" do
       ref = make_ref()
 
+      state = base_state()
+      buffer = state.workspace.buffers.active
+
       state =
-        base_state()
-        |> track_pending_request(ref, :signature_help)
+        state
+        |> track_pending_request(
+          ref,
+          {:signature_help, self(), buffer, Minga.Buffer.version(buffer),
+           Minga.Buffer.cursor(buffer)}
+        )
         |> ShellWorkflow.switch(:fake)
 
       foreign_shell_state = Runtime.state(state.shell_runtime)
@@ -642,12 +740,18 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
     test "delayed completion response does not spawn processing or replay after a shell switch" do
       ref = make_ref()
-      trigger = %CompletionTrigger{phase: {:pending, %{ref => :primary}, {0, 0}}}
+      state = base_state()
+      buffer = state.workspace.buffers.active
+      trigger = %CompletionTrigger{phase: {:pending, {0, 0}}, gen: 1}
       payload = CompletionPayload.new(1, trigger: trigger)
 
       state =
-        base_state()
+        state
         |> ModalWorkflow.transition({:completion, payload})
+        |> track_pending_request(
+          ref,
+          {:completion_result, :primary, self(), buffer, Minga.Buffer.version(buffer), 1, {0, 0}}
+        )
         |> ShellWorkflow.switch(:fake)
 
       foreign_shell_state = Runtime.state(state.shell_runtime)
@@ -663,9 +767,9 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       {new_state, effects} = LspEventHandler.handle(state, {:lsp_response, ref, response})
 
       assert effects == [:render_now]
-      assert new_state == state
+      assert LSPState.fetch_pending_request(new_state.lsp, ref) == :error
       assert Runtime.state(new_state.shell_runtime) == foreign_shell_state
-      refute_receive {:completion_processed, _, _, _, _}, 50
+      refute_receive {:completion_processed, _, _, _, _, _, _}, 50
 
       restored = ShellWorkflow.switch(new_state, :traditional)
       assert Runtime.state(restored.shell_runtime).modal == :none
@@ -675,12 +779,22 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       ref = make_ref()
       item = %{"label" => "resolved", "documentation" => "old", "sortText" => "resolved"}
       completion = Completion.new(Completion.parse_response(%{"items" => [item]}), {0, 0})
-      payload = CompletionPayload.new(1, completion: completion)
+      state = base_state()
+      buffer = state.workspace.buffers.active
+
+      payload =
+        CompletionPayload.new(1,
+          completion: completion,
+          trigger: %CompletionTrigger{gen: 1, phase: {:pending, {0, 0}}}
+        )
 
       state =
-        base_state()
+        state
         |> ModalWorkflow.transition({:completion, payload})
-        |> track_pending_request(ref, :completion_resolve)
+        |> track_pending_request(
+          ref,
+          {:completion_resolve, self(), buffer, Minga.Buffer.version(buffer), 1, item}
+        )
         |> ShellWorkflow.switch(:fake)
 
       foreign_shell_state = Runtime.state(state.shell_runtime)
@@ -713,7 +827,16 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
           {0, 0}
         )
 
-      new_state = CompletionHandling.apply_processed(state, 7, :primary, processed, {0, 0})
+      new_state =
+        CompletionHandling.apply_processed(
+          state,
+          7,
+          :primary,
+          processed,
+          {0, 0},
+          state.workspace.buffers.active,
+          Minga.Buffer.version(state.workspace.buffers.active)
+        )
 
       assert new_state == state
       restored = ShellWorkflow.switch(new_state, :traditional)
@@ -753,10 +876,10 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
       assert [%Minga.Language.Highlight.Span{layer: 2}] = Tuple.to_list(highlight.spans)
     end
 
-    test "untracked completion response is processed off-thread, then becomes visible" do
+    test "untracked completion response is ignored without trigger-local fallback" do
       state = buffer_state("hello\n")
       ref = make_ref()
-      trigger = %CompletionTrigger{phase: {:pending, %{ref => :primary}, {0, 0}}}
+      trigger = %CompletionTrigger{phase: {:pending, {0, 0}}, gen: 1}
       payload = CompletionPayload.new(1, trigger: trigger)
       state = ModalWorkflow.transition(state, {:completion, payload})
 
@@ -775,25 +898,8 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
         LspEventHandler.handle(state, {:lsp_response, ref, {:ok, completion_result}})
 
       assert effects == [:render_now]
-
-      # The handler only does cheap ref bookkeeping: pending refs are cleared
-      # synchronously, but the parse/sort/filter is deferred to a Task (#2633),
-      # so the menu is not yet visible right after handle/2 returns.
-      assert ModalWorkflow.completion(new_state) == nil
-
-      new_trigger = ModalWorkflow.completion_trigger(new_state)
-      assert %CompletionTrigger{phase: :idle} = new_trigger
-
-      # Drive the async result the Task sends back, exactly as the Editor's
-      # {:completion_processed, ...} handle_info clause does, and confirm the
-      # completion ultimately becomes visible.
-      assert_receive {:completion_processed, gen, mode, processed, trigger_pos}, 5_000
-      applied = CompletionHandling.apply_processed(new_state, gen, mode, processed, trigger_pos)
-
-      completion = ModalWorkflow.completion(applied)
-      assert %Completion{} = completion
-      assert [%{label: "hello_world"}] = completion.filtered
-      assert completion.selected == 0
+      assert new_state == state
+      refute_receive {:completion_processed, _, _, _, _, _, _}, 50
     end
   end
 
@@ -1189,15 +1295,53 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
     }
   end
 
-  defp track_pending_request(state, ref, kind)
-       when kind in [
-              :completion_resolve,
-              :signature_help,
-              :code_lens,
-              :code_lens_resolve,
-              :inlay_hint
-            ] do
-    %{state | lsp: LSPState.track_response_request(state.lsp, ref, kind)}
+  defp track_pending_request(
+         state,
+         ref,
+         {:completion_result, role, client, buffer, version, gen, trigger_pos}
+       ) do
+    %{
+      state
+      | lsp:
+          LSPState.track_completion_result_request(
+            state.lsp,
+            ref,
+            role,
+            client,
+            buffer,
+            version,
+            gen,
+            trigger_pos
+          )
+    }
+  end
+
+  defp track_pending_request(
+         state,
+         ref,
+         {:completion_resolve, client, buffer, version, gen, raw_item}
+       ) do
+    %{
+      state
+      | lsp:
+          LSPState.track_completion_resolve_request(
+            state.lsp,
+            ref,
+            client,
+            buffer,
+            version,
+            gen,
+            raw_item
+          )
+    }
+  end
+
+  defp track_pending_request(state, ref, {:signature_help, client, buffer, version, cursor}) do
+    %{
+      state
+      | lsp:
+          LSPState.track_signature_help_request(state.lsp, ref, client, buffer, version, cursor)
+    }
   end
 
   defp track_format(state, ref, buffer, version, opts \\ []) do
@@ -1306,6 +1450,63 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
        frontend: %MingaEditor.State.Frontend{port_manager: self()},
        workspace: workspace
      }, inactive_path, active_path}
+  end
+
+  defp buffer_that_dies_on_version(path) do
+    test = self()
+
+    spawn(fn ->
+      receive do
+        {:"$gen_call", from, :file_path} ->
+          GenServer.reply(from, path)
+          stale_version_buffer_loop(path)
+
+        other ->
+          send(test, {:unexpected_stale_buffer_message, other})
+      end
+    end)
+  end
+
+  defp stale_version_buffer_loop(path) do
+    receive do
+      {:"$gen_call", from, :file_path} ->
+        GenServer.reply(from, path)
+        stale_version_buffer_loop(path)
+
+      {:"$gen_call", from, :cursor} ->
+        GenServer.reply(from, {0, 1})
+        stale_version_buffer_loop(path)
+
+      {:"$gen_call", _from, :version} ->
+        exit(:version_probe)
+    end
+  end
+
+  defp buffer_that_dies_on_content_and_cursor(version) do
+    test = self()
+
+    spawn(fn ->
+      receive do
+        {:"$gen_call", from, :version} ->
+          GenServer.reply(from, version)
+          content_death_buffer_loop(test)
+
+        other ->
+          send(test, {:unexpected_content_death_buffer_message, other})
+      end
+    end)
+  end
+
+  defp content_death_buffer_loop(test) do
+    receive do
+      {:"$gen_call", _from, :content_and_cursor} ->
+        send(test, {:buffer_content_and_cursor_requested, self()})
+        exit(:content_probe)
+
+      other ->
+        send(test, {:unexpected_content_death_buffer_message, other})
+        content_death_buffer_loop(test)
+    end
   end
 
   defp tmp_lsp_path(name) do

--- a/test/minga_editor/state/lsp/pending_requests_test.exs
+++ b/test/minga_editor/state/lsp/pending_requests_test.exs
@@ -136,25 +136,53 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
     end
   end
 
-  test "legacy response tracking is constrained to L07 and L08 kinds" do
+  test "L07 response tracking uses typed variants while L08 legacy atoms remain" do
+    client = spawn_process()
+    buffer = spawn_process()
+    raw_item = %{"label" => "a"}
+
     assert {:ok, pending} =
-             PendingRequests.track_response(
+             PendingRequests.track_completion_result(
                PendingRequests.new(),
                make_ref(),
-               :completion_resolve
+               :primary,
+               client,
+               buffer,
+               1,
+               2,
+               {3, 4}
              )
 
-    assert {:ok, pending} = PendingRequests.track_response(pending, make_ref(), :signature_help)
+    assert {:ok, pending} =
+             PendingRequests.track_completion_resolve(
+               pending,
+               make_ref(),
+               client,
+               buffer,
+               1,
+               2,
+               raw_item
+             )
+
+    assert {:ok, pending} =
+             PendingRequests.track_signature_help(pending, make_ref(), client, buffer, 1, {3, 4})
+
     assert {:ok, pending} = PendingRequests.track_response(pending, make_ref(), :code_lens)
 
     assert {:ok, pending} =
              PendingRequests.track_response(pending, make_ref(), :code_lens_resolve)
 
     assert {:ok, _pending} = PendingRequests.track_response(pending, make_ref(), :inlay_hint)
-    kind = String.to_existing_atom("definition")
+
+    completion_resolve = String.to_existing_atom("completion_resolve")
+    signature_help = String.to_existing_atom("signature_help")
 
     assert_raise FunctionClauseError, fn ->
-      PendingRequests.track_response(PendingRequests.new(), make_ref(), kind)
+      PendingRequests.track_response(PendingRequests.new(), make_ref(), completion_resolve)
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      PendingRequests.track_response(PendingRequests.new(), make_ref(), signature_help)
     end
   end
 
@@ -189,22 +217,24 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
     end
   end
 
-  test "rejects duplicate refs across response operation and format requests" do
+  test "rejects duplicate refs across L07 L08 response operation and format requests" do
     ref = make_ref()
     operation = operation(spawn_process(), ref)
     pending = PendingRequests.new()
 
     assert {:ok, pending} =
-             PendingRequests.track_response(
+             PendingRequests.track_completion_result(
                pending,
                ref,
-               :definition,
+               :primary,
                self(),
                spawn_process(),
                0,
-               nil,
+               1,
                {0, 0}
              )
+
+    assert PendingRequests.track_response(pending, ref, :code_lens) == {:error, :duplicate_ref}
 
     assert PendingRequests.track_operation(pending, ref, :references, 1, nil) ==
              {:error, :duplicate_ref}
@@ -229,8 +259,7 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
 
     assert {:ok, pending} = PendingRequests.track_operation(pending, other_ref, :rename, 2, 20)
 
-    assert {:ok, pending} =
-             PendingRequests.track_response(pending, response_ref, :completion_resolve)
+    assert {:ok, pending} = PendingRequests.track_response(pending, response_ref, :code_lens)
 
     assert {:ok, pending} = PendingRequests.track_format(pending, format)
 
@@ -238,7 +267,7 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
     assert requests == [{:operation, :references, 1, 10}]
     assert PendingRequests.fetch(pending, current_ref) == :error
     assert PendingRequests.fetch(pending, other_ref) == {:ok, {:operation, :rename, 2, 20}}
-    assert PendingRequests.fetch(pending, response_ref) == {:ok, {:response, :completion_resolve}}
+    assert PendingRequests.fetch(pending, response_ref) == {:ok, {:response, :code_lens}}
     assert PendingRequests.fetch_format(pending, format.ref) == {:ok, format}
   end
 

--- a/test/minga_editor/state/tab_switch_test.exs
+++ b/test/minga_editor/state/tab_switch_test.exs
@@ -395,26 +395,26 @@ defmodule MingaEditor.State.TabSwitchTest do
       assert new_state.render.layout == nil
     end
 
-    test "generic pending requests are Editor-global across tab switches" do
+    test "L08 legacy pending requests are Editor-global across tab switches" do
       {state, _buf1, _buf2} = state_with_two_file_tabs()
       tb = state.shell_runtime.state.tab_bar
       current_id = tb.active_id
       target_id = Enum.find(tb.tabs, &(&1.id != tb.active_id)).id
       ref = make_ref()
 
-      state = %{state | lsp: LSPState.track_response_request(state.lsp, ref, :completion_resolve)}
+      state = %{state | lsp: LSPState.track_response_request(state.lsp, ref, :code_lens)}
 
       {switched, _effects} = EditorState.switch_tab(state, target_id)
 
       assert LSPState.fetch_pending_request(switched.lsp, ref) ==
-               {:ok, {:response, :completion_resolve}}
+               {:ok, {:response, :code_lens}}
 
       refute :lsp_pending in TabBar.get(switched.shell_runtime.state.tab_bar, current_id).context.present_fields
 
       {switched_back, _effects} = EditorState.switch_tab(switched, current_id)
 
       assert LSPState.fetch_pending_request(switched_back.lsp, ref) ==
-               {:ok, {:response, :completion_resolve}}
+               {:ok, {:response, :code_lens}}
 
       refute :lsp_pending in TabBar.get(switched_back.shell_runtime.state.tab_bar, target_id).context.present_fields
     end


### PR DESCRIPTION
# TL;DR

Completion and signature-help LSP responses now carry and validate the identity of the request that produced them before they can mutate editor state. Stale debounce messages, buffer/tab drift, dead origin buffers, and outdated async results are rejected without disturbing current completion state.

## Context

Delayed completion and signature responses previously depended on split correlation state. Some paths classified response refs inside `CompletionTrigger`, while others used LSP state, and async completion processing could outlive the buffer, version, generation, or selected item that started it.

This PR gives those request kinds one correlation owner and removes the obsolete fallback authority.

## Changes

- Add typed pending-request variants for completion results, completion resolve, and signature help under `MingaEditor.State.LSP.PendingRequests`.
- Use the existing completion generation as the only debounce identity.
- Validate captured client, buffer PID, version, generation, trigger position, cursor, and raw completion-item identity at the appropriate producer and consumer boundaries.
- Consume response refs exactly once before dispatch.
- Keep malformed secondary completion responses from canceling a valid primary batch.
- Preserve resolved documentation across completion refiltering by updating both the source items and filtered projection for the exact raw item.
- Reject dead-buffer races without sending unowned resolve or signature requests or spawning stale completion processing.
- Remove trigger-local ref classification, untracked completion fallback, legacy completion/signature atoms, and selected-index resolve identity.
- Preserve the existing code-lens and inlay-hint legacy variants for their separate follow-up.

## Verification

- `git diff --check`
- `make lint`
- Focused L07 suite across pending requests, trigger, handler, documentation preview, async processing, signature help, and tab switching: 124 tests passed.
- Final handler suite after adding deterministic coverage for a buffer dying between version validation and prefix extraction: 44 tests passed.
- Final acceptance reviewer: PASS, confidence 0.98.

Default-concurrency full-suite runs exposed unrelated five-second `MingaAgent.SessionManager` timeouts. Each failed test passed alone, and no L07-focused test failed. CI remains the broad validation gate.

## Acceptance Criteria Addressed

- Completion and signature responses mutate state only when their captured request identity is still current.
- Stale debounce and async completion messages are inert.
- Completion resolve uses stable raw-item identity rather than filtered-list position.
- Dead origin buffers cannot produce untracked requests or crash response handling.
- Existing code-lens and inlay-hint correlation behavior remains unchanged.
