### PR TITLE
fix(lsp): validate decoration response origin

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -4786,3 +4786,33 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Merge evidence:** PR #3232 merged on 2026-07-24 after required CI run `30134673953` passed.
 - **Findings resolved:** L07 implementation plus every mandatory correction from the correctness, Ponytail, and Elixir reviews are applied; final acceptance passed with no findings.
 - **Completion date:** 2026-07-24
+
+### W119/L08: Validate code lens and inlay decorations against captured origin
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** L08
+- **Decision:** APPROVE_REVISED_CAP, one clean cutover from legacy L08 atoms to captured current-origin code-lens tracking plus one viewport-bearing inlay-hint variant.
+- **Planning profile:** `L08RoutePlanner`, editor-lifecycle-planner, read-only; superseded by corrected lock from `agent://L08PlanVerifier`.
+- **Implementation profile:** `L08RouteWorker`, editor-lifecycle-worker, no delegation.
+- **Baseline:** `a01f7e7128a95924575f472662996af89a1463ab`.
+- **Ready provenance:** Corrected lock from `agent://L08PlanVerifier`; budget approval from `agent://L08BudgetDecision` raised the hard formatted caps to net `+120` production lines across the five named production files and net `+300` test lines across the four named test files.
+- **Observable result:** Code-lens, codeLens/resolve, and inlay-hint responses are taken once and accepted only when the captured client, active buffer, buffer version, active tab, and, for inlay hints, effective viewport top and rows still match. Dead capture sends and tracks nothing. Accepted empty initial code-lens and inlay responses clear their `State.LSP` stores and buffer decoration groups; failed or invalid responses retain presentation.
+- **Implementation result:** Removed the L08 legacy atom tracking API and handler dispatch; reused the L06 current-origin tuple for code lens and codeLens/resolve with nil cursor; added exactly one `{:inlay_hint, client, buffer, version, tab_id, viewport_top, viewport_rows}` variant; made initial producers capture file path, version, tab, and the effective inlay viewport before sending; made codeLens/resolve inherit the accepted initial origin; removed empty decoration early returns.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`, `lib/minga_editor/handlers/lsp_event_handler.ex`, `lib/minga_editor/lsp_actions.ex`, `lib/minga_editor/lsp_decorations.ex`, `lib/minga_editor/state/lsp.ex`, `lib/minga_editor/state/lsp/pending_requests.ex`, `test/minga_editor/handlers/lsp_event_handler_test.exs`, `test/minga_editor/lsp_actions_test.exs`, `test/minga_editor/state/lsp/pending_requests_test.exs`, and `test/minga_editor/state/tab_switch_test.exs`.
+- **Focused validation:** Mandatory review corrections applied; residual resolve-title guard correction applied; final test-strength corrections applied; `mix test test/minga_editor/handlers/lsp_event_handler_test.exs` passed `49 tests`; full locked suite `mix test test/minga_editor/state/lsp/pending_requests_test.exs test/minga_editor/handlers/lsp_event_handler_test.exs test/minga_editor/lsp_actions_test.exs test/minga_editor/state/tab_switch_test.exs test/minga_editor/handlers/file_event_handler_test.exs test/minga_editor/handlers/session_restore_test.exs` passed `121 tests`; `make lint` passed after the production residuals.
+- **Broad validation:** `git diff --check` and `make lint` passed; `mix test.llm --max-cases 8` passed `58 doctests, 98 properties, 9,804 tests, 0 failures, 1 skipped, 616 excluded`. A preceding `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` run hit the unchanged load-sensitive `MingaAgent.SessionManagerTest` five-second call timeout; the same command passed on current main, and the isolated test plus the bounded-concurrency broad run passed on this branch.
+- **Reviewer verdict:** Initial correctness and Elixir reviews found response-shape totality and resolve-title blockers; all were corrected. Ponytail returned LEAN. Final acceptance found two test-strength blockers for effective-viewport selection and independent top/rows staleness; both were corrected, and targeted re-review returned PASS with `0.99` confidence.
+- **Production lines added/removed before roadmap evidence:** `+225/-106`, net `+119`, within the revised `+120` cap from `agent://L08BudgetDecision`.
+- **Test lines added/removed before roadmap evidence:** `+409/-111`, net `+298`, within the revised `+300` cap from `agent://L08BudgetDecision`.
+- **Concepts added:** L08 inlay-hint viewport identity with top and rows; code-lens origin inheritance for resolve requests.
+- **Concepts removed:** L08 legacy atom pending requests, legacy handler dispatch, send-before-version L08 producer paths, and empty-list decoration retention.
+- **Retained constraints:** No new module, process, registry, dependency, behaviour, protocol, configuration, public API, compatibility shim, metadata map, generation, URI/path pending field, code-lens ordinal, result cache, decoration id, or store owner change.
+- **Discoveries affecting later work:** None; L08 closes the LSP code-lens and inlay decoration stale/empty gap without changing diagnostics, semantic tokens, parser highlighting, completion/signature identity, transport, or frontend protocol behavior.
+- **Unresolved questions:** None.
+- **needs_replan:** false.
+- **PR URL:** RESERVED
+- **Implementation commit SHA:** RESERVED
+- **Merge SHA:** RESERVED
+- **Merge evidence:** RESERVED
+- **Findings resolved:** L08 is implemented as the approved ROUTE follow-on.
+- **Completion date:** 2026-07-24

--- a/lib/minga_editor/handlers/lsp_event_handler.ex
+++ b/lib/minga_editor/handlers/lsp_event_handler.ex
@@ -195,8 +195,19 @@ defmodule MingaEditor.Handlers.LspEventHandler do
          result
        ) do
     if response_current?(state, client, buffer, version, tab_id, cursor),
-      do: dispatch_current_response(kind, state, result),
+      do: dispatch_current_response(kind, state, result, {client, buffer, version, tab_id}),
       else: state
