### PR TITLE
refactor(input): isolate key-local routing

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -28,6 +28,7 @@ Current accepted inventory:
 - **VERIFIED:** L01, L02, L04, L05, L10, L11, L12, L13, L14, L15, L16, L19, L20, L22, L23, L24, L25, L26, L27, L28, L29, L30; D05, D06, D08, D09, D10, D11, D13, D14, D15, D18, D19, D20, D21, D22, D23, D24, D25, D26, D27, D28, D29, D30, D31, D32, D34, D35, D36, D39, D40; S03, S04, S05, S06, S07, S09, S11, S12, S14, S15, S18, S20, S22, S23, S25, S26, S28, S29, S32, S33, S34, S35; E02, E03, E05, E08; ES03, ES05, ES07, ES08, ES09, ES10, ES12, ES14, ES16, ES17, ES18, ES21, ES24.
 - **DROPPED:** S21. W088 records the merged decision and evidence.
 - **VERIFIED routed follow-on:** ES01, ES02, ES06, ES19, ES20, L06, L07, L08, L09, L17.
+- **IMPLEMENTED routed follow-on:** S08. W129 records implementation evidence; it is not VERIFIED until merge.
 - **DROPPED routed follow-on:** S30. W127 records why ES02 fully resolved the route.
 - **CANDIDATE, lifecycle:** (none)
 - **CANDIDATE, deletion:** (none)
