### PR TITLE
fix(editor): include inactive tab buffers in shutdown

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -124,6 +124,19 @@ Ten independent read-only `archie` reviews at `xhigh` resolved all 28 routed fin
 | ES19 | `APPROVE_DIRECT` | `Session.State` owns active agent UI and the agent Workspace payload owns inactive agent UI; transfer authority on activation instead of mirroring. |
 | ES20 | `APPROVE_DIRECT` | Add kind-specific payloads inside existing Tab and Workspace owners. Do not share one payload type or create a generalized tagged-state abstraction. |
 
+#### L03 worktree implementation evidence at `fix-editor-route-l03`
+
+- **Status:** IMPLEMENTED in worktree, not yet PR-verified or merged.
+- **Outcome:** `MingaEditor.Handlers.BufferRegistry.buffer_inventory/1` now derives the ordered active-workspace plus inactive file-tab buffer pid inventory. Dirty confirmation, `:wqa`, and lifecycle tracking consume that owner, while `MingaEditor.State.remove_buffer/2` remains the retirement boundary.
+- **Failing-before proof:** After adding the locked regressions and before production changes, `mix test.debug test/minga_editor/state/buffer_lifecycle_test.exs test/minga_editor/commands/buffer_management_save_quit_test.exs` failed because `BufferRegistry.buffer_inventory/1` was undefined, `:quit_all` did not publish the dirty confirmation for an inactive-tab-only dirty buffer, and `:wqa` left the inactive file unchanged.
+- **Focused validation:** `mix test.debug test/minga_editor/state/buffer_lifecycle_test.exs test/minga_editor/commands/buffer_management_save_quit_test.exs` passed with 20 tests. `mix test.debug test/minga_editor/commands/buffer_management_kill_test.exs` passed with 5 tests.
+- **Broad validation:** `make lint` passed. `ERL_FLAGS='+S 2:2' mix test.llm` passed with 58 doctests, 98 properties, 9,857 tests, 0 failures, 1 skipped, and 616 excluded.
+- **Diff check:** `git diff --check` passed.
+- **Production lines added/removed:** 32 added / 18 removed, net +14.
+- **Test lines added/removed:** 177 added / 0 removed, net +177.
+- **Concepts added/removed:** Added one BufferRegistry-owned ordered live-plus-tab buffer inventory. Removed the duplicate private tab tracking predicate in favor of the shared inventory. No module, process, dependency, protocol, configuration, persistence shape, retirement path, or save-result contract was added.
+- **Completion date:** 2026-07-25.
+
 Dependency order from the decisions is mandatory: ES06 before L06, L06 before L07 and L08, and L06 before L09; ES20 before L18 and ES19; L17 before L18; ES19 before ES02, ES02 before S30, and S30 before ES01. Same-owner work remains serialized even where no hard dependency exists.
 
 Retained constraints:

--- a/lib/minga_editor/commands/buffer_management.ex
+++ b/lib/minga_editor/commands/buffer_management.ex
@@ -25,6 +25,7 @@ defmodule MingaEditor.Commands.BufferManagement do
   alias MingaEditor.EffectScheduler
   alias MingaEditor.Commands.Movement
   alias MingaEditor.Commands.Search, as: SearchCommands
+  alias MingaEditor.Handlers.BufferRegistry
   alias MingaEditor.HighlightSync
   alias MingaEditor.PickerUI
   alias MingaEditor.SemanticTokenSync
@@ -1992,7 +1993,7 @@ defmodule MingaEditor.Commands.BufferManagement do
 
   @spec any_buffer_dirty?(state()) :: boolean()
   defp any_buffer_dirty?(state) do
