### PR TITLE
fix(input): reset focus owners on interrupt

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -5100,3 +5100,26 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Unresolved questions:** None.
 - **needs_replan:** false.
 - **Completion date:** 2026-07-25
+
+### W130/L21: Route Ctrl-G through existing focus owners and active-window scope
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** L21
+- **Decision:** APPROVE_DIRECT, `Input.Interrupt` remains the Ctrl-G transaction coordinator while bottom panel, agent prompt, file tree, registered sidebar, TUI space-leader, and session scope remain with their existing owners.
+- **Planning profile:** `L21Planner`, editor-lifecycle-planner, locked READY at baseline `3e0b78dae40448c83e5b2258a28064d5bcdaac76`.
+- **Implementation profile:** `L21Worker`, editor-lifecycle-worker, no delegation.
+- **Baseline:** `3e0b78dae40448c83e5b2258a28064d5bcdaac76`.
+- **Failure reproduction:** The locked source trace reproduced the stale Ctrl-G route before the correction: `Input.Interrupt.reset_to_known_good/1` hardcoded `keymap_scope` to `:editor` and never called the focus-owner transitions for bottom panel, agent prompt input, file tree, registered sidebars, or TUI space leader. During implementation, the expanded focused test suite first exposed test-fixture child-spec collisions while adding those regressions; after unique supervised buffer ids, the owner and scope regressions passed against the corrected route.
+- **Observable result:** Ctrl-G now dismisses modal and which-key state, cancels the BEAM TUI space-leader transaction, blurs bottom panel focus without hiding or changing filter/height, blurs agent prompt input without clearing prompt buffer content, normalizes and unfocuses file-tree help/edit/filter interactions without hiding loaded trees, clears registered sidebar focus without closing visible sidebars, resets Vim mode state, and derives the final keymap scope from the active window so buffer/empty windows return to `:editor` and active agent-chat windows remain `:agent`.
+- **Changed files:** `lib/minga_editor/input/interrupt.ex`, `test/minga_editor/input/interrupt_test.exs`, `docs/workstreams/editor-lifecycle-roadmap.md`.
+- **Focused validation:** `mix test test/minga_editor/input/interrupt_test.exs` passed `33` tests after the owner and active-window regressions were added. `mix test test/minga_editor/shell/traditional/input_state_test.exs test/minga_editor/shell/traditional/sidebars_test.exs test/minga_editor/input/agent_panel_nav_test.exs test/minga_editor/input/scoped_file_tree_test.exs` passed `24` tests, preserving adjacent input, sidebar, agent panel, and scoped file-tree behavior.
+- **Broad validation:** `mix format --check-formatted lib/minga_editor/input/interrupt.ex test/minga_editor/input/interrupt_test.exs` passed. `make lint` passed changed-file Credo, compile, format, and incremental Dialyzer with `Total errors: 0`. `git diff --check` produced no output. Final `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` passed `58 doctests, 98 properties, 9837 tests, 0 failures, 1 skipped, 616 excluded`; the run retained existing parser-manager and LSP shutdown warnings.
+- **Residue check:** Focused source search found no remaining `maybe_reset_scope`, no hardcoded `set_keymap_scope(state.workspace, :editor)` fallback in `Input.Interrupt`, and no stale `keymap_scope.*:editor` reset path in that module.
+- **Production lines added/removed before roadmap evidence:** `+85/-36`, net `+49`, within the locked production net cap of `<= +50`.
+- **Test lines added/removed before roadmap evidence:** `+178/-6`, net `+172`, limited to the locked focus-owner and active-window scope regressions plus unique supervised buffer ids needed by the expanded looped cases.
+- **Concepts added:** Ctrl-G coordination of existing focus owners, active-window-derived interrupt scope, and focused regression coverage for each owner.
+- **Concepts removed:** Removed the hardcoded Ctrl-G `:editor` scope reset and stale focus ownership after interrupt.
+- **Retained constraints:** No new module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, duplicated state owner, frontend behavior, GUI CUA replay change, visibility-closing behavior, prompt-buffer clearing, file-tree content clearing, sidebar closure, or input handler ordering change was introduced.
+- **Discoveries affecting later work:** `Input.Interrupt` keeps one aggregate focus-owner log label to stay inside the locked production cap; the observable owner transitions and scope derivation are covered directly. Expanded interrupt tests that start more than one `Minga.Buffer.Process` in one test must use unique supervised child ids.
+- **Unresolved questions:** None.
+- **needs_replan:** false.

