### PR TITLE
fix(ui): preserve successor prompt callbacks

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -5147,3 +5147,26 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Unresolved questions:** None.
 - **needs_replan:** false.
 - **Completion date:** 2026-07-25
+
+### W132/S17: Close prompt callbacks before context-aware successor handling
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** S17
+- **Decision:** APPROVE_DIRECT, `PromptUI` owns successor-safe callback sequencing through `ModalWorkflow`; context-aware prompt handlers may open a successor modal without a trailing prompt close dismissing it.
+- **Planning profile:** `S17Planner`, editor-lifecycle-planner, locked READY at baseline `3e0b78dae40448c83e5b2258a28064d5bcdaac76`.
+- **Implementation profile:** `S17Worker`, no delegation.
+- **Baseline:** `9cd0615c1c00028f8b2349a3e5543ffb3d933fb7`.
+- **Failure reproduction:** After adding the locked successor-safety regressions, `mix test test/minga_editor/prompt_ui_test.exs` failed before the source correction: submit did not call the context-aware callback (`Process.get(:successor_submit_context) == nil`) and cancel did not call the context-aware callback (`Process.get(:successor_cancel_context) == nil`). The baseline source invoked submit/cancel callbacks while the original prompt modal was still active and then closed/dismissed afterward, so a callback-opened successor could be removed by the trailing close.
+- **Observable result:** Enter now captures prompt text and context, closes the completed prompt through `ModalWorkflow.close/1`, invokes `on_submit/3` when available or legacy `on_submit/2` otherwise, and returns the callback state directly. Escape now dismisses through `ModalWorkflow.dismiss/1`, routes optional cancel callbacks through private multi-clause pattern dispatch with exact `on_cancel/2` > `on_cancel/1` > dismissed-state precedence, and returns the callback state directly. Submit and cancel callbacks observe `modal == :none` before opening a successor, and that successor prompt remains active.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`, `lib/minga_editor/prompt_ui.ex`, `lib/minga_editor/ui/prompt/handler.ex`, `lib/minga_editor/ui/prompt/project_remove_confirm.ex`, and `test/minga_editor/prompt_ui_test.exs`.
+- **Focused validation:** `mix test test/minga_editor/prompt_ui_test.exs` passed `32 tests`; final focused prompt command `mix test test/minga_editor/prompt_ui_test.exs test/minga_editor/input/prompt_test.exs test/minga_editor/minibuffer_data_test.exs test/minga_editor/ui/picker/project_remove_source_test.exs` passed `69 tests`.
+- **Broad validation:** `mix format lib/minga_editor/prompt_ui.ex test/minga_editor/prompt_ui_test.exs` passed after the mandatory dispatch correction; `git diff --check` produced no output; `make lint` passed changed-file Credo, compile, format, and incremental Dialyzer with `Total errors: 0`; `ERL_FLAGS='+S 2:2' mix test.llm --max-cases 4` passed `58 doctests, 98 properties, 9831 tests, 0 failures, 1 skipped, 616 excluded`.
+- **Residue check:** Focused searches found no remaining `PromptUI` trailing submit close, no `do_cancel(...) |> close` sequencing, and no `cond do` in `lib/minga_editor/prompt_ui.ex`. The remaining `ProjectRemoveConfirm` modal-context lookup is only the legacy direct-call fallback; the normal context-aware path resolves from the captured callback context.
+- **Production lines added/removed before roadmap evidence:** `lib/` diff is `+52/-28`, net `+24`, within the locked `+25` production cap.
+- **Test lines added/removed before roadmap evidence:** `test/` diff is `+94/-0`, net `+94`.
+- **Concepts added:** Context-aware prompt callback arities `on_submit/3` and `on_cancel/2`, pre-callback close/dismiss sequencing, and mutation-proof successor modal regressions for both submit and cancel.
+- **Concepts removed:** The prompt workflow's post-callback submit close and cancel dismiss sequencing that could remove a successor modal.
+- **Retained constraints:** Prompt text editing, Tab completion, minibuffer rendering, Input.Prompt routing, picker sequencing, modal data shape, PromptState context field, ModalWorkflow ownership, and legacy `on_submit/2` and `on_cancel/1` handler behavior remain intact. No new module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, or alternate context representation was introduced.
+- **Discoveries affecting later work:** The worktree baseline is `9cd0615c1c00028f8b2349a3e5543ffb3d933fb7` while the planner recorded source freshness at `3e0b78dae40448c83e5b2258a28064d5bcdaac76`; refreshed `PromptUI`, `ProjectRemoveConfirm`, handler, prompt state, and ModalWorkflow symbols still matched the locked failure and owner shape, so no replan trigger was found.
+- **Unresolved questions:** None.
+- **needs_replan:** false.

--- a/lib/minga_editor/prompt_ui.ex
+++ b/lib/minga_editor/prompt_ui.ex
@@ -24,6 +24,7 @@ defmodule MingaEditor.PromptUI do
   alias MingaEditor.State.ModalOverlay
   alias MingaEditor.State.ModalOverlay.Prompt, as: PromptPayload
   alias MingaEditor.State.Prompt, as: PromptState
+  alias MingaEditor.Shell.Traditional.ModalWorkflow
 
   @escape 27
   @enter 13
@@ -69,19 +70,14 @@ defmodule MingaEditor.PromptUI do
       context: context
     }
 
-    MingaEditor.Shell.Traditional.ModalWorkflow.open(
-      state,
-      {:prompt, PromptPayload.new(prompt_state)}
-    )
+    ModalWorkflow.open(state, {:prompt, PromptPayload.new(prompt_state)})
   end
 
   @doc """
   Closes the prompt without calling any handler callback.
   """
   @spec close(state()) :: state()
-  def close(state) do
-    MingaEditor.Shell.Traditional.ModalWorkflow.dismiss(state)
-  end
+  def close(state), do: ModalWorkflow.dismiss(state)
 
   @doc """
   Returns true if a prompt is currently open.
@@ -101,11 +97,10 @@ defmodule MingaEditor.PromptUI do
 
     case key do
       @escape ->
-        {state |> do_cancel(prompt) |> close(), nil}
+        {do_cancel(state, prompt), nil}
 
       @enter ->
-        new_state = prompt.handler.on_submit(prompt.text, state)
-        {close(new_state), nil}
+        {do_submit(state, prompt), nil}
 
       @tab ->
         {do_tab(state, prompt), nil}
@@ -152,10 +147,7 @@ defmodule MingaEditor.PromptUI do
     {:prompt, payload} = state.shell_runtime.state.modal
     new_pui = fun.(payload.prompt_ui)
 
-    MingaEditor.Shell.Traditional.ModalWorkflow.transition(
-      state,
-      {:prompt, PromptPayload.put_prompt_ui(payload, new_pui)}
-    )
+    ModalWorkflow.transition(state, {:prompt, PromptPayload.put_prompt_ui(payload, new_pui)})
   end
 
   # ── Private ────────────────────────────────────────────────────────────────
@@ -168,10 +160,26 @@ defmodule MingaEditor.PromptUI do
     end
   end
 
-  @spec do_cancel(state(), PromptState.t()) :: state()
-  defp do_cancel(state, %{handler: handler}) do
-    if function_exported?(handler, :on_cancel, 1), do: handler.on_cancel(state), else: state
+  @spec do_submit(state(), PromptState.t()) :: state()
+  defp do_submit(state, %{text: text, handler: handler, context: context}) do
+    state = ModalWorkflow.close(state)
+
+    if function_exported?(handler, :on_submit, 3),
+      do: handler.on_submit(text, state, context),
+      else: handler.on_submit(text, state)
   end
+
+  @spec do_cancel(state(), PromptState.t()) :: state()
+  defp do_cancel(state, %{handler: handler, context: context}) do
+    state = ModalWorkflow.dismiss(state)
+
+    {function_exported?(handler, :on_cancel, 2), function_exported?(handler, :on_cancel, 1)}
+    |> call_cancel(handler, state, context)
+  end
+
+  defp call_cancel({true, _}, handler, state, context), do: handler.on_cancel(state, context)
+  defp call_cancel({false, true}, handler, state, _context), do: handler.on_cancel(state)
+  defp call_cancel({false, false}, _handler, state, _context), do: state
 
   @spec do_tab(state(), PromptState.t()) :: state()
   defp do_tab(state, prompt) do

--- a/lib/minga_editor/ui/prompt/handler.ex
+++ b/lib/minga_editor/ui/prompt/handler.ex
@@ -9,8 +9,8 @@ defmodule MingaEditor.UI.Prompt.Handler do
   ## Callbacks
 
   - `label/0` — the prompt label shown before the input field (e.g., "Title: ")
-  - `on_submit/2` — called when the user presses Enter; receives the input text and editor state
-  - `on_cancel/1` — optional; called when the user presses Escape; defaults to returning state unchanged
+  - `on_submit/2` or `on_submit/3` — called when the user presses Enter; receives the input text and editor state, plus stored context for `/3`
+  - `on_cancel/1` or `on_cancel/2` — optional; called when the user presses Escape; receives stored context for `/2` and defaults to returning state unchanged
 
   ## Example
 
@@ -41,8 +41,15 @@ defmodule MingaEditor.UI.Prompt.Handler do
   @doc "Called when the user presses Enter. Receives the input text and editor state."
   @callback on_submit(text :: String.t(), state :: EditorState.t()) :: EditorState.t()
 
+  @doc "Optional context-aware submit callback. Preferred over `on_submit/2` when implemented."
+  @callback on_submit(text :: String.t(), state :: EditorState.t(), context :: map() | nil) ::
+              EditorState.t()
+
   @doc "Optional. Called when the user presses Escape. Defaults to leaving the editor state unchanged."
   @callback on_cancel(state :: EditorState.t()) :: EditorState.t()
+
+  @doc "Optional context-aware cancel callback. Preferred over `on_cancel/1` when implemented."
+  @callback on_cancel(state :: EditorState.t(), context :: map() | nil) :: EditorState.t()
 
   @doc """
   Called when the user presses Tab. Returns the completed text.
@@ -52,5 +59,5 @@ defmodule MingaEditor.UI.Prompt.Handler do
   """
   @callback on_tab(text :: String.t()) :: String.t()
 
-  @optional_callbacks [on_cancel: 1, on_tab: 1]
+  @optional_callbacks [on_submit: 3, on_cancel: 1, on_cancel: 2, on_tab: 1]
 end

--- a/lib/minga_editor/ui/prompt/project_remove_confirm.ex
+++ b/lib/minga_editor/ui/prompt/project_remove_confirm.ex
@@ -15,10 +15,22 @@ defmodule MingaEditor.UI.Prompt.ProjectRemoveConfirm do
 
   @impl true
   @spec on_submit(String.t(), EditorState.t()) :: EditorState.t()
-  def on_submit(text, state) do
+  def on_submit(text, state), do: confirm(text, state, project_path(nil, state))
+
+  @impl true
+  @spec on_submit(String.t(), EditorState.t(), map() | nil) :: EditorState.t()
+  def on_submit(text, state, context), do: confirm(text, state, project_path(context, state))
+
+  @impl true
+  @spec on_cancel(EditorState.t()) :: EditorState.t()
+  def on_cancel(state),
+    do: NoticeWorkflow.publish(state, "Project removal cancelled")
+
+  @spec confirm(String.t(), EditorState.t(), String.t() | nil) :: EditorState.t()
+  defp confirm(text, state, path) do
     answer = text |> String.trim() |> String.downcase()
 
-    case {answer, project_path(state)} do
+    case {answer, path} do
       {answer, path} when answer in ["y", "yes"] and is_binary(path) ->
         Project.remove(path)
         NoticeWorkflow.publish(state, "Removed project: #{path}")
@@ -31,17 +43,14 @@ defmodule MingaEditor.UI.Prompt.ProjectRemoveConfirm do
     end
   end
 
-  @impl true
-  @spec on_cancel(EditorState.t()) :: EditorState.t()
-  def on_cancel(state),
-    do: NoticeWorkflow.publish(state, "Project removal cancelled")
+  @spec project_path(map() | nil, EditorState.t()) :: String.t() | nil
+  defp project_path(%{path: path}, _state) when is_binary(path), do: path
 
-  @spec project_path(EditorState.t()) :: String.t() | nil
-  defp project_path(%{
+  defp project_path(_context, %{
          shell_runtime: %{state: %{modal: {:prompt, %{prompt_ui: %{context: %{path: path}}}}}}
        })
        when is_binary(path),
        do: path
 
-  defp project_path(_state), do: nil
+  defp project_path(_context, _state), do: nil
 end

--- a/test/minga_editor/prompt_ui_test.exs
+++ b/test/minga_editor/prompt_ui_test.exs
@@ -42,6 +42,59 @@ defmodule MingaEditor.PromptUITest do
     end
   end
 
+  defmodule SuccessorSubmitHandler do
+    @behaviour MingaEditor.UI.Prompt.Handler
+
+    @impl true
+    def label, do: "Original: "
+
+    @impl true
+    def on_submit(text, state) do
+      Process.put(:successor_submit_legacy_called, text)
+      PromptUI.open(state, RenameHandler, label: "Next: ", default: text)
+    end
+
+    @impl true
+    def on_submit(text, state, context) do
+      Process.put(:successor_submit_context, context)
+
+      Process.put(
+        :successor_submit_modal_before_open,
+        MingaEditor.Shell.Runtime.state(state.shell_runtime).modal
+      )
+
+      PromptUI.open(state, RenameHandler, label: "Next: ", default: "#{context.prefix}:#{text}")
+    end
+  end
+
+  defmodule SuccessorCancelHandler do
+    @behaviour MingaEditor.UI.Prompt.Handler
+
+    @impl true
+    def label, do: "Cancel: "
+
+    @impl true
+    def on_submit(_text, state), do: state
+
+    @impl true
+    def on_cancel(state) do
+      Process.put(:successor_cancel_legacy_called, true)
+      state
+    end
+
+    @impl true
+    def on_cancel(state, context) do
+      Process.put(:successor_cancel_context, context)
+
+      Process.put(
+        :successor_cancel_modal_before_open,
+        MingaEditor.Shell.Runtime.state(state.shell_runtime).modal
+      )
+
+      PromptUI.open(state, RenameHandler, label: "Next: ", default: context.reason)
+    end
+  end
+
   @escape 27
   @enter 13
   @backspace 127
@@ -237,6 +290,31 @@ defmodule MingaEditor.PromptUITest do
       assert Process.get(:submitted) == ""
       refute PromptUI.open?(state)
     end
+
+    test "Enter closes before context-aware submit and preserves successor prompt" do
+      state =
+        base_state()
+        |> PromptUI.open(SuccessorSubmitHandler, default: "value", context: %{prefix: "ctx"})
+
+      {state, nil} = PromptUI.handle_key(state, @enter, 0)
+      pui = prompt_state(state)
+
+      assert Process.get(:successor_submit_context) == %{prefix: "ctx"}
+      assert Process.get(:successor_submit_modal_before_open) == :none
+      refute Process.get(:successor_submit_legacy_called)
+      assert pui.handler == RenameHandler
+      assert pui.label == "Next: "
+      assert pui.text == "ctx:value"
+    end
+
+    test "ProjectRemoveConfirm uses captured context after prompt is closed" do
+      state =
+        MingaEditor.UI.Prompt.ProjectRemoveConfirm.on_submit("yes", base_state(), %{
+          path: "/tmp/project"
+        })
+
+      assert state.shell_runtime.state.notice.message == "Removed project: /tmp/project"
+    end
   end
 
   describe "handle_key/3 — cancel" do
@@ -254,6 +332,22 @@ defmodule MingaEditor.PromptUITest do
 
       assert actual == PromptUI.close(opened)
       refute PromptUI.open?(actual)
+    end
+
+    test "Escape dismisses before context-aware cancel and preserves successor prompt" do
+      state =
+        base_state()
+        |> PromptUI.open(SuccessorCancelHandler, default: "draft", context: %{reason: "retry"})
+
+      {state, nil} = PromptUI.handle_key(state, @escape, 0)
+      pui = prompt_state(state)
+
+      assert Process.get(:successor_cancel_context) == %{reason: "retry"}
+      assert Process.get(:successor_cancel_modal_before_open) == :none
+      refute Process.get(:successor_cancel_legacy_called)
+      assert pui.handler == RenameHandler
+      assert pui.label == "Next: "
+      assert pui.text == "retry"
     end
   end
 


### PR DESCRIPTION
## TL;DR

Close or dismiss the current prompt before callbacks so a callback-opened successor modal survives.

## Changes

- Capture prompt context, then close before submit callback dispatch.
- Dismiss before cancel callback dispatch.
- Prefer context-aware `on_submit/3` and `on_cancel/2`, preserving legacy arities.
- Return callback state directly without trailing modal cleanup.
- Make ProjectRemoveConfirm use captured context on the normal PromptUI path.
- Add mutation-proof successor submit/cancel regressions.
- Record W129/S17 implementation evidence in the lifecycle roadmap.

## Verification

- Focused: 69 tests passed.
- Full: 58 doctests, 98 properties, 9831 tests, 0 failures, 1 skipped.
- `make lint` passed, Dialyzer reported 0 errors.
- `git diff --check` passed.
- Production delta: +24 lines, within the locked +25 cap.
- Ponytail: LEAN.
- Correctness review: PASS.
- Elixir clause correction applied.
- Final reviewer: PASS with 0.99 confidence.