-    Enum.any?(state.workspace.buffers.list, fn pid ->
+    Enum.any?(BufferRegistry.buffer_inventory(state), fn pid ->
       try do
         Buffer.dirty?(pid)
       catch
@@ -2193,7 +2194,8 @@ defmodule MingaEditor.Commands.BufferManagement do
   end
 
   @spec save_all_buffers(state()) :: save_result()
-  defp save_all_buffers(state), do: save_all_buffers(state, state.workspace.buffers.list)
+  defp save_all_buffers(state),
+    do: save_all_buffers(state, BufferRegistry.buffer_inventory(state))
 
   @spec save_all_buffers(state(), [pid()]) :: save_result()
   defp save_all_buffers(state, []), do: {:ok, state}

--- a/lib/minga_editor/handlers/buffer_registry.ex
+++ b/lib/minga_editor/handlers/buffer_registry.ex
@@ -203,9 +203,15 @@ defmodule MingaEditor.Handlers.BufferRegistry do
     Enum.reduce(pids, state, &monitor_buffer(&2, &1))
   end
 
+  @spec buffer_inventory(state()) :: [pid()]
+  def buffer_inventory(%EditorState{} = state) do
+    active_pids = Enum.filter(state.workspace.buffers.list, &is_pid/1)
+    Enum.uniq(active_pids ++ inactive_file_tab_buffer_pids(state, active_tab_id(state)))
+  end
+
   @spec buffer_tracked?(state(), pid()) :: boolean()
   def buffer_tracked?(state, pid) when is_pid(pid) do
-    pid in state.workspace.buffers.list or buffer_tracked_in_tabs?(state, pid)
+    pid in buffer_inventory(state)
   end
 
   # Like register_buffer but adds the buffer in the background without
@@ -378,7 +384,7 @@ defmodule MingaEditor.Handlers.BufferRegistry do
   defp find_file_tab_by_live_path(tab_bar, workspace_id, path) do
     tab_bar
     |> TabBar.visible_file_tabs(workspace_id)
-    |> Enum.find(fn tab -> Enum.any?(tab_buffer_list(tab), &buffer_path_matches?(&1, path)) end)
+    |> Enum.find(&tab_path_matches?(&1, path))
   end
 
   @spec file_ref_for_path(state(), String.t()) :: FileRef.t()
@@ -414,22 +420,21 @@ defmodule MingaEditor.Handlers.BufferRegistry do
     end
   end
 
-  @spec buffer_tracked_in_tabs?(state(), pid()) :: boolean()
-  defp buffer_tracked_in_tabs?(%{shell_runtime: %{state: %{tab_bar: %{tabs: tabs}}}}, pid) do
-    Enum.any?(tabs, fn tab -> pid in tab_buffer_list(tab) end)
+  @spec inactive_file_tab_buffer_pids(state(), Tab.id() | nil) :: [pid()]
+  defp inactive_file_tab_buffer_pids(_state, nil), do: []
+
+  defp inactive_file_tab_buffer_pids(
+         %{shell_runtime: %{state: %{tab_bar: %TabBar{tabs: tabs}}}},
+         active_tab_id
+       ) do
+    Enum.flat_map(tabs, fn
+      %Tab{id: ^active_tab_id} -> []
+      %Tab{kind: :file, context: context} -> TabContext.buffer_pids(context)
+      _tab -> []
+    end)
   end
 
-  defp buffer_tracked_in_tabs?(_state, _pid), do: false
-
-  @spec tab_buffer_list(MingaEditor.State.Tab.t() | term()) :: [pid()]
-  defp tab_buffer_list(%MingaEditor.State.Tab{context: context}) when is_map(context) do
-    case TabContext.to_workspace_map(context) do
-      %{buffers: %Buffers{list: buffers}} -> Enum.filter(buffers, &is_pid/1)
-      _ -> []
-    end
-  end
-
-  defp tab_buffer_list(_tab), do: []
+  defp inactive_file_tab_buffer_pids(_state, _active_tab_id), do: []
 
   @spec active_buffer_matches_file_ref?(state(), FileRef.t()) :: boolean()
   defp active_buffer_matches_file_ref?(
@@ -444,6 +449,13 @@ defmodule MingaEditor.Handlers.BufferRegistry do
   end
 
   defp active_buffer_matches_file_ref?(_state, _file_ref), do: false
+
+  @spec tab_path_matches?(Tab.t(), String.t()) :: boolean()
+  defp tab_path_matches?(%Tab{context: context}, path) do
+    Enum.any?(TabContext.buffer_pids(context), &buffer_path_matches?(&1, path))
+  end
+
+  defp tab_path_matches?(_tab, _path), do: false
 
   @spec buffer_path_matches?(pid(), String.t()) :: boolean()
   defp buffer_path_matches?(pid, path) do

--- a/test/minga_editor/commands/buffer_management_save_quit_test.exs
+++ b/test/minga_editor/commands/buffer_management_save_quit_test.exs
@@ -5,10 +5,30 @@ defmodule MingaEditor.Commands.BufferManagementSaveQuitTest do
   use Minga.Test.EditorCase, async: false, rendering: :disabled
 
   alias Minga.Buffer
+  alias Minga.Buffer.Process, as: BufferProcess
+  alias Minga.Frontend.WaitRequestCompletion
+  alias Minga.Frontend.WaitRequests
   alias MingaEditor.Commands.BufferManagement
   alias MingaEditor.State, as: EditorState
+  alias MingaEditor.Shell.Traditional.State, as: TraditionalState
+  alias MingaEditor.State.Buffers
+  alias MingaEditor.State.Tab.Context, as: TabContext
+  alias MingaEditor.State.TabBar
 
   @moduletag :tmp_dir
+
+  setup_all do
+    case Process.whereis(WaitRequests) do
+      nil ->
+        {:ok, tracker} = WaitRequests.start_link()
+        on_exit(fn -> GenServer.stop(tracker, :normal) end)
+
+      _pid ->
+        :ok
+    end
+
+    :ok
+  end
 
   setup do
     previous_shutdown_fn = Application.get_env(:minga, :shutdown_fn)
@@ -104,6 +124,75 @@ defmodule MingaEditor.Commands.BufferManagementSaveQuitTest do
     assert_received {:shutdown, 0}
   end
 
+  test "successful :wqa saves dirty inactive-tab-only buffer and invokes shutdown", %{
+    tmp_dir: root
+  } do
+    active_path = Path.join(root, "active.txt")
+    inactive_path = Path.join(root, "inactive.txt")
+    File.write!(active_path, "active")
+    File.write!(inactive_path, "inactive")
+
+    ctx = start_editor("active", file_path: active_path)
+    {:ok, inactive_buffer} = BufferProcess.start_link(file_path: inactive_path)
+    :ok = Buffer.insert_text(inactive_buffer, " edited")
+    put_inactive_file_tab(ctx, inactive_buffer, "inactive.txt")
+
+    send_ex_sync(ctx, "wqa")
+
+    assert File.read!(inactive_path) == " editedinactive"
+    refute Buffer.dirty?(inactive_buffer)
+    assert_received {:shutdown, 0}
+  end
+
+  test ":quit_all asks for confirmation when only inactive tab inventory is dirty", %{
+    tmp_dir: root
+  } do
+    active_path = Path.join(root, "active.txt")
+    inactive_path = Path.join(root, "inactive.txt")
+    File.write!(active_path, "active")
+    File.write!(inactive_path, "inactive")
+
+    ctx = start_editor("active", file_path: active_path)
+    {:ok, inactive_buffer} = BufferProcess.start_link(file_path: inactive_path)
+    :ok = Buffer.insert_text(inactive_buffer, " edited")
+    state = put_inactive_file_tab(ctx, inactive_buffer, "inactive.txt")
+
+    result = BufferManagement.execute(state, :quit_all)
+
+    assert state_notice_message(result) == "Modified buffers exist. Really quit? (y/n)"
+    refute_received {:shutdown, 0}
+  end
+
+  test "confirmed :quit_all cancels wait requests for dirty inactive tab inventory", %{
+    tmp_dir: root
+  } do
+    active_path = Path.join(root, "active.txt")
+    inactive_path = Path.join(root, "inactive.txt")
+    File.write!(active_path, "active")
+    File.write!(inactive_path, "inactive")
+
+    ctx = start_editor("active", file_path: active_path)
+    {:ok, inactive_buffer} = BufferProcess.start_link(file_path: inactive_path)
+    :ok = Buffer.insert_text(inactive_buffer, " edited")
+    state = put_inactive_file_tab(ctx, inactive_buffer, "inactive.txt")
+    request_id = "save-quit-test-#{System.unique_integer([:positive])}"
+    :ok = WaitRequests.register(inactive_buffer, inactive_path, request_id, self())
+
+    state =
+      state
+      |> BufferManagement.execute(:quit_all)
+      |> BufferManagement.execute(:confirm_quit_yes)
+
+    assert %EditorState{} = state
+
+    assert_receive %WaitRequestCompletion{
+      request_id: ^request_id,
+      outcome: {:cancelled, "discarded after quit confirmation"}
+    }
+
+    assert_received {:shutdown, 0}
+  end
+
   test "active buffer exit is a failed :wq" do
     ctx = start_editor("")
     state = editor_state(ctx)
@@ -136,5 +225,39 @@ defmodule MingaEditor.Commands.BufferManagementSaveQuitTest do
 
     assert %EditorState{} = result
     refute_received {:shutdown, 0}
+  end
+
+  defp put_inactive_file_tab(ctx, buffer, label) do
+    :sys.replace_state(ctx.editor, fn state ->
+      tb = state.shell_runtime.state.tab_bar
+      {tb, tab} = TabBar.insert(tb, :file, label)
+
+      workspace =
+        MingaEditor.Session.State.set_buffers(
+          state.workspace,
+          %Buffers{active: buffer, list: [buffer], active_index: 0}
+        )
+
+      tb = TabBar.update_context(tb, tab.id, TabContext.snapshot(workspace))
+      install_tab_bar(state, tb)
+    end)
+  end
+
+  defp install_tab_bar(state, %TabBar{} = tb) do
+    shell_state =
+      TraditionalState.install_tab_bar(
+        MingaEditor.Shell.Runtime.state(state.shell_runtime),
+        tb
+      )
+
+    %{
+      state
+      | shell_runtime:
+          MingaEditor.Shell.Runtime.install_traditional_state(state.shell_runtime, shell_state)
+    }
+  end
+
+  defp state_notice_message(state) do
+    MingaEditor.Shell.Traditional.NoticeWorkflow.message(state)
   end
 end

--- a/test/minga_editor/state/buffer_lifecycle_test.exs
+++ b/test/minga_editor/state/buffer_lifecycle_test.exs
@@ -8,6 +8,7 @@ defmodule MingaEditor.State.BufferLifecycleTest do
   alias Minga.Buffer.Process, as: BufferProcess
   alias Minga.Project.FileRef
   alias MingaEditor.Agent.UIState
+  alias MingaEditor.Handlers.BufferRegistry
   alias MingaEditor.Shell.Registry
   alias MingaEditor.Shell.Runtime
   alias MingaEditor.Shell.Traditional.State, as: TraditionalState
@@ -325,6 +326,45 @@ defmodule MingaEditor.State.BufferLifecycleTest do
     end
   end
 
+  describe "buffer inventory" do
+    test "returns workspace buffers first, then inactive file-tab buffers without active stale context" do
+      buf_a = start_buffer("a")
+      buf_b = start_buffer("b")
+      buf_c = start_buffer("c")
+      stale = start_buffer("stale")
+
+      state = state_for_buffer(buf_a, list: [buf_a, buf_b])
+      {state, tab_b} = state_with_inactive_tab_buffer(state, buf_c)
+
+      tb =
+        state.shell_runtime.state.tab_bar
+        |> TabBar.update_context(1, %{
+          buffers: %Buffers{active: stale, list: [stale], active_index: 0}
+        })
+        |> TabBar.update_context(tab_b.id, %{
+          buffers: %Buffers{active: buf_b, list: [buf_b, buf_c], active_index: 0},
+          editing: VimState.new(),
+          viewport: Viewport.new(24, 80)
+        })
+
+      state = install_tab_bar(state, tb)
+
+      assert BufferRegistry.buffer_inventory(state) == [buf_a, buf_b, buf_c]
+    end
+
+    test "buffer_tracked?/2 includes inactive-tab-only buffers" do
+      active = start_buffer("active")
+      inactive = start_buffer("inactive")
+      unrelated = start_buffer("unrelated")
+
+      state = state_for_buffer(active)
+      {state, _tab} = state_with_inactive_tab_buffer(state, inactive)
+
+      assert BufferRegistry.buffer_tracked?(state, inactive)
+      refute BufferRegistry.buffer_tracked?(state, unrelated)
+    end
+  end
+
   describe "remove_buffer/2" do
     test "closing active, only, inactive, and special buffers updates buffers and monitor refs" do
       state = base_state()
@@ -590,5 +630,19 @@ defmodule MingaEditor.State.BufferLifecycleTest do
              MingaEditor.Shell.Runtime.install_traditional_state(root.shell_runtime, shell_state)
        }
      end), tab_b}
