### PR TITLE
docs(editor): verify L08 routed follow-on

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -27,7 +27,7 @@ Current accepted inventory:
 
 - **VERIFIED:** L01, L02, L04, L05, L10, L11, L12, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30; D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40; S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S22, S23, S25, S26, S28, S29, S32, S33, S34, S35; E02, E03, E05, E08; ES03, ES05, ES07, ES08, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES21, ES24.
 - **DROPPED:** S21. W088 records the merged decision and evidence.
-- **VERIFIED routed follow-on:** ES06, L06, L07.
+- **VERIFIED routed follow-on:** ES06, L06, L07, L08.
 - **CANDIDATE, lifecycle:** (none)
 - **CANDIDATE, deletion:** (none)
 - **CANDIDATE, shrink:** (none)
@@ -4789,7 +4789,7 @@ New split and float popup windows initialize their viewport metadata from `state
 
 ### W119/L08: Validate code lens and inlay decorations against captured origin
 
-- **Status:** IMPLEMENTED
+- **Status:** VERIFIED
 - **Audit ID:** L08
 - **Decision:** APPROVE_REVISED_CAP, one clean cutover from legacy L08 atoms to captured current-origin code-lens tracking plus one viewport-bearing inlay-hint variant.
 - **Planning profile:** `L08RoutePlanner`, editor-lifecycle-planner, read-only; superseded by corrected lock from `agent://L08PlanVerifier`.
@@ -4810,9 +4810,9 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Discoveries affecting later work:** None; L08 closes the LSP code-lens and inlay decoration stale/empty gap without changing diagnostics, semantic tokens, parser highlighting, completion/signature identity, transport, or frontend protocol behavior.
 - **Unresolved questions:** None.
 - **needs_replan:** false.
-- **PR URL:** RESERVED
-- **Implementation commit SHA:** RESERVED
-- **Merge SHA:** RESERVED
-- **Merge evidence:** RESERVED
-- **Findings resolved:** L08 is implemented as the approved ROUTE follow-on.
-- **Completion date:** 2026-07-24
+- **PR URL:** https://github.com/jsmestad/minga/pull/3234
+- **Implementation commit SHA:** `a371e7c1960b8d256afb361ed804b9e062dbf433`.
+- **Merge SHA:** `5ac70382cf1bdf66edd00076ff7bdd15649e7ef7`.
+- **Merge evidence:** PR #3234 merged after required CI run `30138455844` passed; current main contains the implementation and test tree reviewed at `a371e7c1960b8d256afb361ed804b9e062dbf433`.
+- **Findings resolved:** L08 is fully resolved as the approved ROUTE follow-on.
+- **Completion date:** 2026-07-25


### PR DESCRIPTION
# TL;DR

Mark W119/L08 verified after the implementation merged with required CI passing.

## Changes

- Move W119/L08 from IMPLEMENTED to VERIFIED.
- Add L08 to the verified routed follow-on inventory.
- Record PR #3234, implementation SHA, merge SHA, CI run, completion date, and resolved finding status.

## Verification

- `git diff --check`
- `make lint`
- Final roadmap reviewer: PASS with 0.99 confidence
