### PR TITLE
docs(editor): verify ES01 window carrier

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -27,7 +27,7 @@ Current accepted inventory:
 
 - **VERIFIED:** L01, L02, L04, L05, L10, L11, L12, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30; D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40; S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S22, S23, S25, S26, S28, S29, S32, S33, S34, S35; E02, E03, E05, E08; ES03, ES05, ES07, ES08, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES21, ES24.
 - **DROPPED:** S21. W088 records the merged decision and evidence.
-- **VERIFIED routed follow-on:** ES02, ES06, ES19, ES20, L06, L07, L08, L09, L17.
+- **VERIFIED routed follow-on:** ES01, ES02, ES06, ES19, ES20, L06, L07, L08, L09, L17.
 - **DROPPED routed follow-on:** S30. W127 records why ES02 fully resolved the route.
 - **CANDIDATE, lifecycle:** (none)
 - **CANDIDATE, deletion:** (none)
@@ -5047,7 +5047,7 @@ New split and float popup windows initialize their viewport metadata from `state
 
 ### W128/ES01: Move render-window materialization to the renderer owner
 
-- **Status:** IMPLEMENTED
+- **Status:** VERIFIED
 - **Audit ID:** ES01
 - **Decision:** APPROVE_DIRECT, keep `WindowIntent` as the cache-free ten-field Editor-to-Renderer DTO, move materialization into `Renderer.RenderWindow`, and delete renderer working fields with no renderer consumer.
 - **Planning profile:** `ES01Planner`, editor-lifecycle-planner, locked READY at baseline `907eeef1f67251f232ae0991eced1be2f98f75fa`.
@@ -5068,3 +5068,9 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Unresolved questions:** None.
 - **needs_replan:** false.
 - **Completion date:** 2026-07-25
+- **PR URL:** https://github.com/jsmestad/minga/pull/3251
+- **Implementation commit SHA:** `58ab60834a10df6e37b2b05bcc4b8e34693883e6`
+- **Merge SHA:** `a47d9b9e3fe0eabcc8f909841a12e17905b5dd47`
+- **CI run:** https://github.com/jsmestad/minga/actions/runs/30169648170
+- **Reviewer verdict:** `PASS` at `0.99` confidence after the cache-source mutation proof and exact WindowIntent domain types passed targeted correctness and Elixir rechecks.
+- **Findings resolved:** ES01 is complete. Per-window transfer and renderer working values have explicit separate owners, all required fields are enforced, renderer cache provenance is preserved, and no callback or receipt boundary was widened.


### PR DESCRIPTION
## TL;DR

Mark W128/ES01 verified after PR #3251 merged with required CI passing.

## Evidence

- Implementation: `58ab60834a10df6e37b2b05bcc4b8e34693883e6`
- Merge: `a47d9b9e3fe0eabcc8f909841a12e17905b5dd47`
- CI: https://github.com/jsmestad/minga/actions/runs/30169648170
- Reviewer: PASS with 0.99 confidence

## Verification

- `git diff --check`
- `make lint`