@@ -5074,3 +5075,28 @@ New split and float popup windows initialize their viewport metadata from `state
 - **CI run:** https://github.com/jsmestad/minga/actions/runs/30169648170
 - **Reviewer verdict:** `PASS` at `0.99` confidence after the cache-source mutation proof and exact WindowIntent domain types passed targeted correctness and Elixir rechecks.
 - **Findings resolved:** ES01 is complete. Per-window transfer and renderer working values have explicit separate owners, all required fields are enforced, renderer cache provenance is preserved, and no callback or receipt boundary was widened.
+
+
+### W129/S08: Complete key-local Router seam for GUI space-leader replay
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** S08
+- **Planning profile:** `S08Planner`, editor-lifecycle-planner, read-only.
+- **Implementation profile:** `S08Worker`, editor-lifecycle-worker, no delegation.
+- **Ready provenance:** Locked by `agent://S08Planner` for baseline `3e0b78dae40448c83e5b2258a28064d5bcdaac76`; the locked owner is `MingaEditor.Input.Router` for complete key-local routing, with `MingaEditor.handle_info/2` and `Router.post_action_housekeeping/2` retaining universal GUI housekeeping ownership.
+- **Observable result:** `Router.route_key/3` now performs only key-local work: notice preclear, pending-quit key semantics, shell availability, overlay/surface handler routing, keystroke history, and keyboard-specific completion/signature-help handling. `Router.dispatch/3` remains the full keyboard event wrapper around `capture_snapshot/1`, `route_key/3`, and one `post_action_housekeeping/2` call. GUI space-leader fallback and retract replay now call `route_key/3`, so the existing GUI action envelope submits universal render/scheduling housekeeping once.
+- **Failure reproduction:** Before the correction, the new focused tests failed in two observable ways: `Router.route_key/3` was undefined, and `GuiActionHandler.dispatch(state, {:space_leader_chord, ?j, 0})` advanced `latest_intent_revision` from `0` to `1` before the outer GUI housekeeping call. This proved the replay path entered full `Router.dispatch/3` and rendered inside the semantic GUI action handler path.
+- **Implementation result:** Added the single public `Router.route_key/3` seam by moving the existing key-local preclear, pending-quit, shell routing, history, and completion handling before universal housekeeping; rebuilt `Router.dispatch/3` as a small full-key-event wrapper; removed the now-obsolete `post_key_housekeeping/7` wrapper; changed `CUA.SpaceLeader.dispatch_key_normally/3` to call `route_key/3`; left protocol decoding, Swift/Go frontend behavior, keymap lookup, shell handler ordering, TUI space-leader timing, and `GuiActionHandler` action selection unchanged.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`; `lib/minga_editor/input/router.ex`; `lib/minga_editor/input/cua/space_leader.ex`; `test/minga_editor/input/router_test.exs`; `test/minga_editor/handlers/gui_action_handler_test.exs`.
+- **Focused validation:** `mix test test/minga_editor/input/router_test.exs test/minga_editor/handlers/gui_action_handler_test.exs` first failed with the undefined `Router.route_key/3` and premature GUI space-leader render revision, then passed `58` tests after the correction. The final focused run after adding the completion preservation edge passed `59` tests.
+- **Broad validation:** `make lint` passed changed-source Credo, compile, format, and incremental Dialyzer with `Total errors: 0`. Final constrained validation `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` passed `58 doctests, 98 properties, 9831 tests, 0 failures, 1 skipped, 616 excluded`. The run still emitted existing parser manager teardown warnings, one existing LSP stale-buffer warning, and one `erl_child_setup` warning, but all modules and tests passed.
+- **Diff and residue validation:** `git diff --check` produced no output. Focused residue search found no `Router.dispatch/3`, `post_action_housekeeping/2`, `do_render/1`, document-highlight scheduling, or inlay scheduling in `CUA.SpaceLeader` or `GuiActionHandler`; no `post_key_housekeeping` reference remains; the only new router seam is `MingaEditor.Input.Router.route_key/3`, and GUI replay calls that seam.
+- **Production lines added/removed before roadmap evidence:** `+32/-85`, net `-53`, within the locked production cap of net `<= +25`; per-file numstat: `lib/minga_editor/input/router.ex 31/84`, `lib/minga_editor/input/cua/space_leader.ex 1/1`.
+- **Test lines added/removed before roadmap evidence:** `+90/-0`; per-file numstat: `test/minga_editor/input/router_test.exs 64/0`, `test/minga_editor/handlers/gui_action_handler_test.exs 26/0`.
+- **Concepts added:** One key-local Router seam, `MingaEditor.Input.Router.route_key/3`, as explicitly permitted by the locked plan. No new module, process, dependency, behaviour, protocol, registry, configuration, compatibility shim, event struct, action result type, data representation, or public API family was added.
+- **Concepts removed:** Removed GUI space-leader replay's dependency on the full key event dispatch path, the resulting duplicate universal housekeeping/render submission, and the obsolete post-key housekeeping wrapper.
+- **Retained constraints:** Universal housekeeping remains solely in `Router.post_action_housekeeping/2`; `MingaEditor.handle_info/2` remains the GUI event envelope; `GuiActionHandler` remains semantic GUI action selection only; `CUA.SpaceLeader` remains stateless GUI space-leader interpretation and replay; pending-quit yes/no/Escape and ignored-key semantics, shell handler order, keystroke history, keyboard completion/signature-help handling, protocol decoding, keymap semantics, and TUI space-leader ownership are retained.
+- **Discoveries affecting later work:** None. The locked owner, contract, scope, dependency, and production-line budget remained valid; no replan trigger or overlapping implementation dependency was found.
+- **Unresolved questions:** None.
+- **needs_replan:** false.
+- **Completion date:** 2026-07-25

--- a/lib/minga_editor/input/cua/space_leader.ex
+++ b/lib/minga_editor/input/cua/space_leader.ex
@@ -132,7 +132,7 @@ defmodule MingaEditor.Input.CUA.SpaceLeader do
   @spec dispatch_key_normally(EditorState.t(), non_neg_integer(), non_neg_integer()) ::
           EditorState.t()
   defp dispatch_key_normally(state, codepoint, modifiers) do
-    MingaEditor.Input.Router.dispatch(state, codepoint, modifiers)
+    MingaEditor.Input.Router.route_key(state, codepoint, modifiers)
   end
 
   @spec execute_command(EditorState.t(), atom() | tuple()) :: EditorState.t()

--- a/lib/minga_editor/input/router.ex
+++ b/lib/minga_editor/input/router.ex
@@ -1,17 +1,15 @@
 defmodule MingaEditor.Input.Router do
   @moduledoc """
   Dispatches key presses through the active shell's overlay and surface
-  handler lists, then runs centralized post-action housekeeping.
+  handler lists.
 
-  `dispatch/3` asks the active shell for ordered `overlay` handlers first.
-  The first handler that returns `{:handled, state}` stops dispatch; if all
-  overlays pass through, the router repeats the same walk for the shell's
-  `surface` handlers.
+  `route_key/3` runs only key-local routing: notice preclear, pending-quit
+  key handling, shell availability, overlay/surface handler walking,
+  keystroke history, and keyboard-specific completion/signature-help updates.
 
-  After dispatch, `post_key_housekeeping/6` runs keyboard-specific steps
-  (completion triggering) then delegates to `post_action_housekeeping/2`
-  for the universal pipeline shared by all input paths (keyboard, mouse,
-  GUI actions).
+  `dispatch/3` is the full keyboard event convenience wrapper: it captures the
+  pre-action snapshot, calls `route_key/3`, then runs universal housekeeping
+  through `post_action_housekeeping/2`.
   """
 
   alias Minga.Buffer
@@ -62,13 +60,22 @@ defmodule MingaEditor.Input.Router do
   end
 
   @doc """
-  Dispatches a key press through shell-provided handlers and runs post-key housekeeping.
-
-  Captures the buffer version, active buffer, and mode before dispatch so
-  housekeeping can detect what changed.
+  Dispatches a full key press event and runs universal post-action housekeeping.
   """
   @spec dispatch(EditorState.t(), non_neg_integer(), non_neg_integer()) :: EditorState.t()
   def dispatch(state, codepoint, modifiers) do
+    snapshot = capture_snapshot(state)
+
+    state
+    |> route_key(codepoint, modifiers)
+    |> post_action_housekeeping(snapshot)
+  end
+
+  @doc """
+  Routes a key press through shell-provided handlers without universal housekeeping.
+  """
+  @spec route_key(EditorState.t(), non_neg_integer(), non_neg_integer()) :: EditorState.t()
+  def route_key(state, codepoint, modifiers) do
     # Ctrl-G owns explicit notice dismissal in Interrupt. Every other keyboard
     # command acknowledges an ordinary notice before any handler runs.
     state = preclear_notice(state, codepoint, modifiers)
@@ -78,7 +85,7 @@ defmodule MingaEditor.Input.Router do
     if state.session.pending_quit do
       return_dispatch_confirm_quit(state, codepoint)
     else
-      dispatch_normal(state, codepoint, modifiers)
+      route_key_normal(state, codepoint, modifiers)
     end
   end
 
@@ -91,46 +98,21 @@ defmodule MingaEditor.Input.Router do
     alias MingaEditor.Commands
 
     case codepoint do
-      ?y ->
-        Commands.execute(state, :confirm_quit_yes)
-
-      cancel when cancel in [?n, 27] ->
-        new_state = Commands.execute(state, :confirm_quit_no)
-        # Run housekeeping so the cleared prompt triggers a render.
-        post_key_housekeeping(
-          new_state,
-          state.workspace.buffers.active,
-          buffer_version(state),
-          Editing.mode(state),
-          Editing.inserting?(state),
-          {cancel, 0}
-        )
-
-      _ ->
-        state
+      ?y -> Commands.execute(state, :confirm_quit_yes)
+      cancel when cancel in [?n, 27] -> Commands.execute(state, :confirm_quit_no)
+      _ -> state
     end
   end
 
-  @spec dispatch_normal(EditorState.t(), non_neg_integer(), non_neg_integer()) :: EditorState.t()
-  defp dispatch_normal(state, codepoint, modifiers) do
-    old_buffer = state.workspace.buffers.active
+  @spec route_key_normal(EditorState.t(), non_neg_integer(), non_neg_integer()) :: EditorState.t()
+  defp route_key_normal(state, codepoint, modifiers) do
     old_mode = Editing.mode(state)
     was_inserting = Editing.inserting?(state)
-    buf_version_before = buffer_version(state)
-    old_cursor = safe_cursor(old_buffer)
 
-    state = dispatch_split(state, codepoint, modifiers)
-    state = record_keystroke(state, codepoint, modifiers, old_mode)
-
-    post_key_housekeeping(
-      state,
-      old_buffer,
-      buf_version_before,
-      old_mode,
-      was_inserting,
-      {codepoint, modifiers},
-      old_cursor
-    )
+    state
+    |> dispatch_split(codepoint, modifiers)
+    |> record_keystroke(codepoint, modifiers, old_mode)
+    |> maybe_handle_completion(was_inserting, codepoint, modifiers)
   end
 
   # Walks overlay handlers first (ConflictPrompt, Picker, Completion).
@@ -190,41 +172,6 @@ defmodule MingaEditor.Input.Router do
     |> maybe_schedule_document_highlight(snapshot.old_buffer, snapshot.old_cursor)
     |> LspActions.schedule_inlay_hints_on_scroll()
     |> maybe_render(snapshot.buf_version)
-  end
-
-  @doc """
-  Keyboard-specific post-key housekeeping. Handles completion triggering
-  (which needs the codepoint/modifiers), then delegates to
-  `post_action_housekeeping/2` for the universal pipeline.
-  """
-  @spec post_key_housekeeping(
-          EditorState.t(),
-          pid() | nil,
-          non_neg_integer(),
-          atom(),
-          boolean(),
-          {non_neg_integer(), non_neg_integer()},
-          {non_neg_integer(), non_neg_integer()} | nil
-        ) :: EditorState.t()
-  def post_key_housekeeping(
-        state,
-        old_buffer,
-        buf_version_before,
-        old_mode,
-        was_inserting,
-        {codepoint, modifiers},
-        old_cursor \\ nil
-      ) do
-    snapshot = %{
-      old_buffer: old_buffer,
-      buf_version: buf_version_before,
-      old_mode: old_mode,
-      old_cursor: old_cursor
-    }
-
-    state
-    |> maybe_handle_completion(was_inserting, codepoint, modifiers)
-    |> post_action_housekeeping(snapshot)
   end
 
   @spec maybe_handle_completion(EditorState.t(), boolean(), non_neg_integer(), non_neg_integer()) ::

--- a/test/minga_editor/handlers/gui_action_handler_test.exs
+++ b/test/minga_editor/handlers/gui_action_handler_test.exs
@@ -81,6 +81,32 @@ defmodule MingaEditor.Handlers.GuiActionHandlerTest do
     refute_receive {:"$gen_cast", {:render, _, _, _}}, 0
   end
 
+  test "space leader replay is key-local and outer housekeeping submits exactly one render", %{
+    sidebar_registry: table
+  } do
+    state = base_state(table, backend: :gui)
+    state = %{state | render: MingaEditor.State.Render.connect_renderer(state.render, self())}
+    snapshot = MingaEditor.Input.Router.capture_snapshot(state)
+    revision = state.render.render_correlation.latest_intent_revision
+
+    handled = GuiActionHandler.dispatch(state, {:space_leader_chord, ?j, 0})
+
+    {line, _col} = Minga.Buffer.cursor(handled.workspace.buffers.active)
+    assert line == 1
+    assert MingaEditor.KeystrokeHistory.size(handled.interaction.keystroke_history) == 1
+    assert handled.render.render_correlation.latest_intent_revision == revision
+    refute_receive {:"$gen_cast", {:render, _, _, _}}, 0
+
+    rendered = MingaEditor.Input.Router.post_action_housekeeping(handled, snapshot)
+
+    assert rendered.render.render_correlation.latest_intent_revision == revision + 1
+
+    assert_receive {:"$gen_cast",
+                    {:render, %MingaEditor.RenderPipeline.Intent{}, _seq, _pushed_at}}
+
+    refute_receive {:"$gen_cast", {:render, _, _, _}}, 0
+  end
+
   test "notification dismiss removes only the selected notification", %{sidebar_registry: table} do
     state =
       table

--- a/test/minga_editor/input/router_test.exs
+++ b/test/minga_editor/input/router_test.exs
@@ -623,6 +623,56 @@ defmodule MingaEditor.Input.RouterTest do
     %{state | render: render}
   end
 
+  describe "route_key/3" do
+    alias MingaEditor.KeystrokeHistory
+
+    test "routes a key locally without universal render housekeeping" do
+      state = base_state()
+      state = %{state | render: Render.connect_renderer(state.render, self())}
+      revision = state.render.render_correlation.latest_intent_revision
+
+      routed = Router.route_key(state, ?j, 0)
+
+      assert BufferProcess.cursor(routed.workspace.buffers.active) == {1, 0}
+      assert KeystrokeHistory.size(routed.interaction.keystroke_history) == 1
+      [entry] = KeystrokeHistory.entries(routed.interaction.keystroke_history)
+      assert entry.key == {?j, 0}
+      assert routed.render.render_correlation.latest_intent_revision == revision
+      refute_receive {:"$gen_cast", {:render, _, _, _}}, 0
+    end
+
+    test "preserves keyboard-specific completion handling for CUA insertion" do
+      state = base_state(editing_model: :cua)
+      BufferProcess.move_to(state.workspace.buffers.active, {0, 1})
+
+      completion =
+        Minga.Editing.Completion.new(
+          [
+            completion_item("print"),
+            completion_item("put"),
+            completion_item("assert")
+          ],
+          {0, 1}
+        )
+
+      payload = MingaEditor.State.ModalOverlay.Completion.new(1, completion: completion)
+
+      state = MingaEditor.Shell.Traditional.ModalWorkflow.open(state, {:completion, payload})
+
+      routed = Router.route_key(state, ?p, 0)
+
+      assert BufferProcess.content(routed.workspace.buffers.active) == "hpello\nworld\nthird"
+
+      labels =
+        routed
+        |> MingaEditor.Shell.Traditional.ModalWorkflow.completion()
+        |> Map.fetch!(:filtered)
+        |> Enum.map(& &1.label)
+
+      assert labels == ["print", "put"]
+    end
+  end
+
   describe "keystroke recording" do
     alias MingaEditor.KeystrokeHistory
 
@@ -651,5 +701,19 @@ defmodule MingaEditor.Input.RouterTest do
       keys = Enum.map(KeystrokeHistory.entries(state.interaction.keystroke_history), & &1.key)
       assert keys == [{?j, 0}, {?k, 0}, {?l, 0}]
     end
+  end
+
+  defp completion_item(label) do
+    %{
+      label: label,
+      insert_text: label,
+      filter_text: label,
+      kind: :function,
+      detail: "",
+      documentation: "",
+      sort_text: label,
+      text_edit: nil,
+      raw: nil
+    }
   end
 end


### PR DESCRIPTION
## TL;DR

Complete the key-local Router seam so GUI space-leader replay does not trigger nested universal housekeeping.

## Context

S08 found GUI replay calling the full input envelope from inside an existing GUI action envelope. That could schedule rendering twice and mixed key-local routing with event-level cleanup.

## Changes

- Add `MingaEditor.Input.Router.route_key/3` for key-local dispatch, history, and completion.
- Keep snapshot capture and universal post-action housekeeping in `Router.dispatch/3`.
- Route GUI space-leader fallback and retract replay through the key-local seam.
- Delete the obsolete post-key housekeeping wrapper.
- Record W129/S08 implementation evidence in the lifecycle roadmap.

## Verification

- Focused: 59 tests passed.
- Full: 58 doctests, 98 properties, 9831 tests, 0 failures, 1 skipped.
- `make lint` passed, Dialyzer reported 0 errors.
- `git diff --check` passed.
- Production delta: -53 lines.
- Ponytail: LEAN.
- Correctness review: PASS.
- Elixir craftsmanship: PASS/LEAN.
- Final reviewer: PASS with 0.99 confidence.