--- a/lib/minga_editor/input/interrupt.ex
+++ b/lib/minga_editor/input/interrupt.ex
@@ -2,37 +2,29 @@ defmodule MingaEditor.Input.Interrupt do
   @moduledoc """
   Ctrl-G interrupt handler. First handler in the input stack.
 
-  Intercepts Ctrl-G (codepoint 7) and resets the editor to a known-good
-  state. This is Minga's equivalent of Emacs's `C-g`: it cancels
-  whatever is in progress and returns the user to normal mode in the
-  editor scope.
-
-  Sits before every other handler (including ConflictPrompt) so it
-  works even when a modal overlay is swallowing all input. This is the
-  last resort for focus confusion freezes where the editor is running
-  but keys go to the wrong place.
-
-  ## What gets reset
-
-  - `keymap_scope` → `:editor`
-  - Vim mode → `:normal` with fresh mode state
-  - Modal overlay → dismissed
-  - Which-key popup → dismissed
-  - Agent pending prefix → cleared
-  - Status message → cleared
-
-  A `*Messages*` log entry records what was reset for debuggability.
+  Cancels transient input, blurs focused owners without hiding durable
+  surfaces, resets mode state, and derives the surviving keymap scope from
+  the active window.
   """
 
   @behaviour MingaEditor.Input.Handler
 
   @type state :: MingaEditor.Input.Handler.handler_state()
 
+  alias MingaEditor.Agent.PromptBuffer
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Extension.Sidebar
+  alias MingaEditor.Input.CUA.TUISpaceLeader
+  alias MingaEditor.Session.State, as: SessionState
+  alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.ModalWorkflow
   alias MingaEditor.Shell.Traditional.NoticeWorkflow
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.Shell.Traditional.WhichKeyWorkflow
+  alias MingaEditor.Shell.Traditional.Workflow
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.WhichKey
   alias MingaEditor.VimState
@@ -59,30 +51,93 @@ defmodule MingaEditor.Input.Interrupt do
 
   # ── Reset logic ──────────────────────────────────────────────────────────
 
-  @spec reset_to_known_good(EditorState.t()) :: {EditorState.t(), [String.t()]}
   defp reset_to_known_good(state) do
     {state, resets} = {state, []}
 
-    {state, resets} = maybe_reset_scope(state, resets)
-    {state, resets} = maybe_reset_mode(state, resets)
     {state, resets} = maybe_dismiss_modal(state, resets)
     {state, resets} = maybe_clear_whichkey(state, resets)
+    {state, resets} = maybe_reset_focus_owners(state, resets)
+    {state, resets} = maybe_reset_mode(state, resets)
+    {state, resets} = maybe_derive_scope(state, resets)
     {state, resets} = maybe_clear_agent_prefix(state, resets)
     {state, resets} = maybe_clear_status(state, resets)
 
     {state, resets}
   end
 
