### PR TITLE
docs(editor): verify ES02 render intent

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -27,7 +27,7 @@ Current accepted inventory:
 
 - **VERIFIED:** L01, L02, L04, L05, L10, L11, L12, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30; D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40; S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S22, S23, S25, S26, S28, S29, S32, S33, S34, S35; E02, E03, E05, E08; ES03, ES05, ES07, ES08, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES21, ES24.
 - **DROPPED:** S21. W088 records the merged decision and evidence.
-- **VERIFIED routed follow-on:** ES06, ES20, L06, L07, L08, L09, L17.
+- **VERIFIED routed follow-on:** ES02, ES06, ES19, ES20, L06, L07, L08, L09, L17.
 - **CANDIDATE, lifecycle:** (none)
 - **CANDIDATE, deletion:** (none)
 - **CANDIDATE, shrink:** (none)
@@ -4996,7 +4996,7 @@ New split and float popup windows initialize their viewport metadata from `state
 
 ### W126/ES02: Preserve strict nested render Intent through materialization
 
-- **Status:** IMPLEMENTED
+- **Status:** VERIFIED
 - **Audit ID:** ES02
 - **Decision:** APPROVE_DIRECT, `RenderPipeline.Intent` remains the sole cache-free Editor-to-Renderer contract; renderer materialization preserves nested `Intent`, `FrameIntent`, `WorkspaceIntent`, and `WindowIntent` identity and keeps renderer-owned caches only on `RenderPipeline.Input`.
 - **Planning profile:** `ES02Planner`, editor-lifecycle-planner, locked READY at baseline `b3f552749a65b1c8e2dfbed1a5ff3e731782f303`.
@@ -5017,3 +5017,10 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Discoveries affecting later work:** Unconstrained high-parallel full-suite runs can still expose unrelated async timing flakes in agent provider/session tests; low-concurrency quick and full `test.llm` runs are green. Existing test support shell layout callbacks need to handle strict render input anywhere they are used by render-model or emit fixtures.
 - **Unresolved questions:** None.
 - **needs_replan:** false.
+- **PR URL:** https://github.com/jsmestad/minga/pull/3248
+- **Implementation commit SHA:** `413bb6b9602fbda4b5851f42a3de562fa64ae67f`
+- **Merge SHA:** `24fc5ee0b6be7af03573f7c4f074fc0d3c3f1993`
+- **CI run:** https://github.com/jsmestad/minga/actions/runs/30166982260
+- **Reviewer verdict:** `PASS` at `0.99` confidence after the fresh-active-tab Chrome projection blocker was corrected and targeted re-review confirmed both tab and workspace semantic models consume the live nested buffer owner.
+- **Findings resolved:** ES02 is complete. Accepted render intent remains strict and nested through renderer materialization, renderer-local caches and windows retain their owners, and emit/layout/focus/chrome consumers no longer depend on broad Editor-shaped transfer maps.
+- **Completion date:** 2026-07-25


### PR DESCRIPTION
## TL;DR

Mark W126/ES02 verified after PR #3248 merged with required CI passing.

## Evidence

- Implementation SHA: `413bb6b9602fbda4b5851f42a3de562fa64ae67f`
- Merge SHA: `24fc5ee0b6be7af03573f7c4f074fc0d3c3f1993`
- CI run: https://github.com/jsmestad/minga/actions/runs/30166982260
- Final roadmap reviewer: PASS with 0.99 confidence

## Verification

- `git diff --check`
- `make lint`