+  end
+
+  defp dispatch_pending_response(
+         {:inlay_hint, client, buffer, version, tab_id, viewport_top, viewport_rows},
+         state,
+         result
+       ) do
+    if response_current?(state, client, buffer, version, tab_id, nil) and
+         inlay_viewport_current?(state, viewport_top, viewport_rows),
+       do: dispatch_lsp_response(:inlay_hint, state, result),
+       else: state
   end
 
   defp dispatch_pending_response(
@@ -209,16 +220,6 @@ defmodule MingaEditor.Handlers.LspEventHandler do
 
   defp dispatch_pending_response({:semantic_tokens, buf_pid}, state, result) do
     SemanticTokenSync.handle_response(state, buf_pid, result)
-  end
-
-  defp dispatch_pending_response({:response, kind}, state, result)
-       when kind in [:code_lens, :code_lens_resolve, :inlay_hint] do
-    dispatch_lsp_response(kind, state, result)
-  end
-
-  defp dispatch_pending_response({:response, kind}, state, _result) do
-    Minga.Log.debug(:lsp, "Ignored legacy LSP response kind: #{inspect(kind)}")
-    state
   end
 
   @spec apply_completion_resolve_response(EditorState.t(), map(), term()) :: EditorState.t()
@@ -353,10 +354,13 @@ defmodule MingaEditor.Handlers.LspEventHandler do
     state
   end
 
-  defp dispatch_current_response(:hover, state, result),
+  defp dispatch_current_response(:hover, state, result, _origin),
     do: apply_traditional_lsp_response(:hover, state, result)
 
-  defp dispatch_current_response(kind, state, result),
+  defp dispatch_current_response(:code_lens, state, result, origin),
+    do: LspActions.handle_code_lens_response(state, result, origin)
+
+  defp dispatch_current_response(kind, state, result, _origin),
     do: dispatch_lsp_response(kind, state, result)
 
   @spec completion_resolve_current?(
@@ -408,6 +412,16 @@ defmodule MingaEditor.Handlers.LspEventHandler do
       match?([^client | _], Minga.LSP.SyncServer.clients_for_buffer(buffer)) and
       buffer_value(buffer, &Minga.Buffer.version/1) == version and
       (is_nil(cursor) or buffer_value(buffer, &Minga.Buffer.cursor/1) == cursor)
+  end
+
+  defp inlay_viewport_current?(state, top, rows) do
+    viewport =
+      MingaEditor.Session.State.current_viewport(
+        state.workspace,
+        state.frontend.terminal_viewport
+      )
+
+    viewport.top == top and viewport.rows == rows
   end
 
   defp buffer_value(buffer, fun) do

--- a/lib/minga_editor/lsp_actions.ex
+++ b/lib/minga_editor/lsp_actions.ex
@@ -615,20 +615,19 @@ defmodule MingaEditor.LspActions do
   defp request_code_lens_for_capability(state, _client, false, _buf), do: state
 
   defp request_code_lens_for_capability(state, client, true, buf) do
-    request_code_lens_for_path(state, client, Buffer.file_path(buf))
-  end
+    case capture_lsp_origin(state, buf) do
+      {:ok, path, version, tab_id} ->
+        uri = SyncServer.path_to_uri(path)
+        params = %{"textDocument" => %{"uri" => uri}}
+        ref = Client.request(client, "textDocument/codeLens", params)
+        track_response_request(state, ref, :code_lens, client, buf, version, tab_id, nil)
 
-  @spec request_code_lens_for_path(state(), pid(), String.t() | nil) :: state()
-  defp request_code_lens_for_path(state, _client, nil) do
-    NoticeWorkflow.publish(state, "Buffer has no file path")
-  end
+      :no_file ->
+        NoticeWorkflow.publish(state, "Buffer has no file path")
 
-  defp request_code_lens_for_path(state, client, path) do
-    uri = SyncServer.path_to_uri(path)
-    params = %{"textDocument" => %{"uri" => uri}}
-    ref = Client.request(client, "textDocument/codeLens", params)
-
-    track_response_request(state, ref, :code_lens)
+      :stale ->
+        state
+    end
   end
 
   # ── Inlay hints ───────────────────────────────────────────────────────────
@@ -659,27 +658,29 @@ defmodule MingaEditor.LspActions do
   defp request_inlay_hints_for_capability(state, _client, false, _buf), do: state
 
   defp request_inlay_hints_for_capability(state, client, true, buf) do
-    request_inlay_hints_for_path(state, client, Buffer.file_path(buf))
-  end
+    case capture_lsp_origin(state, buf) do
+      {:ok, path, version, tab_id} ->
+        viewport = effective_viewport(state)
+        top = viewport.top
+        rows = viewport.rows
+        uri = SyncServer.path_to_uri(path)
 
-  @spec request_inlay_hints_for_path(state(), pid(), String.t() | nil) :: state()
-  defp request_inlay_hints_for_path(state, _client, nil), do: state
+        params = %{
+          "textDocument" => %{"uri" => uri},
+          "range" => %{
+            "start" => %{"line" => top, "character" => 0},
+            "end" => %{"line" => top + rows, "character" => 0}
+          }
+        }
 
-  defp request_inlay_hints_for_path(state, client, path) do
-    uri = SyncServer.path_to_uri(path)
-    vp = state.frontend.terminal_viewport
+        ref = Client.request(client, "textDocument/inlayHint", params)
 
-    params = %{
-      "textDocument" => %{"uri" => uri},
-      "range" => %{
-        "start" => %{"line" => vp.top, "character" => 0},
-        "end" => %{"line" => vp.top + vp.rows, "character" => 0}
-      }
-    }
+        %{state | lsp: LSPState.remember_inlay_viewport(state.lsp, top)}
+        |> track_inlay_hint_request(ref, client, buf, version, tab_id, top, rows)
 
-    ref = Client.request(client, "textDocument/inlayHint", params)
-
-    track_response_request(state, ref, :inlay_hint)
+      _ ->
+        state
+    end
   end
 
   @inlay_hint_scroll_debounce_ms 200
@@ -720,14 +721,15 @@ defmodule MingaEditor.LspActions do
   defp cancel_timer(nil), do: :ok
   defp cancel_timer(timer), do: Process.cancel_timer(timer)
 
-  # Returns the viewport top for the active window. Proper Editor state uses the
-  # active window transition boundary; render-shaped maps carry the frontend viewport directly.
-  @spec effective_viewport_top(state()) :: non_neg_integer()
-  defp effective_viewport_top(%EditorState{} = state) do
-    MingaEditor.Session.State.current_viewport(state.workspace, state.frontend.terminal_viewport).top
+  @spec effective_viewport(state()) :: MingaEditor.Viewport.t()
+  defp effective_viewport(%EditorState{} = state) do
+    MingaEditor.Session.State.current_viewport(state.workspace, state.frontend.terminal_viewport)
   end
 
-  defp effective_viewport_top(state), do: state.frontend.terminal_viewport.top
+  defp effective_viewport(state), do: state.frontend.terminal_viewport
+
+  @spec effective_viewport_top(state()) :: non_neg_integer()
+  defp effective_viewport_top(state), do: effective_viewport(state).top
 
   # ── Response handlers ──────────────────────────────────────────────────────
 
@@ -1586,27 +1588,29 @@ defmodule MingaEditor.LspActions do
     PickerUI.open(state, LocationSource, %{locations: items, title: "Outgoing Calls"})
   end
 
-  # ── Code lens response ────────────────────────────────────────────────────
-
   @doc "Handles a textDocument/codeLens response (stores for rendering)."
   @spec handle_code_lens_response(state(), {:ok, term()} | {:error, term()}) :: state()
-  def handle_code_lens_response(state, {:error, _}) do
+  def handle_code_lens_response(state, result), do: handle_code_lens_response(state, result, nil)
+
+  @spec handle_code_lens_response(
+          state(),
+          {:ok, term()} | {:error, term()},
+          {pid(), pid(), non_neg_integer(), MingaEditor.State.Tab.id() | nil} | nil
+        ) :: state()
+  def handle_code_lens_response(state, {:error, _}, _origin) do
     Log.debug(:lsp, "Code lens request failed")
     state
   end
 
-  def handle_code_lens_response(state, {:ok, nil}), do: state
-  def handle_code_lens_response(state, {:ok, []}), do: state
+  def handle_code_lens_response(state, {:ok, nil}, _origin), do: clear_code_lenses(state)
+  def handle_code_lens_response(state, {:ok, []}, _origin), do: clear_code_lenses(state)
 
-  def handle_code_lens_response(state, {:ok, lenses}) when is_list(lenses) do
-    # Separate resolved lenses (have command) from unresolved ones (need codeLens/resolve)
+  def handle_code_lens_response(state, {:ok, lenses}, origin) when is_list(lenses) do
     {resolved, unresolved} =
       Enum.split_with(lenses, fn lens -> lens["command"] != nil end)
 
-    # Send resolve requests for lenses that have no command
-    state = resolve_code_lenses(state, unresolved)
+    state = resolve_code_lenses(state, unresolved, origin)
 
-    # Store resolved lenses for rendering
     parsed =
       Enum.map(resolved, fn lens ->
         range = lens["range"]
@@ -1623,6 +1627,13 @@ defmodule MingaEditor.LspActions do
     LspDecorations.apply_code_lenses(state)
   end
 
+  def handle_code_lens_response(state, {:ok, _}, _origin), do: state
+
+  defp clear_code_lenses(state) do
+    %{state | lsp: LSPState.set_code_lenses(state.lsp, [])}
+    |> LspDecorations.apply_code_lenses()
+  end
+
   # ── Inlay hint response ──────────────────────────────────────────────────
 
   @doc "Handles a textDocument/inlayHint response (stores for rendering)."
@@ -1632,8 +1643,8 @@ defmodule MingaEditor.LspActions do
     state
   end
 
-  def handle_inlay_hint_response(state, {:ok, nil}), do: state
-  def handle_inlay_hint_response(state, {:ok, []}), do: state
+  def handle_inlay_hint_response(state, {:ok, nil}), do: clear_inlay_hints(state)
+  def handle_inlay_hint_response(state, {:ok, []}), do: clear_inlay_hints(state)
 
   def handle_inlay_hint_response(state, {:ok, hints}) when is_list(hints) do
     parsed =
@@ -1662,6 +1673,13 @@ defmodule MingaEditor.LspActions do
       %{state | lsp: (&LSPState.set_inlay_hints(&1, parsed)).(state.lsp)}
 
     LspDecorations.apply_inlay_hints(state)
+  end
+
+  def handle_inlay_hint_response(state, {:ok, _}), do: state
+
+  defp clear_inlay_hints(state) do
+    %{state | lsp: LSPState.set_inlay_hints(state.lsp, [])}
+    |> LspDecorations.apply_inlay_hints()
   end
 
   # ── WorkspaceEdit application ─────────────────────────────────────────────
@@ -1857,13 +1875,43 @@ defmodule MingaEditor.LspActions do
     end
   end
 
-  defp track_response_request(state, ref, kind) do
-    %{state | lsp: LSPState.track_response_request(state.lsp, ref, kind)}
+  defp track_inlay_hint_request(
+         state,
+         ref,
+         client,
+         buffer,
+         version,
+         tab_id,
+         viewport_top,
+         viewport_rows
+       ) do
+    %{
+      state
+      | lsp:
+          LSPState.track_inlay_hint_request(
+            state.lsp,
+            ref,
+            client,
+            buffer,
+            version,
+            tab_id,
+            viewport_top,
+            viewport_rows
+          )
+    }
   end
 
   defp track_response_request(state, ref, kind, client, buffer, cursor) do
-    version = Buffer.version(buffer)
+    case capture_lsp_origin(state, buffer) do
+      {:ok, _path, version, tab_id} ->
+        track_response_request(state, ref, kind, client, buffer, version, tab_id, cursor)
 
+      _ ->
+        state
+    end
+  end
+
+  defp track_response_request(state, ref, kind, client, buffer, version, tab_id, cursor) do
     lsp =
       LSPState.track_response_request(
         state.lsp,
@@ -1872,13 +1920,20 @@ defmodule MingaEditor.LspActions do
         client,
         buffer,
         version,
-        active_tab_id(state),
+        tab_id,
         cursor
       )
 
     %{state | lsp: lsp}
+  end
+
+  defp capture_lsp_origin(state, buffer) do
+    case Buffer.file_path(buffer) do
+      nil -> :no_file
+      path -> {:ok, path, Buffer.version(buffer), active_tab_id(state)}
+    end
   catch
-    :exit, _ -> state
+    :exit, _ -> :stale
   end
 
   @spec mark_operation_running(state(), Operation.id(), String.t()) :: state()
@@ -2223,24 +2278,14 @@ defmodule MingaEditor.LspActions do
   defp severity_to_lsp(:info), do: 3
   defp severity_to_lsp(:hint), do: 4
 
-  # Sends codeLens/resolve requests for lenses that have no command yet.
-  @spec resolve_code_lenses(state(), [map()]) :: state()
-  defp resolve_code_lenses(state, []), do: state
+  defp resolve_code_lenses(state, [], _origin), do: state
+  defp resolve_code_lenses(state, _unresolved, nil), do: state
 
-  defp resolve_code_lenses(state, unresolved) do
-    buf = state.workspace.buffers.active
-
-    case lsp_client_for(state, buf) do
-      nil ->
-        state
-
-      client ->
-        Enum.reduce(unresolved, state, fn lens, st ->
-          ref = Client.request(client, "codeLens/resolve", lens)
-
-          track_response_request(st, ref, :code_lens_resolve)
-        end)
-    end
+  defp resolve_code_lenses(state, unresolved, {client, buffer, version, tab_id}) do
+    Enum.reduce(unresolved, state, fn lens, st ->
+      ref = Client.request(client, "codeLens/resolve", lens)
+      track_response_request(st, ref, :code_lens_resolve, client, buffer, version, tab_id, nil)
+    end)
   end
 
   @doc "Handles a codeLens/resolve response, merging the resolved lens into the existing list."
@@ -2256,10 +2301,7 @@ defmodule MingaEditor.LspActions do
     command = lens["command"]
 
     case command do
-      nil ->
-        state
-
-      %{"title" => title} ->
+      %{"title" => title} when is_binary(title) ->
         range = lens["range"]
         {line, _col} = extract_position(range["start"])
         entry = %{line: line, title: title, data: lens}
@@ -2268,6 +2310,9 @@ defmodule MingaEditor.LspActions do
           %{state | lsp: (&LSPState.append_code_lens(&1, entry)).(state.lsp)}
 
         LspDecorations.apply_code_lenses(state)
+
+      _ ->
+        state
     end
   end
 

--- a/lib/minga_editor/lsp_decorations.ex
+++ b/lib/minga_editor/lsp_decorations.ex
@@ -24,7 +24,6 @@ defmodule MingaEditor.LspDecorations do
   """
   @spec apply_code_lenses(state()) :: state()
   def apply_code_lenses(%{workspace: %{buffers: %{active: nil}}} = state), do: state
-  def apply_code_lenses(%{lsp: %{code_lenses: []}} = state), do: state
 
   def apply_code_lenses(
         %{workspace: %{buffers: %{active: buf}}, lsp: %{code_lenses: lenses}} = state
@@ -55,7 +54,6 @@ defmodule MingaEditor.LspDecorations do
   """
   @spec apply_inlay_hints(state()) :: state()
   def apply_inlay_hints(%{workspace: %{buffers: %{active: nil}}} = state), do: state
-  def apply_inlay_hints(%{lsp: %{inlay_hints: []}} = state), do: state
 
   def apply_inlay_hints(
         %{workspace: %{buffers: %{active: buf}}, lsp: %{inlay_hints: hints}} = state

--- a/lib/minga_editor/state/lsp.ex
+++ b/lib/minga_editor/state/lsp.ex
@@ -15,7 +15,6 @@ defmodule MingaEditor.State.LSP do
   alias MingaEditor.State.LSP.PendingRequests
 
   @type server_status :: :starting | :initializing | :ready | :crashed
-  @type legacy_response_kind :: :code_lens | :code_lens_resolve | :inlay_hint
   @type current_origin_response_kind ::
           :definition
           | :peek_definition
@@ -32,7 +31,8 @@ defmodule MingaEditor.State.LSP do
           | :prepare_outgoing_hierarchy
           | :incoming_calls
           | :outgoing_calls
-  @type response_kind :: legacy_response_kind() | current_origin_response_kind()
+          | :code_lens
+          | :code_lens_resolve
   @type pending_request :: PendingRequests.request()
   @type operation_request ::
           {:operation, :references | :rename, MingaEditor.State.Operation.id(),
@@ -129,11 +129,6 @@ defmodule MingaEditor.State.LSP do
   end
 
   # ── Pending requests and formatting operations ────────────────────────────
-  @spec track_response_request(t(), reference(), legacy_response_kind()) :: t()
-  def track_response_request(%__MODULE__{} = lsp, ref, kind) when is_reference(ref) do
-    {:ok, pending_requests} = PendingRequests.track_response(lsp.pending_requests, ref, kind)
-    %{lsp | pending_requests: pending_requests}
-  end
 
   @spec track_response_request(
           t(),
@@ -169,6 +164,41 @@ defmodule MingaEditor.State.LSP do
       )
 
     %{lsp | pending_requests: pending_requests}
+  end
+
+  @spec track_inlay_hint_request(
+          t(),
+          reference(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          MingaEditor.State.Tab.id() | nil,
+          non_neg_integer(),
+          pos_integer()
+        ) :: t()
+  def track_inlay_hint_request(
+        %__MODULE__{} = lsp,
+        ref,
+        client,
+        buffer,
+        version,
+        tab_id,
+        viewport_top,
+        viewport_rows
+      ) do
+    accept_pending(
+      lsp,
+      PendingRequests.track_inlay_hint(
+        lsp.pending_requests,
+        ref,
+        client,
+        buffer,
+        version,
+        tab_id,
+        viewport_top,
+        viewport_rows
+      )
+    )
   end
 
   @spec track_completion_result_request(

--- a/lib/minga_editor/state/lsp/pending_requests.ex
+++ b/lib/minga_editor/state/lsp/pending_requests.ex
@@ -12,9 +12,10 @@ defmodule MingaEditor.State.LSP.PendingRequests do
   @type operation_kind :: :references | :rename
   @type position :: {non_neg_integer(), non_neg_integer()}
   @type request ::
-          {:response, MingaEditor.State.LSP.legacy_response_kind()}
-          | {:response, MingaEditor.State.LSP.current_origin_response_kind(), pid(), pid(),
-             non_neg_integer(), MingaEditor.State.Tab.id() | nil, position() | nil}
+          {:response, MingaEditor.State.LSP.current_origin_response_kind(), pid(), pid(),
+           non_neg_integer(), MingaEditor.State.Tab.id() | nil, position() | nil}
+          | {:inlay_hint, pid(), pid(), non_neg_integer(), MingaEditor.State.Tab.id() | nil,
+             non_neg_integer(), pos_integer()}
           | {:completion_result, MingaEditor.CompletionTrigger.response_role(), pid(), pid(),
              non_neg_integer(), non_neg_integer(), position()}
           | {:completion_resolve, pid(), pid(), non_neg_integer(), non_neg_integer(), map()}
@@ -38,13 +39,6 @@ defmodule MingaEditor.State.LSP.PendingRequests do
   defguardp valid_cursor_guard(cursor)
             when is_tuple(cursor) and tuple_size(cursor) == 2 and is_integer(elem(cursor, 0)) and
                    elem(cursor, 0) >= 0 and is_integer(elem(cursor, 1)) and elem(cursor, 1) >= 0
-
-  @spec track_response(t(), reference(), MingaEditor.State.LSP.legacy_response_kind()) ::
-          {:ok, t()} | {:error, :duplicate_ref}
-  def track_response(%__MODULE__{} = pending, ref, kind)
-      when is_reference(ref) and kind in [:code_lens, :code_lens_resolve, :inlay_hint] do
-    track_request(pending, ref, {:response, kind})
-  end
 
   @spec track_completion_result(
           t(),
@@ -115,7 +109,14 @@ defmodule MingaEditor.State.LSP.PendingRequests do
         ) :: {:ok, t()} | {:error, :duplicate_ref}
   def track_response(%__MODULE__{} = pending, ref, kind, client, buffer, version, tab_id, nil)
       when is_reference(ref) and is_pid(client) and is_pid(buffer) and is_integer(version) and
-             kind in [:document_symbol, :workspace_symbol, :incoming_calls, :outgoing_calls] and
+             kind in [
+               :document_symbol,
+               :workspace_symbol,
+               :incoming_calls,
+               :outgoing_calls,
+               :code_lens,
+               :code_lens_resolve
+             ] and
              version >= 0 and (is_nil(tab_id) or (is_integer(tab_id) and tab_id > 0)) do
     track_request(pending, ref, {:response, kind, client, buffer, version, tab_id, nil})
   end
@@ -138,6 +139,37 @@ defmodule MingaEditor.State.LSP.PendingRequests do
              version >= 0 and (is_nil(tab_id) or (is_integer(tab_id) and tab_id > 0)) and
              valid_cursor_guard(cursor) do
     track_request(pending, ref, {:response, kind, client, buffer, version, tab_id, cursor})
+  end
+
+  @spec track_inlay_hint(
+          t(),
+          reference(),
+          pid(),
+          pid(),
+          non_neg_integer(),
+          MingaEditor.State.Tab.id() | nil,
+          non_neg_integer(),
+          pos_integer()
+        ) :: {:ok, t()} | {:error, :duplicate_ref}
+  def track_inlay_hint(
+        %__MODULE__{} = pending,
+        ref,
+        client,
+        buffer,
+        version,
+        tab_id,
+        viewport_top,
+        viewport_rows
+      )
+      when is_reference(ref) and is_pid(client) and is_pid(buffer) and is_integer(version) and
+             version >= 0 and (is_nil(tab_id) or (is_integer(tab_id) and tab_id > 0)) and
+             is_integer(viewport_top) and viewport_top >= 0 and is_integer(viewport_rows) and
+             viewport_rows > 0 do
+    track_request(
+      pending,
+      ref,
+      {:inlay_hint, client, buffer, version, tab_id, viewport_top, viewport_rows}
+    )
   end
 
   @spec track_hover_mouse(

--- a/test/minga_editor/handlers/lsp_event_handler_test.exs
+++ b/test/minga_editor/handlers/lsp_event_handler_test.exs
@@ -75,22 +75,32 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
                       code_lens_ref}
 
       assert_receive {:lsp_request, "textDocument/inlayHint",
-                      %{"textDocument" => %{"uri" => ^active_uri}}, inlay_hint_caller,
-                      inlay_hint_ref}
+                      %{
+                        "textDocument" => %{"uri" => ^active_uri},
+                        "range" => %{
+                          "start" => %{"line" => request_top},
+                          "end" => %{"line" => request_end}
+                        }
+                      }, inlay_hint_caller, inlay_hint_ref}
 
       assert code_lens_caller == self()
       assert inlay_hint_caller == self()
+      version = Minga.Buffer.version(active_buffer)
+      request_rows = request_end - request_top
+      assert {request_top, request_rows} == {7, 9}
 
       assert LSPState.fetch_pending_request(new_state.lsp, code_lens_ref) ==
-               {:ok, {:response, :code_lens}}
+               {:ok, {:response, :code_lens, active_client, active_buffer, version, nil, nil}}
 
       assert LSPState.fetch_pending_request(new_state.lsp, inlay_hint_ref) ==
-               {:ok, {:response, :inlay_hint}}
+               {:ok,
+                {:inlay_hint, active_client, active_buffer, version, nil, request_top,
+                 request_rows}}
 
       refute_receive {:lsp_request, _, %{"textDocument" => %{"uri" => ^inactive_uri}}, _, _}
     end
 
-    test "L06 producers capture current origin identity while L08 producers stay legacy" do
+    test "L06 and L08 producers capture current origin identity" do
       state = file_buffer_state("hello\n")
       client = start_fake_lsp_client()
       buffer = state.workspace.buffers.active
@@ -119,24 +129,21 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
           state
         end)
 
-      nil_cursor_kinds = [
-        {&MingaEditor.LspActions.document_symbols/1, "textDocument/documentSymbol",
-         :document_symbol},
-        {&MingaEditor.LspActions.workspace_symbols(&1, "query"), "workspace/symbol",
-         :workspace_symbol}
-      ]
-
-      Enum.each(nil_cursor_kinds, fn {producer, method, kind} ->
-        state = producer.(state)
-        assert_receive {:lsp_request, ^method, _params, _caller, ref}
-
-        assert LSPState.fetch_pending_request(state.lsp, ref) ==
-                 {:ok, {:response, kind, client, buffer, Minga.Buffer.version(buffer), nil, nil}}
-      end)
-
       state = MingaEditor.LspActions.code_lens(state)
       assert_receive {:lsp_request, "textDocument/codeLens", _params, _caller, ref}
-      assert LSPState.fetch_pending_request(state.lsp, ref) == {:ok, {:response, :code_lens}}
+
+      assert LSPState.fetch_pending_request(state.lsp, ref) ==
+               {:ok,
+                {:response, :code_lens, client, buffer, Minga.Buffer.version(buffer), nil, nil}}
+
+      state = MingaEditor.LspActions.inlay_hints(state)
+      assert_receive {:lsp_request, "textDocument/inlayHint", params, _caller, ref}
+      rows = params["range"]["end"]["line"] - params["range"]["start"]["line"]
+
+      assert LSPState.fetch_pending_request(state.lsp, ref) ==
+               {:ok,
+                {:inlay_hint, client, buffer, Minga.Buffer.version(buffer), nil,
+                 params["range"]["start"]["line"], rows}}
     end
 
     test "producer tracking ignores a response ref when origin buffer dies before version capture" do
@@ -152,6 +159,217 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
 
       assert_receive {:lsp_request, "workspace/symbol", _params, _caller, ref}
       assert LSPState.fetch_pending_request(new_state.lsp, ref) == :error
+    end
+
+    test "L08 producer sends nothing when origin buffer dies before capture completes" do
+      path = tmp_lsp_path("dead-code-lens")
+      File.write!(path, "dead\n")
+      on_exit(fn -> File.rm(path) end)
+      buffer = buffer_that_dies_on_version(path)
+      state = %{file_buffer_state("live\n") | workspace: workspace_for(buffer)}
+      client = start_fake_lsp_client()
+      register_lsp_client(buffer, client)
+
+      assert MingaEditor.LspActions.code_lens(state) == state
+      refute_receive {:lsp_request, "textDocument/codeLens", _params, _caller, _ref}
+    end
+
+    test "L08 stale responses are taken once without touching presentation" do
+      state = file_buffer_state("hello\n")
+      client = start_fake_lsp_client()
+      buffer = state.workspace.buffers.active
+      register_lsp_client(buffer, client)
+      ref = make_ref()
+
+      lsp =
+        state.lsp
+        |> LSPState.track_response_request(
+          ref,
+          :code_lens,
+          client,
+          buffer,
+          Minga.Buffer.version(buffer),
+          nil,
+          nil
+        )
+        |> LSPState.set_code_lenses([%{line: 0, title: "old"}])
+
+      other = start_supervised!({BufferProcess, content: "other"}, id: {:buffer, make_ref()})
+
+      stale = %{
+        state
+        | workspace: %{state.workspace | buffers: %Buffers{active: other, list: [other]}},
+          lsp: lsp
+      }
+
+      {result, effects} =
+        LspEventHandler.handle(stale, {:lsp_response, ref, {:ok, [code_lens_response("new")]}})
+
+      assert effects == [:render_now]
+      assert LSPState.fetch_pending_request(result.lsp, ref) == :error
+      assert result.lsp.code_lenses == [%{line: 0, title: "old"}]
+    end
+
+    test "inlay stale viewport top or rows is taken once without clearing hints" do
+      state = file_buffer_state("hello\n")
+      client = start_fake_lsp_client()
+      buffer = state.workspace.buffers.active
+      register_lsp_client(buffer, client)
+
+      for {top, rows} <- [{1, 24}, {0, 25}] do
+        ref = make_ref()
+
+        lsp =
+          state.lsp
+          |> LSPState.track_inlay_hint_request(
+            ref,
+            client,
+            buffer,
+            Minga.Buffer.version(buffer),
+            nil,
+            top,
+            rows
+          )
+          |> LSPState.set_inlay_hints([
+            %{line: 0, col: 0, label: "old", padding_left: false, padding_right: false}
+          ])
+
+        {result, effects} =
+          LspEventHandler.handle(
+            %{state | lsp: lsp},
+            {:lsp_response, ref, {:ok, [inlay_hint_response("new")]}}
+          )
+
+        assert effects == [:render_now]
+        assert LSPState.fetch_pending_request(result.lsp, ref) == :error
+        assert [%{label: "old"}] = result.lsp.inlay_hints
+      end
+    end
+
+    test "correlated L08 error nil and invalid shapes apply retained or clearing semantics" do
+      state = file_buffer_state("hello\n")
+      client = start_fake_lsp_client()
+      buffer = state.workspace.buffers.active
+      register_lsp_client(buffer, client)
+      version = Minga.Buffer.version(buffer)
+      code_error_ref = make_ref()
+      code_nil_ref = make_ref()
+      code_invalid_ref = make_ref()
+      inlay_invalid_ref = make_ref()
+
+      viewport =
+        MingaEditor.Session.State.current_viewport(
+          state.workspace,
+          state.frontend.terminal_viewport
+        )
+
+      lsp =
+        state.lsp
+        |> LSPState.set_code_lenses([%{line: 0, title: "old"}])
+        |> LSPState.set_inlay_hints([
+          %{line: 0, col: 0, label: "old", padding_left: false, padding_right: false}
+        ])
+        |> LSPState.track_response_request(
+          code_error_ref,
+          :code_lens,
+          client,
+          buffer,
+          version,
+          nil,
+          nil
+        )
+        |> LSPState.track_response_request(
+          code_nil_ref,
+          :code_lens,
+          client,
+          buffer,
+          version,
+          nil,
+          nil
+        )
+        |> LSPState.track_response_request(
+          code_invalid_ref,
+          :code_lens,
+          client,
+          buffer,
+          version,
+          nil,
+          nil
+        )
+        |> LSPState.track_inlay_hint_request(
+          inlay_invalid_ref,
+          client,
+          buffer,
+          version,
+          nil,
+          viewport.top,
+          viewport.rows
+        )
+
+      {after_error, _effects} =
+        LspEventHandler.handle(
+          %{state | lsp: lsp},
+          {:lsp_response, code_error_ref, {:error, "fail"}}
+        )
+
+      assert after_error.lsp.code_lenses == [%{line: 0, title: "old"}]
+
+      {after_invalid_code, _effects} =
+        LspEventHandler.handle(
+          after_error,
+          {:lsp_response, code_invalid_ref, {:ok, %{"bad" => true}}}
+        )
+
+      assert after_invalid_code.lsp.code_lenses == [%{line: 0, title: "old"}]
+
+      {after_invalid_inlay, _effects} =
+        LspEventHandler.handle(
+          after_invalid_code,
+          {:lsp_response, inlay_invalid_ref, {:ok, %{"bad" => true}}}
+        )
+
+      assert [%{label: "old"}] = after_invalid_inlay.lsp.inlay_hints
+
+      {after_nil, _effects} =
+        LspEventHandler.handle(after_invalid_inlay, {:lsp_response, code_nil_ref, {:ok, nil}})
+
+      assert after_nil.lsp.code_lenses == []
+    end
+
+    test "unresolved code lens resolve inherits accepted initial origin" do
+      state = file_buffer_state("hello\n")
+      client = start_fake_lsp_client()
+      buffer = state.workspace.buffers.active
+      register_lsp_client(buffer, client)
+      ref = make_ref()
+
+      state = %{
+        state
+        | lsp:
+            LSPState.track_response_request(
+              state.lsp,
+              ref,
+              :code_lens,
+              client,
+              buffer,
+              Minga.Buffer.version(buffer),
+              nil,
+              nil
+            )
+      }
+
+      {result, _effects} =
+        LspEventHandler.handle(
+          state,
+          {:lsp_response, ref, {:ok, [unresolved_code_lens_response()]}}
+        )
+
+      assert_receive {:lsp_request, "codeLens/resolve", _params, _caller, resolve_ref}
+
+      assert LSPState.fetch_pending_request(result.lsp, resolve_ref) ==
+               {:ok,
+                {:response, :code_lens_resolve, client, buffer, Minga.Buffer.version(buffer), nil,
+                 nil}}
     end
 
     test "references uses one structured identity from request through no-result response" do
@@ -1360,6 +1578,21 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
     %{state | lsp: (&LSPState.track_format(&1, operation)).(state.lsp)}
   end
 
+  defp code_lens_response(title) do
+    %{
+      "range" => %{"start" => %{"line" => 0, "character" => 0}},
+      "command" => %{"title" => title}
+    }
+  end
+
+  defp unresolved_code_lens_response do
+    %{"range" => %{"start" => %{"line" => 0, "character" => 0}}, "data" => %{"id" => 1}}
+  end
+
+  defp inlay_hint_response(label) do
+    %{"position" => %{"line" => 0, "character" => 0}, "label" => label}
+  end
+
   defp lsp_location(buffer, line, col) do
     %{
       "uri" => Minga.LSP.SyncServer.path_to_uri(Minga.Buffer.file_path(buffer)),
@@ -1437,17 +1670,26 @@ defmodule MingaEditor.Handlers.LspEventHandlerTest do
         id: {:buffer, make_ref()}
       )
 
+    active_viewport = %{MingaEditor.Viewport.new(9, 80, 0) | top: 7}
+    terminal_viewport = %{MingaEditor.Viewport.new(3, 80) | top: 2}
+    workspace = workspace_for(active_buffer)
+    active_window = Window.set_viewport(workspace.windows.map[1], active_viewport)
+
     workspace = %{
-      workspace_for(active_buffer)
+      workspace
       | buffers: %Buffers{
           active: active_buffer,
           list: [inactive_buffer, active_buffer],
           active_index: 1
-        }
+        },
+        windows: %{workspace.windows | map: %{1 => active_window}}
     }
 
     {%EditorState{
-       frontend: %MingaEditor.State.Frontend{port_manager: self()},
+       frontend: %MingaEditor.State.Frontend{
+         port_manager: self(),
+         terminal_viewport: terminal_viewport
+       },
        workspace: workspace
      }, inactive_path, active_path}
   end

--- a/test/minga_editor/lsp_actions_test.exs
+++ b/test/minga_editor/lsp_actions_test.exs
@@ -3,6 +3,7 @@ defmodule MingaEditor.LspActionsTest do
 
   use ExUnit.Case, async: true
 
+  alias Minga.Core.Decorations
   alias Minga.Buffer.Process, as: BufferProcess
   alias MingaEditor.HoverPopup
   alias MingaEditor.LspActions
@@ -227,11 +228,19 @@ defmodule MingaEditor.LspActionsTest do
       assert [%{title: "1 reference", line: 0}] = result.lsp.code_lenses
     end
 
-    test "code lens response leaves state unchanged for empty or failed responses" do
-      for response <- [{:error, "timeout"}, {:ok, nil}, {:ok, []}] do
-        state = fake_state()
-        assert LspActions.handle_code_lens_response(state, response) == state
-      end
+    test "code lens response clears accepted empty results and preserves failed presentation" do
+      buffer = start_buffer!("def hello do\n  :ok\nend")
+      state = fake_state_with_buffer(buffer)
+      state = LspActions.handle_code_lens_response(state, {:ok, [code_lens("old")]})
+      assert Decorations.virtual_texts_for_line(Minga.Buffer.decorations(buffer), 0) != []
+
+      failed = LspActions.handle_code_lens_response(state, {:error, "timeout"})
+      assert failed.lsp.code_lenses == state.lsp.code_lenses
+      assert Decorations.virtual_texts_for_line(Minga.Buffer.decorations(buffer), 0) != []
+
+      cleared = LspActions.handle_code_lens_response(state, {:ok, []})
+      assert cleared.lsp.code_lenses == []
+      assert Decorations.virtual_texts_for_line(Minga.Buffer.decorations(buffer), 0) == []
     end
 
     test "resolve response merges commands and preserves existing lenses on ignored responses" do
@@ -256,6 +265,16 @@ defmodule MingaEditor.LspActionsTest do
 
       state = fake_state()
       assert LspActions.handle_code_lens_resolve_response(state, {:ok, nil}) == state
+
+      ignored_resolves = [
+        put_in(code_lens("ignored")["command"], %{"command" => "refs"}),
+        put_in(code_lens("ignored")["command"], %{"title" => 42})
+      ]
+
+      for ignored <- ignored_resolves do
+        assert LspActions.handle_code_lens_resolve_response(existing_state, {:ok, ignored}) ==
+                 existing_state
+      end
     end
   end
 
@@ -294,13 +313,19 @@ defmodule MingaEditor.LspActionsTest do
       assert second.label == ": int"
     end
 
-    test "leaves existing hints unchanged for empty or failed responses" do
-      for response <- [{:error, "fail"}, {:ok, nil}, {:ok, []}] do
-        state = fake_state()
-        lsp = MingaEditor.State.LSP.set_inlay_hints(state.lsp, [%{line: 0}])
-        state = %{state | lsp: lsp}
-        assert LspActions.handle_inlay_hint_response(state, response) == state
-      end
+    test "clears accepted empty hints and preserves failed presentation" do
+      buffer = start_buffer!("x = 1 + 2")
+      state = fake_state_with_buffer(buffer)
+      state = LspActions.handle_inlay_hint_response(state, {:ok, [inlay_hint(": int")]})
+      assert Decorations.virtual_texts_for_line(Minga.Buffer.decorations(buffer), 0) != []
+
+      failed = LspActions.handle_inlay_hint_response(state, {:error, "fail"})
+      assert failed.lsp.inlay_hints == state.lsp.inlay_hints
+      assert Decorations.virtual_texts_for_line(Minga.Buffer.decorations(buffer), 0) != []
+
+      cleared = LspActions.handle_inlay_hint_response(state, {:ok, nil})
+      assert cleared.lsp.inlay_hints == []
+      assert Decorations.virtual_texts_for_line(Minga.Buffer.decorations(buffer), 0) == []
     end
 
     test "schedules hints only when a Zig viewport changes, replacing existing timers" do
@@ -418,6 +443,10 @@ defmodule MingaEditor.LspActionsTest do
       "range" => range(0, 0, 5),
       "command" => %{"title" => title, "command" => "refs"}
     }
+  end
+
+  defp inlay_hint(label) do
+    %{"position" => %{"line" => 0, "character" => 2}, "label" => label, "kind" => 1}
   end
 
   defp start_buffer!(content) do

--- a/test/minga_editor/state/lsp/pending_requests_test.exs
+++ b/test/minga_editor/state/lsp/pending_requests_test.exs
@@ -68,57 +68,32 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
     assert PendingRequests.fetch(pending, ref) == :error
   end
 
-  test "current-origin response accepts nil cursor only for buffer-scoped L06 kinds" do
+  test "current-origin response accepts nil cursor for L06 and code lens kinds" do
     client = spawn_process()
     buffer = spawn_process()
 
-    assert {:ok, pending} =
-             PendingRequests.track_response(
-               PendingRequests.new(),
-               make_ref(),
-               :document_symbol,
-               client,
-               buffer,
-               7,
-               nil,
-               nil
-             )
+    for kind <- [
+          :document_symbol,
+          :workspace_symbol,
+          :incoming_calls,
+          :outgoing_calls,
+          :code_lens,
+          :code_lens_resolve
+        ] do
+      assert {:ok, pending} =
+               PendingRequests.track_response(
+                 PendingRequests.new(),
+                 make_ref(),
+                 kind,
+                 client,
+                 buffer,
+                 7,
+                 nil,
+                 nil
+               )
 
-    assert {:ok, pending} =
-             PendingRequests.track_response(
-               pending,
-               make_ref(),
-               :workspace_symbol,
-               client,
-               buffer,
-               7,
-               nil,
-               nil
-             )
-
-    assert {:ok, pending} =
-             PendingRequests.track_response(
-               pending,
-               make_ref(),
-               :incoming_calls,
-               client,
-               buffer,
-               7,
-               nil,
-               nil
-             )
-
-    assert {:ok, _pending} =
-             PendingRequests.track_response(
-               pending,
-               make_ref(),
-               :outgoing_calls,
-               client,
-               buffer,
-               7,
-               nil,
-               nil
-             )
+      assert map_size(pending.by_ref) == 1
+    end
 
     cursor_required_kind = String.to_existing_atom("definition")
 
@@ -136,7 +111,7 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
     end
   end
 
-  test "L07 response tracking uses typed variants while L08 legacy atoms remain" do
+  test "L07 responses and L08 inlay use typed variants" do
     client = spawn_process()
     buffer = spawn_process()
     raw_item = %{"label" => "a"}
@@ -167,23 +142,15 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
     assert {:ok, pending} =
              PendingRequests.track_signature_help(pending, make_ref(), client, buffer, 1, {3, 4})
 
-    assert {:ok, pending} = PendingRequests.track_response(pending, make_ref(), :code_lens)
+    inlay_ref = make_ref()
 
     assert {:ok, pending} =
-             PendingRequests.track_response(pending, make_ref(), :code_lens_resolve)
+             PendingRequests.track_inlay_hint(pending, inlay_ref, client, buffer, 1, nil, 5, 24)
 
-    assert {:ok, _pending} = PendingRequests.track_response(pending, make_ref(), :inlay_hint)
+    assert PendingRequests.fetch(pending, inlay_ref) ==
+             {:ok, {:inlay_hint, client, buffer, 1, nil, 5, 24}}
 
-    completion_resolve = String.to_existing_atom("completion_resolve")
-    signature_help = String.to_existing_atom("signature_help")
-
-    assert_raise FunctionClauseError, fn ->
-      PendingRequests.track_response(PendingRequests.new(), make_ref(), completion_resolve)
-    end
-
-    assert_raise FunctionClauseError, fn ->
-      PendingRequests.track_response(PendingRequests.new(), make_ref(), signature_help)
-    end
+    refute function_exported?(PendingRequests, :track_response, 3)
   end
 
   test "current-origin response rejects invalid version and cursor" do
@@ -215,11 +182,38 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
         {-1, 0}
       )
     end
+
+    assert_raise FunctionClauseError, fn ->
+      PendingRequests.track_inlay_hint(
+        PendingRequests.new(),
+        make_ref(),
+        client,
+        buffer,
+        0,
+        nil,
+        -1,
+        1
+      )
+    end
+
+    assert_raise FunctionClauseError, fn ->
+      PendingRequests.track_inlay_hint(
+        PendingRequests.new(),
+        make_ref(),
+        client,
+        buffer,
+        0,
+        nil,
+        0,
+        0
+      )
+    end
   end
 
   test "rejects duplicate refs across L07 L08 response operation and format requests" do
     ref = make_ref()
     operation = operation(spawn_process(), ref)
+
     pending = PendingRequests.new()
 
     assert {:ok, pending} =
@@ -234,7 +228,8 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
                {0, 0}
              )
 
-    assert PendingRequests.track_response(pending, ref, :code_lens) == {:error, :duplicate_ref}
+    assert PendingRequests.track_inlay_hint(pending, ref, self(), spawn_process(), 0, nil, 0, 1) ==
+             {:error, :duplicate_ref}
 
     assert PendingRequests.track_operation(pending, ref, :references, 1, nil) ==
              {:error, :duplicate_ref}
@@ -259,15 +254,28 @@ defmodule MingaEditor.State.LSP.PendingRequestsTest do
 
     assert {:ok, pending} = PendingRequests.track_operation(pending, other_ref, :rename, 2, 20)
 
-    assert {:ok, pending} = PendingRequests.track_response(pending, response_ref, :code_lens)
+    assert {:ok, pending} =
+             PendingRequests.track_response(
+               pending,
+               response_ref,
+               :code_lens,
+               spawn_process(),
+               spawn_process(),
+               0,
+               nil,
+               nil
+             )
 
     assert {:ok, pending} = PendingRequests.track_format(pending, format)
 
-    assert {requests, pending} = PendingRequests.take_operations_for_tab(pending, 10)
-    assert requests == [{:operation, :references, 1, 10}]
+    {_requests, pending} = PendingRequests.take_operations_for_tab(pending, 10)
+
     assert PendingRequests.fetch(pending, current_ref) == :error
     assert PendingRequests.fetch(pending, other_ref) == {:ok, {:operation, :rename, 2, 20}}
-    assert PendingRequests.fetch(pending, response_ref) == {:ok, {:response, :code_lens}}
+
+    assert {:ok, {:response, :code_lens, _client, _buffer, 0, nil, nil}} =
+             PendingRequests.fetch(pending, response_ref)
+
     assert PendingRequests.fetch_format(pending, format.ref) == {:ok, format}
   end
 

--- a/test/minga_editor/state/tab_switch_test.exs
+++ b/test/minga_editor/state/tab_switch_test.exs
@@ -395,26 +395,45 @@ defmodule MingaEditor.State.TabSwitchTest do
       assert new_state.render.layout == nil
     end
 
-    test "L08 legacy pending requests are Editor-global across tab switches" do
-      {state, _buf1, _buf2} = state_with_two_file_tabs()
+    test "L08 current-origin requests are Editor-global across tab switches" do
+      {state, buf1, _buf2} = state_with_two_file_tabs()
       tb = state.shell_runtime.state.tab_bar
       current_id = tb.active_id
-      target_id = Enum.find(tb.tabs, &(&1.id != tb.active_id)).id
-      ref = make_ref()
+      target_id = Enum.find(tb.tabs, &(&1.id != current_id)).id
+      client = self()
+      code_ref = make_ref()
+      inlay_ref = make_ref()
 
-      state = %{state | lsp: LSPState.track_response_request(state.lsp, ref, :code_lens)}
+      state = %{
+        state
+        | lsp:
+            state.lsp
+            |> LSPState.track_response_request(
+              code_ref,
+              :code_lens,
+              client,
+              buf1,
+              0,
+              current_id,
+              nil
+            )
+            |> LSPState.track_inlay_hint_request(inlay_ref, client, buf1, 0, current_id, 0, 24)
+      }
 
       {switched, _effects} = EditorState.switch_tab(state, target_id)
 
-      assert LSPState.fetch_pending_request(switched.lsp, ref) ==
-               {:ok, {:response, :code_lens}}
+      assert {:ok, {:response, :code_lens, ^client, ^buf1, 0, ^current_id, nil}} =
+               LSPState.fetch_pending_request(switched.lsp, code_ref)
+
+      assert {:ok, {:inlay_hint, ^client, ^buf1, 0, ^current_id, 0, 24}} =
+               LSPState.fetch_pending_request(switched.lsp, inlay_ref)
 
       refute :lsp_pending in TabBar.get(switched.shell_runtime.state.tab_bar, current_id).context.present_fields
 
       {switched_back, _effects} = EditorState.switch_tab(switched, current_id)
 
-      assert LSPState.fetch_pending_request(switched_back.lsp, ref) ==
-               {:ok, {:response, :code_lens}}
+      assert {:ok, {:response, :code_lens, ^client, ^buf1, 0, ^current_id, nil}} =
+               LSPState.fetch_pending_request(switched_back.lsp, code_ref)
 
       refute :lsp_pending in TabBar.get(switched_back.shell_runtime.state.tab_bar, target_id).context.present_fields
     end


### PR DESCRIPTION
# TL;DR

Prevent stale code-lens and inlay-hint responses from mutating a different buffer, tab, version, client, or viewport than the request that produced them.

## Context

Editor-global LSP correlation already had one typed owner after the L06 and L07 work, but code-lens and inlay-hint requests still used legacy atom tracking. Their responses could be applied against current editor state rather than the captured request origin. Empty accepted responses also retained stale decorations.

## Changes

- Reuse the current-origin pending-request shape for code lens and codeLens/resolve.
- Add one inlay-hint pending variant carrying effective viewport top and rows.
- Capture request identity before sending and skip dead captures.
- Take each response once, reject stale origins, and preserve existing presentation for failed or invalid results.
- Clear code-lens and inlay stores plus matching decoration groups for accepted empty results.
- Remove the L08 legacy atom tracking and handler paths.
- Record W119 implementation and review evidence in the lifecycle roadmap.

## Verification

- `git diff --check`
- `make lint`
- Focused L08 suite: 121 tests passed
- `mix test.llm --max-cases 8`: 58 doctests, 98 properties, 9,804 tests, 0 failures, 1 skipped
- Final targeted reviewer recheck: PASS, 0.99 confidence

## Review notes

The production diff is net +119 lines, within the architecture-approved +120 cap. The test diff is net +298 lines, within the +300 cap. L06 ordinary response correlation and L07 completion/signature identity remain on their existing paths.