-  @spec maybe_reset_scope(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
-  defp maybe_reset_scope(%{workspace: %{keymap_scope: :editor}} = state, resets),
-    do: {state, resets}
+  defp maybe_derive_scope(%{workspace: %{keymap_scope: current_scope}} = state, resets) do
+    scope = SessionState.scope_for_active_window(state.workspace)
 
-  defp maybe_reset_scope(%{workspace: %{keymap_scope: scope}} = state, resets) do
-    {%{state | workspace: MingaEditor.Session.State.set_keymap_scope(state.workspace, :editor)},
-     ["scope #{scope} → :editor" | resets]}
+    if current_scope == scope do
+      {state, resets}
+    else
+      {%{state | workspace: SessionState.set_keymap_scope(state.workspace, scope)},
+       ["scope #{current_scope} → #{scope}" | resets]}
+    end
   end
 
-  @spec maybe_reset_mode(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
+  defp maybe_reset_focus_owners(state, resets) do
+    new_state =
+      state
+      |> maybe_cancel_space_leader()
+      |> maybe_blur_bottom_panel()
+      |> maybe_blur_agent_prompt()
+      |> maybe_unfocus_file_tree()
+      |> maybe_clear_sidebar_focus()
+
+    if new_state == state, do: {state, resets}, else: {new_state, ["focus owners reset" | resets]}
+  end
+
+  defp maybe_cancel_space_leader(
+         %{shell_runtime: %{state: %TraditionalState{} = shell_state}} = state
+       ) do
+    if TraditionalState.space_leader_pending?(shell_state) or
+         TraditionalState.space_leader_timer(shell_state) != nil,
+       do: TUISpaceLeader.cancel(state),
+       else: state
+  end
+
+  defp maybe_cancel_space_leader(state), do: state
+
+  defp maybe_blur_bottom_panel(
+         %{shell_runtime: %{state: %TraditionalState{bottom_panel: %{focused: true}}}} = state
+       ),
+       do: %{state | shell_runtime: Runtime.blur_bottom_panel(state.shell_runtime)}
+
+  defp maybe_blur_bottom_panel(state), do: state
+
+  defp maybe_blur_agent_prompt(
+         %{workspace: %{agent_ui: %{panel: %{input_focused: true}}}} = state
+       ) do
+    Workflow.install_agent_ui(
+      state,
+      PromptBuffer.set_input_focused(state.workspace.agent_ui, false)
+    )
+  end
+
+  defp maybe_blur_agent_prompt(state), do: state
+
+  defp maybe_unfocus_file_tree(%{workspace: %{file_tree: %FileTreeState{} = file_tree}} = state) do
+    new_file_tree =
+      file_tree
+      |> FileTreeState.hide_help()
+      |> FileTreeState.cancel_editing()
+      |> FileTreeState.accept_filter()
+      |> FileTreeState.unfocus()
+
+    if new_file_tree == file_tree,
+      do: state,
+      else: %{state | workspace: SessionState.set_file_tree(state.workspace, new_file_tree)}
+  end
+
+  defp maybe_clear_sidebar_focus(%EditorState{} = state) do
+    table = state.extension_surfaces.sidebar_registry
+
+    if SidebarWorkflow.active_id(state) != nil or Enum.any?(Sidebar.all(table), & &1.focused?),
+      do: SidebarWorkflow.select(state, nil),
+      else: state
+  end
+
   defp maybe_reset_mode(%{workspace: %{editing: %{mode: mode}}} = state, resets)
        when mode != :normal do
     {%{state | workspace: MingaEditor.Session.State.transition_mode(state.workspace, :normal)},
@@ -102,7 +157,6 @@ defmodule MingaEditor.Input.Interrupt do
     end
   end
 
-  @spec mode_state_dirty?(term(), Minga.Mode.State.t()) :: boolean()
   defp mode_state_dirty?(%Minga.Mode.State{} = current, %Minga.Mode.State{} = fresh) do
     current.leader_node != fresh.leader_node or
       current.leader_keys != fresh.leader_keys or
@@ -116,7 +170,6 @@ defmodule MingaEditor.Input.Interrupt do
 
   defp mode_state_dirty?(_current, _fresh), do: true
 
-  @spec maybe_dismiss_modal(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
   defp maybe_dismiss_modal(state, resets) do
     if ModalOverlay.active?(state.shell_runtime.state.modal) do
       {ModalWorkflow.dismiss(state), ["modal dismissed" | resets]}
@@ -125,7 +178,6 @@ defmodule MingaEditor.Input.Interrupt do
     end
   end
 
-  @spec maybe_clear_whichkey(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
   defp maybe_clear_whichkey(
          %{shell_runtime: %{state: %{whichkey: %WhichKey{node: nil, show: false}}}} = state,
          resets
@@ -136,7 +188,6 @@ defmodule MingaEditor.Input.Interrupt do
     {WhichKeyWorkflow.dismiss(state), ["which-key dismissed" | resets]}
   end
 
-  @spec maybe_clear_agent_prefix(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
   defp maybe_clear_agent_prefix(state, resets) do
     case state.workspace.agent_ui.view |> UIState.View.pending_prefix() do
       nil ->
@@ -153,7 +204,6 @@ defmodule MingaEditor.Input.Interrupt do
     end
   end
 
-  @spec maybe_clear_status(EditorState.t(), [String.t()]) :: {EditorState.t(), [String.t()]}
   defp maybe_clear_status(
          %{
            shell_runtime: %{state: %{notice: %MingaEditor.Shell.Traditional.Notice{message: nil}}}
@@ -168,7 +218,6 @@ defmodule MingaEditor.Input.Interrupt do
 
   # ── Logging ──────────────────────────────────────────────────────────────
 
-  @spec log_resets(EditorState.t(), [String.t()]) :: EditorState.t()
   defp log_resets(state, []) do
     Minga.Log.info(:editor, "C-g: already in clean state")
     state

--- a/test/minga_editor/input/interrupt_test.exs
+++ b/test/minga_editor/input/interrupt_test.exs
@@ -1,22 +1,29 @@
 defmodule MingaEditor.Input.InterruptTest do
   use ExUnit.Case, async: true
 
-  alias MingaEditor.Session.State, as: SessionState
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Editing.Completion
   alias Minga.Mode
+  alias Minga.Project.FileTree
   alias MingaEditor.Agent.UIState
   alias MingaEditor.Agent.UIState.View
+  alias MingaEditor.BottomPanel
+  alias MingaEditor.Extension.Sidebar
   alias MingaEditor.HoverPopup
   alias MingaEditor.Input
   alias MingaEditor.Input.Interrupt
+  alias MingaEditor.Session.State, as: SessionState
   alias MingaEditor.Shell.Runtime
-  alias MingaEditor.State, as: EditorState
-  alias MingaEditor.State.Buffers
-  alias MingaEditor.State.Feedback
   alias MingaEditor.Shell.Traditional.HoverPopupWorkflow
   alias MingaEditor.Shell.Traditional.ModalWorkflow
+  alias MingaEditor.Shell.Traditional.SidebarWorkflow
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
   alias MingaEditor.Shell.Traditional.WhichKeyWorkflow
+  alias MingaEditor.State, as: EditorState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.ExtensionSurfaces
+  alias MingaEditor.State.Feedback
+  alias MingaEditor.State.FileTree, as: FileTreeState
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.OperationFeedback
   alias MingaEditor.State.ModalOverlay.Completion, as: CompletionPayload
@@ -25,16 +32,18 @@ defmodule MingaEditor.Input.InterruptTest do
   alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
   alias MingaEditor.State.Picker
   alias MingaEditor.State.Prompt, as: PromptState
+  alias MingaEditor.State.Windows
   alias MingaEditor.VimState
+  alias MingaEditor.Window
 
   @ctrl_g 7
   @modal_variants [:picker, :prompt, :completion, :conflict]
 
   defp base_state(opts \\ []) do
     buf_opts = Keyword.get(opts, :buffer_opts, content: "hello\nworld")
-    buf = start_supervised!({BufferProcess, buf_opts})
+    buf = start_supervised!({BufferProcess, buf_opts}, id: {:interrupt_buffer, make_ref()})
 
-    %EditorState{
+    state = %EditorState{
       frontend: %MingaEditor.State.Frontend{port_manager: self()},
       workspace: %MingaEditor.Session.State{
         editing: VimState.new(),
@@ -46,6 +55,32 @@ defmodule MingaEditor.Input.InterruptTest do
       },
       interaction: %MingaEditor.State.Interaction{}
     }
+
+    case Keyword.fetch(opts, :sidebar_registry) do
+      {:ok, table} -> %{state | extension_surfaces: %ExtensionSurfaces{sidebar_registry: table}}
+      :error -> state
+    end
+  end
+
+  defp install_shell_state(state, shell_state) do
+    %{state | shell_runtime: Runtime.install_traditional_state(state.shell_runtime, shell_state)}
+  end
+
+  defp install_bottom_panel(state, panel) do
+    shell_state = TraditionalState.install_bottom_panel(Runtime.state(state.shell_runtime), panel)
+    install_shell_state(state, shell_state)
+  end
+
+  defp with_active_buffer_window(state) do
+    window = Window.new(1, state.workspace.buffers.active, 24, 80)
+    windows = %Windows{map: %{1 => window}, active: 1, next_id: 2}
+    %{state | workspace: %{state.workspace | windows: windows}}
+  end
+
+  defp with_active_agent_window(state) do
+    window = Window.new_agent_chat(1, 24, 80)
+    windows = %Windows{map: %{1 => window}, active: 1, next_id: 2}
+    %{state | workspace: %{state.workspace | windows: windows}}
   end
 
   @spec open_modal_variant(EditorState.t(), ModalOverlay.variant()) :: EditorState.t()
@@ -168,6 +203,143 @@ defmodule MingaEditor.Input.InterruptTest do
       assert state.workspace.keymap_scope == :editor
       assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
       assert new_state.workspace.keymap_scope == :editor
+    end
+
+    test "derives :editor from an active buffer window despite stale owner scopes" do
+      for stale_scope <- [:file_tree, :git_status, :agent] do
+        state =
+          base_state()
+          |> with_active_buffer_window()
+          |> then(fn state ->
+            %{state | workspace: SessionState.set_keymap_scope(state.workspace, stale_scope)}
+          end)
+
+        assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+        assert new_state.workspace.keymap_scope == :editor
+      end
+    end
+
+    test "derives :agent from an active agent chat window" do
+      state =
+        base_state()
+        |> with_active_agent_window()
+        |> then(fn state ->
+          %{state | workspace: SessionState.set_keymap_scope(state.workspace, :editor)}
+        end)
+
+      assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+      assert new_state.workspace.keymap_scope == :agent
+    end
+  end
+
+  describe "focus owner reset" do
+    test "blurs focused bottom panel without hiding or changing panel settings" do
+      panel = %BottomPanel{visible: true, focused: true, filter: :warnings, height_percent: 45}
+      state = base_state() |> install_bottom_panel(panel)
+
+      assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+      new_panel = Runtime.state(new_state.shell_runtime).bottom_panel
+      assert new_panel.visible == true
+      assert new_panel.filter == :warnings
+      assert new_panel.height_percent == 45
+      refute BottomPanel.focused?(new_panel)
+    end
+
+    test "normalizes hidden bottom panel focus without showing it" do
+      panel = %BottomPanel{visible: false, focused: true}
+      state = base_state() |> install_bottom_panel(panel)
+
+      assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+
+      assert %BottomPanel{visible: false, focused: false} =
+               Runtime.state(new_state.shell_runtime).bottom_panel
+    end
+
+    test "blurs focused agent prompt without clearing draft text" do
+      prompt =
+        start_supervised!({BufferProcess, content: "draft"}, id: {:prompt_buffer, make_ref()})
+
+      agent_ui = UIState.new() |> UIState.attach_prompt_buffer(prompt)
+      agent_ui = %{agent_ui | panel: %{agent_ui.panel | visible: true, input_focused: true}}
+
+      state = MingaEditor.Shell.Traditional.Workflow.install_agent_ui(base_state(), agent_ui)
+
+      assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+      assert new_state.workspace.agent_ui.panel.visible == true
+      assert new_state.workspace.agent_ui.panel.input_focused == false
+      assert BufferProcess.content(new_state.workspace.agent_ui.panel.prompt_buffer) == "draft"
+    end
+
+    test "unfocuses file tree and normalizes local interactions" do
+      for interaction <- [
+            :browse,
+            :help,
+            :filtering,
+            {:editing, %{index: 0, text: "x", type: :rename, original_name: "old"}}
+          ] do
+        file_tree =
+          %FileTreeState{}
+          |> FileTreeState.open(FileTree.new(File.cwd!(), width: 24), nil)
+          |> Map.put(:interaction, interaction)
+
+        state = base_state()
+        state = %{state | workspace: SessionState.set_file_tree(state.workspace, file_tree)}
+
+        assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+        assert FileTreeState.visible?(new_state.workspace.file_tree)
+        refute FileTreeState.focused?(new_state.workspace.file_tree)
+        assert new_state.workspace.file_tree.interaction == :browse
+      end
+    end
+
+    test "does not make hidden file tree visible" do
+      file_tree = %FileTreeState{}
+      state = base_state()
+      state = %{state | workspace: SessionState.set_file_tree(state.workspace, file_tree)}
+
+      assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+      refute FileTreeState.visible?(new_state.workspace.file_tree)
+    end
+
+    test "clears registered sidebar focus while preserving visibility" do
+      table = Module.concat(__MODULE__, "Sidebar#{System.unique_integer([:positive])}")
+      start_supervised!({Sidebar, name: table})
+
+      assert :ok =
+               Sidebar.register(table, {:extension, :alpha}, %{
+                 id: "outline",
+                 display_name: "Outline",
+                 visible?: true,
+                 focused?: true
+               })
+
+      state =
+        base_state(sidebar_registry: table)
+        |> SidebarWorkflow.select("outline")
+
+      assert SidebarWorkflow.active_id(state) == "outline"
+
+      assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+      assert Sidebar.get(table, "outline").visible?
+      refute Sidebar.get(table, "outline").focused?
+      assert SidebarWorkflow.active_id(new_state) == nil
+    end
+
+    test "cancels pending TUI space leader timer" do
+      timer = Process.send_after(self(), :stale_space_leader, 10_000)
+
+      state = base_state()
+      shell_state = Runtime.state(state.shell_runtime)
+      {generation, shell_state} = TraditionalState.begin_space_leader(shell_state)
+      shell_state = TraditionalState.install_space_leader_timer(shell_state, generation, timer)
+      state = install_shell_state(state, shell_state)
+
+      assert TraditionalState.space_leader_pending?(Runtime.state(state.shell_runtime))
+      assert {:handled, new_state} = Interrupt.handle_key(state, @ctrl_g, 0)
+      shell_state = Runtime.state(new_state.shell_runtime)
+      refute TraditionalState.space_leader_pending?(shell_state)
+      assert TraditionalState.space_leader_timer(shell_state) == nil
+      assert Process.read_timer(timer) == false
     end
   end
 


### PR DESCRIPTION
## TL;DR

Make Ctrl-G cancel transient input across existing focus owners without closing durable surfaces or forcing editor scope.

## Changes

- Cancel pending TUI space-leader input and its timer.
- Blur bottom panel and agent prompt while preserving visibility and draft state.
- Normalize focused file-tree interactions to browse without hiding the tree.
- Clear registered sidebar focus without closing the sidebar.
- Derive final keymap scope from the active window after cleanup.
- Add focused regressions for every owner and scope transition.
- Record W129/L21 implementation evidence in the lifecycle roadmap.

## Verification

- Focused: 57 tests passed.
- Full: 58 doctests, 98 properties, 9837 tests, 0 failures, 1 skipped.
- `make lint` passed, Dialyzer reported 0 errors.
- `git diff --check` passed.
- Production delta: +49 lines, within the locked +50 cap.
- Ponytail: LEAN.
- Correctness review: PASS.
- Elixir craftsmanship: PASS.
- Final reviewer: PASS with 0.99 confidence.