+  end
+
+  defp install_tab_bar(state, %TabBar{} = tb) do
+    shell_state =
+      TraditionalState.install_tab_bar(
+        MingaEditor.Shell.Runtime.state(state.shell_runtime),
+        tb
+      )
+
+    %{
+      state
+      | shell_runtime:
+          MingaEditor.Shell.Runtime.install_traditional_state(state.shell_runtime, shell_state)
+    }
   end
 end


### PR DESCRIPTION
## TL;DR

Include buffers retained only by inactive file tabs in save-all, dirty shutdown confirmation, and lifecycle tracking.

## Changes

- Add one BufferRegistry-owned ordered inventory of workspace and inactive file-tab buffers.
- Route dirty checks, save-all, and buffer tracking through that inventory.
- Preserve `MingaEditor.State.remove_buffer/2` as the retirement boundary.
- Add regressions for ordering, stale active contexts, inactive-tab save, dirty confirmation, and wait-request cancellation.
- Update the lifecycle roadmap.

## Validation

- Focused lifecycle and save/quit tests pass: 20 tests.
- Focused kill-buffer tests pass: 5 tests.
- `make lint` passes.
- Full `mix test.llm` passes: 9,857 tests, 0 failures.
- Production delta: net +14, within the locked +25 cap.
- Correctness review: PASS.
- Ponytail: LEAN.
- Elixir craftsmanship: PASS.
- Final reviewer: PASS at 0.99 confidence.
