### PR TITLE
fix(agent): preserve transcript unpin on status changes

### DIFF
--- a/docs/workstreams/editor-lifecycle-roadmap.md
+++ b/docs/workstreams/editor-lifecycle-roadmap.md
@@ -5257,6 +5257,25 @@ New split and float popup windows initialize their viewport metadata from `state
 - **Concepts removed:** Removed the dead `last_window_fps` GUI adapter cache field and its two private producer writes.
 - **Retained constraints:** `last_window_content_fps`, `last_window_overlay_fps`, `last_window_content_epochs`, `last_window_row_keys`, `last_window_rows`, `pending_window_delta_ids`, nested renderer `adapter_gui_caches`, emit side-channel dedupe, frame acknowledgement lineage, recovery fields, and WindowCache resident/snapshot fields remain unchanged.
 - **Discoveries affecting later work:** No replan trigger, owner drift, public API change, protocol/frontend wire change, frame-logic change, compatibility need, production budget miss, or additional dead D11 field was found.
+### W136/D39: Delete status-driven agent auto-scroll re-pinning
+
+- **Status:** IMPLEMENTED
+- **Audit ID:** D39
+- **Decision:** APPROVE_DIRECT, delete only the status-driven `:thinking` auto-scroll re-pinning chain while preserving explicit scroll-to-bottom, frontend pin intents, resident transcript state, protocol behavior, and prompt-clearing scroll behavior.
+- **Planning profile:** `D39Refresh`, editor-lifecycle-planner, read-only, locked READY at baseline `0b22c1f192cc6fe6a7b2c18e0dc7d7b28a8b81f7`.
+- **Implementation profile:** `D39WorkerNext`, editor-lifecycle-worker, no delegation.
+- **Failure reproduction:** After adding the locked focused regression, `mix test test/minga_editor/agent/focused_event_workflows_test.exs` failed before the production deletion because `StatusEventWorkflow.status_changed(state, :thinking)` changed an explicitly unpinned transcript from `pinned: false` to `pinned: true`.
+- **Observable result:** `:thinking` status changes still synchronize the Traditional agent status, start turn activity, start the spinner, synchronize tab and active shell status, run compaction status handling, schedule render, and leave an already-unpinned transcript at its existing offset until an explicit pin or scroll-to-bottom transition occurs.
+- **Changed files:** `docs/workstreams/editor-lifecycle-roadmap.md`, `lib/minga_editor/agent/status_event_workflow.ex`, `lib/minga_editor/agent/ui_state.ex`, `lib/minga_editor/shell/traditional/workflow.ex`, and `test/minga_editor/agent/focused_event_workflows_test.exs`.
+- **Focused validation:** The new focused regression first failed with `Expected false or nil, got true` for `refute state.workspace.agent_ui.panel.scroll.pinned`; after the deletion, `mix test test/minga_editor/agent/focused_event_workflows_test.exs` passed `23` tests. `mix test test/minga_editor/handlers/gui_action_handler_test.exs test/minga_editor/input/agent_nav_test.exs` passed `35` tests, preserving explicit frontend pin intents and keyboard `G` scroll-to-bottom behavior.
+- **Broad validation:** `mix test test/minga_editor/agent test/minga_editor/handlers/gui_action_handler_test.exs test/minga_editor/input` passed `805` tests. `make lint` passed changed-source Credo, compile, formatting, and incremental Dialyzer with `Total errors: 0`. `mix test.llm --max-cases 1` passed `58 doctests, 98 properties, 9852 tests, 0 failures, 1 skipped, 616 excluded`; two earlier default-concurrency `make test.llm` attempts failed in unrelated SessionManager call timeouts in `MingaAgent.Tools.IntrospectionTest` and `MingaAgent.SessionManagerTest`, and their focused rerun passed.
+- **Residue check:** Focused source search found no remaining `engage_scroll`, `engage_agent_scroll`, or `engage_auto_scroll` references under `lib/` or `test/`.
+- **Production lines added/removed before roadmap evidence:** `lib/` diff is `+0/-16`, net `-16`, within the locked production net cap of `<= 0`.
+- **Test lines added/removed before roadmap evidence:** `test/` diff is `+6/-3`, net `+3`, limited to the locked unpinned `:thinking` regression.
+- **Concepts added:** One focused regression for status-preserving unpinned transcript behavior.
+- **Concepts removed:** Removed the status-driven auto-scroll re-pinning chain: `StatusEventWorkflow.engage_scroll/2`, `TraditionalWorkflow.engage_agent_scroll/1`, and `UIState.engage_auto_scroll/1`.
+- **Retained constraints:** `UIState.scroll_to_bottom/1`, `UIState.set_pinned/2`, `UIState.scroll_up/2`, `UIState.scroll_down/2`, prompt-clearing scroll-to-bottom, resident transcript projection, frontend protocol opcodes, render metrics, mouse and key routing, and `Minga.Editing.Scroll` semantics remain unchanged. No module, process, dependency, behaviour, protocol, registry, public API, configuration, compatibility shim, replacement abstraction, data representation, scroll owner, or transcript owner was added.
+- **Discoveries affecting later work:** Default-concurrency `make test.llm` remains vulnerable to unrelated SessionManager call timeouts; a low-concurrency full `mix test.llm --max-cases 1` passed in this worktree. No D39 replan trigger, stale owner, dependency drift, frontend protocol change, or overlapping implementation dependency was found.
 - **Unresolved questions:** None.
 - **needs_replan:** false.
 - **Completion date:** 2026-07-25

--- a/lib/minga_editor/agent/status_event_workflow.ex
+++ b/lib/minga_editor/agent/status_event_workflow.ex
@@ -50,17 +50,12 @@ defmodule MingaEditor.Agent.StatusEventWorkflow do
           {EditorState.t(), compaction_action()}
   defp transition_status(state, status) do
     state = TraditionalWorkflow.install_agent_status(state, status)
-    state = engage_scroll(state, status)
     state = update_turn_activity(state, status)
     state = update_spinner(state, status)
     state = sync_tab_agent_status(state, status)
     state = sync_active_shell_agent_status(state, status)
     apply_status_compaction(state, status)
   end
-
-  @spec engage_scroll(EditorState.t(), Tab.agent_status()) :: EditorState.t()
-  defp engage_scroll(state, :thinking), do: TraditionalWorkflow.engage_agent_scroll(state)
-  defp engage_scroll(state, _status), do: state
 
   @spec update_turn_activity(EditorState.t(), Tab.agent_status()) :: EditorState.t()
   defp update_turn_activity(state, status) when status in [:thinking, :tool_executing],

--- a/lib/minga_editor/agent/ui_state.ex
+++ b/lib/minga_editor/agent/ui_state.ex
@@ -235,12 +235,6 @@ defmodule MingaEditor.Agent.UIState do
     %{state | panel: %{panel | scroll: Minga.Editing.scroll_to_top(panel.scroll)}}
   end
 
-  @doc "Re-engages auto-scroll. Delegates to `Minga.Editing.pin_to_bottom/1`."
-  @spec engage_auto_scroll(t()) :: t()
-  def engage_auto_scroll(%__MODULE__{panel: panel} = state) do
-    %{state | panel: %{panel | scroll: Minga.Editing.pin_to_bottom(panel.scroll)}}
-  end
-
   @doc "Records whether prompt input owns focus; buffer attachment belongs to PromptBuffer."
   @spec set_input_focused(t(), boolean()) :: t()
   def set_input_focused(%__MODULE__{panel: panel} = state, focused?) when is_boolean(focused?) do

--- a/lib/minga_editor/shell/traditional/workflow.ex
+++ b/lib/minga_editor/shell/traditional/workflow.ex
@@ -74,11 +74,6 @@ defmodule MingaEditor.Shell.Traditional.Workflow do
   def clear_agent_approval(%EditorState{} = state),
     do: transition_agent(state, &AgentState.clear_pending_approval/1)
 
-  @doc "Engages active agent chat auto-scroll."
-  @spec engage_agent_scroll(EditorState.t()) :: EditorState.t()
-  def engage_agent_scroll(%EditorState{} = state),
-    do: install_agent_ui(state, UIState.engage_auto_scroll(state.workspace.agent_ui))
-
   @doc "Installs a changed Traditional agent lifecycle value."
   @spec install_agent_state(EditorState.t(), AgentState.t()) :: EditorState.t()
   def install_agent_state(

--- a/test/minga_editor/agent/focused_event_workflows_test.exs
+++ b/test/minga_editor/agent/focused_event_workflows_test.exs
@@ -31,13 +31,16 @@ defmodule MingaEditor.Agent.FocusedEventWorkflowsTest do
   alias MingaAgent.Session
   alias MingaEditor.Test.FakeShell
 
-  test "status workflow synchronizes owner state before installing a render" do
-    state = event_state()
+  test "status workflow preserves an unpinned transcript before installing a render" do
+    state =
+      event_state()
+      |> TraditionalWorkflow.install_agent_ui(UIState.new() |> UIState.scroll_down(7))
 
     state = StatusEventWorkflow.status_changed(state, :thinking)
 
     assert TraditionalState.agent(state.shell_runtime.state).runtime.status == :thinking
-    assert state.workspace.agent_ui.panel.scroll.pinned
+    refute state.workspace.agent_ui.panel.scroll.pinned
+    assert state.workspace.agent_ui.panel.scroll.offset == 7
     assert state.workspace.agent_ui.view.activity.started_at
     assert RenderCorrelation.scheduled?(state.render.render_correlation)
   end


### PR DESCRIPTION
## TL;DR

Stop agent status changes from re-pinning a transcript that the user explicitly unpinned.

## Changes

- Delete the status-driven three-link auto-scroll re-pinning chain.
- Preserve explicit scroll-to-bottom and frontend pin/unpin intents.
- Preserve status, activity, spinner, tab, compaction, and render scheduling behavior.
- Add a regression that retains both the unpinned flag and scroll offset across `:thinking`.
- Update the lifecycle roadmap.

## Validation

- Focused status workflow tests pass: 23 tests.
- Explicit pin and navigation tests pass: 35 tests.
- Broad relevant agent/input tests pass: 805 tests.
- `make lint` passes.
- Full constrained `mix test.llm` passes: 9,852 tests, 0 failures.
- Production delta: net -16.
- Correctness review: PASS.
- Ponytail: LEAN after mandatory roadmap evidence was clarified.
- Elixir craftsmanship: PASS.
- Final reviewer: PASS at 0.99 confidence.
